### PR TITLE
feat(cli): add -a alias for --app and fail fast on unknown options (R36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `--region <r>`                   | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                        |
 | `--profile <p>`                  | AWS profile (or `$AWS_PROFILE`)                                                                                                       |
-| `--app <cmd\|cdk.out>`           | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths         |
+| `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths         |
 | `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                            |
 | `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                                  |
 | `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                          |
@@ -226,6 +226,9 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 | `--dry-run`                      | (revert) print the plan; make no changes                                                                                              |
 | `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                                  |
 | `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                         |
+
+Unknown options (`--apq`) and options missing their value (`--app` at the end of
+the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.
 
 ### Interactive flows (TTY only — CI is never prompted)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,12 +110,15 @@ keeps the pre-revert **exit 1** — no AWS write happened, so the drift still st
 the standalone `revert` command keeps its own exit-0-on-abort behaviour (R30).
 
 Flags (all parsed in [src/cli-args.ts](../src/cli-args.ts)): `--region` (no silent
-default — resolves via SDK chain, errors if absent), `--profile`, `--app <cmd|cdk.out>`
+default — resolves via SDK chain, errors if absent), `--profile`, `-a/--app <cmd|cdk.out>`
 (+ `$CDKRD_APP` / cdk.json `"app"`), `-c/--context key=value` (repeatable),
 `--json`, `--fail-on declared|undeclared`, `--show-all` (inventory mode: ignore
 baseline, show ALL undeclared), `--pre-deploy` (check vs local synth template),
 `--dry-run` (revert preview), `--yes/-y`. With no stack arg, every stack the app
 defines is targeted; a stack arg selects by exact name or glob (`cdkrd check 'Dev*'`).
+The known-flag set is closed: an unknown option or a value flag missing its
+value is a fail-fast **exit 2** error, so a typo'd flag never silently becomes
+a stack name (R36).
 
 Exit codes: `0` clean · `1` drift detected · `2` error.
 

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,7 +1,31 @@
 // Tiny shared CLI arg parser (no dependency).
 import type { FailOn } from './report/report.js';
 
-const VALUE_FLAGS = new Set(['--region', '--profile', '--fail-on', '--app', '-c', '--context']);
+// The complete known-option surface. parseCommonArgs is shared by all three
+// verbs, so verb-specific flags (--dry-run) are accepted here and interpreted
+// by the verb. Anything NOT listed is a fail-fast error — a typo'd flag must
+// never silently turn its value into a positional stack name (cdkrd has an
+// AWS-mutating verb, so a misparse can target the wrong stacks).
+const VALUE_FLAGS = new Set([
+  '--region',
+  '--profile',
+  '--fail-on',
+  '--app',
+  '-a',
+  '-c',
+  '--context',
+]);
+const BOOLEAN_FLAGS = new Set([
+  '--json',
+  '--show-all',
+  '--yes',
+  '-y',
+  '--pre-deploy',
+  '--dry-run',
+  '--remove-unblessed',
+  '--verbose',
+  '-v',
+]);
 
 export interface CommonArgs {
   stackNames: string[]; // positional stack names (may be empty → all stacks the CDK app defines)
@@ -19,40 +43,53 @@ export interface CommonArgs {
 }
 
 export function parseCommonArgs(args: string[]): CommonArgs {
-  const get = (flag: string): string | undefined => {
-    const i = args.indexOf(flag);
-    return i >= 0 ? args[i + 1] : undefined;
-  };
-  const has = (flag: string): boolean => args.includes(flag);
-
-  // positionals = tokens that are neither a flag nor the value following a value-flag;
-  // collect repeatable -c/--context key=value overrides along the way
+  const values: Record<string, string> = {}; // canonical value-flag → its (last) value
+  const found = new Set<string>(); // boolean flags seen
   const stackNames: string[] = [];
   const context: Record<string, string> = {};
+
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === undefined) continue;
-    if (a.startsWith('-')) {
-      if ((a === '-c' || a === '--context') && i + 1 < args.length) {
-        const kv = args[i + 1] ?? '';
-        const eq = kv.indexOf('=');
-        if (eq > 0) context[kv.slice(0, eq)] = kv.slice(eq + 1);
-      }
-      if (VALUE_FLAGS.has(a)) i++; // skip its value
+    if (!a.startsWith('-')) {
+      stackNames.push(a);
       continue;
     }
-    stackNames.push(a);
+    if (VALUE_FLAGS.has(a)) {
+      const v = args[i + 1];
+      // a following token that is itself a flag is NOT a value (catches `--region --json`)
+      if (v === undefined || v.startsWith('-')) {
+        throw new Error(`option "${a}" requires a value — see cdkrd --help`);
+      }
+      if (a === '-c' || a === '--context') {
+        const eq = v.indexOf('=');
+        if (eq <= 0) {
+          throw new Error(`option "${a}" expects key=value, got "${v}" — see cdkrd --help`);
+        }
+        context[v.slice(0, eq)] = v.slice(eq + 1);
+      } else {
+        values[a === '-a' ? '--app' : a] = v;
+      }
+      i++; // consume the value
+      continue;
+    }
+    if (BOOLEAN_FLAGS.has(a)) {
+      found.add(a);
+      continue;
+    }
+    throw new Error(`unknown option "${a}" — see cdkrd --help`);
   }
 
+  const has = (flag: string): boolean => found.has(flag);
   return {
     stackNames,
     context,
-    region: get('--region') ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION,
-    profile: get('--profile') ?? process.env.AWS_PROFILE,
-    // --app > CDKRD_APP env (cdk.json "app" fallback resolved in the synth layer)
-    app: get('--app') ?? process.env.CDKRD_APP,
+    region: values['--region'] ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION,
+    profile: values['--profile'] ?? process.env.AWS_PROFILE,
+    // -a/--app > CDKRD_APP env (cdk.json "app" fallback resolved in the synth layer)
+    app: values['--app'] ?? process.env.CDKRD_APP,
     json: has('--json'),
-    failOn: get('--fail-on') === 'declared' ? 'declared' : 'undeclared',
+    failOn: values['--fail-on'] === 'declared' ? 'declared' : 'undeclared',
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,7 +25,7 @@ OPTIONS
   --region <r>                AWS region (or $AWS_REGION / $AWS_DEFAULT_REGION);
                               CDK stacks with explicit env.region are auto-detected
   --profile <p>               AWS profile (or $AWS_PROFILE)
-  --app <cmd|cdk.out>         CDK app command or pre-synthesized assembly dir
+  -a, --app <cmd|cdk.out>     CDK app command or pre-synthesized assembly dir
                               (or $CDKRD_APP / cdk.json "app") — enables stack
                               auto-discovery + construct-path output
   -c, --context key=value     context for synth (repeatable; cdk.json is the base)
@@ -63,6 +63,11 @@ async function main(argv: string[]): Promise<number> {
   }
   if (cmd === '--version' || cmd === '-v') {
     console.log(version());
+    return 0;
+  }
+  // `cdkrd <verb> --help` — unknown options now fail fast, so route help here
+  if (rest.includes('--help') || rest.includes('-h')) {
+    console.log(HELP);
     return 0;
   }
   switch (cmd) {

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -52,4 +52,42 @@ describe('parseCommonArgs', () => {
     expect(parseCommonArgs(['S', '-v']).verbose).toBe(true);
     expect(parseCommonArgs(['S']).verbose).toBe(false);
   });
+
+  it('accepts --dry-run as a known flag (interpreted by revert)', () => {
+    expect(parseCommonArgs(['S', '--dry-run']).stackNames).toEqual(['S']);
+  });
+
+  it('-a is an alias for --app — value goes to app, never to stackNames', () => {
+    const a = parseCommonArgs(['MyStack', '-a', 'cdk.out']);
+    expect(a.app).toBe('cdk.out');
+    expect(a.stackNames).toEqual(['MyStack']);
+    expect(parseCommonArgs(['-a', 'cdk.out'])).toEqual(parseCommonArgs(['--app', 'cdk.out']));
+  });
+
+  it('collects repeatable -c/--context key=value', () => {
+    const a = parseCommonArgs(['-c', 'k1=v1', '--context', 'k2=v=2']);
+    expect(a.context).toEqual({ k1: 'v1', k2: 'v=2' });
+    expect(a.stackNames).toEqual([]);
+  });
+
+  it('fails fast on unknown options instead of silently dropping them', () => {
+    expect(() => parseCommonArgs(['--apq', 'cdk.out'])).toThrow(/unknown option "--apq"/);
+    expect(() => parseCommonArgs(['-x'])).toThrow(/unknown option "-x"/);
+    expect(() => parseCommonArgs(['S', '--dryrun'])).toThrow(/unknown option "--dryrun"/);
+  });
+
+  it('errors when a value flag is missing its value', () => {
+    expect(() => parseCommonArgs(['--app'])).toThrow(/option "--app" requires a value/);
+    expect(() => parseCommonArgs(['-a'])).toThrow(/option "-a" requires a value/);
+    // the next token being another flag is NOT a value
+    expect(() => parseCommonArgs(['--region', '--json'])).toThrow(
+      /option "--region" requires a value/
+    );
+    expect(() => parseCommonArgs(['-c', '--json'])).toThrow(/option "-c" requires a value/);
+  });
+
+  it('errors on malformed -c/--context (no key=value)', () => {
+    expect(() => parseCommonArgs(['-c', 'noequals'])).toThrow(/expects key=value/);
+    expect(() => parseCommonArgs(['--context', '=v'])).toThrow(/expects key=value/);
+  });
 });


### PR DESCRIPTION
## Summary

Real-dogfood CLI parsing bug (R36, /tmp/cdkrd-r36-cli-flag-safety.md): `cdkrd check -a cdk.out` silently dropped the unknown `-a` and re-interpreted `cdk.out` as a positional **stack name**, falling back to cdk.json synth — the opposite of the intent.

- **`-a` is now an alias for `--app`** (mirrors the `cdk` CLI; `-c`/`-v`/`-y` precedents exist).
- **Unknown options fail fast**: the known-flag set (value + boolean + short forms) is closed in `cli-args.ts`; an unknown `-` token is `error: unknown option "<tok>" — see cdkrd --help` + exit 2. A typo'd flag never silently becomes a stack name (cdkrd has an AWS-mutating verb).
- **Missing values are explicit errors**: `--app` at end of line, or `--region --json` (next token is a flag) → `option "..." requires a value` + exit 2, instead of picking up `undefined` or another flag string.
- Bonus, same hazard class: malformed `-c/--context` without `key=value` errors; `cdkrd <verb> --help` routes to HELP (it can no longer be silently ignored).

Docs: `-a` in HELP / README options table / ARCHITECTURE flag list; fail-fast behavior noted in README + ARCHITECTURE.

## Tests

- `-a cdk.out` ≡ `--app cdk.out` (goes to `app`, never leaks into `stackNames`)
- unknown flags (`--apq` / `-x` / `--dryrun`) throw
- missing values (`--app` alone, `--region --json`, `-c --json`) throw
- malformed `-c` throws; regression for all boolean/value/short flags
- 26 files / 258 tests pass; smoke-tested on `dist/cli.js` (exit 2 + messages verified)

## Notes for review

- HELP is missing a `--verbose` line (pre-existing on main, README/parser have it) — left for R35, which is editing that HELP region in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)