### PR TITLE
feat(check)!: fold --fail-on into --fail[=declared|undeclared] (R56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to
 - With no stack and no `--all`, the CDK app is synthesized (`--app` / `cdk.json`)
   and every stack it defines is targeted. A stack arg containing `*`/`?` is a glob.
 - Key flags: `--region`, `--profile`, `--app`, `-c/--context key=value`, `--json`,
-  `--fail` / `--fail-on declared|undeclared` (check), `--show-all`, `--pre-deploy` (check), `--all`,
+  `--fail[=declared|undeclared]` (check), `--show-all`, `--pre-deploy` (check), `--all`,
   `--dry-run`/`--yes` (revert). check is report-only by default; `--fail` makes
   drift exit 1 (errors always 2).
 - See `src/cli.ts` `HELP` and README.md "Commands & options" for the full surface.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,7 +34,7 @@ un-deployed code edits would show as false "drift".
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
 5. classify (tag):  declared | undeclared | readGap | unresolved | skipped
-6. report + exit code (report-only by default; --fail → 1 on drift; 2 error) + --fail-on <tier>
+6. report + exit code (report-only by default; --fail → 1 on drift; 2 error) (--fail=<tier> selects tiers)
 ```
 
 cdkrd is **CDK-only**: every run resolves the CDK app (synth, or a pre-synthesized

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ After `check` finds drift, the human decision is binary, and the verbs mirror it
   (`readGap` / `unresolved` / `skipped`) — **never** guessed, so no false drift.
 - A resource **deleted out of band** — the most blatant drift there is — is
   reported in the `deleted` tier and always counts as failing drift under
-  `--fail`, regardless of `--fail-on`.
+  `--fail`, regardless of `--fail=<tier>`.
 
 `cdkrd` is **reality vs intent**, not code vs template: it deliberately does not
 reimplement `cdk diff`, so undeployed code changes never show up as drift
@@ -159,22 +159,21 @@ when drift remains after it.
 # - run: npx cdkrd check --fail --app cdk.out --region us-east-1
 ```
 
-| option                           | meaning                                                                                                                       |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `--region <r>`                   | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                |
-| `--profile <p>`                  | AWS profile (or `$AWS_PROFILE`)                                                                                               |
-| `-a, --app <cmd\|cdk.out>`       | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths |
-| `-c, --context key=value`        | context for synth (repeatable; cdk.json is the base layer)                                                                    |
-| `--json`                         | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
-| `--fail`                         | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0                          |
-| `--fail-on declared\|undeclared` | which tier fails (default `undeclared` = both; `deleted` always fails); implies `--fail`                                      |
-| `--show-all`                     | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
-| `--verbose` / `-v`               | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
-| `--pre-deploy`                   | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
-| `--dry-run`                      | (revert) print the plan; make no changes                                                                                      |
-| `--remove-unaccepted`            | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
-| `--yes` / `-y`                   | skip confirmations (revert apply; accept records all without the multiselect)                                                 |
-| `--no-interactive`               | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to write    |
+| option                          | meaning                                                                                                                                                         |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--region <r>`                  | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                                                  |
+| `--profile <p>`                 | AWS profile (or `$AWS_PROFILE`)                                                                                                                                 |
+| `-a, --app <cmd\|cdk.out>`      | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths                                   |
+| `-c, --context key=value`       | context for synth (repeatable; cdk.json is the base layer)                                                                                                      |
+| `--json`                        | machine-readable output (see [JSON contract](#json-output-contract))                                                                                            |
+| `--fail[=declared\|undeclared]` | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0. `=tier` selects which tiers fail (`deleted` always fails) |
+| `--show-all`                    | inventory mode: show ALL current undeclared state, ignoring the baseline                                                                                        |
+| `--verbose` / `-v`              | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists                                     |
+| `--pre-deploy`                  | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite                                           |
+| `--dry-run`                     | (revert) print the plan; make no changes                                                                                                                        |
+| `--remove-unaccepted`           | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                                                            |
+| `--yes` / `-y`                  | skip confirmations (revert apply; accept records all without the multiselect)                                                                                   |
+| `--no-interactive`              | never prompt: optional prompts are skipped, required-decision prompts error (exit 2). `accept` then needs `--yes` to write                                      |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
 the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,7 +114,7 @@ Flags (all parsed in [src/cli-args.ts](../src/cli-args.ts)): `--region` (no sile
 default — resolves via SDK chain, errors if absent), `--profile`, `-a/--app <cmd|cdk.out>`
 (+ `$CDKRD_APP` / cdk.json `"app"`), `-c/--context key=value` (repeatable),
 `--json`, `--fail` (check: exit 1 on drift + never prompt — automation mode, R53),
-`--fail-on declared|undeclared` (implies `--fail`), `--show-all` (inventory mode:
+`--fail[=declared|undeclared]` (the =tier form selects failing tiers), `--show-all` (inventory mode:
 ignore baseline, show ALL undeclared), `--pre-deploy` (check vs local synth template),
 `--dry-run` (revert preview), `--yes/-y`. With no stack arg, every stack the app
 defines is targeted; a stack arg selects by exact name or glob (`cdkrd check 'Dev*'`).
@@ -479,16 +479,16 @@ longer exists in AWS (released/deleted via the console, another tool, etc.). The
 live read returns a not-found error (`ResourceNotFoundException` from Cloud
 Control; `NoSuchBucket` / `QueueDoesNotExist` / `NoSuchEntity` / `InvalidAllocationID.NotFound` /
 … from the SDK overrides), which the router maps to `deleted`. It is always a
-drift tier (independent of `--fail-on`) and is reported as `not revertable`
+drift tier (independent of `--fail=<tier>`) and is reported as `not revertable`
 (reason: `deleted — recreate via cdk deploy`) — a patch cannot recreate a
 resource.
 
 **Exit (R53, the `cdk diff --fail` / `cdk drift --fail` convention):** `check`
 is report-only by default — drift prints but exits 0, with a stderr note naming
-the flag. `--fail` (or `--fail-on`, which implies it) makes drift exit 1 AND
+the flag. `--fail` makes drift exit 1 AND
 suppresses all prompts: one flag expresses "automation" (locally-run scripts
 inherit the terminal's TTY, so prompts would otherwise fire mid-script). Errors
-always exit 2. In fail mode, `--fail-on declared` makes only `deleted` +
+always exit 2. In fail mode, `--fail=declared` makes only `deleted` +
 `declared` fail; default `undeclared` = all three of `deleted` / `declared` /
 `undeclared`. `ignored` / `readGap` / `unresolved` / `skipped` are
 informational — surfaced, never silently dropped, but never false drift.

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -6,15 +6,7 @@ import type { FailOn } from './report/report.js';
 // by the verb. Anything NOT listed is a fail-fast error — a typo'd flag must
 // never silently turn its value into a positional stack name (cdkrd has an
 // AWS-mutating verb, so a misparse can target the wrong stacks).
-const VALUE_FLAGS = new Set([
-  '--region',
-  '--profile',
-  '--fail-on',
-  '--app',
-  '-a',
-  '-c',
-  '--context',
-]);
+const VALUE_FLAGS = new Set(['--region', '--profile', '--app', '-a', '-c', '--context']);
 const BOOLEAN_FLAGS = new Set([
   '--json',
   '--show-all',
@@ -26,8 +18,12 @@ const BOOLEAN_FLAGS = new Set([
   '--verbose',
   '-v',
   '--no-interactive',
-  '--fail',
 ]);
+// `--fail` is a HYBRID flag (R56): boolean alone (`--fail` = all drift tiers
+// fail), with an optional `=tier` value (`--fail=declared`). Only the `=` form
+// carries a value — a space-separated `--fail declared` would be ambiguous with
+// a positional stack name. This replaced the separate `--fail-on` flag, which
+// confused next to `--fail` (what would `--fail --fail-on declared` mean?).
 
 export interface CommonArgs {
   stackNames: string[]; // positional stack names (may be empty → all stacks the CDK app defines)
@@ -42,8 +38,8 @@ export interface CommonArgs {
   preDeploy: boolean; // compare live vs the LOCAL synth template (drift your next deploy would clobber)
   // (check) automation mode, following the `cdk diff --fail` / `cdk drift --fail`
   // convention (R53): drift sets exit 1 and prompts are suppressed. Without it,
-  // check REPORTS drift but exits 0 (report-only). Passing --fail-on <tier>
-  // implies --fail (selecting which tiers fail only makes sense in fail mode).
+  // check REPORTS drift but exits 0 (report-only). `--fail=declared|undeclared`
+  // selects which tiers fail (R56; the value lands in `failOn`).
   fail: boolean;
   removeUnaccepted: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
   verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
@@ -107,6 +103,20 @@ export function parseCommonArgs(args: string[]): CommonArgs {
       }
       continue;
     }
+    if (flag === '--fail') {
+      // hybrid: `--fail` alone, or `--fail=declared|undeclared` (the `=` form
+      // only — see the comment above BOOLEAN_FLAGS). Validate the tier during
+      // parse so a typo (`--fail=declarred`) is a loud error, not a silent
+      // fall-through to the `undeclared` default (R41 spirit).
+      if (inlineValue !== undefined && inlineValue !== 'declared' && inlineValue !== 'undeclared') {
+        throw new Error(
+          `--fail expects no value, =declared, or =undeclared, got "${inlineValue}" — see cdkrd --help`
+        );
+      }
+      found.add('--fail');
+      if (inlineValue !== undefined) values['--fail'] = inlineValue;
+      continue;
+    }
     if (BOOLEAN_FLAGS.has(flag)) {
       // a boolean flag takes no value: `--json=true` is a mistake, not a stack name
       if (inlineValue !== undefined) {
@@ -118,15 +128,6 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     throw new Error(`unknown option "${a}" — see cdkrd --help`);
   }
 
-  // Validate enumerated values during parse so a typo (`--fail-on declarred`) is a
-  // loud error, not a silent fall-through to the `undeclared` default.
-  const failOnRaw = values['--fail-on'];
-  if (failOnRaw !== undefined && failOnRaw !== 'declared' && failOnRaw !== 'undeclared') {
-    throw new Error(
-      `--fail-on expects "declared" or "undeclared", got "${failOnRaw}" — see cdkrd --help`
-    );
-  }
-
   const has = (flag: string): boolean => found.has(flag);
   return {
     stackNames,
@@ -136,8 +137,8 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     // -a/--app > CDKRD_APP env (cdk.json "app" fallback resolved in the synth layer)
     app: values['--app'] ?? process.env.CDKRD_APP,
     json: has('--json'),
-    failOn: failOnRaw === 'declared' ? 'declared' : 'undeclared',
-    fail: has('--fail') || failOnRaw !== undefined, // --fail-on implies fail mode
+    failOn: values['--fail'] === 'declared' ? 'declared' : 'undeclared',
+    fail: has('--fail'),
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,11 +30,11 @@ OPTIONS
                               auto-discovery + construct-path output
   -c, --context key=value     context for synth (repeatable; cdk.json is the base)
   --json                      machine-readable output
-  --fail                      (check) exit 1 on drift + never prompt — for scripts/CI
-                              (same convention as \`cdk diff --fail\`); without it,
-                              check REPORTS drift but exits 0
-  --fail-on declared|undeclared   which tier fails (default: undeclared = both);
-                              implies --fail
+  --fail[=declared|undeclared]  (check) exit 1 on drift + never prompt — for
+                              scripts/CI (same convention as \`cdk diff --fail\`);
+                              without it, check REPORTS drift but exits 0. The
+                              =tier form selects which tiers fail (default:
+                              undeclared = all drift; deleted always fails)
   --show-all                  inventory mode: show ALL current undeclared state
                               (not just changes since accept)
   --verbose                   (check) expand informational tiers / (revert) the

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -1,9 +1,9 @@
 // `cdkrd check [<stack>...] [--region r] [--profile p] [--app ...] [-c k=v]
-//             [--json] [--fail] [--fail-on declared|undeclared] [--show-all]`
+//             [--json] [--fail[=declared|undeclared]] [--show-all]`
 // Read-only. Reports drift per stack; undeclared findings are filtered against the
 // baseline file (if present) so a stack with an accepted baseline reports CLEAN.
 // Exit (R53, the `cdk diff --fail` convention): report-only by default — drift
-// exits 0 (a hint names --fail); with --fail (or --fail-on, which implies it)
+// exits 0 (a hint names --fail); with --fail (optionally --fail=declared)
 // drift exits 1 and prompts are suppressed. Errors always exit 2. The exit is
 // the worst across all checked stacks.
 import { isCancel, select } from '@clack/prompts';
@@ -108,8 +108,7 @@ export function postAcceptNote(remainingUndeclared: number, remainingDeclared: n
 /**
  * Map a stack's drift code to check's final exit (R53, the `cdk diff --fail` /
  * `cdk drift --fail` convention): without --fail, check is REPORT-ONLY — drift
- * (1) exits 0; errors (2) always propagate. With --fail (or --fail-on, which
- * implies it), drift exits 1. Pure + exported for tests.
+ * (1) exits 0; errors (2) always propagate. With --fail (or --fail=<tier>), drift exits 1. Pure + exported for tests.
  */
 export function finalCheckExit(code: number, fail: boolean): number {
   return fail || code !== 1 ? code : 0;
@@ -368,7 +367,7 @@ export async function runCheck(args: string[]): Promise<number> {
   // green pipeline (R53). Suppressed under --json (machine consumers read stdout).
   if (anyDrift && !a.fail && !a.json) {
     console.error(
-      'note: drift found — exit 0 (report-only). Pass --fail (or --fail-on <tier>) to make drift fail this command.'
+      'note: drift found — exit 0 (report-only). Pass --fail (or --fail=declared) to make drift fail this command.'
     );
   }
   return worst;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -1,6 +1,6 @@
 // Tiered, CI-greppable report. Plain text or --json. No TUI/panes.
 // Exit: report() returns 0 clean / 1 drift; check maps 1→0 unless --fail (R53).
-// --fail-on selects which tiers count as failure.
+// --fail=<tier> selects which tiers count as failure.
 //
 // Default layout is deliberately terse (a 40-resource CLEAN stack was 30+ lines):
 //   header -> DRIFT tier sections (full detail) -> result: -> info: footer
@@ -72,7 +72,7 @@ function tierStyle(t: Tier): (s: string) => string {
   return style.infoTier;
 }
 
-// `deleted` is ALWAYS a failure (the most blatant drift), independent of --fail-on.
+// `deleted` is ALWAYS a failure (the most blatant drift), independent of --fail=<tier>.
 function failTiers(failOn: FailOn): Tier[] {
   return failOn === 'declared' ? ['deleted', 'declared'] : ['deleted', 'declared', 'undeclared'];
 }
@@ -145,13 +145,13 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   }
   // result: line — the conclusion. Lists ONLY the non-zero DRIFT tier counts (the
   // informational breakdown lives on the `info:` line, so the two never duplicate);
-  // CLEAN prints just `CLEAN`. `fail-on` is noted only when non-default (it changes
+  // CLEAN prints just `CLEAN`. `fail=declared` is noted only when non-default (it changes
   // the verdict). `^result:` stays greppable for the verdict; the formal
   // machine-readable contract is `--json` (the info: footer may span lines).
   const driftCounts = DRIFT_TIERS.filter((t) => byTier(t).length > 0)
     .map((t) => `${t}=${byTier(t).length}`)
     .join(' ');
-  const failNote = (opts.failOn ?? 'undeclared') === 'declared' ? ' (fail-on=declared)' : '';
+  const failNote = (opts.failOn ?? 'undeclared') === 'declared' ? ' (fail=declared)' : '';
   // the verdict is the one line that must stand out: green CLEAN / red drift count
   const verdict =
     drifted === 0 ? style.clean('CLEAN') : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -14,8 +14,7 @@ describe('parseCommonArgs', () => {
       '--region',
       'us-east-1',
       'MyStack',
-      '--fail-on',
-      'declared',
+      '--fail=declared',
       '--app',
       'node app.js',
     ]);
@@ -24,7 +23,7 @@ describe('parseCommonArgs', () => {
     expect(a.app).toBe('node app.js');
   });
 
-  it('defaults: fail-on undeclared, flags false, region undefined when no flag/env', () => {
+  it('defaults: failOn undeclared, flags false, region undefined when no flag/env', () => {
     const saved = { r: process.env.AWS_REGION, d: process.env.AWS_DEFAULT_REGION };
     delete process.env.AWS_REGION;
     delete process.env.AWS_DEFAULT_REGION;
@@ -91,23 +90,37 @@ describe('parseCommonArgs', () => {
     expect(() => parseCommonArgs(['--context', '=v'])).toThrow(/expects key=value/);
   });
 
-  it('validates --fail-on, rejecting typos instead of falling back to undeclared (R41)', () => {
-    expect(parseCommonArgs(['S', '--fail-on', 'declared']).failOn).toBe('declared');
-    expect(parseCommonArgs(['S', '--fail-on', 'undeclared']).failOn).toBe('undeclared');
-    expect(() => parseCommonArgs(['S', '--fail-on', 'declarred'])).toThrow(
-      /--fail-on expects "declared" or "undeclared", got "declarred"/
-    );
-    expect(() => parseCommonArgs(['S', '--fail-on', 'deleted'])).toThrow(/--fail-on expects/);
-  });
-
   it('--fail parses as a boolean; default is report-only (fail=false) (R53)', () => {
     expect(parseCommonArgs(['S']).fail).toBe(false);
     expect(parseCommonArgs(['S', '--fail']).fail).toBe(true);
+    expect(parseCommonArgs(['S', '--fail']).failOn).toBe('undeclared'); // bare --fail = all drift
   });
 
-  it('--fail-on implies fail mode — selecting a failing tier only makes sense when failing (R53)', () => {
-    expect(parseCommonArgs(['S', '--fail-on', 'declared']).fail).toBe(true);
-    expect(parseCommonArgs(['S', '--fail-on', 'undeclared']).fail).toBe(true);
+  it('--fail=<tier> selects the failing tier and implies fail mode (R56)', () => {
+    expect(parseCommonArgs(['S', '--fail=declared']).failOn).toBe('declared');
+    expect(parseCommonArgs(['S', '--fail=declared']).fail).toBe(true);
+    expect(parseCommonArgs(['S', '--fail=undeclared']).failOn).toBe('undeclared');
+    expect(parseCommonArgs(['S', '--fail=undeclared']).fail).toBe(true);
+  });
+
+  it('--fail rejects a bad tier instead of falling back to undeclared (R41 spirit)', () => {
+    expect(() => parseCommonArgs(['S', '--fail=declarred'])).toThrow(
+      /--fail expects no value, =declared, or =undeclared, got "declarred"/
+    );
+    expect(() => parseCommonArgs(['S', '--fail=deleted'])).toThrow(/--fail expects/);
+    expect(() => parseCommonArgs(['S', '--fail='])).toThrow(/--fail expects/);
+  });
+
+  it('--fail never consumes the NEXT token (a tier needs the = form; tokens stay stack names)', () => {
+    const a = parseCommonArgs(['--fail', 'declared']);
+    expect(a.fail).toBe(true);
+    expect(a.failOn).toBe('undeclared'); // 'declared' was NOT taken as a tier...
+    expect(a.stackNames).toEqual(['declared']); // ...it is a (oddly named) stack arg
+  });
+
+  it('--fail-on is GONE — fails fast as an unknown option (R56)', () => {
+    expect(() => parseCommonArgs(['S', '--fail-on', 'declared'])).toThrow(/unknown option/);
+    expect(() => parseCommonArgs(['S', '--fail-on=declared'])).toThrow(/unknown option/);
   });
 
   it('accepts --flag=value form, equal to the space form (R41)', () => {
@@ -115,7 +128,6 @@ describe('parseCommonArgs', () => {
     expect(parseCommonArgs(['-a=cdk.out'])).toEqual(parseCommonArgs(['--app', 'cdk.out']));
     expect(parseCommonArgs(['MyStack', '--region=eu-west-1']).region).toBe('eu-west-1');
     expect(parseCommonArgs(['MyStack', '--region=eu-west-1']).stackNames).toEqual(['MyStack']);
-    expect(parseCommonArgs(['--fail-on=declared']).failOn).toBe('declared');
   });
 
   it('splits --context=key=value on the first = only (R41)', () => {

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -104,9 +104,9 @@ describe('report', () => {
       expect(run([F('undeclared')]).text).toMatch(/result: 1 drift\(s\) \(undeclared=1\)/);
     });
 
-    it('fail-on=declared is noted only when set', () => {
-      expect(run([F('declared')]).text).not.toContain('fail-on');
-      expect(run([F('declared')], { failOn: 'declared' }).text).toContain('(fail-on=declared)');
+    it('fail=declared is noted only when set (R56 flag spelling)', () => {
+      expect(run([F('declared')]).text).not.toContain('fail=');
+      expect(run([F('declared')], { failOn: 'declared' }).text).toContain('(fail=declared)');
     });
 
     it('folds a single informational tier into a one-line info: footer', () => {


### PR DESCRIPTION
## Summary

User feedback on R53: having both `--fail` and `--fail-on` invites confusion — what would `--fail --fail-on declared` mean? Does `--fail-on` fail on its own? (It did, by implication — which is exactly the kind of rule users shouldn't need to learn.)

**One flag now carries both:**

- `--fail` — drift exits 1 + prompts suppressed; ALL drift tiers fail (deleted/declared/undeclared)
- `--fail=declared` — same, but only `deleted` + `declared` fail
- `--fail=undeclared` — explicit spelling of the default tier set

Only the `=` form takes the tier — a space-separated value would be ambiguous with a positional stack name (a test pins that `--fail declared` keeps `declared` as a stack arg). Bad tiers fail fast (`--fail expects no value, =declared, or =undeclared`).

## Breaking

`--fail-on` is gone (pre-release, no alias) — it fails fast as `unknown option`. The non-default verdict suffix changed `(fail-on=declared)` → `(fail=declared)`.

## Tests

354/354 (+4 reshaped: =tier parsing/implication, bad-tier + empty-value rejection, no-token-consumption, --fail-on-is-gone). HELP / README option table / CLAUDE.md / DESIGN.md / ARCHITECTURE swept.

## Gates

typecheck / lint+format / build / tests pass; check+docs markers set; worktree-developed.