### PR TITLE
test(integ): drift-direction mutation matrix for the basic fixture (R64)

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -34,12 +34,14 @@ never commit recordings from confidential stacks.
 These do NOT run in CI (they need credentials and mutate a real account):
 
 - **Before every release** (the `/verify-pr` gate): run EVERY fixture —
-  `basic` (+ `verify-deleted-guards.sh` + `verify-vs-cdk-drift.sh`), `iam`,
-  `lambda`, `revert`, `policies`.
+  `basic` (+ `verify-deleted-guards.sh` + `verify-vs-cdk-drift.sh` +
+  `verify-mutation-matrix.sh`), `iam`, `lambda`, `revert`, `policies`.
 - **After changing** `src/read/**`, `src/revert/**`, `src/normalize/**`, or
   `src/commands/gather.ts`: run at least `basic` + `revert` (and `policies` if
   `writers.ts` changed) before merging.
-- Scripts that share a fixture/stack (`basic`'s three) must run sequentially,
+- **After changing** `src/diff/**` or `src/baseline/**`: run
+  `basic/verify-mutation-matrix.sh` (the drift-direction matrix) before merging.
+- Scripts that share a fixture/stack (`basic`'s four) must run sequentially,
   never concurrently.
 
 ## basic
@@ -80,6 +82,27 @@ Empirical proof of the README capability table, against `cdk drift` itself
 
 If `cdk drift` ever starts detecting the undeclared change, this test fails —
 the signal to re-verify the README comparison-table claims.
+
+### basic / verify-mutation-matrix.sh
+
+False-negative matrix (R64): after a FULL accept (snapshot-complete baseline),
+one bucket is walked through every drift direction the model distinguishes;
+each must be detected, named, and resolved back to CLEAN:
+
+| #   | direction         | mutation                        | must name                            | resolve  |
+| --- | ----------------- | ------------------------------- | ------------------------------------ | -------- |
+| M1  | declared-change   | versioning suspended            | `VersioningConfiguration`            | `revert` |
+| M2  | undeclared-add    | acceleration appears            | `appeared since accept` (R62)        | `accept` |
+| M3  | undeclared-change | accepted acceleration flips     | `AccelerateConfiguration`            | `accept` |
+| M4  | undeclared-add    | out-of-band bucket tags         | `Tags` + `appeared since accept`     | `accept` |
+| M5  | value-remove      | accepted tags deleted           | `baseline value removed since accept`| `accept` |
+
+Every mutation ends at CLEAN, so the script also exercises the accept delta
+loop (R39) each round and the declared revert path once.
+
+```bash
+cd basic && bash verify-mutation-matrix.sh
+```
 
 ## iam / lambda
 

--- a/tests/integration/basic/verify-mutation-matrix.sh
+++ b/tests/integration/basic/verify-mutation-matrix.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# cdk-real-drift mutation-matrix integration test (real AWS) — R64.
+#
+# False-NEGATIVE coverage: after a full accept (snapshot-complete baseline),
+# walk one resource through every drift DIRECTION the model distinguishes and
+# assert each one is detected, named, and resolvable back to CLEAN:
+#
+#   M1 declared-change    versioning Enabled -> Suspended   resolve: revert
+#   M2 undeclared-add     acceleration appears (R62:        resolve: accept
+#                         "appeared since accept" on a
+#                         snapshot-complete resource)
+#   M3 undeclared-change  accepted acceleration value flips resolve: accept
+#   M4 undeclared-add     out-of-band bucket tags appear    resolve: accept
+#   M5 value-remove       accepted tags deleted ->          resolve: accept
+#                         "baseline value removed since accept"
+#
+# Each mutation ends back at CLEAN, so the matrix also exercises the accept
+# delta loop (R39) and the declared revert path once. Reuses the `basic`
+# fixture/stack; run sequentially with the other basic scripts, never
+# concurrently. Tip: CDKRD_CORPUS_DIR=/tmp/corpus records every check here as
+# golden-corpus cases (R63) — fictional names, safe to commit.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/basic && npm install && bash verify-mutation-matrix.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkdriftIntegBasic
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+SLEEP="${CDKRD_INTEG_SLEEP:-5}"
+OUT=/tmp/cdkrd-mutation-matrix.out
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+# check must exit 1 AND the output must name every given pattern
+expect_drift() {
+  local name="$1"; shift
+  sleep "$SLEEP"
+  $CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+  local rc=${PIPESTATUS[0]}
+  [ "$rc" -eq 1 ] || fail "$name: expected drift exit 1, got $rc"
+  for pattern in "$@"; do
+    grep -q "$pattern" "$OUT" || fail "$name: expected output to name: $pattern"
+  done
+}
+
+expect_clean() {
+  local name="$1"
+  sleep "$SLEEP"
+  $CLI check "$STACK" --region "$REGION" --fail \
+    || fail "$name: expected CLEAN (exit 0) after resolving"
+}
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
+[ -n "$BUCKET" ] || fail "could not resolve bucket physical id"
+
+echo "=== full accept (snapshot-complete baseline) + CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+expect_clean "baseline"
+
+echo "=== M1 declared-change: suspend versioning (template says Enabled) ==="
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+  --versioning-configuration Status=Suspended --region "$REGION" || fail "M1 inject"
+expect_drift "M1" "DECLARED DRIFT" "VersioningConfiguration"
+$CLI revert "$STACK" --region "$REGION" --yes || fail "M1 revert"
+expect_clean "M1"
+
+echo "=== M2 undeclared-add: acceleration appears after a complete accept (R62) ==="
+aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
+  --accelerate-configuration Status=Enabled --region "$REGION" || fail "M2 inject"
+expect_drift "M2" "UNDECLARED DRIFT" "AccelerateConfiguration" "appeared since accept"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "M2 accept"
+expect_clean "M2"
+
+echo "=== M3 undeclared-change: accepted acceleration value flips ==="
+aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
+  --accelerate-configuration Status=Suspended --region "$REGION" || fail "M3 inject"
+expect_drift "M3" "UNDECLARED DRIFT" "AccelerateConfiguration"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "M3 accept"
+expect_clean "M3"
+
+echo "=== M4 undeclared-add: out-of-band bucket tags ==="
+aws s3api put-bucket-tagging --bucket "$BUCKET" \
+  --tagging 'TagSet=[{Key=CdkrdMutation,Value=m4}]' --region "$REGION" || fail "M4 inject"
+expect_drift "M4" "UNDECLARED DRIFT" "Tags" "appeared since accept"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "M4 accept"
+expect_clean "M4"
+
+echo "=== M5 value-remove: the accepted tags disappear ==="
+aws s3api delete-bucket-tagging --bucket "$BUCKET" --region "$REGION" || fail "M5 inject"
+expect_drift "M5" "UNDECLARED DRIFT" "Tags" "baseline value removed since accept"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "M5 accept"
+expect_clean "M5"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Why

False-NEGATIVE hardening (part 2 of the FP/FN plan): the only empirical proof that real drift is detected is injecting known drift and asserting detection. Existing scripts each cover one direction; this walks ONE resource through ALL of them.

## What

`basic/verify-mutation-matrix.sh` — after a snapshot-complete accept:

| # | direction | resolve |
|---|---|---|
| M1 | declared-change (versioning) | `revert --yes` |
| M2 | undeclared-add → asserts the R62 `appeared since accept` note | `accept --yes` |
| M3 | undeclared-change of an accepted value | `accept --yes` |
| M4 | undeclared-add via out-of-band tags | `accept --yes` |
| M5 | value-remove → asserts `baseline value removed since accept` | `accept --yes` |

Each mutation must be detected (exit 1), NAMED in the output, and end back at CLEAN — so the accept delta loop (R39) runs every round and the declared revert path once. `CDKRD_CORPUS_DIR` turns the run into golden-corpus recording (R63).

README: added to the release gate list + a new when-to-run rule (`src/diff/**` / `src/baseline/**` changes → run this script).

## Live run

Not yet executed against real AWS (needs credentials) — first live run is on the user, like policies/verify.sh. Bash syntax checked; all 390 unit tests + gates green (script itself is CI-excluded).

## Gates

- [x] typecheck / lint+format / build / unit tests (`check` marker)
- [x] docs (integration README) (`docs` marker)