### PR TITLE
fix(normalize): suppress post-revert phantom drift — empty-struct values + suspended S3 versioning (R46)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -303,9 +303,13 @@ progress, tagged `CDK_ASSEMBLY_E1002`/error by toolkit-lib) in alarming **red** 
 ([src/synth/io-host.ts](../src/synth/io-host.ts)).
 
 **The `isTrivialEmpty` asymmetry (intentional trade-off).** An undeclared value that
-is `false`, `''`, `[]`, or `{}` is suppressed (`isTrivialEmpty` in noise.ts) — AWS
+is `false`, `''`, `[]`, or an object whose every value is itself trivially empty
+(recursively — `{}` included) is suppressed (`isTrivialEmpty` in noise.ts) — AWS
 returns a "feature off / empty" value for almost every unset option, so without this
 the undeclared residual would be dominated by `X: false` noise on every resource.
+The object recursion covers feature-off STRUCTS AWS materializes (e.g. the empty
+`VpcConfig {Ipv6AllowedForDualStack:false, SecurityGroupIds:[], SubnetIds:[]}` a
+Lambda reports after a Cloud Control update — R46); arrays stay length-0-only.
 The cost: on the FIRST run / under `--show-all` (inventory), an explicitly-OFF
 feature is **not shown** (you can't see "encryption is false" in the inventory). The
 asymmetry is one-directional and self-correcting for the case that matters: once a
@@ -332,9 +336,12 @@ unrelated mid-revert drift on the revert. A `verifying convergence (re-reading
 N resource(s))...` line attributes the wait, and if a touched resource still
 reads as drifted, ONE re-read after a short delay guards against SDK-writer
 eventual consistency (the slow full re-gather used to grant that propagation
-time by accident). Exit semantics: no drift at all → `no drift to revert.` +
-exit 0; drift exists but **nothing is revertable** → `nothing revertable — N
-drift(s) remain.` + exit 1 (drift-remains semantics, not a usage error — R35).
+time by accident). When drift survives, each surviving finding is listed
+(id.path + tier) under the `N drift(s) remain.` line so the user doesn't have
+to re-run `check` to learn what failed to converge (R46). Exit semantics: no
+drift at all → `no drift to revert.` + exit 0; drift exists but **nothing is
+revertable** → `nothing revertable — N drift(s) remain.` + exit 1
+(drift-remains semantics, not a usage error — R35).
 
 - **Targets**: declared drift → the **deployed-template** value; undeclared drift →
   the **baseline** value (an unaccepted out-of-band _addition_ reverts by REMOVAL).

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -24,9 +24,9 @@ import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
 import { type GatherResult, regatherTouched } from './gather.js';
 
-const driftCount = (findings: Finding[]): number =>
-  findings.filter((f) => f.tier === 'deleted' || f.tier === 'declared' || f.tier === 'undeclared')
-    .length;
+const isDrift = (f: Finding): boolean =>
+  f.tier === 'deleted' || f.tier === 'declared' || f.tier === 'undeclared';
+const driftCount = (findings: Finding[]): number => findings.filter(isDrift).length;
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -363,12 +363,19 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     await sleep(p.convergeRetryDelayMs ?? CONVERGE_RETRY_DELAY_MS);
     post = reconcile(await regatherTouched(gathered, touched, region));
   }
-  const remaining = driftCount(post);
+  const remainingDrift = post.filter(isDrift);
+  const remaining = remainingDrift.length;
   console.log(
     remaining === 0
       ? style.clean(`${stackName}: CLEAN after revert.`)
       : style.drift(`${stackName}: ${remaining} drift(s) remain.`)
   );
+  // Say WHICH drift survived — without this the user must re-run `check` just to
+  // learn what didn't converge (R46). A terse id-per-line pointer, not a report.
+  for (const f of remainingDrift) {
+    const id = f.constructPath ?? f.logicalId;
+    console.log(`  - ${id}${f.path ? `.${f.path}` : ''} (${f.tier})`);
+  }
   if (remaining > 0) worst = Math.max(worst, 1);
   return { exit: worst, aborted: false };
 }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4,6 +4,10 @@
 // A4: defaults AWS applies that are NOT in the CFn schema's `default` field.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
+  // S3 versioning can never return to the never-enabled state — a revert "remove"
+  // lands on Suspended, which IS the off state. Without this entry an undeclared
+  // {Status:"Suspended"} re-reports forever and revert can never converge (R46).
+  'AWS::S3::Bucket': { VersioningConfiguration: { Status: 'Suspended' } },
 };
 
 // Strip AWS-managed (aws:*) tag ELEMENTS from the live side so a declared tag
@@ -143,11 +147,17 @@ export function isStringlyEqualScalar(a: unknown, b: unknown): boolean {
   return false;
 }
 
-// A1: trivially-empty/off values AWS returns for unset features.
+// A1: trivially-empty/off values AWS returns for unset features. Objects recurse:
+// a struct whose EVERY value is itself trivially empty is a feature-off struct —
+// e.g. the empty VpcConfig ({Ipv6AllowedForDualStack:false, SecurityGroupIds:[],
+// SubnetIds:[]}) that Lambda materializes after a Cloud Control UpdateResource,
+// which otherwise phantom-drifts on every revert (R46). Arrays stay length-0-only
+// (no element recursion — [false] may be a meaningful list), same conservative
+// stance as the top-level scalars (0 stays meaningful, false does not).
 export function isTrivialEmpty(v: unknown): boolean {
   if (v === false || v === '') return true;
   if (Array.isArray(v)) return v.length === 0;
-  if (v && typeof v === 'object') return Object.keys(v).length === 0;
+  if (v && typeof v === 'object') return Object.values(v).every(isTrivialEmpty);
   return false;
 }
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -201,3 +201,62 @@ describe('classifyResource regressions (dogfood false-positive classes)', () => 
     );
   });
 });
+
+describe('classifyResource post-revert phantom drift (R46)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'R',
+    resourceType,
+    physicalId: 'p',
+    declared,
+  });
+  const undeclaredPaths = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    classifyResource(res(resourceType, declared), live, bare)
+      .filter((f) => f.tier === 'undeclared')
+      .map((f) => f.path);
+
+  it('the empty VpcConfig struct a CC update materializes on a Lambda is not drift', () => {
+    const emptyVpc = { Ipv6AllowedForDualStack: false, SecurityGroupIds: [], SubnetIds: [] };
+    expect(undeclaredPaths('AWS::Lambda::Function', {}, { VpcConfig: emptyVpc })).toEqual([]);
+    // a REAL out-of-band VPC attachment is still reported
+    expect(
+      undeclaredPaths(
+        'AWS::Lambda::Function',
+        {},
+        { VpcConfig: { ...emptyVpc, SubnetIds: ['subnet-0aaa111bbb'] } }
+      )
+    ).toEqual(['VpcConfig']);
+  });
+
+  it('undeclared S3 versioning: Suspended (the post-revert off state) is not drift; Enabled is', () => {
+    expect(
+      undeclaredPaths('AWS::S3::Bucket', {}, { VersioningConfiguration: { Status: 'Suspended' } })
+    ).toEqual([]);
+    expect(
+      undeclaredPaths('AWS::S3::Bucket', {}, { VersioningConfiguration: { Status: 'Enabled' } })
+    ).toEqual(['VersioningConfiguration']);
+  });
+
+  it('DECLARED Enabled vs live Suspended stays declared drift (KNOWN_DEFAULTS never touches the declared loop)', () => {
+    const findings = classifyResource(
+      res('AWS::S3::Bucket', { VersioningConfiguration: { Status: 'Enabled' } }),
+      { VersioningConfiguration: { Status: 'Suspended' } },
+      bare
+    );
+    expect(findings.filter((f) => f.tier === 'declared').map((f) => f.path)).toEqual([
+      'VersioningConfiguration.Status',
+    ]);
+  });
+});

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -21,6 +21,21 @@ describe('noise suppressors', () => {
     expect(isTrivialEmpty(true)).toBe(false);
   });
 
+  it('isTrivialEmpty: recurses into objects — a feature-off struct is empty (R46)', () => {
+    // the empty VpcConfig Lambda materializes after a Cloud Control update
+    expect(
+      isTrivialEmpty({ Ipv6AllowedForDualStack: false, SecurityGroupIds: [], SubnetIds: [] })
+    ).toBe(true);
+    expect(isTrivialEmpty({ a: { b: [], c: false }, d: '' })).toBe(true); // nested
+    // any real content keeps the struct reported
+    expect(isTrivialEmpty({ Status: 'Suspended' })).toBe(false);
+    expect(isTrivialEmpty({ a: false, b: 'x' })).toBe(false);
+    expect(isTrivialEmpty({ SubnetIds: ['subnet-0aaa111'] })).toBe(false);
+    // arrays do NOT recurse — only length 0 is empty ([false] may be a meaningful list)
+    expect(isTrivialEmpty([false])).toBe(false);
+    expect(isTrivialEmpty({ L: [false] })).toBe(false);
+  });
+
   it('canonicalizeTagListsDeep: sorts {Key,Value}[] by Key so reordering is not drift', () => {
     const a = canonicalizeTagListsDeep({
       Tags: [
@@ -145,6 +160,12 @@ describe('noise suppressors', () => {
 
   it('IAM Role known defaults present', () => {
     expect(KNOWN_DEFAULTS['AWS::IAM::Role'].MaxSessionDuration).toBe(3600);
+  });
+
+  it('S3 suspended versioning is a known default — the off state a revert lands on (R46)', () => {
+    expect(KNOWN_DEFAULTS['AWS::S3::Bucket'].VersioningConfiguration).toEqual({
+      Status: 'Suspended',
+    });
   });
 
   it('stripAwsTagsDeep removes aws:* tags (list + map), keeps the rest', () => {

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -359,6 +359,9 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     const { outcome, logs } = await run();
     expect(outcome).toEqual({ exit: 1, aborted: false });
     expect(logs).toContain('s: 1 drift(s) remain.');
+    // R46: each surviving drift is listed (id.path + tier) so the user does not
+    // have to re-run `check` just to learn what failed to converge.
+    expect(logs).toContain('  - B.VersioningConfiguration.Status (declared)');
     expect(cc.commandCalls(GetResourceCommand)).toHaveLength(2); // first read + one retry, no more
   });
 });


### PR DESCRIPTION
## Symptom (dogfood)

`check` found 6 drifts → `revert` applied all 6 ops successfully → the convergence check still said `2 drift(s) remain.`, and a follow-up `check` kept reporting 2 undeclared drifts forever. Both leftovers are phantom drift that **revert itself manufactures**:

1. **Lambda `VpcConfig` empty struct** — the Cloud Control `UpdateResource` round-trip materializes `VpcConfig: {Ipv6AllowedForDualStack:false, SecurityGroupIds:[], SubnetIds:[]}` in the live model. `isTrivialEmpty` only suppressed top-level `false`/`''`/`[]`/`{}`, so this feature-off struct re-reported on every Lambda revert.
2. **S3 `VersioningConfiguration: {Status:"Suspended"}`** — versioning can never return to never-enabled; the plan's `remove` op lands on `Suspended`, which re-reported as undeclared drift forever (remove → Suspended → drift → remove …).

## Fix

- `isTrivialEmpty` now recurses into objects: a struct whose every value is itself trivially empty is suppressed. Arrays stay length-0-only (no element recursion — conservative).
- `KNOWN_DEFAULTS['AWS::S3::Bucket'] = { VersioningConfiguration: { Status: 'Suspended' } }` — Suspended is the off state and the only convergence target a revert remove can reach. Scope guard: KNOWN_DEFAULTS is consulted only in the undeclared loop, so undeclared `Enabled` is still reported and declared `Enabled` vs live `Suspended` stays declared drift (both unit-tested).
- UX: the convergence check lists each surviving drift (`- id.path (tier)`) under the `N drift(s) remain.` line, so the user no longer needs to re-run `check` to learn what failed to converge.

docs/ARCHITECTURE.md §6 (isTrivialEmpty asymmetry) and §7 (convergence re-check) updated to match.

## Tests

- `isTrivialEmpty` recursion: empty VpcConfig struct / nested struct → empty; `{Status:"Suspended"}`, `{a:false,b:"x"}`, `[false]` → not empty.
- classify: empty `VpcConfig` suppressed, real VPC attachment still reported; undeclared `Suspended` suppressed, undeclared `Enabled` reported; declared `Enabled` vs live `Suspended` → declared drift.
- revertStack converge: surviving drift line `  - B.VersioningConfiguration.Status (declared)` asserted.

## Gates

typecheck / lint+format / build / tests all pass (28 files, 315 tests); `check` + `docs` markers set.
