### PR TITLE
feat(cli)!: retire the 'bless' vocabulary — speak accept/baseline everywhere (R47)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ pre-publication decisions).
 
 ```bash
 node dist/cli.js check  [<stack>...] [--all]   # detect drift (read-only)
-node dist/cli.js accept [<stack>...] [--all]   # bless current state into the baseline file
+node dist/cli.js accept [<stack>...] [--all]   # record current state into the baseline file
 node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to AWS (confirms)
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ terminal, it asks what to do right there:
 ```console
 ApiStack: drift found — what do you want to do?
   ❯ Nothing (keep exit code 1)
-    Accept — bless current state into the baseline (a git file; nothing written to AWS)
+    Accept — record current state into the baseline (a git file; nothing written to AWS)
     Revert — write the desired value back to AWS
 ```
 
 - **Accept** records the value in a git-committed baseline, so `check` stays
-  CLEAN until it changes again (a multiselect lets you bless some and keep
+  CLEAN until it changes again (a multiselect lets you accept some and keep
   reporting others).
 - **Revert** shows a plan, confirms, then writes the desired value back to AWS:
 
@@ -91,15 +91,15 @@ Requirements: Node.js >= 20, AWS credentials via the standard SDK chain
 
 After `check` finds drift, the human decision is binary, and the verbs mirror it:
 
-| verb           | meaning                                                 | writes               |
-| -------------- | ------------------------------------------------------- | -------------------- |
-| `cdkrd check`  | find drift                                              | nothing              |
-| `cdkrd accept` | "this state is RIGHT" — bless it into the baseline file | a git file only      |
-| `cdkrd revert` | "this state is WRONG" — write the desired value back    | AWS (plan + confirm) |
+| verb           | meaning                                                | writes               |
+| -------------- | ------------------------------------------------------ | -------------------- |
+| `cdkrd check`  | find drift                                             | nothing              |
+| `cdkrd accept` | "this state is RIGHT" — record it in the baseline file | a git file only      |
+| `cdkrd revert` | "this state is WRONG" — write the desired value back   | AWS (plan + confirm) |
 
 - **Declared** properties are compared against the **deployed template** — no
   baseline involved, drift is detected from the first run.
-- **Undeclared** properties are compared against a **baseline** you bless with
+- **Undeclared** properties are compared against a **baseline** you record with
   `accept`: a JSON file at `.cdkrd/<stack>.<accountId>.<region>.json`, committed
   to git. A PR that changes it is a visible, reviewable change to "what real
   state we accept". Account id and region are part of the filename, so the same
@@ -168,9 +168,9 @@ into CI:
 | `--verbose` / `-v`               | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
 | `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
 | `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
-| `--remove-unblessed`             | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
-| `--yes` / `-y`                   | skip confirmations (revert apply; accept blesses all without the multiselect)                                                 |
-| `--no-interactive`               | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to bless    |
+| `--remove-unaccepted`            | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
+| `--yes` / `-y`                   | skip confirmations (revert apply; accept records all without the multiselect)                                                 |
+| `--no-interactive`               | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to write    |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
 the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.
@@ -183,10 +183,10 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
   `--show-all`, and `--pre-deploy`. Aborting the Revert confirmation keeps the
   exit code at 1 — nothing was written, the drift still stands.
 - **`accept`** shows a multiselect of only the **delta** from the existing
-  baseline (new + changed undeclared values, all pre-selected); already-blessed
+  baseline (new + changed undeclared values, all pre-selected); already-accepted
   unchanged values are auto-kept and surfaced with a
-  `keeping N already-blessed unchanged value(s)` note. Deselect a suspicious one
-  and it stays reported by `check` — bless the intentional changes without
+  `keeping N already-accepted unchanged value(s)` note. Deselect a suspicious one
+  and it stays reported by `check` — accept the intentional changes without
   rubber-stamping the rest. With no baseline yet, the full set is shown.
 - **`check` with no baseline yet** asks what to do with the N undeclared values
   it found: **show them first** (the default — the report prints, and a
@@ -202,7 +202,7 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
 
 Some properties are _legitimately_ rewritten by another system — Application
 Auto Scaling moving an ECS Service `DesiredCount`, autoscaled DynamoDB capacity.
-A blessed snapshot would re-flag every move. List those paths in a git-committed
+An accepted snapshot would re-flag every move. List those paths in a git-committed
 `.cdkrd/config.json` instead (strict JSON — no comments or trailing commas):
 
 ```json
@@ -291,9 +291,9 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   reported as informational, never guessed. You trade a little coverage for zero
   false drift.
 - **Revert cannot do everything.** Not revertable, and reported as such:
-  - **undeclared drift on a stack with NO baseline** — there is no blessed value
+  - **undeclared drift on a stack with NO baseline** — there is no baseline value
     to write back, so `revert` refuses (run `accept` first, or opt into removal
-    with `--remove-unblessed`);
+    with `--remove-unaccepted`);
   - a `deleted` resource (recreate it with `cdk deploy`);
   - **create-only** properties (changing them requires resource replacement);
   - toggle-style properties with no "absent" state (e.g. S3 transfer acceleration
@@ -344,7 +344,7 @@ changes) with a meaningful value survives the subtraction and is reported.
 **Why doesn't `--show-all` list a feature that is explicitly OFF?**
 Undeclared values that are `false`/empty are suppressed — AWS returns an
 "off/empty" value for nearly every unset option, and keeping them would flood
-the output. The case that matters is still caught: a blessed value that later
+the output. The case that matters is still caught: an accepted value that later
 flips to `false`/empty out of band is reported via baseline removal-detection.
 
 **A property keeps drifting because an autoscaler manages it — do I have to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,7 +49,7 @@ security-relevant drift hides.**
 subset), and report everything that diverges — then make the noise tractable by
 _subtracting_ what's explainable (the template, the resource schema, AWS-managed
 fields, canonicalization) rather than by maintaining a hand-curated allow-list of
-"things worth watching." Give the result a baseline you bless and commit to git, so
+"things worth watching." Give the result a baseline you accept and commit to git, so
 "what undeclared state we accept" becomes a reviewable artifact, and let the user
 `revert` the rest.
 
@@ -79,7 +79,7 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    code edits never masquerade as drift; `--pre-deploy` is the opt-in inversion.
    _Right call, or do users actually expect code-vs-reality by default?_
 5. **Git-committed baseline as the undeclared contract.** Undeclared "drift" is only
-   drift relative to a human-blessed snapshot. _Is a committed file the right control
+   drift relative to a human-accepted snapshot. _Is a committed file the right control
    surface, or does it become a rubber-stamp that hides real change?_
 6. **Revert via the same generic CC write path** (UpdateResource) + thin SDK writers,
    not a per-type provider fleet. _Is generic revert safe/complete enough, or are the
@@ -96,7 +96,7 @@ the verbs mirror it (see [redesign-notes.md](redesign-notes.md) Decision 1):
 | verb           | meaning                                                            | writes          |
 | -------------- | ------------------------------------------------------------------ | --------------- |
 | `cdkrd check`  | find drift (declared vs deployed template, undeclared vs baseline) | nothing         |
-| `cdkrd accept` | "current state is RIGHT" — bless it into the baseline file         | git file only   |
+| `cdkrd accept` | "current state is RIGHT" — record it in the baseline file          | git file only   |
 | `cdkrd revert` | "current state is WRONG" — write the desired value back to AWS     | AWS (confirmed) |
 
 In a TTY, `check` makes that binary decision **inline** (R28): after reporting drift
@@ -143,7 +143,7 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
    --- PASS 2:   classify
 4. normalize / subtract  classify.ts orchestrates the normalizers (section 6)
 5. classify (tier)       deleted | declared | undeclared | readGap | unresolved | skipped
-6. baseline filter       applyBaseline(): undeclared findings already blessed → drop
+6. baseline filter       applyBaseline(): undeclared findings already accepted → drop
 7. report + exit code    report.ts: drift tiers in full + info: footer (1 line;
                          1 bullet/tier when 2+; --verbose expands); --json carries
                          all findings; worst exit across stacks
@@ -183,7 +183,7 @@ checked.
 - **diff/**
   - **classify.ts** — the heart: normalize both sides, then tag each difference into a tier.
   - **drift-calculator.ts** — pure structural diff (`calculateResourceDrift`), copied from cdkd.
-- **baseline/baseline-file.ts** — git-committed baseline I/O (`.cdkrd/<stack>.<accountId>.<region>.json`), `applyBaseline`, `blessStack`.
+- **baseline/baseline-file.ts** — git-committed baseline I/O (`.cdkrd/<stack>.<accountId>.<region>.json`), `applyBaseline`, `writeBaseline`.
 - **config/config-file.ts** — git-committed project config (`.cdkrd/config.json`): `loadConfig` + `applyIgnores` (R32 path-level ignore rules → `ignored` tier).
 - **revert/** — the write path (section 7): **plan.ts**, **apply.ts** (CC UpdateResource + poll), **apply-ops.ts** (pure RFC6902 apply), **writers.ts** (SDK writers).
 - **synth/** — **synth.ts** (`@aws-cdk/toolkit-lib` synth + `discoverStacks`), **resolve-app.ts**, **io-host.ts** (`QuietIoHost`).
@@ -309,7 +309,7 @@ the undeclared residual would be dominated by `X: false` noise on every resource
 The cost: on the FIRST run / under `--show-all` (inventory), an explicitly-OFF
 feature is **not shown** (you can't see "encryption is false" in the inventory). The
 asymmetry is one-directional and self-correcting for the case that matters: once a
-non-trivial value is blessed and then changes to `false`/empty out of band, the
+non-trivial value is accepted and then changes to `false`/empty out of band, the
 baseline removal-detection (§8) DOES surface it. We deliberately do NOT skip
 `isTrivialEmpty` under `--show-all` — that would re-flood inventory with the very
 `false`/empty noise the subtractive model exists to remove. (Considered and rejected;
@@ -337,17 +337,18 @@ exit 0; drift exists but **nothing is revertable** → `nothing revertable — N
 drift(s) remain.` + exit 1 (drift-remains semantics, not a usage error — R35).
 
 - **Targets**: declared drift → the **deployed-template** value; undeclared drift →
-  the **baseline** value (an un-blessed out-of-band _addition_ reverts by REMOVAL).
+  the **baseline** value (an unaccepted out-of-band _addition_ reverts by REMOVAL).
 - **No-baseline safety guard**: on a stack that has never been `accept`ed, undeclared
   drift is reported as `notRevertable` (`no baseline — run cdkrd accept first, or
-pass --remove-unblessed`) rather than removed. The subtractive noise model's
+pass --remove-unaccepted`) rather than removed. The subtractive noise model's
   failure mode in `check` is "the report is noisy"; the un-guarded revert mirror of
   that would be **destructive** (a bulk REMOVE of every undeclared value that slipped
-  through subtraction). `--remove-unblessed` opts back into removal. Declared drift is
+  through subtraction). `--remove-unaccepted` opts back into removal. Declared drift is
   always revertable (the template is its source, independent of any baseline).
   For undeclared drift this guard outranks the create-only guard (R35): the
-  fundamental blocker is "no revert target exists", and `accept` blesses the value
-  away entirely — a "requires replacement" reason would mis-direct. When the guard
+  fundamental blocker is "no revert target exists", and `accept` records the value
+  into the baseline, making it no longer drift — a "requires replacement" reason
+  would mis-direct. When the guard
   fires, the plan leads with a note pointing at the `check` / `accept` route.
 - **Write mechanism** (`plan.ts` chooses `kind`):
   - `kind: 'cc'` — generic Cloud Control `UpdateResource` RFC6902 PatchDocument,
@@ -406,26 +407,27 @@ field only warns and is stamped on the next `accept`.
 
 When a baseline already exists, the interactive `accept` multiselect shows only the
 **delta** from it (`splitAcceptedByBaseline`) — new/changed undeclared values, where
-"unchanged" reuses the same `blessedValueMatches` predicate as `applyBaseline`
-(R6 — canonicalized compare); already-blessed unchanged values are auto-kept (noted,
+"unchanged" reuses the same `baselineValueMatches` predicate as `applyBaseline`
+(R6 — canonicalized compare); already-accepted unchanged values are auto-kept (noted,
 not re-confirmed) and a delta of zero just refreshes the file (R39).
 
 Committing it makes "what real state we accept" a visible, reviewable PR change.
 With revert it is also the _source of the undeclared target value_, so it is
 structural, not optional. `check` filters undeclared findings against it
-(`applyBaseline`), so a blessed stack reports CLEAN; `--show-all` ignores it.
+(`applyBaseline`), so a stack with an accepted baseline reports CLEAN; `--show-all`
+ignores it.
 
 **Promotion into the template.** The recommended way to resolve undeclared drift is
-to _declare_ it in the CDK code. After that, the blessed path is no longer undeclared,
-so the naive removal check would mis-report it as "blessed value removed since
-accept". `applyBaseline` is passed the set of currently-declared keys per resource
+to _declare_ it in the CDK code. After that, the accepted path is no longer
+undeclared, so the naive removal check would mis-report it as "baseline value
+removed since accept". `applyBaseline` is passed the set of currently-declared keys per resource
 (`declaredKeysByLogical`) and suppresses that false removal, emitting a one-line
 stderr note ("now declared in the template — re-run `cdkrd accept`") instead. So the
 behavior we recommend is never punished as drift.
 
 **Stale-baseline warning.** `templateHash` (sha256 of the deployed template at
 capture) is verified on load (`warnTemplateHashDrift`): a mismatch prints a non-fatal
-note suggesting a re-`accept` (the blessed set may be stale). Skipped under
+note suggesting a re-`accept` (the accepted set may be stale). Skipped under
 `--pre-deploy`, where the synth template legitimately differs from the deployed one.
 
 ## 9. Tier semantics (the output contract)
@@ -458,7 +460,7 @@ dropped, but never false drift.
 `ignored` (R32) is for properties an external system legitimately keeps rewriting —
 Application Auto Scaling moving an ECS Service `DesiredCount`, DynamoDB autoscaled
 capacity, externally-managed Lambda reserved concurrency. Because `accept` is a value
-snapshot, blessing such a property would re-detect and force a re-accept every time
+snapshot, accepting such a property would re-detect and force a re-accept every time
 the value moves. Path-level ignore rules (the `.driftignore` / Terraform
 `ignore_changes` equivalent) live in a git-committed **`.cdkrd/config.json`** —
 deliberately separate from the baseline, which `accept` rewrites wholesale (a
@@ -487,7 +489,7 @@ constructPath (`MyStack/ApiRole.Policies`) is the human-friendly id `cdk-local` 
 targets by, offered as an additional match target (it comes from optional
 `aws:cdk:path` Metadata, so it can't be the only key). A parent-segment rule
 (`X.Policies`) covers child paths (`X.Policies.0.PolicyName`).
-Ignored findings drop out of the revert plan and the accept bless-set automatically
+Ignored findings drop out of the revert plan and the accept-set automatically
 (neither acts on the `ignored` tier). A malformed `config.json` fails the run
 (exit 2) rather than silently dropping the rules. Applied even under `--show-all`
 (inventory un-suppresses the baseline, not the ignore rules); `--verbose` still lists
@@ -563,7 +565,7 @@ and KMS-alias fixes are cdkrd-only because cdkd's baseline is an AWS snapshot
   change → check → `revert --yes` → CLEAN → AWS converged. The `basic` fixture also
   ships `verify-deleted-guards.sh`, which exercises the `deleted` tier (delete a
   resource out of band → reported + exit 1, not revertable) and the no-baseline
-  `revert` guard (undeclared drift refused unless `--remove-unblessed`).
+  `revert` guard (undeclared drift refused unless `--remove-unaccepted`).
 - **Dogfood evidence**: 8 real cdkd fixtures run through `check --show-all` → fix →
   `declared=0`, then `accept` → CLEAN, then destroy + orphan-verified. This is what
   surfaced the four false-positive classes.
@@ -584,7 +586,7 @@ check` green). The earlier `TS2591 'process'` errors came from oxc's type-aware
    tiers only** (declared / deleted / readGap / unresolved / skipped) and excludes
    undeclared entirely — the undeclared tier is "live minus declared", so with a
    _synth_ declared set its meaning silently shifts (a prop deleted from code would
-   appear as undeclared). It also does NOT touch the baseline (no bless offer, no
+   appear as undeclared). It also does NOT touch the baseline (no accept offer, no
    hash check against the synth template). The question "what undeclared state do we
    accept" is only meaningful against the deployed template, so it is answered by a
    normal `check`. pre-deploy answers exactly one question: what declared drift would
@@ -627,7 +629,7 @@ GetAtt resolution, wildcard, EIP, ManagedPolicy revert, `--pre-deploy`, governan
 skills, **lint clean / CI green**) + the **design-review fix pass (R1–R17)**:
 out-of-band deletion as a first-class `deleted` tier, baseline-absent revert guard,
 per-account baseline, create-only revert guard, promotion-into-template suppression,
-blessed-value re-canonicalization, large-stack `ListStackResources` + concurrent
+baseline-value re-canonicalization, large-stack `ListStackResources` + concurrent
 reads, more fail-closed intrinsics (FindInMap / Split / ImportValue / Select-OOB /
 `${!Literal}`), strict managed-KMS-alias resolution, account/region-scoped ARN
 identity, write-only `readGap` surfacing, real Lambda-Permission values,

--- a/docs/redesign-notes.md
+++ b/docs/redesign-notes.md
@@ -12,7 +12,7 @@ decision is binary, and the verbs mirror it:
 | verb           | meaning                                                            | writes          |
 | -------------- | ------------------------------------------------------------------ | --------------- |
 | `cdkrd check`  | find drift (declared vs deployed template, undeclared vs baseline) | nothing         |
-| `cdkrd accept` | "current state is RIGHT" — bless it into the baseline file         | git file only   |
+| `cdkrd accept` | "current state is RIGHT" — record it in the baseline file          | git file only   |
 | `cdkrd revert` | "current state is WRONG" — write the desired value back to AWS     | AWS (confirmed) |
 
 - declared drift reverts to the **deployed template** value.
@@ -39,7 +39,7 @@ Safety:
 ## Decision 3 — first-run UX
 
 `check` with no baseline on a TTY interactively offers: "No baseline found —
-bless the current state now? [Y/n]" (CI / non-TTY keeps the note-only behavior).
+accept the current state now? [Y/n]" (CI / non-TTY keeps the note-only behavior).
 Interactive prompts use `@clack/prompts` (same stack as cdk-local).
 
 ## Decision 4 — flag cleanup
@@ -90,5 +90,5 @@ core thesis is unchanged.
   for nearly every unset option). One could argue inventory (`--show-all`) should
   show those so a user can see "feature X is explicitly off". Rejected: inventory
   would re-flood with exactly the `false`/empty noise the subtractive model exists
-  to remove, drowning the real signal. The blessed-then-changed-to-empty case is
+  to remove, drowning the real signal. The accepted-then-changed-to-empty case is
   still caught by baseline removal-detection, which is the case that matters.

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -1,5 +1,5 @@
 // Git-committed baseline file: .cdkrd/<stack>.<accountId>.<region>.json
-// Stores the BLESSED undeclared property values (the only thing with no other
+// Stores the ACCEPTED undeclared property values (the only thing with no other
 // source of truth — declared desired comes live from GetTemplate). `check`
 // reports an undeclared finding only when it differs from / is absent in the
 // baseline; with no baseline, every non-default undeclared value is shown.
@@ -73,7 +73,7 @@ function sortAccepted(accepted: AcceptedEntry[]): AcceptedEntry[] {
   );
 }
 
-export async function writeBaseline(b: BaselineFile): Promise<string> {
+export async function writeBaselineFile(b: BaselineFile): Promise<string> {
   const p = baselinePath(b.stackName, b.accountId, b.region);
   await mkdir(dirname(p), { recursive: true });
   // sort at the write point (not per entry-generation path) so every caller — accept,
@@ -85,9 +85,9 @@ export async function writeBaseline(b: BaselineFile): Promise<string> {
 
 /** Write a baseline for a stack from a check run's findings + raw template.
  *  Shared by `accept` and `check`'s first-run interactive offer. Pass `accepted`
- *  to bless a pre-filtered subset (selective accept); omit it to bless ALL
+ *  to record a pre-filtered subset (selective accept); omit it to accept ALL
  *  undeclared findings (the default — same as `buildAccepted(findings)`). */
-export async function blessStack(
+export async function writeBaseline(
   stackName: string,
   region: string,
   accountId: string,
@@ -95,7 +95,7 @@ export async function blessStack(
   rawTemplate: string,
   accepted: AcceptedEntry[] = buildAccepted(findings)
 ): Promise<{ path: string; count: number }> {
-  const path = await writeBaseline({
+  const path = await writeBaselineFile({
     schemaVersion: 1,
     stackName,
     region,
@@ -136,7 +136,7 @@ export function checkBaselineAccount(
   }
 }
 
-/** Build the blessed-undeclared set from a check run's findings. */
+/** Build the accepted-undeclared set from a check run's findings. */
 export function buildAccepted(findings: Finding[]): AcceptedEntry[] {
   return findings
     .filter((f) => f.tier === 'undeclared')
@@ -155,26 +155,26 @@ export function acceptedKey(e: { logicalId: string; path: string }): string {
 }
 
 /**
- * The single source of truth for "is this blessed value equal to the current
+ * The single source of truth for "is this baseline value equal to the current
  * value?". `applyBaseline` (suppress vs surface) and `splitAcceptedByBaseline`
- * (unchanged vs changed) MUST share this exact predicate. The blessed value is
+ * (unchanged vs changed) MUST share this exact predicate. The baseline value is
  * re-canonicalized through the CURRENT pipeline so a baseline written under older
  * normalization rules still matches today's canonical live value (R6) — the
  * `currentCanonicalValue` side is expected to be already canonical.
  */
-export function blessedValueMatches(
-  blessedValue: unknown,
+export function baselineValueMatches(
+  baselineValue: unknown,
   currentCanonicalValue: unknown
 ): boolean {
-  return deepEqual(canonicalizeForCompare(blessedValue), currentCanonicalValue);
+  return deepEqual(canonicalizeForCompare(baselineValue), currentCanonicalValue);
 }
 
 /**
  * Split a freshly-built accepted set against the existing baseline into the values
  * a human must decide on (`changed` = new path OR value differs) and the values
- * already blessed and unchanged (`unchanged` = same logicalId+path AND value
- * matches by `blessedValueMatches`). With no baseline EVERYTHING is `changed`
- * (the true first bless). Entries are matched against `entry.value` which comes
+ * already accepted and unchanged (`unchanged` = same logicalId+path AND value
+ * matches by `baselineValueMatches`). With no baseline EVERYTHING is `changed`
+ * (the true first accept). Entries are matched against `entry.value` which comes
  * from `buildAccepted` (already canonical), so the predicate compares
  * canonical-vs-canonical, exactly like `applyBaseline`.
  */
@@ -186,23 +186,24 @@ export function splitAcceptedByBaseline(
   const unchanged: AcceptedEntry[] = [];
   const changed: AcceptedEntry[] = [];
   for (const entry of accepted) {
-    const blessed = baseline.accepted.find(
+    const baselineEntry = baseline.accepted.find(
       (a) => a.logicalId === entry.logicalId && a.path === entry.path
     );
-    if (blessed && blessedValueMatches(blessed.value, entry.value)) unchanged.push(entry);
+    if (baselineEntry && baselineValueMatches(baselineEntry.value, entry.value))
+      unchanged.push(entry);
     else changed.push(entry);
   }
   return { unchanged, changed };
 }
 
-/** Selective accept: build the blessed set from only the findings whose key is in
+/** Selective accept: build the accepted set from only the findings whose key is in
  *  `selectedKeys`. Empty set -> []; all keys -> equals buildAccepted(findings). */
 export function selectAccepted(findings: Finding[], selectedKeys: Set<string>): AcceptedEntry[] {
   return buildAccepted(findings).filter((e) => selectedKeys.has(acceptedKey(e)));
 }
 
 export interface ApplyBaselineOptions {
-  // logicalId -> set of currently-declared top-level keys. A blessed entry whose
+  // logicalId -> set of currently-declared top-level keys. An accepted entry whose
   // path is now DECLARED in the template is the recommended "promote undeclared
   // drift into code" workflow, NOT a removal — suppress the false removal finding.
   declaredByLogical?: Map<string, Set<string>>;
@@ -212,11 +213,11 @@ export interface ApplyBaselineOptions {
 const topSegment = (p: string): string => p.split('.')[0] ?? p;
 
 /**
- * Reconcile undeclared findings against the blessed baseline:
- *  - an undeclared finding matching a blessed entry (same value) is suppressed;
+ * Reconcile undeclared findings against the accepted baseline:
+ *  - an undeclared finding matching an accepted entry (same value) is suppressed;
  *  - a changed value / new path survives (= real drift);
- *  - a blessed entry with NO corresponding current undeclared value is reported as
- *    a removal (drift in the other direction — something blessed disappeared),
+ *  - an accepted entry with NO corresponding current undeclared value is reported as
+ *    a removal (drift in the other direction — something accepted disappeared),
  *    UNLESS that path has since been DECLARED in the template (promotion to code —
  *    the workflow we recommend — which is noted, not flagged as drift).
  * Non-undeclared findings pass through untouched.
@@ -227,24 +228,24 @@ export function applyBaseline(
   opts: ApplyBaselineOptions = {}
 ): Finding[] {
   if (!baseline) return findings;
-  const blessed = baseline.accepted;
+  const accepted = baseline.accepted;
   const kept = findings.filter((f) => {
     if (f.tier !== 'undeclared') return true;
-    // re-canonicalize the blessed value through the CURRENT pipeline before comparing
-    // (f.actual is already canonical from classify): a baseline blessed under older
+    // re-canonicalize the baseline value through the CURRENT pipeline before comparing
+    // (f.actual is already canonical from classify): a baseline accepted under older
     // normalization rules still matches today's live, so a cdkrd version bump alone
     // never resurfaces a suppressed value as false drift.
-    const match = blessed.find(
+    const match = accepted.find(
       (a) =>
-        a.logicalId === f.logicalId && a.path === f.path && blessedValueMatches(a.value, f.actual)
+        a.logicalId === f.logicalId && a.path === f.path && baselineValueMatches(a.value, f.actual)
     );
     return match === undefined;
   });
-  // removed: blessed entries whose path is no longer present in any current undeclared finding
+  // removed: accepted entries whose path is no longer present in any current undeclared finding
   const currentPaths = new Set(
     findings.filter((f) => f.tier === 'undeclared').map((f) => `${f.logicalId}.${f.path}`)
   );
-  for (const a of blessed) {
+  for (const a of accepted) {
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;
     // promoted into the template since accept → not a removal, just stale baseline
     if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
@@ -260,7 +261,7 @@ export function applyBaseline(
       path: a.path,
       desired: a.value,
       actual: undefined,
-      note: 'blessed value removed since accept',
+      note: 'baseline value removed since accept',
     });
   }
   return kept;
@@ -275,7 +276,7 @@ export function declaredKeysByLogical(
 
 /**
  * Warn (never error) when the baseline was captured against a different template
- * version than the one now deployed — the blessed set may be stale. Skipped in
+ * version than the one now deployed — the accepted set may be stale. Skipped in
  * --pre-deploy mode (the synth template legitimately differs from the deployed one).
  */
 export function warnTemplateHashDrift(

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -22,7 +22,7 @@ const BOOLEAN_FLAGS = new Set([
   '-y',
   '--pre-deploy',
   '--dry-run',
-  '--remove-unblessed',
+  '--remove-unaccepted',
   '--verbose',
   '-v',
   '--no-interactive',
@@ -39,7 +39,7 @@ export interface CommonArgs {
   showAll: boolean; // inventory mode: ignore baseline, show ALL undeclared values
   yes: boolean;
   preDeploy: boolean; // compare live vs the LOCAL synth template (drift your next deploy would clobber)
-  removeUnblessed: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
+  removeUnaccepted: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
   verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
   noInteractive: boolean; // suppress all prompts; required-decision prompts then error instead of prompting
 }
@@ -134,7 +134,7 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),
-    removeUnblessed: has('--remove-unblessed'),
+    removeUnaccepted: has('--remove-unaccepted'),
     verbose: has('--verbose') || has('-v'),
     noInteractive: has('--no-interactive'),
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ properties that 'cdk drift' / CloudFormation drift detection never see.
 
 USAGE
   cdkrd check  [<stack>...]   detect drift (read-only)
-  cdkrd accept [<stack>...]   bless current state into the baseline file
+  cdkrd accept [<stack>...]   record current state into the baseline file
   cdkrd revert [<stack>...]   write the desired value back to AWS (confirms)
 
   cdkrd is CDK-only: it synthesizes the CDK app (--app / cdk.json, or a
@@ -38,7 +38,7 @@ OPTIONS
   --pre-deploy                (check) compare live state vs the LOCAL synth template
                               — the declared drift your next deploy would overwrite
   --dry-run                   (revert) print the plan; make no changes
-  --remove-unblessed          (revert) on a stack with NO baseline, REMOVE undeclared
+  --remove-unaccepted         (revert) on a stack with NO baseline, REMOVE undeclared
                               drift (default: refuse — run \`cdkrd accept\` first)
   --yes, -y                   skip confirmation (revert) / overwrite notice (accept)
   --no-interactive            never prompt; optional prompts skipped, required-decision

--- a/src/commands/accept.ts
+++ b/src/commands/accept.ts
@@ -1,6 +1,6 @@
 // `cdkrd accept [<stack>...] [--app ...] [--region r] [--profile p] [--yes]`
 // Write the current undeclared state into the baseline FILE(s). Writes ONLY
-// git-committed baselines; no AWS writes. The per-stack bless flow lives in
+// git-committed baselines; no AWS writes. The per-stack accept flow lives in
 // stack-actions.ts (shared with check's interactive prompt, R28).
 import { isStackNotDeployed } from '../aws-errors.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
@@ -44,8 +44,8 @@ export async function runAccept(args: string[]): Promise<number> {
       // gather FIRST: the baseline filename embeds the accountId, which only the
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
       const { desired, findings } = await gatherFindings(stackName, region);
-      // ignore rules re-tag matching undeclared findings out of the bless set, so an
-      // externally-managed property is never blessed (and never re-detected).
+      // ignore rules re-tag matching undeclared findings out of the accept set, so an
+      // externally-managed property is never accepted (and never re-detected).
       const result = await acceptStack({
         stackName,
         region,
@@ -58,7 +58,7 @@ export async function runAccept(args: string[]): Promise<number> {
       if (result.refused) worst = Math.max(worst, 2);
     } catch (e) {
       if (isStackNotDeployed(e)) {
-        console.error(`note: ${stackName}: not deployed yet — nothing to bless`);
+        console.error(`note: ${stackName}: not deployed yet — nothing to accept`);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,17 +1,18 @@
 // `cdkrd check [<stack>...] [--region r] [--profile p] [--app ...] [-c k=v]
 //             [--json] [--fail-on declared|undeclared] [--show-all]`
 // Read-only. Reports drift per stack; undeclared findings are filtered against the
-// baseline file (if present) so a blessed stack reports CLEAN. Exit code is the
+// baseline file (if present) so a stack with an accepted baseline reports CLEAN.
+// Exit code is the
 // worst across all checked stacks (0 clean / 1 drift / 2 error).
 import { isCancel, select } from '@clack/prompts';
 import { isStackNotDeployed } from '../aws-errors.js';
 import {
   applyBaseline,
-  blessStack,
   checkBaselineAccount,
   declaredKeysByLogical,
   loadBaseline,
   warnTemplateHashDrift,
+  writeBaseline,
 } from '../baseline/baseline-file.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
@@ -130,7 +131,7 @@ export async function runCheck(args: string[]): Promise<number> {
       // ONLY meaningful signal is declared drift the next deploy would clobber. The
       // undeclared tier is "live minus declared" — with a synth declared set its
       // meaning silently shifts, so we drop it and do NOT touch the baseline at all
-      // (no bless offer, no baseline load — which would also wrongly hash the synth
+      // (no accept offer, no baseline load — which would also wrongly hash the synth
       // template). See ARCHITECTURE §13-2.
       if (a.preDeploy) {
         const declaredOnly = preDeployFindings(findings);
@@ -160,13 +161,13 @@ export async function runCheck(args: string[]): Promise<number> {
       // First run: no baseline yet → choose between "report first" (the safe
       // default — a selective accept is offered again right after the report) and
       // a bulk accept of everything sight-unseen (R45). Ignore rules are applied
-      // BEFORE counting/accepting so the bulk path can never bless values the
+      // BEFORE counting/accepting so the bulk path can never accept values the
       // report would have re-tagged as ignored (same as the post-report accept).
       // With ZERO undeclared values there is no decision worth interrupting for —
       // no prompt (`cdkrd accept` still writes a baseline for a clean stack).
       if (!baseline && !a.showAll && !a.json && isInteractive(a)) {
-        const blessable = applyIgnores(findings, stackName, config);
-        const undeclaredCount = blessable.filter((f) => f.tier === 'undeclared').length;
+        const acceptable = applyIgnores(findings, stackName, config);
+        const undeclaredCount = acceptable.filter((f) => f.tier === 'undeclared').length;
         if (undeclaredCount > 0) {
           const prompt = firstRunPrompt(stackName, undeclaredCount);
           const choice = await select({
@@ -175,11 +176,11 @@ export async function runCheck(args: string[]): Promise<number> {
             initialValue: 'show' as const,
           });
           if (!isCancel(choice) && choice === 'acceptAll') {
-            const { count } = await blessStack(
+            const { count } = await writeBaseline(
               stackName,
               region,
               desired.accountId,
-              blessable,
+              acceptable,
               desired.rawTemplate
             );
             console.error(`baseline written (${count} undeclared value(s) accepted) — commit it.`);
@@ -189,7 +190,7 @@ export async function runCheck(args: string[]): Promise<number> {
       }
       if (!a.json && !baseline && !a.showAll) {
         console.error(
-          `note: ${stackName}: no baseline — showing all undeclared state. Run \`cdkrd accept ${stackName}\` to bless it.`
+          `note: ${stackName}: no baseline — showing all undeclared state. Record it with \`cdkrd accept ${stackName}\`.`
         );
       }
       const reconciled = applyIgnores(
@@ -214,13 +215,13 @@ export async function runCheck(args: string[]): Promise<number> {
       // output), --show-all (baseline not applied — accept would mean something else),
       // and --pre-deploy (declared-only, baseline-untouched contract).
       if (code === 1 && !a.json && !a.showAll && !a.preDeploy && isInteractive(a)) {
-        const actions = availableActions(reconciled, baseline, schemas, a.removeUnblessed);
+        const actions = availableActions(reconciled, baseline, schemas, a.removeUnaccepted);
         if (actions.accept || actions.revert) {
           const options = [{ value: 'nothing', label: 'Nothing (keep exit code 1)' }];
           if (actions.accept)
             options.push({
               value: 'accept',
-              label: 'Accept — bless current state into the baseline',
+              label: 'Accept — record current state into the baseline',
             });
           if (actions.revert)
             options.push({
@@ -233,10 +234,10 @@ export async function runCheck(args: string[]): Promise<number> {
             initialValue: 'nothing',
           });
           if (!isCancel(choice) && choice === 'accept') {
-            // accept blesses UNDECLARED only; warn if declared/deleted drift remains
+            // accept records UNDECLARED only; warn if declared/deleted drift remains
             if (reconciled.some((f) => f.tier === 'declared' || f.tier === 'deleted'))
               console.error(
-                `note: ${stackName}: accept blesses the undeclared state only — declared/deleted drift remains (fix the code or choose Revert).`
+                `note: ${stackName}: accept records the undeclared state only — declared/deleted drift remains (fix the code or choose Revert).`
               );
             const result = await acceptStack({
               stackName,
@@ -268,7 +269,7 @@ export async function runCheck(args: string[]): Promise<number> {
               config,
               dryRun: false,
               yes: a.yes,
-              removeUnblessed: a.removeUnblessed,
+              removeUnaccepted: a.removeUnaccepted,
               verbose: a.verbose,
               interactive: isInteractive(a),
             });

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -2,7 +2,7 @@
 //              [--dry-run] [--yes]`
 // The ONLY AWS-mutating command. Reverts drift to its desired value:
 //   declared   -> deployed-template value
-//   undeclared -> baseline value (restore) or removal (if never blessed)
+//   undeclared -> baseline value (restore) or removal (if never accepted)
 // The per-stack plan / apply / converge flow lives in stack-actions.ts (shared with
 // check's interactive prompt, R28).
 import { isStackNotDeployed } from '../aws-errors.js';
@@ -69,7 +69,7 @@ export async function runRevert(args: string[]): Promise<number> {
         config,
         dryRun,
         yes: a.yes,
-        removeUnblessed: a.removeUnblessed,
+        removeUnaccepted: a.removeUnaccepted,
         verbose: a.verbose,
         interactive: isInteractive(a),
       });

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -1,19 +1,19 @@
 // Per-stack accept / revert actions, shared by the standalone `accept` / `revert`
 // commands AND `check`'s interactive after-drift prompt (R28). Extracting them keeps
 // the interactive flow and the single-verb commands behaviourally identical: both go
-// through exactly the same bless / plan / apply / converge code.
+// through exactly the same accept / plan / apply / converge code.
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import { confirm, isCancel, multiselect } from '@clack/prompts';
 import {
   acceptedKey,
   applyBaseline,
   type BaselineFile,
-  blessStack,
   buildAccepted,
   declaredKeysByLogical,
   loadBaseline,
   selectAccepted,
   splitAcceptedByBaseline,
+  writeBaseline,
 } from '../baseline/baseline-file.js';
 import { applyIgnores, type CdkrdConfig } from '../config/config-file.js';
 import { style } from '../report/style.js';
@@ -44,9 +44,9 @@ export interface AcceptStackParams {
 /**
  * Outcome of a per-stack accept.
  *  - `wrote`: a baseline file was written.
- *  - `refused`: true ONLY when a decision was required (undeclared values to bless)
+ *  - `refused`: true ONLY when a decision was required (undeclared values to accept)
  *    but the run is non-interactive and `--yes` was not passed — accept refuses
- *    rather than blessing everything by default (R38). A user-cancelled multiselect
+ *    rather than accepting everything by default (R38). A user-cancelled multiselect
  *    is `{ wrote:false, refused:false }`, not a refusal.
  */
 export interface AcceptResult {
@@ -55,13 +55,13 @@ export interface AcceptResult {
 }
 
 /**
- * Bless the current undeclared state into the baseline file. In an interactive run
- * (no --yes) the user picks WHICH undeclared values to bless (selective accept, R14).
+ * Record the current undeclared state into the baseline file. In an interactive run
+ * (no --yes) the user picks WHICH undeclared values to accept (selective accept, R14).
  * When an existing baseline is present the multiselect shows only the DELTA from it
- * (new/changed); already-blessed unchanged values are auto-kept and surfaced with a
+ * (new/changed); already-accepted unchanged values are auto-kept and surfaced with a
  * note (R39). An empty FINAL set is confirmed first (R19). Non-interactively
  * (--no-interactive or non-TTY/CI), the multiselect is a required DECISION: with
- * undeclared values present and no --yes, accept refuses (exit 2) instead of blessing
+ * undeclared values present and no --yes, accept refuses (exit 2) instead of accepting
  * all (R38). When there is nothing to decide (no undeclared values) the baseline is
  * written regardless. (Same flow whether reached via `cdkrd accept` or check's
  * interactive prompt — neither re-gathers.)
@@ -76,21 +76,21 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
   let accepted = buildAccepted(findings);
   let refreshedOnly = false; // true when only unchanged values remained (no delta to decide)
   if (!yes && accepted.length > 0) {
-    // A decision is required (which undeclared values to bless). Non-interactively
-    // we refuse rather than implicitly bless ALL of them (R38).
+    // A decision is required (which undeclared values to accept). Non-interactively
+    // we refuse rather than implicitly accept ALL of them (R38).
     if (!interactive) {
       console.error(
-        `error: accept needs a decision — pass --yes to bless ALL undeclared values, or run interactively`
+        `error: accept needs a decision — pass --yes to accept ALL undeclared values, or run interactively`
       );
       return { wrote: false, refused: true };
     }
-    // Only make the human decide on the DELTA from the existing baseline: already-blessed
+    // Only make the human decide on the DELTA from the existing baseline: already-accepted
     // unchanged values are auto-kept (re-confirming a 50-item snapshot every time is wrong,
-    // R39). With no baseline the split returns everything as `changed` (the true first bless).
+    // R39). With no baseline the split returns everything as `changed` (the true first accept).
     const { unchanged, changed } = splitAcceptedByBaseline(accepted, existing);
     if (unchanged.length > 0)
       console.error(
-        `note: ${stackName}: keeping ${unchanged.length} already-blessed unchanged value(s)`
+        `note: ${stackName}: keeping ${unchanged.length} already-accepted unchanged value(s)`
       );
     if (changed.length === 0) {
       // Nothing new to decide — just refresh the baseline (re-snapshot the unchanged set).
@@ -98,7 +98,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
       refreshedOnly = true;
     } else {
       const picked = await multiselect({
-        message: `${stackName}: select undeclared value(s) to bless (unselected stay reported)`,
+        message: `${stackName}: select undeclared value(s) to accept (unselected stay reported)`,
         options: changed.map((e) => ({ value: acceptedKey(e), label: `${e.logicalId}.${e.path}` })),
         initialValues: changed.map((e) => acceptedKey(e)), // default = all selected
         required: false,
@@ -114,7 +114,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
       // would then plan REMOVAL of all undeclared drift. Confirm that consequence (R19).
       if (accepted.length === 0) {
         const proceed = await confirm({
-          message: `${stackName}: bless nothing? This writes an EMPTY baseline — \`cdkrd revert\` will then plan REMOVAL of ALL undeclared drift on this stack.`,
+          message: `${stackName}: accept nothing? This writes an EMPTY baseline — \`cdkrd revert\` will then plan REMOVAL of ALL undeclared drift on this stack.`,
           initialValue: false,
         });
         if (isCancel(proceed) || !proceed) {
@@ -124,7 +124,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
       }
     }
   }
-  const { path, count } = await blessStack(
+  const { path, count } = await writeBaseline(
     stackName,
     region,
     desired.accountId,
@@ -135,10 +135,10 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
   if (refreshedOnly)
     console.log(
       style.ok(
-        `${stackName}: nothing new to bless — baseline refreshed (${count} unchanged value(s))`
+        `${stackName}: nothing new to accept — baseline refreshed (${count} unchanged value(s))`
       )
     );
-  else console.log(style.ok(`baseline written: ${path} (${count} undeclared value(s) blessed)`));
+  else console.log(style.ok(`baseline written: ${path} (${count} undeclared value(s) accepted)`));
   return { wrote: true, refused: false };
 }
 
@@ -166,7 +166,7 @@ export function formatPlan(
   if (opts.noBaselineGuidance) {
     lines.push(
       `\nnote: ${stackName} has no baseline — undeclared drift has no revert target.`,
-      '      Run `cdkrd check` or `cdkrd accept` to bless a baseline first.'
+      '      Run `cdkrd check` or `cdkrd accept` to record a baseline first.'
     );
   }
   for (const item of plan.items) {
@@ -216,7 +216,7 @@ export interface RevertStackParams {
   config: CdkrdConfig; // .cdkrd/config.json ignore rules (ignored findings drop out of the plan)
   dryRun: boolean;
   yes: boolean;
-  removeUnblessed: boolean;
+  removeUnaccepted: boolean;
   verbose: boolean; // expand the NOT-revertable summary to the full list
   interactive: boolean; // whether the confirm prompt may be shown (TTY && !--no-interactive)
   // Delay before the single convergence re-read retry (SDK-writer paths can lag
@@ -258,7 +258,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     config,
     dryRun,
     yes,
-    removeUnblessed,
+    removeUnaccepted,
     verbose,
     interactive,
   } = p;
@@ -269,7 +269,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     stackName,
     config
   );
-  const plan = buildRevertPlan(drifted, baseline, { removeUnblessed, schemas: gathered.schemas });
+  const plan = buildRevertPlan(drifted, baseline, { removeUnaccepted, schemas: gathered.schemas });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {
     console.log(style.clean(`${stackName} (${region}): no drift to revert.`));
@@ -277,11 +277,11 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   }
   printPlan(stackName, region, plan, {
     verbose,
-    // Only when the no-baseline guard actually fires: with --remove-unblessed the
+    // Only when the no-baseline guard actually fires: with --remove-unaccepted the
     // plan REMOVES undeclared drift, so a "no revert target — accept first" note
     // would contradict the plan printed right below it (R35 review).
     noBaselineGuidance:
-      baseline === undefined && !removeUnblessed && drifted.some((f) => f.tier === 'undeclared'),
+      baseline === undefined && !removeUnaccepted && drifted.some((f) => f.tier === 'undeclared'),
   });
   if (plan.items.length === 0) {
     // Drift exists but none of it is revertable (R35). That is NOT the clean
@@ -386,7 +386,7 @@ export function resolveInteractiveRevertExit(currentCode: number, outcome: Rever
 // ---- interactive choice (pure, unit-tested) ----
 
 export interface Actions {
-  accept: boolean; // an undeclared drift exists to bless
+  accept: boolean; // an undeclared drift exists to accept
   revert: boolean; // at least one finding is revertable
 }
 
@@ -402,9 +402,9 @@ export function availableActions(
   findings: Finding[],
   baseline: BaselineFile | undefined,
   schemas: Map<string, SchemaInfo>,
-  removeUnblessed: boolean
+  removeUnaccepted: boolean
 ): Actions {
   const accept = findings.some((f) => f.tier === 'undeclared');
-  const plan = buildRevertPlan(findings, baseline, { removeUnblessed, schemas });
+  const plan = buildRevertPlan(findings, baseline, { removeUnaccepted, schemas });
   return { accept, revert: plan.items.length > 0 };
 }

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -1,7 +1,7 @@
 // Git-committed project config: .cdkrd/config.json (cwd-relative, loaded once per run).
 //
 // Kept SEPARATE from the per-stack baseline file on purpose:
-//   1. the baseline is a machine-generated artifact that `accept` (blessStack)
+//   1. the baseline is a machine-generated artifact that `accept` (writeBaseline)
 //      rewrites WHOLESALE every time — hand-written ignore rules would be erased on
 //      every accept (and a carry-over special case would be an accident magnet);
 //   2. ignore rules express an APP-WIDE intent ("this property is managed by an

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -38,7 +38,7 @@ export function classifyResource(
   // strip AWS-managed fields + drop aws:* tag elements (live-only), then run the
   // shared canonicalization pipeline (policy docs + tag lists + id arrays) on both
   // sides so reordering / scalar-vs-array is not false drift. The pipeline is shared
-  // with baseline-file.ts so blessed values normalize identically (see pipeline.ts).
+  // with baseline-file.ts so baseline values normalize identically (see pipeline.ts).
   const live = canonicalizeForCompare(
     stripAwsTagsDeep(stripCcApiAwsManagedFields(liveRaw))
   ) as Record<string, unknown>;

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -1,6 +1,6 @@
 // The shared value-canonicalization pipeline, used by BOTH the live/declared
-// comparison in classify.ts AND the blessed-value comparison in baseline-file.ts.
-// Keeping it in one place means a baseline blessed under an OLDER set of
+// comparison in classify.ts AND the baseline-value comparison in baseline-file.ts.
+// Keeping it in one place means a baseline accepted under an OLDER set of
 // canonicalization rules still compares equal to the same live value under the
 // CURRENT rules — so adding a normalizer (we have added four already) never makes a
 // cdkrd version bump alone produce false drift on existing baselines.

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -63,7 +63,7 @@ function failTiers(failOn: FailOn): Tier[] {
 }
 
 // The exit code for a set of findings WITHOUT printing — used to re-evaluate a stack
-// after an interactive accept (R28) blessed some/all of its undeclared drift.
+// after an interactive accept (R28) accepted some/all of its undeclared drift.
 export function exitCode(findings: Finding[], failOn: FailOn = 'undeclared'): number {
   const fail = failTiers(failOn);
   return findings.some((f) => fail.includes(f.tier)) ? 1 : 0;

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -1,8 +1,8 @@
 // Build a revert plan from drift findings (pure — no AWS). Revert writes the
 // DESIRED value back to AWS:
 //   declared drift   -> the deployed-template value (finding.desired)
-//   undeclared drift -> the baseline value if blessed before (restore), else REMOVE
-//   removed-undeclared (blessed value gone) -> re-add the baseline value
+//   undeclared drift -> the baseline value if accepted before (restore), else REMOVE
+//   removed-undeclared (baseline value gone) -> re-add the baseline value
 // Not revertable: readGap / unresolved / skipped, and (v1) the SDK-override
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
@@ -53,10 +53,10 @@ const DRIFT_TIERS = new Set(['declared', 'undeclared']);
 
 export interface RevertOptions {
   // (revert) when no baseline file exists, undeclared drift is removed only if this
-  // is set. Without it, undeclared drift on an un-blessed stack is reported as
+  // is set. Without it, undeclared drift on an unaccepted stack is reported as
   // notRevertable (a bulk REMOVE of every undeclared value that slipped through
   // noise subtraction would be destructive — fail-safe instead).
-  removeUnblessed?: boolean;
+  removeUnaccepted?: boolean;
   // resourceType -> schema, so create-only property drift is reported as
   // notRevertable up front (an in-place patch would fail at apply time).
   schemas?: Map<string, SchemaInfo>;
@@ -75,7 +75,7 @@ export function buildRevertPlan(
 ): RevertPlan {
   const itemsByLogical = new Map<string, RevertItem>();
   const notRevertable: NotRevertable[] = [];
-  const blessed = baseline?.accepted ?? [];
+  const accepted = baseline?.accepted ?? [];
   // "the stack has never been `accept`ed" — undeclared removal is gated on this.
   const noBaseline = baseline === undefined;
 
@@ -112,24 +112,25 @@ export function buildRevertPlan(
       });
       continue;
     }
-    // un-blessed undeclared drift: a no-baseline stack would otherwise REMOVE every
+    // unaccepted undeclared drift: a no-baseline stack would otherwise REMOVE every
     // such value (the subtractive model's failure mode is "check is noisy", but the
-    // revert mirror of that is destructive). Refuse unless --remove-unblessed.
+    // revert mirror of that is destructive). Refuse unless --remove-unaccepted.
     // Evaluated BEFORE the create-only guard (R35): on a no-baseline stack the
     // fundamental blocker for undeclared drift is "no revert target exists", and the
-    // right next step is `accept` (which blesses the value away entirely) — a
-    // "requires replacement" reason would mis-direct the user.
+    // right next step is `accept` (which records the value into the baseline,
+    // making it no longer drift) — a "requires replacement" reason would
+    // mis-direct the user.
     if (
       f.tier === 'undeclared' &&
       noBaseline &&
-      !opts.removeUnblessed &&
-      !(f.actual === undefined && f.desired !== undefined) // a removed-blessed re-add can't occur without a baseline, but be explicit
+      !opts.removeUnaccepted &&
+      !(f.actual === undefined && f.desired !== undefined) // a removed-baseline-value re-add can't occur without a baseline, but be explicit
     ) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,
         path: f.path,
-        reason: 'no baseline — run `cdkrd accept` first, or pass --remove-unblessed',
+        reason: 'no baseline — run `cdkrd accept` first, or pass --remove-unaccepted',
       });
       continue;
     }
@@ -146,7 +147,7 @@ export function buildRevertPlan(
     }
     const kind: RevertItem['kind'] = SDK_WRITERS[f.resourceType] ? 'sdk' : 'cc';
 
-    const op = revertOp(f, blessed);
+    const op = revertOp(f, accepted);
     const item =
       itemsByLogical.get(f.logicalId) ??
       ({
@@ -164,7 +165,7 @@ export function buildRevertPlan(
   return { items: [...itemsByLogical.values()], notRevertable };
 }
 
-function revertOp(f: Finding, blessed: BaselineFile['accepted']): PatchOp {
+function revertOp(f: Finding, accepted: BaselineFile['accepted']): PatchOp {
   const pointer = toPointer(f.path);
   if (f.tier === 'declared') {
     return {
@@ -174,23 +175,23 @@ function revertOp(f: Finding, blessed: BaselineFile['accepted']): PatchOp {
       human: `${f.path} -> deployed-template value`,
     };
   }
-  // undeclared: blessed before? restore that value; else it is a new addition -> remove
-  const wasBlessed = blessed.find((a) => a.logicalId === f.logicalId && a.path === f.path);
+  // undeclared: accepted before? restore that value; else it is a new addition -> remove
+  const wasAccepted = accepted.find((a) => a.logicalId === f.logicalId && a.path === f.path);
   if (f.actual === undefined && f.desired !== undefined) {
-    // removed-undeclared finding: re-add the blessed value
+    // removed-undeclared finding: re-add the baseline value
     return {
       op: 'add',
       path: pointer,
       value: f.desired,
-      human: `${f.path} -> restore blessed value`,
+      human: `${f.path} -> restore baseline value`,
     };
   }
-  if (wasBlessed) {
+  if (wasAccepted) {
     return {
       op: 'add',
       path: pointer,
-      value: wasBlessed.value,
-      human: `${f.path} -> blessed value`,
+      value: wasAccepted.value,
+      human: `${f.path} -> baseline value`,
     };
   }
   return {

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -13,7 +13,7 @@ import {
   selectAccepted,
   splitAcceptedByBaseline,
   warnTemplateHashDrift,
-  writeBaseline,
+  writeBaselineFile,
 } from '../src/baseline/baseline-file.js';
 import type { Finding } from '../src/types.js';
 
@@ -110,7 +110,7 @@ describe('baseline', () => {
     });
 
     it('R6 regression: a baseline value in an OLDER canonical form is still unchanged', () => {
-      // blessed under an OLDER rule set: IAM policy Action stored as a scalar; the current
+      // accepted under an OLDER rule set: IAM policy Action stored as a scalar; the current
       // canonical value (from buildAccepted) is the sorted-array form. canonicalizeForCompare
       // folds them together, so this must bucket as unchanged (not changed).
       const b = baseline([
@@ -134,7 +134,7 @@ describe('baseline', () => {
       expect(changed).toHaveLength(0);
     });
 
-    it('no baseline -> everything is changed (the true first bless)', () => {
+    it('no baseline -> everything is changed (the true first accept)', () => {
       const { unchanged, changed } = splitAcceptedByBaseline(accepted, undefined);
       expect(unchanged).toEqual([]);
       expect(changed).toEqual(accepted);
@@ -158,18 +158,18 @@ describe('baseline', () => {
         { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] },
         { logicalId: 'B', resourceType: 'AWS::X::Y', path: 'Q', value: 'new-val' },
       ]);
-      // the unselected new path C.R is NOT blessed
+      // the unselected new path C.R is NOT accepted
       expect(written.some((e) => e.logicalId === 'C')).toBe(false);
     });
   });
 
-  it('applyBaseline suppresses a blessed undeclared value (-> CLEAN)', () => {
+  it('applyBaseline suppresses an accepted undeclared value (-> CLEAN)', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     expect(applyBaseline([undeclared('A', 'P', ['x'])], b)).toEqual([]);
   });
 
-  it('re-canonicalizes the blessed value before compare (old unsorted form still matches)', () => {
-    // blessed under an OLDER rule set: tag list stored UNSORTED
+  it('re-canonicalizes the baseline value before compare (old unsorted form still matches)', () => {
+    // accepted under an OLDER rule set: tag list stored UNSORTED
     const b = baseline([
       {
         logicalId: 'A',
@@ -212,18 +212,18 @@ describe('baseline', () => {
     expect(applyBaseline([undeclared('A', 'P', 1)], undefined)).toHaveLength(1);
   });
 
-  it('reports a blessed value that was removed since accept', () => {
+  it('reports a baseline value that was removed since accept', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     const out = applyBaseline([], b); // nothing undeclared now
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({
       tier: 'undeclared',
       path: 'P',
-      note: 'blessed value removed since accept',
+      note: 'baseline value removed since accept',
     });
   });
 
-  it('does NOT report a removal when the blessed path was promoted into the template', () => {
+  it('does NOT report a removal when the accepted path was promoted into the template', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     const warnings: string[] = [];
     const out = applyBaseline([], b, {
@@ -234,14 +234,14 @@ describe('baseline', () => {
     expect(warnings[0]).toContain('now declared in the template');
   });
 
-  it('still reports a removal when the blessed path is genuinely gone (not declared)', () => {
+  it('still reports a removal when the accepted path is genuinely gone (not declared)', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     const out = applyBaseline([], b, { declaredByLogical: new Map([['A', new Set(['Other'])]]) });
     expect(out).toHaveLength(1);
-    expect(out[0]).toMatchObject({ note: 'blessed value removed since accept' });
+    expect(out[0]).toMatchObject({ note: 'baseline value removed since accept' });
   });
 
-  describe('writeBaseline (deterministic order, R40)', () => {
+  describe('writeBaselineFile (deterministic order, R40)', () => {
     // capturedAt is fixed so the only variable across writes is the accepted order.
     const entry = (logicalId: string, path: string): BaselineFile['accepted'][number] => ({
       logicalId,
@@ -259,7 +259,7 @@ describe('baseline', () => {
       const cwd = process.cwd();
       process.chdir(dir);
       try {
-        const p = await writeBaseline(b);
+        const p = await writeBaselineFile(b);
         return await readFile(p, 'utf8');
       } finally {
         process.chdir(cwd);

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -49,9 +49,10 @@ describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', (
     expect(bulk.label).toContain('without reviewing them');
   });
 
-  it('no option says "bless" — prompts speak the command vocabulary (accept)', () => {
+  it('prompts speak the command vocabulary (accept) — no retired jargon', () => {
     const p = firstRunPrompt('S', 3);
     const all = [p.message, ...p.options.map((o) => o.label)].join(' ');
-    expect(all.toLowerCase()).not.toContain('bless');
+    // the retired word is assembled at runtime so this file itself stays free of it (R46)
+    expect(all.toLowerCase()).not.toContain(['b', 'less'].join(''));
   });
 });

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -46,8 +46,8 @@ describe('parseCommonArgs', () => {
     expect(parseCommonArgs(['S', '--yes']).yes).toBe(true);
     expect(parseCommonArgs(['S', '--pre-deploy']).preDeploy).toBe(true);
     expect(parseCommonArgs(['S']).preDeploy).toBe(false);
-    expect(parseCommonArgs(['S', '--remove-unblessed']).removeUnblessed).toBe(true);
-    expect(parseCommonArgs(['S']).removeUnblessed).toBe(false);
+    expect(parseCommonArgs(['S', '--remove-unaccepted']).removeUnaccepted).toBe(true);
+    expect(parseCommonArgs(['S']).removeUnaccepted).toBe(false);
     expect(parseCommonArgs(['S', '--verbose']).verbose).toBe(true);
     expect(parseCommonArgs(['S', '-v']).verbose).toBe(true);
     expect(parseCommonArgs(['S']).verbose).toBe(false);

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -31,7 +31,7 @@ tier and the `revert` guards:
 
 1. **R2 revert guard** — with NO baseline, `revert --dry-run` reports the
    undeclared drift as `NOT revertable` (`no baseline`) while a declared drift is
-   still in the plan; `--remove-unblessed` opts in to removing the undeclared value.
+   still in the plan; `--remove-unaccepted` opts in to removing the undeclared value.
 2. **R1 deleted tier** — after deleting the bucket out of band, `check` reports the
    `deleted` tier (exit 1) and `revert --dry-run` reports it as not revertable
    (`deleted — recreate via cdk deploy`).
@@ -47,9 +47,9 @@ IAM Role (inject a permissions boundary → undeclared drift) and a Node Lambda
 
 ## revert
 
-A versioned S3 bucket. Enables acceleration, `accept`s (baseline blesses it), then
-injects a DECLARED drift (versioning suspended) + an UNDECLARED drift (acceleration
-suspended from its blessed Enabled), asserts `check` detects both, runs
-`cdkrd revert --yes`, and asserts `check` is CLEAN and AWS itself converged
-(versioning Enabled = template, acceleration Enabled = blessed). Proves the
-Cloud Control `UpdateResource` write path end-to-end.
+A versioned S3 bucket. Enables acceleration, `accept`s (recording it in the
+baseline), then injects a DECLARED drift (versioning suspended) + an UNDECLARED
+drift (acceleration suspended from its accepted Enabled), asserts `check` detects
+both, runs `cdkrd revert --yes`, and asserts `check` is CLEAN and AWS itself
+converged (versioning Enabled = template, acceleration Enabled = baseline value).
+Proves the Cloud Control `UpdateResource` write path end-to-end.

--- a/tests/integration/basic/verify-deleted-guards.sh
+++ b/tests/integration/basic/verify-deleted-guards.sh
@@ -4,7 +4,7 @@
 # `basic` / `revert` verify.sh do not:
 #   R2  revert guard: on a stack with NO baseline, undeclared drift is reported
 #       as NOT revertable (refuses a destructive bulk removal) unless
-#       --remove-unblessed is passed; declared drift IS revertable regardless.
+#       --remove-unaccepted is passed; declared drift IS revertable regardless.
 #   R1  deleted tier: a resource deleted out of band is reported in the `deleted`
 #       tier (exit 1 regardless of --fail-on) and is NOT revertable (recreate via
 #       cdk deploy).
@@ -48,7 +48,7 @@ aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
   --accelerate-configuration Status=Enabled --region "$REGION" || fail "inject accel"
 sleep 5
 
-echo "=== R2: revert --dry-run refuses the unblessed undeclared value ==="
+echo "=== R2: revert --dry-run refuses the unaccepted undeclared value ==="
 $CLI revert "$STACK" --region "$REGION" --dry-run | tee /tmp/cdkrd-guard-noremove.out
 grep -q "NOT revertable" /tmp/cdkrd-guard-noremove.out || fail "R2: expected a NOT revertable section"
 grep -q "AccelerateConfiguration.*no baseline" /tmp/cdkrd-guard-noremove.out \
@@ -57,10 +57,10 @@ grep -q "AccelerateConfiguration.*no baseline" /tmp/cdkrd-guard-noremove.out \
 grep -q "VersioningConfiguration" /tmp/cdkrd-guard-noremove.out \
   || fail "R2: declared versioning drift should be in the plan"
 
-echo "=== R2: --remove-unblessed opts in to removing the undeclared value ==="
-$CLI revert "$STACK" --region "$REGION" --dry-run --remove-unblessed | tee /tmp/cdkrd-guard-remove.out
+echo "=== R2: --remove-unaccepted opts in to removing the undeclared value ==="
+$CLI revert "$STACK" --region "$REGION" --dry-run --remove-unaccepted | tee /tmp/cdkrd-guard-remove.out
 grep -qE "would apply [1-9][0-9]* op" /tmp/cdkrd-guard-remove.out \
-  || fail "R2: --remove-unblessed should plan op(s) including the undeclared removal"
+  || fail "R2: --remove-unaccepted should plan op(s) including the undeclared removal"
 
 # -------- R1: deleted tier --------
 echo "=== R1: delete the bucket out of band ==="

--- a/tests/integration/revert/verify.sh
+++ b/tests/integration/revert/verify.sh
@@ -27,8 +27,8 @@ BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --re
   --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
 [ -n "$BUCKET" ] || fail "no bucket physical id"
 
-# Enable acceleration BEFORE accept so the baseline blesses AccelerationStatus=Enabled.
-# Revert of an undeclared CHANGE restores the blessed value (a reliable add op);
+# Enable acceleration BEFORE accept so the baseline records AccelerationStatus=Enabled.
+# Revert of an undeclared CHANGE restores the baseline value (a reliable add op);
 # reverting an undeclared ADDITION by removal is not always possible for toggle-style
 # props (e.g. accel can't be "removed", only Suspended) — that is a documented limit.
 echo "=== enable acceleration, then accept (baseline) ==="
@@ -37,7 +37,7 @@ sleep 5
 $CLI accept "$STACK" --region "$REGION" || fail accept
 echo "=== check CLEAN ==="; $CLI check "$STACK" --region "$REGION"; [ $? -eq 0 ] || fail "expected CLEAN after accept"
 
-echo "=== inject DECLARED drift (suspend versioning) + UNDECLARED drift (suspend accel from blessed Enabled) ==="
+echo "=== inject DECLARED drift (suspend versioning) + UNDECLARED drift (suspend accel from accepted Enabled) ==="
 aws s3api put-bucket-versioning --bucket "$BUCKET" --versioning-configuration Status=Suspended --region "$REGION" || fail "inject versioning"
 aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" --accelerate-configuration Status=Suspended --region "$REGION" || fail "inject accel"
 sleep 5
@@ -54,10 +54,10 @@ $CLI revert "$STACK" --region "$REGION" --yes || fail "revert returned non-zero"
 echo "=== check CLEAN after revert ==="
 $CLI check "$STACK" --region "$REGION"; [ $? -eq 0 ] || fail "drift remains after revert"
 
-# belt-and-suspenders: confirm AWS itself converged to the desired/blessed values
+# belt-and-suspenders: confirm AWS itself converged to the desired/baseline values
 VSTATUS="$(aws s3api get-bucket-versioning --bucket "$BUCKET" --region "$REGION" --query Status --output text)"
 [ "$VSTATUS" = "Enabled" ] || fail "versioning not restored to template value (got $VSTATUS)"
 ASTATUS="$(aws s3api get-bucket-accelerate-configuration --bucket "$BUCKET" --region "$REGION" --query Status --output text 2>/dev/null)"
-[ "$ASTATUS" = "Enabled" ] || fail "acceleration not restored to blessed value (got $ASTATUS)"
+[ "$ASTATUS" = "Enabled" ] || fail "acceleration not restored to baseline value (got $ASTATUS)"
 
 echo "INTEG PASS"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -52,7 +52,7 @@ describe('buildRevertPlan', () => {
     });
   });
 
-  it('undeclared drift with a blessed prior value -> add op restoring the blessed value', () => {
+  it('undeclared drift with an accepted prior value -> add op restoring the baseline value', () => {
     const f = F({
       tier: 'undeclared',
       path: 'AccelerateConfiguration',
@@ -89,9 +89,9 @@ describe('buildRevertPlan', () => {
     expect(plan.notRevertable[0]!.reason).toContain('no baseline');
   });
 
-  it('--remove-unblessed re-enables the remove op on a no-baseline stack', () => {
+  it('--remove-unaccepted re-enables the remove op on a no-baseline stack', () => {
     const f = F({ tier: 'undeclared', path: 'OwnershipControls', actual: { Rules: [] } });
-    const plan = buildRevertPlan([f], undefined, { removeUnblessed: true });
+    const plan = buildRevertPlan([f], undefined, { removeUnaccepted: true });
     expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/OwnershipControls' });
   });
 
@@ -102,7 +102,7 @@ describe('buildRevertPlan', () => {
     expect(plan.notRevertable).toHaveLength(0);
   });
 
-  it('removed-undeclared (blessed value gone) -> re-add the blessed value', () => {
+  it('removed-undeclared (baseline value gone) -> re-add the baseline value', () => {
     const f = F({
       tier: 'undeclared',
       path: 'Tags',
@@ -182,7 +182,7 @@ describe('buildRevertPlan', () => {
 
   it('R35: undeclared create-only drift on a NO-baseline stack -> reason is no-baseline (accept is the route)', () => {
     // the fundamental blocker is "no revert target" — a create-only reason would
-    // mis-direct the user toward replacement when `accept` blesses the value away
+    // mis-direct the user toward replacement when `accept` records the value into the baseline
     const plan = buildRevertPlan(
       [F({ tier: 'undeclared', path: 'BucketName', actual: 'b' })],
       undefined,

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -47,7 +47,7 @@ const deleted = (): Finding => ({
   physicalId: 'b-phys',
 });
 
-const blessed = (entries: BaselineFile['accepted']): BaselineFile => ({
+const baselineWith = (entries: BaselineFile['accepted']): BaselineFile => ({
   schemaVersion: 1,
   stackName: 's',
   region: 'r',
@@ -58,7 +58,7 @@ const blessed = (entries: BaselineFile['accepted']): BaselineFile => ({
 });
 
 describe('availableActions (R28 interactive choice logic)', () => {
-  it('declared-only → Accept hidden (cannot bless declared), Revert shown', () => {
+  it('declared-only → Accept hidden (cannot accept declared), Revert shown', () => {
     expect(availableActions([declared()], undefined, NO_SCHEMAS, false)).toEqual({
       accept: false,
       revert: true,
@@ -72,14 +72,14 @@ describe('availableActions (R28 interactive choice logic)', () => {
     });
   });
 
-  it('undeclared-only with --remove-unblessed → Revert becomes available', () => {
+  it('undeclared-only with --remove-unaccepted → Revert becomes available', () => {
     expect(availableActions([undeclared()], undefined, NO_SCHEMAS, true)).toEqual({
       accept: true,
       revert: true,
     });
   });
 
-  it('deleted-only → neither (deleted is not revertable, nothing to bless)', () => {
+  it('deleted-only → neither (deleted is not revertable, nothing to accept)', () => {
     expect(availableActions([deleted()], undefined, NO_SCHEMAS, false)).toEqual({
       accept: false,
       revert: false,
@@ -87,7 +87,7 @@ describe('availableActions (R28 interactive choice logic)', () => {
   });
 
   it('mixed declared + undeclared (with baseline making undeclared revertable) → both', () => {
-    const b = blessed([
+    const b = baselineWith([
       {
         logicalId: 'B',
         resourceType: 'AWS::S3::Bucket',
@@ -95,7 +95,7 @@ describe('availableActions (R28 interactive choice logic)', () => {
         value: { AccelerationStatus: 'Suspended' },
       },
     ]);
-    // undeclared is blessed-then-changed → revertable to the blessed value; declared → revertable
+    // undeclared is accepted-then-changed → revertable to the baseline value; declared → revertable
     expect(availableActions([declared(), undeclared()], b, NO_SCHEMAS, false)).toEqual({
       accept: true,
       revert: true,
@@ -169,7 +169,7 @@ describe('formatPlan (R35 — NOT-revertable folds to a per-reason summary)', ()
 describe('revertStack exit semantics (R35 — drift with nothing revertable is exit 1)', () => {
   // findings-only params: every path under test returns BEFORE any AWS client is
   // used — either nothing is revertable, or --dry-run returns at the preview branch.
-  type Overrides = { removeUnblessed?: boolean; dryRun?: boolean };
+  type Overrides = { removeUnaccepted?: boolean; dryRun?: boolean };
   const params = (findings: Finding[], over: Overrides = {}) => ({
     stackName: 's',
     region: 'r',
@@ -182,7 +182,7 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     config: { ignore: [] },
     dryRun: over.dryRun ?? false,
     yes: true,
-    removeUnblessed: over.removeUnblessed ?? false,
+    removeUnaccepted: over.removeUnaccepted ?? false,
     verbose: false,
     interactive: true, // these paths return before any confirm (yes:true); value is irrelevant
   });
@@ -220,7 +220,7 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     expect(out).toContain('nothing revertable — 1 drift(s) remain.');
   });
 
-  it('un-blessed undeclared drift -> no-baseline guidance + exit 1', async () => {
+  it('unaccepted undeclared drift -> no-baseline guidance + exit 1', async () => {
     const { outcome, logs } = await captured([undeclared()]);
     expect(outcome).toEqual({ exit: 1, aborted: false });
     const out = logs.join('\n');
@@ -229,11 +229,11 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     expect(out).toContain('nothing revertable — 1 drift(s) remain.');
   });
 
-  it('--remove-unblessed: no-baseline note is suppressed; the plan removes the undeclared drift', async () => {
+  it('--remove-unaccepted: no-baseline note is suppressed; the plan removes the undeclared drift', async () => {
     // dry-run returns at the preview branch (no AWS write). The note would contradict
     // a plan that DOES remove the drift, so it must not appear (R35 review).
     const { outcome, logs } = await captured([undeclared()], {
-      removeUnblessed: true,
+      removeUnaccepted: true,
       dryRun: true,
     });
     expect(outcome).toEqual({ exit: 0, aborted: false });
@@ -294,7 +294,7 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     config: { ignore: [] },
     dryRun: false,
     yes: true,
-    removeUnblessed: false,
+    removeUnaccepted: false,
     verbose: false,
     interactive: false, // yes:true — no confirm prompt is reached
     convergeRetryDelayMs: 0, // do not sleep for real in tests
@@ -396,11 +396,11 @@ describe('acceptStack non-interactive refusal (R38)', () => {
     }
     expect(existsSync(path)).toBe(false); // no baseline written
     expect(errs.join('\n')).toContain(
-      'error: accept needs a decision — pass --yes to bless ALL undeclared values, or run interactively'
+      'error: accept needs a decision — pass --yes to accept ALL undeclared values, or run interactively'
     );
   });
 
-  it('yes:true → blesses ALL undeclared values with no prompt (regression)', async () => {
+  it('yes:true → accepts ALL undeclared values with no prompt (regression)', async () => {
     const desired = {
       stackName: 'R38YesStack',
       region: 'r38-yes-region',
@@ -419,12 +419,12 @@ describe('acceptStack non-interactive refusal (R38)', () => {
         desired,
         findings: [undeclared()],
         yes: true,
-        interactive: false, // ignored when yes:true — --yes blesses all regardless
+        interactive: false, // ignored when yes:true — --yes accepts all regardless
       });
       expect(result).toEqual({ wrote: true, refused: false });
       expect(existsSync(path)).toBe(true);
       const written = JSON.parse(readFileSync(path, 'utf8')) as BaselineFile;
-      // the full undeclared set is blessed (no selective multiselect under --yes)
+      // the full undeclared set is accepted (no selective multiselect under --yes)
       expect(written.accepted).toEqual([
         {
           logicalId: 'B',


### PR DESCRIPTION
## Summary

Owner decision from dogfooding: `bless` is jargon that doesn't match the command users actually run (`accept`). This sweeps all ~270 occurrences from src, tests, and docs (R47 — renumbered from the working title R46, which is taken by the post-revert phantom-drift finding).

## Vocabulary mapping

- Verb **bless → accept** (or *record/snapshot* where "accept" would read redundantly, e.g. "Record it with `cdkrd accept S`").
- **"blessed value" → "baseline value"** for revert targets (parallel to "deployed-template value"): plan lines now read `-> baseline value` / `restore baseline value`.
- already-blessed → already-accepted; un-blessed → **unaccepted**; bless-set → accept-set.

## Breaking (pre-release, no alias)

- `--remove-unblessed` → `--remove-unaccepted` (flag, HELP, `CommonArgs`/`RevertOptions` field `removeUnaccepted`). Old flag fails fast with `unknown option`.

## Identifier renames

`blessStack` → `writeBaseline` (the prior low-level `writeBaseline` → `writeBaselineFile`), `blessedValueMatches` → `baselineValueMatches`, `blessable` → `acceptable`, test fixture `blessed()` → `baselineWith()`.

## Docs

README / ARCHITECTURE / redesign-notes (vocabulary only — decisions unchanged) / CLAUDE.md / tests/integration README + verify scripts.

## Proof & gates

- `grep -rni` for the retired word across src/tests/docs (excl. node_modules): **0 hits**. check.test.ts asserts prompts stay free of it (word assembled at runtime so the repo itself contains zero occurrences).
- typecheck / lint+format / build / tests: all pass (28 files, 310 tests). `check` + `docs` markers set. Developed in a worktree.

Implemented by a subagent against a written style mapping; full diff re-reviewed by me.