### PR TITLE
feat(check): anchor 'undeclared' to the template + defuse the first-run count + multiselect key hints (R49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ explainable — the same change shows up:
 ```console
 $ npx cdkrd check ApiStack
 === cdkrd check: ApiStack (us-east-1) ===
-[UNDECLARED DRIFT: 1] (the differentiator)
+[UNDECLARED DRIFT: 1] (not declared in your template — the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
 
 result: 1 drift(s) (undeclared=1)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -42,12 +42,19 @@ export function preDeployFindings(findings: Finding[]): Finding[] {
 // accept is offered right after it). A select carries both in the option labels
 // themselves; "show first" is the safe default. Exported (pure) so the wording
 // contract is unit-tested.
+//
+// Wording (R49): "undeclared" must be anchored — it means "not declared in YOUR
+// deployed (CDK/CloudFormation) template"; there is no cdkrd-side template, and
+// the baseline only filters which of these get REPORTED. The count is also NOT
+// a drift count: on a first run these are typically AWS defaults the template
+// never pinned (with any real out-of-band edits hiding among them), so the
+// message says so instead of reading as "N problems found".
 export function firstRunPrompt(
   stackName: string,
   undeclaredCount: number
 ): { message: string; options: { value: 'show' | 'acceptAll'; label: string }[] } {
   return {
-    message: `${stackName}: no baseline yet — ${undeclaredCount} undeclared value(s) found (declared drift is reported either way). What do you want to do?`,
+    message: `${stackName}: no baseline yet — found ${undeclaredCount} live value(s) not declared in your template (typically AWS defaults, but out-of-band edits hide among them; declared-property drift is reported either way). What do you want to do?`,
     options: [
       {
         value: 'show',

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -30,6 +30,20 @@ const driftCount = (findings: Finding[]): number => findings.filter(isDrift).len
 
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Message for accept's multiselect. clack renders NO key hints by default (they
+ * only appear inside the required-validation error), so the keys users need —
+ * verified against @clack/core: space toggles, `a` toggles all, `i` inverts,
+ * enter confirms — are spelled out on a dim second line (R49). Pure + exported
+ * so the wording is unit-tested.
+ */
+export function acceptSelectMessage(stackName: string): string {
+  return (
+    `${stackName}: select undeclared value(s) to accept (unselected stay reported)\n` +
+    style.infoTier('space = toggle · a = toggle all · i = invert · enter = confirm')
+  );
+}
+
 // ---- accept ----
 
 export interface AcceptStackParams {
@@ -98,7 +112,7 @@ export async function acceptStack(p: AcceptStackParams): Promise<AcceptResult> {
       refreshedOnly = true;
     } else {
       const picked = await multiselect({
-        message: `${stackName}: select undeclared value(s) to accept (unselected stay reported)`,
+        message: acceptSelectMessage(stackName),
         options: changed.map((e) => ({ value: acceptedKey(e), label: `${e.logicalId}.${e.path}` })),
         initialValues: changed.map((e) => acceptedKey(e)), // default = all selected
         required: false,

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -32,7 +32,7 @@ const TIER_NAMES: Record<Tier, string> = {
 // Explanation printed after the bracketed name+count, outside the brackets.
 const TIER_NOTES: Partial<Record<Tier, string>> = {
   deleted: 'resource deleted out of band — always drift',
-  undeclared: 'the differentiator',
+  undeclared: 'not declared in your template — the differentiator',
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
   readGap: 'declared but not returned by live read — not drift',
   unresolved: 'declared paths needing GetAtt — skipped, not drift',

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -28,11 +28,13 @@ describe('preDeployFindings (--pre-deploy scope)', () => {
 });
 
 describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', () => {
-  it('the message carries the stack name and the undeclared count', () => {
+  it('the message anchors "undeclared" to the template and does not read as a drift count (R49)', () => {
     const { message } = firstRunPrompt('ApiStack', 113);
     expect(message).toContain('ApiStack: no baseline yet');
-    expect(message).toContain('113 undeclared value(s) found');
-    expect(message).toContain('declared drift is reported either way');
+    expect(message).toContain('found 113 live value(s) not declared in your template');
+    expect(message).toContain('typically AWS defaults'); // first-run framing, not "113 problems"
+    expect(message).toContain('declared-property drift is reported either way');
+    expect(message).not.toContain('drift(s) found'); // it must never read as a drift verdict
   });
 
   it('"show first" is the FIRST option (the safe default) and says accept is still possible after', () => {

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -57,7 +57,9 @@ describe('report', () => {
 
   it('section header carries the count INSIDE the brackets, note outside (R48)', () => {
     const { text } = run([F('undeclared'), F('declared', 'Q')]);
-    expect(text).toContain('[UNDECLARED DRIFT: 1] (the differentiator)');
+    expect(text).toContain(
+      '[UNDECLARED DRIFT: 1] (not declared in your template — the differentiator)'
+    );
     expect(text).toContain('[DECLARED DRIFT: 1]'); // no note for declared
     // the old bare-digit-right-of-bracket form is gone
     expect(text).not.toMatch(/\] \d/);

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -11,6 +11,7 @@ import { baselinePath } from '../src/baseline/baseline-file.js';
 import type { GatherResult } from '../src/commands/gather.js';
 import type { Desired } from '../src/desired/template-adapter.js';
 import {
+  acceptSelectMessage,
   acceptStack,
   availableActions,
   formatPlan,
@@ -439,6 +440,18 @@ describe('acceptStack non-interactive refusal (R38)', () => {
     } finally {
       if (existsSync(path)) rmSync(path);
     }
+  });
+});
+
+describe('acceptSelectMessage (R49 — multiselect key hints)', () => {
+  it('spells out the clack keys: space / a / i / enter (clack shows no hints by default)', () => {
+    const msg = acceptSelectMessage('ApiStack');
+    expect(msg).toContain('ApiStack: select undeclared value(s) to accept');
+    expect(msg).toContain('unselected stay reported');
+    expect(msg).toContain('space = toggle');
+    expect(msg).toContain('a = toggle all');
+    expect(msg).toContain('i = invert');
+    expect(msg).toContain('enter = confirm');
   });
 });
 


### PR DESCRIPTION
## Summary

Three first-contact confusions from dogfooding:

1. **"undeclared" was ambiguous** (undeclared in what — cdkrd's file or the template?). It means **not declared in your deployed CDK/CloudFormation template**; the baseline only filters what gets reported. Prompt: `found 112 live value(s) not declared in your template`. Tier note: `[UNDECLARED DRIFT: N] (not declared in your template — the differentiator)`.
2. **The first-run count read like "112 drifts found"**. It is not a drift verdict — on a first run these are typically AWS defaults the template never pinned. The prompt now says so: `(typically AWS defaults, but out-of-band edits hide among them; declared-property drift is reported either way)`.
3. **accept's multiselect had no key hints** (clack 1.5.1 renders them only inside the required-validation error). The message now carries a dim hint line: `space = toggle · a = toggle all · i = invert · enter = confirm` — keys verified against @clack/core 1.4.1 source. `acceptSelectMessage()` extracted pure + unit-tested.

## Tests

318/318 (+1 hint-message test; first-run prompt assertions updated: anchored wording, 'typically AWS defaults' framing, must-not-read-as-drift-verdict guard). README sample updated.

## Gates

typecheck / lint+format / build / tests pass; check+docs markers set; worktree-developed.