### PR TITLE
feat(corpus): golden-corpus record + offline replay harness (R63)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -79,6 +79,7 @@ NEW (cdkd does NOT have these):
 - **desired-adapter** — GetTemplate + DescribeStackResources → resolved declared
 - **baseline file I/O** — git-committed JSON
 - **report** — tiered text + JSON
+- **golden corpus** — recorded real pipeline inputs+findings, replayed offline in CI (R63)
 
 ## Roadmap (private until Phase 4)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -660,6 +660,20 @@ and KMS-alias fixes are cdkrd-only because cdkd's baseline is an AWS snapshot
   baseline, revert plan + apply-ops + writers + the interactive abort→exit mapping
   (`resolveInteractiveRevertExit`, R30), overrides incl. EIP, glob, cli-args,
   template-adapter incl. `--pre-deploy` override, report.
+- **Golden corpus** (R63, [record.ts](../src/corpus/record.ts) +
+  `tests/corpus-replay.test.ts`): the normalize→classify pipeline is pure, so a
+  resource's classification is fully determined by (resolved declared, raw live
+  model, schema info, opts). `CDKRD_CORPUS_DIR=<dir> cdkrd check ...` records
+  those inputs + the produced findings per readable resource during a REAL
+  gather; committed cases under `tests/corpus/` are replayed offline through
+  `classifyResource` on every CI run and must reproduce the findings exactly.
+  This converts every dogfood / integ run into permanent false-positive AND
+  false-negative regression coverage without AWS access. Account ids are
+  sanitized at record time (uniformly, so ARN-identity suppression replays);
+  resource/stack NAMES are not — recordings are reviewed before committing,
+  and cases from confidential stacks are never committed (integ fixtures use
+  fictional names and are always safe). An intended behavior change updates a
+  case's `expected` in the same PR, making the semantic change reviewable.
 - **Integration fixtures** under `tests/integration/{basic,iam,lambda,revert}` (real
   CDK apps + `verify.sh`). The revert integ proves deploy → accept → out-of-band
   change → check → `revert --yes` → CLEAN → AWS converged. The `basic` fixture also

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -2,6 +2,7 @@
 
 import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
 import { classifyResource } from '../diff/classify.js';
 import { resolveProperties } from '../normalize/intrinsic-resolver.js';
@@ -154,8 +155,27 @@ export async function gatherFindings(
   const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
+  // CDKRD_CORPUS_DIR records every readable resource as a golden-corpus case
+  // (the pure pipeline inputs + the findings they produced) for offline replay —
+  // see src/corpus/record.ts (R63). Account ids are sanitized at record time.
+  const corpusDir = process.env[CORPUS_DIR_ENV];
   for (const r of desired.resources) {
-    findings.push(...(await classifyRead(cfn, r, reads.get(r.logicalId), schemas, classifyOpts)));
+    const resourceFindings = await classifyRead(
+      cfn,
+      r,
+      reads.get(r.logicalId),
+      schemas,
+      classifyOpts
+    );
+    findings.push(...resourceFindings);
+    const live = reads.get(r.logicalId)?.live;
+    const schema = schemas.get(r.resourceType);
+    if (corpusDir && live && schema) {
+      await recordCorpusCase(
+        corpusDir,
+        buildCorpusCase(r, live, schema, classifyOpts, resourceFindings)
+      );
+    }
   }
   return { desired, findings, schemas };
 }

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -1,0 +1,146 @@
+// Golden-corpus recording (R63). The normalize→classify pipeline is pure, so a
+// resource's classification is fully determined by (resolved declared, raw live
+// model, schema info, classify opts). Recording those four during a REAL gather
+// turns every dogfood / integ run into permanent offline regression coverage:
+// the replay test (tests/corpus-replay.test.ts) re-runs `classifyResource` on
+// every committed case in tests/corpus/ and asserts the findings byte-for-byte
+// — no AWS, runs in CI on every push.
+//
+// Recording is opt-in: `CDKRD_CORPUS_DIR=<dir> cdkrd check ...` writes one JSON
+// case per readable resource. Account ids are sanitized automatically
+// (replaced with 111111111111 EVERYWHERE, so ARN-identity suppression still
+// replays identically); resource/stack NAMES are NOT — review a recording
+// before committing it, and never commit cases recorded from confidential
+// stacks (integ fixtures use fictional names and are always safe).
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { UNRESOLVED } from '../normalize/intrinsic-resolver.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
+
+export const CORPUS_DIR_ENV = 'CDKRD_CORPUS_DIR';
+
+// The UNRESOLVED marker is a Symbol (not JSON-serializable); a recorded declared
+// model swaps it for this sentinel string, and replay swaps it back — otherwise
+// JSON.stringify would silently DROP the key and the replayed classification
+// would diverge from the live one (no `unresolved` finding).
+export const UNRESOLVED_SENTINEL = '__cdkrd_corpus_unresolved__';
+
+function swapUnresolved(v: unknown, from: unknown, to: unknown): unknown {
+  if (v === from) return to;
+  if (Array.isArray(v)) return v.map((x) => swapUnresolved(x, from, to));
+  if (v && typeof v === 'object')
+    return Object.fromEntries(Object.entries(v).map(([k, x]) => [k, swapUnresolved(x, from, to)]));
+  return v;
+}
+
+export function encodeUnresolved<T>(v: T): T {
+  return swapUnresolved(v, UNRESOLVED, UNRESOLVED_SENTINEL) as T;
+}
+
+export function decodeUnresolved<T>(v: T): T {
+  return swapUnresolved(v, UNRESOLVED_SENTINEL, UNRESOLVED) as T;
+}
+
+// JSON-serializable mirror of the classifyResource inputs + expected output.
+export interface CorpusCase {
+  corpusVersion: 1;
+  // free-text: what this case locks in (filled in by hand when curating)
+  description?: string;
+  resource: {
+    logicalId: string;
+    resourceType: string;
+    physicalId?: string;
+    constructPath?: string;
+    declared: Record<string, unknown>; // RESOLVED declared (post intrinsic resolution)
+    siblingPolicyNames?: string[] | 'unresolved';
+  };
+  liveRaw: Record<string, unknown>; // un-stripped live model, as the reader returned it
+  schema: {
+    readOnly: string[];
+    writeOnly: string[];
+    createOnly: string[];
+    readOnlyPaths: string[];
+    writeOnlyPaths: string[];
+    createOnlyPaths: string[];
+    defaults: Record<string, unknown>;
+  };
+  opts: { accountId: string; region: string; kmsAliasTargets: Record<string, string> };
+  expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
+}
+
+/** Deep-replace every occurrence of `accountId` inside string values (ARNs,
+ *  physical ids, policy principals, ...) with the fixed sanitized id. Applied
+ *  uniformly to inputs AND expected findings, so account-scoped suppression
+ *  (arn-identity) replays exactly as it ran live. */
+export function sanitizeAccountId<T>(value: T, accountId: string): T {
+  if (!accountId) return value;
+  const walk = (v: unknown): unknown => {
+    if (typeof v === 'string') return v.split(accountId).join('111111111111');
+    if (Array.isArray(v)) return v.map(walk);
+    if (v && typeof v === 'object')
+      return Object.fromEntries(Object.entries(v).map(([k, x]) => [k, walk(x)]));
+    return v;
+  };
+  return walk(value) as T;
+}
+
+/** Assemble a corpus case from one classified resource (already-sanitized by the caller). */
+export function buildCorpusCase(
+  resource: DesiredResource,
+  liveRaw: Record<string, unknown>,
+  schema: SchemaInfo,
+  opts: { accountId: string; region: string; kmsAliasTargets: Record<string, string> },
+  findings: Finding[]
+): CorpusCase {
+  const c: CorpusCase = {
+    corpusVersion: 1,
+    resource: {
+      logicalId: resource.logicalId,
+      resourceType: resource.resourceType,
+      ...(resource.physicalId !== undefined && { physicalId: resource.physicalId }),
+      ...(resource.constructPath !== undefined && { constructPath: resource.constructPath }),
+      declared: encodeUnresolved(resource.declared),
+      ...(resource.siblingPolicyNames !== undefined && {
+        siblingPolicyNames: resource.siblingPolicyNames,
+      }),
+    },
+    liveRaw,
+    schema: {
+      readOnly: [...schema.readOnly].sort(),
+      writeOnly: [...schema.writeOnly].sort(),
+      createOnly: [...schema.createOnly].sort(),
+      readOnlyPaths: [...schema.readOnlyPaths].sort(),
+      writeOnlyPaths: [...schema.writeOnlyPaths].sort(),
+      createOnlyPaths: [...schema.createOnlyPaths].sort(),
+      defaults: schema.defaults,
+    },
+    opts,
+    expected: findings,
+  };
+  return sanitizeAccountId(c, opts.accountId);
+}
+
+/** Revive a case's schema arrays into the SchemaInfo Sets classify expects. */
+export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
+  return {
+    readOnly: new Set(s.readOnly),
+    writeOnly: new Set(s.writeOnly),
+    createOnly: new Set(s.createOnly),
+    readOnlyPaths: [...s.readOnlyPaths],
+    writeOnlyPaths: [...s.writeOnlyPaths],
+    createOnlyPaths: [...s.createOnlyPaths],
+    defaults: s.defaults,
+  };
+}
+
+/** `AWS::S3::Bucket` + `MyBucket` -> `AWS__S3__Bucket.MyBucket.json` */
+export function corpusFileName(resourceType: string, logicalId: string): string {
+  return `${resourceType.replace(/::/g, '__')}.${logicalId}.json`;
+}
+
+export async function recordCorpusCase(dir: string, c: CorpusCase): Promise<string> {
+  await mkdir(dir, { recursive: true });
+  const p = join(dir, corpusFileName(c.resource.resourceType, c.resource.logicalId));
+  await writeFile(p, JSON.stringify(c, null, 2) + '\n', 'utf8');
+  return p;
+}

--- a/tests/corpus-record.test.ts
+++ b/tests/corpus-record.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  buildCorpusCase,
+  corpusFileName,
+  decodeUnresolved,
+  encodeUnresolved,
+  reviveSchema,
+  sanitizeAccountId,
+  UNRESOLVED_SENTINEL,
+} from '../src/corpus/record.js';
+import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+describe('corpus recording (R63)', () => {
+  it('sanitizeAccountId replaces the account id inside any nested string', () => {
+    const v = {
+      arn: 'arn:aws:iam::123456789012:role/x',
+      list: ['123456789012', { deep: 'a 123456789012 b' }],
+      n: 5,
+    };
+    expect(sanitizeAccountId(v, '123456789012')).toEqual({
+      arn: 'arn:aws:iam::111111111111:role/x',
+      list: ['111111111111', { deep: 'a 111111111111 b' }],
+      n: 5,
+    });
+  });
+
+  it('sanitizeAccountId with an empty account id is the identity', () => {
+    expect(sanitizeAccountId({ a: '1' }, '')).toEqual({ a: '1' });
+  });
+
+  it('encode/decode round-trips the UNRESOLVED symbol through JSON', () => {
+    const declared = { Role: UNRESOLVED, Nested: { Arn: [UNRESOLVED, 'x'] } };
+    const encoded = encodeUnresolved(declared);
+    expect(JSON.parse(JSON.stringify(encoded))).toEqual({
+      Role: UNRESOLVED_SENTINEL,
+      Nested: { Arn: [UNRESOLVED_SENTINEL, 'x'] },
+    });
+    expect(decodeUnresolved(encoded)).toEqual(declared);
+  });
+
+  it('corpusFileName flattens :: and appends the logical id', () => {
+    expect(corpusFileName('AWS::S3::Bucket', 'MyBucket')).toBe('AWS__S3__Bucket.MyBucket.json');
+  });
+
+  it('buildCorpusCase serializes schema sets, sanitizes, and reviveSchema restores them', () => {
+    const resource: DesiredResource = {
+      logicalId: 'R',
+      resourceType: 'AWS::X::Y',
+      physicalId: 'arn:aws:x:us-east-1:123456789012:y/r',
+      declared: { A: 'arn:aws:iam::123456789012:role/r' },
+    };
+    const schema: SchemaInfo = {
+      readOnly: new Set(['Arn']),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: ['Arn'],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+    };
+    const findings: Finding[] = [
+      {
+        tier: 'undeclared',
+        logicalId: 'R',
+        resourceType: 'AWS::X::Y',
+        path: 'P',
+        actual: 'arn:aws:x:us-east-1:123456789012:y/p',
+        physicalId: 'arn:aws:x:us-east-1:123456789012:y/r',
+      },
+    ];
+    const c = buildCorpusCase(
+      resource,
+      { A: 'arn:aws:iam::123456789012:role/r' },
+      schema,
+      { accountId: '123456789012', region: 'us-east-1', kmsAliasTargets: {} },
+      findings
+    );
+    // sanitized EVERYWHERE, consistently (inputs, opts, and expected findings)
+    expect(c.resource.physicalId).toBe('arn:aws:x:us-east-1:111111111111:y/r');
+    expect(c.opts.accountId).toBe('111111111111');
+    expect(c.expected[0]!.actual).toBe('arn:aws:x:us-east-1:111111111111:y/p');
+    // schema sets serialized as sorted arrays; revive restores Sets
+    expect(c.schema.readOnly).toEqual(['Arn']);
+    expect(reviveSchema(c.schema).readOnly.has('Arn')).toBe(true);
+    // JSON-safe end to end
+    expect(() => JSON.stringify(c)).not.toThrow();
+  });
+});

--- a/tests/corpus-replay.test.ts
+++ b/tests/corpus-replay.test.ts
@@ -1,0 +1,51 @@
+// Golden-corpus replay (R63): every case in tests/corpus/ is a REAL pipeline
+// input set (resolved declared + raw live model + schema + opts) recorded from
+// a live gather (`CDKRD_CORPUS_DIR=... cdkrd check ...`) or hand-curated. The
+// normalize→classify pipeline is pure, so replaying `classifyResource` offline
+// must reproduce the recorded findings exactly — any diff is a regression (or
+// an intended behavior change, in which case the case's `expected` is updated
+// in the same PR, making the semantic change visible in review).
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+import { type CorpusCase, decodeUnresolved, reviveSchema } from '../src/corpus/record.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding } from '../src/types.js';
+
+const corpusDir = join(dirname(fileURLToPath(import.meta.url)), 'corpus');
+const files = readdirSync(corpusDir)
+  .filter((f) => f.endsWith('.json'))
+  .sort();
+
+const byTierPath = (a: Finding, b: Finding): number => {
+  const ka = `${a.tier} ${a.path}`;
+  const kb = `${b.tier} ${b.path}`;
+  return ka < kb ? -1 : ka > kb ? 1 : 0;
+};
+
+describe('golden corpus replay (R63)', () => {
+  it('corpus is not empty', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  for (const file of files) {
+    it(file, () => {
+      const c = JSON.parse(readFileSync(join(corpusDir, file), 'utf8')) as CorpusCase;
+      expect(c.corpusVersion).toBe(1);
+      const resource = {
+        ...c.resource,
+        declared: decodeUnresolved(c.resource.declared),
+      } as DesiredResource;
+      // classify strips/mutates its inputs' copies — pass fresh clones so a
+      // case file is never the thing being mutated.
+      const got = classifyResource(
+        resource,
+        structuredClone(c.liveRaw),
+        reviveSchema(c.schema),
+        c.opts
+      );
+      expect([...got].sort(byTierPath)).toEqual([...c.expected].sort(byTierPath));
+    });
+  }
+});

--- a/tests/corpus/AWS__IAM__Role.ServiceRole.json
+++ b/tests/corpus/AWS__IAM__Role.ServiceRole.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "description": "IAM role: scalar-vs-array Action folds in the declared trust-policy compare (policy canonicalization); sibling-owned DefaultPolicy entry dropped from live Policies while the out-of-band ttttt inline policy still surfaces; KNOWN_DEFAULTS MaxSessionDuration/Path suppressed; RoleName == physicalId suppressed.",
+  "resource": {
+    "logicalId": "ServiceRole",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CorpusStack-ServiceRole-ABC123",
+    "constructPath": "CorpusStack/Service/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": { "Service": "lambda.amazonaws.com" }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    },
+    "siblingPolicyNames": ["ServiceRoleDefaultPolicy"]
+  },
+  "liveRaw": {
+    "RoleName": "CorpusStack-ServiceRole-ABC123",
+    "Arn": "arn:aws:iam::111111111111:role/CorpusStack-ServiceRole-ABC123",
+    "RoleId": "AROAEXAMPLEEXAMPLE",
+    "AssumeRolePolicyDocument": {
+      "Statement": [
+        {
+          "Action": ["sts:AssumeRole"],
+          "Effect": "Allow",
+          "Principal": { "Service": "lambda.amazonaws.com" }
+        }
+      ],
+      "Version": "2012-10-17"
+    },
+    "MaxSessionDuration": 3600,
+    "Path": "/",
+    "Policies": [
+      {
+        "PolicyName": "ServiceRoleDefaultPolicy",
+        "PolicyDocument": {
+          "Statement": [{ "Action": ["s3:PutObject"], "Effect": "Allow", "Resource": ["*"] }],
+          "Version": "2012-10-17"
+        }
+      },
+      {
+        "PolicyName": "ttttt",
+        "PolicyDocument": {
+          "Statement": [{ "Action": ["s3:GetObject"], "Effect": "Allow", "Resource": ["*"] }],
+          "Version": "2012-10-17"
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RoleName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ServiceRole",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Policies",
+      "actual": [
+        {
+          "PolicyName": "ttttt",
+          "PolicyDocument": {
+            "Statement": [{ "Action": ["s3:GetObject"], "Effect": "Allow", "Resource": ["*"] }],
+            "Version": "2012-10-17"
+          }
+        }
+      ],
+      "physicalId": "CorpusStack-ServiceRole-ABC123",
+      "constructPath": "CorpusStack/Service/Role"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.Handler.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "Unresolved declared value (GetAtt that could not be resolved) lands in the unresolved tier, never compared; schema default (PackageType=Zip) suppresses an undeclared live value; a genuinely undeclared one (ReservedConcurrentExecutions) surfaces.",
+  "resource": {
+    "logicalId": "Handler",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "corpus-handler",
+    "declared": {
+      "FunctionName": "corpus-handler",
+      "Role": "__cdkrd_corpus_unresolved__",
+      "Runtime": "nodejs20.x"
+    }
+  },
+  "liveRaw": {
+    "FunctionName": "corpus-handler",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:corpus-handler",
+    "Role": "arn:aws:iam::111111111111:role/corpus-handler-role",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "ReservedConcurrentExecutions": 5
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["FunctionName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FunctionName"],
+    "defaults": { "PackageType": "Zip" }
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "Handler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Role",
+      "physicalId": "corpus-handler"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Handler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "ReservedConcurrentExecutions",
+      "actual": 5,
+      "physicalId": "corpus-handler"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Redshift__Cluster.Warehouse.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Warehouse.json
@@ -1,0 +1,45 @@
+{
+  "corpusVersion": 1,
+  "description": "Write-only + read-gap: a declared top-level write-only key (MasterUserPassword) is ONE readGap finding and never compared; a declared key absent from the live read (Port) is a readGap, not drift.",
+  "resource": {
+    "logicalId": "Warehouse",
+    "resourceType": "AWS::Redshift::Cluster",
+    "physicalId": "corpus-warehouse",
+    "declared": {
+      "NodeType": "dc2.large",
+      "MasterUserPassword": "not-a-real-secret",
+      "Port": 5439
+    }
+  },
+  "liveRaw": {
+    "NodeType": "dc2.large"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["MasterUserPassword"],
+    "createOnly": [],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["MasterUserPassword"],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Warehouse",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "corpus-warehouse"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "Warehouse",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "Port",
+      "note": "declared but not returned by live read",
+      "physicalId": "corpus-warehouse"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.CorpusBucket.json
+++ b/tests/corpus/AWS__S3__Bucket.CorpusBucket.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "description": "S3 bucket: readOnly Arn stripped; aws:* tags + empty arrays suppressed; KNOWN_DEFAULTS VersioningConfiguration(Suspended) suppressed; out-of-band transfer acceleration surfaces as the one undeclared finding.",
+  "resource": {
+    "logicalId": "CorpusBucket",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "corpus-bucket",
+    "declared": {
+      "BucketName": "corpus-bucket"
+    }
+  },
+  "liveRaw": {
+    "BucketName": "corpus-bucket",
+    "Arn": "arn:aws:s3:::corpus-bucket",
+    "AccelerateConfiguration": { "AccelerationStatus": "Enabled" },
+    "VersioningConfiguration": { "Status": "Suspended" },
+    "AnalyticsConfigurations": [],
+    "Tags": [{ "Key": "aws:cloudformation:stack-name", "Value": "CorpusStack" }]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["BucketName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["BucketName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "CorpusBucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AccelerateConfiguration",
+      "actual": { "AccelerationStatus": "Enabled" },
+      "physicalId": "corpus-bucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.WorkQueue.json
+++ b/tests/corpus/AWS__SQS__Queue.WorkQueue.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "description": "SQS queue: stringly-typed scalar (declared number 5 vs live string \"5\") is NOT drift; a real declared change (VisibilityTimeout 30 -> 60) IS; readOnly QueueUrl/Arn stripped.",
+  "resource": {
+    "logicalId": "WorkQueue",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/corpus-work-queue",
+    "declared": {
+      "QueueName": "corpus-work-queue",
+      "DelaySeconds": 5,
+      "VisibilityTimeout": 30
+    }
+  },
+  "liveRaw": {
+    "QueueName": "corpus-work-queue",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/corpus-work-queue",
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:corpus-work-queue",
+    "DelaySeconds": "5",
+    "VisibilityTimeout": 60
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["QueueName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "WorkQueue",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "desired": 30,
+      "actual": 60,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/corpus-work-queue"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -19,6 +19,16 @@ All accept/revert calls in the scripts pass `--yes`: since the interactive
 prompts landed (R28/R38/R45), a write decision without `--yes` would refuse
 (exit 2) when stdin is not a TTY — and stop to wait for input when it is (R50).
 
+## Recording golden-corpus cases (R63)
+
+Any `check` in these scripts (or a manual dogfood run) can double as corpus
+recording: `CDKRD_CORPUS_DIR=/tmp/corpus bash verify.sh` writes one JSON case
+per readable resource (pipeline inputs + findings, account ids sanitized).
+Review a recording, add a `description`, and commit it under `tests/corpus/` —
+the offline replay test then locks that classification in CI forever. Integ
+fixtures use fictional names, so their recordings are always safe to commit;
+never commit recordings from confidential stacks.
+
 ## When to run (R50)
 
 These do NOT run in CI (they need credentials and mutate a real account):


### PR DESCRIPTION
## Why

FP/FN hardening (user GO: "やれること全部"). Live integ is slow/credentialed and dogfood findings evaporate after the session — this makes both permanent.

## What

The normalize→classify pipeline is pure, so `CDKRD_CORPUS_DIR=<dir> cdkrd check ...` records each readable resource's pipeline inputs (resolved declared, raw live model, schema, opts) **plus the findings they produced**; `tests/corpus-replay.test.ts` replays every committed case through `classifyResource` in CI and must reproduce the findings exactly.

- Account ids sanitized uniformly at record time (ARN-identity suppression still replays); UNRESOLVED Symbol round-trips via a sentinel string. Names are not sanitized — recordings are reviewed before commit; integ-fixture recordings (fictional names) are always safe.
- 5 hand-curated seed cases lock: readOnly strip / aws:* tags / trivial-empty / KNOWN_DEFAULTS / schema defaults / policy scalar-vs-array canonicalization / sibling-DefaultPolicy filter (rogue ttttt-style inline policy still surfaces) / stringly scalars / write-only readGap / declared-but-unread readGap / unresolved tier.
- Intended behavior changes update a case's `expected` in the same PR → semantic diffs are reviewable.

## Tests

390 pass (13 new: 6 replay incl. non-empty guard, 5 seed cases, +record unit tests).

## Gates

- [x] typecheck / lint+format / build / unit tests (`check` marker)
- [x] docs: ARCHITECTURE §12, DESIGN components, integration README recording section (`docs` marker)