### PR TITLE
feat(baseline): sort accepted entries deterministically on write (R40)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -58,10 +58,28 @@ export async function loadBaseline(
   }
 }
 
+/** Deterministic order for `accepted` entries: lexicographic by (logicalId, path).
+ *  The single point where order is imposed — read/compare logic is order-independent,
+ *  so this only affects the bytes on disk. Without it the entries inherit findings
+ *  order (= template Resources order), so a pure CDK refactor that reorders construct
+ *  definitions would produce a whole-file reordering diff on the next `accept` even
+ *  though no accepted VALUE changed — breaking "the baseline PR diff = a review of the
+ *  real state we accept". A non-locale comparator keeps it byte-stable across machines. */
+function sortAccepted(accepted: AcceptedEntry[]): AcceptedEntry[] {
+  return [...accepted].sort(
+    (a, b) =>
+      (a.logicalId < b.logicalId ? -1 : a.logicalId > b.logicalId ? 1 : 0) ||
+      (a.path < b.path ? -1 : a.path > b.path ? 1 : 0)
+  );
+}
+
 export async function writeBaseline(b: BaselineFile): Promise<string> {
   const p = baselinePath(b.stackName, b.accountId, b.region);
   await mkdir(dirname(p), { recursive: true });
-  await writeFile(p, JSON.stringify(b, null, 2) + '\n', 'utf8'); // pretty + stable for clean PR diffs
+  // sort at the write point (not per entry-generation path) so every caller — accept,
+  // selective accept, check's first-run offer — lands the same deterministic order.
+  const stable: BaselineFile = { ...b, accepted: sortAccepted(b.accepted) };
+  await writeFile(p, JSON.stringify(stable, null, 2) + '\n', 'utf8'); // pretty + stable for clean PR diffs
   return p;
 }
 

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 import {
   acceptedKey,
@@ -9,6 +12,7 @@ import {
   hashTemplate,
   selectAccepted,
   warnTemplateHashDrift,
+  writeBaseline,
 } from '../src/baseline/baseline-file.js';
 import type { Finding } from '../src/types.js';
 
@@ -157,6 +161,54 @@ describe('baseline', () => {
     const out = applyBaseline([], b, { declaredByLogical: new Map([['A', new Set(['Other'])]]) });
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({ note: 'blessed value removed since accept' });
+  });
+
+  describe('writeBaseline (deterministic order, R40)', () => {
+    // capturedAt is fixed so the only variable across writes is the accepted order.
+    const entry = (logicalId: string, path: string): BaselineFile['accepted'][number] => ({
+      logicalId,
+      resourceType: 'AWS::X::Y',
+      path,
+      value: [logicalId, path],
+    });
+    const withOrder = (accepted: BaselineFile['accepted']): BaselineFile => ({
+      ...baseline(accepted),
+      capturedAt: '2026-06-12T00:00:00.000Z',
+    });
+
+    async function writeInTmp(b: BaselineFile): Promise<string> {
+      const dir = await mkdtemp(join(tmpdir(), 'cdkrd-baseline-'));
+      const cwd = process.cwd();
+      process.chdir(dir);
+      try {
+        const p = await writeBaseline(b);
+        return await readFile(p, 'utf8');
+      } finally {
+        process.chdir(cwd);
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+
+    it('same entries in different order -> byte-identical file', async () => {
+      const orderA = [entry('B', 'q'), entry('A', 'p'), entry('A', 'a')];
+      const orderB = [entry('A', 'a'), entry('B', 'q'), entry('A', 'p')];
+      const a = await writeInTmp(withOrder(orderA));
+      const b = await writeInTmp(withOrder(orderB));
+      expect(a).toBe(b);
+    });
+
+    it('writes accepted sorted lexicographically by (logicalId, path)', async () => {
+      const out = await writeInTmp(withOrder([entry('B', 'q'), entry('A', 'p'), entry('A', 'a')]));
+      const parsed = JSON.parse(out) as BaselineFile;
+      expect(parsed.accepted.map((e) => `${e.logicalId}.${e.path}`)).toEqual(['A.a', 'A.p', 'B.q']);
+    });
+
+    it('does not mutate the caller-supplied accepted array', async () => {
+      const accepted = [entry('B', 'q'), entry('A', 'p')];
+      const snapshot = accepted.map((e) => e.logicalId);
+      await writeInTmp(withOrder(accepted));
+      expect(accepted.map((e) => e.logicalId)).toEqual(snapshot);
+    });
   });
 
   describe('warnTemplateHashDrift', () => {


### PR DESCRIPTION
## What

Sort the baseline `accepted` array by `(logicalId, path)` at the single write point in `writeBaseline`, so the bytes on disk are deterministic regardless of the order findings arrive in.

## Why (R40)

`accepted` entries were written in findings order (= template `Resources` order). A pure CDK refactor that reorders construct definitions would then produce a **whole-file reordering diff on the next `accept` even though no accepted value changed** — breaking the bet that "the baseline PR diff = a review of the real state we accept" (README:147).

## How

- Sort happens at the **single write point** (`writeBaseline`), not per entry-generation path — so every caller (`accept`, selective accept, `check`'s first-run offer) lands the same order.
- A **non-locale** comparator (`<`/`>`, not `localeCompare`) keeps output byte-stable across machines.
- The array is **copied before sorting**, so callers' findings order is untouched.
- Read/compare logic (`applyBaseline`) is already order-independent — **no behavior change**, only the on-disk byte order.

The optional R39 `Map`-indexing of the blessed `find` was left out: R39 has not landed, and the instruction flagged it as not needed at current scale.

## Tests

Added to `tests/baseline.test.ts` (with `capturedAt` fixed so order is the only variable):
- same entries in different order → **byte-identical** file
- `accepted` written sorted lexicographically by `(logicalId, path)`
- caller-supplied array is not mutated

## Gates

| Gate | Result |
| --- | --- |
| typecheck (`vp run typecheck`) | pass |
| lint + format (`vp check --fix`) | pass (0 errors; 7 pre-existing warnings, none in changed files) |
| build (`vp run build`) | pass |
| unit tests (`vp run test`) | pass — 255 tests (baseline.test.ts: 23) |

`check` + `docs` markers set. No docs change needed — this hardens an existing README claim without altering the user-facing surface.
