### PR TITLE
test(integ): cover all 5 SDK writers + prove the cdk-drift gap; harden scripts for the interactive era (R50)

### DIFF
--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -5,18 +5,11 @@ description: Comprehensive pre-release verification. Run quality checks, docs co
 
 # Pre-Release Verification
 
-Heavy verification gate. cdk-real-drift (cdkrd) is a solo, local-only repo with
-**no GitHub remote and no pull-request workflow** — so this is not a PR gate, it
-is a **pre-release** readiness check. Run it before cutting a release (the name
-`verify-pr` and the `verify-pr` marker are kept to match the markgate gate
-layout shared with the sibling repos). Per-commit verification is handled by
-`/check`; this skill is a superset of `/check` + `/check-docs` plus a live-test
-and a retrospective.
-
-There is no CI-status step, no `gh` step, no remote-branch step, and no real-AWS
-deploy/destroy/local/schema integ step here — cdkrd's `integ` gate is a separate,
-read-only real-AWS verification that is not wired into this flow (see
-`.markgate.yml`).
+Heavy verification gate — a **pre-release** readiness check, not a per-PR gate
+(per-PR verification is `/check` + `/check-docs` + CI on the pull request). Run
+it before cutting a release. This skill is a superset of `/check` +
+`/check-docs` plus the real-AWS integration fixtures, a live-test, and a
+retrospective.
 
 ## Checklist
 
@@ -80,7 +73,17 @@ Run each check and report pass/fail:
      credentials and no offline fixture), say so explicitly rather than skip
      silently, and DO NOT set the `verify-pr` marker — let the human decide.
 
-7. **Retrospective + rules update**
+7. **Integration fixtures (real AWS) — required before a release (R50)**
+   - Run EVERY fixture under `tests/integration/` (see its README "When to
+     run"): `basic/verify.sh`, `basic/verify-deleted-guards.sh`,
+     `basic/verify-vs-cdk-drift.sh`, `iam`, `lambda`, `revert`, `policies`.
+     Scripts sharing a fixture (`basic`'s three) run sequentially.
+   - Each must print `INTEG PASS`. These mutate a real AWS account (and clean
+     up after themselves) — they need credentials and a bootstrapped account.
+   - If credentials are absent, say so explicitly and DO NOT set the
+     `verify-pr` marker — let the human run them or decide.
+
+8. **Retrospective + rules update**
    - Walk back over the session that produced this change. For each surprise,
      friction, or correction, ask: "one-off, or a recurring pattern?"
    - For each pattern, propose where it should be reflected so it doesn't recur:
@@ -107,6 +110,7 @@ Present results as a table:
 | docs consistency               | pass/fail                 |
 | code review                    | pass/issues found         |
 | live-test changed behavior     | pass/skipped/issues found |
+| integration fixtures (7)       | pass/skipped/issues found |
 | retrospective + rule proposals | done/skipped              |
 
 If all pass, confirm "Ready to release."

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -15,6 +15,23 @@ bash verify.sh       # deploy -> accept -> check CLEAN -> inject drift -> check 
 `verify.sh` exits non-zero (and prints `INTEG FAIL: ...`) if any assertion fails;
 prints `INTEG PASS` on success.
 
+All scripts call the CLI with `--no-interactive` (and `--yes` for accept/revert):
+since the interactive prompts landed (R28/R38/R45), a bare `check`/`accept` run
+from a terminal would stop and wait for input mid-script (R50).
+
+## When to run (R50)
+
+These do NOT run in CI (they need credentials and mutate a real account):
+
+- **Before every release** (the `/verify-pr` gate): run EVERY fixture —
+  `basic` (+ `verify-deleted-guards.sh` + `verify-vs-cdk-drift.sh`), `iam`,
+  `lambda`, `revert`, `policies`.
+- **After changing** `src/read/**`, `src/revert/**`, `src/normalize/**`, or
+  `src/commands/gather.ts`: run at least `basic` + `revert` (and `policies` if
+  `writers.ts` changed) before merging.
+- Scripts that share a fixture/stack (`basic`'s three) must run sequentially,
+  never concurrently.
+
 ## basic
 
 One versioned S3 bucket. Asserts:
@@ -40,6 +57,20 @@ tier and the `revert` guards:
 cd basic && bash verify-deleted-guards.sh
 ```
 
+### basic / verify-vs-cdk-drift.sh
+
+Empirical proof of the README capability table, against `cdk drift` itself
+(reuses the `basic` stack; needs an aws-cdk with the `drift` command):
+
+1. After an **undeclared** change (transfer acceleration), `cdk drift --fail`
+   exits 0 (CFn drift detection cannot see it) while `cdkrd check` exits 1 and
+   names `AccelerateConfiguration` — the differentiator, demonstrated.
+2. After a **declared** change (versioning suspended), BOTH detect it — cdkrd
+   is a superset, not a sidegrade.
+
+If `cdk drift` ever starts detecting the undeclared change, this test fails —
+the signal to re-verify the README comparison-table claims.
+
 ## iam / lambda
 
 IAM Role (inject a permissions boundary → undeclared drift) and a Node Lambda
@@ -53,3 +84,15 @@ drift (acceleration suspended from its accepted Enabled), asserts `check` detect
 both, runs `cdkrd revert --yes`, and asserts `check` is CLEAN and AWS itself
 converged (versioning Enabled = template, acceleration Enabled = baseline value).
 Proves the Cloud Control `UpdateResource` write path end-to-end.
+
+## policies
+
+One resource per SDK writer (`SDK_WRITERS` in `src/revert/writers.ts`):
+`AWS::S3::BucketPolicy`, `AWS::SNS::TopicPolicy`, `AWS::SQS::QueuePolicy`,
+`AWS::IAM::Policy` (standalone inline), `AWS::IAM::ManagedPolicy`. After
+accept + CLEAN, a `CdkrdInjected` statement is spliced into EVERY policy
+document out of band; asserts `check` reports all 5 declared drifts, `revert
+--yes` converges through all 5 writers, `check` is CLEAN again, and direct AWS
+reads confirm the injected statement is gone while the declared one survived
+(for the managed policy: on the new default version). Covers the SDK-override
+read path AND the SDK write path for every writer type end-to-end.

--- a/tests/integration/basic/verify-deleted-guards.sh
+++ b/tests/integration/basic/verify-deleted-guards.sh
@@ -68,7 +68,7 @@ aws s3api delete-bucket --bucket "$BUCKET" --region "$REGION" || fail "delete-bu
 sleep 5
 
 echo "=== R1: check reports the deleted tier + exit 1 ==="
-$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-guard-deleted.out
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-guard-deleted.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "R1: expected exit 1 on a deleted resource, got $rc"
 grep -qi "DELETED (resource deleted out of band" /tmp/cdkrd-guard-deleted.out \

--- a/tests/integration/basic/verify-vs-cdk-drift.sh
+++ b/tests/integration/basic/verify-vs-cdk-drift.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# cdkrd vs `cdk drift` comparison test (real AWS). Proves the README comparison
+# table empirically, in both directions:
+#   1. an UNDECLARED change (transfer acceleration; not in the template) is
+#      INVISIBLE to `cdk drift` / CloudFormation drift detection but DETECTED
+#      by cdkrd — the differentiator;
+#   2. a DECLARED change (versioning suspended) is detected by BOTH — cdkrd is
+#      a superset, not a sidegrade.
+# If `cdk drift` ever starts seeing the undeclared change, this test FAILS —
+# that is the signal to re-verify the README capability-table claims.
+# Reuses the `basic` fixture/stack (run the basic scripts and this one
+# sequentially, never concurrently). Needs aws-cdk new enough to have `cdk
+# drift` (fixture pins ^2.0.0 -> latest v2). Drift detection takes ~30-60s.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkdriftIntegBasic
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+npx cdk drift --help >/dev/null 2>&1 || fail "this aws-cdk has no 'cdk drift' — update the fixture's aws-cdk"
+
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
+[ -n "$BUCKET" ] || fail "no bucket physical id"
+
+echo "=== inject UNDECLARED drift (enable transfer acceleration) ==="
+aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
+  --accelerate-configuration Status=Enabled --region "$REGION" || fail "inject accel"
+sleep 5
+
+echo "=== cdk drift must NOT see the undeclared change ==="
+npx cdk drift "$STACK" --fail 2>&1 | tee /tmp/cdkrd-vs-drift-1.out
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "cdk drift detected the undeclared change — capability changed? Re-verify the README comparison table"
+
+echo "=== cdkrd MUST see it ==="
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-vs-drift-2.out
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "cdkrd missed the undeclared change"
+grep -q "AccelerateConfiguration" /tmp/cdkrd-vs-drift-2.out || fail "AccelerateConfiguration not reported"
+
+echo "=== inject DECLARED drift (suspend versioning) ==="
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+  --versioning-configuration Status=Suspended --region "$REGION" || fail "inject versioning"
+sleep 5
+
+echo "=== declared parity: cdk drift sees it ... ==="
+npx cdk drift "$STACK" --fail 2>&1 | tee /tmp/cdkrd-vs-drift-3.out
+[ "${PIPESTATUS[0]}" -ne 0 ] || fail "cdk drift missed the declared change (expected --fail exit != 0)"
+
+echo "=== ... and cdkrd sees BOTH ==="
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-vs-drift-4.out
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "cdkrd expected drift exit 1"
+grep -q "VersioningConfiguration" /tmp/cdkrd-vs-drift-4.out || fail "declared versioning drift not reported"
+grep -q "AccelerateConfiguration" /tmp/cdkrd-vs-drift-4.out || fail "undeclared accel drift not reported"
+
+echo "INTEG PASS (cdkrd superset of cdk drift confirmed: declared parity + undeclared exclusive)"

--- a/tests/integration/basic/verify.sh
+++ b/tests/integration/basic/verify.sh
@@ -30,10 +30,10 @@ echo "=== deploy fixture ==="
 npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
 
 echo "=== accept (write baseline) ==="
-$CLI accept "$STACK" --region "$REGION" || fail "accept"
+$CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN ==="
-$CLI check "$STACK" --region "$REGION"
+$CLI check "$STACK" --region "$REGION" --no-interactive
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
 
 echo "=== inject undeclared drift (enable transfer acceleration) ==="
@@ -44,7 +44,7 @@ aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
   --accelerate-configuration Status=Enabled --region "$REGION" || fail "inject drift"
 
 echo "=== check should DETECT the undeclared drift ==="
-$CLI check "$STACK" --region "$REGION" | tee /tmp/cdk-real-drift-integ.out
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdk-real-drift-integ.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "AccelerateConfiguration" /tmp/cdk-real-drift-integ.out || fail "AccelerateConfiguration not reported"

--- a/tests/integration/iam/verify.sh
+++ b/tests/integration/iam/verify.sh
@@ -31,10 +31,10 @@ echo "=== deploy fixture ==="
 npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
 
 echo "=== accept (write baseline) ==="
-$CLI accept "$STACK" --region "$REGION" || fail "accept"
+$CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN ==="
-$CLI check "$STACK" --region "$REGION"
+$CLI check "$STACK" --region "$REGION" --no-interactive
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
 
 echo "=== inject undeclared drift (attach permissions boundary) ==="
@@ -46,7 +46,7 @@ aws iam put-role-permissions-boundary \
   --permissions-boundary arn:aws:iam::aws:policy/ReadOnlyAccess || fail "inject drift"
 
 echo "=== check should DETECT the undeclared drift ==="
-$CLI check "$STACK" --region "$REGION" | tee /tmp/cdk-real-drift-integ-iam.out
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdk-real-drift-integ-iam.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "PermissionsBoundary" /tmp/cdk-real-drift-integ-iam.out || fail "PermissionsBoundary not reported"

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -36,10 +36,10 @@ echo "=== deploy fixture ==="
 npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
 
 echo "=== accept (write baseline) ==="
-$CLI accept "$STACK" --region "$REGION" || fail "accept"
+$CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN ==="
-$CLI check "$STACK" --region "$REGION"
+$CLI check "$STACK" --region "$REGION" --no-interactive
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
 
 echo "=== inject undeclared drift (set reserved concurrent executions) ==="
@@ -52,7 +52,7 @@ aws lambda put-function-concurrency \
   --region "$REGION" || fail "inject drift"
 
 echo "=== check should DETECT the undeclared drift ==="
-$CLI check "$STACK" --region "$REGION" | tee /tmp/cdk-real-drift-integ-lambda.out
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdk-real-drift-integ-lambda.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "ReservedConcurrentExecutions" /tmp/cdk-real-drift-integ-lambda.out || fail "ReservedConcurrentExecutions not reported"

--- a/tests/integration/policies/app.ts
+++ b/tests/integration/policies/app.ts
@@ -1,0 +1,85 @@
+// CDK app for the cdk-real-drift POLICIES integration test: one resource per
+// SDK writer (see src/revert/writers.ts SDK_WRITERS) so verify.sh exercises
+// every type-specific write path end-to-end:
+//   AWS::S3::BucketPolicy / AWS::SNS::TopicPolicy / AWS::SQS::QueuePolicy /
+//   AWS::IAM::Policy (standalone inline) / AWS::IAM::ManagedPolicy
+// The bucket is never written to (no autoDeleteObjects needed — destroy works
+// on an empty bucket, and a leaner policy makes the drift injection simpler).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  AnyPrincipal,
+  Effect,
+  ManagedPolicy,
+  Policy,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Topic, TopicPolicy } from "aws-cdk-lib/aws-sns";
+import { Queue, QueuePolicy } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkdriftIntegPolicies");
+
+// S3 bucket + resource policy (creates AWS::S3::BucketPolicy at Data/Policy)
+const bucket = new Bucket(stack, "Data", { removalPolicy: RemovalPolicy.DESTROY });
+bucket.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "DenyInsecureTransport",
+    effect: Effect.DENY,
+    principals: [new AnyPrincipal()],
+    actions: ["s3:*"],
+    resources: [bucket.bucketArn, bucket.arnForObjects("*")],
+    conditions: { Bool: { "aws:SecureTransport": "false" } },
+  })
+);
+
+// SNS topic + topic policy
+const topic = new Topic(stack, "Events");
+new TopicPolicy(stack, "EventsPolicy", { topics: [topic] }).document.addStatements(
+  new PolicyStatement({
+    sid: "AllowS3Publish",
+    principals: [new ServicePrincipal("s3.amazonaws.com")],
+    actions: ["sns:Publish"],
+    resources: [topic.topicArn],
+  })
+);
+
+// SQS queue + queue policy
+const queue = new Queue(stack, "Jobs");
+new QueuePolicy(stack, "JobsPolicy", { queues: [queue] }).document.addStatements(
+  new PolicyStatement({
+    sid: "AllowSnsSend",
+    principals: [new ServicePrincipal("sns.amazonaws.com")],
+    actions: ["sqs:SendMessage"],
+    resources: [queue.queueArn],
+  })
+);
+
+// IAM role + standalone inline policy (AWS::IAM::Policy) + managed policy
+const role = new Role(stack, "Worker", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+});
+new Policy(stack, "WorkerInline", {
+  roles: [role],
+  statements: [
+    new PolicyStatement({
+      sid: "ReadData",
+      actions: ["s3:GetObject"],
+      resources: [bucket.arnForObjects("*")],
+    }),
+  ],
+});
+new ManagedPolicy(stack, "WorkerManaged", {
+  roles: [role],
+  statements: [
+    new PolicyStatement({
+      sid: "ListData",
+      actions: ["s3:ListBucket"],
+      resources: [bucket.bucketArn],
+    }),
+  ],
+});
+
+app.synth();

--- a/tests/integration/policies/cdk.json
+++ b/tests/integration/policies/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/policies/package.json
+++ b/tests/integration/policies/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-policies",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift SDK-writer (policies) integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/policies/verify.sh
+++ b/tests/integration/policies/verify.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# cdkrd SDK-WRITER integration test (real AWS, AWS-mutating). Exercises ALL FIVE
+# SDK_WRITERS end-to-end (src/revert/writers.ts):
+#   AWS::S3::BucketPolicy / AWS::SNS::TopicPolicy / AWS::SQS::QueuePolicy /
+#   AWS::IAM::Policy / AWS::IAM::ManagedPolicy
+# Flow: deploy -> accept (baseline) -> check CLEAN -> inject a "CdkrdInjected"
+# statement into every policy document out-of-band -> check DETECTS 5 declared
+# drifts -> revert --yes (SDK writers) -> check CLEAN -> AWS direct reads confirm
+# the injected statement is GONE while the declared one survived -> destroy.
+# Self-cleaning trap; no orphans on failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkdriftIntegPolicies
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+# Append a statement to a policy document (both passed as JSON strings).
+splice() {
+  node -e '
+    const doc = JSON.parse(process.argv[1]);
+    const stmt = JSON.parse(process.argv[2]);
+    doc.Statement = Array.isArray(doc.Statement) ? doc.Statement : [doc.Statement];
+    doc.Statement.push(stmt);
+    process.stdout.write(JSON.stringify(doc));
+  ' "$1" "$2"
+}
+
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?ResourceType=='$1'].PhysicalResourceId" --output text
+}
+BUCKET="$(phys 'AWS::S3::Bucket')"
+TOPIC_ARN="$(phys 'AWS::SNS::Topic')"
+QUEUE_URL="$(phys 'AWS::SQS::Queue')"
+INLINE_NAME="$(phys 'AWS::IAM::Policy')"
+MANAGED_ARN="$(phys 'AWS::IAM::ManagedPolicy')"
+ROLE_NAME="$(phys 'AWS::IAM::Role')"
+for v in BUCKET TOPIC_ARN QUEUE_URL INLINE_NAME MANAGED_ARN ROLE_NAME; do
+  [ -n "${!v}" ] || fail "could not resolve $v"
+done
+QUEUE_ARN="$(aws sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-names QueueArn \
+  --region "$REGION" --query 'Attributes.QueueArn' --output text)"
+
+echo "=== accept (baseline) ==="
+$CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail accept
+echo "=== check CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "=== inject a CdkrdInjected statement into all 5 policy documents ==="
+# S3 bucket policy (Deny is always writable under BlockPublicPolicy; harmless action)
+DOC="$(aws s3api get-bucket-policy --bucket "$BUCKET" --region "$REGION" --query Policy --output text)"
+aws s3api put-bucket-policy --bucket "$BUCKET" --region "$REGION" --policy \
+  "$(splice "$DOC" "{\"Sid\":\"CdkrdInjected\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:GetBucketTagging\",\"Resource\":\"arn:aws:s3:::$BUCKET\"}")" \
+  || fail "inject bucket policy"
+# SNS topic policy
+DOC="$(aws sns get-topic-attributes --topic-arn "$TOPIC_ARN" --region "$REGION" --query 'Attributes.Policy' --output text)"
+aws sns set-topic-attributes --topic-arn "$TOPIC_ARN" --region "$REGION" --attribute-name Policy --attribute-value \
+  "$(splice "$DOC" "{\"Sid\":\"CdkrdInjected\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudwatch.amazonaws.com\"},\"Action\":\"sns:Publish\",\"Resource\":\"$TOPIC_ARN\"}")" \
+  || fail "inject topic policy"
+# SQS queue policy
+DOC="$(aws sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-names Policy --region "$REGION" --query 'Attributes.Policy' --output text)"
+NEWDOC="$(splice "$DOC" "{\"Sid\":\"CdkrdInjected\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"events.amazonaws.com\"},\"Action\":\"sqs:SendMessage\",\"Resource\":\"$QUEUE_ARN\"}")"
+aws sqs set-queue-attributes --queue-url "$QUEUE_URL" --region "$REGION" \
+  --attributes "$(node -e 'process.stdout.write(JSON.stringify({Policy: process.argv[1]}))' "$NEWDOC")" \
+  || fail "inject queue policy"
+# IAM inline policy (AWS::IAM::Policy — put-role-policy overwrites by name)
+DOC="$(aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name "$INLINE_NAME" --query PolicyDocument --output json)"
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name "$INLINE_NAME" --policy-document \
+  "$(splice "$DOC" '{"Sid":"CdkrdInjected","Effect":"Allow","Action":"s3:GetBucketLocation","Resource":"*"}')" \
+  || fail "inject inline policy"
+# IAM managed policy (new default version)
+VER="$(aws iam get-policy --policy-arn "$MANAGED_ARN" --query 'Policy.DefaultVersionId' --output text)"
+DOC="$(aws iam get-policy-version --policy-arn "$MANAGED_ARN" --version-id "$VER" --query 'PolicyVersion.Document' --output json)"
+aws iam create-policy-version --policy-arn "$MANAGED_ARN" --set-as-default --policy-document \
+  "$(splice "$DOC" '{"Sid":"CdkrdInjected","Effect":"Allow","Action":"s3:GetBucketLocation","Resource":"*"}')" \
+  || fail "inject managed policy"
+echo "(waiting for IAM/SQS propagation)"; sleep 15
+
+echo "=== check DETECTS all 5 declared drifts ==="
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-policies-pre.out
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
+for name in "Data/Policy" "EventsPolicy" "JobsPolicy" "WorkerInline" "WorkerManaged"; do
+  grep -q "$name" /tmp/cdkrd-policies-pre.out || fail "$name drift not reported"
+done
+
+echo "=== revert --yes (all 5 SDK writers) ==="
+$CLI revert "$STACK" --region "$REGION" --yes --no-interactive || fail "revert returned non-zero"
+
+echo "=== check CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "drift remains after revert"
+
+echo "=== belt-and-suspenders: injected statement gone, declared statement survived ==="
+sleep 5
+aws s3api get-bucket-policy --bucket "$BUCKET" --region "$REGION" --query Policy --output text > /tmp/cdkrd-pol-s3.json
+grep -q "CdkrdInjected" /tmp/cdkrd-pol-s3.json && fail "bucket policy still injected"
+grep -q "DenyInsecureTransport" /tmp/cdkrd-pol-s3.json || fail "bucket policy lost its declared statement"
+aws sns get-topic-attributes --topic-arn "$TOPIC_ARN" --region "$REGION" --query 'Attributes.Policy' --output text | grep -q "CdkrdInjected" && fail "topic policy still injected"
+aws sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-names Policy --region "$REGION" --query 'Attributes.Policy' --output text | grep -q "CdkrdInjected" && fail "queue policy still injected"
+aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name "$INLINE_NAME" --query PolicyDocument --output json | grep -q "CdkrdInjected" && fail "inline policy still injected"
+VER="$(aws iam get-policy --policy-arn "$MANAGED_ARN" --query 'Policy.DefaultVersionId' --output text)"
+aws iam get-policy-version --policy-arn "$MANAGED_ARN" --version-id "$VER" --query 'PolicyVersion.Document' --output json | grep -q "CdkrdInjected" && fail "managed policy still injected"
+
+echo "INTEG PASS"

--- a/tests/integration/revert/verify.sh
+++ b/tests/integration/revert/verify.sh
@@ -34,8 +34,8 @@ BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --re
 echo "=== enable acceleration, then accept (baseline) ==="
 aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" --accelerate-configuration Status=Enabled --region "$REGION" || fail "enable accel"
 sleep 5
-$CLI accept "$STACK" --region "$REGION" || fail accept
-echo "=== check CLEAN ==="; $CLI check "$STACK" --region "$REGION"; [ $? -eq 0 ] || fail "expected CLEAN after accept"
+$CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail accept
+echo "=== check CLEAN ==="; $CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "expected CLEAN after accept"
 
 echo "=== inject DECLARED drift (suspend versioning) + UNDECLARED drift (suspend accel from accepted Enabled) ==="
 aws s3api put-bucket-versioning --bucket "$BUCKET" --versioning-configuration Status=Suspended --region "$REGION" || fail "inject versioning"
@@ -43,16 +43,16 @@ aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" --accelerate-co
 sleep 5
 
 echo "=== check DETECTS drift ==="
-$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-revert-pre.out
+$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-revert-pre.out
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
 grep -q "VersioningConfiguration" /tmp/cdkrd-revert-pre.out || fail "declared versioning drift not reported"
 grep -q "AccelerateConfiguration" /tmp/cdkrd-revert-pre.out || fail "undeclared accel drift not reported"
 
 echo "=== revert --yes (writes to AWS via Cloud Control) ==="
-$CLI revert "$STACK" --region "$REGION" --yes || fail "revert returned non-zero"
+$CLI revert "$STACK" --region "$REGION" --yes --no-interactive || fail "revert returned non-zero"
 
 echo "=== check CLEAN after revert ==="
-$CLI check "$STACK" --region "$REGION"; [ $? -eq 0 ] || fail "drift remains after revert"
+$CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "drift remains after revert"
 
 # belt-and-suspenders: confirm AWS itself converged to the desired/baseline values
 VSTATUS="$(aws s3api get-bucket-versioning --bucket "$BUCKET" --region "$REGION" --query Status --output text)"


### PR DESCRIPTION
## Why

Integ coverage had three holes (review finding, user-approved):

1. **None of the 5 `SDK_WRITERS` write paths had an end-to-end test** (only the generic Cloud Control path, via `revert`).
2. **The README's central claim vs `cdk drift` was never verified empirically.**
3. **The scripts predated the interactive prompts** — a bare `check`/`accept` from a terminal now stops at R28/R38/R45 prompts mid-script (latent breakage nobody hit because integ runs were rare — which is itself the cadence problem).

## What

- **NEW `tests/integration/policies`** — one resource per SDK writer (BucketPolicy / TopicPolicy / QueuePolicy / IAM Policy / ManagedPolicy). Splices a `CdkrdInjected` statement into every policy document out of band → `check` reports 5 declared drifts → `revert --yes` converges through all 5 writers → `check` CLEAN → **direct AWS reads** confirm the injected statement is gone and the declared one survived (managed policy: on the new default version). Fixture is synth-validated (`cdk synth` passes).
- **NEW `basic/verify-vs-cdk-drift.sh`** — `cdk drift --fail` exits 0 on the undeclared change (CFn drift detection can't see it) while cdkrd exits 1 and names it; both detect the declared change (superset parity). Fails loudly if `cdk drift` ever gains the capability → signal to re-verify the README table.
- **Hardened all existing verify scripts**: `accept` → `--yes --no-interactive`, `check` → `--no-interactive`.
- **Cadence**: `tests/integration/README.md` "When to run" (every fixture pre-release; `basic`+`revert` after read/revert/normalize/gather changes; `policies` when `writers.ts` changes) + `/verify-pr` skill now REQUIRES the fixtures before setting the release marker (also dropped its stale "no GitHub remote" intro).

## Verification

- `bash -n` on all 7 scripts; splice helper smoke-tested (incl. scalar-Statement normalization); `cdk synth` of the new fixture passes.
- **Not live-run here** (no AWS credentials in this session) — first real execution should be `policies/verify.sh` + `basic/verify-vs-cdk-drift.sh` with your profile.
- Unit gates unaffected: 318/318 pass; check+docs markers set; worktree-developed.