### PR TITLE
fix(read): resolve AWS::Budgets::Budget by physical id, not declared name only (R65)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -186,9 +186,15 @@ function normalizeLambdaPrincipal(p: unknown): unknown {
   return p;
 }
 
-const readBudget: OverrideReader = async ({ declared, accountId, region }) => {
+const readBudget: OverrideReader = async ({ physicalId, declared, accountId, region }) => {
+  // The CFn physical id of AWS::Budgets::Budget IS the budget name — and unlike
+  // declared.Budget.BudgetName it is always present, including the common case
+  // where the template declares no name and CFn generates one
+  // (`<logicalId>-<region>-<ts>-...`). Resolving by declared name only skipped
+  // exactly those budgets whole-resource (dogfood, R65); declared name stays as
+  // the fallback for safety.
   const budget = declared.Budget as Record<string, unknown> | undefined;
-  const name = str(budget?.BudgetName);
+  const name = str(physicalId) || str(budget?.BudgetName);
   if (!name || !accountId) return undefined;
   const c = new BudgetsClient({ region, ...READ_RETRY });
   const r = await c.send(new DescribeBudgetCommand({ AccountId: accountId, BudgetName: name }));

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -223,6 +223,20 @@ describe('SDK overrides', () => {
   it('Budgets: undefined without a budget name', async () => {
     expect(await SDK_OVERRIDES['AWS::Budgets::Budget'](ctx({ Budget: {} }))).toBeUndefined();
   });
+  it('Budgets: resolves by PHYSICAL ID when the template declares no name (R65)', async () => {
+    // the CFn-generated-name case: the physical id IS the budget name
+    budgets.on(DescribeBudgetCommand).resolves({
+      Budget: { BudgetName: 'CfnBudget-us-east-1-123-abc', BudgetType: 'COST', TimeUnit: 'DAILY' },
+    });
+    const out = await SDK_OVERRIDES['AWS::Budgets::Budget'](
+      ctx({ Budget: {} }, 'CfnBudget-us-east-1-123-abc')
+    );
+    expect(out).toEqual({
+      Budget: { BudgetName: 'CfnBudget-us-east-1-123-abc', BudgetType: 'COST', TimeUnit: 'DAILY' },
+    });
+    const input = budgets.commandCalls(DescribeBudgetCommand).at(-1)!.args[0].input;
+    expect(input.BudgetName).toBe('CfnBudget-us-east-1-123-abc');
+  });
 
   describe('Route53 RecordSet', () => {
     it('reads an alias record + aligns the trailing dot to the declared style', async () => {


### PR DESCRIPTION
## Why

First authorized FP/FN dogfood sweep (read-only `check` on a real stack) found BOTH `AWS::Budgets::Budget` resources skipped whole-resource: `SDK override: target not resolvable from template`. A skipped resource is a whole-resource false negative — out-of-band budget changes were invisible.

## What

`readBudget` resolved the name from `declared.Budget.BudgetName`, which is absent whenever the template declares no name and CFn generates one (the common CDK case: `CfnBudgetCostForDaily-us-east-1-<ts>-...`). The CFn **physical id of a Budget IS the budget name** and is always present → resolve by physical id first, declared name as fallback.

## Evidence

Live stack before: both budgets in `[SKIPPED: 2]`. Unit test added for the generated-name case (asserts the DescribeBudget call uses the physical id). 391 tests green. Will re-run the read-only check against the same stack after merge.

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: no documented surface changed (resolution mechanism is not in README/ARCHITECTURE) (`docs`)