### PR TITLE
test(corpus): 6 normalize-path seeds + 4 LIVE-recorded cases; fix mutation-matrix M4/M5 to CORS (R68)

### DIFF
--- a/tests/corpus/AWS__DynamoDB__Table.Sessions.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Sessions.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "description": "Tag canonicalization: live aws:* tag elements stripped + declared/live tag ORDER difference folded (sorted by Key) -> tags are not drift; a genuinely undeclared live property (TableClass) still surfaces.",
+  "resource": {
+    "logicalId": "Sessions",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "corpus-sessions",
+    "declared": {
+      "TableName": "corpus-sessions",
+      "Tags": [
+        { "Key": "team", "Value": "platform" },
+        { "Key": "env", "Value": "dev" }
+      ]
+    }
+  },
+  "liveRaw": {
+    "TableName": "corpus-sessions",
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/corpus-sessions",
+    "Tags": [
+      { "Key": "aws:cloudformation:stack-name", "Value": "CorpusStack" },
+      { "Key": "env", "Value": "dev" },
+      { "Key": "team", "Value": "platform" }
+    ],
+    "TableClass": "STANDARD_INFREQUENT_ACCESS"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["TableName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TableName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Sessions",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "TableClass",
+      "actual": "STANDARD_INFREQUENT_ACCESS",
+      "physicalId": "corpus-sessions"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__Role.CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092.json
+++ b/tests/corpus/AWS__IAM__Role.CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK-generated custom-resource provider role classifies fully CLEAN \u2014 KNOWN_DEFAULTS (MaxSessionDuration/Path), readOnly strips, and trust-policy canonicalization are all quiet on a genuine CC GetResource model.",
+  "resource": {
+    "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+    "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
+          }
+        ]
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+    "RoleId": "AROAXXXJN2LNXYWNCK53V"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.QueueTrigger.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.QueueTrigger.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "description": "ARN<->name identity: declared bare FunctionName vs live full ARN (same account/region, exact name suffix) is NOT drift; a REAL change on a sibling property (BatchSize) still surfaces as declared drift.",
+  "resource": {
+    "logicalId": "QueueTrigger",
+    "resourceType": "AWS::Lambda::EventSourceMapping",
+    "physicalId": "a1b2c3d4-0000-1111-2222-333344445555",
+    "declared": {
+      "FunctionName": "corpus-handler",
+      "EventSourceArn": "arn:aws:sqs:us-east-1:111111111111:corpus-work-queue",
+      "BatchSize": 10
+    }
+  },
+  "liveRaw": {
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:corpus-handler",
+    "EventSourceArn": "arn:aws:sqs:us-east-1:111111111111:corpus-work-queue",
+    "BatchSize": 20
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["EventSourceArn"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventSourceArn"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "QueueTrigger",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "BatchSize",
+      "desired": 10,
+      "actual": 20,
+      "physicalId": "a1b2c3d4-0000-1111-2222-333344445555"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
+++ b/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
@@ -1,0 +1,111 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK-generated Lambda; the R66 KNOWN_DEFAULTS keep everything quiet EXCEPT LoggingConfig (per-function LogGroup name \u2014 not a constant, so deliberately not blanket-suppressed; current behavior locked).",
+  "resource": {
+    "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+    "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler",
+    "declared": {
+      "Code": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "faa95a81ae7d7373f3e1f242268f904eb748d8d0fdd306e8a6fe515a1905a7d6.zip"
+      },
+      "Timeout": 900,
+      "MemorySize": 128,
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+      "Runtime": "nodejs24.x",
+      "Description": "Lambda function for auto-deleting objects in cdkdriftintegbasic-data666c94c7-7pabf0qbkwro S3 bucket."
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "Lambda function for auto-deleting objects in cdkdriftintegbasic-data666c94c7-7pabf0qbkwro S3 bucket.",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 900,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+    "Runtime": "nodejs24.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegBasic/9e1bdec0-6666-11f1-ba55-121596894369",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkdriftIntegBasic",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq"
+      },
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.VpcHandler.json
+++ b/tests/corpus/AWS__Lambda__Function.VpcHandler.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "description": "Id-array set semantics: nested SecurityGroupIds/SubnetIds in a different ORDER than declared are not drift (sorted as id-sets); the R66 Lambda KNOWN_DEFAULTS keep a default-config function quiet.",
+  "resource": {
+    "logicalId": "VpcHandler",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "corpus-vpc-handler",
+    "declared": {
+      "FunctionName": "corpus-vpc-handler",
+      "Runtime": "nodejs20.x",
+      "VpcConfig": {
+        "SecurityGroupIds": ["sg-0bbbbbb222222", "sg-0aaaaaa111111"],
+        "SubnetIds": ["subnet-0ddddd444444", "subnet-0ccccc333333"]
+      }
+    }
+  },
+  "liveRaw": {
+    "FunctionName": "corpus-vpc-handler",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:corpus-vpc-handler",
+    "Runtime": "nodejs20.x",
+    "VpcConfig": {
+      "SecurityGroupIds": ["sg-0aaaaaa111111", "sg-0bbbbbb222222"],
+      "SubnetIds": ["subnet-0ccccc333333", "subnet-0ddddd444444"]
+    },
+    "PackageType": "Zip",
+    "TracingConfig": { "Mode": "PassThrough" },
+    "EphemeralStorage": { "Size": 512 },
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["FunctionName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FunctionName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
+++ b/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
@@ -1,0 +1,169 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (mutation-matrix integ run, final state): a real versioned+encrypted bucket; raw classify (pre-baseline) surfaces exactly the 3 real undeclared values (AccelerateConfiguration left Suspended by M3, PublicAccessBlockConfiguration, OwnershipControls) while encryption struct extras (BucketKeyEnabled/BlockedEncryptionTypes), aws:* tags, generated names and readOnly fields stay quiet.",
+  "resource": {
+    "logicalId": "Data666C94C7",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+    "constructPath": "CdkdriftIntegBasic/Data",
+    "declared": {
+      "BucketEncryption": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ],
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkdriftintegbasic-data666c94c7-7pabf0qbkwro.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro.s3.dualstack.us-east-1.amazonaws.com",
+    "VersioningConfiguration": {
+      "Status": "Enabled"
+    },
+    "AbacStatus": "Disabled",
+    "AccelerateConfiguration": {
+      "AccelerationStatus": "Suspended"
+    },
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+    "RegionalDomainName": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegBasic",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Data666C94C7",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegBasic/9e1bdec0-6666-11f1-ba55-121596894369",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AccelerateConfiguration",
+      "actual": {
+        "AccelerationStatus": "Suspended"
+      },
+      "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+      "constructPath": "CdkdriftIntegBasic/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+      "constructPath": "CdkdriftIntegBasic/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+      "constructPath": "CdkdriftIntegBasic/Data"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK auto-delete bucket policy read via the SDK override classifies fully CLEAN \u2014 policy canonicalization is quiet on a genuine round-tripped document.",
+  "resource": {
+    "logicalId": "DataPolicyB80589C3",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+    "constructPath": "CdkdriftIntegBasic/Data/Policy",
+    "declared": {
+      "Bucket": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+              "arn:aws:s3:::cdkdriftintegbasic-data666c94c7-7pabf0qbkwro/*"
+            ]
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF"
+          },
+          "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+          "Resource": [
+            "arn:aws:s3:::cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+            "arn:aws:s3:::cdkdriftintegbasic-data666c94c7-7pabf0qbkwro/*"
+          ]
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SNS__TopicPolicy.AlarmTopicPolicy.json
+++ b/tests/corpus/AWS__SNS__TopicPolicy.AlarmTopicPolicy.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "description": "Policy-document canonicalization: statement ORDER difference + scalar-vs-array Action/Resource forms fold to equal — a reordered but semantically identical live policy is not drift.",
+  "resource": {
+    "logicalId": "AlarmTopicPolicy",
+    "resourceType": "AWS::SNS::TopicPolicy",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic",
+    "declared": {
+      "Topics": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"],
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "AllowPublish",
+            "Effect": "Allow",
+            "Principal": { "Service": "cloudwatch.amazonaws.com" },
+            "Action": "sns:Publish",
+            "Resource": "arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"
+          },
+          {
+            "Sid": "AllowSubscribe",
+            "Effect": "Allow",
+            "Principal": { "Service": "events.amazonaws.com" },
+            "Action": "sns:Subscribe",
+            "Resource": "arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Topics": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"],
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "AllowSubscribe",
+          "Effect": "Allow",
+          "Principal": { "Service": "events.amazonaws.com" },
+          "Action": ["sns:Subscribe"],
+          "Resource": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"]
+        },
+        {
+          "Sid": "AllowPublish",
+          "Effect": "Allow",
+          "Principal": { "Service": "cloudwatch.amazonaws.com" },
+          "Action": ["sns:Publish"],
+          "Resource": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"]
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": []
+}

--- a/tests/corpus/AWS__SecretsManager__Secret.DbSecret.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.DbSecret.json
@@ -1,0 +1,34 @@
+{
+  "corpusVersion": 1,
+  "description": "KMS managed-alias identity (STRICT path): declared alias/aws/secretsmanager vs the live key ARN resolves through kmsAliasTargets to the SAME managed key -> not drift. (A customer-managed key swap would not match the target and WOULD surface.)",
+  "resource": {
+    "logicalId": "DbSecret",
+    "resourceType": "AWS::SecretsManager::Secret",
+    "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:corpus-db-secret-AbCdEf",
+    "declared": {
+      "Name": "corpus-db-secret",
+      "KmsKeyId": "alias/aws/secretsmanager"
+    }
+  },
+  "liveRaw": {
+    "Name": "corpus-db-secret",
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/secretsmanager": "0a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.Flow.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.Flow.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "CC-API managed-field strip: generated/timestamp fields (CreationDate, RevisionId — top-level AND nested CreatedAt) are stripped from the live model and never report; the REMAINDER of a partially-stripped struct still surfaces honestly (LoggingConfiguration keeps {Level:OFF} — a string, deliberately NOT folded by isTrivialEmpty; if an SFN known-default is ever added, this expected changes visibly in that PR).",
+  "resource": {
+    "logicalId": "Flow",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:corpus-flow",
+    "declared": {
+      "StateMachineName": "corpus-flow",
+      "RoleArn": "arn:aws:iam::111111111111:role/corpus-flow-role"
+    }
+  },
+  "liveRaw": {
+    "StateMachineName": "corpus-flow",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:corpus-flow",
+    "RoleArn": "arn:aws:iam::111111111111:role/corpus-flow-role",
+    "CreationDate": "2026-06-12T00:00:00.000Z",
+    "RevisionId": "11111111-2222-3333-4444-555566667777",
+    "LoggingConfiguration": {
+      "Level": "OFF",
+      "CreatedAt": "2026-06-12T00:00:00.000Z"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["StateMachineName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["StateMachineName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Flow",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "LoggingConfiguration",
+      "actual": { "Level": "OFF" },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:corpus-flow"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -94,11 +94,13 @@ each must be detected, named, and resolved back to CLEAN:
 | M1  | declared-change   | versioning suspended            | `VersioningConfiguration`            | `revert` |
 | M2  | undeclared-add    | acceleration appears            | `appeared since accept` (R62)        | `accept` |
 | M3  | undeclared-change | accepted acceleration flips     | `AccelerateConfiguration`            | `accept` |
-| M4  | undeclared-add    | out-of-band bucket tags         | `Tags` + `appeared since accept`     | `accept` |
-| M5  | value-remove      | accepted tags deleted           | `baseline value removed since accept`| `accept` |
+| M4  | undeclared-add    | out-of-band CORS config         | `CorsConfiguration` + `appeared since accept` | `accept` |
+| M5  | value-remove      | accepted CORS deleted           | `baseline value removed since accept`| `accept` |
 
 Every mutation ends at CLEAN, so the script also exercises the accept delta
-loop (R39) each round and the declared revert path once.
+loop (R39) each round and the declared revert path once. (M4/M5 use CORS, not
+tags: S3 refuses a TagSet replacement that drops the CFn `aws:*` system tags —
+found on the first live run, R68.)
 
 ```bash
 cd basic && bash verify-mutation-matrix.sh

--- a/tests/integration/basic/verify-mutation-matrix.sh
+++ b/tests/integration/basic/verify-mutation-matrix.sh
@@ -10,9 +10,14 @@
 #                         "appeared since accept" on a
 #                         snapshot-complete resource)
 #   M3 undeclared-change  accepted acceleration value flips resolve: accept
-#   M4 undeclared-add     out-of-band bucket tags appear    resolve: accept
-#   M5 value-remove       accepted tags deleted ->          resolve: accept
+#   M4 undeclared-add     out-of-band CORS config appears   resolve: accept
+#   M5 value-remove       accepted CORS deleted ->          resolve: accept
 #                         "baseline value removed since accept"
+#
+# M4/M5 use CORS, not tags (first live run, R68): put-bucket-tagging REPLACES
+# the whole TagSet and S3 refuses to drop the CFn-applied aws:* system tags
+# ("System tags cannot be removed by requester") — CORS has no system-managed
+# entries to collide with.
 #
 # Each mutation ends back at CLEAN, so the matrix also exercises the accept
 # delta loop (R39) and the declared revert path once. Reuses the `basic`
@@ -95,16 +100,17 @@ expect_drift "M3" "UNDECLARED DRIFT" "AccelerateConfiguration"
 $CLI accept "$STACK" --region "$REGION" --yes || fail "M3 accept"
 expect_clean "M3"
 
-echo "=== M4 undeclared-add: out-of-band bucket tags ==="
-aws s3api put-bucket-tagging --bucket "$BUCKET" \
-  --tagging 'TagSet=[{Key=CdkrdMutation,Value=m4}]' --region "$REGION" || fail "M4 inject"
-expect_drift "M4" "UNDECLARED DRIFT" "Tags" "appeared since accept"
+echo "=== M4 undeclared-add: out-of-band CORS configuration ==="
+aws s3api put-bucket-cors --bucket "$BUCKET" --region "$REGION" --cors-configuration \
+  '{"CORSRules":[{"AllowedMethods":["GET"],"AllowedOrigins":["https://example.com"]}]}' \
+  || fail "M4 inject"
+expect_drift "M4" "UNDECLARED DRIFT" "CorsConfiguration" "appeared since accept"
 $CLI accept "$STACK" --region "$REGION" --yes || fail "M4 accept"
 expect_clean "M4"
 
-echo "=== M5 value-remove: the accepted tags disappear ==="
-aws s3api delete-bucket-tagging --bucket "$BUCKET" --region "$REGION" || fail "M5 inject"
-expect_drift "M5" "UNDECLARED DRIFT" "Tags" "baseline value removed since accept"
+echo "=== M5 value-remove: the accepted CORS configuration disappears ==="
+aws s3api delete-bucket-cors --bucket "$BUCKET" --region "$REGION" || fail "M5 inject"
+expect_drift "M5" "UNDECLARED DRIFT" "CorsConfiguration" "baseline value removed since accept"
 $CLI accept "$STACK" --region "$REGION" --yes || fail "M5 accept"
 expect_clean "M5"
 


### PR DESCRIPTION
## What

**Corpus: 7 → 17 cases** (406 unit tests).

- **6 hand-curated seeds** for normalize paths with no coverage: ARN↔name identity, KMS managed-alias STRICT path (kmsAliasTargets), tag strip+sort, nested id-array sets + R66 Lambda defaults, CC-API field strip (incl. the honest `{Level:OFF}` remainder), policy statement-order/scalar-array canonicalization.
- **4 LIVE recordings** from the authorized mutation-matrix integ run (`CDKRD_CORPUS_DIR`), reviewed: fictional names only, account ids auto-sanitized, descriptions added. Real CC GetResource models now lock: CDK provider role CLEAN, provider Lambda (only per-function LoggingConfig surfaces — locked), the fixture bucket's raw inventory, a real BucketPolicy round-trip CLEAN.

**Mutation matrix — first live run (user-authorized):**
- Run 1: M1–M3 PASS; M4 exposed a real S3 constraint — `put-bucket-tagging` replaces the whole TagSet and S3 refuses to drop CFn `aws:*` system tags.
- Fixed M4/M5 to CORS configuration; run 2: **INTEG PASS end-to-end (M1–M5)** including the R62 `appeared since accept` / `baseline value removed since accept` wording asserts and the declared-revert round trip.

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: integ README matrix table updated to CORS (`docs`)
- [x] live evidence: /tmp/r64-live2.out INTEG PASS (account 531991745243, us-east-1, self-cleaned)