### PR TITLE
fix(diff): detect out-of-band inline policies on sibling-managed IAM roles

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,8 @@ un-deployed code edits would show as false "drift".
      - policy canonical (Action/Resource/Principal scalar-vs-array unify, statement
        sort, account-id<->root-ARN; Version kept only when declared — never fabricated)
      - aws:* tags (list + map), scalar schema-defaults + per-type known-defaults
-     - sibling AWS::IAM::Policy suppression on a role's live Policies
+     - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
+       Policies (an out-of-band inline policy next to them still reports)
 5. classify (tag):  declared | undeclared | readGap | unresolved | skipped
 6. report + exit code (0 clean / 1 drift / 2 error) + --fail-on <tier>
 ```

--- a/README.md
+++ b/README.md
@@ -279,8 +279,8 @@ covers them. If you scope tighter, the calls are:
 `cloudcontrol:UpdateResource` (which resolves to each type's own update permissions),
 plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 `sns:SetTopicAttributes`, `sqs:SetQueueAttributes`, `iam:PutRolePolicy` /
-`PutUserPolicy` / `PutGroupPolicy`, `iam:CreatePolicyVersion` /
-`DeletePolicyVersion` / `ListPolicyVersions`.
+`DeleteRolePolicy` / `PutUserPolicy` / `PutGroupPolicy`,
+`iam:CreatePolicyVersion` / `DeletePolicyVersion` / `ListPolicyVersions`.
 
 **If you never run `revert`, cdkrd needs no write permissions at all.**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,7 +247,7 @@ all live changes
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)
   − stringly-typed scalar (true vs "true", 5432 vs "5432") → equal (isStringlyEqualScalar)
     (scalars only — a typed vs string *array* like [80,443] vs ["80","443"] still reports; fail-safe noise)
-  − sibling AWS::IAM::Policy on a role → suppressed
+  − sibling AWS::IAM::Policy entries in a role's Policies → filtered BY NAME (see below)
   = undeclared residual                → the unique signal
 ```
 
@@ -301,6 +301,20 @@ dogfood also fixed the synth IoHost printing the CDK app's stderr passthrough (b
 progress, tagged `CDK_ASSEMBLY_E1002`/error by toolkit-lib) in alarming **red** —
 `planIoMessage` re-tags app passthrough to the default color, matching cdk-local
 ([src/synth/io-host.ts](../src/synth/io-host.ts)).
+
+**Sibling `AWS::IAM::Policy` entries are filtered BY NAME, not suppressed
+wholesale.** The CDK grant pattern puts a role's permissions in a sibling
+`AWS::IAM::Policy` resource (the "DefaultPolicy"), which reflects into the role's
+live `Policies` — pure noise on the role, since the sibling resource's own check
+already owns its content drift. But suppressing the role's whole `Policies`
+property would also hide an out-of-band inline policy added NEXT to the sibling —
+exactly the differentiator case. So the template adapter maps each role to its
+sibling **PolicyNames** (`collectRolesWithSiblingPolicies`,
+[template-adapter.ts](../src/desired/template-adapter.ts)) and classify drops only
+the live entries matching those names — the residual (rogue inline policies)
+surfaces as undeclared drift. A sibling `PolicyName` the resolver can't evaluate
+statically falls back to suppressing the whole property for that role (fail-safe:
+no false positives over an unidentifiable sibling entry).
 
 **The `isTrivialEmpty` asymmetry (intentional trade-off).** An undeclared value that
 is `false`, `''`, `[]`, or an object whose every value is itself trivially empty
@@ -366,6 +380,14 @@ pass --remove-unaccepted`) rather than removed. The subtractive noise model's
     `AWS::S3::BucketPolicy`, `AWS::SNS::TopicPolicy`, `AWS::SQS::QueuePolicy`,
     `AWS::IAM::Policy`, and `AWS::IAM::ManagedPolicy` (`CreatePolicyVersion` +
     SetAsDefault, pruning the oldest version at the 5-version cap).
+  - **Property-scoped SDK writers** (`SDK_PROP_WRITERS`): a CC-writable type where
+    ONE property must bypass Cloud Control. An IAM Role's top-level `Policies`
+    finding reverts per entry (`DeleteRolePolicy` / `PutRolePolicy` by
+    PolicyName, driven by the op's `value` + `prior`) — a CC `remove /Policies`
+    would also wipe the sibling-managed DefaultPolicy entries that classify
+    filtered OUT of the finding (§6). Scoped to the EXACT top-level path: deeper
+    `Policies.*` declared drift still patches via CC. A resource with both kinds
+    of findings splits into one `cc` item and one `sdk` item.
 - **Not revertable (reported honestly, never silently skipped)**:
   `AWS::Lambda::Permission` (add/remove statement model keyed by StatementId, not a
   settable document), `AWS::Budgets::Budget` (`UpdateBudget` needs a full NewBudget

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -19,7 +19,7 @@ import { applyIgnores, type CdkrdConfig } from '../config/config-file.js';
 import { style } from '../report/style.js';
 import { applyRevertItem } from '../revert/apply.js';
 import { buildRevertPlan, type RevertPlan } from '../revert/plan.js';
-import { SDK_WRITERS } from '../revert/writers.js';
+import { resolveSdkWriter } from '../revert/writers.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
 import { type GatherResult, regatherTouched } from './gather.js';
@@ -335,7 +335,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     if (item.kind === 'sdk') {
       const res = byLogical.get(item.logicalId);
       try {
-        await SDK_WRITERS[item.resourceType]!(
+        const writer = resolveSdkWriter(item.resourceType, item.ops);
+        if (!writer) throw new Error(`no SDK writer for ${item.resourceType}`);
+        await writer(
           {
             physicalId: item.physicalId,
             declared: res?.declared ?? {},

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -168,9 +168,10 @@ export async function loadDesired(
   }
 
   const resources: DesiredResource[] = [];
-  // Roles whose inline Policies are managed by a SIBLING AWS::IAM::Policy resource
-  // (the CDK pattern). Their live Policies would otherwise show as undeclared.
-  const rolesWithSiblingPolicy = collectRolesWithSiblingPolicies(template.Resources ?? {});
+  // Roles whose inline Policies are managed by SIBLING AWS::IAM::Policy resources
+  // (the CDK pattern). classify uses the per-role POLICY NAMES to drop only the
+  // sibling-owned live entries — an out-of-band inline policy still surfaces.
+  const rolesWithSiblingPolicy = collectRolesWithSiblingPolicies(template.Resources ?? {}, ctx);
 
   for (const [logicalId, res] of Object.entries(
     (template.Resources ?? {}) as Record<string, any>
@@ -187,7 +188,8 @@ export async function loadDesired(
       // re-resolves declaredRaw once liveAttrs is populated, reducing UNRESOLVED.
       declared: resolveProperties(declaredRaw, ctx),
       declaredRaw,
-      siblingManaged: res.Type === 'AWS::IAM::Role' && rolesWithSiblingPolicy.has(logicalId),
+      siblingPolicyNames:
+        res.Type === 'AWS::IAM::Role' ? rolesWithSiblingPolicy.get(logicalId) : undefined,
     });
   }
   return { stackName, region, accountId, resources, rawTemplate, ctx };
@@ -199,14 +201,38 @@ function prettyConstructPath(p: string): string {
   return p.endsWith('/Resource') ? p.slice(0, -'/Resource'.length) : p;
 }
 
-export function collectRolesWithSiblingPolicies(resources: Record<string, any>): Set<string> {
-  const roles = new Set<string>();
+/**
+ * Map each role logicalId to the PolicyNames of the sibling AWS::IAM::Policy
+ * resources attached to it. A sibling whose PolicyName cannot be resolved to a
+ * string (an intrinsic the resolver can't evaluate) marks the role 'unresolved' —
+ * classify then falls back to suppressing the whole live Policies property rather
+ * than risk a false positive on the unidentifiable sibling entry.
+ */
+export function collectRolesWithSiblingPolicies(
+  resources: Record<string, any>,
+  ctx?: ResolverContext
+): Map<string, string[] | 'unresolved'> {
+  const roles = new Map<string, string[] | 'unresolved'>();
   for (const res of Object.values(resources)) {
     if (res?.Type !== 'AWS::IAM::Policy') continue;
+    const name = resolvePolicyName(res.Properties?.PolicyName, ctx);
     for (const r of (res.Properties?.Roles ?? []) as unknown[]) {
       const ref = r && typeof r === 'object' ? (r as Record<string, unknown>).Ref : undefined;
-      if (typeof ref === 'string') roles.add(ref);
+      if (typeof ref !== 'string') continue;
+      const prev = roles.get(ref);
+      if (prev === 'unresolved') continue;
+      if (name === undefined) roles.set(ref, 'unresolved');
+      else roles.set(ref, [...(prev ?? []), name]);
     }
   }
   return roles;
+}
+
+// CDK emits literal PolicyNames (e.g. "RoleDefaultPolicyABC123"); hand-written
+// templates may use intrinsics, which we resolve when a ctx is available.
+function resolvePolicyName(raw: unknown, ctx?: ResolverContext): string | undefined {
+  if (typeof raw === 'string') return raw;
+  if (raw === undefined || raw === null || !ctx) return undefined;
+  const resolved = resolveProperties({ PolicyName: raw }, ctx).PolicyName;
+  return typeof resolved === 'string' ? resolved : undefined; // UNRESOLVED is a symbol, never a string
 }

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -66,6 +66,25 @@ export function classifyResource(
   deepStripPaths(live, schema.writeOnlyPaths);
   deepStripPaths(declared, schema.writeOnlyPaths);
 
+  // Sibling-managed inline Policies (the CDK pattern: grants land in a sibling
+  // AWS::IAM::Policy resource, which reflects into the role's live Policies). Drop
+  // ONLY the live entries owned by a sibling — their content drift is the sibling
+  // resource's own finding — so an out-of-band inline policy added to the role
+  // still surfaces (as undeclared, or inside the declared compare). 'unresolved'
+  // (a sibling PolicyName we cannot resolve statically) falls back to suppressing
+  // the whole property: no false positives over an unidentifiable sibling entry.
+  const sibling = resource.siblingPolicyNames;
+  if (sibling !== undefined && 'Policies' in live) {
+    if (sibling === 'unresolved') {
+      if (!('Policies' in declared)) delete live.Policies;
+    } else if (Array.isArray(live.Policies)) {
+      const names = new Set<unknown>(sibling);
+      live.Policies = live.Policies.filter(
+        (p) => !(p && typeof p === 'object' && names.has((p as Record<string, unknown>).PolicyName))
+      );
+    }
+  }
+
   // declared drift (A3: declared key absent in live = read gap, not drift).
   // NOTE: no `schema.writeOnly.has(k)` guard here — a top-level write-only key was
   // already emitted as a readGap above AND stripped from `declared` by writeOnlyPaths,
@@ -117,8 +136,6 @@ export function classifyResource(
     if (isAllAwsTags(v)) continue;
     if (physicalId !== undefined && v === physicalId) continue;
     if (isTrivialEmpty(v)) continue;
-    // inline Policies managed by a sibling AWS::IAM::Policy are not role drift
-    if (resource.siblingManaged && k === 'Policies') continue;
     findings.push({ tier: 'undeclared', logicalId, resourceType, path: k, actual: v });
   }
 

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -8,12 +8,16 @@
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
 import type { Finding, SchemaInfo } from '../types.js';
-import { SDK_WRITERS } from './writers.js';
+import { SDK_PROP_WRITERS, SDK_WRITERS } from './writers.js';
 
 export interface PatchOp {
   op: 'add' | 'remove';
   path: string; // RFC6902 JSON pointer into the resource Properties model
   value?: unknown;
+  // the finding's CURRENT live value, for property-scoped SDK writers that revert
+  // per entry (e.g. IAM Role inline Policies). Never serialized to Cloud Control
+  // (toPatchDocument picks op/path/value only).
+  prior?: unknown;
   human: string; // one-line description for the plan display
 }
 
@@ -145,11 +149,18 @@ export function buildRevertPlan(
       });
       continue;
     }
-    const kind: RevertItem['kind'] = SDK_WRITERS[f.resourceType] ? 'sdk' : 'cc';
+    // property-scoped SDK writers match the EXACT top-level finding path only
+    // (deeper paths keep going through Cloud Control); a resource can therefore
+    // split into one cc item and one sdk item per scoped path — key the grouping
+    // by kind (+ path when prop-scoped) so each item resolves to ONE writer.
+    const propScoped =
+      !SDK_WRITERS[f.resourceType] && SDK_PROP_WRITERS[f.resourceType]?.[f.path] !== undefined;
+    const kind: RevertItem['kind'] = SDK_WRITERS[f.resourceType] || propScoped ? 'sdk' : 'cc';
 
     const op = revertOp(f, accepted);
+    const key = `${f.logicalId} ${kind}${propScoped ? ` ${f.path}` : ''}`;
     const item =
-      itemsByLogical.get(f.logicalId) ??
+      itemsByLogical.get(key) ??
       ({
         logicalId: f.logicalId,
         displayId,
@@ -159,7 +170,7 @@ export function buildRevertPlan(
         ops: [],
       } as RevertItem);
     item.ops.push(op);
-    itemsByLogical.set(f.logicalId, item);
+    itemsByLogical.set(key, item);
   }
 
   return { items: [...itemsByLogical.values()], notRevertable };
@@ -175,7 +186,9 @@ function revertOp(f: Finding, accepted: BaselineFile['accepted']): PatchOp {
       human: `${f.path} -> deployed-template value`,
     };
   }
-  // undeclared: accepted before? restore that value; else it is a new addition -> remove
+  // undeclared: accepted before? restore that value; else it is a new addition -> remove.
+  // `prior` carries the finding's current live value for property-scoped SDK
+  // writers (per-entry revert); Cloud Control serialization ignores it.
   const wasAccepted = accepted.find((a) => a.logicalId === f.logicalId && a.path === f.path);
   if (f.actual === undefined && f.desired !== undefined) {
     // removed-undeclared finding: re-add the baseline value
@@ -191,12 +204,14 @@ function revertOp(f: Finding, accepted: BaselineFile['accepted']): PatchOp {
       op: 'add',
       path: pointer,
       value: wasAccepted.value,
+      prior: f.actual,
       human: `${f.path} -> baseline value`,
     };
   }
   return {
     op: 'remove',
     path: pointer,
+    prior: f.actual,
     human: `${f.path} -> remove (undeclared, not in baseline)`,
   };
 }

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -24,6 +24,7 @@
 import {
   CreatePolicyVersionCommand,
   DeletePolicyVersionCommand,
+  DeleteRolePolicyCommand,
   IAMClient,
   ListPolicyVersionsCommand,
   PutGroupPolicyCommand,
@@ -142,6 +143,50 @@ const writeIamManagedPolicy: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// Inline Policies on an IAM Role, reverted PER ENTRY (PutRolePolicy /
+// DeleteRolePolicy by PolicyName) instead of a whole-property Cloud Control patch:
+// a CC `remove /Policies` would also wipe the sibling-AWS::IAM::Policy entries
+// (the CDK DefaultPolicy) that classify filtered OUT of the finding. Each op
+// carries the finding's current live subset in `prior` (set by plan.ts); the
+// desired subset is `value` for an add (baseline restore), empty for a remove.
+// Entries in prior but not desired are deleted; every desired entry is (re)put.
+interface InlinePolicy {
+  PolicyName: string;
+  PolicyDocument: unknown;
+}
+const asInlinePolicies = (v: unknown): InlinePolicy[] =>
+  Array.isArray(v)
+    ? v.filter(
+        (p): p is InlinePolicy =>
+          !!p && typeof p === 'object' && typeof (p as InlinePolicy).PolicyName === 'string'
+      )
+    : [];
+
+const writeIamRoleInlinePolicies: SdkWriter = async (ctx, ops) => {
+  const role = str(ctx.physicalId); // an AWS::IAM::Role physical id IS the role name
+  if (!role) throw new Error('cannot resolve role name for revert');
+  const c = new IAMClient({ region: ctx.region });
+  for (const op of ops) {
+    if (op.path !== '/Policies')
+      throw new Error(`unsupported inline-policy revert path: ${op.path}`);
+    const desired = op.op === 'add' ? asInlinePolicies(op.value) : [];
+    const keep = new Set(desired.map((p) => p.PolicyName));
+    for (const p of asInlinePolicies(op.prior)) {
+      if (!keep.has(p.PolicyName))
+        await c.send(new DeleteRolePolicyCommand({ RoleName: role, PolicyName: p.PolicyName }));
+    }
+    for (const p of desired) {
+      await c.send(
+        new PutRolePolicyCommand({
+          RoleName: role,
+          PolicyName: p.PolicyName,
+          PolicyDocument: JSON.stringify(p.PolicyDocument),
+        })
+      );
+    }
+  }
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::S3::BucketPolicy': writeS3BucketPolicy,
   'AWS::SNS::TopicPolicy': writeSnsTopicPolicy,
@@ -149,3 +194,22 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::IAM::Policy': writeIamPolicy,
   'AWS::IAM::ManagedPolicy': writeIamManagedPolicy,
 };
+
+// Property-scoped SDK writers: CC-writable types where ONE property must be
+// reverted via the type's own SDK instead of a Cloud Control patch. Keyed by
+// resource type -> EXACT top-level finding path. Deeper paths (e.g. a declared
+// drift at Policies.0...) still go through Cloud Control as before.
+export const SDK_PROP_WRITERS: Record<string, Record<string, SdkWriter>> = {
+  'AWS::IAM::Role': { Policies: writeIamRoleInlinePolicies },
+};
+
+/** Resolve the SDK writer for a kind='sdk' revert item: the whole-type writer, or
+ *  the property-scoped writer matching the item's ops (all ops in a prop-scoped
+ *  item share one top-level pointer — plan.ts groups by exact finding path). */
+export function resolveSdkWriter(resourceType: string, ops: PatchOp[]): SdkWriter | undefined {
+  const whole = SDK_WRITERS[resourceType];
+  if (whole) return whole;
+  const byProp = SDK_PROP_WRITERS[resourceType];
+  const top = ops[0]?.path.split('/')[1]?.replace(/~1/g, '/').replace(/~0/g, '~');
+  return byProp && top ? byProp[top] : undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,5 +54,10 @@ export interface DesiredResource {
   constructPath?: string | undefined; // CDK construct path from aws:cdk:path Metadata (display only)
   declared: Record<string, unknown>; // intrinsic-resolved + NoValue-pruned (may carry UNRESOLVED)
   declaredRaw?: Record<string, unknown>; // raw Properties, re-resolved by gather once liveAttrs are read
-  siblingManaged?: boolean; // an IAM Role whose inline Policies are managed by a sibling AWS::IAM::Policy
+  // inline Policies on an IAM Role owned by sibling AWS::IAM::Policy resources (the
+  // CDK pattern). classify drops ONLY the live entries whose PolicyName is listed
+  // here, so an out-of-band inline policy is still reported. 'unresolved' = a
+  // sibling PolicyName is not statically resolvable -> fall back to suppressing the
+  // whole live Policies property (no false positives).
+  siblingPolicyNames?: string[] | 'unresolved' | undefined;
 }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -260,3 +260,69 @@ describe('classifyResource post-revert phantom drift (R46)', () => {
     ]);
   });
 });
+
+describe('sibling-managed inline Policies (IAM Role)', () => {
+  const noSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const DOC = {
+    Version: '2012-10-17',
+    Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }],
+  };
+  const sibling = { PolicyName: 'RoleDefaultPolicyABC', PolicyDocument: DOC };
+  const rogue = { PolicyName: 'rogue-inline', PolicyDocument: DOC };
+  const role = (
+    siblingPolicyNames?: string[] | 'unresolved',
+    declared: Record<string, unknown> = {}
+  ): DesiredResource => ({
+    logicalId: 'Role',
+    resourceType: 'AWS::IAM::Role',
+    physicalId: 'role-name',
+    declared,
+    siblingPolicyNames,
+  });
+
+  it('a live Policies entry owned by a sibling is filtered out (no finding)', () => {
+    const findings = classifyResource(
+      role(['RoleDefaultPolicyABC']),
+      { Policies: [sibling] },
+      noSchema
+    );
+    expect(findings).toEqual([]);
+  });
+
+  it('an out-of-band inline policy NEXT TO a sibling surfaces as undeclared with ONLY the rogue entry', () => {
+    const findings = classifyResource(
+      role(['RoleDefaultPolicyABC']),
+      { Policies: [sibling, rogue] },
+      noSchema
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ tier: 'undeclared', path: 'Policies' });
+    const actual = findings[0]!.actual as { PolicyName: string }[];
+    expect(actual.map((p) => p.PolicyName)).toEqual(['rogue-inline']);
+  });
+
+  it('with NO sibling, every live inline policy is undeclared (unchanged behavior)', () => {
+    const findings = classifyResource(role(undefined), { Policies: [rogue] }, noSchema);
+    expect(tiers(findings).undeclared).toEqual(['Policies']);
+  });
+
+  it("'unresolved' sibling names fall back to suppressing the whole property", () => {
+    const findings = classifyResource(role('unresolved'), { Policies: [sibling, rogue] }, noSchema);
+    expect(findings).toEqual([]);
+  });
+
+  it('declared role Policies + sibling entries in live: the sibling entry is not false declared drift', () => {
+    const declared = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }] };
+    const live = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }, sibling] };
+    const findings = classifyResource(role(['RoleDefaultPolicyABC'], declared), live, noSchema);
+    expect(findings).toEqual([]);
+  });
+});

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -44,6 +44,28 @@ cd basic && bash verify-deleted-guards.sh
 
 IAM Role (inject a permissions boundary → undeclared drift) and a Node Lambda
 (inject reserved concurrency → undeclared drift); each asserts detect + clean destroy.
+The IAM fixture role also carries a CDK-generated sibling `AWS::IAM::Policy`
+(`addToPolicy` → DefaultPolicy), so the boundary test doubles as a no-false-positive
+check for the sibling filter.
+
+### iam / verify-inline-policy.sh
+
+A second script in the `iam` fixture covering the sibling-DefaultPolicy blind
+spot end-to-end (an out-of-band inline policy on a role whose grants live in a
+sibling `AWS::IAM::Policy`):
+
+1. `accept` then `check` reports CLEAN — the sibling DefaultPolicy entry in the
+   role's live `Policies` is filtered by name, not reported as drift.
+2. After `put-role-policy` adds a rogue inline policy out-of-band, `check` reports
+   `Policies` drift (exit 1) naming ONLY the rogue policy — the sibling entry does
+   not leak into the finding.
+3. `revert --yes` deletes ONLY the rogue policy (per-name `DeleteRolePolicy`, not a
+   whole-property Cloud Control patch): the DefaultPolicy survives with its
+   document intact, and `check` is CLEAN again.
+
+```bash
+cd iam && bash verify-inline-policy.sh
+```
 
 ## revert
 

--- a/tests/integration/iam/app.ts
+++ b/tests/integration/iam/app.ts
@@ -1,12 +1,23 @@
-// Minimal CDK app for the cdk-real-drift IAM integration test.
+// Minimal CDK app for the cdk-real-drift IAM integration tests.
 // One IAM Role assumed by ec2.amazonaws.com, no permissions boundary declared.
+// addToPolicy() creates the sibling AWS::IAM::Policy (the CDK "DefaultPolicy"
+// pattern) that verify-inline-policy.sh exercises: the sibling's entry in the
+// role's live Policies must be filtered, while an out-of-band inline policy
+// added next to it must still be detected and reverted.
 import { App, Stack } from "aws-cdk-lib";
-import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 
 const app = new App();
 const stack = new Stack(app, "CdkRealDriftIntegIam");
-new Role(stack, "TestRole", {
+const role = new Role(stack, "TestRole", {
   assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
   description: "cdk-real-drift IAM integration test role",
 });
+role.addToPolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ["s3:ListAllMyBuckets"],
+    resources: ["*"],
+  }),
+);
 app.synth();

--- a/tests/integration/iam/verify-inline-policy.sh
+++ b/tests/integration/iam/verify-inline-policy.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# cdk-real-drift IAM inline-policy integration test (real AWS).
+#
+# Reproduces the sibling-DefaultPolicy blind spot end-to-end: the fixture role
+# carries a CDK-generated sibling AWS::IAM::Policy (addToPolicy -> DefaultPolicy),
+# whose entry in the role's live Policies must be FILTERED (no false positive),
+# while an inline policy added out-of-band NEXT TO it must be DETECTED as
+# undeclared drift and REVERTED per-name — deleting only the rogue policy and
+# leaving the DefaultPolicy untouched.
+#
+#   deploy fixture -> accept (baseline) -> check CLEAN (sibling filtered)
+#   -> put-role-policy (rogue inline policy) -> check DETECTS Policies drift
+#   -> revert --yes -> rogue policy GONE, DefaultPolicy INTACT -> check CLEAN
+#
+# A cleanup trap destroys the stack + removes the baseline even on failure.
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit), Docker NOT needed.
+# Usage:  cd tests/integration/iam && npm install && bash verify-inline-policy.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIam
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ROGUE=CdkrdRogueInlinePolicy
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (role + sibling DefaultPolicy) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ROLE_NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::IAM::Role'].PhysicalResourceId" --output text)"
+[ -n "$ROLE_NAME" ] || fail "could not resolve role physical id"
+DEFAULT_POLICY="$(aws iam list-role-policies --role-name "$ROLE_NAME" --query 'PolicyNames[0]' --output text)"
+[ -n "$DEFAULT_POLICY" ] && [ "$DEFAULT_POLICY" != "None" ] || fail "fixture has no sibling DefaultPolicy"
+echo "role=$ROLE_NAME defaultPolicy=$DEFAULT_POLICY"
+
+echo "=== accept (write baseline) ==="
+$CLI accept "$STACK" --region "$REGION" || fail "accept"
+
+echo "=== check should be CLEAN (sibling DefaultPolicy filtered, no false positive) ==="
+$CLI check "$STACK" --region "$REGION"
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept — sibling DefaultPolicy leaked as drift?"
+
+echo "=== inject undeclared drift (out-of-band inline policy next to the sibling) ==="
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name "$ROGUE" \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sqs:ListQueues","Resource":"*"}]}' \
+  || fail "inject drift"
+
+echo "=== check should DETECT the rogue inline policy (and ONLY it) ==="
+OUT=/tmp/cdk-real-drift-integ-iam-inline.out
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "Policies" "$OUT" || fail "Policies drift not reported"
+grep -q "$ROGUE" "$OUT" || fail "rogue policy name not in the reported value"
+grep -q "$DEFAULT_POLICY" "$OUT" && fail "sibling DefaultPolicy leaked into the finding"
+
+echo "=== revert should delete ONLY the rogue policy ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+POLICIES="$(aws iam list-role-policies --role-name "$ROLE_NAME" --query 'PolicyNames' --output text)"
+echo "post-revert inline policies: $POLICIES"
+echo "$POLICIES" | grep -q "$ROGUE" && fail "rogue policy still attached after revert"
+echo "$POLICIES" | grep -q "$DEFAULT_POLICY" || fail "revert wiped the sibling DefaultPolicy"
+aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name "$DEFAULT_POLICY" \
+  --query 'PolicyDocument.Statement[0].Action' --output text | grep -q "s3:ListAllMyBuckets" \
+  || fail "sibling DefaultPolicy document changed"
+
+echo "=== check should be CLEAN again ==="
+$CLI check "$STACK" --region "$REGION"
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "INTEG PASS"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -255,3 +255,97 @@ describe('buildRevertPlan', () => {
     ]);
   });
 });
+
+describe('property-scoped SDK writer routing (IAM Role inline Policies)', () => {
+  const POLICIES = [{ PolicyName: 'rogue', PolicyDocument: { Version: '2012-10-17' } }];
+  const roleFinding = (over: Partial<Finding> = {}): Finding =>
+    F({
+      tier: 'undeclared',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      actual: POLICIES,
+      ...over,
+    });
+
+  it('an exact Policies finding on a role routes to kind=sdk and the remove op carries prior', () => {
+    const plan = buildRevertPlan([roleFinding()], baseline([]));
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'remove',
+      path: '/Policies',
+      prior: POLICIES,
+    });
+  });
+
+  it('an accepted Policies finding -> add op with the baseline value AND prior (current live subset)', () => {
+    const baselineValue = [{ PolicyName: 'rogue', PolicyDocument: { Version: 'old' } }];
+    const plan = buildRevertPlan(
+      [roleFinding()],
+      baseline([
+        { logicalId: 'R', resourceType: 'AWS::IAM::Role', path: 'Policies', value: baselineValue },
+      ])
+    );
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Policies',
+      value: baselineValue,
+      prior: POLICIES,
+    });
+  });
+
+  it('a DEEP declared Policies path on a role still goes through Cloud Control (kind=cc)', () => {
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'declared',
+          resourceType: 'AWS::IAM::Role',
+          path: 'Policies.0.PolicyDocument',
+          desired: { Version: '2012-10-17' },
+        }),
+      ],
+      undefined
+    );
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('cc');
+  });
+
+  it('mixed findings on one role split into a cc item and an sdk item', () => {
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'declared',
+          resourceType: 'AWS::IAM::Role',
+          path: 'Description',
+          desired: 'x',
+          actual: 'y',
+        }),
+        roleFinding(),
+      ],
+      baseline([])
+    );
+    expect(plan.items).toHaveLength(2);
+    expect(plan.items.map((i) => i.kind).sort()).toEqual(['cc', 'sdk']);
+    // the cc patch document never serializes `prior`
+    const cc = plan.items.find((i) => i.kind === 'cc')!;
+    expect(toPatchDocument(cc)).not.toContain('prior');
+  });
+
+  it('prior is never serialized into the Cloud Control patch document', () => {
+    const item = {
+      logicalId: 'R',
+      displayId: 'R',
+      resourceType: 'AWS::S3::Bucket',
+      physicalId: 'p',
+      kind: 'cc' as const,
+      ops: [
+        { op: 'remove' as const, path: '/X', prior: ['secret'], human: 'X -> remove' },
+        { op: 'add' as const, path: '/Y', value: 1, prior: 2, human: 'Y -> add' },
+      ],
+    };
+    expect(toPatchDocument(item)).toBe(
+      '[{"op":"remove","path":"/X"},{"op":"add","path":"/Y","value":1}]'
+    );
+  });
+});

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -15,21 +15,65 @@ import {
 } from '../src/desired/template-adapter.js';
 
 describe('collectRolesWithSiblingPolicies', () => {
-  it('finds roles referenced by a sibling AWS::IAM::Policy', () => {
+  it('maps roles referenced by sibling AWS::IAM::Policy resources to the policy NAMES', () => {
     const resources = {
       MyRole: { Type: 'AWS::IAM::Role' },
-      MyPolicy: { Type: 'AWS::IAM::Policy', Properties: { Roles: [{ Ref: 'MyRole' }] } },
+      MyPolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'MyRoleDefaultPolicyABC', Roles: [{ Ref: 'MyRole' }] },
+      },
+      ExtraPolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'extra', Roles: [{ Ref: 'MyRole' }] },
+      },
       Other: { Type: 'AWS::S3::Bucket' },
     };
-    expect([...collectRolesWithSiblingPolicies(resources)]).toEqual(['MyRole']);
+    expect(collectRolesWithSiblingPolicies(resources)).toEqual(
+      new Map([['MyRole', ['MyRoleDefaultPolicyABC', 'extra']]])
+    );
   });
 
   it('ignores non-Ref role entries and non-policy resources', () => {
     const resources = {
-      P: { Type: 'AWS::IAM::Policy', Properties: { Roles: ['literal-name'] } },
+      P: { Type: 'AWS::IAM::Policy', Properties: { PolicyName: 'p', Roles: ['literal-name'] } },
       Q: { Type: 'AWS::IAM::ManagedPolicy', Properties: { Roles: [{ Ref: 'R' }] } },
     };
     expect(collectRolesWithSiblingPolicies(resources).size).toBe(0); // literal not a Ref; ManagedPolicy not Policy
+  });
+
+  it("marks the role 'unresolved' when a sibling PolicyName cannot be resolved (sticky)", () => {
+    const resources = {
+      A: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'literal', Roles: [{ Ref: 'MyRole' }] },
+      },
+      B: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: { 'Fn::GetAtt': ['X', 'Y'] }, Roles: [{ Ref: 'MyRole' }] },
+      },
+      C: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'after', Roles: [{ Ref: 'MyRole' }] },
+      },
+    };
+    // no ctx -> the intrinsic cannot resolve; 'unresolved' wins and stays
+    expect(collectRolesWithSiblingPolicies(resources).get('MyRole')).toBe('unresolved');
+  });
+
+  it('resolves an intrinsic PolicyName when a resolver ctx is provided', () => {
+    const resources = {
+      P: {
+        Type: 'AWS::IAM::Policy',
+        Properties: {
+          PolicyName: { 'Fn::Sub': 'pol-${AWS::Region}' },
+          Roles: [{ Ref: 'MyRole' }],
+        },
+      },
+    };
+    const ctx = buildResolverContext({}, {}, {}, 'us-east-1', '111122223333', 's', 'sid');
+    expect(collectRolesWithSiblingPolicies(resources, ctx).get('MyRole')).toEqual([
+      'pol-us-east-1',
+    ]);
   });
 });
 

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1,16 +1,18 @@
 import {
   CreatePolicyVersionCommand,
   DeletePolicyVersionCommand,
+  DeleteRolePolicyCommand,
   GetPolicyCommand,
   GetPolicyVersionCommand,
   IAMClient,
   ListPolicyVersionsCommand,
+  PutRolePolicyCommand,
 } from '@aws-sdk/client-iam';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
 import type { PatchOp } from '../src/revert/plan.js';
-import { SDK_WRITERS } from '../src/revert/writers.js';
+import { resolveSdkWriter, SDK_WRITERS } from '../src/revert/writers.js';
 
 const iam = mockClient(IAMClient);
 
@@ -107,5 +109,80 @@ describe('IAM ManagedPolicy writer', () => {
         addOp(DESIRED),
       ])
     ).rejects.toThrow(/managed policy arn/);
+  });
+});
+
+describe('IAM Role inline Policies prop-scoped writer', () => {
+  const DOC = {
+    Version: '2012-10-17',
+    Statement: [{ Effect: 'Allow', Action: '*', Resource: '*' }],
+  };
+  const writer = () => resolveSdkWriter('AWS::IAM::Role', [removePoliciesOp([])])!;
+  const removePoliciesOp = (prior: unknown): PatchOp => ({
+    op: 'remove',
+    path: '/Policies',
+    prior,
+    human: 'Policies -> remove',
+  });
+  const addPoliciesOp = (value: unknown, prior: unknown): PatchOp => ({
+    op: 'add',
+    path: '/Policies',
+    value,
+    prior,
+    human: 'Policies -> baseline value',
+  });
+  const roleCtx = ctx({ physicalId: 'my-role' });
+
+  it('resolveSdkWriter finds the prop-scoped writer from the op pointer', () => {
+    expect(resolveSdkWriter('AWS::IAM::Role', [removePoliciesOp([])])).toBeDefined();
+    expect(
+      resolveSdkWriter('AWS::IAM::Role', [{ op: 'remove', path: '/Description', human: '' }])
+    ).toBeUndefined();
+    expect(resolveSdkWriter('AWS::S3::BucketPolicy', [])).toBe(
+      SDK_WRITERS['AWS::S3::BucketPolicy']
+    );
+  });
+
+  it('remove: deletes ONLY the rogue policies named in prior (sibling policies untouched)', async () => {
+    iam.on(DeleteRolePolicyCommand).resolves({});
+    const rogue = [
+      { PolicyName: 'rogue-a', PolicyDocument: DOC },
+      { PolicyName: 'rogue-b', PolicyDocument: DOC },
+    ];
+    await writer()(roleCtx, [removePoliciesOp(rogue)]);
+    const dels = iam.commandCalls(DeleteRolePolicyCommand);
+    expect(dels.map((c) => c.args[0].input)).toEqual([
+      { RoleName: 'my-role', PolicyName: 'rogue-a' },
+      { RoleName: 'my-role', PolicyName: 'rogue-b' },
+    ]);
+    expect(iam.commandCalls(PutRolePolicyCommand)).toHaveLength(0);
+  });
+
+  it('add (baseline restore): puts every desired entry and deletes prior entries not in desired', async () => {
+    iam.on(DeleteRolePolicyCommand).resolves({});
+    iam.on(PutRolePolicyCommand).resolves({});
+    const baseline = [{ PolicyName: 'kept', PolicyDocument: DOC }];
+    const prior = [
+      { PolicyName: 'kept', PolicyDocument: { changed: true } },
+      { PolicyName: 'extra', PolicyDocument: DOC },
+    ];
+    await writer()(roleCtx, [addPoliciesOp(baseline, prior)]);
+    expect(iam.commandCalls(DeleteRolePolicyCommand).map((c) => c.args[0].input)).toEqual([
+      { RoleName: 'my-role', PolicyName: 'extra' },
+    ]);
+    expect(iam.commandCalls(PutRolePolicyCommand).map((c) => c.args[0].input)).toEqual([
+      { RoleName: 'my-role', PolicyName: 'kept', PolicyDocument: JSON.stringify(DOC) },
+    ]);
+  });
+
+  it('rejects a non-top-level Policies pointer (deep paths belong to Cloud Control)', async () => {
+    await expect(
+      writer()(roleCtx, [{ op: 'remove', path: '/Policies/0', prior: [], human: '' }])
+    ).rejects.toThrow('unsupported inline-policy revert path');
+  });
+
+  it('a missing prior on a remove op is a safe no-op (never a bulk wipe)', async () => {
+    await writer()(roleCtx, [{ op: 'remove', path: '/Policies', human: '' }]);
+    expect(iam.commandCalls(DeleteRolePolicyCommand)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Problem

An inline policy added out-of-band to an IAM role was NOT detected when the role had a CDK-generated sibling `AWS::IAM::Policy` (the DefaultPolicy / grant pattern) — exactly the "extra inline policy" case README cites as the differentiator. The old `siblingManaged` flag suppressed the role's **entire** live `Policies` property, and the sibling resource's own reader only fetches its declared `PolicyName`, so the rogue policy was invisible from both sides.

## Fix

**Detection** — `collectRolesWithSiblingPolicies` now maps each role to its siblings' **PolicyNames** (resolving intrinsic names via the resolver ctx; unresolvable → `'unresolved'` → fail-safe whole-property suppression for that role). `classify` filters only the name-matched live entries, before BOTH the declared and undeclared compares:

- a rogue inline policy next to the sibling surfaces as `undeclared` drift with only the rogue entries in the finding;
- the `inlinePolicies` + grants combo no longer reports the sibling entry as false declared drift.

**Revert** — a Cloud Control `remove /Policies` would also wipe the sibling DefaultPolicy, so a new **property-scoped SDK writer** (`SDK_PROP_WRITERS['AWS::IAM::Role'].Policies`) reverts per entry with `DeleteRolePolicy` / `PutRolePolicy`, driven by the op's `value` (blessed subset) + new `prior` field (current live subset; never serialized into CC patches). Scoped to the exact top-level `Policies` path — deeper declared paths keep the CC route; mixed findings on one role split into one `cc` + one `sdk` item.

## Verification

- **New integ test `tests/integration/iam/verify-inline-policy.sh` — INTEG PASS** against real AWS (us-east-1):
  1. deploy role + sibling DefaultPolicy → `accept` → `check` CLEAN (no false positive);
  2. `put-role-policy` rogue inline policy → `check` exits 1 reporting `Policies` with ONLY the rogue entry (DefaultPolicy name absent from output);
  3. `revert --yes` → rogue policy deleted, DefaultPolicy present with document intact, convergence re-check + final `check` CLEAN.
- Existing `tests/integration/iam/verify.sh` (permissions-boundary) re-run against the updated fixture — INTEG PASS.
- 327 unit tests pass (18 new: name collection incl. intrinsic/unresolved, classify filtering incl. the declared-combo case, plan routing/`prior` serialization guarantees, writer delete/put/no-bulk-wipe).
- `/check` + `/check-docs` gates run; docs updated (ARCHITECTURE §6/§7, DESIGN pipeline line, README revert permissions now include `iam:DeleteRolePolicy`).
