### PR TITLE
feat(check): first-run prompt states the declared-side drift count when present (R51)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -49,12 +49,23 @@ export function preDeployFindings(findings: Finding[]): Finding[] {
 // a drift count: on a first run these are typically AWS defaults the template
 // never pinned (with any real out-of-band edits hiding among them), so the
 // message says so instead of reading as "N problems found".
+//
+// declaredDriftCount (R51): a user whose out-of-band edit hit a DECLARED
+// property sees a prompt that only talks about NOT-declared values and reads it
+// as "the tool missed my change". When declared-side drift exists (declared or
+// deleted tier — both are reported regardless of the baseline decision), say so
+// explicitly instead of the generic "either way" clause.
 export function firstRunPrompt(
   stackName: string,
-  undeclaredCount: number
+  undeclaredCount: number,
+  declaredDriftCount = 0
 ): { message: string; options: { value: 'show' | 'acceptAll'; label: string }[] } {
+  const declaredNote =
+    declaredDriftCount > 0
+      ? `Also found ${declaredDriftCount} declared-side drift(s) — reported below whichever you choose.`
+      : 'Declared-side drift is reported either way.';
   return {
-    message: `${stackName}: no baseline yet — found ${undeclaredCount} live value(s) not declared in your template (typically AWS defaults, but out-of-band edits hide among them; declared-property drift is reported either way). What do you want to do?`,
+    message: `${stackName}: no baseline yet — found ${undeclaredCount} live value(s) not declared in your template (typically AWS defaults, but out-of-band edits hide among them). ${declaredNote} What do you want to do?`,
     options: [
       {
         value: 'show',
@@ -175,8 +186,11 @@ export async function runCheck(args: string[]): Promise<number> {
       if (!baseline && !a.showAll && !a.json && isInteractive(a)) {
         const acceptable = applyIgnores(findings, stackName, config);
         const undeclaredCount = acceptable.filter((f) => f.tier === 'undeclared').length;
+        const declaredDriftCount = acceptable.filter(
+          (f) => f.tier === 'declared' || f.tier === 'deleted'
+        ).length;
         if (undeclaredCount > 0) {
-          const prompt = firstRunPrompt(stackName, undeclaredCount);
+          const prompt = firstRunPrompt(stackName, undeclaredCount, declaredDriftCount);
           const choice = await select({
             message: prompt.message,
             options: prompt.options,

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -33,8 +33,22 @@ describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', (
     expect(message).toContain('ApiStack: no baseline yet');
     expect(message).toContain('found 113 live value(s) not declared in your template');
     expect(message).toContain('typically AWS defaults'); // first-run framing, not "113 problems"
-    expect(message).toContain('declared-property drift is reported either way');
+    expect(message).toContain('Declared-side drift is reported either way');
     expect(message).not.toContain('drift(s) found'); // it must never read as a drift verdict
+  });
+
+  it('declared-side drift present → the prompt says it was FOUND, with its count (R51)', () => {
+    const { message } = firstRunPrompt('ApiStack', 113, 3);
+    expect(message).toContain(
+      'Also found 3 declared-side drift(s) — reported below whichever you choose.'
+    );
+    expect(message).not.toContain('either way'); // the generic clause is replaced, not appended
+  });
+
+  it('no declared-side drift → the generic either-way clause (R51)', () => {
+    const { message } = firstRunPrompt('ApiStack', 113, 0);
+    expect(message).toContain('Declared-side drift is reported either way.');
+    expect(message).not.toContain('Also found');
   });
 
   it('"show first" is the FIRST option (the safe default) and says accept is still possible after', () => {


### PR DESCRIPTION
## Summary

Dogfooding: change a DECLARED property out-of-band, run a first (no-baseline) `check`, and the prompt only talks about values "not declared in your template" — it reads as if the tool missed your change.

The findings are already gathered before the prompt, so when declared-side drift (declared or deleted tier) exists the prompt now says:

> ... (typically AWS defaults, but out-of-band edits hide among them). **Also found 1 declared-side drift(s) — reported below whichever you choose.** What do you want to do?

The generic `Declared-side drift is reported either way.` clause remains for the zero case.

## Notes

- Count taken post-ignore from the same finding set the report uses.
- `firstRunPrompt` gains an optional `declaredDriftCount` (pure, unit-tested; 3 new wording tests — replaced-not-appended, zero-case, count rendering).

## Gates

typecheck / lint+format / build / tests (28 files, 337) all pass; check+docs markers set; worktree-developed.