### PR TITLE
docs(readme): drop the no-AWS-Config cost line from the Why section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ result: 1 drift(s) (undeclared=1)
 | **Revert** undeclared drift                                         |   ✅    |                ❌                 |
 | **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |
 
-No AWS Config, no recorders — nothing to enable or pay for per-resource.
-
 ## Quick start
 
 _Not yet on npm — coming with the first public release._


### PR DESCRIPTION
Removes the "No AWS Config, no recorders — nothing to enable or pay for per-resource." line after the comparison table; the Why section ends on the table.

Gates: check (typecheck / lint+format / build / 301 tests) and docs markers set.