### PR TITLE
fix(report): tidy check-report spacing + expand multi-tier info footer (R37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ When drift is found, `check` prompts inline — no separate command needed:
 
 [UNDECLARED DRIFT (the differentiator)] 1
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
-
 result: 1 drift(s) (undeclared=1)
 
 ApiStack: drift found — what do you want to do?
@@ -96,10 +95,10 @@ same change shows up:
 
 ```console
 $ npx cdkrd check ApiStack
+=== cdkrd check: ApiStack (us-east-1) ===
 
 [UNDECLARED DRIFT (the differentiator)] 1
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access","PolicyDocument":{"Statement":[{"Action":["s3:*"],"Effect":"Allow","Resource":["*"]}]}}]
-
 result: 1 drift(s) (undeclared=1)
 ```
 
@@ -121,7 +120,6 @@ is reported in the `deleted` tier and always sets exit 1, regardless of `--fail-
 
 [DELETED (resource deleted out of band — always drift)] 1
   ApiStack/EventsQueue (AWS::SQS::Queue) — resource deleted out of band
-
 result: 1 drift(s) (deleted=1)
 ```
 
@@ -220,7 +218,7 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 | `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
 | `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                  |
 | `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
-| `--verbose` / `-v`               | (check) expand informational tiers from the `info:` line / (revert) the per-reason NOT-revertable summary — to full lists     |
+| `--verbose` / `-v`               | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
 | `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
 | `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
 | `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
@@ -262,16 +260,20 @@ trailing commas.)
 Rules glob (`*` / `?`) against either `<logicalId>.<path>` or the friendly
 `<constructPath>.<path>` (e.g. `MyStack/ApiRole.Policies`); a parent rule covers child
 paths. Matching findings move to the informational `ignored` tier — still visible
-on the `info:` line and under `--verbose`, never exit-affecting, and excluded from
+in the `info:` footer and under `--verbose`, never exit-affecting, and excluded from
 `revert` plans and `accept`. A **deleted resource is never ignorable**.
 
 ## Output
 
 Drift tiers (`deleted` / `declared` / `undeclared`) are always printed in full —
 they are the point. Informational tiers (`readGap` / `unresolved` / `skipped` /
-`ignored`) fold into a one-line `info:` footer with per-reason counts; `--verbose`
-expands them. Zero-count tiers are omitted. Greppable: `^result:` is the verdict,
-`^info:` the rest.
+`ignored`) fold into an `info:` footer with per-reason counts — a single line when
+one tier is present, one bullet line per tier when there are several; `--verbose`
+expands them to full lists. Zero-count tiers are omitted. A CLEAN stack with one
+informational tier is exactly three lines (header / `result:` / `info:`); in a
+multi-stack run, consecutive stack reports are separated by a single blank line.
+Greppable: `^result:` is the verdict; for machine consumption the formal contract
+is `--json` (the `info:` footer may span multiple lines).
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
@@ -280,8 +282,11 @@ expands them. Zero-count tiers are omitted. Greppable: `^result:` is the verdict
   ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"
       actual ="Suspended"
-
 result: 1 drift(s) (declared=1)
+info:
+  - readGap=1 (write-only 1)
+  - skipped=2 (custom resource 2)
+  run with --verbose for the list
 ```
 
 ### JSON output contract

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,8 +144,9 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
 4. normalize / subtract  classify.ts orchestrates the normalizers (section 6)
 5. classify (tier)       deleted | declared | undeclared | readGap | unresolved | skipped
 6. baseline filter       applyBaseline(): undeclared findings already blessed → drop
-7. report + exit code    report.ts: drift tiers in full + 1-line info: footer (--verbose
-                         expands); --json carries all findings; worst exit across stacks
+7. report + exit code    report.ts: drift tiers in full + info: footer (1 line;
+                         1 bullet/tier when 2+; --verbose expands); --json carries
+                         all findings; worst exit across stacks
 ```
 
 The two-pass structure (PR "resolve Fn::GetAtt against live attributes") is what
@@ -473,12 +474,19 @@ Ignored findings drop out of the revert plan and the accept bless-set automatica
 (exit 2) rather than silently dropping the rules. Applied even under `--show-all`
 (inventory un-suppresses the baseline, not the ignore rules); `--verbose` still lists
 the ignored entries. A CLI to manage rules (`cdkrd ignore <pattern>`) is a future
-open question (§13) — v1 is hand-edited. **Default text layout (R25):** the three DRIFT tiers print in
-full; the three INFORMATIONAL tiers are folded into a single `info:` footer line
-(per-tier counts + a reason breakdown, e.g. `skipped=24 (custom resource 12, override
-target unresolved 12)`); `--verbose` expands them to full lists; 0-count tiers are
-never printed. The `result:` line carries the verdict + non-zero drift counts only
-(the informational breakdown lives on `info:`, so the two never duplicate). `--json`
+open question (§13) — v1 is hand-edited. **Default text layout (R25, spacing R37):**
+the three DRIFT tiers print in full; the INFORMATIONAL tiers are folded into an
+`info:` footer (per-tier counts + a reason breakdown, e.g. `skipped=24 (custom
+resource 12, override target unresolved 12)`) — a single line when one tier is
+present, one bullet line per tier (with a single `--verbose` hint) when 2+;
+`--verbose` expands them to full lists; 0-count tiers are never printed. No blank
+line precedes the header or the `result:` line, so a CLEAN stack with one
+informational tier is exactly 3 lines; blank lines remain between the header and
+the drift sections (grouping), and the check loop puts one blank line between
+consecutive stack reports in a multi-stack run. The `result:` line carries the
+verdict + non-zero drift counts only (the informational breakdown lives on `info:`,
+so the two never duplicate); `^result:` stays greppable, but the formal
+machine-readable contract is `--json` (the `info:` footer may span lines). `--json`
 is unaffected — it always carries every finding. A `Custom::*` resource is `skipped`
 without any API call (note: `custom resource — no cloud-side model to read`).
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -15,7 +15,7 @@ import {
 } from '../baseline/baseline-file.js';
 import { parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
-import { exitCode, report } from '../report/report.js';
+import { exitCode, report, stackSeparator } from '../report/report.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { Finding } from '../types.js';
@@ -81,6 +81,9 @@ export async function runCheck(args: string[]): Promise<number> {
   }
 
   let worst = 0;
+  // R37: one blank line between consecutive stack reports (text mode only) — done
+  // here at the call site so a single-stack run never gets a stray leading blank.
+  const separate = stackSeparator();
   for (const { stackName, region } of stacks) {
     if (!region) {
       console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
@@ -110,6 +113,7 @@ export async function runCheck(args: string[]): Promise<number> {
           console.error(
             `note: ${stackName}: --pre-deploy reports declared drift only (undeclared tiers are evaluated against the deployed template — run check without --pre-deploy)`
           );
+        if (!a.json) separate();
         worst = Math.max(
           worst,
           report(applyIgnores(declaredOnly, stackName, config), `${stackName} (${region})`, {
@@ -160,6 +164,7 @@ export async function runCheck(args: string[]): Promise<number> {
         stackName,
         config
       );
+      if (!a.json) separate();
       let code = report(reconciled, `${stackName} (${region})`, {
         json: a.json,
         failOn: a.failOn,

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -2,10 +2,14 @@
 // Exit: 0 clean / 1 drift. --fail-on selects which tiers count as failure.
 //
 // Default layout is deliberately terse (a 40-resource CLEAN stack was 30+ lines):
-//   header -> DRIFT tier sections (full detail) -> result: -> info: (1-line footer)
-// DRIFT tiers (deleted/declared/undeclared) are ALWAYS shown in full — they are the
-// point. INFORMATIONAL tiers (readGap/unresolved/skipped) are folded into a single
-// `info:` summary line (counts + reason breakdown); `--verbose` expands them to full
+//   header -> DRIFT tier sections (full detail) -> result: -> info: footer
+// No blank line before the header or the result: line (R37) — a CLEAN stack with
+// one informational tier is exactly 3 lines. Blank lines remain BETWEEN the header
+// and drift sections, and between sections (visual grouping). DRIFT tiers
+// (deleted/declared/undeclared) are ALWAYS shown in full — they are the point.
+// INFORMATIONAL tiers (readGap/unresolved/skipped) are folded into the `info:`
+// footer (counts + reason breakdown): one line when a single tier is present, a
+// one-line-per-tier bullet list when 2+ (R37); `--verbose` expands them to full
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
 import type { Finding, Tier } from '../types.js';
@@ -96,33 +100,50 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     for (const f of items) log('  ' + formatFinding(f));
   };
 
-  log(`\n=== cdkrd check: ${header} ===`);
+  log(`=== cdkrd check: ${header} ===`);
   // DRIFT tiers: always full detail (the point of the tool)
   for (const tier of DRIFT_TIERS) section(tier);
   // result: line — the conclusion. Lists ONLY the non-zero DRIFT tier counts (the
   // informational breakdown lives on the `info:` line, so the two never duplicate);
   // CLEAN prints just `CLEAN`. `fail-on` is noted only when non-default (it changes
-  // the verdict). grep contract: `^result:` for the verdict, `^info:` for the rest.
+  // the verdict). `^result:` stays greppable for the verdict; the formal
+  // machine-readable contract is `--json` (the info: footer may span lines).
   const driftCounts = DRIFT_TIERS.filter((t) => byTier(t).length > 0)
     .map((t) => `${t}=${byTier(t).length}`)
     .join(' ');
   const failNote = (opts.failOn ?? 'undeclared') === 'declared' ? ' (fail-on=declared)' : '';
   const verdict = drifted === 0 ? 'CLEAN' : `${drifted} drift(s) (${driftCounts})`;
-  log(`\nresult: ${verdict}${failNote}`);
+  log(`result: ${verdict}${failNote}`);
   // INFORMATIONAL tiers: footer below result — full sections under --verbose, else a
-  // single folded summary line (counts + reason breakdown).
+  // folded summary (counts + reason breakdown): one `info: ...` line for a single
+  // tier, a one-line-per-tier bullet list (with ONE --verbose hint) for 2+ (R37).
   if (opts.verbose) {
     for (const tier of INFO_TIERS) section(tier);
   } else {
-    const summary = INFO_TIERS.map((t) => {
+    const summaries = INFO_TIERS.map((t) => {
       const items = byTier(t);
       return items.length ? `${t}=${items.length} (${groupReasons(items)})` : null;
-    })
-      .filter((s): s is string => s !== null)
-      .join(' · ');
-    if (summary) log(`info: ${summary} — run with --verbose for the list`);
+    }).filter((s): s is string => s !== null);
+    if (summaries.length === 1) {
+      log(`info: ${summaries[0]} — run with --verbose for the list`);
+    } else if (summaries.length > 1) {
+      log('info:');
+      for (const s of summaries) log(`  - ${s}`);
+      log('  run with --verbose for the list');
+    }
   }
   return drifted === 0 ? 0 : 1;
+}
+
+// R37: multi-stack runs print ONE blank line between consecutive stack reports —
+// never before the first (so a single-stack run has no stray leading blank). Lives
+// at the check-loop call site, not inside report(); exported pure for unit tests.
+export function stackSeparator(log: (s: string) => void = console.log): () => void {
+  let first = true;
+  return () => {
+    if (first) first = false;
+    else log('');
+  };
 }
 function j(v: unknown): string {
   const s = JSON.stringify(v);

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { report } from '../src/report/report.js';
+import { report, stackSeparator } from '../src/report/report.js';
 import type { Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
@@ -88,7 +88,7 @@ describe('report', () => {
     it('result: line lists only non-zero DRIFT counts; CLEAN prints just CLEAN', () => {
       expect(
         run([reason('skipped', 'custom resource — no cloud-side model to read')]).text
-      ).toContain('\nresult: CLEAN');
+      ).toMatch(/^result: CLEAN$/m);
       // the old full (deleted=0 declared=0 ...) enumeration is gone
       expect(run([F('undeclared')]).text).not.toContain('deleted=0');
       expect(run([F('undeclared')]).text).toMatch(/result: 1 drift\(s\) \(undeclared=1\)/);
@@ -99,7 +99,17 @@ describe('report', () => {
       expect(run([F('declared')], { failOn: 'declared' }).text).toContain('(fail-on=declared)');
     });
 
-    it('folds informational tiers into a single info: line with a reason breakdown', () => {
+    it('folds a single informational tier into a one-line info: footer', () => {
+      const { text } = run([
+        reason('skipped', 'custom resource — no cloud-side model to read', 'Custom::Foo'),
+      ]);
+      expect(text).not.toContain('[SKIPPED');
+      expect(text).toContain(
+        'info: skipped=1 (custom resource 1) — run with --verbose for the list'
+      );
+    });
+
+    it('expands 2+ informational tiers to one bullet per tier with ONE --verbose hint (R37)', () => {
       const findings: Finding[] = [
         reason('readGap', 'write-only — cannot be read back'),
         reason('skipped', 'custom resource — no cloud-side model to read', 'Custom::Foo'),
@@ -112,9 +122,15 @@ describe('report', () => {
       const { text } = run(findings);
       expect(text).not.toContain('[SKIPPED');
       expect(text).not.toContain('[READ GAP');
-      expect(text).toMatch(/info: .*readGap=1 \(write-only 1\)/);
-      expect(text).toMatch(/skipped=2 \(.*custom resource 1.*override target unresolved 1.*\)/);
-      expect(text).toContain('--verbose');
+      const lines = text.split('\n');
+      const infoIdx = lines.indexOf('info:');
+      expect(infoIdx).toBeGreaterThan(-1);
+      expect(lines[infoIdx + 1]).toBe('  - readGap=1 (write-only 1)');
+      expect(lines[infoIdx + 2]).toMatch(
+        /^ {2}- skipped=2 \(.*custom resource 1.*override target unresolved 1.*\)$/
+      );
+      expect(lines[infoIdx + 3]).toBe('  run with --verbose for the list');
+      expect(text.match(/--verbose/g)).toHaveLength(1);
     });
 
     it('result: appears ABOVE the info: footer', () => {
@@ -162,7 +178,7 @@ describe('report', () => {
     it('ignored is informational — folds into info: and never sets exit 1', () => {
       const { code, text } = run([ignored('*.DesiredCount')]);
       expect(code).toBe(0);
-      expect(text).toContain('\nresult: CLEAN');
+      expect(text).toMatch(/^result: CLEAN$/m);
       expect(text).toMatch(/info: ignored=1 \("\*\.DesiredCount" 1\)/);
       expect(text).not.toContain('[IGNORED');
     });
@@ -171,6 +187,51 @@ describe('report', () => {
       const { text } = run([ignored('*.DesiredCount')], { verbose: true });
       expect(text).toContain('[IGNORED');
       expect(text).not.toContain('info:');
+    });
+  });
+
+  describe('R37 spacing', () => {
+    const skipped: Finding = {
+      tier: 'skipped',
+      logicalId: 'L',
+      resourceType: 'Custom::Foo',
+      path: '',
+      note: 'custom resource — no cloud-side model to read',
+    };
+
+    it('CLEAN with one informational tier is exactly 3 lines: header/result/info, no blanks', () => {
+      const { text } = run([skipped]);
+      expect(text.split('\n')).toEqual([
+        '=== cdkrd check: stack (us-east-1) ===',
+        'result: CLEAN',
+        'info: skipped=1 (custom resource 1) — run with --verbose for the list',
+      ]);
+    });
+
+    it('drift keeps a blank line after the header but none before result:', () => {
+      const lines = run([F('declared')]).text.split('\n');
+      expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
+      expect(lines[1]).toBe(''); // blank between header and the drift section (grouping)
+      expect(lines[2]).toBe('[DECLARED DRIFT] 1');
+      const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
+      expect(lines[resultIdx - 1]).not.toBe(''); // result follows the section directly
+    });
+
+    it('multi-stack: ONE blank line between consecutive reports, none before the first', () => {
+      const out: string[] = [];
+      const log = (s: string) => out.push(s);
+      const separate = stackSeparator(log);
+      separate();
+      report([], 'StackA (ap-northeast-1)', { log });
+      separate();
+      report([], 'StackB (us-east-1)', { log });
+      expect(out.join('\n').split('\n')).toEqual([
+        '=== cdkrd check: StackA (ap-northeast-1) ===',
+        'result: CLEAN',
+        '',
+        '=== cdkrd check: StackB (us-east-1) ===',
+        'result: CLEAN',
+      ]);
     });
   });
 });


### PR DESCRIPTION
## What

R37 cleans up `cdkrd check` text-report whitespace and makes the `info:` footer readable when several informational tiers are present.

- **No leading blank line** before the `=== cdkrd check: ... ===` header or the `result:` line. A CLEAN stack with one informational tier is now exactly **3 lines** (header / result / info).
- Blank lines **between the header and drift tier sections** are kept — they group the output visually.
- **Multi-stack runs**: the check loop now inserts **one blank line between consecutive stack reports** (never before the first). Done at the call site via the exported pure `stackSeparator()` helper, not inside `report()`.
- **`info:` footer readability**:
  - 1 informational tier → unchanged one-liner: `info: skipped=11 (custom resource 11) — run with --verbose for the list`
  - 2+ tiers → one bullet line per tier, with a single `--verbose` hint:

    ```console
    info:
      - readGap=7 (declared but not returned by live read 5 · write-only 2)
      - skipped=11 (custom resource 11)
      run with --verbose for the list
    ```

## Greppable contract

`^result:` stays greppable for the verdict. Since the `info:` footer may now span multiple lines, the README "Greppable: `^info:`" claim is corrected — the formal machine-readable contract is `--json`.

## Docs

README console examples (Quick start / What `cdk drift` can't see / deleted / Output) and `docs/ARCHITECTURE.md` layout description updated to match.

## Tests

`tests/report.test.ts`: asserts the 3-line CLEAN form, the 2+-tier bullet expansion with a single `--verbose` hint, the kept header/section blank line, and the multi-stack single-blank separator. All 256 unit tests pass.

## Scope note (R35)

Does NOT touch `revert` plan display (`stack-actions.ts` `printPlan`) — that is R35's territory. The same "no leading newline before the header" convention should be applied there by the R35 agent.

Gates: `/check` ✅ · `/check-docs` ✅
