### PR TITLE
feat(check)!: report-only by default; --fail makes drift exit 1 and suppresses prompts (R53)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,9 @@ node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to
 - With no stack and no `--all`, the CDK app is synthesized (`--app` / `cdk.json`)
   and every stack it defines is targeted. A stack arg containing `*`/`?` is a glob.
 - Key flags: `--region`, `--profile`, `--app`, `-c/--context key=value`, `--json`,
-  `--fail-on declared|undeclared`, `--show-all`, `--pre-deploy` (check), `--all`,
-  `--dry-run`/`--yes` (revert). Exit codes: `0` clean, `1` drift, `2` error.
+  `--fail` / `--fail-on declared|undeclared` (check), `--show-all`, `--pre-deploy` (check), `--all`,
+  `--dry-run`/`--yes` (revert). check is report-only by default; `--fail` makes
+  drift exit 1 (errors always 2).
 - See `src/cli.ts` `HELP` and README.md "Commands & options" for the full surface.
 
 ## State of the Repo

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,7 +34,7 @@ un-deployed code edits would show as false "drift".
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
 5. classify (tag):  declared | undeclared | readGap | unresolved | skipped
-6. report + exit code (0 clean / 1 drift / 2 error) + --fail-on <tier>
+6. report + exit code (report-only by default; --fail → 1 on drift; 2 error) + --fail-on <tier>
 ```
 
 cdkrd is **CDK-only**: every run resolves the CDK app (synth, or a pre-synthesized

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ terminal, it asks what to do right there:
 
 ```console
 ApiStack: drift found — what do you want to do?
-  ❯ Nothing (keep exit code 1)
+  ❯ Nothing (decide later)
     Accept — record current state into the baseline (a git file; nothing written to AWS)
     Revert — write the desired value back to AWS
 ```
@@ -113,8 +113,8 @@ After `check` finds drift, the human decision is binary, and the verbs mirror it
 - Anything not confidently comparable is reported honestly as informational
   (`readGap` / `unresolved` / `skipped`) — **never** guessed, so no false drift.
 - A resource **deleted out of band** — the most blatant drift there is — is
-  reported in the `deleted` tier and always sets exit 1, regardless of
-  `--fail-on`.
+  reported in the `deleted` tier and always counts as failing drift under
+  `--fail`, regardless of `--fail-on`.
 
 `cdkrd` is **reality vs intent**, not code vs template: it deliberately does not
 reimplement `cdk diff`, so undeployed code changes never show up as drift
@@ -146,14 +146,17 @@ tells cdkrd which stacks to look at.
 | `cdkrd accept [<stack>...]` | snapshot undeclared state into the baseline (CI / non-TTY: `--yes`)    |
 | `cdkrd revert [<stack>...]` | write the desired value back to AWS (confirms; `--dry-run` to preview) |
 
-**Exit codes:** `0` clean · `1` drift · `2` error — so `check` drops straight
-into CI:
+**Exit codes:** `check` is **report-only by default** — drift prints but exits
+`0` (a note names the flag). Pass **`--fail`** (the `cdk diff --fail` /
+`cdk drift --fail` convention) to exit `1` on drift and suppress all prompts —
+the one flag for scripts and CI. Errors always exit `2`; `revert` exits `1`
+when drift remains after it.
 
 ```yaml
 - run: npm ci # cdkrd resolves the CDK app, so its deps must be installed
-- run: npx cdkrd check --region us-east-1 # fails the job on drift
+- run: npx cdkrd check --fail --region us-east-1 # fails the job on drift
 # or point at a prebuilt assembly artifact instead of synthesizing:
-# - run: npx cdkrd check --app cdk.out --region us-east-1
+# - run: npx cdkrd check --fail --app cdk.out --region us-east-1
 ```
 
 | option                           | meaning                                                                                                                       |
@@ -163,7 +166,8 @@ into CI:
 | `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths |
 | `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                    |
 | `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
-| `--fail-on declared\|undeclared` | which tier sets exit 1 (default `undeclared` = both; `deleted` always fails)                                                  |
+| `--fail`                         | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0                          |
+| `--fail-on declared\|undeclared` | which tier fails (default `undeclared` = both; `deleted` always fails); implies `--fail`                                      |
 | `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
 | `--verbose` / `-v`               | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
 | `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
@@ -180,8 +184,8 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
 - **`check` with drift** offers `Nothing / Accept / Revert` inline (shown above).
   `Nothing` is the default; Enter keeps plain-check behavior. Accept and Revert
   run exactly the same code as the standalone commands. Skipped under `--json`,
-  `--show-all`, and `--pre-deploy`. Aborting the Revert confirmation keeps the
-  exit code at 1 — nothing was written, the drift still stands.
+  `--show-all`, `--pre-deploy`, and `--fail`. Aborting the Revert confirmation
+  writes nothing — the drift still stands and stays reported.
 - **`accept`** shows a multiselect of only the **delta** from the existing
   baseline (new + changed undeclared values, all pre-selected); already-accepted
   unchanged values are auto-kept and surfaced with a
@@ -194,9 +198,9 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
   **show them first** (the report prints, and a selective accept is offered
   right after it). With zero undeclared values there is nothing to decide, so
   no prompt. After an interactive accept, a closing note states what remains:
-  a PARTIAL accept exits **0** for that run (the accept succeeded; unselected
-  values stay reported — and exit 1 — from the next `check` on), while
-  remaining declared/deleted drift keeps exit 1 (accept cannot address it).
+  a PARTIAL accept is a success (unselected values simply stay reported from
+  the next `check` on), and any remaining declared/deleted drift is named —
+  accept cannot address it (fix the code or choose Revert).
 - Flag combinations: `--no-interactive` alone = the read side completes but
   write **decisions** are refused with exit 2 (the safe side);
   `--no-interactive --yes` = full automation; `--yes` alone in a TTY

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -104,16 +104,18 @@ it prompts `Nothing / Accept / Revert` and branches into the SAME per-stack code
 `accept` / `revert` (extracted to [stack-actions.ts](../src/commands/stack-actions.ts)
 as `acceptStack` / `revertStack`, so the interactive flow and the single-verb commands
 can never diverge). Default is `Nothing` (plain-check behaviour); skipped under
-`--json` / `--show-all` / `--pre-deploy` / non-TTY. Aborting the Revert confirmation
-keeps the pre-revert **exit 1** — no AWS write happened, so the drift still stands
-(symmetric with `Nothing`); `revertStack` signals this via `RevertOutcome.aborted` so
-the standalone `revert` command keeps its own exit-0-on-abort behaviour (R30).
+`--json` / `--show-all` / `--pre-deploy` / `--fail` / non-TTY. Aborting the Revert
+confirmation keeps the pre-revert drift state — no AWS write happened, so the
+drift still stands and stays reported (symmetric with `Nothing`); `revertStack`
+signals this via `RevertOutcome.aborted` so the standalone `revert` command keeps
+its own exit-0-on-abort behaviour (R30).
 
 Flags (all parsed in [src/cli-args.ts](../src/cli-args.ts)): `--region` (no silent
 default — resolves via SDK chain, errors if absent), `--profile`, `-a/--app <cmd|cdk.out>`
 (+ `$CDKRD_APP` / cdk.json `"app"`), `-c/--context key=value` (repeatable),
-`--json`, `--fail-on declared|undeclared`, `--show-all` (inventory mode: ignore
-baseline, show ALL undeclared), `--pre-deploy` (check vs local synth template),
+`--json`, `--fail` (check: exit 1 on drift + never prompt — automation mode, R53),
+`--fail-on declared|undeclared` (implies `--fail`), `--show-all` (inventory mode:
+ignore baseline, show ALL undeclared), `--pre-deploy` (check vs local synth template),
 `--dry-run` (revert preview), `--yes/-y`. With no stack arg, every stack the app
 defines is targeted; a stack arg selects by exact name or glob (`cdkrd check 'Dev*'`).
 The known-flag set is closed: an unknown option or a value flag missing its
@@ -475,16 +477,20 @@ note suggesting a re-`accept` (the accepted set may be stale). Skipped under
 longer exists in AWS (released/deleted via the console, another tool, etc.). The
 live read returns a not-found error (`ResourceNotFoundException` from Cloud
 Control; `NoSuchBucket` / `QueueDoesNotExist` / `NoSuchEntity` / `InvalidAllocationID.NotFound` /
-… from the SDK overrides), which the router maps to `deleted`. It **always** sets
-exit 1 regardless of `--fail-on` (CloudFormation's own drift detection reports
-DELETED too — a drift tool that returned exit 0 on a deleted resource would be
-defective). It is reported as `not revertable` (reason: `deleted — recreate via
-cdk deploy`) — a patch cannot recreate a resource.
+… from the SDK overrides), which the router maps to `deleted`. It is always a
+drift tier (independent of `--fail-on`) and is reported as `not revertable`
+(reason: `deleted — recreate via cdk deploy`) — a patch cannot recreate a
+resource.
 
-`--fail-on declared` makes only `deleted` + `declared` set exit 1; default
-`undeclared` = all three of `deleted` / `declared` / `undeclared`. `ignored` /
-`readGap` / `unresolved` / `skipped` are informational — surfaced, never silently
-dropped, but never false drift.
+**Exit (R53, the `cdk diff --fail` / `cdk drift --fail` convention):** `check`
+is report-only by default — drift prints but exits 0, with a stderr note naming
+the flag. `--fail` (or `--fail-on`, which implies it) makes drift exit 1 AND
+suppresses all prompts: one flag expresses "automation" (locally-run scripts
+inherit the terminal's TTY, so prompts would otherwise fire mid-script). Errors
+always exit 2. In fail mode, `--fail-on declared` makes only `deleted` +
+`declared` fail; default `undeclared` = all three of `deleted` / `declared` /
+`undeclared`. `ignored` / `readGap` / `unresolved` / `skipped` are
+informational — surfaced, never silently dropped, but never false drift.
 
 `ignored` (R32) is for properties an external system legitimately keeps rewriting —
 Application Auto Scaling moving an ECS Service `DesiredCount`, DynamoDB autoscaled

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -26,6 +26,7 @@ const BOOLEAN_FLAGS = new Set([
   '--verbose',
   '-v',
   '--no-interactive',
+  '--fail',
 ]);
 
 export interface CommonArgs {
@@ -39,6 +40,11 @@ export interface CommonArgs {
   showAll: boolean; // inventory mode: ignore baseline, show ALL undeclared values
   yes: boolean;
   preDeploy: boolean; // compare live vs the LOCAL synth template (drift your next deploy would clobber)
+  // (check) automation mode, following the `cdk diff --fail` / `cdk drift --fail`
+  // convention (R53): drift sets exit 1 and prompts are suppressed. Without it,
+  // check REPORTS drift but exits 0 (report-only). Passing --fail-on <tier>
+  // implies --fail (selecting which tiers fail only makes sense in fail mode).
+  fail: boolean;
   removeUnaccepted: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
   verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
   noInteractive: boolean; // suppress all prompts; required-decision prompts then error instead of prompting
@@ -131,6 +137,7 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     app: values['--app'] ?? process.env.CDKRD_APP,
     json: has('--json'),
     failOn: failOnRaw === 'declared' ? 'declared' : 'undeclared',
+    fail: has('--fail') || failOnRaw !== undefined, // --fail-on implies fail mode
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,11 @@ OPTIONS
                               auto-discovery + construct-path output
   -c, --context key=value     context for synth (repeatable; cdk.json is the base)
   --json                      machine-readable output
-  --fail-on declared|undeclared   which tier sets exit 1 (default: undeclared = both)
+  --fail                      (check) exit 1 on drift + never prompt — for scripts/CI
+                              (same convention as \`cdk diff --fail\`); without it,
+                              check REPORTS drift but exits 0
+  --fail-on declared|undeclared   which tier fails (default: undeclared = both);
+                              implies --fail
   --show-all                  inventory mode: show ALL current undeclared state
                               (not just changes since accept)
   --verbose                   (check) expand informational tiers / (revert) the
@@ -49,7 +53,9 @@ OPTIONS
   side: accept/revert without --yes exit 2). --no-interactive --yes = full automation.
 
 EXIT CODES
-  0 = clean   1 = drift detected   2 = error
+  check:  0 = clean (or drift without --fail)   1 = drift (--fail)   2 = error
+  accept: 0 = written   2 = error/refused
+  revert: 0 = converged/aborted   1 = drift remains   2 = error/apply failure
 
 The baseline lives at .cdkrd/<stack>.<accountId>.<region>.json — commit it; review its diff in PRs.`;
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,9 +1,11 @@
 // `cdkrd check [<stack>...] [--region r] [--profile p] [--app ...] [-c k=v]
-//             [--json] [--fail-on declared|undeclared] [--show-all]`
+//             [--json] [--fail] [--fail-on declared|undeclared] [--show-all]`
 // Read-only. Reports drift per stack; undeclared findings are filtered against the
 // baseline file (if present) so a stack with an accepted baseline reports CLEAN.
-// Exit code is the
-// worst across all checked stacks (0 clean / 1 drift / 2 error).
+// Exit (R53, the `cdk diff --fail` convention): report-only by default — drift
+// exits 0 (a hint names --fail); with --fail (or --fail-on, which implies it)
+// drift exits 1 and prompts are suppressed. Errors always exit 2. The exit is
+// the worst across all checked stacks.
 import { isCancel, select } from '@clack/prompts';
 import { isStackNotDeployed } from '../aws-errors.js';
 import {
@@ -85,13 +87,10 @@ export function firstRunPrompt(
 
 /**
  * Closing note after an interactive accept inside `check` (R52). A PARTIAL
- * accept used to end with `baseline written: ...` and then a silent exit 1 —
- * reading as "accept failed". Semantics (user decision, R52): a successful
- * interactive accept is a SUCCESS for THIS run — deliberately-unselected
- * undeclared values do not fail this exit; they surface (exit 1) from the
- * next check on. This path is TTY-only, so no CI contract is affected.
- * DECLARED/DELETED drift is outside accept's reach and keeps exit 1 — exiting
- * 0 over a real un-addressed drift would be a false green.
+ * accept used to end with `baseline written: ...` and a silent failure-looking
+ * exit. State plainly what remains; the exit story itself is R53's: check is
+ * report-only (exit 0 on drift) unless --fail, and the interactive prompts
+ * never fire in fail mode, so this note never coexists with a drift exit.
  */
 export function postAcceptNote(remainingUndeclared: number, remainingDeclared: number): string {
   if (remainingDeclared > 0) {
@@ -99,11 +98,21 @@ export function postAcceptNote(remainingUndeclared: number, remainingDeclared: n
       remainingUndeclared > 0
         ? ` ${remainingUndeclared} unaccepted value(s) also stay reported.`
         : '';
-    return `accept succeeded, but ${remainingDeclared} declared/deleted drift(s) remain un-addressed (fix the code or revert) — exit 1.${alsoUndeclared}`;
+    return `accept succeeded, but ${remainingDeclared} declared/deleted drift(s) remain un-addressed (fix the code or choose Revert).${alsoUndeclared}`;
   }
   if (remainingUndeclared > 0)
-    return `accept succeeded — ${remainingUndeclared} unaccepted value(s) stay reported from the next check on; exit 0 for this run.`;
-  return 'stack is now CLEAN — exit 0.';
+    return `accept succeeded — ${remainingUndeclared} unaccepted value(s) stay reported from the next check on.`;
+  return 'stack is now CLEAN.';
+}
+
+/**
+ * Map a stack's drift code to check's final exit (R53, the `cdk diff --fail` /
+ * `cdk drift --fail` convention): without --fail, check is REPORT-ONLY — drift
+ * (1) exits 0; errors (2) always propagate. With --fail (or --fail-on, which
+ * implies it), drift exits 1. Pure + exported for tests.
+ */
+export function finalCheckExit(code: number, fail: boolean): number {
+  return fail || code !== 1 ? code : 0;
 }
 
 export async function runCheck(args: string[]): Promise<number> {
@@ -152,6 +161,7 @@ export async function runCheck(args: string[]): Promise<number> {
   }
 
   let worst = 0;
+  let anyDrift = false; // for the report-only hint (R53)
   // R37: one blank line between consecutive stack reports (text mode only) — done
   // here at the call site so a single-stack run never gets a stray leading blank.
   const separate = stackSeparator();
@@ -185,14 +195,17 @@ export async function runCheck(args: string[]): Promise<number> {
             `note: ${stackName}: --pre-deploy reports declared drift only (undeclared tiers are evaluated against the deployed template — run check without --pre-deploy)`
           );
         if (!a.json) separate();
-        worst = Math.max(
-          worst,
-          report(applyIgnores(declaredOnly, stackName, config), `${stackName} (${region})`, {
+        const preDeployCode = report(
+          applyIgnores(declaredOnly, stackName, config),
+          `${stackName} (${region})`,
+          {
             json: a.json,
             failOn: a.failOn,
             verbose: a.verbose,
-          })
+          }
         );
+        if (preDeployCode === 1) anyDrift = true;
+        worst = Math.max(worst, finalCheckExit(preDeployCode, a.fail));
         continue;
       }
 
@@ -210,7 +223,7 @@ export async function runCheck(args: string[]): Promise<number> {
       // report would have re-tagged as ignored (same as the post-report accept).
       // With ZERO undeclared values there is no decision worth interrupting for —
       // no prompt (`cdkrd accept` still writes a baseline for a clean stack).
-      if (!baseline && !a.showAll && !a.json && isInteractive(a)) {
+      if (!baseline && !a.showAll && !a.json && !a.fail && isInteractive(a)) {
         const acceptable = applyIgnores(findings, stackName, config);
         const undeclaredCount = acceptable.filter((f) => f.tier === 'undeclared').length;
         const declaredDriftCount = acceptable.filter(
@@ -262,10 +275,10 @@ export async function runCheck(args: string[]): Promise<number> {
       // of making the user re-run a separate command. Skipped for --json (machine
       // output), --show-all (baseline not applied — accept would mean something else),
       // and --pre-deploy (declared-only, baseline-untouched contract).
-      if (code === 1 && !a.json && !a.showAll && !a.preDeploy && isInteractive(a)) {
+      if (code === 1 && !a.json && !a.showAll && !a.preDeploy && !a.fail && isInteractive(a)) {
         const actions = availableActions(reconciled, baseline, schemas, a.removeUnaccepted);
         if (actions.accept || actions.revert) {
-          const options = [{ value: 'nothing', label: 'Nothing (keep exit code 1)' }];
+          const options = [{ value: 'nothing', label: 'Nothing (decide later)' }];
           if (actions.accept)
             options.push({
               value: 'accept',
@@ -339,7 +352,8 @@ export async function runCheck(args: string[]): Promise<number> {
           }
         }
       }
-      worst = Math.max(worst, code);
+      if (code === 1) anyDrift = true;
+      worst = Math.max(worst, finalCheckExit(code, a.fail));
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — skipped`);
@@ -348,6 +362,14 @@ export async function runCheck(args: string[]): Promise<number> {
       console.error(`error: ${stackName}: ${(e as Error).message}`);
       worst = Math.max(worst, 2);
     }
+  }
+  // Report-only mode found drift: say so, and say how to make it fail — a script
+  // author piping this must discover --fail from the output, not from a surprise
+  // green pipeline (R53). Suppressed under --json (machine consumers read stdout).
+  if (anyDrift && !a.fail && !a.json) {
+    console.error(
+      'note: drift found — exit 0 (report-only). Pass --fail (or --fail-on <tier>) to make drift fail this command.'
+    );
   }
   return worst;
 }

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -1,5 +1,6 @@
 // Tiered, CI-greppable report. Plain text or --json. No TUI/panes.
-// Exit: 0 clean / 1 drift. --fail-on selects which tiers count as failure.
+// Exit: report() returns 0 clean / 1 drift; check maps 1→0 unless --fail (R53).
+// --fail-on selects which tiers count as failure.
 //
 // Default layout is deliberately terse (a 40-resource CLEAN stack was 30+ lines):
 //   header -> DRIFT tier sections (full detail) -> result: -> info: footer

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { firstRunPrompt, postAcceptNote, preDeployFindings } from '../src/commands/check.js';
+import {
+  finalCheckExit,
+  firstRunPrompt,
+  postAcceptNote,
+  preDeployFindings,
+} from '../src/commands/check.js';
 import type { Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
@@ -74,28 +79,46 @@ describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', (
   });
 });
 
-describe('postAcceptNote (R52 — a partial accept is a SUCCESS for this run)', () => {
-  it('partial accept (undeclared remain) → success + exit 0, remainder surfaces next check', () => {
+describe('postAcceptNote (R52 — a partial accept is a SUCCESS, said plainly)', () => {
+  it('partial accept (undeclared remain) → success; remainder surfaces from the next check', () => {
     const note = postAcceptNote(112, 0);
     expect(note).toContain('accept succeeded');
     expect(note).toContain('112 unaccepted value(s) stay reported from the next check on');
-    expect(note).toContain('exit 0 for this run');
   });
 
-  it('everything accepted → CLEAN, exit 0', () => {
-    expect(postAcceptNote(0, 0)).toBe('stack is now CLEAN — exit 0.');
+  it('everything accepted → CLEAN', () => {
+    expect(postAcceptNote(0, 0)).toBe('stack is now CLEAN.');
   });
 
-  it("declared/deleted drift remains → exit 1 (outside accept's reach), undeclared remainder also named", () => {
+  it("declared/deleted drift remains → named (outside accept's reach), undeclared remainder too", () => {
     const note = postAcceptNote(112, 2);
     expect(note).toContain('2 declared/deleted drift(s) remain un-addressed');
-    expect(note).toContain('exit 1');
     expect(note).toContain('112 unaccepted value(s) also stay reported');
   });
 
-  it('declared drift remains, nothing else → exit 1 without the undeclared clause', () => {
+  it('declared drift remains, nothing else → no undeclared clause', () => {
     const note = postAcceptNote(0, 1);
-    expect(note).toContain('exit 1');
+    expect(note).toContain('declared/deleted drift(s) remain');
     expect(note).not.toContain('also stay reported');
+  });
+});
+
+describe('finalCheckExit (R53 — report-only by default, --fail opts into exit 1)', () => {
+  it('without --fail, drift (1) maps to 0 — report-only', () => {
+    expect(finalCheckExit(1, false)).toBe(0);
+  });
+
+  it('with --fail, drift stays 1', () => {
+    expect(finalCheckExit(1, true)).toBe(1);
+  });
+
+  it('clean stays 0 either way', () => {
+    expect(finalCheckExit(0, false)).toBe(0);
+    expect(finalCheckExit(0, true)).toBe(0);
+  });
+
+  it('errors (2) ALWAYS propagate, with or without --fail', () => {
+    expect(finalCheckExit(2, false)).toBe(2);
+    expect(finalCheckExit(2, true)).toBe(2);
   });
 });

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -100,6 +100,16 @@ describe('parseCommonArgs', () => {
     expect(() => parseCommonArgs(['S', '--fail-on', 'deleted'])).toThrow(/--fail-on expects/);
   });
 
+  it('--fail parses as a boolean; default is report-only (fail=false) (R53)', () => {
+    expect(parseCommonArgs(['S']).fail).toBe(false);
+    expect(parseCommonArgs(['S', '--fail']).fail).toBe(true);
+  });
+
+  it('--fail-on implies fail mode — selecting a failing tier only makes sense when failing (R53)', () => {
+    expect(parseCommonArgs(['S', '--fail-on', 'declared']).fail).toBe(true);
+    expect(parseCommonArgs(['S', '--fail-on', 'undeclared']).fail).toBe(true);
+  });
+
   it('accepts --flag=value form, equal to the space form (R41)', () => {
     expect(parseCommonArgs(['--app=cdk.out'])).toEqual(parseCommonArgs(['--app', 'cdk.out']));
     expect(parseCommonArgs(['-a=cdk.out'])).toEqual(parseCommonArgs(['--app', 'cdk.out']));

--- a/tests/integration/basic/verify-deleted-guards.sh
+++ b/tests/integration/basic/verify-deleted-guards.sh
@@ -68,7 +68,7 @@ aws s3api delete-bucket --bucket "$BUCKET" --region "$REGION" || fail "delete-bu
 sleep 5
 
 echo "=== R1: check reports the deleted tier + exit 1 ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-guard-deleted.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-guard-deleted.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "R1: expected exit 1 on a deleted resource, got $rc"
 grep -qi "DELETED (resource deleted out of band" /tmp/cdkrd-guard-deleted.out \

--- a/tests/integration/basic/verify-vs-cdk-drift.sh
+++ b/tests/integration/basic/verify-vs-cdk-drift.sh
@@ -46,7 +46,7 @@ npx cdk drift "$STACK" --fail 2>&1 | tee /tmp/cdkrd-vs-drift-1.out
 [ "${PIPESTATUS[0]}" -eq 0 ] || fail "cdk drift detected the undeclared change — capability changed? Re-verify the README comparison table"
 
 echo "=== cdkrd MUST see it ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-vs-drift-2.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-vs-drift-2.out
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "cdkrd missed the undeclared change"
 grep -q "AccelerateConfiguration" /tmp/cdkrd-vs-drift-2.out || fail "AccelerateConfiguration not reported"
 
@@ -60,7 +60,7 @@ npx cdk drift "$STACK" --fail 2>&1 | tee /tmp/cdkrd-vs-drift-3.out
 [ "${PIPESTATUS[0]}" -ne 0 ] || fail "cdk drift missed the declared change (expected --fail exit != 0)"
 
 echo "=== ... and cdkrd sees BOTH ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-vs-drift-4.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-vs-drift-4.out
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "cdkrd expected drift exit 1"
 grep -q "VersioningConfiguration" /tmp/cdkrd-vs-drift-4.out || fail "declared versioning drift not reported"
 grep -q "AccelerateConfiguration" /tmp/cdkrd-vs-drift-4.out || fail "undeclared accel drift not reported"

--- a/tests/integration/basic/verify.sh
+++ b/tests/integration/basic/verify.sh
@@ -33,7 +33,7 @@ echo "=== accept (write baseline) ==="
 $CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive
+$CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
 
 echo "=== inject undeclared drift (enable transfer acceleration) ==="
@@ -44,7 +44,7 @@ aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
   --accelerate-configuration Status=Enabled --region "$REGION" || fail "inject drift"
 
 echo "=== check should DETECT the undeclared drift ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdk-real-drift-integ.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdk-real-drift-integ.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "AccelerateConfiguration" /tmp/cdk-real-drift-integ.out || fail "AccelerateConfiguration not reported"

--- a/tests/integration/iam/verify-inline-policy.sh
+++ b/tests/integration/iam/verify-inline-policy.sh
@@ -47,10 +47,10 @@ DEFAULT_POLICY="$(aws iam list-role-policies --role-name "$ROLE_NAME" --query 'P
 echo "role=$ROLE_NAME defaultPolicy=$DEFAULT_POLICY"
 
 echo "=== accept (write baseline) ==="
-$CLI accept "$STACK" --region "$REGION" || fail "accept"
+$CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN (sibling DefaultPolicy filtered, no false positive) ==="
-$CLI check "$STACK" --region "$REGION"
+$CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept — sibling DefaultPolicy leaked as drift?"
 
 echo "=== inject undeclared drift (out-of-band inline policy next to the sibling) ==="
@@ -60,7 +60,7 @@ aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name "$ROGUE" \
 
 echo "=== check should DETECT the rogue inline policy (and ONLY it) ==="
 OUT=/tmp/cdk-real-drift-integ-iam-inline.out
-$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "Policies" "$OUT" || fail "Policies drift not reported"
@@ -79,7 +79,7 @@ aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name "$DEFAULT_POLICY"
   || fail "sibling DefaultPolicy document changed"
 
 echo "=== check should be CLEAN again ==="
-$CLI check "$STACK" --region "$REGION"
+$CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
 
 echo "INTEG PASS"

--- a/tests/integration/iam/verify.sh
+++ b/tests/integration/iam/verify.sh
@@ -34,7 +34,7 @@ echo "=== accept (write baseline) ==="
 $CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive
+$CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
 
 echo "=== inject undeclared drift (attach permissions boundary) ==="
@@ -46,7 +46,7 @@ aws iam put-role-permissions-boundary \
   --permissions-boundary arn:aws:iam::aws:policy/ReadOnlyAccess || fail "inject drift"
 
 echo "=== check should DETECT the undeclared drift ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdk-real-drift-integ-iam.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdk-real-drift-integ-iam.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "PermissionsBoundary" /tmp/cdk-real-drift-integ-iam.out || fail "PermissionsBoundary not reported"

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -39,7 +39,7 @@ echo "=== accept (write baseline) ==="
 $CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail "accept"
 
 echo "=== check should be CLEAN ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive
+$CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
 
 echo "=== inject undeclared drift (set reserved concurrent executions) ==="
@@ -52,7 +52,7 @@ aws lambda put-function-concurrency \
   --region "$REGION" || fail "inject drift"
 
 echo "=== check should DETECT the undeclared drift ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdk-real-drift-integ-lambda.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdk-real-drift-integ-lambda.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "ReservedConcurrentExecutions" /tmp/cdk-real-drift-integ-lambda.out || fail "ReservedConcurrentExecutions not reported"

--- a/tests/integration/policies/verify.sh
+++ b/tests/integration/policies/verify.sh
@@ -57,7 +57,7 @@ QUEUE_ARN="$(aws sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-n
 echo "=== accept (baseline) ==="
 $CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail accept
 echo "=== check CLEAN ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "expected CLEAN after accept"
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after accept"
 
 echo "=== inject a CdkrdInjected statement into all 5 policy documents ==="
 # S3 bucket policy (Deny is always writable under BlockPublicPolicy; harmless action)
@@ -90,7 +90,7 @@ aws iam create-policy-version --policy-arn "$MANAGED_ARN" --set-as-default --pol
 echo "(waiting for IAM/SQS propagation)"; sleep 15
 
 echo "=== check DETECTS all 5 declared drifts ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-policies-pre.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-policies-pre.out
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
 for name in "Data/Policy" "EventsPolicy" "JobsPolicy" "WorkerInline" "WorkerManaged"; do
   grep -q "$name" /tmp/cdkrd-policies-pre.out || fail "$name drift not reported"
@@ -100,7 +100,7 @@ echo "=== revert --yes (all 5 SDK writers) ==="
 $CLI revert "$STACK" --region "$REGION" --yes --no-interactive || fail "revert returned non-zero"
 
 echo "=== check CLEAN after revert ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "drift remains after revert"
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "drift remains after revert"
 
 echo "=== belt-and-suspenders: injected statement gone, declared statement survived ==="
 sleep 5

--- a/tests/integration/revert/verify.sh
+++ b/tests/integration/revert/verify.sh
@@ -35,7 +35,7 @@ echo "=== enable acceleration, then accept (baseline) ==="
 aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" --accelerate-configuration Status=Enabled --region "$REGION" || fail "enable accel"
 sleep 5
 $CLI accept "$STACK" --region "$REGION" --yes --no-interactive || fail accept
-echo "=== check CLEAN ==="; $CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "expected CLEAN after accept"
+echo "=== check CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after accept"
 
 echo "=== inject DECLARED drift (suspend versioning) + UNDECLARED drift (suspend accel from accepted Enabled) ==="
 aws s3api put-bucket-versioning --bucket "$BUCKET" --versioning-configuration Status=Suspended --region "$REGION" || fail "inject versioning"
@@ -43,7 +43,7 @@ aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" --accelerate-co
 sleep 5
 
 echo "=== check DETECTS drift ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive | tee /tmp/cdkrd-revert-pre.out
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-revert-pre.out
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
 grep -q "VersioningConfiguration" /tmp/cdkrd-revert-pre.out || fail "declared versioning drift not reported"
 grep -q "AccelerateConfiguration" /tmp/cdkrd-revert-pre.out || fail "undeclared accel drift not reported"
@@ -52,7 +52,7 @@ echo "=== revert --yes (writes to AWS via Cloud Control) ==="
 $CLI revert "$STACK" --region "$REGION" --yes --no-interactive || fail "revert returned non-zero"
 
 echo "=== check CLEAN after revert ==="
-$CLI check "$STACK" --region "$REGION" --no-interactive; [ $? -eq 0 ] || fail "drift remains after revert"
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "drift remains after revert"
 
 # belt-and-suspenders: confirm AWS itself converged to the desired/baseline values
 VSTATUS="$(aws s3api get-bucket-versioning --bucket "$BUCKET" --region "$REGION" --query Status --output text)"


### PR DESCRIPTION
## Summary

User decision, adopting the convention the audience already knows from `cdk diff --fail` / `cdk drift --fail`:

- **`check` is report-only by default**: drift prints but exits **0**, with a stderr note — `note: drift found — exit 0 (report-only). Pass --fail (or --fail-on <tier>) to make drift fail this command.` — so script authors discover the flag from output, not from a silently-green pipeline.
- **NEW `--fail`**: drift exits 1 **and** all prompts are suppressed. One flag = automation intent. (Key insight from dogfooding: a locally-run `.sh` inherits the terminal's TTY, so prompts DO fire mid-script — `--no-interactive` expressed the mechanism; `--fail` expresses the intent.) `--fail-on <tier>` implies `--fail`.
- Errors always exit 2. `accept`/`revert` exit semantics unchanged (revert still exits 1 when drift remains).
- `Nothing (keep exit code 1)` → `Nothing (decide later)`; `postAcceptNote` drops exit-code phrasing (prompts never coexist with fail mode).

## Breaking

Pre-release, no alias. Anyone relying on `check`'s implicit exit-1-on-drift must add `--fail` (README CI examples updated accordingly).

## Tests & scripts

352/352 (+6: `finalCheckExit` mapping incl. error-propagation, `--fail` parsing, `--fail-on`-implies-`--fail`; postAcceptNote rewording). All integ scripts' `check` calls switched `--no-interactive` → `--fail` (incl. the new `iam/verify-inline-policy.sh`, whose bare `check`/`accept` calls would have blocked on prompts when run from a terminal).

## Docs

README exit-codes section + CI examples, HELP, CLAUDE.md, DESIGN.md, ARCHITECTURE (§2 flags, exit paragraph, R28/R30 wording).

## Gates

typecheck / lint+format / build / tests pass; check+docs markers set; worktree-developed.