### PR TITLE
feat(revert): scope the post-revert convergence re-check to touched resources (R44)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,10 +319,20 @@ see [redesign-notes.md](redesign-notes.md).)
 always in full — per finding: path, current → target; NOT-revertable findings folded
 to one line per reason, `--verbose` for the full list — R35), asks for confirmation
 (`@clack`; `--yes` skips; non-TTY refuses; `--dry-run` previews), applies, then
-**re-checks for convergence**. Exit semantics: no drift at all → `no drift to
-revert.` + exit 0; drift exists but **nothing is revertable** → `nothing
-revertable — N drift(s) remain.` + exit 1 (drift-remains semantics, not a usage
-error — R35).
+**re-checks for convergence**. The convergence re-check is **scoped to the
+resources the revert touched** (R44, `regatherTouched` in
+[gather.ts](../src/commands/gather.ts)): only the plan's resources are re-read
+and re-classified; every other resource's findings carry forward from the
+pre-revert gather. The template can't have changed (revert writes live state,
+not CFn), and a full re-gather made `revert` hang silently for
+whole-stack-read time after the last `reverted:` line — it could even blame
+unrelated mid-revert drift on the revert. A `verifying convergence (re-reading
+N resource(s))...` line attributes the wait, and if a touched resource still
+reads as drifted, ONE re-read after a short delay guards against SDK-writer
+eventual consistency (the slow full re-gather used to grant that propagation
+time by accident). Exit semantics: no drift at all → `no drift to revert.` +
+exit 0; drift exists but **nothing is revertable** → `nothing revertable — N
+drift(s) remain.` + exit 1 (drift-remains semantics, not a usage error — R35).
 
 - **Targets**: declared drift → the **deployed-template** value; undeclared drift →
   the **baseline** value (an un-blessed out-of-band _addition_ reverts by REMOVAL).

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -8,14 +8,94 @@ import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import { READ_RETRY } from '../read/client-config.js';
 import { fetchManagedAliasTargets, usesManagedKmsAlias } from '../read/kms-aliases.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
-import { readLive } from '../read/router.js';
+import { readLive, type ReadResult } from '../read/router.js';
 import { getSchemaInfo } from '../schema/schema-strip.js';
-import type { Finding, SchemaInfo } from '../types.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
 
 export interface GatherResult {
   desired: Desired;
   findings: Finding[];
   schemas: Map<string, SchemaInfo>; // resourceType -> schema (so revert can honor createOnly)
+}
+
+// Bounded-concurrency live-read pool (pull-next-when-free): serial reads cost
+// ~300ms each, so 200+ resources took >1min; the SDK's adaptive retry handles
+// any throttling. Stores each read in `reads` and feeds ctx.liveAttrs so
+// Fn::GetAtt can resolve against real attributes.
+const POOL_SIZE = 6;
+async function readAll(
+  cc: CloudControlClient,
+  targets: DesiredResource[],
+  region: string,
+  desired: Desired,
+  reads: Map<string, ReadResult>
+): Promise<void> {
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < targets.length) {
+      const r = targets[cursor++]!;
+      const read = await readLive(cc, r, region, desired.accountId);
+      reads.set(r.logicalId, read);
+      if (read.live) desired.ctx.liveAttrs[r.logicalId] = read.live;
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(POOL_SIZE, targets.length) }, () => worker()));
+}
+
+interface ClassifyOpts {
+  accountId: string;
+  region: string;
+  kmsAliasTargets: Record<string, string>;
+}
+
+// Turn ONE resource's read into findings: no-physical-id / deleted / skipped
+// short-circuits, else schema-strip + classify. Shared by gather's pass 2 and
+// the scoped post-revert re-check (regatherTouched).
+async function classifyRead(
+  cfn: CloudFormationClient,
+  r: DesiredResource,
+  read: ReadResult | undefined,
+  schemas: Map<string, SchemaInfo>,
+  classifyOpts: ClassifyOpts
+): Promise<Finding[]> {
+  if (!r.physicalId) {
+    return [
+      {
+        tier: 'skipped',
+        logicalId: r.logicalId,
+        resourceType: r.resourceType,
+        path: '',
+        note: 'no physical id',
+      },
+    ];
+  }
+  if (read?.deleted) {
+    return [
+      {
+        tier: 'deleted',
+        logicalId: r.logicalId,
+        physicalId: r.physicalId,
+        constructPath: r.constructPath,
+        resourceType: r.resourceType,
+        path: '',
+        note: 'resource deleted out of band',
+      },
+    ];
+  }
+  if (!read || read.skippedReason || !read.live) {
+    return [
+      {
+        tier: 'skipped',
+        logicalId: r.logicalId,
+        resourceType: r.resourceType,
+        path: '',
+        note: read?.skippedReason ?? 'not readable',
+      },
+    ];
+  }
+  const schema = schemas.get(r.resourceType) ?? (await getSchemaInfo(cfn, r.resourceType));
+  schemas.set(r.resourceType, schema);
+  return classifyResource(r, read.live, schema, classifyOpts);
 }
 
 export async function gatherFindings(
@@ -36,22 +116,10 @@ export async function gatherFindings(
   // Pass 1: read every resource's live model first, so Fn::GetAtt in any
   // resource's declared props can be resolved against the referenced resource's
   // real attributes (populates ctx.liveAttrs) instead of falling to UNRESOLVED.
-  // Bounded-concurrency worker pool (pull-next-when-free): serial reads cost
-  // ~300ms each, so 200+ resources took >1min; the SDK's adaptive retry handles
-  // any throttling. Pass-2 ordering stays deterministic (iterates desired.resources).
-  const reads = new Map<string, Awaited<ReturnType<typeof readLive>>>();
+  // Pass-2 ordering stays deterministic (iterates desired.resources).
+  const reads = new Map<string, ReadResult>();
   const targets = desired.resources.filter((r) => r.physicalId);
-  const POOL_SIZE = 6;
-  let cursor = 0;
-  const worker = async (): Promise<void> => {
-    while (cursor < targets.length) {
-      const r = targets[cursor++]!;
-      const read = await readLive(cc, r, region, desired.accountId);
-      reads.set(r.logicalId, read);
-      if (read.live) desired.ctx.liveAttrs[r.logicalId] = read.live;
-    }
-  };
-  await Promise.all(Array.from({ length: Math.min(POOL_SIZE, targets.length) }, () => worker()));
+  await readAll(cc, targets, region, desired, reads);
 
   // Re-resolve EVERY resource's declared now that pass 1 populated all live
   // attributes, so Fn::GetAtt resolves. Hoisted out of pass 2 because pass 1.5
@@ -74,18 +142,7 @@ export async function gatherFindings(
       SDK_OVERRIDES[r.resourceType] &&
       reads.get(r.logicalId)?.skippedReason
   );
-  let rc = 0;
-  const retryWorker = async (): Promise<void> => {
-    while (rc < retryTargets.length) {
-      const r = retryTargets[rc++]!;
-      const read = await readLive(cc, r, region, desired.accountId);
-      reads.set(r.logicalId, read);
-      if (read.live) desired.ctx.liveAttrs[r.logicalId] = read.live;
-    }
-  };
-  await Promise.all(
-    Array.from({ length: Math.min(POOL_SIZE, retryTargets.length) }, () => retryWorker())
-  );
+  await readAll(cc, retryTargets, region, desired, reads);
 
   // KMS managed-alias resolution (R9): only if the stack declares any `alias/aws/*`,
   // fetch alias -> target key id once so classify can tell a managed-default key from
@@ -98,42 +155,60 @@ export async function gatherFindings(
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
   for (const r of desired.resources) {
-    if (!r.physicalId) {
-      findings.push({
-        tier: 'skipped',
-        logicalId: r.logicalId,
-        resourceType: r.resourceType,
-        path: '',
-        note: 'no physical id',
-      });
-      continue;
-    }
-    const read = reads.get(r.logicalId);
-    if (read?.deleted) {
-      findings.push({
-        tier: 'deleted',
-        logicalId: r.logicalId,
-        physicalId: r.physicalId,
-        constructPath: r.constructPath,
-        resourceType: r.resourceType,
-        path: '',
-        note: 'resource deleted out of band',
-      });
-      continue;
-    }
-    if (!read || read.skippedReason || !read.live) {
-      findings.push({
-        tier: 'skipped',
-        logicalId: r.logicalId,
-        resourceType: r.resourceType,
-        path: '',
-        note: read?.skippedReason ?? 'not readable',
-      });
-      continue;
-    }
-    const schema = await getSchemaInfo(cfn, r.resourceType);
-    schemas.set(r.resourceType, schema);
-    findings.push(...classifyResource(r, read.live, schema, classifyOpts));
+    findings.push(...(await classifyRead(cfn, r, reads.get(r.logicalId), schemas, classifyOpts)));
   }
   return { desired, findings, schemas };
+}
+
+/**
+ * Scoped re-gather for the post-revert convergence check (R44): re-read and
+ * re-classify ONLY the `touched` resources, carrying every other resource's
+ * findings forward from the original gather unchanged. The deployed template
+ * cannot have changed (revert writes live state, not CloudFormation), so
+ * `gathered.desired` and `gathered.schemas` stay valid — this turns a
+ * whole-stack re-gather (template fetch + a live read per resource) into a
+ * handful of reads, which is what made `revert` hang silently after the last
+ * `reverted:` line. Out-of-band changes to UNTOUCHED resources during the
+ * revert are deliberately not picked up — that is `check`'s job, and the old
+ * full re-gather could even contradict the plan the user just confirmed by
+ * blaming unrelated new drift on the revert.
+ *
+ * Returned findings are unordered across resources (untouched first, then the
+ * fresh ones) — the convergence check only counts drift, it never renders them.
+ * Mutates `gathered` the same way gatherFindings does (ctx.liveAttrs, resolved
+ * declared, schemas cache).
+ */
+export async function regatherTouched(
+  gathered: GatherResult,
+  touched: Set<string>,
+  region: string
+): Promise<Finding[]> {
+  const cfn = new CloudFormationClient({ region, ...READ_RETRY });
+  const cc = new CloudControlClient({ region, ...READ_RETRY });
+  const { desired, schemas } = gathered;
+  const targets = desired.resources.filter((r) => touched.has(r.logicalId));
+
+  const reads = new Map<string, ReadResult>();
+  await readAll(
+    cc,
+    targets.filter((r) => r.physicalId),
+    region,
+    desired,
+    reads
+  );
+  // Re-resolve declared against the refreshed liveAttrs (mirrors gather's hoisted
+  // re-resolve) — GetAtt targets among the touched resources may have moved.
+  for (const r of targets) {
+    if (r.declaredRaw) r.declared = resolveProperties(r.declaredRaw, desired.ctx);
+  }
+  const kmsAliasTargets = targets.some((r) => usesManagedKmsAlias(r.declared))
+    ? await fetchManagedAliasTargets(region)
+    : {};
+  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets };
+
+  const fresh: Finding[] = [];
+  for (const r of targets) {
+    fresh.push(...(await classifyRead(cfn, r, reads.get(r.logicalId), schemas, classifyOpts)));
+  }
+  return [...gathered.findings.filter((f) => !touched.has(f.logicalId)), ...fresh];
 }

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -21,11 +21,13 @@ import { buildRevertPlan, type RevertPlan } from '../revert/plan.js';
 import { SDK_WRITERS } from '../revert/writers.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
-import { type GatherResult, gatherFindings } from './gather.js';
+import { type GatherResult, regatherTouched } from './gather.js';
 
 const driftCount = (findings: Finding[]): number =>
   findings.filter((f) => f.tier === 'deleted' || f.tier === 'declared' || f.tier === 'undeclared')
     .length;
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // ---- accept ----
 
@@ -210,7 +212,13 @@ export interface RevertStackParams {
   removeUnblessed: boolean;
   verbose: boolean; // expand the NOT-revertable summary to the full list
   interactive: boolean; // whether the confirm prompt may be shown (TTY && !--no-interactive)
+  // Delay before the single convergence re-read retry (SDK-writer paths can lag
+  // behind their API response — eventual consistency). Overridable so unit tests
+  // don't sleep for real.
+  convergeRetryDelayMs?: number;
 }
+
+const CONVERGE_RETRY_DELAY_MS = 3000;
 
 /**
  * Outcome of a per-stack revert.
@@ -328,16 +336,23 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     if (!r.ok) worst = Math.max(worst, 2);
   }
 
-  // re-check convergence (re-gather is allowed here — the world changed)
-  const remaining = driftCount(
-    applyIgnores(
-      applyBaseline((await gatherFindings(stackName, region)).findings, baseline, {
-        declaredByLogical,
-      }),
-      stackName,
-      config
-    )
-  );
+  // Re-check convergence — scoped to the resources the revert just touched (R44).
+  // A full gatherFindings here re-read the ENTIRE stack (a long silent wait that
+  // scaled with stack size, not with the revert); regatherTouched re-reads only
+  // plan.items and carries every other finding forward from the original gather.
+  const touched = new Set(plan.items.map((i) => i.logicalId));
+  console.log(`\nverifying convergence (re-reading ${touched.size} resource(s))...`);
+  const reconcile = (findings: Finding[]): Finding[] =>
+    applyIgnores(applyBaseline(findings, baseline, { declaredByLogical }), stackName, config);
+  let post = reconcile(await regatherTouched(gathered, touched, region));
+  if (driftCount(post.filter((f) => touched.has(f.logicalId))) > 0) {
+    // A touched resource still reads as drifted. SDK-writer paths (IAM etc.) are
+    // eventually consistent — the old slow full re-gather granted propagation time
+    // for free; the scoped read must wait deliberately. One retry only.
+    await sleep(p.convergeRetryDelayMs ?? CONVERGE_RETRY_DELAY_MS);
+    post = reconcile(await regatherTouched(gathered, touched, region));
+  }
+  const remaining = driftCount(post);
   console.log(
     remaining === 0
       ? `${stackName}: CLEAN after revert.`

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -9,7 +9,9 @@ import {
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
-import { gatherFindings } from '../src/commands/gather.js';
+import { type GatherResult, gatherFindings, regatherTouched } from '../src/commands/gather.js';
+import type { Desired } from '../src/desired/template-adapter.js';
+import type { Finding, ResolverContext, SchemaInfo } from '../src/types.js';
 
 // Build N AWS::SQS::Queue resources whose declared props match the live read, so the
 // only differences are ordering-sensitive iteration (no real drift noise).
@@ -73,6 +75,114 @@ describe('gatherFindings pass-1 worker pool', () => {
     expect(completionOrder).not.toEqual(ids);
     // ...yet findings stay in deterministic desired.resources order
     expect(findings.map((f) => f.logicalId)).toEqual(ids);
+  });
+});
+
+describe('regatherTouched (R44 — scoped post-revert convergence re-gather)', () => {
+  const EMPTY_SCHEMA: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const ctx = (): ResolverContext => ({
+    params: {},
+    pseudo: {},
+    conditions: {},
+    physIds: {},
+    liveAttrs: {},
+    mappings: {},
+    exports: {},
+    condCache: new Map(),
+  });
+  const queue = (id: string): Desired['resources'][number] => ({
+    logicalId: id,
+    resourceType: 'AWS::SQS::Queue',
+    physicalId: `${id}-phys`,
+    declared: { QueueName: `${id}-q` },
+  });
+  const gathered = (findings: Finding[]): GatherResult => ({
+    desired: {
+      stackName: 'S',
+      region: 'us-east-1',
+      accountId: '111122223333',
+      resources: [queue('A'), queue('B')],
+      rawTemplate: '{}',
+      ctx: ctx(),
+    },
+    findings,
+    schemas: new Map([['AWS::SQS::Queue', EMPTY_SCHEMA]]),
+  });
+  const aFinding = (): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'A',
+    resourceType: 'AWS::SQS::Queue',
+    path: 'DelaySeconds',
+    physicalId: 'A-phys',
+    actual: 30,
+  });
+  const bFinding = (): Finding => ({
+    tier: 'declared',
+    logicalId: 'B',
+    resourceType: 'AWS::SQS::Queue',
+    path: 'QueueName',
+    physicalId: 'B-phys',
+    desired: 'B-q',
+    actual: 'B-LIVE',
+  });
+
+  it('re-reads ONLY the touched resources and carries untouched findings forward verbatim', async () => {
+    const cc = mockClient(CloudControlClient);
+    // B converged (live == declared); A would still read as drifted if it were read
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Identifier: 'B-phys',
+        Properties: JSON.stringify({ QueueName: 'B-q' }),
+      },
+    });
+
+    const g = gathered([aFinding(), bFinding()]);
+    const post = await regatherTouched(g, new Set(['B']), 'us-east-1');
+
+    // exactly one read, and it was B — A was never re-read
+    const calls = cc.commandCalls(GetResourceCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input.Identifier).toBe('B-phys');
+    // A's pre-revert finding survives untouched; B is now clean (no fresh finding)
+    expect(post).toEqual([aFinding()]);
+  });
+
+  it('a still-drifted touched resource yields a fresh drift finding', async () => {
+    const cc = mockClient(CloudControlClient);
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Identifier: 'B-phys',
+        Properties: JSON.stringify({ QueueName: 'B-STILL-LIVE' }),
+      },
+    });
+
+    const post = await regatherTouched(gathered([bFinding()]), new Set(['B']), 'us-east-1');
+    expect(post).toHaveLength(1);
+    expect(post[0]).toMatchObject({
+      tier: 'declared',
+      logicalId: 'B',
+      path: 'QueueName',
+      actual: 'B-STILL-LIVE',
+    });
+  });
+
+  it('a touched resource deleted mid-revert surfaces as deleted', async () => {
+    const cc = mockClient(CloudControlClient);
+    const notFound = new Error('gone');
+    notFound.name = 'ResourceNotFoundException';
+    cc.on(GetResourceCommand).rejects(notFound);
+
+    const post = await regatherTouched(gathered([bFinding()]), new Set(['B']), 'us-east-1');
+    expect(post).toHaveLength(1);
+    expect(post[0]).toMatchObject({ tier: 'deleted', logicalId: 'B' });
   });
 });
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -1,4 +1,10 @@
 import { existsSync, readFileSync, rmSync } from 'node:fs';
+import {
+  CloudControlClient,
+  GetResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
+import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it, vi } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
 import { baselinePath } from '../src/baseline/baseline-file.js';
@@ -235,6 +241,125 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     expect(out).not.toContain('has no baseline — undeclared drift has no revert target');
     expect(out).toContain('remove (undeclared, not in baseline)'); // a real revert item is planned
     expect(out).toContain('(dry-run) would apply');
+  });
+});
+
+describe('revertStack convergence re-check (R44 — scoped to touched resources)', () => {
+  const EMPTY_SCHEMA = {
+    readOnly: new Set<string>(),
+    writeOnly: new Set<string>(),
+    createOnly: new Set<string>(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  } as SchemaInfo;
+
+  // One bucket with declared VersioningConfiguration drift (the declared() fixture).
+  const gathered = (): GatherResult =>
+    ({
+      desired: {
+        stackName: 's',
+        region: 'r',
+        accountId: '111122223333',
+        resources: [
+          {
+            logicalId: 'B',
+            resourceType: 'AWS::S3::Bucket',
+            physicalId: 'b-phys',
+            declared: { VersioningConfiguration: { Status: 'Enabled' } },
+          },
+        ],
+        rawTemplate: '{}',
+        ctx: {
+          params: {},
+          pseudo: {},
+          conditions: {},
+          physIds: {},
+          liveAttrs: {},
+          mappings: {},
+          exports: {},
+          condCache: new Map(),
+        },
+      },
+      findings: [declared()],
+      schemas: new Map([['AWS::S3::Bucket', EMPTY_SCHEMA]]),
+    }) as GatherResult;
+
+  const params = () => ({
+    stackName: 's',
+    region: 'r',
+    gathered: gathered(),
+    baseline: undefined,
+    config: { ignore: [] },
+    dryRun: false,
+    yes: true,
+    removeUnblessed: false,
+    verbose: false,
+    interactive: false, // yes:true — no confirm prompt is reached
+    convergeRetryDelayMs: 0, // do not sleep for real in tests
+  });
+
+  const liveRead = (status: string) => ({
+    ResourceDescription: {
+      Identifier: 'b-phys',
+      Properties: JSON.stringify({ VersioningConfiguration: { Status: status } }),
+    },
+  });
+
+  const run = async () => {
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (s: unknown) => logs.push(String(s));
+    try {
+      const outcome = await revertStack(params());
+      return { outcome, logs: logs.join('\n') };
+    } finally {
+      console.log = orig;
+    }
+  };
+
+  const mockApplySuccess = (cc: ReturnType<typeof mockClient>) => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' },
+    });
+  };
+
+  it('converged on the first scoped read → CLEAN, exit 0, exactly ONE re-read', async () => {
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc);
+    cc.on(GetResourceCommand).resolves(liveRead('Enabled'));
+
+    const { outcome, logs } = await run();
+    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(logs).toContain('verifying convergence (re-reading 1 resource(s))...');
+    expect(logs).toContain('s: CLEAN after revert.');
+    // scoped: the single touched resource was read once — no full-stack re-gather,
+    // and no eventual-consistency retry when the first read already converged
+    expect(cc.commandCalls(GetResourceCommand)).toHaveLength(1);
+  });
+
+  it('stale first read → ONE retry, then CLEAN (eventual-consistency guard)', async () => {
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc);
+    let reads = 0;
+    cc.on(GetResourceCommand).callsFake(() => liveRead(++reads === 1 ? 'Suspended' : 'Enabled'));
+
+    const { outcome, logs } = await run();
+    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(logs).toContain('s: CLEAN after revert.');
+    expect(cc.commandCalls(GetResourceCommand)).toHaveLength(2);
+  });
+
+  it('still drifted after the retry → "1 drift(s) remain." + exit 1', async () => {
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc);
+    cc.on(GetResourceCommand).resolves(liveRead('Suspended'));
+
+    const { outcome, logs } = await run();
+    expect(outcome).toEqual({ exit: 1, aborted: false });
+    expect(logs).toContain('s: 1 drift(s) remain.');
+    expect(cc.commandCalls(GetResourceCommand)).toHaveLength(2); // first read + one retry, no more
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the long **silent** wait between the last `reverted:` line and the
`CLEAN after revert.` verdict (dogfooding finding R44).

The post-revert convergence check used a FULL `gatherFindings` — re-fetching
the deployed template and re-reading EVERY resource's live model — so a
1-resource revert waited for whole-stack-read time, with no output.

## Changes

- **`src/commands/gather.ts`**
  - Extracted the bounded-concurrency read pool (`readAll`) and the
    per-resource read→findings step (`classifyRead`); pass 1 / pass 1.5 /
    pass 2 behavior is unchanged.
  - New `regatherTouched(gathered, touched, region)`: re-reads and
    re-classifies ONLY the touched resources, carrying every other finding
    forward from the pre-revert gather. The template cannot have changed —
    revert writes live state, not CloudFormation.
- **`src/commands/stack-actions.ts`**
  - Convergence check now uses `regatherTouched` scoped to `plan.items`.
  - Prints `verifying convergence (re-reading N resource(s))...` so the
    remaining wait is attributed.
  - If a touched resource still reads as drifted, ONE re-read after a 3s
    delay guards against SDK-writer eventual consistency (the slow full
    re-gather used to grant propagation time by accident). Delay is
    overridable via `convergeRetryDelayMs` so tests don't sleep.
- **`docs/ARCHITECTURE.md`** §7: documents the scoped semantics, including
  that mid-revert drift on UNTOUCHED resources is deliberately not picked up
  (that is `check`'s job — the old behavior could even contradict the plan
  the user just confirmed).

## Tests

- `tests/gather.test.ts` — `regatherTouched`: only touched resources are
  re-read (call-level assertion), untouched findings carry forward verbatim,
  still-drifted yields a fresh finding, deleted-mid-revert surfaces as
  `deleted`.
- `tests/stack-actions.test.ts` — `revertStack` convergence: converged →
  CLEAN/exit 0 with exactly ONE re-read; stale first read → one retry then
  CLEAN (2 reads); still drifted after retry → `1 drift(s) remain.` /exit 1
  (2 reads, no more).

## Gates

| Check | Result |
| --- | --- |
| typecheck | pass |
| lint + format (`vp check`) | pass |
| build | pass |
| tests | 27 files, 301 tests, all pass (+6 new) |

`check` + `docs` markers set.
