### PR TITLE
fix(config): reject unknown top-level keys in .cdkrd/config.json (R62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ baseline.
 Some properties are _legitimately_ rewritten by another system — Application
 Auto Scaling moving an ECS Service `DesiredCount`, autoscaled DynamoDB capacity.
 An accepted snapshot would re-flag every move. List those paths in a git-committed
-`.cdkrd/config.json` instead (strict JSON — no comments or trailing commas):
+`.cdkrd/config.json` instead (strict JSON — no comments or trailing commas, and
+unknown keys are rejected so a typo can't silently disable your rules):
 
 ```json
 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -542,8 +542,10 @@ targets by, offered as an additional match target (it comes from optional
 `aws:cdk:path` Metadata, so it can't be the only key). A parent-segment rule
 (`X.Policies`) covers child paths (`X.Policies.0.PolicyName`).
 Ignored findings drop out of the revert plan and the accept-set automatically
-(neither acts on the `ignored` tier). A malformed `config.json` fails the run
-(exit 2) rather than silently dropping the rules. Applied even under `--show-all`
+(neither acts on the `ignored` tier). A malformed `config.json` — invalid JSON,
+a wrong-typed `ignore`, or an unknown top-level key (R62: a typo like `"ignroe"`
+would otherwise load as an empty config and silently disable every rule) — fails
+the run (exit 2) rather than silently dropping the rules. Applied even under `--show-all`
 (inventory un-suppresses the baseline, not the ignore rules); `--verbose` still lists
 the ignored entries. A CLI to manage rules (`cdkrd ignore <pattern>`) is a future
 open question (§13) — v1 is hand-edited. **Default text layout (R25, spacing

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -25,13 +25,16 @@ export interface CdkrdConfig {
 }
 
 const CONFIG_PATH = '.cdkrd/config.json';
+const KNOWN_KEYS = new Set(['ignore']);
 
 /**
  * Load `.cdkrd/config.json` (cwd-relative). Absent file -> empty config (backward
- * compatible, no migration needed). Invalid JSON or a wrong-typed `ignore` throws
- * a clear error (caller surfaces exit 2): a silently-ignored ignore-rule file is
- * the most dangerous failure mode (the user thinks a property is suppressed when it
- * is not), so this fails fast.
+ * compatible, no migration needed). Invalid JSON, a wrong-typed `ignore`, or an
+ * unknown top-level key throws a clear error (caller surfaces exit 2): a
+ * silently-ignored ignore-rule file is the most dangerous failure mode (the user
+ * thinks a property is suppressed when it is not), so this fails fast. Unknown-key
+ * rejection closes the typo variant of the same mode (`"ignroe"` would otherwise
+ * load as an empty config without a sound).
  */
 export async function loadConfig(): Promise<CdkrdConfig> {
   let raw: string;
@@ -49,6 +52,11 @@ export async function loadConfig(): Promise<CdkrdConfig> {
   }
   if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
     throw new Error(`${CONFIG_PATH} must be a JSON object`);
+  const unknown = Object.keys(parsed).filter((k) => !KNOWN_KEYS.has(k));
+  if (unknown.length > 0)
+    throw new Error(
+      `${CONFIG_PATH}: unknown key(s) ${unknown.map((k) => `"${k}"`).join(', ')} — known keys: ${[...KNOWN_KEYS].map((k) => `"${k}"`).join(', ')}`
+    );
   const ignore = (parsed as Record<string, unknown>).ignore ?? [];
   if (!Array.isArray(ignore) || !ignore.every((x) => typeof x === 'string'))
     throw new Error(`${CONFIG_PATH}: "ignore" must be an array of strings`);

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -208,4 +208,14 @@ describe('loadConfig', () => {
     await write('["*.DesiredCount"]');
     await expect(loadConfig()).rejects.toThrow(/must be a JSON object/);
   });
+
+  it('unknown key → throws (a typo like "ignroe" must not silently disable rules)', async () => {
+    await write('{ "ignroe": ["*.DesiredCount"] }');
+    await expect(loadConfig()).rejects.toThrow(/unknown key\(s\) "ignroe" — known keys: "ignore"/);
+  });
+
+  it('unknown key alongside a valid one → still throws, listing only the unknown', async () => {
+    await write('{ "ignore": [], "concurency": 4 }');
+    await expect(loadConfig()).rejects.toThrow(/unknown key\(s\) "concurency"/);
+  });
 });


### PR DESCRIPTION
## Summary

`loadConfig` read only the `ignore` key and silently ignored everything else, so a misspelled key (`"ignroe"`) loaded as an empty config and disabled every ignore rule without a sound — the exact failure mode the loader's own comment calls the most dangerous ("the user thinks a property is suppressed when it is not"). Unknown top-level keys now fail the run (exit 2), listing the unknown key(s) and the known-key set.

- `src/config/config-file.ts`: `KNOWN_KEYS` allowlist + unknown-key rejection after the object-shape check; doc comment updated.
- `tests/config-file.test.ts`: typo'd key throws; unknown key alongside a valid `ignore` throws listing only the unknown one.
- `README.md` / `docs/ARCHITECTURE.md`: one-line notes that unknown keys are rejected (fail-fast family already documented).

Surfaced as a side product of the baseline-storage design discussion (no design change came out of that — this hardening is independent of it).

## Gates

- /check: typecheck, lint+format, build, 365 unit tests — all pass.
- /check-docs: config.json mentions (README ignore section + FAQ, ARCHITECTURE §ignore, why-a-baseline-file) verified consistent.