### PR TITLE
feat(check): --undeclared-only / --declared-only scope flags (R59)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to
 - With no stack and no `--all`, the CDK app is synthesized (`--app` / `cdk.json`)
   and every stack it defines is targeted. A stack arg containing `*`/`?` is a glob.
 - Key flags: `--region`, `--profile`, `--app`, `-c/--context key=value`, `--json`,
-  `--fail` (check), `--show-all`, `--pre-deploy` (check), `--all`,
+  `--fail`, `--pre-deploy`, `--undeclared-only`, `--declared-only` (check), `--show-all`, `--all`,
   `--dry-run`/`--yes` (revert). check is report-only by default; `--fail` makes
   drift exit 1 (errors always 2).
 - See `src/cli.ts` `HELP` and README.md "Commands & options" for the full surface.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ when drift remains after it.
 | `--show-all`               | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
 | `--verbose` / `-v`         | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
 | `--pre-deploy`             | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
+| `--undeclared-only`        | (check) undeclared drift only — pair cdkrd with `cdk drift` / CFn drift detection for the declared side                       |
+| `--declared-only`          | (check) declared drift vs the DEPLOYED template only (undeclared tier skipped; baseline untouched). Not `--pre-deploy`        |
 | `--dry-run`                | (revert) print the plan; make no changes                                                                                      |
 | `--remove-unaccepted`      | (revert) on a stack with NO baseline, REMOVE undeclared drift (default: refuse — run `accept` first)                          |
 | `--yes` / `-y`             | skip confirmations (revert apply; accept records all without the multiselect)                                                 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,6 +116,7 @@ default — resolves via SDK chain, errors if absent), `--profile`, `-a/--app <c
 `--json`, `--fail` (check: exit 1 on drift + never prompt — automation mode, R53),
 `--show-all` (inventory mode:
 ignore baseline, show ALL undeclared), `--pre-deploy` (check vs local synth template),
+`--undeclared-only` / `--declared-only` (scope to one tier — R59; at most one scope flag),
 `--dry-run` (revert preview), `--yes/-y`. With no stack arg, every stack the app
 defines is targeted; a stack arg selects by exact name or glob (`cdkrd check 'Dev*'`).
 The known-flag set is closed: an unknown option or a value flag missing its

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -13,6 +13,8 @@ const BOOLEAN_FLAGS = new Set([
   '--yes',
   '-y',
   '--pre-deploy',
+  '--undeclared-only',
+  '--declared-only',
   '--dry-run',
   '--remove-unaccepted',
   '--verbose',
@@ -29,6 +31,18 @@ export interface CommonArgs {
   showAll: boolean; // inventory mode: ignore baseline, show ALL undeclared values
   yes: boolean;
   preDeploy: boolean; // compare live vs the LOCAL synth template (drift your next deploy would clobber)
+  // (check) scope flags (R59) — at most ONE of --pre-deploy / --declared-only /
+  // --undeclared-only; the parser rejects combinations.
+  // --undeclared-only skips the declared-side comparison entirely — for pairing
+  // cdkrd with `cdk drift` / CFn drift detection, which already own declared
+  // drift. Deleted resources still report (a gone resource has no undeclared
+  // values to check; silence would be a lie).
+  undeclaredOnly: boolean;
+  // --declared-only skips the undeclared tier (baseline untouched): declared
+  // drift vs the DEPLOYED template only. NOT the same as --pre-deploy, which
+  // compares against the LOCAL SYNTH template (a different question: what would
+  // my next deploy clobber).
+  declaredOnly: boolean;
   // (check) automation mode, following the `cdk diff --fail` / `cdk drift --fail`
   // convention (R53): drift sets exit 1 and prompts are suppressed. Without it,
   // check REPORTS drift but exits 0 (report-only).
@@ -106,6 +120,13 @@ export function parseCommonArgs(args: string[]): CommonArgs {
   }
 
   const has = (flag: string): boolean => found.has(flag);
+  // scope flags select WHICH comparison runs — more than one is contradictory
+  // (--pre-deploy + --undeclared-only would compare nothing) or redundant
+  // (--pre-deploy is already declared-side). Reject at parse.
+  const scopes = ['--pre-deploy', '--declared-only', '--undeclared-only'].filter(has);
+  if (scopes.length > 1) {
+    throw new Error(`${scopes.join(' and ')} are mutually exclusive — see cdkrd --help`);
+  }
   return {
     stackNames,
     context,
@@ -118,6 +139,8 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),
+    undeclaredOnly: has('--undeclared-only'),
+    declaredOnly: has('--declared-only'),
     removeUnaccepted: has('--remove-unaccepted'),
     verbose: has('--verbose') || has('-v'),
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,6 +39,10 @@ OPTIONS
                               NOT-revertable summary to full per-finding lists
   --pre-deploy                (check) compare live state vs the LOCAL synth template
                               — the declared drift your next deploy would overwrite
+  --undeclared-only           (check) undeclared drift only — pair cdkrd with
+                              \`cdk drift\` / CFn drift detection for the declared side
+  --declared-only             (check) declared drift vs the DEPLOYED template only
+                              (undeclared tier skipped; baseline untouched)
   --dry-run                   (revert) print the plan; make no changes
   --remove-unaccepted         (revert) on a stack with NO baseline, REMOVE undeclared
                               drift (default: refuse — run \`cdkrd accept\` first)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -33,9 +33,22 @@ import {
 
 // --pre-deploy reports declared-side drift the next deploy would clobber; the
 // undeclared tier is meaningless against a synth (not deployed) declared set, so
-// it is excluded. Exported (pure) so the contract is unit-tested.
+// it is excluded. --declared-only reuses the same filter against the DEPLOYED
+// template (R59). Exported (pure) so the contract is unit-tested.
 export function preDeployFindings(findings: Finding[]): Finding[] {
   return findings.filter((f) => f.tier !== 'undeclared');
+}
+
+// --undeclared-only (R59): the declared-side comparison is delegated to
+// `cdk drift` / CFn drift detection, so declared findings AND the
+// declared-comparison byproducts (readGap = declared-but-unreadable,
+// unresolved = declared-but-GetAtt) drop out. `deleted` stays — a gone resource
+// has no undeclared values to check, and hiding it would be a lie. Exported
+// (pure) so the contract is unit-tested.
+export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
+  return findings.filter(
+    (f) => f.tier !== 'declared' && f.tier !== 'readGap' && f.tier !== 'unresolved'
+  );
 }
 
 // The first-run (no-baseline) prompt (R45). The old Yes/No confirm hid the two
@@ -175,11 +188,30 @@ export async function runCheck(args: string[]): Promise<number> {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
         continue;
       }
-      const { findings, desired, schemas } = await gatherFindings(
-        stackName,
-        region,
-        synthTemplates?.get(stackName)
-      );
+      const gathered = await gatherFindings(stackName, region, synthTemplates?.get(stackName));
+      const { desired, schemas } = gathered;
+      let findings = gathered.findings;
+
+      // Scope flags (R59). --undeclared-only delegates the declared side to
+      // `cdk drift` / CFn drift detection (no double reporting when pairing);
+      // --declared-only is the inverse (undeclared tier skipped, baseline
+      // untouched) — unlike --pre-deploy, it compares against the DEPLOYED
+      // template. Filtering up front keeps everything downstream consistent:
+      // first-run prompt counts, baseline notes, interactive actions, reverts.
+      if (a.undeclaredOnly) {
+        findings = undeclaredOnlyFindings(findings);
+        if (!a.json)
+          console.error(
+            `note: ${stackName}: --undeclared-only — declared-side drift is not compared (pair with cdk drift / CFn drift detection)`
+          );
+      }
+      if (a.declaredOnly) {
+        findings = preDeployFindings(findings); // same filter: drop the undeclared tier
+        if (!a.json)
+          console.error(
+            `note: ${stackName}: --declared-only — undeclared values are not compared (baseline untouched)`
+          );
+      }
 
       // --pre-deploy: the declared set comes from the LOCAL synth template, so the
       // ONLY meaningful signal is declared drift the next deploy would clobber. The
@@ -247,7 +279,7 @@ export async function runCheck(args: string[]): Promise<number> {
           }
         }
       }
-      if (!a.json && !baseline && !a.showAll) {
+      if (!a.json && !baseline && !a.showAll && !a.declaredOnly) {
         console.error(
           `note: ${stackName}: no baseline — showing all undeclared state. Record it with \`cdkrd accept ${stackName}\`.`
         );

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -4,6 +4,7 @@ import {
   firstRunPrompt,
   postAcceptNote,
   preDeployFindings,
+  undeclaredOnlyFindings,
 } from '../src/commands/check.js';
 import type { Finding } from '../src/types.js';
 
@@ -29,6 +30,24 @@ describe('preDeployFindings (--pre-deploy scope)', () => {
   it('is a no-op when there are no undeclared findings (regression)', () => {
     const findings = [F('declared'), F('readGap')];
     expect(preDeployFindings(findings)).toEqual(findings);
+  });
+});
+
+describe('undeclaredOnlyFindings (R59 — pair-with-cdk-drift scope)', () => {
+  it('drops declared findings AND declared-comparison byproducts (readGap/unresolved)', () => {
+    const out = undeclaredOnlyFindings([
+      F('declared'),
+      F('undeclared'),
+      F('readGap', 'Q'),
+      F('unresolved', 'R'),
+    ]);
+    expect(out.map((f) => f.tier)).toEqual(['undeclared']);
+  });
+
+  it('keeps deleted (a gone resource has no undeclared values; silence would lie) and skipped', () => {
+    const kept: Finding['tier'][] = ['deleted', 'undeclared', 'skipped'];
+    const out = undeclaredOnlyFindings(kept.map((t) => F(t)));
+    expect(out.map((f) => f.tier)).toEqual(kept);
   });
 });
 

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -87,6 +87,22 @@ describe('parseCommonArgs', () => {
     expect(parseCommonArgs(['S', '--fail']).fail).toBe(true);
   });
 
+  it('scope flags parse and are mutually exclusive (R59)', () => {
+    expect(parseCommonArgs(['S', '--undeclared-only']).undeclaredOnly).toBe(true);
+    expect(parseCommonArgs(['S', '--declared-only']).declaredOnly).toBe(true);
+    expect(parseCommonArgs(['S']).undeclaredOnly).toBe(false);
+    expect(parseCommonArgs(['S']).declaredOnly).toBe(false);
+    expect(() => parseCommonArgs(['S', '--pre-deploy', '--undeclared-only'])).toThrow(
+      /mutually exclusive/
+    );
+    expect(() => parseCommonArgs(['S', '--pre-deploy', '--declared-only'])).toThrow(
+      /mutually exclusive/
+    );
+    expect(() => parseCommonArgs(['S', '--declared-only', '--undeclared-only'])).toThrow(
+      /mutually exclusive/
+    );
+  });
+
   it('--fail takes no value — the =tier form is GONE (R58)', () => {
     expect(() => parseCommonArgs(['S', '--fail=declared'])).toThrow(
       /option "--fail" does not take a value/


### PR DESCRIPTION
## Summary

User request: a team already running `cdk drift` / CFn drift detection for the declared side wants cdkrd scoped to its differentiator (undeclared) — and the inverse exists too. Tier-wide scoping is NOT expressible via `.cdkrd/config.json` ignore rules (path patterns only), and the removed `--fail-on` never offered undeclared-ONLY anyway.

- **`--undeclared-only`** — skips the declared-side comparison: `declared` findings AND the declared-comparison byproducts (`readGap`, `unresolved`) drop out, so pairing with `cdk drift` double-reports nothing. `deleted` stays (a gone resource has no undeclared values to check; silence would lie).
- **`--declared-only`** — skips the undeclared tier (baseline untouched): declared drift **vs the DEPLOYED template**. Deliberately distinct from `--pre-deploy`, which compares against the LOCAL SYNTH template (a different question: what would my next deploy clobber).
- At most ONE scope flag; the parser rejects combinations (`mutually exclusive`).
- Filtering happens right after gather → first-run prompt counts, baseline notes, interactive actions, and revert plans are all naturally scoped. The no-baseline note is suppressed under `--declared-only`.

## Tests

358/358 (+3: `undeclaredOnlyFindings` keep/drop contracts, parse + 3-way exclusivity). HELP / README option rows / CLAUDE.md / ARCHITECTURE updated.

## Gates

typecheck / lint+format / build / tests pass; check+docs markers set; worktree-developed.