### PR TITLE
feat: accept multiselect shows only the delta from the baseline (R39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,11 +237,17 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
   exactly the same code as the standalone commands. Skipped under `--json`,
   `--show-all`, and `--pre-deploy`. Aborting the Revert confirmation keeps the
   exit code at 1 (nothing was written — the drift still stands).
-- **`accept`** shows a multiselect of the undeclared values, all pre-selected.
-  Deselect a suspicious one and it stays reported by `check` — bless the intentional
-  changes without rubber-stamping the rest. Non-interactively (CI / non-TTY /
-  `--no-interactive`) this selection can't be made, so `accept` refuses with exit 2
-  unless `--yes` is passed to bless **all** undeclared values.
+- **`accept`** shows a multiselect of only the **delta** from the existing
+  baseline (new + changed undeclared values), all pre-selected. Values already
+  blessed and unchanged are auto-kept (you never re-confirm a 50-item snapshot
+  after changing one thing) and surfaced with a
+  `keeping N already-blessed unchanged value(s)` note. Deselect a suspicious one
+  and it stays reported by `check` — bless the intentional changes without
+  rubber-stamping the rest. With no baseline yet, the full set is shown (the true
+  first bless); when nothing is new, the baseline is just refreshed.
+  Non-interactively (CI / non-TTY / `--no-interactive`) this selection can't be
+  made, so `accept` refuses with exit 2 unless `--yes` is passed to bless **all**
+  undeclared values.
 - **`check` with no baseline yet** offers to bless the current state on the spot.
 
 Flag combinations: `--no-interactive` alone = the read side completes but write

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,6 +391,12 @@ field only warns and is stamped on the next `accept`.
 > `<stack>.<region>.json` files are local dogfood artifacts. They are simply not found
 > under the new path (→ "no baseline", run `accept`); delete them after re-accepting.
 
+When a baseline already exists, the interactive `accept` multiselect shows only the
+**delta** from it (`splitAcceptedByBaseline`) — new/changed undeclared values, where
+"unchanged" reuses the same `blessedValueMatches` predicate as `applyBaseline`
+(R6 — canonicalized compare); already-blessed unchanged values are auto-kept (noted,
+not re-confirmed) and a delta of zero just refreshes the file (R39).
+
 Committing it makes "what real state we accept" a visible, reviewable PR change.
 With revert it is also the _source of the undeclared target value_, so it is
 structural, not optional. `check` filters undeclared findings against it

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -154,6 +154,47 @@ export function acceptedKey(e: { logicalId: string; path: string }): string {
   return `${e.logicalId}::${e.path}`;
 }
 
+/**
+ * The single source of truth for "is this blessed value equal to the current
+ * value?". `applyBaseline` (suppress vs surface) and `splitAcceptedByBaseline`
+ * (unchanged vs changed) MUST share this exact predicate. The blessed value is
+ * re-canonicalized through the CURRENT pipeline so a baseline written under older
+ * normalization rules still matches today's canonical live value (R6) — the
+ * `currentCanonicalValue` side is expected to be already canonical.
+ */
+export function blessedValueMatches(
+  blessedValue: unknown,
+  currentCanonicalValue: unknown
+): boolean {
+  return deepEqual(canonicalizeForCompare(blessedValue), currentCanonicalValue);
+}
+
+/**
+ * Split a freshly-built accepted set against the existing baseline into the values
+ * a human must decide on (`changed` = new path OR value differs) and the values
+ * already blessed and unchanged (`unchanged` = same logicalId+path AND value
+ * matches by `blessedValueMatches`). With no baseline EVERYTHING is `changed`
+ * (the true first bless). Entries are matched against `entry.value` which comes
+ * from `buildAccepted` (already canonical), so the predicate compares
+ * canonical-vs-canonical, exactly like `applyBaseline`.
+ */
+export function splitAcceptedByBaseline(
+  accepted: AcceptedEntry[],
+  baseline: BaselineFile | undefined
+): { unchanged: AcceptedEntry[]; changed: AcceptedEntry[] } {
+  if (!baseline) return { unchanged: [], changed: [...accepted] };
+  const unchanged: AcceptedEntry[] = [];
+  const changed: AcceptedEntry[] = [];
+  for (const entry of accepted) {
+    const blessed = baseline.accepted.find(
+      (a) => a.logicalId === entry.logicalId && a.path === entry.path
+    );
+    if (blessed && blessedValueMatches(blessed.value, entry.value)) unchanged.push(entry);
+    else changed.push(entry);
+  }
+  return { unchanged, changed };
+}
+
 /** Selective accept: build the blessed set from only the findings whose key is in
  *  `selectedKeys`. Empty set -> []; all keys -> equals buildAccepted(findings). */
 export function selectAccepted(findings: Finding[], selectedKeys: Set<string>): AcceptedEntry[] {
@@ -195,9 +236,7 @@ export function applyBaseline(
     // never resurfaces a suppressed value as false drift.
     const match = blessed.find(
       (a) =>
-        a.logicalId === f.logicalId &&
-        a.path === f.path &&
-        deepEqual(canonicalizeForCompare(a.value), f.actual)
+        a.logicalId === f.logicalId && a.path === f.path && blessedValueMatches(a.value, f.actual)
     );
     return match === undefined;
   });

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -13,6 +13,7 @@ import {
   declaredKeysByLogical,
   loadBaseline,
   selectAccepted,
+  splitAcceptedByBaseline,
 } from '../baseline/baseline-file.js';
 import { applyIgnores, type CdkrdConfig } from '../config/config-file.js';
 import { applyRevertItem } from '../revert/apply.js';
@@ -52,21 +53,25 @@ export interface AcceptResult {
 
 /**
  * Bless the current undeclared state into the baseline file. In an interactive run
- * (no --yes) the user picks WHICH undeclared values to bless (selective accept, R14);
- * an empty selection is confirmed first (R19). Non-interactively (--no-interactive or
- * non-TTY/CI), the multiselect is a required DECISION: with undeclared values present
- * and no --yes, accept refuses (exit 2) instead of blessing all (R38). When there is
- * nothing to decide (no undeclared values) the baseline is written regardless. (Same
- * flow whether reached via `cdkrd accept` or check's interactive prompt — neither
- * re-gathers.)
+ * (no --yes) the user picks WHICH undeclared values to bless (selective accept, R14).
+ * When an existing baseline is present the multiselect shows only the DELTA from it
+ * (new/changed); already-blessed unchanged values are auto-kept and surfaced with a
+ * note (R39). An empty FINAL set is confirmed first (R19). Non-interactively
+ * (--no-interactive or non-TTY/CI), the multiselect is a required DECISION: with
+ * undeclared values present and no --yes, accept refuses (exit 2) instead of blessing
+ * all (R38). When there is nothing to decide (no undeclared values) the baseline is
+ * written regardless. (Same flow whether reached via `cdkrd accept` or check's
+ * interactive prompt — neither re-gathers.)
  */
 export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
   const { stackName, region, desired, findings, yes, interactive } = p;
-  if (!yes && (await loadBaseline(stackName, desired.accountId, region)))
+  const existing = await loadBaseline(stackName, desired.accountId, region);
+  if (!yes && existing)
     console.error(
       `note: ${stackName}: overwriting existing baseline (it is git-tracked; review the diff). Pass --yes to silence.`
     );
   let accepted = buildAccepted(findings);
+  let refreshedOnly = false; // true when only unchanged values remained (no delta to decide)
   if (!yes && accepted.length > 0) {
     // A decision is required (which undeclared values to bless). Non-interactively
     // we refuse rather than implicitly bless ALL of them (R38).
@@ -76,30 +81,45 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
       );
       return { wrote: false, refused: true };
     }
-    const picked = await multiselect({
-      message: `${stackName}: select undeclared value(s) to bless (unselected stay reported)`,
-      options: accepted.map((e) => ({ value: acceptedKey(e), label: `${e.logicalId}.${e.path}` })),
-      initialValues: accepted.map((e) => acceptedKey(e)), // default = all selected
-      required: false,
-    });
-    if (isCancel(picked)) {
-      console.error(`note: ${stackName}: accept cancelled — baseline unchanged`);
-      return { wrote: false, refused: false };
-    }
-    // Empty selection writes an EMPTY baseline, which CREATES the file and lifts R2's
-    // no-baseline revert guard — `revert` would then plan REMOVAL of all undeclared
-    // drift. Confirm that consequence explicitly before writing (R19).
-    if (picked.length === 0) {
-      const proceed = await confirm({
-        message: `${stackName}: bless nothing? This writes an EMPTY baseline — \`cdkrd revert\` will then plan REMOVAL of ALL undeclared drift on this stack.`,
-        initialValue: false,
+    // Only make the human decide on the DELTA from the existing baseline: already-blessed
+    // unchanged values are auto-kept (re-confirming a 50-item snapshot every time is wrong,
+    // R39). With no baseline the split returns everything as `changed` (the true first bless).
+    const { unchanged, changed } = splitAcceptedByBaseline(accepted, existing);
+    if (unchanged.length > 0)
+      console.error(
+        `note: ${stackName}: keeping ${unchanged.length} already-blessed unchanged value(s)`
+      );
+    if (changed.length === 0) {
+      // Nothing new to decide — just refresh the baseline (re-snapshot the unchanged set).
+      accepted = unchanged;
+      refreshedOnly = true;
+    } else {
+      const picked = await multiselect({
+        message: `${stackName}: select undeclared value(s) to bless (unselected stay reported)`,
+        options: changed.map((e) => ({ value: acceptedKey(e), label: `${e.logicalId}.${e.path}` })),
+        initialValues: changed.map((e) => acceptedKey(e)), // default = all selected
+        required: false,
       });
-      if (isCancel(proceed) || !proceed) {
+      if (isCancel(picked)) {
         console.error(`note: ${stackName}: accept cancelled — baseline unchanged`);
         return { wrote: false, refused: false };
       }
+      const selectedChanged = selectAccepted(findings, new Set(picked));
+      accepted = [...unchanged, ...selectedChanged]; // auto-kept unchanged + the user's picks
+      // The FINAL written set being empty (no unchanged + nothing picked) writes an EMPTY
+      // baseline, which CREATES the file and lifts R2's no-baseline revert guard — `revert`
+      // would then plan REMOVAL of all undeclared drift. Confirm that consequence (R19).
+      if (accepted.length === 0) {
+        const proceed = await confirm({
+          message: `${stackName}: bless nothing? This writes an EMPTY baseline — \`cdkrd revert\` will then plan REMOVAL of ALL undeclared drift on this stack.`,
+          initialValue: false,
+        });
+        if (isCancel(proceed) || !proceed) {
+          console.error(`note: ${stackName}: accept cancelled — baseline unchanged`);
+          return { wrote: false, refused: false };
+        }
+      }
     }
-    accepted = selectAccepted(findings, new Set(picked));
   }
   const { path, count } = await blessStack(
     stackName,
@@ -109,7 +129,11 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
     desired.rawTemplate,
     accepted
   );
-  console.log(`baseline written: ${path} (${count} undeclared value(s) blessed)`);
+  if (refreshedOnly)
+    console.log(
+      `${stackName}: nothing new to bless — baseline refreshed (${count} unchanged value(s))`
+    );
+  else console.log(`baseline written: ${path} (${count} undeclared value(s) blessed)`);
   return { wrote: true, refused: false };
 }
 

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -11,6 +11,7 @@ import {
   checkBaselineAccount,
   hashTemplate,
   selectAccepted,
+  splitAcceptedByBaseline,
   warnTemplateHashDrift,
   writeBaseline,
 } from '../src/baseline/baseline-file.js';
@@ -82,6 +83,83 @@ describe('baseline', () => {
     it('all selected -> equals buildAccepted output', () => {
       const all = new Set(buildAccepted(findings).map(acceptedKey));
       expect(selectAccepted(findings, all)).toEqual(buildAccepted(findings));
+    });
+  });
+
+  describe('splitAcceptedByBaseline (delta-only accept, R39)', () => {
+    const accepted = [
+      { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }, // unchanged
+      { logicalId: 'B', resourceType: 'AWS::X::Y', path: 'Q', value: 'new-val' }, // changed value
+      { logicalId: 'C', resourceType: 'AWS::X::Y', path: 'R', value: 1 }, // new path
+    ];
+
+    it('3-way buckets unchanged / changed-value / new-path correctly', () => {
+      const b = baseline([
+        { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] },
+        { logicalId: 'B', resourceType: 'AWS::X::Y', path: 'Q', value: 'old-val' },
+        // C.R absent from baseline => new
+      ]);
+      const { unchanged, changed } = splitAcceptedByBaseline(accepted, b);
+      expect(unchanged).toEqual([
+        { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] },
+      ]);
+      expect(changed).toEqual([
+        { logicalId: 'B', resourceType: 'AWS::X::Y', path: 'Q', value: 'new-val' },
+        { logicalId: 'C', resourceType: 'AWS::X::Y', path: 'R', value: 1 },
+      ]);
+    });
+
+    it('R6 regression: a baseline value in an OLDER canonical form is still unchanged', () => {
+      // blessed under an OLDER rule set: IAM policy Action stored as a scalar; the current
+      // canonical value (from buildAccepted) is the sorted-array form. canonicalizeForCompare
+      // folds them together, so this must bucket as unchanged (not changed).
+      const b = baseline([
+        {
+          logicalId: 'A',
+          resourceType: 'AWS::IAM::Role',
+          path: 'AssumeRolePolicyDocument',
+          value: { Statement: [{ Effect: 'Allow', Action: 's3:Get' }] }, // scalar Action
+        },
+      ]);
+      const current = [
+        {
+          logicalId: 'A',
+          resourceType: 'AWS::IAM::Role',
+          path: 'AssumeRolePolicyDocument',
+          value: { Statement: [{ Effect: 'Allow', Action: ['s3:Get'] }] }, // canonical array
+        },
+      ];
+      const { unchanged, changed } = splitAcceptedByBaseline(current, b);
+      expect(unchanged).toHaveLength(1);
+      expect(changed).toHaveLength(0);
+    });
+
+    it('no baseline -> everything is changed (the true first bless)', () => {
+      const { unchanged, changed } = splitAcceptedByBaseline(accepted, undefined);
+      expect(unchanged).toEqual([]);
+      expect(changed).toEqual(accepted);
+    });
+
+    it('no new/changed -> changed empty, all unchanged (the refresh path)', () => {
+      const b = baseline(accepted.map((e) => ({ ...e })));
+      const { unchanged, changed } = splitAcceptedByBaseline(accepted, b);
+      expect(unchanged).toEqual(accepted);
+      expect(changed).toEqual([]);
+    });
+
+    it('final written set = unchanged + selected (an unselected new entry is excluded)', () => {
+      // emulate acceptStack's composition: auto-kept unchanged + user-picked changed.
+      const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+      const { unchanged, changed } = splitAcceptedByBaseline(accepted, b);
+      // user selects only B.Q (the changed value), leaves the new C.R unselected
+      const selected = changed.filter((e) => e.logicalId === 'B');
+      const written = [...unchanged, ...selected];
+      expect(written).toEqual([
+        { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] },
+        { logicalId: 'B', resourceType: 'AWS::X::Y', path: 'Q', value: 'new-val' },
+      ]);
+      // the unselected new path C.R is NOT blessed
+      expect(written.some((e) => e.logicalId === 'C')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## R39 — accept multiselect shows only the delta from the baseline

> **Stacked on #5 (R38).** Base is `wt-r38` so this diff shows only the R39 changes. Merge #5 first; GitHub will retarget this to `main` automatically.

Real dogfooding turned up a UX problem: after changing **one** thing in the console, `accept`'s multiselect listed **all** undeclared values (50+) — every already-blessed value re-presented for confirmation every time. Not a bug (the baseline is a full snapshot, so accept must re-bless the whole set), but a human should only have to decide on the **delta**.

### What changed
When an existing baseline is present, `accept`'s multiselect now shows only the **new/changed** undeclared values:

- `splitAcceptedByBaseline()` buckets the accepted set into `unchanged` / `changed`, reusing the **same** `blessedValueMatches()` predicate as `applyBaseline` (R6 canonicalized compare) — the comparison is no longer double-implemented.
- Already-blessed **unchanged** values are auto-kept and surfaced with a `keeping N already-blessed unchanged value(s)` note.
- Final written baseline = **all unchanged (auto-kept) + the picks from the delta**. Unselected new/changed stay reported (current semantics).
- A **zero delta** refreshes the baseline with `nothing new to bless — baseline refreshed (N unchanged value(s))` and no multiselect.
- **No baseline yet** → the full set is presented (the true first bless).
- The R19 empty-baseline confirm now fires on the **final** written set being empty.

### Tests
- `splitAcceptedByBaseline` 3-way split; R6 regression (old-normalization value still judged unchanged); final set = unchanged + selected; no-baseline → all presented; zero-delta refresh path.

### Docs
- README accept bullet → delta-only + auto-keep.
- ARCHITECTURE §8 → one paragraph on the delta multiselect.

Gates: typecheck ✓ / lint+format ✓ / build ✓ / 265 tests ✓.
