### PR TITLE
fix(revert): no-baseline guidance is a FORK, not a sequence; repair latent integ greps (R55)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -362,17 +362,18 @@ revertable** → `nothing revertable — N drift(s) remain.` + exit 1
 - **Targets**: declared drift → the **deployed-template** value; undeclared drift →
   the **baseline** value (an unaccepted out-of-band _addition_ reverts by REMOVAL).
 - **No-baseline safety guard**: on a stack that has never been `accept`ed, undeclared
-  drift is reported as `notRevertable` (`no baseline — run cdkrd accept first, or
-pass --remove-unaccepted`) rather than removed. The subtractive noise model's
-  failure mode in `check` is "the report is noisy"; the un-guarded revert mirror of
-  that would be **destructive** (a bulk REMOVE of every undeclared value that slipped
-  through subtraction). `--remove-unaccepted` opts back into removal. Declared drift is
-  always revertable (the template is its source, independent of any baseline).
-  For undeclared drift this guard outranks the create-only guard (R35): the
-  fundamental blocker is "no revert target exists", and `accept` records the value
-  into the baseline, making it no longer drift — a "requires replacement" reason
-  would mis-direct. When the guard
-  fires, the plan leads with a note pointing at the `check` / `accept` route.
+  drift is reported as `notRevertable` (`no baseline — accept it if the live value
+is right, or --remove-unaccepted to remove it`) rather than removed. The
+  subtractive noise model's failure mode in `check` is "the report is noisy"; the
+  un-guarded revert mirror of that would be **destructive** (a bulk REMOVE of every
+  undeclared value that slipped through subtraction). Declared drift is always
+  revertable (the template is its source, independent of any baseline). For
+  undeclared drift this guard outranks the create-only guard (R35): the fundamental
+  blocker is "no revert target exists" — a "requires replacement" reason would
+  mis-direct. The guard's wording is a FORK, not a sequence (R55): `accept`
+  endorses the live value (it stops being drift entirely — accept is never a step
+  toward reverting that same value), while `--remove-unaccepted` removes it. When
+  the guard fires, the plan leads with a note spelling out that fork.
 - **Write mechanism** (`plan.ts` chooses `kind`):
   - `kind: 'cc'` — generic Cloud Control `UpdateResource` RFC6902 PatchDocument,
     polled via `GetResourceRequestStatus` ([apply.ts](../src/revert/apply.ts)).

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -212,9 +212,12 @@ export function formatPlan(
 ): string[] {
   const lines: string[] = [`\n=== cdkrd revert: ${stackName} (${region}) ===`];
   if (opts.noBaselineGuidance) {
+    // A fork, not a sequence (R55): accepting these values endorses them (they
+    // stop being drift) — it is NOT a step toward reverting them.
     lines.push(
-      `\nnote: ${stackName} has no baseline — undeclared drift has no revert target.`,
-      '      Run `cdkrd check` or `cdkrd accept` to record a baseline first.'
+      `\nnote: ${stackName} has no baseline — these undeclared values have no recorded state to restore.`,
+      '      If the live values are RIGHT, accept them (they stop being drift);',
+      '      if they should be REMOVED, re-run revert with --remove-unaccepted.'
     );
   }
   for (const item of plan.items) {

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -120,10 +120,11 @@ export function buildRevertPlan(
     // such value (the subtractive model's failure mode is "check is noisy", but the
     // revert mirror of that is destructive). Refuse unless --remove-unaccepted.
     // Evaluated BEFORE the create-only guard (R35): on a no-baseline stack the
-    // fundamental blocker for undeclared drift is "no revert target exists", and the
-    // right next step is `accept` (which records the value into the baseline,
-    // making it no longer drift) — a "requires replacement" reason would
-    // mis-direct the user.
+    // fundamental blocker for undeclared drift is "no revert target exists".
+    // The reason wording is a FORK, not a sequence (R55): "accept first, then
+    // revert" reads as if accept were a step toward reverting THESE values, but
+    // accepting them endorses them (they stop being drift entirely) — accept is
+    // for values that are RIGHT; --remove-unaccepted is for values that are WRONG.
     if (
       f.tier === 'undeclared' &&
       noBaseline &&
@@ -134,7 +135,8 @@ export function buildRevertPlan(
         displayId,
         resourceType: f.resourceType,
         path: f.path,
-        reason: 'no baseline — run `cdkrd accept` first, or pass --remove-unaccepted',
+        reason:
+          'no baseline — accept it if the live value is right, or --remove-unaccepted to remove it',
       });
       continue;
     }

--- a/tests/integration/basic/verify-deleted-guards.sh
+++ b/tests/integration/basic/verify-deleted-guards.sh
@@ -49,7 +49,7 @@ aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
 sleep 5
 
 echo "=== R2: revert --dry-run refuses the unaccepted undeclared value ==="
-$CLI revert "$STACK" --region "$REGION" --dry-run | tee /tmp/cdkrd-guard-noremove.out
+$CLI revert "$STACK" --region "$REGION" --dry-run --verbose | tee /tmp/cdkrd-guard-noremove.out
 grep -q "NOT revertable" /tmp/cdkrd-guard-noremove.out || fail "R2: expected a NOT revertable section"
 grep -q "AccelerateConfiguration.*no baseline" /tmp/cdkrd-guard-noremove.out \
   || fail "R2: undeclared accel should be not-revertable (no baseline)"
@@ -71,7 +71,7 @@ echo "=== R1: check reports the deleted tier + exit 1 ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-guard-deleted.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "R1: expected exit 1 on a deleted resource, got $rc"
-grep -qi "DELETED (resource deleted out of band" /tmp/cdkrd-guard-deleted.out \
+grep -qi "resource deleted out of band" /tmp/cdkrd-guard-deleted.out \
   || fail "R1: deleted tier header not reported"
 
 echo "=== R1: deleted tier is NOT revertable (recreate via cdk deploy) ==="

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -159,13 +159,14 @@ describe('formatPlan (R35 — NOT-revertable folds to a per-reason summary)', ()
     }
   });
 
-  it('noBaselineGuidance leads with the accept-first route', () => {
+  it('noBaselineGuidance explains the accept-vs-remove FORK, not a sequence (R55)', () => {
     const plan: RevertPlan = { items: [], notRevertable: [nr('no baseline — x')] };
     const lines = formatPlan('MyStack', 'r', plan, { noBaselineGuidance: true });
     expect(lines[1]).toBe(
-      '\nnote: MyStack has no baseline — undeclared drift has no revert target.'
+      '\nnote: MyStack has no baseline — these undeclared values have no recorded state to restore.'
     );
-    expect(lines[2]).toContain('cdkrd check` or `cdkrd accept');
+    expect(lines[2]).toContain('If the live values are RIGHT, accept them');
+    expect(lines[3]).toContain('REMOVED, re-run revert with --remove-unaccepted');
   });
 });
 
@@ -227,8 +228,10 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     const { outcome, logs } = await captured([undeclared()]);
     expect(outcome).toEqual({ exit: 1, aborted: false });
     const out = logs.join('\n');
-    expect(out).toContain('note: s has no baseline — undeclared drift has no revert target.');
-    expect(out).toContain('NOT revertable: 1 (no baseline — run `cdkrd accept` first');
+    expect(out).toContain(
+      'note: s has no baseline — these undeclared values have no recorded state to restore.'
+    );
+    expect(out).toContain('NOT revertable: 1 (no baseline — accept it if the live value is right');
     expect(out).toContain('nothing revertable — 1 drift(s) remain.');
   });
 
@@ -241,7 +244,9 @@ describe('revertStack exit semantics (R35 — drift with nothing revertable is e
     });
     expect(outcome).toEqual({ exit: 0, aborted: false });
     const out = logs.join('\n');
-    expect(out).not.toContain('has no baseline — undeclared drift has no revert target');
+    expect(out).not.toContain(
+      'has no baseline — these undeclared values have no recorded state to restore'
+    );
     expect(out).toContain('remove (undeclared, not in baseline)'); // a real revert item is planned
     expect(out).toContain('(dry-run) would apply');
   });


### PR DESCRIPTION
## Summary

Dogfooding: the no-baseline revert plan told users `no baseline — run cdkrd accept first, or pass --remove-unaccepted` — reading as if accept were a STEP toward reverting those values. It is not: **accepting a value endorses it** (it stops being drift entirely). Accept is for values that are RIGHT; `--remove-unaccepted` is for values that should be REMOVED.

New wording:

- notRevertable reason: `no baseline — accept it if the live value is right, or --remove-unaccepted to remove it`
- plan-leading note:
  ```
  note: <stack> has no baseline — these undeclared values have no recorded state to restore.
        If the live values are RIGHT, accept them (they stop being drift);
        if they should be REMOVED, re-run revert with --remove-unaccepted.
  ```

## Also: two latent integ-script breaks repaired (found in review)

- `basic/verify-deleted-guards.sh` R2 grep expected per-finding NOT-revertable lines — folded away since R35; the dry-run now passes `--verbose`.
- Its R1 deleted-header grep predated R48's `[DELETED: N] (...)` format.

## Gates

352/352 tests (assertions updated to the fork wording); typecheck/lint/build pass; check+docs markers set; worktree-developed.