### PR TITLE
feat!: add --no-interactive; non-interactive accept now requires --yes (R38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 | command                     | does                                                                   |
 | --------------------------- | ---------------------------------------------------------------------- |
 | `cdkrd check [<stack>...]`  | compare live state vs template (declared) + baseline (undeclared)      |
-| `cdkrd accept [<stack>...]` | snapshot current undeclared state into the baseline file               |
+| `cdkrd accept [<stack>...]` | snapshot undeclared state into the baseline (CI / non-TTY: `--yes`)    |
 | `cdkrd revert [<stack>...]` | write the desired value back to AWS (confirms; `--dry-run` to preview) |
 
 - Stack selection (no args = all app stacks / glob / exact name):
@@ -225,11 +225,12 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 | `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
 | `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
 | `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                 |
+| `--no-interactive`               | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to bless    |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
 the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.
 
-### Interactive flows (TTY only — CI is never prompted)
+### Interactive flows (TTY only, opt out with `--no-interactive` — CI is never prompted)
 
 - **`check` with drift** offers `Nothing / Accept / Revert` inline (shown above).
   `Nothing` is the default; Enter keeps plain-check behavior. Accept and Revert run
@@ -238,8 +239,15 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
   exit code at 1 (nothing was written — the drift still stands).
 - **`accept`** shows a multiselect of the undeclared values, all pre-selected.
   Deselect a suspicious one and it stays reported by `check` — bless the intentional
-  changes without rubber-stamping the rest.
+  changes without rubber-stamping the rest. Non-interactively (CI / non-TTY /
+  `--no-interactive`) this selection can't be made, so `accept` refuses with exit 2
+  unless `--yes` is passed to bless **all** undeclared values.
 - **`check` with no baseline yet** offers to bless the current state on the spot.
+
+Flag combinations: `--no-interactive` alone = the read side completes but write
+**decisions** are refused (the safe side — `accept` without `--yes` exits 2, and
+`revert` without `--yes` exits 2); `--no-interactive --yes` = full automation;
+`--yes` alone in a TTY auto-approves confirmations only (select prompts still show).
 
 ### Ignoring externally-managed properties
 

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -25,6 +25,7 @@ const BOOLEAN_FLAGS = new Set([
   '--remove-unblessed',
   '--verbose',
   '-v',
+  '--no-interactive',
 ]);
 
 export interface CommonArgs {
@@ -40,6 +41,17 @@ export interface CommonArgs {
   preDeploy: boolean; // compare live vs the LOCAL synth template (drift your next deploy would clobber)
   removeUnblessed: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
   verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
+  noInteractive: boolean; // suppress all prompts; required-decision prompts then error instead of prompting
+}
+
+/**
+ * Whether prompts may be shown: only in a real TTY AND when --no-interactive was not
+ * passed. The single source of truth — command code threads this in rather than reading
+ * `process.stdin.isTTY` directly. Optional prompts skip when false; required-decision
+ * prompts error (exit 2) when false.
+ */
+export function isInteractive(a: CommonArgs): boolean {
+  return Boolean(process.stdin.isTTY) && !a.noInteractive;
 }
 
 export function parseCommonArgs(args: string[]): CommonArgs {
@@ -124,5 +136,6 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     preDeploy: has('--pre-deploy'),
     removeUnblessed: has('--remove-unblessed'),
     verbose: has('--verbose') || has('-v'),
+    noInteractive: has('--no-interactive'),
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,7 +41,12 @@ OPTIONS
   --remove-unblessed          (revert) on a stack with NO baseline, REMOVE undeclared
                               drift (default: refuse — run \`cdkrd accept\` first)
   --yes, -y                   skip confirmation (revert) / overwrite notice (accept)
+  --no-interactive            never prompt; optional prompts skipped, required-decision
+                              prompts error (exit 2). accept then needs --yes
   --help, -h    --version, -v
+
+  --no-interactive alone = read side completes, write DECISIONS refused (the safe
+  side: accept/revert without --yes exit 2). --no-interactive --yes = full automation.
 
 EXIT CODES
   0 = clean   1 = drift detected   2 = error

--- a/src/commands/accept.ts
+++ b/src/commands/accept.ts
@@ -3,7 +3,7 @@
 // git-committed baselines; no AWS writes. The per-stack bless flow lives in
 // stack-actions.ts (shared with check's interactive prompt, R28).
 import { isStackNotDeployed } from '../aws-errors.js';
-import { parseCommonArgs } from '../cli-args.js';
+import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
@@ -46,13 +46,16 @@ export async function runAccept(args: string[]): Promise<number> {
       const { desired, findings } = await gatherFindings(stackName, region);
       // ignore rules re-tag matching undeclared findings out of the bless set, so an
       // externally-managed property is never blessed (and never re-detected).
-      await acceptStack({
+      const result = await acceptStack({
         stackName,
         region,
         desired,
         findings: applyIgnores(findings, stackName, config),
         yes: a.yes,
+        interactive: isInteractive(a),
       });
+      // a non-interactive accept that needed a decision but had no --yes refuses (R38)
+      if (result.refused) worst = Math.max(worst, 2);
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — nothing to bless`);

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -13,7 +13,7 @@ import {
   loadBaseline,
   warnTemplateHashDrift,
 } from '../baseline/baseline-file.js';
-import { parseCommonArgs } from '../cli-args.js';
+import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { exitCode, report } from '../report/report.js';
 import { resolveApp } from '../synth/resolve-app.js';
@@ -129,7 +129,7 @@ export async function runCheck(args: string[]): Promise<number> {
       // stale-baseline warning (pre-deploy already returned above, so always safe here)
       if (baseline) warnTemplateHashDrift(baseline, desired.rawTemplate, stackName);
       // first run: no baseline yet → offer to bless interactively (TTY only)
-      if (!baseline && !a.showAll && !a.json && process.stdin.isTTY) {
+      if (!baseline && !a.showAll && !a.json && isInteractive(a)) {
         const ok = await confirm({
           message: `${stackName}: no baseline yet — bless the current UNDECLARED state as the baseline? (declared drift, i.e. reality vs the deployed template, is reported either way)`,
         });
@@ -170,7 +170,7 @@ export async function runCheck(args: string[]): Promise<number> {
       // of making the user re-run a separate command. Skipped for --json (machine
       // output), --show-all (baseline not applied — accept would mean something else),
       // and --pre-deploy (declared-only, baseline-untouched contract).
-      if (code === 1 && !a.json && !a.showAll && !a.preDeploy && process.stdin.isTTY) {
+      if (code === 1 && !a.json && !a.showAll && !a.preDeploy && isInteractive(a)) {
         const actions = availableActions(reconciled, baseline, schemas, a.removeUnblessed);
         if (actions.accept || actions.revert) {
           const options = [{ value: 'nothing', label: 'Nothing (keep exit code 1)' }];
@@ -195,14 +195,15 @@ export async function runCheck(args: string[]): Promise<number> {
               console.error(
                 `note: ${stackName}: accept blesses the undeclared state only — declared/deleted drift remains (fix the code or choose Revert).`
               );
-            const wrote = await acceptStack({
+            const result = await acceptStack({
               stackName,
               region,
               desired,
               findings: applyIgnores(findings, stackName, config),
               yes: a.yes,
+              interactive: isInteractive(a),
             });
-            if (wrote) {
+            if (result.wrote) {
               // re-evaluate exit WITHOUT re-querying AWS: re-apply the new baseline to
               // the findings we already have (ignores re-applied so the exit matches).
               const nb = await loadBaseline(stackName, desired.accountId, region);
@@ -226,6 +227,7 @@ export async function runCheck(args: string[]): Promise<number> {
               yes: a.yes,
               removeUnblessed: a.removeUnblessed,
               verbose: a.verbose,
+              interactive: isInteractive(a),
             });
             // R30: an aborted confirm did NOT write to AWS, so the drift still
             // stands — keep the pre-revert exit 1 (symmetric with "Nothing").

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -11,7 +11,7 @@ import {
   checkBaselineAccount,
   loadBaseline,
 } from '../baseline/baseline-file.js';
-import { parseCommonArgs } from '../cli-args.js';
+import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { loadConfig } from '../config/config-file.js';
 import { gatherFindings } from './gather.js';
 import { resolveStacks } from './resolve-stacks.js';
@@ -71,6 +71,7 @@ export async function runRevert(args: string[]): Promise<number> {
         yes: a.yes,
         removeUnblessed: a.removeUnblessed,
         verbose: a.verbose,
+        interactive: isInteractive(a),
       });
       worst = Math.max(worst, exit);
     } catch (e) {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -34,23 +34,48 @@ export interface AcceptStackParams {
   desired: Desired;
   findings: Finding[]; // the gather's findings (undeclared still present, pre-baseline)
   yes: boolean;
+  interactive: boolean; // whether the multiselect decision prompt may be shown (TTY && !--no-interactive)
 }
 
 /**
- * Bless the current undeclared state into the baseline file. In a TTY (no --yes) the
- * user picks WHICH undeclared values to bless (selective accept, R14); an empty
- * selection is confirmed first (R19). Returns true if a baseline was written, false
- * if the user cancelled. (Same flow whether reached via `cdkrd accept` or check's
- * interactive prompt — neither re-gathers.)
+ * Outcome of a per-stack accept.
+ *  - `wrote`: a baseline file was written.
+ *  - `refused`: true ONLY when a decision was required (undeclared values to bless)
+ *    but the run is non-interactive and `--yes` was not passed — accept refuses
+ *    rather than blessing everything by default (R38). A user-cancelled multiselect
+ *    is `{ wrote:false, refused:false }`, not a refusal.
  */
-export async function acceptStack(p: AcceptStackParams): Promise<boolean> {
-  const { stackName, region, desired, findings, yes } = p;
+export interface AcceptResult {
+  wrote: boolean;
+  refused: boolean;
+}
+
+/**
+ * Bless the current undeclared state into the baseline file. In an interactive run
+ * (no --yes) the user picks WHICH undeclared values to bless (selective accept, R14);
+ * an empty selection is confirmed first (R19). Non-interactively (--no-interactive or
+ * non-TTY/CI), the multiselect is a required DECISION: with undeclared values present
+ * and no --yes, accept refuses (exit 2) instead of blessing all (R38). When there is
+ * nothing to decide (no undeclared values) the baseline is written regardless. (Same
+ * flow whether reached via `cdkrd accept` or check's interactive prompt — neither
+ * re-gathers.)
+ */
+export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
+  const { stackName, region, desired, findings, yes, interactive } = p;
   if (!yes && (await loadBaseline(stackName, desired.accountId, region)))
     console.error(
       `note: ${stackName}: overwriting existing baseline (it is git-tracked; review the diff). Pass --yes to silence.`
     );
   let accepted = buildAccepted(findings);
-  if (!yes && process.stdin.isTTY && accepted.length > 0) {
+  if (!yes && accepted.length > 0) {
+    // A decision is required (which undeclared values to bless). Non-interactively
+    // we refuse rather than implicitly bless ALL of them (R38).
+    if (!interactive) {
+      console.error(
+        `error: accept needs a decision — pass --yes to bless ALL undeclared values, or run interactively`
+      );
+      return { wrote: false, refused: true };
+    }
     const picked = await multiselect({
       message: `${stackName}: select undeclared value(s) to bless (unselected stay reported)`,
       options: accepted.map((e) => ({ value: acceptedKey(e), label: `${e.logicalId}.${e.path}` })),
@@ -59,7 +84,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<boolean> {
     });
     if (isCancel(picked)) {
       console.error(`note: ${stackName}: accept cancelled — baseline unchanged`);
-      return false;
+      return { wrote: false, refused: false };
     }
     // Empty selection writes an EMPTY baseline, which CREATES the file and lifts R2's
     // no-baseline revert guard — `revert` would then plan REMOVAL of all undeclared
@@ -71,7 +96,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<boolean> {
       });
       if (isCancel(proceed) || !proceed) {
         console.error(`note: ${stackName}: accept cancelled — baseline unchanged`);
-        return false;
+        return { wrote: false, refused: false };
       }
     }
     accepted = selectAccepted(findings, new Set(picked));
@@ -85,7 +110,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<boolean> {
     accepted
   );
   console.log(`baseline written: ${path} (${count} undeclared value(s) blessed)`);
-  return true;
+  return { wrote: true, refused: false };
 }
 
 // ---- revert ----
@@ -160,6 +185,7 @@ export interface RevertStackParams {
   yes: boolean;
   removeUnblessed: boolean;
   verbose: boolean; // expand the NOT-revertable summary to the full list
+  interactive: boolean; // whether the confirm prompt may be shown (TTY && !--no-interactive)
 }
 
 /**
@@ -185,8 +211,18 @@ export interface RevertOutcome {
  * gather) — only the convergence re-check re-gathers.
  */
 export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> {
-  const { stackName, region, gathered, baseline, config, dryRun, yes, removeUnblessed, verbose } =
-    p;
+  const {
+    stackName,
+    region,
+    gathered,
+    baseline,
+    config,
+    dryRun,
+    yes,
+    removeUnblessed,
+    verbose,
+    interactive,
+  } = p;
   let worst = 0;
   const declaredByLogical = declaredKeysByLogical(gathered.desired.resources);
   const drifted = applyIgnores(
@@ -224,7 +260,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     return { exit: 0, aborted: false };
   }
   if (!yes) {
-    if (!process.stdin.isTTY) {
+    if (!interactive) {
       console.error(
         `\nrefusing to write to AWS non-interactively — pass --yes to apply (or --dry-run to preview).`
       );

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { parseCommonArgs } from '../src/cli-args.js';
+import { isInteractive, parseCommonArgs } from '../src/cli-args.js';
 
 describe('parseCommonArgs', () => {
   it('collects positional stack names, not flag values', () => {
@@ -124,5 +124,39 @@ describe('parseCommonArgs', () => {
     expect(() => parseCommonArgs(['--dry-run=1'])).toThrow(
       /option "--dry-run" does not take a value/
     );
+  });
+
+  it('recognizes --no-interactive (default false)', () => {
+    expect(parseCommonArgs(['S', '--no-interactive']).noInteractive).toBe(true);
+    expect(parseCommonArgs(['S']).noInteractive).toBe(false);
+  });
+});
+
+describe('isInteractive (TTY × --no-interactive truth matrix)', () => {
+  const args = (noInteractive: boolean) =>
+    parseCommonArgs(noInteractive ? ['--no-interactive'] : []);
+
+  // Stub process.stdin.isTTY across the matrix; restore in finally so other tests
+  // (and the real terminal) are unaffected.
+  const withTTY = (tty: boolean, fn: () => void) => {
+    const saved = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+    Object.defineProperty(process.stdin, 'isTTY', { value: tty, configurable: true });
+    try {
+      fn();
+    } finally {
+      if (saved) Object.defineProperty(process.stdin, 'isTTY', saved);
+      else delete (process.stdin as { isTTY?: boolean }).isTTY;
+    }
+  };
+
+  it('true ONLY when TTY && !noInteractive', () => {
+    withTTY(true, () => {
+      expect(isInteractive(args(false))).toBe(true); // TTY, interactive allowed
+      expect(isInteractive(args(true))).toBe(false); // TTY but opted out
+    });
+    withTTY(false, () => {
+      expect(isInteractive(args(false))).toBe(false); // no TTY
+      expect(isInteractive(args(true))).toBe(false); // no TTY + opted out
+    });
   });
 });

--- a/tests/no-direct-tty.test.ts
+++ b/tests/no-direct-tty.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+
+// R38: interactivity flows through the single `isInteractive(args)` helper in
+// cli-args.ts. Command code must NOT read `process.stdin.isTTY` directly — only
+// cli-args.ts may. This guards against a new prompt re-introducing a raw TTY check
+// that would ignore `--no-interactive`.
+const COMMAND_FILES = [
+  '../src/commands/check.ts',
+  '../src/commands/accept.ts',
+  '../src/commands/revert.ts',
+  '../src/commands/stack-actions.ts',
+];
+
+describe('no direct process.stdin.isTTY in command code (R38)', () => {
+  for (const rel of COMMAND_FILES) {
+    it(`${rel} does not read stdin.isTTY directly`, () => {
+      const src = readFileSync(fileURLToPath(new URL(rel, import.meta.url)), 'utf8');
+      expect(src).not.toContain('stdin.isTTY');
+    });
+  }
+
+  it('the helper lives in cli-args.ts', () => {
+    const src = readFileSync(fileURLToPath(new URL('../src/cli-args.ts', import.meta.url)), 'utf8');
+    expect(src).toContain('stdin.isTTY');
+    expect(src).toContain('export function isInteractive');
+  });
+});

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vite-plus/test';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
+import { baselinePath } from '../src/baseline/baseline-file.js';
 import type { GatherResult } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
 import {
+  acceptStack,
   availableActions,
   formatPlan,
   resolveInteractiveRevertExit,
@@ -174,6 +178,7 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     yes: true,
     removeUnblessed: over.removeUnblessed ?? false,
     verbose: false,
+    interactive: true, // these paths return before any confirm (yes:true); value is irrelevant
   });
 
   const captured = async (findings: Finding[], over: Overrides = {}) => {
@@ -230,6 +235,82 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     expect(out).not.toContain('has no baseline — undeclared drift has no revert target');
     expect(out).toContain('remove (undeclared, not in baseline)'); // a real revert item is planned
     expect(out).toContain('(dry-run) would apply');
+  });
+});
+
+describe('acceptStack non-interactive refusal (R38)', () => {
+  it('yes:false + interactive:false + undeclared present → refuses, writes nothing, errors', async () => {
+    // Unique account/region so no baseline file exists on disk for this stack.
+    const desired = {
+      stackName: 'R38Stack',
+      region: 'r38-region',
+      accountId: '999988887777',
+      resources: [],
+      rawTemplate: '{}',
+      ctx: {},
+    } as unknown as Desired;
+    const path = baselinePath(desired.stackName, desired.accountId, desired.region);
+    if (existsSync(path)) rmSync(path);
+
+    const errs: string[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      errs.push(String(m));
+    });
+    try {
+      const result = await acceptStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings: [undeclared()],
+        yes: false,
+        interactive: false,
+      });
+      expect(result).toEqual({ wrote: false, refused: true });
+    } finally {
+      spy.mockRestore();
+    }
+    expect(existsSync(path)).toBe(false); // no baseline written
+    expect(errs.join('\n')).toContain(
+      'error: accept needs a decision — pass --yes to bless ALL undeclared values, or run interactively'
+    );
+  });
+
+  it('yes:true → blesses ALL undeclared values with no prompt (regression)', async () => {
+    const desired = {
+      stackName: 'R38YesStack',
+      region: 'r38-yes-region',
+      accountId: '999988887777',
+      resources: [],
+      rawTemplate: '{}',
+      ctx: {},
+    } as unknown as Desired;
+    const path = baselinePath(desired.stackName, desired.accountId, desired.region);
+    if (existsSync(path)) rmSync(path);
+
+    try {
+      const result = await acceptStack({
+        stackName: desired.stackName,
+        region: desired.region,
+        desired,
+        findings: [undeclared()],
+        yes: true,
+        interactive: false, // ignored when yes:true — --yes blesses all regardless
+      });
+      expect(result).toEqual({ wrote: true, refused: false });
+      expect(existsSync(path)).toBe(true);
+      const written = JSON.parse(readFileSync(path, 'utf8')) as BaselineFile;
+      // the full undeclared set is blessed (no selective multiselect under --yes)
+      expect(written.accepted).toEqual([
+        {
+          logicalId: 'B',
+          resourceType: 'AWS::S3::Bucket',
+          path: 'AccelerateConfiguration',
+          value: { AccelerationStatus: 'Enabled' },
+        },
+      ]);
+    } finally {
+      if (existsSync(path)) rmSync(path);
+    }
   });
 });
 


### PR DESCRIPTION
## R38 — `--no-interactive` flag

Adds a global `--no-interactive` flag and routes every prompt decision through a single `isInteractive()` helper (no more direct `process.stdin.isTTY` reads in command code).

### Semantics
- **Optional prompts** (check's first-run bless offer, after-drift select) → **skipped** when non-interactive; exit code unchanged.
- **Required-decision prompts** → **error (exit 2)** when non-interactive:
  - `accept`'s multiselect (which undeclared values to bless): with values present and no `--yes`, refuses instead of blessing ALL.
  - `revert`'s write confirmation: keeps its existing non-interactive refusal.

### Combinations
- `--no-interactive` alone = read side completes, write **decisions** refused (safe side).
- `--no-interactive --yes` = full automation.
- `--yes` alone in a TTY = auto-approves confirmations only (select prompts still show).

### ⚠️ Breaking change
`accept` in a non-TTY (CI) without `--yes` now **exits 2** instead of implicitly blessing all undeclared values. Pass `--yes` to bless all in CI. (Fixed at pre-release per spec.)

### Tests
- `--no-interactive` parsing + `isInteractive()` truth matrix (TTY × flag).
- Guard test: command source no longer reads `stdin.isTTY` directly (only `cli-args.ts`).
- `acceptStack` non-interactive refusal returns `{ wrote:false, refused:true }`, writes no baseline.

Gates: typecheck ✓ / lint+format ✓ / build ✓ / 260 tests ✓.
