### PR TITLE
fix(read): project BudgetLimit in the Budgets reader; fold numeric-string formatting variants (R67)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -164,11 +164,21 @@ export function canonicalizeIdArraysDeep(v: unknown): unknown {
 // typed `[80, 443]` vs live `["80", "443"]` still reports drift. The direction is a
 // false POSITIVE (noise), never hidden drift, so it is fail-safe; collapsing it would
 // need a drift-calculator change. Revisit only if a real fixture hits it.
+const DECIMAL_RE = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/;
+
 export function isStringlyEqualScalar(a: unknown, b: unknown): boolean {
   const prim = (v: unknown): v is boolean | number =>
     typeof v === 'boolean' || typeof v === 'number';
-  if (prim(a) && typeof b === 'string') return String(a) === b;
-  if (prim(b) && typeof a === 'string') return String(b) === a;
+  const eq = (p: boolean | number, s: string): boolean => {
+    if (String(p) === s) return true;
+    // Numeric FORMATTING variants (R67): AWS returns decimal strings like "5.0"
+    // for a declared number 5 (Budgets BudgetLimit.Amount). Numbers only, and the
+    // string must be a plain decimal literal (no '' -> 0, no '0x10' = 16), so a
+    // genuine value change still differs.
+    return typeof p === 'number' && DECIMAL_RE.test(s.trim()) && Number(s) === p;
+  };
+  if (prim(a) && typeof b === 'string') return eq(a, b);
+  if (prim(b) && typeof a === 'string') return eq(b, a);
   return false;
 }
 

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -200,7 +200,21 @@ const readBudget: OverrideReader = async ({ physicalId, declared, accountId, reg
   const r = await c.send(new DescribeBudgetCommand({ AccountId: accountId, BudgetName: name }));
   const b = r.Budget;
   if (!b) return undefined;
-  return { Budget: { BudgetName: b.BudgetName, BudgetType: b.BudgetType, TimeUnit: b.TimeUnit } };
+  // BudgetLimit is in the projection (R67): once R65 made budgets readable, a
+  // declared BudgetLimit compared against a projection WITHOUT it reported
+  // `desired={...} actual=undefined` false drift. The live Amount is a string
+  // ("5.0") vs the declared number (5) — isStringlyEqualScalar's numeric arm
+  // folds that. The projection otherwise stays deliberately thin: nested
+  // live-only keys are ignored by the declared compare, but computed fields
+  // (CalculatedSpend) must never be offered for comparison at all.
+  return {
+    Budget: {
+      BudgetName: b.BudgetName,
+      BudgetType: b.BudgetType,
+      TimeUnit: b.TimeUnit,
+      ...(b.BudgetLimit !== undefined && { BudgetLimit: b.BudgetLimit }),
+    },
+  };
 };
 
 // AWS::EC2::EIP — Cloud Control API GetResource throws ValidationException for

--- a/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
+++ b/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "description": "Budgets budget (dogfood R65/R67): CFn-generated name (declared has no BudgetName; nested live-only BudgetName is ignored by the declared compare); declared numeric Amount 40 vs live decimal string \"40.0\" folds (stringly numeric); NotificationsWithSubscribers is an honest readGap (DescribeBudget cannot return it).",
+  "resource": {
+    "logicalId": "MonthlyCost",
+    "resourceType": "AWS::Budgets::Budget",
+    "physicalId": "MonthlyCost-us-east-1-1679810595490-abcDEFghij",
+    "declared": {
+      "Budget": {
+        "BudgetLimit": { "Amount": 40, "Unit": "USD" },
+        "BudgetType": "COST",
+        "TimeUnit": "MONTHLY"
+      },
+      "NotificationsWithSubscribers": [
+        {
+          "Notification": {
+            "ComparisonOperator": "GREATER_THAN",
+            "NotificationType": "ACTUAL",
+            "Threshold": 80
+          },
+          "Subscribers": [{ "Address": "corpus@example.com", "SubscriptionType": "EMAIL" }]
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Budget": {
+      "BudgetName": "MonthlyCost-us-east-1-1679810595490-abcDEFghij",
+      "BudgetType": "COST",
+      "TimeUnit": "MONTHLY",
+      "BudgetLimit": { "Amount": "40.0", "Unit": "USD" }
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "MonthlyCost",
+      "resourceType": "AWS::Budgets::Budget",
+      "path": "NotificationsWithSubscribers",
+      "note": "declared but not returned by live read",
+      "physicalId": "MonthlyCost-us-east-1-1679810595490-abcDEFghij"
+    }
+  ]
+}

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -138,6 +138,20 @@ describe('noise suppressors', () => {
     expect(isStringlyEqualScalar({ a: 1 }, '[object Object]')).toBe(false);
   });
 
+  it('isStringlyEqualScalar: numeric FORMATTING variants fold, value changes do not (R67)', async () => {
+    const { isStringlyEqualScalar } = await import('../src/normalize/noise.js');
+    // AWS decimal-string forms of a declared number (Budgets BudgetLimit.Amount)
+    expect(isStringlyEqualScalar(5, '5.0')).toBe(true);
+    expect(isStringlyEqualScalar('40.00', 40)).toBe(true);
+    expect(isStringlyEqualScalar(1500, '1.5e3')).toBe(true);
+    // real drift preserved
+    expect(isStringlyEqualScalar(5, '5.5')).toBe(false);
+    // strict decimal literal only: no '' -> 0, no hex, booleans never numeric
+    expect(isStringlyEqualScalar(0, '')).toBe(false);
+    expect(isStringlyEqualScalar(16, '0x10')).toBe(false);
+    expect(isStringlyEqualScalar(true, '1')).toBe(false);
+  });
+
   it('isAllAwsTags: every element an aws:* {Key,Value}', () => {
     expect(isAllAwsTags([{ Key: 'aws:cloudformation:stack-id', Value: 'x' }])).toBe(true);
     expect(

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -213,12 +213,25 @@ describe('SDK overrides', () => {
     ).toBeUndefined();
   });
 
-  it('Budgets: reads the budget by name + account', async () => {
-    budgets
-      .on(DescribeBudgetCommand)
-      .resolves({ Budget: { BudgetName: 'b', BudgetType: 'COST', TimeUnit: 'MONTHLY' } });
+  it('Budgets: reads the budget by name + account, projecting BudgetLimit (R67)', async () => {
+    budgets.on(DescribeBudgetCommand).resolves({
+      Budget: {
+        BudgetName: 'b',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        BudgetLimit: { Amount: '40.0', Unit: 'USD' },
+        CalculatedSpend: { ActualSpend: { Amount: '12.3', Unit: 'USD' } }, // computed — never projected
+      },
+    });
     const out = await SDK_OVERRIDES['AWS::Budgets::Budget'](ctx({ Budget: { BudgetName: 'b' } }));
-    expect(out).toEqual({ Budget: { BudgetName: 'b', BudgetType: 'COST', TimeUnit: 'MONTHLY' } });
+    expect(out).toEqual({
+      Budget: {
+        BudgetName: 'b',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        BudgetLimit: { Amount: '40.0', Unit: 'USD' },
+      },
+    });
   });
   it('Budgets: undefined without a budget name', async () => {
     expect(await SDK_OVERRIDES['AWS::Budgets::Budget'](ctx({ Budget: {} }))).toBeUndefined();


### PR DESCRIPTION
## Why

Re-running the authorized dogfood sweep after R65/R66 exposed the next FP in line: budgets became readable, and the declared `Budget.BudgetLimit` immediately reported `desired={"Amount":40,"Unit":"USD"} actual=undefined` — the reader's thin projection never returned BudgetLimit. And once projected, live `Amount` is a decimal STRING (`"40.0"`) vs the declared number `40`, which the exact-String() stringly rule does not fold.

## What

- `readBudget` projects `BudgetLimit` (computed fields like CalculatedSpend stay excluded).
- `isStringlyEqualScalar`: strict numeric arm — a plain decimal literal (`/^-?\d+(\.\d+)?([eE][+-]?\d+)?$/`) equal in value to the declared number folds; `''`→0, hex, and booleans never match.

## Evidence

396 tests green (+ stringly numeric matrix, BudgetLimit projection assert, and a golden-corpus case locking the full budget classification: CFn-generated name ignored, "40.0" vs 40 folded, NotificationsWithSubscribers honest readGap). Will re-run the live read-only check after merge — expected: `result: CLEAN — 2 unrecorded`.

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: no documented surface changed (`docs`)