### PR TITLE
feat(report): count inside section brackets + verdict separation (R48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ explainable — the same change shows up:
 ```console
 $ npx cdkrd check ApiStack
 === cdkrd check: ApiStack (us-east-1) ===
-
-[UNDECLARED DRIFT (the differentiator)] 1
+[UNDECLARED DRIFT: 1] (the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
+
 result: 1 drift(s) (undeclared=1)
 ```
 
@@ -229,11 +229,11 @@ consumption the formal contract is `--json`. Output is colorized on a TTY
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-
-[DECLARED DRIFT] 1
+[DECLARED DRIFT: 1]
   ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"
       actual ="Suspended"
+
 result: 1 drift(s) (declared=1)
 info:
   - readGap=1 (write-only 1)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -494,16 +494,21 @@ Ignored findings drop out of the revert plan and the accept-set automatically
 (exit 2) rather than silently dropping the rules. Applied even under `--show-all`
 (inventory un-suppresses the baseline, not the ignore rules); `--verbose` still lists
 the ignored entries. A CLI to manage rules (`cdkrd ignore <pattern>`) is a future
-open question (§13) — v1 is hand-edited. **Default text layout (R25, spacing R37):**
-the three DRIFT tiers print in full; the INFORMATIONAL tiers are folded into an
-`info:` footer (per-tier counts + a reason breakdown, e.g. `skipped=24 (custom
-resource 12, override target unresolved 12)`) — a single line when one tier is
-present, one bullet line per tier (with a single `--verbose` hint) when 2+;
-`--verbose` expands them to full lists; 0-count tiers are never printed. No blank
-line precedes the header or the `result:` line, so a CLEAN stack with one
-informational tier is exactly 3 lines; blank lines remain between the header and
-the drift sections (grouping), and the check loop puts one blank line between
-consecutive stack reports in a multi-stack run. The `result:` line carries the
+open question (§13) — v1 is hand-edited. **Default text layout (R25, spacing
+R37/R48):** the three DRIFT tiers print in full; the INFORMATIONAL tiers are
+folded into an `info:` footer (per-tier counts + a reason breakdown, e.g.
+`skipped=24 (custom resource 12, override target unresolved 12)`) — a single
+line when one tier is present, one bullet line per tier (with a single
+`--verbose` hint) when 2+; `--verbose` expands them to full lists; 0-count
+tiers are never printed. Section headers carry the count INSIDE the brackets
+(`[DECLARED DRIFT: 3]`, the explanatory note outside) — a bare digit right of
+`]` read as noise (R48). No blank line precedes the header; the FIRST drift
+section follows the header directly, later sections get a grouping blank, and
+`result:` gets a blank line before it ONLY when a drift section was printed —
+the verdict must not read as a member of the section above it, while a CLEAN
+stack with one informational tier stays exactly 3 lines (R48 revising R37).
+The check loop puts one blank line between consecutive stack reports in a
+multi-stack run. The `result:` line carries the
 verdict + non-zero drift counts only (the informational breakdown lives on `info:`,
 so the two never duplicate); `^result:` stays greppable, but the formal
 machine-readable contract is `--json` (the `info:` footer may span lines). `--json`

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -3,9 +3,14 @@
 //
 // Default layout is deliberately terse (a 40-resource CLEAN stack was 30+ lines):
 //   header -> DRIFT tier sections (full detail) -> result: -> info: footer
-// No blank line before the header or the result: line (R37) — a CLEAN stack with
-// one informational tier is exactly 3 lines. Blank lines remain BETWEEN the header
-// and drift sections, and between sections (visual grouping). DRIFT tiers
+// Spacing (R37, revised by R48): no blank line before the header; the FIRST drift
+// section follows the header directly (no stray blank); subsequent sections get a
+// blank line between them (grouping); `result:` gets a blank line before it ONLY
+// when at least one drift section was printed — so the verdict never reads as a
+// member of the section above it, while a CLEAN stack with one informational tier
+// stays exactly 3 lines. Section headers carry the count INSIDE the brackets
+// (`[DECLARED DRIFT: 3]`) — a bare digit to the right of `]` read as noise (R48);
+// the explanatory note follows outside the brackets. DRIFT tiers
 // (deleted/declared/undeclared) are ALWAYS shown in full — they are the point.
 // INFORMATIONAL tiers (readGap/unresolved/skipped) are folded into the `info:`
 // footer (counts + reason breakdown): one line when a single tier is present, a
@@ -15,14 +20,23 @@
 import type { Finding, Tier } from '../types.js';
 import { style } from './style.js';
 
-const TIER_TITLES: Record<Tier, string> = {
-  deleted: 'DELETED (resource deleted out of band — always drift)',
+const TIER_NAMES: Record<Tier, string> = {
+  deleted: 'DELETED',
   declared: 'DECLARED DRIFT',
-  undeclared: 'UNDECLARED DRIFT (the differentiator)',
-  ignored: 'IGNORED (matched a .cdkrd/config.json ignore rule — not drift)',
-  readGap: 'READ GAP (declared but not returned by live read — not drift)',
-  unresolved: 'UNRESOLVED (declared paths needing GetAtt — skipped, not drift)',
-  skipped: 'SKIPPED (CC API unsupported / no physical id)',
+  undeclared: 'UNDECLARED DRIFT',
+  ignored: 'IGNORED',
+  readGap: 'READ GAP',
+  unresolved: 'UNRESOLVED',
+  skipped: 'SKIPPED',
+};
+// Explanation printed after the bracketed name+count, outside the brackets.
+const TIER_NOTES: Partial<Record<Tier, string>> = {
+  deleted: 'resource deleted out of band — always drift',
+  undeclared: 'the differentiator',
+  ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
+  readGap: 'declared but not returned by live read — not drift',
+  unresolved: 'declared paths needing GetAtt — skipped, not drift',
+  skipped: 'CC API unsupported / no physical id',
 };
 const DRIFT_TIERS: Tier[] = ['deleted', 'declared', 'undeclared'];
 const INFO_TIERS: Tier[] = ['ignored', 'readGap', 'unresolved', 'skipped'];
@@ -106,16 +120,28 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   }
 
   const byTier = (t: Tier) => findings.filter((f) => f.tier === t);
-  const section = (tier: Tier): void => {
+  // Count inside the brackets (`[NAME: N]`), explanation outside (dim) — see the
+  // layout comment at the top (R48). `leadingBlank` separates a section from
+  // whatever precedes it; the FIRST drift section sits directly under the header.
+  const section = (tier: Tier, leadingBlank: boolean): boolean => {
     const items = byTier(tier);
-    if (items.length === 0) return; // 0-count tiers are never printed
-    log('\n' + tierStyle(tier)(`[${TIER_TITLES[tier]}] ${items.length}`));
+    if (items.length === 0) return false; // 0-count tiers are never printed
+    const note = TIER_NOTES[tier];
+    log(
+      (leadingBlank ? '\n' : '') +
+        tierStyle(tier)(`[${TIER_NAMES[tier]}: ${items.length}]`) +
+        (note ? ' ' + style.infoTier(`(${note})`) : '')
+    );
     for (const f of items) log('  ' + formatFinding(f));
+    return true;
   };
 
   log(style.header(`=== cdkrd check: ${header} ===`));
   // DRIFT tiers: always full detail (the point of the tool)
-  for (const tier of DRIFT_TIERS) section(tier);
+  let driftSections = 0;
+  for (const tier of DRIFT_TIERS) {
+    if (section(tier, driftSections > 0)) driftSections++;
+  }
   // result: line — the conclusion. Lists ONLY the non-zero DRIFT tier counts (the
   // informational breakdown lives on the `info:` line, so the two never duplicate);
   // CLEAN prints just `CLEAN`. `fail-on` is noted only when non-default (it changes
@@ -128,12 +154,14 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // the verdict is the one line that must stand out: green CLEAN / red drift count
   const verdict =
     drifted === 0 ? style.clean('CLEAN') : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;
-  log(`result: ${verdict}${failNote}`);
+  // A blank line before the verdict ONLY when drift sections were printed — it must
+  // not read as a member of the last section (R48); a CLEAN stack stays 3 lines.
+  log((driftSections > 0 ? '\n' : '') + `result: ${verdict}${failNote}`);
   // INFORMATIONAL tiers: footer below result — full sections under --verbose, else a
   // folded summary (counts + reason breakdown): one `info: ...` line for a single
   // tier, a one-line-per-tier bullet list (with ONE --verbose hint) for 2+ (R37).
   if (opts.verbose) {
-    for (const tier of INFO_TIERS) section(tier);
+    for (const tier of INFO_TIERS) section(tier, true);
   } else {
     const summaries = INFO_TIERS.map((t) => {
       const items = byTier(t);

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -55,6 +55,14 @@ describe('report', () => {
     expect(text).toContain('result:');
   });
 
+  it('section header carries the count INSIDE the brackets, note outside (R48)', () => {
+    const { text } = run([F('undeclared'), F('declared', 'Q')]);
+    expect(text).toContain('[UNDECLARED DRIFT: 1] (the differentiator)');
+    expect(text).toContain('[DECLARED DRIFT: 1]'); // no note for declared
+    // the old bare-digit-right-of-bracket form is gone
+    expect(text).not.toMatch(/\] \d/);
+  });
+
   it('shows the CDK construct path instead of the logical id when present', () => {
     const f: Finding = {
       tier: 'undeclared',
@@ -208,13 +216,20 @@ describe('report', () => {
       ]);
     });
 
-    it('drift keeps a blank line after the header but none before result:', () => {
+    it('drift: first section directly under the header; blank line BEFORE result: (R48)', () => {
       const lines = run([F('declared')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toBe(''); // blank between header and the drift section (grouping)
-      expect(lines[2]).toBe('[DECLARED DRIFT] 1');
+      expect(lines[1]).toBe('[DECLARED DRIFT: 1]'); // no stray blank after the header
       const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
-      expect(lines[resultIdx - 1]).not.toBe(''); // result follows the section directly
+      expect(lines[resultIdx - 1]).toBe(''); // the verdict is separated from the section above
+    });
+
+    it('two drift sections: blank BETWEEN them, none after the header (R48)', () => {
+      const lines = run([F('declared'), F('undeclared', 'Q')]).text.split('\n');
+      expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
+      expect(lines[1]).toBe('[DECLARED DRIFT: 1]');
+      const undeclaredIdx = lines.findIndex((l) => l.startsWith('[UNDECLARED'));
+      expect(lines[undeclaredIdx - 1]).toBe(''); // grouping blank between sections
     });
 
     it('multi-stack: ONE blank line between consecutive reports, none before the first', () => {


### PR DESCRIPTION
## Summary

Dogfooding feedback on the check report layout (post-R43-colors, the structure itself was still confusing):

1. `result: 5 drift(s)` read as a member of the UNDECLARED section right above it.
2. The bare digit right of the bracket (`[DECLARED DRIFT] 3`) is easy to miss and unclear.
3. The blank line between the `===` header and the first section bought nothing.

## New layout

```console
=== cdkrd check: ApiStack (us-east-1) ===
[DECLARED DRIFT: 3]
  ...

[UNDECLARED DRIFT: 2] (the differentiator)
  ...

result: 5 drift(s) (declared=3 undeclared=2)
info: ...
```

- Count INSIDE the brackets; the explanatory note moves outside (dim on a TTY).
- First drift section directly under the header; grouping blank only BETWEEN sections.
- Blank line before `result:` ONLY when a drift section was printed — R37's terseness invariant holds (CLEAN + one info tier is still exactly 3 lines; multi-stack separator unchanged).

## Tests

312/312 pass; updated R37 spacing tests to the R48 contract + new assertions: bracket format (`[UNDECLARED DRIFT: 1] (the differentiator)`), a no-bare-digit-after-`]` regex, first-section/verdict spacing, two-section grouping.

## Gates

typecheck / lint+format / build / tests all pass; `check` + `docs` markers set; worktree-developed. README samples + ARCHITECTURE layout paragraph updated.