### PR TITLE
feat(check): make the first-run (no-baseline) prompt an informed choice (R45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,11 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
   `keeping N already-blessed unchanged value(s)` note. Deselect a suspicious one
   and it stays reported by `check` — bless the intentional changes without
   rubber-stamping the rest. With no baseline yet, the full set is shown.
-- **`check` with no baseline yet** offers to bless the current state on the spot.
+- **`check` with no baseline yet** asks what to do with the N undeclared values
+  it found: **show them first** (the default — the report prints, and a
+  selective accept is offered right after it), or **accept ALL of them** into
+  the baseline without reviewing them. With zero undeclared values there is
+  nothing to decide, so no prompt.
 - Flag combinations: `--no-interactive` alone = the read side completes but
   write **decisions** are refused with exit 2 (the safe side);
   `--no-interactive --yes` = full automation; `--yes` alone in a TTY

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -3,7 +3,7 @@
 // Read-only. Reports drift per stack; undeclared findings are filtered against the
 // baseline file (if present) so a blessed stack reports CLEAN. Exit code is the
 // worst across all checked stacks (0 clean / 1 drift / 2 error).
-import { confirm, isCancel, select } from '@clack/prompts';
+import { isCancel, select } from '@clack/prompts';
 import { isStackNotDeployed } from '../aws-errors.js';
 import {
   applyBaseline,
@@ -33,6 +33,31 @@ import {
 // it is excluded. Exported (pure) so the contract is unit-tested.
 export function preDeployFindings(findings: Finding[]): Finding[] {
   return findings.filter((f) => f.tier !== 'undeclared');
+}
+
+// The first-run (no-baseline) prompt (R45). The old Yes/No confirm hid the two
+// facts the decision hinges on: HOW MANY values "Yes" would accept sight-unseen,
+// and that "No" is not a dead end (the report prints first and a selective
+// accept is offered right after it). A select carries both in the option labels
+// themselves; "show first" is the safe default. Exported (pure) so the wording
+// contract is unit-tested.
+export function firstRunPrompt(
+  stackName: string,
+  undeclaredCount: number
+): { message: string; options: { value: 'show' | 'acceptAll'; label: string }[] } {
+  return {
+    message: `${stackName}: no baseline yet — ${undeclaredCount} undeclared value(s) found (declared drift is reported either way). What do you want to do?`,
+    options: [
+      {
+        value: 'show',
+        label: 'Show them first — you can still accept (selectively) right after the report',
+      },
+      {
+        value: 'acceptAll',
+        label: `Accept ALL ${undeclaredCount} into the baseline now, without reviewing them`,
+      },
+    ],
+  };
 }
 
 export async function runCheck(args: string[]): Promise<number> {
@@ -132,21 +157,34 @@ export async function runCheck(args: string[]): Promise<number> {
       if (baseline) checkBaselineAccount(baseline, desired.accountId, stackName);
       // stale-baseline warning (pre-deploy already returned above, so always safe here)
       if (baseline) warnTemplateHashDrift(baseline, desired.rawTemplate, stackName);
-      // first run: no baseline yet → offer to bless interactively (TTY only)
+      // First run: no baseline yet → choose between "report first" (the safe
+      // default — a selective accept is offered again right after the report) and
+      // a bulk accept of everything sight-unseen (R45). Ignore rules are applied
+      // BEFORE counting/accepting so the bulk path can never bless values the
+      // report would have re-tagged as ignored (same as the post-report accept).
+      // With ZERO undeclared values there is no decision worth interrupting for —
+      // no prompt (`cdkrd accept` still writes a baseline for a clean stack).
       if (!baseline && !a.showAll && !a.json && isInteractive(a)) {
-        const ok = await confirm({
-          message: `${stackName}: no baseline yet — bless the current UNDECLARED state as the baseline? (declared drift, i.e. reality vs the deployed template, is reported either way)`,
-        });
-        if (!isCancel(ok) && ok) {
-          const { count } = await blessStack(
-            stackName,
-            region,
-            desired.accountId,
-            findings,
-            desired.rawTemplate
-          );
-          console.error(`baseline written (${count} undeclared value(s) blessed) — commit it.`);
-          baseline = await loadBaseline(stackName, desired.accountId, region);
+        const blessable = applyIgnores(findings, stackName, config);
+        const undeclaredCount = blessable.filter((f) => f.tier === 'undeclared').length;
+        if (undeclaredCount > 0) {
+          const prompt = firstRunPrompt(stackName, undeclaredCount);
+          const choice = await select({
+            message: prompt.message,
+            options: prompt.options,
+            initialValue: 'show' as const,
+          });
+          if (!isCancel(choice) && choice === 'acceptAll') {
+            const { count } = await blessStack(
+              stackName,
+              region,
+              desired.accountId,
+              blessable,
+              desired.rawTemplate
+            );
+            console.error(`baseline written (${count} undeclared value(s) accepted) — commit it.`);
+            baseline = await loadBaseline(stackName, desired.accountId, region);
+          }
         }
       }
       if (!a.json && !baseline && !a.showAll) {

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { preDeployFindings } from '../src/commands/check.js';
+import { firstRunPrompt, preDeployFindings } from '../src/commands/check.js';
 import type { Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
@@ -24,5 +24,34 @@ describe('preDeployFindings (--pre-deploy scope)', () => {
   it('is a no-op when there are no undeclared findings (regression)', () => {
     const findings = [F('declared'), F('readGap')];
     expect(preDeployFindings(findings)).toEqual(findings);
+  });
+});
+
+describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', () => {
+  it('the message carries the stack name and the undeclared count', () => {
+    const { message } = firstRunPrompt('ApiStack', 113);
+    expect(message).toContain('ApiStack: no baseline yet');
+    expect(message).toContain('113 undeclared value(s) found');
+    expect(message).toContain('declared drift is reported either way');
+  });
+
+  it('"show first" is the FIRST option (the safe default) and says accept is still possible after', () => {
+    const { options } = firstRunPrompt('S', 5);
+    expect(options[0]!.value).toBe('show');
+    expect(options[0]!.label).toContain('Show them first');
+    expect(options[0]!.label).toContain('accept (selectively) right after');
+  });
+
+  it('the bulk option states the count and that values have NOT been reviewed', () => {
+    const { options } = firstRunPrompt('S', 113);
+    const bulk = options.find((o) => o.value === 'acceptAll')!;
+    expect(bulk.label).toContain('Accept ALL 113');
+    expect(bulk.label).toContain('without reviewing them');
+  });
+
+  it('no option says "bless" — prompts speak the command vocabulary (accept)', () => {
+    const p = firstRunPrompt('S', 3);
+    const all = [p.message, ...p.options.map((o) => o.label)].join(' ');
+    expect(all.toLowerCase()).not.toContain('bless');
   });
 });


### PR DESCRIPTION
## Summary

Dogfooding feedback: the first-run `no baseline yet — bless ... ?` Yes/No confirm didn't convey that **Yes = accept ALL 113 values without seeing them**, nor that **No still allows a selective accept right after the report**. `bless` also isn't the vocabulary the user runs (`accept` is).

## Changes

- The confirm becomes a **select whose labels carry the semantics**:
  ```
  ApiStack: no baseline yet — 113 undeclared value(s) found (declared drift is reported either way). What do you want to do?
    ❯ Show them first — you can still accept (selectively) right after the report
      Accept ALL 113 into the baseline now, without reviewing them
  ```
  "Show first" is the safe default (Enter ≒ old No, but now self-explanatory).
- **Ignore rules applied before counting/accepting** — the bulk path previously passed raw findings to `blessStack`, so it could bless values the report re-tags as `ignored`; the post-report accept path already applied them. Now aligned.
- **Zero undeclared values → no prompt** (nothing to decide; `cdkrd accept` still writes a baseline for a clean stack).
- Prompt vocabulary: `accept` instead of `bless` (`baseline written (N ... accepted)`). The repo-wide `bless` retirement is R46 (next PR).
- `firstRunPrompt()` exported pure; README "Interactive prompts" updated.

## Tests

`tests/check.test.ts`: message carries stack name + count; "show" is the FIRST option and mentions the post-report accept; bulk label states the count and "without reviewing them"; no option says "bless". (+4, total 310.)

## Gates

typecheck / lint+format / build / tests all pass; `check` + `docs` markers set; developed in a worktree.