### PR TITLE
feat(report)!: no baseline = UNRECORDED, not drift; first-run Quick start (R60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,26 @@ npm install -D cdk-real-drift   # in your CDK project
 npx cdkrd check                 # checks every stack your app defines
 ```
 
-`check` is the only command you run day to day. When it finds drift in a
-terminal, it asks what to do right there:
+**First run** — your template never pins every live value (AWS defaults,
+generated names), so `check` first asks you to record a baseline of those
+UNRECORDED values (they are not drift — there is nothing to compare them to
+yet):
+
+```console
+ApiStack: no baseline yet — found 42 live value(s) not declared in your
+template (typically AWS defaults, but out-of-band edits hide among them).
+Declared-side drift is reported either way. What do you want to do?
+  ❯ Accept ALL 42 into the baseline now, without reviewing them
+    Show them first — you can still accept (selectively) right after the report
+```
+
+Accept writes `.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing
+written to AWS** — commit it. From here on `check` reports CLEAN until reality
+actually changes. (Declared drift — template vs reality — is detected from this
+very first run, baseline or not.)
+
+**Day to day** — someone changes something from the console; the next `check`
+reports it and asks right there:
 
 ```console
 ApiStack: drift found — what do you want to do?
@@ -62,10 +80,10 @@ ApiStack: drift found — what do you want to do?
     Revert — write the desired value back to AWS
 ```
 
-- **Accept** records the value in a git-committed baseline, so `check` stays
-  CLEAN until it changes again (a multiselect lets you accept some and keep
-  reporting others).
-- **Revert** shows a plan, confirms, then writes the desired value back to AWS:
+- **Accept** records the value in the baseline, so `check` stays CLEAN until it
+  changes again (a multiselect lets you accept some and keep reporting others).
+- **Revert** shows a plan, lets you pick which op(s) to write, confirms, then
+  writes the desired values back to AWS:
 
 ```console
 === cdkrd revert: ApiStack (us-east-1) ===
@@ -80,9 +98,8 @@ verifying convergence (re-reading 1 resource(s))...
 ApiStack: CLEAN after revert.
 ```
 
-**Declared drift is detected from the very first `check`** — the deployed
-template is the reference, no setup needed. `accept` and `revert` also exist as
-standalone commands for CI / scripting.
+`accept` and `revert` also exist as standalone commands; in CI, run
+`npx cdkrd check --fail`.
 
 Requirements: Node.js >= 20, AWS credentials via the standard SDK chain
 (env vars, `--profile`, SSO).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -555,6 +555,17 @@ so the two never duplicate); `^result:` stays greppable, but the formal
 machine-readable contract is `--json` (the `info:` footer may span lines). `--json`
 is unaffected — it always carries every finding. A `Custom::*` resource is `skipped`
 without any API call (note: `custom resource — no cloud-side model to read`).
+**No baseline = UNRECORDED, not drift (R60):** the baseline is the contract that
+defines undeclared drift; with no baseline there is nothing to violate, so on a
+no-baseline stack the undeclared tier renders as `[UNRECORDED: N]` (note:
+`no baseline yet — accept to record`), is excluded from the verdict and the
+`--fail` exit, and the `result:` line carries the count + the way out
+(`— N unrecorded value(s) await a baseline (run cdkrd accept)`). Declared and
+deleted drift still report and fail normally. The interactive after-report
+prompt still fires for unrecorded values (`unrecorded values found — what do
+you want to do?`) so "show them first" keeps its promise of a selective accept.
+In `--json` the findings keep `tier: "undeclared"` (the documented enum), but
+`drifted` excludes them. `--show-all` keeps its existing inventory semantics.
 **Color (R43):** output is colorized via semantic helpers
 ([style.ts](../src/report/style.ts), picocolors) — green/red bold verdicts,
 yellow undeclared tier, dim informational footers — ONLY when stdout is a real

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -279,11 +279,6 @@ export async function runCheck(args: string[]): Promise<number> {
           }
         }
       }
-      if (!a.json && !baseline && !a.showAll && !a.declaredOnly) {
-        console.error(
-          `note: ${stackName}: no baseline — showing all undeclared state. Record it with \`cdkrd accept ${stackName}\`.`
-        );
-      }
       const reconciled = applyIgnores(
         applyBaseline(findings, baseline, {
           declaredByLogical: declaredKeysByLogical(desired.resources),
@@ -294,17 +289,35 @@ export async function runCheck(args: string[]): Promise<number> {
         stackName,
         config
       );
+      // No baseline → the undeclared tier is an UNRECORDED inventory, not drift
+      // (R60): the baseline is the contract that defines undeclared drift, and
+      // with no contract there is nothing to violate. The report renders it as
+      // [UNRECORDED: N], excludes it from the verdict/exit, and points at
+      // `cdkrd accept` on the result line (which replaced the old stderr note).
+      // --show-all keeps its existing inventory semantics untouched.
+      const unrecordedMode = !baseline && !a.showAll;
       if (!a.json) separate();
       let code = report(reconciled, `${stackName} (${region})`, {
         json: a.json,
         verbose: a.verbose,
+        unrecorded: unrecordedMode,
       });
+      const hasUnrecorded = unrecordedMode && reconciled.some((f) => f.tier === 'undeclared');
 
       // R28: drift found in a TTY → offer accept / revert / nothing inline, instead
       // of making the user re-run a separate command. Skipped for --json (machine
       // output), --show-all (baseline not applied — accept would mean something else),
-      // and --pre-deploy (declared-only, baseline-untouched contract).
-      if (code === 1 && !a.json && !a.showAll && !a.preDeploy && !a.fail && isInteractive()) {
+      // and --pre-deploy (declared-only, baseline-untouched contract). UNRECORDED
+      // values do not set code 1 (R60) but still deserve the prompt — "show them
+      // first" promises a selective accept right after the report.
+      if (
+        (code === 1 || hasUnrecorded) &&
+        !a.json &&
+        !a.showAll &&
+        !a.preDeploy &&
+        !a.fail &&
+        isInteractive()
+      ) {
         const actions = availableActions(reconciled, baseline, schemas, a.removeUnaccepted);
         if (actions.accept || actions.revert) {
           const options = [{ value: 'nothing', label: 'Nothing (decide later)' }];
@@ -319,7 +332,10 @@ export async function runCheck(args: string[]): Promise<number> {
               label: 'Revert — write the desired values back to AWS',
             });
           const choice = await select({
-            message: `${stackName}: drift found — what do you want to do?`,
+            message:
+              code === 1
+                ? `${stackName}: drift found — what do you want to do?`
+                : `${stackName}: unrecorded values found — what do you want to do?`,
             options,
             initialValue: 'nothing',
           });

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -44,6 +44,12 @@ const INFO_TIERS: Tier[] = ['ignored', 'readGap', 'unresolved', 'skipped'];
 export interface ReportOptions {
   json?: boolean;
   verbose?: boolean; // expand informational tiers (readGap/unresolved/skipped) to full lists
+  // No baseline exists for this stack (R60): the undeclared tier is then an
+  // UNRECORDED inventory, not drift — the baseline is the contract that defines
+  // undeclared drift, and with no contract there is nothing to violate. The
+  // section renders as [UNRECORDED: N], the values are excluded from the
+  // drift verdict/exit, and the result line points at `cdkrd accept`.
+  unrecorded?: boolean;
   log?: (s: string) => void;
 }
 
@@ -97,7 +103,11 @@ function groupReasons(items: Finding[]): string {
 
 export function report(findings: Finding[], header: string, opts: ReportOptions = {}): number {
   const log = opts.log ?? console.log;
-  const drifted = findings.filter((f) => DRIFT_TIERS.includes(f.tier)).length;
+  // unrecorded mode (R60): undeclared values are an inventory awaiting a
+  // baseline, not drift — they never count toward the verdict or the exit.
+  const isDriftHere = (f: Finding): boolean =>
+    DRIFT_TIERS.includes(f.tier) && !(opts.unrecorded && f.tier === 'undeclared');
+  const drifted = findings.filter(isDriftHere).length;
 
   if (opts.json) {
     log(JSON.stringify({ stack: header, drifted, findings }, null, 2));
@@ -105,16 +115,21 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   }
 
   const byTier = (t: Tier) => findings.filter((f) => f.tier === t);
+  const unrecordedCount = opts.unrecorded ? byTier('undeclared').length : 0;
   // Count inside the brackets (`[NAME: N]`), explanation outside (dim) — see the
   // layout comment at the top (R48). `leadingBlank` separates a section from
   // whatever precedes it; the FIRST drift section sits directly under the header.
   const section = (tier: Tier, leadingBlank: boolean): boolean => {
     const items = byTier(tier);
     if (items.length === 0) return false; // 0-count tiers are never printed
-    const note = TIER_NOTES[tier];
+    const renamed = tier === 'undeclared' && opts.unrecorded;
+    const name = renamed ? 'UNRECORDED' : TIER_NAMES[tier];
+    const note = renamed
+      ? 'not declared in your template; no baseline yet — accept to record'
+      : TIER_NOTES[tier];
     log(
       (leadingBlank ? '\n' : '') +
-        tierStyle(tier)(`[${TIER_NAMES[tier]}: ${items.length}]`) +
+        tierStyle(tier)(`[${name}: ${items.length}]`) +
         (note ? ' ' + style.infoTier(`(${note})`) : '')
     );
     for (const f of items) log('  ' + formatFinding(f));
@@ -131,15 +146,25 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // informational breakdown lives on the `info:` line, so the two never duplicate);
   // CLEAN prints just `CLEAN`. `^result:` stays greppable for the verdict; the formal
   // machine-readable contract is `--json` (the info: footer may span lines).
-  const driftCounts = DRIFT_TIERS.filter((t) => byTier(t).length > 0)
+  const driftCounts = DRIFT_TIERS.filter(
+    (t) => byTier(t).length > 0 && !(opts.unrecorded && t === 'undeclared')
+  )
     .map((t) => `${t}=${byTier(t).length}`)
     .join(' ');
   // the verdict is the one line that must stand out: green CLEAN / red drift count
   const verdict =
     drifted === 0 ? style.clean('CLEAN') : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;
+  // unrecorded values are stated NEXT TO the verdict (not as drift): the count
+  // and the way out, in one place (R60).
+  const unrecordedNote =
+    unrecordedCount > 0
+      ? style.infoTier(
+          ` — ${unrecordedCount} unrecorded value(s) await a baseline (run cdkrd accept)`
+        )
+      : '';
   // A blank line before the verdict ONLY when drift sections were printed — it must
   // not read as a member of the last section (R48); a CLEAN stack stays 3 lines.
-  log((driftSections > 0 ? '\n' : '') + `result: ${verdict}`);
+  log((driftSections > 0 ? '\n' : '') + `result: ${verdict}${unrecordedNote}`);
   // INFORMATIONAL tiers: footer below result — full sections under --verbose, else a
   // folded summary (counts + reason breakdown): one `info: ...` line for a single
   // tier, a one-line-per-tier bullet list (with ONE --verbose hint) for 2+ (R37).

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -16,6 +16,44 @@ function run(findings: Finding[], opts: Parameters<typeof report>[2] = {}) {
   return { code, text: lines.join('\n') };
 }
 
+describe('report unrecorded mode (R60 — no baseline: undeclared is inventory, not drift)', () => {
+  it('undeclared renders as [UNRECORDED: N] and does NOT count as drift', () => {
+    const { code, text } = run([F('undeclared'), F('undeclared', 'Q')], { unrecorded: true });
+    expect(code).toBe(0);
+    expect(text).toContain('[UNRECORDED: 2]');
+    expect(text).toContain('no baseline yet — accept to record');
+    expect(text).not.toContain('UNDECLARED DRIFT');
+    expect(text).toContain(
+      'result: CLEAN — 2 unrecorded value(s) await a baseline (run cdkrd accept)'
+    );
+  });
+
+  it('declared drift still fails, with unrecorded values noted beside the verdict', () => {
+    const { code, text } = run([F('declared'), F('undeclared', 'Q')], { unrecorded: true });
+    expect(code).toBe(1);
+    expect(text).toContain('result: 1 drift(s) (declared=1) — 1 unrecorded value(s)');
+    expect(text).not.toContain('undeclared=1'); // unrecorded never appears as a drift count
+  });
+
+  it('deleted still fails in unrecorded mode (a gone resource is drift, baseline or not)', () => {
+    expect(run([F('deleted', ''), F('undeclared')], { unrecorded: true }).code).toBe(1);
+  });
+
+  it('json: drifted excludes unrecorded values; findings keep the undeclared tier', () => {
+    const { code, text } = run([F('undeclared')], { unrecorded: true, json: true });
+    const parsed = JSON.parse(text);
+    expect(code).toBe(0);
+    expect(parsed.drifted).toBe(0);
+    expect(parsed.findings[0].tier).toBe('undeclared');
+  });
+
+  it('with a baseline (unrecorded: false / absent), undeclared is drift as before', () => {
+    const { code, text } = run([F('undeclared')]);
+    expect(code).toBe(1);
+    expect(text).toContain('[UNDECLARED DRIFT: 1]');
+  });
+});
+
 describe('report', () => {
   it('exit 0 when no drift tiers present', () => {
     expect(run([F('readGap'), F('skipped'), F('unresolved')]).code).toBe(0);


### PR DESCRIPTION
## Summary

Dogfooding: a first (no-baseline) `check` saying **`result: 113 drift(s)`** is wrong on its own terms — the baseline is the contract that defines undeclared drift, and with no contract there is nothing to violate. Those values are **unrecorded**, not drifted.

## Behavior

No-baseline stack (and not `--show-all`):

```console
=== cdkrd check: ApiStack (us-east-1) ===
[UNRECORDED: 113] (not declared in your template; no baseline yet — accept to record)
  ...

result: CLEAN — 113 unrecorded value(s) await a baseline (run cdkrd accept)
```

- Unrecorded values are **excluded from the verdict and the `--fail` exit** (declared/deleted drift still reports and fails normally — incl. mixed: `result: 1 drift(s) (declared=1) — 113 unrecorded value(s) ...`).
- The after-report prompt still fires (`unrecorded values found — what do you want to do?`) so "show them first" keeps its selective-accept promise.
- The old stderr no-baseline note is gone — the result line is the canonical place.
- `--json`: findings keep `tier: "undeclared"` (documented enum); `drifted` excludes unrecorded values.

## README Quick start rewritten (user feedback)

Leading with the Accept/Revert drift prompt was wrong for a quick start — the real first contact is the baseline-recording flow. New structure: install → **first run** (first-run prompt sample, accept-all → commit the git file) → **day to day** (drift prompt + revert sample) → CI one-liner (`check --fail`).

## Tests

363/363 (+5: UNRECORDED rendering + verdict exclusion, mixed declared+unrecorded line, deleted-still-fails, json drifted exclusion, with-baseline regression).

## Gates

typecheck / lint+format / build / tests pass; check+docs markers set; worktree-developed.