### PR TITLE
docs(baseline): add why-a-baseline-file rationale; fix schema-default FAQ claim + terraform plan overclaim (R61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,14 +396,20 @@ A stateless schema comparison gives each property only two modes: report forever
 (noise) or ignore forever (blind). The baseline adds the third one drift
 detection actually needs: _this value is OK — alarm only when it changes_.
 Example: account-level "EBS encryption by default" makes every volume
-`Encrypted: true` while the schema default is `false` — the baseline pins `true`
-and alarms only on `false`.
+`Encrypted: true`. The schema is no help — it declares no default for
+`Encrypted` at all, like ~99% of CloudFormation properties — so without a
+recorded value the only choices are "report `true` forever" or "ignore the
+property forever". The baseline pins `true` and alarms only when it changes.
+Full rationale (with measurements):
+[docs/why-a-baseline-file.md](docs/why-a-baseline-file.md).
 
 **How can `cdkrd` catch a change to a property that is in neither my template
 nor the baseline?**
 The baseline is not a watch-list. Every `check` reads the _full_ live model,
 then subtracts template + schema + baseline. A property that newly appears (or
 changes) with a meaningful value survives the subtraction and is reported.
+Why neither the schema nor `.cdkrd/config.json` can play the baseline's role is
+covered in [docs/why-a-baseline-file.md](docs/why-a-baseline-file.md).
 
 **Why doesn't `--show-all` list a feature that is explicitly OFF?**
 Undeclared values that are `false`/empty are suppressed — AWS returns an

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,11 @@ CloudFormation drift detection, `driftctl`, and `terraform plan` all compare onl
 properties that appear in the template, so a change to a setting you never declared
 (a bucket's `OwnershipControls`, a role's `PermissionsBoundary`, encryption toggled
 off, an extra inline policy, transfer acceleration enabled out-of-band) is invisible
-to them. `cdkrd` reads the **full** live resource model and reports the divergence.
+to them. (`terraform plan` comes closest — its refresh notice surfaces some
+undeclared-attribute changes — but the notice carries no exit-code signal, the next
+`apply` silently absorbs the change into state, and undeclared sub-resources are
+never read at all; see [why-a-baseline-file.md §8](why-a-baseline-file.md#8-prior-art-what-terraform-plan-actually-does-here).)
+`cdkrd` reads the **full** live resource model and reports the divergence.
 
 - **Reality vs intent**, not code vs template. It deliberately does NOT reimplement
   `cdk diff` (which is code-vs-deployed-template). It is a drift tool.
@@ -37,7 +41,8 @@ to them. `cdkrd` reads the **full** live resource model and reports the divergen
 **The problem.** Infrastructure drifts. Someone clicks the console, a script runs, an
 incident gets a hot-fix — and the real resource no longer matches the IaC. Every
 existing drift tool (`cdk drift`, CloudFormation drift detection, `driftctl`,
-`terraform plan`) answers only "do the properties I _declared_ still match?" But the
+`terraform plan` — §1 notes terraform's partial exception) answers only "do the
+properties I _declared_ still match?" But the
 most dangerous drift is often in properties you never declared at all — security
 posture (public-access blocks, encryption, ownership controls, permission
 boundaries, extra inline policies) lives in defaults you never wrote down, so when it
@@ -79,8 +84,10 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    code edits never masquerade as drift; `--pre-deploy` is the opt-in inversion.
    _Right call, or do users actually expect code-vs-reality by default?_
 5. **Git-committed baseline as the undeclared contract.** Undeclared "drift" is only
-   drift relative to a human-accepted snapshot. _Is a committed file the right control
-   surface, or does it become a rubber-stamp that hides real change?_
+   drift relative to a human-accepted snapshot — the full rationale (why the state
+   must exist, and why neither schema defaults nor `config.json` can replace it)
+   is [why-a-baseline-file.md](why-a-baseline-file.md). _Is a committed file the
+   right control surface, or does it become a rubber-stamp that hides real change?_
 6. **Revert via the same generic CC write path** (UpdateResource) + thin SDK writers,
    not a per-type provider fleet. _Is generic revert safe/complete enough, or are the
    not-revertable gaps (toggle props, add/remove-statement types) too sharp an edge?_
@@ -416,6 +423,10 @@ deploy`: a patch can't recreate a resource), a **create-only** property (drift o
   acceleration is only Enabled/Suspended) can't be reverted by removal.
 
 ## 8. Baseline model
+
+This section is the mechanics. The design rationale — why the baseline must be
+state at all, and why neither schema defaults nor `.cdkrd/config.json` can
+replace it — lives in [why-a-baseline-file.md](why-a-baseline-file.md).
 
 `accept` snapshots the current undeclared state into a **git-committed** file
 `.cdkrd/<stack>.<accountId>.<region>.json` ([baseline-file.ts](../src/baseline/baseline-file.ts)):

--- a/docs/why-a-baseline-file.md
+++ b/docs/why-a-baseline-file.md
@@ -1,0 +1,230 @@
+# Why a baseline file?
+
+This document is the long answer to one design question: **could `cdkrd` be
+stateless** — template + schema + a hand-written `.cdkrd/config.json`, with no
+machine-written baseline file? Users ask it in several forms ("isn't the
+CloudFormation schema enough?", "couldn't config.json cover this?", "do I really
+need a committed file?"), and the short FAQ answers in [README.md](../README.md)
+link here. [ARCHITECTURE.md §8](ARCHITECTURE.md#8-baseline-model) describes how
+the baseline works; this document explains why it exists at all.
+
+The honest summary up front: yes, a stateless `cdkrd` is buildable — but it is a
+different, smaller product (§9). Every section below is one reason the state is
+load-bearing.
+
+## 1. Why state at all
+
+Declared properties compare statelessly: the template records the intent, and
+`check` compares live values against it. Undeclared properties have no intent
+recorded anywhere — that is what "undeclared" means. Without a remembered value,
+a stateless comparison gives each undeclared property exactly two modes:
+
+- **report forever** — the value differs from whatever static reference you
+  pick, every run, with no way to say "that's fine" (noise);
+- **ignore forever** — suppress the property and never see it again (blind).
+
+Drift detection needs a third mode: _this value is OK — alarm only when it
+changes_. That mode is, by definition, a remembered value — i.e. state.
+
+Two properties of that state follow immediately:
+
+- **It cannot be recomputed.** Acceptance is a human judgment about the live
+  value; it is not derivable from template + schema + live, because live is the
+  thing being judged.
+- **It is the definition of undeclared drift.** Undeclared "drift" is only
+  meaningful relative to an accepted reference. With no reference there is
+  nothing to violate — which is exactly why a no-baseline stack renders its
+  undeclared values as `[UNRECORDED]`, not drift (R60).
+
+## 2. Why schema defaults cannot substitute
+
+The most tempting stateless reference is the CloudFormation resource schema's
+`default` values: report an undeclared property only when its live value differs
+from the schema default. Three independent reasons this fails:
+
+**Coverage is ~1%.** Measured 2026-06-12 against the us-east-1 registry schema
+bundle: 1,602 resource types, 14,691 top-level properties, of which **161
+properties (1.1%) carry a `default`** — and only 88 types (5.5%) have even one.
+For ~99% of properties the comparison has no right-hand side. Reproduce with:
+
+```sh
+curl -sO https://schema.cloudformation.us-east-1.amazonaws.com/CloudformationSchema.zip
+unzip -oq CloudformationSchema.zip -d schemas
+python3 - <<'EOF'
+import json, glob
+props = [(k, v) for f in glob.glob('schemas/*.json')
+         for k, v in (json.load(open(f)).get('properties') or {}).items()]
+withdef = [1 for _, v in props if isinstance(v, dict) and 'default' in v]
+print(f'{len(withdef)}/{len(props)} top-level properties carry a default')
+EOF
+```
+
+Even the flagship example has no schema help: `AWS::EC2::Volume` declares **no
+default at all** for `Encrypted` (only `type` + `description`).
+
+**Where a default exists, it can be environmentally wrong.** Real defaults are
+service-side behavior, and can be account- or region-dependent: account-level
+"EBS encryption by default" makes every volume `Encrypted: true`; org policies
+and default tags shift other properties. `live ≠ schema-default` does not imply
+"someone changed this out of band" — it often means "this environment's
+legitimate default differs". A stateless comparison reports such values as
+permanent false positives, and the only stateless remedy is an ignore rule
+(blind).
+
+**Change _toward_ the default is invisible by definition.** Under
+default-comparison, "matches the default" means clean. But the dangerous
+direction of undeclared security drift is almost always toward the default:
+encryption disabled, a permissions boundary removed, logging stopped, a
+public-access block dropped. When an attacker resets a good non-default value,
+the stateless report does not fire — it _disappears_. The alarm vanishing IS the
+incident, and the model has no vocabulary for it. The baseline does: the value
+was recorded, and the change from it is reported.
+
+## 3. The false/empty asymmetry
+
+The pipeline deliberately suppresses trivially-empty undeclared values
+(`false`, `""`, empty structs — `isTrivialEmpty` in
+[src/normalize/noise.ts](../src/normalize/noise.ts)): AWS returns an off/empty
+value for nearly every unset option, and keeping them would flood the output
+(see the README FAQ "Why doesn't `--show-all` list a feature that is explicitly
+OFF?").
+
+The consequence for a stateless design: "a good value was LOST" lands exactly in
+the blind spot, because the bad end-state (`false`/empty/absent) looks like
+nothing. Additions are visible statelessly — a meaningful value exists and
+survives the subtraction. Losses are not. The asymmetry points the blind side
+precisely at the security-relevant direction (§2's disable cases). The only
+mechanism that catches a loss is **baseline removal-detection** — "a value
+present at `accept` has disappeared" — and that requires the recorded value.
+
+## 4. Why revert needs the baseline
+
+Undeclared properties have no template value, so the baseline value is the only
+possible restore target. Without it, undeclared revert degrades to "remove /
+reset toward the default", which breaks in two ways:
+
+- **It cannot restore, only bulldoze.** A console-set logging destination that
+  someone later changes should revert to the _accepted_ destination; a
+  reset-to-default "revert" turns logging off entirely.
+- **It proposes actively harmful operations.** Every environment-legitimate
+  deviation (§2) doubles as a standing offer to "fix" it — e.g. setting
+  `Encrypted: false` across an encryption-by-default account.
+
+It also cannot distinguish "changed out of band yesterday" from "has been this
+way since before cdkrd existed" — reverting the latter bulldozes accepted
+reality. This is exactly why the existing no-baseline guard marks undeclared
+findings `notRevertable` and why `--remove-unaccepted` is an explicit opt-in:
+the guard is the temporary form of a blindness that would become permanent
+without the file.
+
+## 5. Why not `.cdkrd/config.json`
+
+`.cdkrd/config.json` already exists (path-level ignore rules), so "couldn't the
+baseline live there?" is natural. Two answers, depending on what would be
+stored:
+
+**Store values there → it's the baseline, relocated badly.** config.json is
+hand-written JSONC (comments included) and stable; the baseline is rewritten
+wholesale by every `accept`. Merging them means either machine writes erase
+human edits and comments, or `accept` churns a hand-edited file on every run.
+And the scopes differ: an ignore rule is app-wide intent ("autoscaling owns
+`DesiredCount` everywhere"), while a baseline entry is a per-stack × account ×
+region **fact** — the filename `<stack>.<accountId>.<region>.json` is the
+isolation mechanism that keeps a personal-account run from colliding with a
+committed shared-account baseline. Value-pinned rules would leak per-account
+facts into the single app-wide file.
+
+**Store only paths there → the third mode is gone.** An ignore rule has no
+value, so it can only express "never look at X again" (mode two of §1). Ignoring
+`*.Encrypted` to silence the encryption-by-default noise makes the tool blind to
+encryption being disabled. And the review artifact degrades: a PR adding
+`ignore *.PermissionsBoundary` records that watching stopped, but not _which_
+boundary ARN was deemed acceptable — exactly the information a security review
+needs.
+
+## 6. Why a git-committed file (vs DynamoDB / SSM / AWS Config)
+
+Given that state must exist (§1), it could live in AWS-side storage. It is a
+git-committed file instead because acceptance is a **contract about acceptable
+real state**: committing it makes every acceptance a reviewable PR diff
+alongside the IaC it protects ("we now accept value V for X" — value-level,
+auditable, blame-able). It also keeps the project tenets: no extra
+infrastructure, no AWS Config dependency, and the contract is readable in review
+without AWS access.
+
+## 7. Zero-config vs zero-state
+
+The file does not cost the first-run experience:
+
+- The **first `check` needs no file** and is fully functional: the declared and
+  deleted tiers are stateless (template vs live) and fail the run from run #1;
+  the undeclared tier shows as `[UNRECORDED: N]` with the accept path spelled
+  out (R49/R60).
+- The baseline is **never hand-authored** — it is the machine-recorded byproduct
+  of one human decision (the interactive accept after the first check, or
+  `cdkrd accept`).
+
+So zero-CONFIG holds for the product's whole life (config.json stays optional),
+while zero-STATE is impossible only for the undeclared tier — because without an
+accepted reference, "undeclared drift" has no definition (§1). Designs that
+claim otherwise just relocate the state somewhere worse: Terraform relocates it
+into a state file that self-updates on the next `apply` with no human accept
+gate (§8), and schema-comparison pretends AWS wrote the state, when 99% of it
+was never written (§2).
+
+## 8. Prior art: what `terraform plan` actually does here
+
+Lumping `terraform plan` with "compares only declared properties" is an
+oversimplification worth spelling out, because Terraform _does_ hold the raw
+material: its state file stores the full provider-schema model of each resource
+(every attribute the provider's Read returns, declared or not), and since
+TF 0.15.4 `terraform plan` prints "Note: Objects have changed outside of
+Terraform" — a refresh diff that includes attributes never written in config.
+Plain `Optional` (non-computed) attributes (e.g.
+`aws_iam_role.permissions_boundary`) even produce a planned revert when set out
+of band.
+
+The accurate, narrower claim — and the actual contrast with `cdkrd`:
+
+1. **No operational signal.** The refresh notice is informational. With no
+   planned actions, plan reports "No changes" and exits 0 (`-detailed-exitcode`
+   included). `Optional+Computed` attributes — the AWS provider's idiom for
+   "unset means AWS/external decides" — never produce planned actions.
+2. **Silent auto-acceptance.** The next `apply` (or refresh write) absorbs the
+   new live value into state and the notice disappears. Terraform's state IS a
+   baseline — but a self-updating one, with no human accept gate and no
+   reviewable diff of "what we now accept". `cdkrd`'s baseline moves only when a
+   human runs `accept`, and the move is a PR diff.
+3. **Undeclared sub-resources are fully invisible.** The AWS provider models
+   many properties as separate resources (`aws_s3_bucket_ownership_controls`,
+   `aws_s3_bucket_public_access_block`, `aws_iam_role_policy`, ...). Never
+   declared → no state entry → not even refreshed. The flagship examples
+   (ownership controls, an extra inline policy) hit exactly this gap.
+
+## 9. What a stateless `cdkrd` would be
+
+Dropping the third mode ("accept this value, alarm when it changes") removes
+the need for the file entirely — and produces a coherent, smaller product:
+declared/deleted drift detection plus an undeclared _inventory_ with ignore
+rules. The honest degradation table:
+
+| capability                               | with baseline                           | stateless (config.json only)                          |
+| ---------------------------------------- | --------------------------------------- | ----------------------------------------------------- |
+| declared / deleted drift                 | works, fails the run                    | unchanged — works, fails the run                      |
+| undeclared change detection              | alarm on change from the accepted value | gone — existence inventory only                       |
+| new vs always-been-there                 | distinguished (vs baseline)             | indistinguishable                                     |
+| loss of a good value (disable direction) | removal-detection alarms                | invisible (the §3 blind spot)                         |
+| undeclared revert                        | restore the accepted value              | remove/reset only — can't restore; proposes harm (§4) |
+| acceptance record                        | reviewable value-level PR diff          | "stopped watching X" only                             |
+
+That product no longer answers this project's thesis — the most dangerous
+direction (disabling security posture) becomes the least visible one — which is
+why the baseline stays.
+
+## 10. The shortest framing
+
+The baseline is **the per-environment defaults database AWS never wrote**:
+14,691 top-level properties whose real, account-specific defaults exist only as
+service behavior, populated by observation (`check` reads the full live model)
+and ratified by a human (`accept`), one decision at a time, as a reviewable git
+artifact.


### PR DESCRIPTION
## Summary

A design conversation re-derived "why is the baseline a file at all — couldn't config.json or schema defaults cover it?" from first principles. Most of that argument chain was undocumented, and two existing doc claims turned out to be wrong or overstated. (Finding R61.)

### 1. New: `docs/why-a-baseline-file.md`

The complete rationale, FAQ-companion to ARCHITECTURE §8 (which stays the mechanics):

- Why the third mode ("this value is OK — alarm only when it changes") is state by definition, and why acceptance can't be recomputed.
- **Why schema defaults can't substitute, with measurements**: only 161/14,691 top-level properties (1.1%) across 1,602 registry schemas carry a `default` (us-east-1, 2026-06-12; reproduction script included). Where defaults exist they can be environmentally wrong (EBS encryption-by-default), and change _toward_ the default — the disable direction, i.e. the dangerous one — is invisible by definition.
- The false/empty asymmetry: `isTrivialEmpty` suppression means "a good value was lost" lands in the stateless blind spot; baseline removal-detection is the only catcher.
- Why revert needs the baseline value (restore vs bulldoze; no-baseline guard rationale).
- Why not `.cdkrd/config.json` (authorship/lifecycle/scope), why a git-committed file (reviewable contract), zero-config vs zero-state, the honest stateless-degradation table, and the Terraform prior-art comparison.

### 2. Fix: README FAQ factual error

The FAQ claimed EBS `Encrypted`'s "schema default is `false`". Verified false — the `AWS::EC2::Volume` registry schema declares **no default at all** for `Encrypted`; the `false` suppression actually comes from `isTrivialEmpty`. Rewritten (the corrected version strengthens the argument: the schema can't help even in principle).

### 3. Fix: `terraform plan` overclaim in ARCHITECTURE §1/§1a

Terraform's refresh notice DOES surface some undeclared-attribute changes (state stores the full provider-schema model). Sharpened to the defensible claim: no exit-code signal, silent absorption into state on the next apply, and total blindness to undeclared sub-resources. Full treatment in the new doc §8.

## Gates

- `/check`: typecheck / lint+format / build / tests (28 files, 363 tests) — all pass, marker set.
- `/check-docs`: cross-links + anchors verified; doc claims checked against `src/cli-args.ts` (`--remove-unaccepted`), `src/report/report.ts` (UNRECORDED), `src/revert/plan.ts` (`notRevertable`), `src/normalize/noise.ts` (`isTrivialEmpty`) — markers set.

Docs-only; no source changes.
