### PR TITLE
feat(cli): validate --fail-on and accept --flag=value form (R41)

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -55,29 +55,58 @@ export function parseCommonArgs(args: string[]): CommonArgs {
       stackNames.push(a);
       continue;
     }
-    if (VALUE_FLAGS.has(a)) {
-      const v = args[i + 1];
-      // a following token that is itself a flag is NOT a value (catches `--region --json`)
-      if (v === undefined || v.startsWith('-')) {
-        throw new Error(`option "${a}" requires a value — see cdkrd --help`);
-      }
-      if (a === '-c' || a === '--context') {
-        const eq = v.indexOf('=');
-        if (eq <= 0) {
-          throw new Error(`option "${a}" expects key=value, got "${v}" — see cdkrd --help`);
+    // Accept `--flag=value` (and `-a=value`) like the cdk CLI / yargs do. Split on
+    // the FIRST '=' only so `--context=env=prod` keeps the value "env=prod" whole.
+    const eq = a.indexOf('=');
+    const flag = eq > 0 ? a.slice(0, eq) : a;
+    const inlineValue = eq > 0 ? a.slice(eq + 1) : undefined;
+
+    if (VALUE_FLAGS.has(flag)) {
+      let v: string;
+      if (inlineValue !== undefined) {
+        // `--app=` with nothing after the '=' is still a missing value
+        if (inlineValue === '') {
+          throw new Error(`option "${flag}" requires a value — see cdkrd --help`);
         }
-        context[v.slice(0, eq)] = v.slice(eq + 1);
+        v = inlineValue;
       } else {
-        values[a === '-a' ? '--app' : a] = v;
+        const next = args[i + 1];
+        // a following token that is itself a flag is NOT a value (catches `--region --json`)
+        if (next === undefined || next.startsWith('-')) {
+          throw new Error(`option "${flag}" requires a value — see cdkrd --help`);
+        }
+        v = next;
+        i++; // consume the value
       }
-      i++; // consume the value
+      if (flag === '-c' || flag === '--context') {
+        const kvEq = v.indexOf('=');
+        if (kvEq <= 0) {
+          throw new Error(`option "${flag}" expects key=value, got "${v}" — see cdkrd --help`);
+        }
+        context[v.slice(0, kvEq)] = v.slice(kvEq + 1);
+      } else {
+        values[flag === '-a' ? '--app' : flag] = v;
+      }
       continue;
     }
-    if (BOOLEAN_FLAGS.has(a)) {
-      found.add(a);
+    if (BOOLEAN_FLAGS.has(flag)) {
+      // a boolean flag takes no value: `--json=true` is a mistake, not a stack name
+      if (inlineValue !== undefined) {
+        throw new Error(`option "${flag}" does not take a value — see cdkrd --help`);
+      }
+      found.add(flag);
       continue;
     }
     throw new Error(`unknown option "${a}" — see cdkrd --help`);
+  }
+
+  // Validate enumerated values during parse so a typo (`--fail-on declarred`) is a
+  // loud error, not a silent fall-through to the `undeclared` default.
+  const failOnRaw = values['--fail-on'];
+  if (failOnRaw !== undefined && failOnRaw !== 'declared' && failOnRaw !== 'undeclared') {
+    throw new Error(
+      `--fail-on expects "declared" or "undeclared", got "${failOnRaw}" — see cdkrd --help`
+    );
   }
 
   const has = (flag: string): boolean => found.has(flag);
@@ -89,7 +118,7 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     // -a/--app > CDKRD_APP env (cdk.json "app" fallback resolved in the synth layer)
     app: values['--app'] ?? process.env.CDKRD_APP,
     json: has('--json'),
-    failOn: values['--fail-on'] === 'declared' ? 'declared' : 'undeclared',
+    failOn: failOnRaw === 'declared' ? 'declared' : 'undeclared',
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -90,4 +90,39 @@ describe('parseCommonArgs', () => {
     expect(() => parseCommonArgs(['-c', 'noequals'])).toThrow(/expects key=value/);
     expect(() => parseCommonArgs(['--context', '=v'])).toThrow(/expects key=value/);
   });
+
+  it('validates --fail-on, rejecting typos instead of falling back to undeclared (R41)', () => {
+    expect(parseCommonArgs(['S', '--fail-on', 'declared']).failOn).toBe('declared');
+    expect(parseCommonArgs(['S', '--fail-on', 'undeclared']).failOn).toBe('undeclared');
+    expect(() => parseCommonArgs(['S', '--fail-on', 'declarred'])).toThrow(
+      /--fail-on expects "declared" or "undeclared", got "declarred"/
+    );
+    expect(() => parseCommonArgs(['S', '--fail-on', 'deleted'])).toThrow(/--fail-on expects/);
+  });
+
+  it('accepts --flag=value form, equal to the space form (R41)', () => {
+    expect(parseCommonArgs(['--app=cdk.out'])).toEqual(parseCommonArgs(['--app', 'cdk.out']));
+    expect(parseCommonArgs(['-a=cdk.out'])).toEqual(parseCommonArgs(['--app', 'cdk.out']));
+    expect(parseCommonArgs(['MyStack', '--region=eu-west-1']).region).toBe('eu-west-1');
+    expect(parseCommonArgs(['MyStack', '--region=eu-west-1']).stackNames).toEqual(['MyStack']);
+    expect(parseCommonArgs(['--fail-on=declared']).failOn).toBe('declared');
+  });
+
+  it('splits --context=key=value on the first = only (R41)', () => {
+    expect(parseCommonArgs(['--context=env=prod']).context).toEqual({ env: 'prod' });
+    // and the value may itself contain more '='
+    expect(parseCommonArgs(['-c=token=a=b']).context).toEqual({ token: 'a=b' });
+  });
+
+  it('errors on --flag= with an empty inline value (R41)', () => {
+    expect(() => parseCommonArgs(['--app='])).toThrow(/option "--app" requires a value/);
+    expect(() => parseCommonArgs(['--region='])).toThrow(/option "--region" requires a value/);
+  });
+
+  it('rejects a value attached to a boolean flag, e.g. --json=true (R41)', () => {
+    expect(() => parseCommonArgs(['--json=true'])).toThrow(/option "--json" does not take a value/);
+    expect(() => parseCommonArgs(['--dry-run=1'])).toThrow(
+      /option "--dry-run" does not take a value/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

R36 follow-up (R41, /tmp/cdkrd-r41-failon-validation.md) — two more "a typo silently changes behavior" hazards in the shared arg parser `src/cli-args.ts`:

1. **`--fail-on` value validation** (required): previously `failOn: values['--fail-on'] === 'declared' ? 'declared' : 'undeclared'` meant any typo (`--fail-on declarred`) silently became `undeclared`. Now an invalid value is `error: --fail-on expects "declared" or "undeclared", got "<v>"` + exit 2 (same throw → `main().catch` path as R36).
2. **`--flag=value` form** (recommended): `--app=cdk.out`, `-a=cdk.out`, `--region=us-east-1`, `--fail-on=declared` are now accepted like the cdk CLI / yargs. Split is on the **first `=` only**, so `--context=env=prod` keeps the value `env=prod` whole. `--app=` with an empty inline value is still a missing-value error.
3. Bonus, same hazard class: a value attached to a **boolean** flag (`--json=true`, `--dry-run=1`) is an explicit `option "..." does not take a value` error rather than a confusing unknown-option.

## Tests

- `--fail-on declared`/`undeclared` regression + typo (`declarred`, `deleted`) → exit 2
- `--app=cdk.out` ≡ `--app cdk.out` (deep-equal), `-a=`, `--region=`, `--fail-on=` forms
- `--context=env=prod` → `{env:'prod'}`; first-`=` split with `-c=token=a=b` → `{token:'a=b'}`
- `--app=`/`--region=` empty inline value → requires-a-value error
- `--json=true`/`--dry-run=1` → does-not-take-a-value error
- 26 files / 263 tests pass; smoke-tested on `dist/cli.js` (all four exit 2 + messages verified)

## Notes for review

- Docs unchanged: `--fail-on`'s valid values (`declared|undeclared`) are already documented and the `=value` form adds no user-visible flag (per the instruction, options table change not needed).
- **Rebase note:** branched off `origin/main` (R36). R38 (PR #5) also edits `cli-args.ts` (adds `noInteractive` field + `isInteractive` helper); the regions are disjoint from R41's (`failOn` line + parse loop), so it should auto-merge, but rebase R41 if R38 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)