### PR TITLE
fix(noise): expand KNOWN_DEFAULTS with dogfood-observed service defaults (R66)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2,12 +2,37 @@
 // Keep conservative — over-suppression hides real undeclared drift.
 
 // A4: defaults AWS applies that are NOT in the CFn schema's `default` field.
+// Every entry is equality-gated: it only suppresses a live value EQUAL to the
+// listed default, so an out-of-band change to anything else still surfaces (and
+// a recorded baseline value that flips back to the default is still drift —
+// the entry only mutes the never-declared/never-decided first sighting). R66
+// entries were all OBSERVED on real default-config stacks during dogfooding.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
   // S3 versioning can never return to the never-enabled state — a revert "remove"
   // lands on Suspended, which IS the off state. Without this entry an undeclared
   // {Status:"Suspended"} re-reports forever and revert can never converge (R46).
-  'AWS::S3::Bucket': { VersioningConfiguration: { Status: 'Suspended' } },
+  'AWS::S3::Bucket': {
+    VersioningConfiguration: { Status: 'Suspended' },
+    AbacStatus: 'Disabled', // R66
+  },
+  // R66 (dogfood-observed service defaults):
+  'AWS::Lambda::Function': {
+    TracingConfig: { Mode: 'PassThrough' },
+    EphemeralStorage: { Size: 512 },
+    PackageType: 'Zip',
+    RecursiveLoop: 'Terminate',
+    RuntimeManagementConfig: { UpdateRuntimeOn: 'Auto' },
+    Architectures: ['x86_64'],
+  },
+  'AWS::Lambda::Url': { InvokeMode: 'BUFFERED' },
+  'AWS::Events::Rule': { EventBusName: 'default' },
+  'AWS::Athena::WorkGroup': { State: 'ENABLED' },
+  // Chatbot applies the AdministratorAccess guardrail when none is declared
+  // (verified live on a default-config SlackChannelConfiguration).
+  'AWS::Chatbot::SlackChannelConfiguration': {
+    GuardrailPolicies: ['arn:aws:iam::aws:policy/AdministratorAccess'],
+  },
 };
 
 // Strip AWS-managed (aws:*) tag ELEMENTS from the live side so a declared tag

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { classifyResource } from '../src/diff/classify.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
+import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
 
 function tiers(findings: Finding[]) {
@@ -324,5 +325,59 @@ describe('sibling-managed inline Policies (IAM Role)', () => {
     const live = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }, sibling] };
     const findings = classifyResource(role(['RoleDefaultPolicyABC'], declared), live, noSchema);
     expect(findings).toEqual([]);
+  });
+});
+
+describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const bare = (resourceType: string): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    physicalId: 'phys',
+    declared: {},
+  });
+
+  it('EVERY entry suppresses its exact default value through the full pipeline', () => {
+    // generic: each (type, key, default) must classify to zero findings — this
+    // also catches a canonicalization step mangling the listed default shape.
+    for (const [resourceType, defs] of Object.entries(KNOWN_DEFAULTS)) {
+      for (const [key, value] of Object.entries(defs)) {
+        const findings = classifyResource(
+          bare(resourceType),
+          { [key]: structuredClone(value) },
+          emptySchema
+        );
+        expect(findings, `${resourceType}.${key}`).toEqual([]);
+      }
+    }
+  });
+
+  it('a NON-default value for a listed key still surfaces (equality-gated)', () => {
+    expect(
+      tiers(
+        classifyResource(
+          bare('AWS::Lambda::Function'),
+          { TracingConfig: { Mode: 'Active' } },
+          emptySchema
+        )
+      ).undeclared
+    ).toEqual(['TracingConfig']);
+    expect(
+      tiers(
+        classifyResource(
+          bare('AWS::Chatbot::SlackChannelConfiguration'),
+          { GuardrailPolicies: ['arn:aws:iam::aws:policy/ReadOnlyAccess'] },
+          emptySchema
+        )
+      ).undeclared
+    ).toEqual(['GuardrailPolicies']);
   });
 });

--- a/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannel.json
+++ b/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannel.json
@@ -1,0 +1,38 @@
+{
+  "corpusVersion": 1,
+  "description": "Chatbot Slack channel (dogfood R66): the service-applied default GuardrailPolicies=[AdministratorAccess] is KNOWN_DEFAULTS-suppressed; declared values match live; nothing surfaces.",
+  "resource": {
+    "logicalId": "SlackChannel",
+    "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
+    "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/corpus-alerts",
+    "declared": {
+      "ConfigurationName": "corpus-alerts",
+      "IamRoleArn": "arn:aws:iam::111111111111:role/corpus-chatbot-role",
+      "SlackChannelId": "C0000000000",
+      "SlackWorkspaceId": "T0000000000",
+      "LoggingLevel": "ERROR",
+      "SnsTopicArns": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"]
+    }
+  },
+  "liveRaw": {
+    "ConfigurationName": "corpus-alerts",
+    "Arn": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/corpus-alerts",
+    "IamRoleArn": "arn:aws:iam::111111111111:role/corpus-chatbot-role",
+    "SlackChannelId": "C0000000000",
+    "SlackWorkspaceId": "T0000000000",
+    "LoggingLevel": "ERROR",
+    "SnsTopicArns": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"],
+    "GuardrailPolicies": ["arn:aws:iam::aws:policy/AdministratorAccess"]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["ConfigurationName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ConfigurationName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": []
+}


### PR DESCRIPTION
## Why

FP-noise reduction from the authorized dogfood sweep + the previously-recorded first-run residual analysis: these service defaults are not in the CFn registry schema's `default` field, so every never-declared default-config resource reported them as unrecorded inventory.

## What

New `KNOWN_DEFAULTS` entries (all observed live): Lambda Function (TracingConfig/EphemeralStorage/PackageType/RecursiveLoop/RuntimeManagementConfig/Architectures), Lambda Url InvokeMode, Events Rule EventBusName, Athena WorkGroup State, S3 AbacStatus, Chatbot GuardrailPolicies (verified on a live stack today).

Safety: equality-gated — only a live value EQUAL to the listed default is muted; any other value still surfaces, and a baseline-recorded value flipping back to a default is still drift (entry match wins before KNOWN_DEFAULTS is consulted).

## Tests

393 pass (+2 classify incl. a generic every-entry-through-the-full-pipeline check, +1 Chatbot golden-corpus case with expected=[]).

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: KNOWN_DEFAULTS is referenced, never enumerated, in docs — nothing stale (`docs`)