### PR TITLE
feat(report): colorize human-facing output on TTYs (R43)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,7 +40,8 @@ cdkrd is **CDK-only**: every run resolves the CDK app (synth, or a pre-synthesiz
 `cdk.out`) to discover which stacks to check. The drift comparison still reads each
 stack's deployed template + live state from AWS — synth only decides scope + labels
 construct paths (and, in `--pre-deploy`, becomes the declared source). Output is plain
-text + JSON (CI-greppable; no TUI/panes).
+text + JSON (CI-greppable; no TUI/panes; ANSI color on a TTY only — piped/`NO_COLOR`
+output stays byte-identical plain text).
 
 ## Subtractive noise model
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,7 +187,9 @@ checked.
 - **config/config-file.ts** — git-committed project config (`.cdkrd/config.json`): `loadConfig` + `applyIgnores` (R32 path-level ignore rules → `ignored` tier).
 - **revert/** — the write path (section 7): **plan.ts**, **apply.ts** (CC UpdateResource + poll), **apply-ops.ts** (pure RFC6902 apply), **writers.ts** (SDK writers).
 - **synth/** — **synth.ts** (`@aws-cdk/toolkit-lib` synth + `discoverStacks`), **resolve-app.ts**, **io-host.ts** (`QuietIoHost`).
-- **report/report.ts** — tiered text + JSON + exit code. **aws-errors.ts** — `isStackNotDeployed` etc. **types.ts** — shared types.
+- **report/report.ts** — tiered text + JSON + exit code. **report/style.ts** —
+  TTY-only semantic colors (R43). **aws-errors.ts** — `isStackNotDeployed` etc.
+  **types.ts** — shared types.
 
 ## 5. Intrinsic resolver (fail-closed + live-attr GetAtt)
 
@@ -505,6 +507,13 @@ so the two never duplicate); `^result:` stays greppable, but the formal
 machine-readable contract is `--json` (the `info:` footer may span lines). `--json`
 is unaffected — it always carries every finding. A `Custom::*` resource is `skipped`
 without any API call (note: `custom resource — no cloud-side model to read`).
+**Color (R43):** output is colorized via semantic helpers
+([style.ts](../src/report/style.ts), picocolors) — green/red bold verdicts,
+yellow undeclared tier, dim informational footers — ONLY when stdout is a real
+TTY and `NO_COLOR` is unset. Piped / CI / `--json` output is byte-identical
+plain text (the helpers are the identity), so the greppable invariant holds;
+`FORCE_COLOR` is deliberately ignored. The pure formatters (`formatFinding`'s
+ids, `formatPlan`) stay plain; styling happens at the printing edge.
 
 A declared **top-level write-only** property (e.g. an IAM Role's
 `AssumeRolePolicyDocument`) is surfaced as a `readGap` (note: `write-only — cannot

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@aws-sdk/client-sns": "^3.1065.0",
     "@aws-sdk/client-sqs": "^3.1065.0",
     "@clack/prompts": "^1.5.1",
+    "picocolors": "^1.1.1",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       constructs:
         specifier: ^10.0.0
         version: 10.6.0
+      picocolors:
+        specifier: ^1.1.1
+        version: 1.1.1
       yaml:
         specifier: ^2.9.0
         version: 2.9.0

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -16,6 +16,7 @@ import {
   splitAcceptedByBaseline,
 } from '../baseline/baseline-file.js';
 import { applyIgnores, type CdkrdConfig } from '../config/config-file.js';
+import { style } from '../report/style.js';
 import { applyRevertItem } from '../revert/apply.js';
 import { buildRevertPlan, type RevertPlan } from '../revert/plan.js';
 import { SDK_WRITERS } from '../revert/writers.js';
@@ -133,9 +134,11 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
   );
   if (refreshedOnly)
     console.log(
-      `${stackName}: nothing new to bless — baseline refreshed (${count} unchanged value(s))`
+      style.ok(
+        `${stackName}: nothing new to bless — baseline refreshed (${count} unchanged value(s))`
+      )
     );
-  else console.log(`baseline written: ${path} (${count} undeclared value(s) blessed)`);
+  else console.log(style.ok(`baseline written: ${path} (${count} undeclared value(s) blessed)`));
   return { wrote: true, refused: false };
 }
 
@@ -198,7 +201,11 @@ function printPlan(
   plan: RevertPlan,
   opts: PlanDisplayOptions
 ): void {
-  for (const line of formatPlan(stackName, region, plan, opts)) console.log(line);
+  // formatPlan stays pure/plain (unit-tested verbatim); only the banner line is
+  // styled here, at the printing edge.
+  for (const line of formatPlan(stackName, region, plan, opts)) {
+    console.log(line.startsWith('\n=== ') ? '\n' + style.header(line.slice(1)) : line);
+  }
 }
 
 export interface RevertStackParams {
@@ -265,7 +272,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   const plan = buildRevertPlan(drifted, baseline, { removeUnblessed, schemas: gathered.schemas });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {
-    console.log(`${stackName} (${region}): no drift to revert.`);
+    console.log(style.clean(`${stackName} (${region}): no drift to revert.`));
     return { exit: 0, aborted: false };
   }
   printPlan(stackName, region, plan, {
@@ -280,7 +287,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // Drift exists but none of it is revertable (R35). That is NOT the clean
     // "no drift to revert" case — the drift still stands, so exit 1 (the same
     // "drift remains" semantics as a post-apply non-convergence; not a usage error).
-    console.log(`\nnothing revertable — ${driftCount(drifted)} drift(s) remain.`);
+    console.log('\n' + style.drift(`nothing revertable — ${driftCount(drifted)} drift(s) remain.`));
     return { exit: 1, aborted: false };
   }
 
@@ -302,7 +309,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       message: `Apply ${opCount} revert op(s) to ${stackName}? This WRITES to AWS.`,
     });
     if (isCancel(ok) || !ok) {
-      console.log('aborted.');
+      console.log(style.infoTier('aborted.'));
       return { exit: 0, aborted: true };
     }
   }
@@ -331,7 +338,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       r = await applyRevertItem(cc, item);
     }
     console.log(
-      r.ok ? `  reverted: ${item.displayId}` : `  FAILED: ${item.displayId} — ${r.error}`
+      r.ok
+        ? style.ok(`  reverted: ${item.displayId}`)
+        : style.fail(`  FAILED: ${item.displayId} — ${r.error}`)
     );
     if (!r.ok) worst = Math.max(worst, 2);
   }
@@ -341,7 +350,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // scaled with stack size, not with the revert); regatherTouched re-reads only
   // plan.items and carries every other finding forward from the original gather.
   const touched = new Set(plan.items.map((i) => i.logicalId));
-  console.log(`\nverifying convergence (re-reading ${touched.size} resource(s))...`);
+  console.log(
+    '\n' + style.infoTier(`verifying convergence (re-reading ${touched.size} resource(s))...`)
+  );
   const reconcile = (findings: Finding[]): Finding[] =>
     applyIgnores(applyBaseline(findings, baseline, { declaredByLogical }), stackName, config);
   let post = reconcile(await regatherTouched(gathered, touched, region));
@@ -355,8 +366,8 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   const remaining = driftCount(post);
   console.log(
     remaining === 0
-      ? `${stackName}: CLEAN after revert.`
-      : `${stackName}: ${remaining} drift(s) remain.`
+      ? style.clean(`${stackName}: CLEAN after revert.`)
+      : style.drift(`${stackName}: ${remaining} drift(s) remain.`)
   );
   if (remaining > 0) worst = Math.max(worst, 1);
   return { exit: worst, aborted: false };

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -13,6 +13,7 @@
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
 import type { Finding, Tier } from '../types.js';
+import { style } from './style.js';
 
 const TIER_TITLES: Record<Tier, string> = {
   deleted: 'DELETED (resource deleted out of band — always drift)',
@@ -36,12 +37,24 @@ export interface ReportOptions {
 
 export function formatFinding(f: Finding): string {
   // prefer the CDK construct path for the human-facing id; fall back to logical id
+  // (the id stays uncolored — it gets copy-pasted; only the values are styled,
+  // and style.* is the identity when stdout is not a TTY, so piped output and
+  // unit-test assertions see plain text)
   const id = f.constructPath ?? f.logicalId;
   let s = `${f.path ? `${id}.${f.path}` : id} (${f.resourceType})`;
   if (f.note) s += ` — ${f.note}`;
-  if (f.tier === 'declared') s += `\n      desired=${j(f.desired)}\n      actual =${j(f.actual)}`;
-  else if (f.tier === 'undeclared') s += ` = ${j(f.actual)}`;
+  if (f.tier === 'declared')
+    s += `\n      desired=${style.desired(j(f.desired))}\n      actual =${style.actual(j(f.actual))}`;
+  else if (f.tier === 'undeclared') s += ` = ${style.actual(j(f.actual))}`;
   return s;
+}
+
+// section-title color by tier: deleted/declared = red (drift), undeclared =
+// yellow (the differentiator), informational tiers = dim.
+function tierStyle(t: Tier): (s: string) => string {
+  if (t === 'undeclared') return style.undeclaredTier;
+  if (t === 'deleted' || t === 'declared') return style.driftTier;
+  return style.infoTier;
 }
 
 // `deleted` is ALWAYS a failure (the most blatant drift), independent of --fail-on.
@@ -96,11 +109,11 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   const section = (tier: Tier): void => {
     const items = byTier(tier);
     if (items.length === 0) return; // 0-count tiers are never printed
-    log(`\n[${TIER_TITLES[tier]}] ${items.length}`);
+    log('\n' + tierStyle(tier)(`[${TIER_TITLES[tier]}] ${items.length}`));
     for (const f of items) log('  ' + formatFinding(f));
   };
 
-  log(`=== cdkrd check: ${header} ===`);
+  log(style.header(`=== cdkrd check: ${header} ===`));
   // DRIFT tiers: always full detail (the point of the tool)
   for (const tier of DRIFT_TIERS) section(tier);
   // result: line — the conclusion. Lists ONLY the non-zero DRIFT tier counts (the
@@ -112,7 +125,9 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     .map((t) => `${t}=${byTier(t).length}`)
     .join(' ');
   const failNote = (opts.failOn ?? 'undeclared') === 'declared' ? ' (fail-on=declared)' : '';
-  const verdict = drifted === 0 ? 'CLEAN' : `${drifted} drift(s) (${driftCounts})`;
+  // the verdict is the one line that must stand out: green CLEAN / red drift count
+  const verdict =
+    drifted === 0 ? style.clean('CLEAN') : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;
   log(`result: ${verdict}${failNote}`);
   // INFORMATIONAL tiers: footer below result — full sections under --verbose, else a
   // folded summary (counts + reason breakdown): one `info: ...` line for a single
@@ -125,11 +140,11 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
       return items.length ? `${t}=${items.length} (${groupReasons(items)})` : null;
     }).filter((s): s is string => s !== null);
     if (summaries.length === 1) {
-      log(`info: ${summaries[0]} — run with --verbose for the list`);
+      log(style.infoTier(`info: ${summaries[0]} — run with --verbose for the list`));
     } else if (summaries.length > 1) {
-      log('info:');
-      for (const s of summaries) log(`  - ${s}`);
-      log('  run with --verbose for the list');
+      log(style.infoTier('info:'));
+      for (const s of summaries) log(style.infoTier(`  - ${s}`));
+      log(style.infoTier('  run with --verbose for the list'));
     }
   }
   return drifted === 0 ? 0 : 1;

--- a/src/report/style.ts
+++ b/src/report/style.ts
@@ -1,0 +1,43 @@
+// Semantic color helpers for human-facing output (R43). Call sites say WHAT a
+// thing is (a drift verdict, an info footer), not what color it is.
+//
+// Colors are enabled ONLY when stdout is a real terminal and NO_COLOR is unset:
+// piped / CI / --json output stays byte-identical plain text, so the
+// CI-greppable invariant (`grep '^result:'`) and the `--json` contract are
+// untouched. FORCE_COLOR is deliberately ignored — test runners set it for
+// their own reporters, and honoring it would make committed-test output
+// environment-dependent.
+import pc from 'picocolors';
+
+export interface Style {
+  header: (s: string) => string; // === cdkrd check/revert: ... === banners
+  driftTier: (s: string) => string; // deleted / declared section titles
+  undeclaredTier: (s: string) => string; // the differentiator tier title
+  infoTier: (s: string) => string; // informational tier titles + info:/note footers
+  clean: (s: string) => string; // result: CLEAN / CLEAN after revert. / no drift
+  drift: (s: string) => string; // result: N drift(s) / N drift(s) remain.
+  desired: (s: string) => string; // desired= value (what it should be)
+  actual: (s: string) => string; // actual = value (what it really is)
+  ok: (s: string) => string; // reverted: / baseline written:
+  fail: (s: string) => string; // FAILED:
+}
+
+/** Build the palette on top of a picocolors instance (identity when disabled). */
+export function makeStyle(c: ReturnType<typeof pc.createColors>): Style {
+  return {
+    header: c.bold,
+    driftTier: (s) => c.bold(c.red(s)),
+    undeclaredTier: (s) => c.bold(c.yellow(s)),
+    infoTier: c.dim,
+    clean: (s) => c.bold(c.green(s)),
+    drift: (s) => c.bold(c.red(s)),
+    desired: c.green,
+    actual: c.red,
+    ok: c.green,
+    fail: (s) => c.bold(c.red(s)),
+  };
+}
+
+export const colorEnabled = process.stdout.isTTY === true && process.env['NO_COLOR'] === undefined;
+
+export const style: Style = makeStyle(pc.createColors(colorEnabled));

--- a/tests/style.test.ts
+++ b/tests/style.test.ts
@@ -1,0 +1,69 @@
+import pc from 'picocolors';
+import { describe, expect, it } from 'vite-plus/test';
+import { report } from '../src/report/report.js';
+import { makeStyle, style } from '../src/report/style.js';
+import type { Finding } from '../src/types.js';
+
+const ESC = '\x1b';
+const SAMPLE = 'result: CLEAN — [tier] 1';
+
+describe('style (R43 — colors only on a TTY)', () => {
+  it('every helper is the identity when colors are disabled (piped / CI output is byte-identical)', () => {
+    const s = makeStyle(pc.createColors(false));
+    for (const fn of Object.values(s)) expect(fn(SAMPLE)).toBe(SAMPLE);
+  });
+
+  it('helpers emit ANSI when colors are enabled', () => {
+    const s = makeStyle(pc.createColors(true));
+    expect(s.clean(SAMPLE)).toContain(ESC);
+    expect(s.clean(SAMPLE)).toContain(SAMPLE);
+    expect(s.undeclaredTier('x')).toContain(`${ESC}[33m`); // yellow — distinct from declared/deleted red
+    expect(s.driftTier('x')).toContain(`${ESC}[31m`); // red
+  });
+
+  it('the module-level style is the identity in a non-TTY environment (this test run)', () => {
+    // vitest workers run with piped stdio, so this asserts the real default path
+    expect(style.drift(SAMPLE)).toBe(SAMPLE);
+  });
+});
+
+describe('report output never carries ANSI when piped (R43)', () => {
+  const findings: Finding[] = [
+    {
+      tier: 'declared',
+      logicalId: 'B',
+      resourceType: 'AWS::S3::Bucket',
+      path: 'VersioningConfiguration',
+      desired: { Status: 'Enabled' },
+      actual: { Status: 'Suspended' },
+    },
+    {
+      tier: 'undeclared',
+      logicalId: 'B',
+      resourceType: 'AWS::S3::Bucket',
+      path: 'AccelerateConfiguration',
+      actual: { AccelerationStatus: 'Enabled' },
+    },
+    {
+      tier: 'skipped',
+      logicalId: 'C',
+      resourceType: 'Custom::X',
+      path: '',
+      note: 'custom resource',
+    },
+  ];
+
+  it('text report: no ESC byte, and `^result:` stays greppable', () => {
+    const lines: string[] = [];
+    report(findings, 'S (us-east-1)', { log: (s) => lines.push(s) });
+    const out = lines.join('\n');
+    expect(out).not.toContain(ESC);
+    expect(out).toMatch(/^result: 2 drift\(s\)/m);
+  });
+
+  it('--json report: no ESC byte ever', () => {
+    const lines: string[] = [];
+    report(findings, 'S (us-east-1)', { json: true, log: (s) => lines.push(s) });
+    expect(lines.join('\n')).not.toContain(ESC);
+  });
+});


### PR DESCRIPTION
## Summary

Colorizes the human-facing CLI output (dogfooding finding R43: "output is
bland; `result:` doesn't stand out").

## Changes

- **New `src/report/style.ts`** — semantic helpers on top of `picocolors`
  (new runtime dep; zero-dep, ~7KB): `header` (bold banners), `driftTier`
  (red bold), `undeclaredTier` (yellow bold — the differentiator, distinct
  from declared/deleted red), `clean` (green bold), `drift` (red bold),
  `desired`/`actual` (green/red values), `ok`/`fail`, `infoTier` (dim).
- **Colors only on a real TTY** with `NO_COLOR` unset. `FORCE_COLOR` is
  deliberately ignored (test runners set it for their own reporters). Piped
  / CI / `--json` output is byte-identical plain text — `grep '^result:'`
  and the `--json` contract are untouched.
- **`report.ts`** — check banner, tier section titles, `result:` verdict,
  `desired=`/`actual =` values, `info:` footer. Finding ids stay plain
  (copy-paste).
- **`stack-actions.ts`** — revert banner (at the printing edge —
  `formatPlan` stays pure/plain and its tests are unchanged),
  `reverted:`/`FAILED:`, convergence verdict, `no drift to revert.`,
  `nothing revertable…`, `aborted.`, accept's `baseline written:` lines.
  stderr notes/errors stay plain.
- **Docs** — ARCHITECTURE.md §9 color paragraph + module map entry,
  DESIGN.md output note. README sample blocks intentionally stay plain
  (piped output IS plain); a TTY-color note for README can ride the next
  README pass.

## Tests (`tests/style.test.ts`)

- Every helper is the identity when colors are disabled (piped/CI output
  byte-identical — proven, not assumed).
- Helpers emit ANSI when enabled (yellow undeclared, red drift).
- Module-level `style` resolves to identity in a non-TTY run.
- Text report: no ESC byte and `^result:` still greppable; `--json`: no
  ESC byte ever.
- All existing report/formatPlan tests pass UNCHANGED (the pure formatters
  stayed plain).

## Gates

| Check | Result |
| --- | --- |
| typecheck | pass |
| lint + format (`vp check`) | pass |
| build | pass |
| tests | 28 files, 306 tests, all pass (+5 new) |

`check` + `docs` markers set. Developed in a worktree per the new
workflow rule (#10).
