### PR TITLE
docs: restructure README around the differentiator; mandate worktrees for all development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,15 +119,18 @@ detail:
     live-test + retrospective; named `verify-pr` for layout parity with cdkd).
   - A `check-gate` PreToolUse hook blocks `git commit` unless both the `check` and
     `docs` markers are fresh. Run the relevant skill before committing.
-- **Use a git worktree for any parallel / concurrent development.** Two agents
-  editing the same checkout collide (a real README clobber happened this way). Each
-  concurrent line of work gets its OWN worktree with DISJOINT files:
+- **ALWAYS develop in a git worktree — never edit or branch in the main
+  checkout, even for a single "sequential" session.** Sessions that believed
+  they were alone have collided twice: a README clobber, and a branch created in
+  the shared checkout that captured another session's staged R44 commit. Every
+  line of work gets its OWN worktree with DISJOINT files:
   `git worktree add .worktrees/<name> -b wt-<name> main` →
   `mise trust .worktrees/<name>/.mise.toml` → `pnpm install` (worktrees have no
   `node_modules`) → work → run gates + set markers → commit on the branch. The
   orchestrator integrates by `git checkout <branch> -- <files>` (NEVER `git merge` —
-  the leaked cdkd session hooks block it), then `git worktree remove`. A single
-  sequential session may still work directly in the main checkout.
+  the leaked cdkd session hooks block it), then `git worktree remove`. The main
+  checkout is reserved for integration: `main` checkouts, pulls, and PR plumbing
+  only.
 - **All changes go through a pull request — never commit directly to `main`.**
   Branch (or worktree branch) → run the gates + set markers → commit → push →
   `gh pr create`. The reviewer re-reviews the PR diff before merge. cdkd's heavier

--- a/README.md
+++ b/README.md
@@ -9,35 +9,64 @@ can't see**. Detect it, accept it, or revert it.
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 -->
 
+## Why
+
+Someone attaches an extra inline policy to one of your roles from the console.
+CloudFormation drift detection only compares properties that **appear in your
+template**, so:
+
+```bash
+$ npx cdk drift ApiStack
+✨  Number of resources with drift: 0
+```
+
+`cdkrd` reads the **full** live resource model and subtracts everything
+explainable — the same change shows up:
+
+<!-- demo GIF (record on publish):
+     cdk drift (clean) -> console change -> cdkrd check finds it -> revert -->
+
+```console
+$ npx cdkrd check ApiStack
+=== cdkrd check: ApiStack (us-east-1) ===
+
+[UNDECLARED DRIFT (the differentiator)] 1
+  ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
+result: 1 drift(s) (undeclared=1)
+```
+
+| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection |
+| ------------------------------------------------------------------- | :-----: | :-------------------------------: |
+| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |
+| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |
+| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |
+| **Revert** undeclared drift                                         |   ✅    |                ❌                 |
+| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |
+
+No AWS Config, no recorders — nothing to enable or pay for per-resource.
+
 ## Quick start
 
 _Not yet on npm — coming with the first public release._
 
 ```bash
 npm install -D cdk-real-drift   # in your CDK project
-
-# `check` is the only command you run. It checks every stack the app defines and,
-# in a terminal, asks what to do right where it found the drift.
-npx cdkrd check
+npx cdkrd check                 # checks every stack your app defines
 ```
 
-When drift is found, `check` prompts inline — no separate command needed:
+`check` is the only command you run day to day. When it finds drift in a
+terminal, it asks what to do right there:
 
 ```console
-=== cdkrd check: ApiStack (us-east-1) ===
-
-[UNDECLARED DRIFT (the differentiator)] 1
-  ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
-result: 1 drift(s) (undeclared=1)
-
 ApiStack: drift found — what do you want to do?
   ❯ Nothing (keep exit code 1)
     Accept — bless current state into the baseline (a git file; nothing written to AWS)
     Revert — write the desired value back to AWS
 ```
 
-- **Accept** records the value in a git-committed baseline, so `check` stays CLEAN
-  until it changes again (a multiselect lets you bless some and keep reporting others).
+- **Accept** records the value in a git-committed baseline, so `check` stays
+  CLEAN until it changes again (a multiselect lets you bless some and keep
+  reporting others).
 - **Revert** shows a plan, confirms, then writes the desired value back to AWS:
 
 ```console
@@ -51,86 +80,16 @@ Apply 1 revert op(s) to ApiStack? This WRITES to AWS. · yes
 ApiStack: CLEAN after revert.
 ```
 
-`accept` and `revert` also exist as standalone commands for CI / scripting.
-**Declared drift is detected from the very first `check`** — the deployed template
-is the reference, no setup needed. Requirements: Node.js >= 20, AWS credentials via
-the standard SDK chain (env vars, `--profile`, SSO).
+**Declared drift is detected from the very first `check`** — the deployed
+template is the reference, no setup needed. `accept` and `revert` also exist as
+standalone commands for CI / scripting.
 
-### Selecting stacks
-
-| invocation            | what is checked                                                                                  |
-| --------------------- | ------------------------------------------------------------------------------------------------ |
-| `cdkrd check`         | every stack the CDK app defines — multi-stack apps are all checked, each in its own `env.region` |
-| `cdkrd check 'Dev*'`  | glob, matched against the app's stack names                                                      |
-| `cdkrd check MyStack` | one stack, selected by name from the app                                                         |
-
-`cdkrd` is **CDK-only**: it always resolves your CDK app to discover which stacks
-exist (and to label findings by construct path). The app comes from `cdk.json` when
-you run in the project directory, or from `--app`: a command
-(`--app "node bin/app.js"`) or a pre-synthesized assembly (`--app cdk.out` — read,
-not executed); `$CDKRD_APP` also works. The drift comparison itself still reads each
-stack's **deployed** template + live state from AWS (reality vs intent) — synth only
-tells cdkrd which stacks to look at.
-
-**Multi-account tip:** the account id is part of the baseline filename, so the same
-stack deployed to several accounts (`env: { account: PERSONAL || SHARED }`) gets one
-baseline per account — they never collide. Commit the shared-environment baselines;
-gitignore personal ones if you prefer (e.g. `.cdkrd/*.<personal-account>.*.json`).
-
-## What `cdk drift` can't see
-
-Someone attaches an extra inline policy to one of your roles from the console.
-CloudFormation drift detection only compares properties that **appear in your
-template**, so:
-
-```bash
-$ npx cdk drift ApiStack
-✨  Number of resources with drift: 0
-```
-
-`cdkrd` reads the **full** live model and subtracts what is explainable, so the
-same change shows up:
-
-<!-- demo GIF (record on publish): cdk drift (clean) -> console change -> cdkrd check finds it -> revert -->
-
-```console
-$ npx cdkrd check ApiStack
-=== cdkrd check: ApiStack (us-east-1) ===
-
-[UNDECLARED DRIFT (the differentiator)] 1
-  ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access","PolicyDocument":{"Statement":[{"Action":["s3:*"],"Effect":"Allow","Resource":["*"]}]}}]
-result: 1 drift(s) (undeclared=1)
-```
-
-…and you accept or revert it right there ([see above](#quick-start)).
-
-| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection |
-| ------------------------------------------------------------------- | :-----: | :-------------------------------: |
-| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |
-| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |
-| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |
-| **Revert** undeclared drift                                         |   ✅    |                ❌                 |
-| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |
-
-A resource that was **deleted out of band** is the most blatant drift there is. It
-is reported in the `deleted` tier and always sets exit 1, regardless of `--fail-on`:
-
-```console
-=== cdkrd check: ApiStack (us-east-1) ===
-
-[DELETED (resource deleted out of band — always drift)] 1
-  ApiStack/EventsQueue (AWS::SQS::Queue) — resource deleted out of band
-result: 1 drift(s) (deleted=1)
-```
-
-`cdkrd` is **reality vs intent**, not code vs template: it deliberately does not
-reimplement `cdk diff`. Undeployed code changes never show up as drift
-(see [`--pre-deploy`](#commands--options) for the opt-in inversion).
+Requirements: Node.js >= 20, AWS credentials via the standard SDK chain
+(env vars, `--profile`, SSO).
 
 ## How it works
 
-Three verbs. After `check` finds drift, the human decision is binary, and the verbs
-mirror it:
+After `check` finds drift, the human decision is binary, and the verbs mirror it:
 
 | verb           | meaning                                                 | writes               |
 | -------------- | ------------------------------------------------------- | -------------------- |
@@ -141,25 +100,156 @@ mirror it:
 - **Declared** properties are compared against the **deployed template** — no
   baseline involved, drift is detected from the first run.
 - **Undeclared** properties are compared against a **baseline** you bless with
-  `accept`: a JSON file at `.cdkrd/<stack>.<accountId>.<region>.json` that you commit.
-  A PR that changes it is a visible, reviewable change to "what real state we accept".
-- There is **no watch-list to maintain**. `cdkrd` snapshots the full live model
-  (Cloud Control API + SDK readers for the gap types) and subtracts everything
-  explainable — schema read-only/write-only/defaults, AWS-managed fields, `aws:*`
-  tags, policy-document and ordering noise. What survives is signal.
+  `accept`: a JSON file at `.cdkrd/<stack>.<accountId>.<region>.json`, committed
+  to git. A PR that changes it is a visible, reviewable change to "what real
+  state we accept". Account id and region are part of the filename, so the same
+  stack deployed to several accounts never collides (gitignore personal-account
+  baselines if you prefer).
+- There is **no watch-list to maintain**. Every `check` snapshots the full live
+  model (Cloud Control API + SDK readers for the gap types) and subtracts
+  everything explainable — schema read-only/write-only/defaults, AWS-managed
+  fields, `aws:*` tags, policy-document and ordering noise. What survives is
+  signal.
 - Anything not confidently comparable is reported honestly as informational
   (`readGap` / `unresolved` / `skipped`) — **never** guessed, so no false drift.
+- A resource **deleted out of band** — the most blatant drift there is — is
+  reported in the `deleted` tier and always sets exit 1, regardless of
+  `--fail-on`.
 
-It synthesizes the CDK app (via `@aws-cdk/toolkit-lib`, or reads a pre-synthesized
-`cdk.out`) to discover your stacks and label findings by **construct path**; the
-comparison then reads each stack's deployed template + live state from AWS.
+`cdkrd` is **reality vs intent**, not code vs template: it deliberately does not
+reimplement `cdk diff`, so undeployed code changes never show up as drift
+(see [`--pre-deploy`](#commands--options) for the opt-in inversion).
 
 Full design and rationale: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
+## Selecting stacks
+
+| invocation            | what is checked                                               |
+| --------------------- | ------------------------------------------------------------- |
+| `cdkrd check`         | every stack the CDK app defines, each in its own `env.region` |
+| `cdkrd check 'Dev*'`  | glob, matched against the app's stack names                   |
+| `cdkrd check MyStack` | one stack, selected by name from the app                      |
+
+`cdkrd` is **CDK-only**: it always resolves your CDK app to discover which
+stacks exist and to label findings by construct path. The app comes from
+`cdk.json` when you run in the project directory, or from `--app`: a command
+(`--app "node bin/app.js"`) or a pre-synthesized assembly (`--app cdk.out` —
+read, not executed); `$CDKRD_APP` also works. The drift comparison itself still
+reads each stack's **deployed** template + live state from AWS — synth only
+tells cdkrd which stacks to look at.
+
+## Commands & options
+
+| command                     | does                                                                   |
+| --------------------------- | ---------------------------------------------------------------------- |
+| `cdkrd check [<stack>...]`  | compare live state vs template (declared) + baseline (undeclared)      |
+| `cdkrd accept [<stack>...]` | snapshot undeclared state into the baseline (CI / non-TTY: `--yes`)    |
+| `cdkrd revert [<stack>...]` | write the desired value back to AWS (confirms; `--dry-run` to preview) |
+
+**Exit codes:** `0` clean · `1` drift · `2` error — so `check` drops straight
+into CI:
+
+```yaml
+- run: npm ci # cdkrd resolves the CDK app, so its deps must be installed
+- run: npx cdkrd check --region us-east-1 # fails the job on drift
+# or point at a prebuilt assembly artifact instead of synthesizing:
+# - run: npx cdkrd check --app cdk.out --region us-east-1
+```
+
+| option                           | meaning                                                                                                                       |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `--region <r>`                   | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                |
+| `--profile <p>`                  | AWS profile (or `$AWS_PROFILE`)                                                                                               |
+| `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths |
+| `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                    |
+| `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
+| `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                  |
+| `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
+| `--verbose` / `-v`               | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
+| `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
+| `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
+| `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
+| `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                 |
+| `--no-interactive`               | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to bless    |
+
+Unknown options (`--apq`) and options missing their value (`--app` at the end of
+the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.
+
+### Interactive prompts (TTY only — CI is never prompted)
+
+- **`check` with drift** offers `Nothing / Accept / Revert` inline (shown above).
+  `Nothing` is the default; Enter keeps plain-check behavior. Accept and Revert
+  run exactly the same code as the standalone commands. Skipped under `--json`,
+  `--show-all`, and `--pre-deploy`. Aborting the Revert confirmation keeps the
+  exit code at 1 — nothing was written, the drift still stands.
+- **`accept`** shows a multiselect of only the **delta** from the existing
+  baseline (new + changed undeclared values, all pre-selected); already-blessed
+  unchanged values are auto-kept and surfaced with a
+  `keeping N already-blessed unchanged value(s)` note. Deselect a suspicious one
+  and it stays reported by `check` — bless the intentional changes without
+  rubber-stamping the rest. With no baseline yet, the full set is shown.
+- **`check` with no baseline yet** offers to bless the current state on the spot.
+- Flag combinations: `--no-interactive` alone = the read side completes but
+  write **decisions** are refused with exit 2 (the safe side);
+  `--no-interactive --yes` = full automation; `--yes` alone in a TTY
+  auto-approves confirmations only (select prompts still show).
+
+### Ignoring externally-managed properties
+
+Some properties are _legitimately_ rewritten by another system — Application
+Auto Scaling moving an ECS Service `DesiredCount`, autoscaled DynamoDB capacity.
+A blessed snapshot would re-flag every move. List those paths in a git-committed
+`.cdkrd/config.json` instead (strict JSON — no comments or trailing commas):
+
+```json
+{
+  "ignore": ["*.DesiredCount", "Prod*:Fn*.ReservedConcurrentExecutions"]
+}
+```
+
+Rules glob (`*` / `?`) against either `<logicalId>.<path>` or the friendly
+`<constructPath>.<path>` (e.g. `MyStack/ApiRole.Policies`); prefix with
+`<stack glob>:` to scope to matching stacks; a parent rule covers child paths.
+Matching findings move to the informational `ignored` tier — still visible under
+`--verbose`, never exit-affecting, and excluded from `revert` plans and `accept`.
+A **deleted resource is never ignorable**.
+
+## Output
+
+Drift tiers (`deleted` / `declared` / `undeclared`) are always printed in full —
+they are the point. Informational tiers (`readGap` / `unresolved` / `skipped` /
+`ignored`) fold into an `info:` footer with per-reason counts; `--verbose`
+expands them to full lists. Greppable: `^result:` is the verdict; for machine
+consumption the formal contract is `--json`.
+
+```console
+=== cdkrd check: ApiStack (us-east-1) ===
+
+[DECLARED DRIFT] 1
+  ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
+      desired="Enabled"
+      actual ="Suspended"
+result: 1 drift(s) (declared=1)
+info:
+  - readGap=1 (write-only 1)
+  - skipped=2 (custom resource 2)
+  run with --verbose for the list
+```
+
+### JSON output contract
+
+`--json` emits
+`{ "stack": "<name> (<region>)", "drifted": <n>, "findings": [...] }`.
+Each finding has a stable shape: `tier` (`deleted` | `declared` | `undeclared` |
+`readGap` | `unresolved` | `skipped` | `ignored`), `logicalId`, `resourceType`,
+`path`, `desired`, `actual`, `note`, `physicalId`, `constructPath`. It always
+carries every finding regardless of `--verbose`. After publication this shape is
+treated as a backward-compatible API.
+
 ## IAM permissions
 
-`check` / `accept` are **read-only**. The AWS managed `ReadOnlyAccess` policy covers
-them. If you scope tighter, the calls are:
+`check` / `accept` are **read-only**. The AWS managed `ReadOnlyAccess` policy
+covers them. If you scope tighter, the calls are:
 
 <details>
 <summary>Minimal read permissions (check / accept)</summary>
@@ -189,138 +279,16 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 
 **If you never run `revert`, cdkrd needs no write permissions at all.**
 
-## Commands & options
-
-| command                     | does                                                                   |
-| --------------------------- | ---------------------------------------------------------------------- |
-| `cdkrd check [<stack>...]`  | compare live state vs template (declared) + baseline (undeclared)      |
-| `cdkrd accept [<stack>...]` | snapshot undeclared state into the baseline (CI / non-TTY: `--yes`)    |
-| `cdkrd revert [<stack>...]` | write the desired value back to AWS (confirms; `--dry-run` to preview) |
-
-- Stack selection (no args = all app stacks / glob / exact name):
-  see [Selecting stacks](#selecting-stacks).
-- **Exit codes:** `0` clean · `1` drift · `2` error — so `check` drops straight into
-  CI:
-
-```yaml
-- run: npm ci # cdkrd resolves the CDK app, so its deps must be installed
-- run: npx cdkrd check --region us-east-1 # fails the job on drift
-# or point at a prebuilt assembly artifact instead of synthesizing:
-# - run: npx cdkrd check --app cdk.out --region us-east-1
-```
-
-| option                           | meaning                                                                                                                       |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `--region <r>`                   | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                |
-| `--profile <p>`                  | AWS profile (or `$AWS_PROFILE`)                                                                                               |
-| `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths |
-| `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                    |
-| `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
-| `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                  |
-| `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
-| `--verbose` / `-v`               | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
-| `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
-| `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
-| `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
-| `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                 |
-| `--no-interactive`               | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to bless    |
-
-Unknown options (`--apq`) and options missing their value (`--app` at the end of
-the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.
-
-### Interactive flows (TTY only, opt out with `--no-interactive` — CI is never prompted)
-
-- **`check` with drift** offers `Nothing / Accept / Revert` inline (shown above).
-  `Nothing` is the default; Enter keeps plain-check behavior. Accept and Revert run
-  exactly the same code as the standalone commands. Skipped under `--json`,
-  `--show-all`, and `--pre-deploy`. Aborting the Revert confirmation keeps the
-  exit code at 1 (nothing was written — the drift still stands).
-- **`accept`** shows a multiselect of only the **delta** from the existing
-  baseline (new + changed undeclared values), all pre-selected. Values already
-  blessed and unchanged are auto-kept (you never re-confirm a 50-item snapshot
-  after changing one thing) and surfaced with a
-  `keeping N already-blessed unchanged value(s)` note. Deselect a suspicious one
-  and it stays reported by `check` — bless the intentional changes without
-  rubber-stamping the rest. With no baseline yet, the full set is shown (the true
-  first bless); when nothing is new, the baseline is just refreshed.
-  Non-interactively (CI / non-TTY / `--no-interactive`) this selection can't be
-  made, so `accept` refuses with exit 2 unless `--yes` is passed to bless **all**
-  undeclared values.
-- **`check` with no baseline yet** offers to bless the current state on the spot.
-
-Flag combinations: `--no-interactive` alone = the read side completes but write
-**decisions** are refused (the safe side — `accept` without `--yes` exits 2, and
-`revert` without `--yes` exits 2); `--no-interactive --yes` = full automation;
-`--yes` alone in a TTY auto-approves confirmations only (select prompts still show).
-
-### Ignoring externally-managed properties
-
-Some properties are _legitimately_ rewritten by another system — Application Auto
-Scaling moving an ECS Service `DesiredCount`, autoscaled DynamoDB capacity. A
-blessed value snapshot would re-flag every move. List those paths in a
-git-committed `.cdkrd/config.json` instead:
-
-```json
-{
-  "ignore": ["*.DesiredCount", "Prod*:Fn*.ReservedConcurrentExecutions"]
-}
-```
-
-`"*.DesiredCount"` ignores that property on any stack / logical id;
-`"Prod*:Fn*.ReservedConcurrentExecutions"` is stack-scoped (`<stack glob>:<pattern>`)
-to stacks matching `Prod*`. (`.cdkrd/config.json` is strict JSON — no comments or
-trailing commas.)
-
-Rules glob (`*` / `?`) against either `<logicalId>.<path>` or the friendly
-`<constructPath>.<path>` (e.g. `MyStack/ApiRole.Policies`); a parent rule covers child
-paths. Matching findings move to the informational `ignored` tier — still visible
-in the `info:` footer and under `--verbose`, never exit-affecting, and excluded from
-`revert` plans and `accept`. A **deleted resource is never ignorable**.
-
-## Output
-
-Drift tiers (`deleted` / `declared` / `undeclared`) are always printed in full —
-they are the point. Informational tiers (`readGap` / `unresolved` / `skipped` /
-`ignored`) fold into an `info:` footer with per-reason counts — a single line when
-one tier is present, one bullet line per tier when there are several; `--verbose`
-expands them to full lists. Zero-count tiers are omitted. A CLEAN stack with one
-informational tier is exactly three lines (header / `result:` / `info:`); in a
-multi-stack run, consecutive stack reports are separated by a single blank line.
-Greppable: `^result:` is the verdict; for machine consumption the formal contract
-is `--json` (the `info:` footer may span multiple lines).
-
-```console
-=== cdkrd check: ApiStack (us-east-1) ===
-
-[DECLARED DRIFT] 1
-  ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
-      desired="Enabled"
-      actual ="Suspended"
-result: 1 drift(s) (declared=1)
-info:
-  - readGap=1 (write-only 1)
-  - skipped=2 (custom resource 2)
-  run with --verbose for the list
-```
-
-### JSON output contract
-
-`--json` emits `{ "stack": "<name> (<region>)", "drifted": <n>, "findings": [...] }`.
-Each finding has a stable shape: `tier` (`deleted` | `declared` | `undeclared` |
-`readGap` | `unresolved` | `skipped` | `ignored`), `logicalId`, `resourceType`, `path`,
-`desired`, `actual`, `note`, `physicalId`, `constructPath`. It always carries every
-finding regardless of `--verbose`. After publication this shape is treated as a
-backward-compatible API.
-
 ## Limitations
 
 - **Fail-closed by design.** A property `cdkrd` cannot confidently compare (an
-  exotic intrinsic, a write-only value, a Cloud-Control-unreadable type) is reported
-  as informational, never guessed. You trade a little coverage for zero false drift.
+  exotic intrinsic, a write-only value, a Cloud-Control-unreadable type) is
+  reported as informational, never guessed. You trade a little coverage for zero
+  false drift.
 - **Revert cannot do everything.** Not revertable, and reported as such:
-  - **undeclared drift on a stack with NO baseline** — there is no blessed value to
-    write back, so `revert` refuses (run `accept` first, or opt into removal with
-    `--remove-unblessed`); the plan leads with a note pointing at that route;
+  - **undeclared drift on a stack with NO baseline** — there is no blessed value
+    to write back, so `revert` refuses (run `accept` first, or opt into removal
+    with `--remove-unblessed`);
   - a `deleted` resource (recreate it with `cdk deploy`);
   - **create-only** properties (changing them requires resource replacement);
   - toggle-style properties with no "absent" state (e.g. S3 transfer acceleration
@@ -328,13 +296,14 @@ backward-compatible API.
   - `AWS::Lambda::Permission` and `AWS::Budgets::Budget` (their write APIs cannot
     safely reconstruct the desired state from what is readable).
 
-  Not-revertable findings fold into a one-line-per-reason summary (`--verbose` for
-  the full list). When drift exists but **nothing** is revertable, `revert` prints
-  `nothing revertable — N drift(s) remain.` and exits 1 (the drift still stands);
-  exit 0 means there was no drift to revert at all.
+  Not-revertable findings fold into a one-line-per-reason summary (`--verbose`
+  for the full list). When drift exists but **nothing** is revertable, `revert`
+  prints `nothing revertable — N drift(s) remain.` and exits 1 (the drift still
+  stands); exit 0 means there was no drift to revert at all.
 
-- **Revert writes the canonical form** of the desired value — semantically equal to
-  your template, but statement/tag ordering or scalar-vs-array may differ textually.
+- **Revert writes the canonical form** of the desired value — semantically equal
+  to your template, but statement/tag ordering or scalar-vs-array may differ
+  textually.
 - **Custom resources** (`Custom::*`) have no cloud-side model and are always
   `skipped` (without an API call).
 - **Lambda Permission:** if only the specific statement was removed out of band
@@ -345,56 +314,44 @@ backward-compatible API.
 
 **How is this different from `cdk deploy --revert-drift`?**
 Two axes. **Coverage:** `--revert-drift` (aws-cdk ≥ v2.1110.0) is built on
-CloudFormation drift detection, so like `cdk drift` it only sees properties in your
-template — undeclared drift (an inline policy or `OwnershipControls` nobody wrote)
-is invisible to it, and is exactly what `cdkrd` exists to catch. **Mechanism:**
-`--revert-drift` reverts as part of a `cdk deploy` and reconciles to the **synth**
-template, so any pending local code changes ship in the same operation. `cdkrd
-revert` is drift-only and per-finding: it reverts to the **deployed** template /
-baseline (never your un-deployed code), touches just the divergence, and previews
-with `--dry-run`. Use `--revert-drift` to fold a declared-drift fix into a release;
-use `cdkrd` to find and undo out-of-band change — declared _or_ undeclared —
-without deploying.
+CloudFormation drift detection, so it only sees properties in your template —
+undeclared drift is invisible to it, and is exactly what `cdkrd` exists to
+catch. **Mechanism:** `--revert-drift` reconciles to the **synth** template as
+part of a `cdk deploy`, so any pending local code changes ship in the same
+operation. `cdkrd revert` is drift-only and per-finding: it reverts to the
+**deployed** template / baseline (never your un-deployed code), touches just the
+divergence, and previews with `--dry-run`.
 
 **Why a committed baseline file — isn't the CloudFormation schema enough?**
 A stateless schema comparison gives each property only two modes: report forever
-(noise) or ignore forever (blind). The baseline adds the third one drift detection
-actually needs: _this value is OK — alarm only when it changes_. Example:
-account-level "EBS encryption by default" makes every volume `Encrypted: true`
-while the schema default is `false` — report-forever is permanent noise, ignoring
-it hides a real disable, the baseline pins `true` and alarms only on `false`.
+(noise) or ignore forever (blind). The baseline adds the third one drift
+detection actually needs: _this value is OK — alarm only when it changes_.
+Example: account-level "EBS encryption by default" makes every volume
+`Encrypted: true` while the schema default is `false` — the baseline pins `true`
+and alarms only on `false`.
 
-**How can `cdkrd` catch a change to a property that is in neither my template nor
-the baseline?**
-The baseline is not a watch-list. Every `check` reads the _full_ live model, then
-subtracts template + schema + baseline. A property that newly appears (or changes)
-with a meaningful value survives the subtraction and is reported — whether or not
-anyone listed it anywhere first.
+**How can `cdkrd` catch a change to a property that is in neither my template
+nor the baseline?**
+The baseline is not a watch-list. Every `check` reads the _full_ live model,
+then subtracts template + schema + baseline. A property that newly appears (or
+changes) with a meaningful value survives the subtraction and is reported.
 
 **Why doesn't `--show-all` list a feature that is explicitly OFF?**
-Undeclared values that are `false`/empty are suppressed — AWS returns an "off/empty"
-value for nearly every unset option, and keeping them would flood the output. The
-case that matters is still caught: a blessed value that later flips to `false`/empty
-out of band is reported via baseline removal-detection.
-
-**Why does the reverted value not match my template character-for-character?**
-Revert writes the canonical (structurally compared) form. It is semantically
-identical; ordering and scalar-vs-array may differ.
+Undeclared values that are `false`/empty are suppressed — AWS returns an
+"off/empty" value for nearly every unset option, and keeping them would flood
+the output. The case that matters is still caught: a blessed value that later
+flips to `false`/empty out of band is reported via baseline removal-detection.
 
 **A property keeps drifting because an autoscaler manages it — do I have to
 re-accept forever?**
 No — list it in `.cdkrd/config.json`
 (see [Ignoring externally-managed properties](#ignoring-externally-managed-properties)).
-It moves to the informational `ignored` tier: visible, never exit-affecting.
 
 **Is it safe to run in CI / on production accounts?**
-`check` and `accept` make read-only AWS calls (plus a local baseline file write for
-`accept`). `revert` is the only mutating command; it never runs without `--yes` or
-an interactive confirmation, and `--dry-run` shows the plan without changes.
-
-**What does it cost?**
-Nothing beyond the API calls it makes (reads with bounded concurrency and adaptive
-retry). No AWS Config, no recorders, nothing to enable or pay for per-resource.
+`check` and `accept` make read-only AWS calls (plus a local baseline file write
+for `accept`). `revert` is the only mutating command; it never runs without
+`--yes` or an interactive confirmation, and `--dry-run` shows the plan without
+changes.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

### README.md (410 → 366 lines)
- Lead with a new **Why** section: the `cdk drift` = 0 vs `cdkrd` = found scenario and the capability comparison table now open the README.
- Remove the duplicated undeclared-drift example (was shown in both Quick start and "What cdk drift can't see").
- Fold the deleted-tier console example and the multi-account tip into single bullets/sentences.
- Tighten Interactive flows, Ignoring, Output, and FAQ prose; drop the FAQ "What does it cost?" (now one line in Why).
- No factual changes: all flags, exit codes, IAM permissions, limitations, and JSON contract claims are preserved verbatim and re-verified against `src/cli.ts` HELP, `src/cli-args.ts`, and `SDK_WRITERS`.

### CLAUDE.md
- Worktree rule tightened: development ALWAYS happens in a worktree — the "single sequential session may work in the main checkout" exception is removed after a branch created in the shared checkout captured another session's staged R44 commit. The main checkout is reserved for integration.

## Gates
- `check` marker set: typecheck / lint+format / build / 295 unit tests pass.
- `docs` marker set: README re-verified against the CLI surface and writers.