### PR TITLE
feat(revert): no-baseline UX — folded NOT-revertable summary, exit 1 when nothing revertable (R35)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,11 +43,11 @@ node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to
 
 ## State of the Repo
 
-- **Pre-release / experimental.** Private until Phase 4; not yet published, no
-  GitHub remote yet (developed solo on `main`).
-- Baseline files live at `.cdkrd/<stack>.<accountId>.<region>.json` — git-committed. A PR (once
-  there is a remote) that changes a baseline is a visible, reviewable change to
-  "what real state we accept".
+- **Pre-release / experimental.** Private until Phase 4; not yet published. Remote:
+  <https://github.com/go-to-k/cdk-real-drift> (developed solo, PR-based).
+- Baseline files live at `.cdkrd/<stack>.<accountId>.<region>.json` — git-committed.
+  A PR that changes a baseline is a visible, reviewable change to "what real state
+  we accept".
 
 ## Build and Test Commands
 
@@ -110,14 +110,13 @@ detail:
 - **Always add unit tests** for new behavior or bug fixes — do not wait to be asked.
 - **Run `vp run build`** after modifying source, before telling the user to test.
 - **Conventional commits**: use `feat:` / `fix:` / `chore:` / `docs:` / `test:`
-  prefixes. A `pr-title-check` workflow enforces PR titles (once there is a remote).
+  prefixes. A `pr-title-check` workflow enforces PR titles.
 - **markgate gates** (see `.markgate.yml`) — each has a companion skill that sets
   its marker:
   - `/check` → `check` marker (typecheck / lint+format / build / unit tests).
   - `/check-docs` → `docs` marker (README / DESIGN / docs consistency with src).
   - `/verify-pr` → `verify-pr` marker (pre-RELEASE superset of check + docs plus a
-    live-test + retrospective; named `verify-pr` for layout parity, but this is a
-    solo local repo with no PR workflow).
+    live-test + retrospective; named `verify-pr` for layout parity with cdkd).
   - A `check-gate` PreToolUse hook blocks `git commit` unless both the `check` and
     `docs` markers are fresh. Run the relevant skill before committing.
 - **Use a git worktree for any parallel / concurrent development.** Two agents
@@ -129,10 +128,11 @@ detail:
   orchestrator integrates by `git checkout <branch> -- <files>` (NEVER `git merge` —
   the leaked cdkd session hooks block it), then `git worktree remove`. A single
   sequential session may still work directly in the main checkout.
-- **Branch / PR / merge gates are deferred until Phase 4** (when the repo gets a
-  remote). cdkrd is developed on `main` (no PR flow yet), so cdkd's branch-protection,
-  verify-pr-merge, pr-review, and integ-\* gates are intentionally NOT ported — they
-  would be meaningless or disruptive without a remote.
+- **All changes go through a pull request — never commit directly to `main`.**
+  Branch (or worktree branch) → run the gates + set markers → commit → push →
+  `gh pr create`. The reviewer re-reviews the PR diff before merge. cdkd's heavier
+  branch-protection / verify-pr-merge / pr-review / integ-\* gates are still not
+  ported — revisit at Phase 4.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # cdk-real-drift (`cdkrd`)
 
 Drift detection for AWS CDK — including the **undeclared properties `cdk drift`
-can't see** (an inline policy added in the console, encryption toggled off, a
-changed bucket setting). Detect it, accept it, or revert it.
+can't see**. Detect it, accept it, or revert it.
 
 <!-- badges (enable on publish):
 [![npm](https://img.shields.io/npm/v/cdk-real-drift)](https://www.npmjs.com/package/cdk-real-drift)

--- a/README.md
+++ b/README.md
@@ -211,20 +211,20 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 # - run: npx cdkrd check --app cdk.out --region us-east-1
 ```
 
-| option                           | meaning                                                                                                                               |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `--region <r>`                   | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                        |
-| `--profile <p>`                  | AWS profile (or `$AWS_PROFILE`)                                                                                                       |
-| `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths         |
-| `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                            |
-| `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                                  |
-| `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                          |
-| `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                              |
-| `--verbose` / `-v`               | (check) expand the informational tiers (`readGap` / `unresolved` / `skipped` / `ignored`) from the `info:` summary line to full lists |
-| `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite                 |
-| `--dry-run`                      | (revert) print the plan; make no changes                                                                                              |
-| `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                                  |
-| `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                         |
+| option                           | meaning                                                                                                                       |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `--region <r>`                   | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                |
+| `--profile <p>`                  | AWS profile (or `$AWS_PROFILE`)                                                                                               |
+| `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths |
+| `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                    |
+| `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
+| `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                  |
+| `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
+| `--verbose` / `-v`               | (check) expand informational tiers from the `info:` line / (revert) the per-reason NOT-revertable summary — to full lists     |
+| `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
+| `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
+| `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
+| `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                 |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
 the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.
@@ -299,12 +299,21 @@ backward-compatible API.
   exotic intrinsic, a write-only value, a Cloud-Control-unreadable type) is reported
   as informational, never guessed. You trade a little coverage for zero false drift.
 - **Revert cannot do everything.** Not revertable, and reported as such:
+  - **undeclared drift on a stack with NO baseline** — there is no blessed value to
+    write back, so `revert` refuses (run `accept` first, or opt into removal with
+    `--remove-unblessed`); the plan leads with a note pointing at that route;
   - a `deleted` resource (recreate it with `cdk deploy`);
   - **create-only** properties (changing them requires resource replacement);
   - toggle-style properties with no "absent" state (e.g. S3 transfer acceleration
     is only `Enabled`/`Suspended`);
   - `AWS::Lambda::Permission` and `AWS::Budgets::Budget` (their write APIs cannot
     safely reconstruct the desired state from what is readable).
+
+  Not-revertable findings fold into a one-line-per-reason summary (`--verbose` for
+  the full list). When drift exists but **nothing** is revertable, `revert` prints
+  `nothing revertable — N drift(s) remain.` and exits 1 (the drift still stands);
+  exit 0 means there was no drift to revert at all.
+
 - **Revert writes the canonical form** of the desired value — semantically equal to
   your template, but statement/tag ordering or scalar-vs-array may differ textually.
 - **Custom resources** (`Custom::*`) have no cloud-side model and are always

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -314,9 +314,14 @@ see [redesign-notes.md](redesign-notes.md).)
 
 ## 7. Revert (the only AWS-mutating path)
 
-[src/revert/](../src/revert/). `revert` builds a plan, prints it (per finding: path,
-current → target), asks for confirmation (`@clack`; `--yes` skips; non-TTY refuses;
-`--dry-run` previews), applies, then **re-checks for convergence**.
+[src/revert/](../src/revert/). `revert` builds a plan, prints it (revertable items
+always in full — per finding: path, current → target; NOT-revertable findings folded
+to one line per reason, `--verbose` for the full list — R35), asks for confirmation
+(`@clack`; `--yes` skips; non-TTY refuses; `--dry-run` previews), applies, then
+**re-checks for convergence**. Exit semantics: no drift at all → `no drift to
+revert.` + exit 0; drift exists but **nothing is revertable** → `nothing
+revertable — N drift(s) remain.` + exit 1 (drift-remains semantics, not a usage
+error — R35).
 
 - **Targets**: declared drift → the **deployed-template** value; undeclared drift →
   the **baseline** value (an un-blessed out-of-band _addition_ reverts by REMOVAL).
@@ -327,6 +332,10 @@ pass --remove-unblessed`) rather than removed. The subtractive noise model's
   that would be **destructive** (a bulk REMOVE of every undeclared value that slipped
   through subtraction). `--remove-unblessed` opts back into removal. Declared drift is
   always revertable (the template is its source, independent of any baseline).
+  For undeclared drift this guard outranks the create-only guard (R35): the
+  fundamental blocker is "no revert target exists", and `accept` blesses the value
+  away entirely — a "requires replacement" reason would mis-direct. When the guard
+  fires, the plan leads with a note pointing at the `check` / `accept` route.
 - **Write mechanism** (`plan.ts` chooses `kind`):
   - `kind: 'cc'` — generic Cloud Control `UpdateResource` RFC6902 PatchDocument,
     polled via `GetResourceRequestStatus` ([apply.ts](../src/revert/apply.ts)).

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -39,7 +39,7 @@ export interface CommonArgs {
   yes: boolean;
   preDeploy: boolean; // compare live vs the LOCAL synth template (drift your next deploy would clobber)
   removeUnblessed: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
-  verbose: boolean; // (check) expand informational tiers (readGap/unresolved/skipped) to full lists
+  verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
 }
 
 export function parseCommonArgs(args: string[]): CommonArgs {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,8 @@ OPTIONS
   --fail-on declared|undeclared   which tier sets exit 1 (default: undeclared = both)
   --show-all                  inventory mode: show ALL current undeclared state
                               (not just changes since accept)
+  --verbose                   (check) expand informational tiers / (revert) the
+                              NOT-revertable summary to full per-finding lists
   --pre-deploy                (check) compare live state vs the LOCAL synth template
                               — the declared drift your next deploy would overwrite
   --dry-run                   (revert) print the plan; make no changes

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -225,6 +225,7 @@ export async function runCheck(args: string[]): Promise<number> {
               dryRun: false,
               yes: a.yes,
               removeUnblessed: a.removeUnblessed,
+              verbose: a.verbose,
             });
             // R30: an aborted confirm did NOT write to AWS, so the drift still
             // stands — keep the pre-revert exit 1 (symmetric with "Nothing").

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -70,6 +70,7 @@ export async function runRevert(args: string[]): Promise<number> {
         dryRun,
         yes: a.yes,
         removeUnblessed: a.removeUnblessed,
+        verbose: a.verbose,
       });
       worst = Math.max(worst, exit);
     } catch (e) {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -90,17 +90,64 @@ export async function acceptStack(p: AcceptStackParams): Promise<boolean> {
 
 // ---- revert ----
 
-function printPlan(stackName: string, region: string, plan: RevertPlan): void {
-  console.log(`\n=== cdkrd revert: ${stackName} (${region}) ===`);
+export interface PlanDisplayOptions {
+  verbose?: boolean; // expand the NOT-revertable per-reason summary to the full per-finding list
+  noBaselineGuidance?: boolean; // no baseline + undeclared drift → lead with the accept-first route
+}
+
+/**
+ * Render the revert plan (pure — exported for unit tests; printPlan logs it).
+ * Revertable items are ALWAYS full detail — confirming what will be written to AWS
+ * is the point of the plan. NOT-revertable findings fold into one line per reason
+ * (count + reason — same idea as check's `info:` footer, R25/R35); `--verbose`
+ * expands them to the full per-finding list.
+ */
+export function formatPlan(
+  stackName: string,
+  region: string,
+  plan: RevertPlan,
+  opts: PlanDisplayOptions = {}
+): string[] {
+  const lines: string[] = [`\n=== cdkrd revert: ${stackName} (${region}) ===`];
+  if (opts.noBaselineGuidance) {
+    lines.push(
+      `\nnote: ${stackName} has no baseline — undeclared drift has no revert target.`,
+      '      Run `cdkrd check` or `cdkrd accept` to bless a baseline first.'
+    );
+  }
   for (const item of plan.items) {
-    console.log(`\n  ${item.displayId} (${item.resourceType})`);
-    for (const op of item.ops) console.log(`    - ${op.human}`);
+    lines.push(`\n  ${item.displayId} (${item.resourceType})`);
+    for (const op of item.ops) lines.push(`    - ${op.human}`);
   }
   if (plan.notRevertable.length > 0) {
-    console.log(`\n  NOT revertable (${plan.notRevertable.length}):`);
-    for (const n of plan.notRevertable)
-      console.log(`    - ${n.displayId}.${n.path} (${n.resourceType}) — ${n.reason}`);
+    if (opts.verbose) {
+      lines.push(`\n  NOT revertable (${plan.notRevertable.length}):`);
+      for (const n of plan.notRevertable)
+        lines.push(`    - ${n.displayId}.${n.path} (${n.resourceType}) — ${n.reason}`);
+    } else {
+      const counts = new Map<string, number>();
+      for (const n of plan.notRevertable) counts.set(n.reason, (counts.get(n.reason) ?? 0) + 1);
+      const groups = [...counts.entries()].sort((a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : 1));
+      groups.forEach(([reason, count], i) => {
+        lines.push(
+          i === 0
+            ? `\n  NOT revertable: ${count} (${reason})`
+            : `                · ${count} (${reason})`
+        );
+      });
+      lines.push('    (run with --verbose for the full list)');
+    }
   }
+  return lines;
+}
+
+function printPlan(
+  stackName: string,
+  region: string,
+  plan: RevertPlan,
+  opts: PlanDisplayOptions
+): void {
+  for (const line of formatPlan(stackName, region, plan, opts)) console.log(line);
 }
 
 export interface RevertStackParams {
@@ -112,12 +159,14 @@ export interface RevertStackParams {
   dryRun: boolean;
   yes: boolean;
   removeUnblessed: boolean;
+  verbose: boolean; // expand the NOT-revertable summary to the full list
 }
 
 /**
  * Outcome of a per-stack revert.
- *  - `exit`: the exit contribution — 0 clean / 1 drift remains / 2 apply failure
- *    (or a non-interactive write refusal).
+ *  - `exit`: the exit contribution — 0 clean / 1 drift remains (including "drift
+ *    exists but nothing is revertable", R35) / 2 apply failure (or a non-interactive
+ *    write refusal).
  *  - `aborted`: true ONLY when the user cancelled the confirm prompt (no AWS write
  *    happened). The standalone `revert` command treats an abort as exit 0 (nothing
  *    changed), but `check`'s interactive flow must NOT let an abort drop a drifted
@@ -136,7 +185,8 @@ export interface RevertOutcome {
  * gather) — only the convergence re-check re-gathers.
  */
 export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> {
-  const { stackName, region, gathered, baseline, config, dryRun, yes, removeUnblessed } = p;
+  const { stackName, region, gathered, baseline, config, dryRun, yes, removeUnblessed, verbose } =
+    p;
   let worst = 0;
   const declaredByLogical = declaredKeysByLogical(gathered.desired.resources);
   const drifted = applyIgnores(
@@ -150,8 +200,17 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     console.log(`${stackName} (${region}): no drift to revert.`);
     return { exit: 0, aborted: false };
   }
-  printPlan(stackName, region, plan);
-  if (plan.items.length === 0) return { exit: 0, aborted: false }; // nothing revertable
+  printPlan(stackName, region, plan, {
+    verbose,
+    noBaselineGuidance: baseline === undefined && drifted.some((f) => f.tier === 'undeclared'),
+  });
+  if (plan.items.length === 0) {
+    // Drift exists but none of it is revertable (R35). That is NOT the clean
+    // "no drift to revert" case — the drift still stands, so exit 1 (the same
+    // "drift remains" semantics as a post-apply non-convergence; not a usage error).
+    console.log(`\nnothing revertable — ${driftCount(drifted)} drift(s) remain.`);
+    return { exit: 1, aborted: false };
+  }
 
   const opCount = plan.items.reduce((n, i) => n + i.ops.length, 0);
   if (dryRun) {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -202,7 +202,11 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   }
   printPlan(stackName, region, plan, {
     verbose,
-    noBaselineGuidance: baseline === undefined && drifted.some((f) => f.tier === 'undeclared'),
+    // Only when the no-baseline guard actually fires: with --remove-unblessed the
+    // plan REMOVES undeclared drift, so a "no revert target — accept first" note
+    // would contradict the plan printed right below it (R35 review).
+    noBaselineGuidance:
+      baseline === undefined && !removeUnblessed && drifted.some((f) => f.tier === 'undeclared'),
   });
   if (plan.items.length === 0) {
     // Drift exists but none of it is revertable (R35). That is NOT the clean

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -112,20 +112,13 @@ export function buildRevertPlan(
       });
       continue;
     }
-    // create-only property: an in-place UpdateResource patch would be rejected (the
-    // change needs a replacement) — report it now instead of failing at apply time.
-    if (opts.schemas?.get(f.resourceType)?.createOnly.has(topSegment(f.path))) {
-      notRevertable.push({
-        displayId,
-        resourceType: f.resourceType,
-        path: f.path,
-        reason: 'create-only property — change requires resource replacement',
-      });
-      continue;
-    }
     // un-blessed undeclared drift: a no-baseline stack would otherwise REMOVE every
     // such value (the subtractive model's failure mode is "check is noisy", but the
     // revert mirror of that is destructive). Refuse unless --remove-unblessed.
+    // Evaluated BEFORE the create-only guard (R35): on a no-baseline stack the
+    // fundamental blocker for undeclared drift is "no revert target exists", and the
+    // right next step is `accept` (which blesses the value away entirely) — a
+    // "requires replacement" reason would mis-direct the user.
     if (
       f.tier === 'undeclared' &&
       noBaseline &&
@@ -137,6 +130,17 @@ export function buildRevertPlan(
         resourceType: f.resourceType,
         path: f.path,
         reason: 'no baseline — run `cdkrd accept` first, or pass --remove-unblessed',
+      });
+      continue;
+    }
+    // create-only property: an in-place UpdateResource patch would be rejected (the
+    // change needs a replacement) — report it now instead of failing at apply time.
+    if (opts.schemas?.get(f.resourceType)?.createOnly.has(topSegment(f.path))) {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason: 'create-only property — change requires resource replacement',
       });
       continue;
     }

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -180,6 +180,28 @@ describe('buildRevertPlan', () => {
     for (const n of plan.notRevertable) expect(n.reason).toContain('not revertable');
   });
 
+  it('R35: undeclared create-only drift on a NO-baseline stack -> reason is no-baseline (accept is the route)', () => {
+    // the fundamental blocker is "no revert target" — a create-only reason would
+    // mis-direct the user toward replacement when `accept` blesses the value away
+    const plan = buildRevertPlan(
+      [F({ tier: 'undeclared', path: 'BucketName', actual: 'b' })],
+      undefined,
+      { schemas: schemaWithCreateOnly('AWS::S3::Bucket', 'BucketName') }
+    );
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable[0]!.reason).toContain('no baseline');
+  });
+
+  it('R35: undeclared create-only drift WITH a baseline -> create-only reason still applies', () => {
+    const plan = buildRevertPlan(
+      [F({ tier: 'undeclared', path: 'BucketName', actual: 'b' })],
+      baseline([]),
+      { schemas: schemaWithCreateOnly('AWS::S3::Bucket', 'BucketName') }
+    );
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable[0]!.reason).toContain('create-only');
+  });
+
   it('create-only declared drift -> notRevertable (needs replacement, not a patch)', () => {
     const plan = buildRevertPlan(
       [F({ tier: 'declared', path: 'BucketName', desired: 'a', actual: 'b' })],

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -157,8 +157,10 @@ describe('formatPlan (R35 — NOT-revertable folds to a per-reason summary)', ()
 });
 
 describe('revertStack exit semantics (R35 — drift with nothing revertable is exit 1)', () => {
-  // findings-only params: every path under test returns BEFORE any AWS client is used
-  const params = (findings: Finding[]) => ({
+  // findings-only params: every path under test returns BEFORE any AWS client is
+  // used — either nothing is revertable, or --dry-run returns at the preview branch.
+  type Overrides = { removeUnblessed?: boolean; dryRun?: boolean };
+  const params = (findings: Finding[], over: Overrides = {}) => ({
     stackName: 's',
     region: 'r',
     gathered: {
@@ -168,18 +170,18 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     } as unknown as GatherResult,
     baseline: undefined,
     config: { ignore: [] },
-    dryRun: false,
+    dryRun: over.dryRun ?? false,
     yes: true,
-    removeUnblessed: false,
+    removeUnblessed: over.removeUnblessed ?? false,
     verbose: false,
   });
 
-  const captured = async (findings: Finding[]) => {
+  const captured = async (findings: Finding[], over: Overrides = {}) => {
     const logs: string[] = [];
     const orig = console.log;
     console.log = (s: unknown) => logs.push(String(s));
     try {
-      const outcome = await revertStack(params(findings));
+      const outcome = await revertStack(params(findings, over));
       return { outcome, logs };
     } finally {
       console.log = orig;
@@ -214,6 +216,20 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     expect(out).toContain('note: s has no baseline — undeclared drift has no revert target.');
     expect(out).toContain('NOT revertable: 1 (no baseline — run `cdkrd accept` first');
     expect(out).toContain('nothing revertable — 1 drift(s) remain.');
+  });
+
+  it('--remove-unblessed: no-baseline note is suppressed; the plan removes the undeclared drift', async () => {
+    // dry-run returns at the preview branch (no AWS write). The note would contradict
+    // a plan that DOES remove the drift, so it must not appear (R35 review).
+    const { outcome, logs } = await captured([undeclared()], {
+      removeUnblessed: true,
+      dryRun: true,
+    });
+    expect(outcome).toEqual({ exit: 0, aborted: false });
+    const out = logs.join('\n');
+    expect(out).not.toContain('has no baseline — undeclared drift has no revert target');
+    expect(out).toContain('remove (undeclared, not in baseline)'); // a real revert item is planned
+    expect(out).toContain('(dry-run) would apply');
   });
 });
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
-import { availableActions, resolveInteractiveRevertExit } from '../src/commands/stack-actions.js';
+import type { GatherResult } from '../src/commands/gather.js';
+import {
+  availableActions,
+  formatPlan,
+  resolveInteractiveRevertExit,
+  revertStack,
+} from '../src/commands/stack-actions.js';
+import type { RevertPlan } from '../src/revert/plan.js';
 import type { Finding, SchemaInfo } from '../src/types.js';
 
 const NO_SCHEMAS = new Map<string, SchemaInfo>();
@@ -83,6 +90,130 @@ describe('availableActions (R28 interactive choice logic)', () => {
       accept: true,
       revert: true,
     });
+  });
+});
+
+describe('formatPlan (R35 — NOT-revertable folds to a per-reason summary)', () => {
+  const nr = (reason: string, path = 'P'): RevertPlan['notRevertable'][number] => ({
+    displayId: 'Stack/Res',
+    resourceType: 'AWS::S3::Bucket',
+    path,
+    reason,
+  });
+
+  it('folds notRevertable into one line per reason, sorted by count desc', () => {
+    const plan: RevertPlan = {
+      items: [],
+      notRevertable: [nr('no baseline — x', 'A'), nr('no baseline — x', 'B'), nr('deleted — y')],
+    };
+    const lines = formatPlan('s', 'r', plan, {});
+    expect(lines).toContain('\n  NOT revertable: 2 (no baseline — x)');
+    expect(lines).toContain('                · 1 (deleted — y)');
+    expect(lines).toContain('    (run with --verbose for the full list)');
+    // no per-finding lines in the folded view
+    expect(lines.some((l) => l.includes('Stack/Res.A'))).toBe(false);
+  });
+
+  it('--verbose expands to the full per-finding list', () => {
+    const plan: RevertPlan = {
+      items: [],
+      notRevertable: [nr('no baseline — x', 'A'), nr('deleted — y')],
+    };
+    const lines = formatPlan('s', 'r', plan, { verbose: true });
+    expect(lines).toContain('\n  NOT revertable (2):');
+    expect(lines).toContain('    - Stack/Res.A (AWS::S3::Bucket) — no baseline — x');
+    expect(lines.some((l) => l.includes('(run with --verbose'))).toBe(false);
+  });
+
+  it('revertable items keep full detail regardless of verbose (the point of the plan)', () => {
+    const plan: RevertPlan = {
+      items: [
+        {
+          logicalId: 'R',
+          displayId: 'Stack/Res',
+          resourceType: 'AWS::S3::Bucket',
+          physicalId: 'p',
+          kind: 'cc',
+          ops: [{ op: 'add', path: '/A', value: 1, human: 'A -> deployed-template value' }],
+        },
+      ],
+      notRevertable: [],
+    };
+    for (const verbose of [false, true]) {
+      const lines = formatPlan('s', 'r', plan, { verbose });
+      expect(lines).toContain('\n  Stack/Res (AWS::S3::Bucket)');
+      expect(lines).toContain('    - A -> deployed-template value');
+    }
+  });
+
+  it('noBaselineGuidance leads with the accept-first route', () => {
+    const plan: RevertPlan = { items: [], notRevertable: [nr('no baseline — x')] };
+    const lines = formatPlan('MyStack', 'r', plan, { noBaselineGuidance: true });
+    expect(lines[1]).toBe(
+      '\nnote: MyStack has no baseline — undeclared drift has no revert target.'
+    );
+    expect(lines[2]).toContain('cdkrd check` or `cdkrd accept');
+  });
+});
+
+describe('revertStack exit semantics (R35 — drift with nothing revertable is exit 1)', () => {
+  // findings-only params: every path under test returns BEFORE any AWS client is used
+  const params = (findings: Finding[]) => ({
+    stackName: 's',
+    region: 'r',
+    gathered: {
+      desired: { accountId: '111122223333', resources: [], rawTemplate: '' },
+      findings,
+      schemas: NO_SCHEMAS,
+    } as unknown as GatherResult,
+    baseline: undefined,
+    config: { ignore: [] },
+    dryRun: false,
+    yes: true,
+    removeUnblessed: false,
+    verbose: false,
+  });
+
+  const captured = async (findings: Finding[]) => {
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (s: unknown) => logs.push(String(s));
+    try {
+      const outcome = await revertStack(params(findings));
+      return { outcome, logs };
+    } finally {
+      console.log = orig;
+    }
+  };
+
+  it('no drift at all -> "no drift to revert." + exit 0 (regression)', async () => {
+    const { outcome, logs } = await captured([]);
+    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(logs.join('\n')).toContain('no drift to revert.');
+  });
+
+  it('informational-only findings -> still exit 0 (not drift)', async () => {
+    const { outcome } = await captured([
+      { tier: 'readGap', logicalId: 'R', resourceType: 'AWS::X::Y', path: 'P' },
+    ]);
+    expect(outcome).toEqual({ exit: 0, aborted: false });
+  });
+
+  it('drift exists but nothing revertable (deleted-only) -> summary + exit 1', async () => {
+    const { outcome, logs } = await captured([deleted()]);
+    expect(outcome).toEqual({ exit: 1, aborted: false });
+    const out = logs.join('\n');
+    expect(out).toContain('NOT revertable: 1 (deleted — recreate via cdk deploy)');
+    expect(out).toContain('nothing revertable — 1 drift(s) remain.');
+  });
+
+  it('un-blessed undeclared drift -> no-baseline guidance + exit 1', async () => {
+    const { outcome, logs } = await captured([undeclared()]);
+    expect(outcome).toEqual({ exit: 1, aborted: false });
+    const out = logs.join('\n');
+    expect(out).toContain('note: s has no baseline — undeclared drift has no revert target.');
+    expect(out).toContain('NOT revertable: 1 (no baseline — run `cdkrd accept` first');
+    expect(out).toContain('nothing revertable — 1 drift(s) remain.');
   });
 });
 


### PR DESCRIPTION
## R35: no-baseline `revert` UX / exit-code fix

Found while dogfooding: running `revert` on a stack with **no baseline** printed a
long flat `NOT revertable (112)` list and exited **0** — reading as "nothing to do"
when drift in fact remains. The R2 no-baseline guard itself is correct; the
presentation and semantics were the problem. Three fixes:

### 1. Fold the NOT-revertable list by reason
Default plan output collapses `notRevertable` to one line per reason
(count + reason), same idea as `check`'s `info:` footer. `--verbose` expands to the
full per-finding list. Revertable items are still shown in full (confirming what
gets written to AWS is the point). `--verbose` is now honored by `revert`.

```text
  NOT revertable: 98 (no baseline — run `cdkrd accept` first, or pass --remove-unblessed)
                · 13 (create-only property — change requires resource replacement)
                · 1 (deleted — recreate via cdk deploy)
    (run with --verbose for the full list)
```

### 2. Drift exists but nothing revertable → exit 1
- truly clean → `no drift to revert.` + exit 0 (unchanged)
- drift remains but 0 revertable → `nothing revertable — N drift(s) remain.` + **exit 1**
  (drift-remains semantics; not a usage error, so not 2)

### 3. No-baseline reason precedence for undeclared
For undeclared drift on a no-baseline stack, the no-baseline guard is now evaluated
**before** the create-only guard, so the reason points at `accept` (the real route)
instead of a misleading "requires replacement". The plan also leads with a one-line
note guiding the user to `check` / `accept` first. (declared create-only order is
unchanged.)

## Tests
- reason folding + `--verbose` expansion (`formatPlan`)
- exit-1-when-nothing-revertable (deleted-only, un-blessed undeclared) vs
  exit-0-no-drift regression (`revertStack`)
- no-baseline reason precedence: undeclared+create-only → no-baseline reason;
  declared create-only reason unchanged (`buildRevertPlan`)

## Gates
typecheck / lint+format / build / 262 unit tests — all green; `check` + `docs`
markgate markers set.

Spec: `/tmp/cdkrd-r35-revert-no-baseline-ux.md`. Reviewer to re-review the diff.
