### PR TITLE
fix(noise): never strip aws:* policy-condition keys; ManagedPolicy empty Description; wave-2 corpus (R69)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -251,7 +251,8 @@ all live changes
   − schema readOnly/writeOnly         → stripped (describe-type, nested + '*')
   − cc-api managed fields             → stripped (timestamps, revision ids)
   − policy-doc representational noise  → canonicalized (scalar/array, stmt order, acct-id↔root-ARN)
-  − aws:* tags (list + map)           → stripped
+  − aws:* tags ({Key,Value}[] anywhere; maps only under a `Tags` key — never
+    IAM condition keys like aws:SecureTransport, R69) → stripped
   − schema defaults + known defaults  → suppressed
   − tag-list / id-array / method-set ORDER → canonicalized (see below)
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -37,9 +37,18 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 
 // Strip AWS-managed (aws:*) tag ELEMENTS from the live side so a declared tag
 // set (which never contains aws:* tags) compares equal to the live set (which
-// AWS augments with aws:cloudformation:* etc.). Handles {Key,Value}[] lists and
-// key->value maps; recurses so nested tag bags are covered too.
+// AWS augments with aws:cloudformation:* etc.). Handles {Key,Value}[] lists at
+// any depth (shape-specific enough to be safe) and key->value maps ONLY under a
+// key named `Tags` (R69): the old strip-any-`aws:`-map-key-anywhere rule also
+// deleted IAM condition keys (`Condition.Bool["aws:SecureTransport"]`,
+// aws:SourceArn, aws:PrincipalOrgID, ...) from live policy documents, turning
+// every CDK enforceSSL-style statement into a desired-vs-undefined false drift
+// (found by the first live policies integ run).
 export function stripAwsTagsDeep(v: unknown): unknown {
+  return stripTagsWalk(v, false);
+}
+
+function stripTagsWalk(v: unknown, underTagsKey: boolean): unknown {
   if (Array.isArray(v)) {
     return v
       .filter(
@@ -51,13 +60,13 @@ export function stripAwsTagsDeep(v: unknown): unknown {
             (t as { Key: string }).Key.startsWith('aws:')
           )
       )
-      .map(stripAwsTagsDeep);
+      .map((t) => stripTagsWalk(t, false));
   }
   if (v && typeof v === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
-      if (k.startsWith('aws:')) continue;
-      out[k] = stripAwsTagsDeep(val);
+      if (underTagsKey && k.startsWith('aws:')) continue;
+      out[k] = stripTagsWalk(val, k === 'Tags');
     }
     return out;
   }

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -128,7 +128,15 @@ const readIamManagedPolicy: OverrideReader = async ({ physicalId, region }) => {
       new GetPolicyVersionCommand({ PolicyArn: physicalId, VersionId: p.DefaultVersionId })
     )
   ).PolicyVersion;
-  return { PolicyDocument: parsePolicy(ver?.Document), Path: p.Path, Description: p.Description };
+  // GetPolicy OMITS Description when it is empty, while CDK templates declare
+  // `Description: ""` — an undefined-valued key here read as `desired="" actual=
+  // undefined` false declared drift (first live policies integ run, R69). An
+  // absent live description IS the empty description.
+  return {
+    PolicyDocument: parsePolicy(ver?.Document),
+    Path: p.Path,
+    Description: p.Description ?? '',
+  };
 };
 
 const readLambdaPermission: OverrideReader = async ({ declared, region }) => {

--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "HTTP-method enum sets are UNORDERED: AllowedMethods/CachedMethods returned in a different order than declared (deep inside DistributionConfig) are not drift; trivially-false live extras (Staging) stay quiet.",
+  "resource": {
+    "logicalId": "Cdn",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E1A2B3C4D5E6F7",
+    "declared": {
+      "DistributionConfig": {
+        "Enabled": true,
+        "DefaultCacheBehavior": {
+          "TargetOriginId": "corpus-origin",
+          "ViewerProtocolPolicy": "redirect-to-https",
+          "AllowedMethods": ["GET", "HEAD", "OPTIONS"],
+          "CachedMethods": ["GET", "HEAD"]
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "Id": "E1A2B3C4D5E6F7",
+    "DistributionConfig": {
+      "Enabled": true,
+      "DefaultCacheBehavior": {
+        "TargetOriginId": "corpus-origin",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "AllowedMethods": ["OPTIONS", "HEAD", "GET"],
+        "CachedMethods": ["HEAD", "GET"]
+      }
+    },
+    "Staging": false
+  },
+  "schema": {
+    "readOnly": ["Id", "DomainName"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "DomainName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": []
+}

--- a/tests/corpus/AWS__Glue__Table.EventsTable.json
+++ b/tests/corpus/AWS__Glue__Table.EventsTable.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "description": "Stringly-typed map values (Glue Table Parameters is Map<String,String>): declared typed booleans/numbers vs the live string forms fold leaf-by-leaf; a REAL nested value change (compressed) still surfaces as declared drift on the parent property.",
+  "resource": {
+    "logicalId": "EventsTable",
+    "resourceType": "AWS::Glue::Table",
+    "physicalId": "corpus_db/corpus_events",
+    "declared": {
+      "DatabaseName": "corpus_db",
+      "TableInput": {
+        "Name": "corpus_events",
+        "Parameters": {
+          "classification": "json",
+          "has_encrypted_data": false,
+          "averageRecordSize": 123,
+          "compressed": false
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "corpus_db",
+    "TableInput": {
+      "Name": "corpus_events",
+      "Parameters": {
+        "classification": "json",
+        "has_encrypted_data": "false",
+        "averageRecordSize": "123",
+        "compressed": "true"
+      }
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DatabaseName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DatabaseName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "EventsTable",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.Parameters.compressed",
+      "desired": false,
+      "actual": "true",
+      "physicalId": "corpus_db/corpus_events"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__ManagedPolicy.WorkerManaged.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.WorkerManaged.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (first policies integ run), live Description normalized to the fixed reader output (R69: GetPolicy omits an empty Description; the reader now maps it to \"\"). Declared Description \"\" is clean; Roles is an honest readGap (attachments are not read).",
+  "resource": {
+    "logicalId": "WorkerManagedF77ABFB4",
+    "resourceType": "AWS::IAM::ManagedPolicy",
+    "physicalId": "arn:aws:iam::111111111111:policy/CdkdriftIntegPolicies-WorkerManagedF77ABFB4-48Y4dASCdT46",
+    "constructPath": "CdkdriftIntegPolicies/WorkerManaged",
+    "declared": {
+      "Description": "",
+      "Path": "/",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": "s3:ListBucket",
+            "Effect": "Allow",
+            "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+            "Sid": "ListData"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"]
+    }
+  },
+  "liveRaw": {
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+          "Effect": "Allow",
+          "Sid": "ListData"
+        }
+      ]
+    },
+    "Path": "/",
+    "Description": ""
+  },
+  "schema": {
+    "readOnly": [
+      "AttachmentCount",
+      "CreateDate",
+      "DefaultVersionId",
+      "IsAttachable",
+      "PermissionsBoundaryUsageCount",
+      "PolicyArn",
+      "PolicyId",
+      "UpdateDate"
+    ],
+    "writeOnly": [],
+    "createOnly": ["Description", "ManagedPolicyName", "Path"],
+    "readOnlyPaths": [
+      "AttachmentCount",
+      "CreateDate",
+      "DefaultVersionId",
+      "IsAttachable",
+      "PermissionsBoundaryUsageCount",
+      "PolicyArn",
+      "PolicyId",
+      "UpdateDate"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description", "ManagedPolicyName", "Path"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "WorkerManagedF77ABFB4",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Roles",
+      "note": "declared but not returned by live read",
+      "physicalId": "arn:aws:iam::111111111111:policy/CdkdriftIntegPolicies-WorkerManagedF77ABFB4-48Y4dASCdT46",
+      "constructPath": "CdkdriftIntegPolicies/WorkerManaged"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.enforce-ssl.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.enforce-ssl.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (first policies integ run) \u2014 the R69 regression case: a real CDK enforceSSL-style bucket policy whose Condition.Bool[\"aws:SecureTransport\"] the old strip-any-aws:-map-key rule DELETED from the live side (desired-vs-undefined false drift). With the strip scoped to Tags maps, this classifies CLEAN.",
+  "resource": {
+    "logicalId": "DataPolicyB80589C3",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+    "constructPath": "CdkdriftIntegPolicies/Data/Policy",
+    "declared": {
+      "Bucket": "cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": "s3:*",
+            "Condition": {
+              "Bool": {
+                "aws:SecureTransport": "false"
+              }
+            },
+            "Effect": "Deny",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+              "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i/*"
+            ],
+            "Sid": "DenyInsecureTransport"
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Sid": "DenyInsecureTransport",
+          "Effect": "Deny",
+          "Principal": {
+            "AWS": "*"
+          },
+          "Action": "s3:*",
+          "Resource": [
+            "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+            "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i/*"
+          ],
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "false"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SQS__QueuePolicy.WorkQueuePolicy.json
+++ b/tests/corpus/AWS__SQS__QueuePolicy.WorkQueuePolicy.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "description": "Principal identity: IAM treats a bare account id and its :root ARN as the same principal — declared root ARN vs live account id (and a multi-principal array in a different order) is not drift.",
+  "resource": {
+    "logicalId": "WorkQueuePolicy",
+    "resourceType": "AWS::SQS::QueuePolicy",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/corpus-work-queue",
+    "declared": {
+      "Queues": ["https://sqs.us-east-1.amazonaws.com/111111111111/corpus-work-queue"],
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": { "AWS": "arn:aws:iam::111111111111:root" },
+            "Action": ["sqs:SendMessage"],
+            "Resource": ["arn:aws:sqs:us-east-1:111111111111:corpus-work-queue"]
+          },
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": [
+                "arn:aws:iam::111111111111:role/corpus-producer",
+                "arn:aws:iam::111111111111:role/corpus-consumer"
+              ]
+            },
+            "Action": ["sqs:ReceiveMessage"],
+            "Resource": ["arn:aws:sqs:us-east-1:111111111111:corpus-work-queue"]
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Queues": ["https://sqs.us-east-1.amazonaws.com/111111111111/corpus-work-queue"],
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::111111111111:role/corpus-consumer",
+              "arn:aws:iam::111111111111:role/corpus-producer"
+            ]
+          },
+          "Action": ["sqs:ReceiveMessage"],
+          "Resource": ["arn:aws:sqs:us-east-1:111111111111:corpus-work-queue"]
+        },
+        {
+          "Effect": "Allow",
+          "Principal": { "AWS": "111111111111" },
+          "Action": ["sqs:SendMessage"],
+          "Resource": ["arn:aws:sqs:us-east-1:111111111111:corpus-work-queue"]
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": []
+}

--- a/tests/integration/policies/verify.sh
+++ b/tests/integration/policies/verify.sh
@@ -45,9 +45,14 @@ phys() {
 BUCKET="$(phys 'AWS::S3::Bucket')"
 TOPIC_ARN="$(phys 'AWS::SNS::Topic')"
 QUEUE_URL="$(phys 'AWS::SQS::Queue')"
-INLINE_NAME="$(phys 'AWS::IAM::Policy')"
 MANAGED_ARN="$(phys 'AWS::IAM::ManagedPolicy')"
 ROLE_NAME="$(phys 'AWS::IAM::Role')"
+# The CFn physical id of AWS::IAM::Policy is an OPAQUE generated string, NOT the
+# policy name on the role (declared PolicyName=WorkerInline..., physical id =
+# Cdkdr-Worke-...) — GetRolePolicy by physical id was NoSuchEntity on the first
+# live run (R69). The fixture role carries exactly one inline policy; ask IAM.
+INLINE_NAME="$(aws iam list-role-policies --role-name "$ROLE_NAME" \
+  --query 'PolicyNames[0]' --output text)"
 for v in BUCKET TOPIC_ARN QUEUE_URL INLINE_NAME MANAGED_ARN ROLE_NAME; do
   [ -n "${!v}" ] || fail "could not resolve $v"
 done

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -193,6 +193,22 @@ describe('noise suppressors', () => {
       Tags: { Team: 'a' },
     });
   });
+
+  it('stripAwsTagsDeep NEVER touches aws:* keys outside a Tags map — IAM condition keys survive (R69)', () => {
+    // the CDK enforceSSL pattern: Condition.Bool["aws:SecureTransport"] is a
+    // policy CONDITION KEY, not a tag — the old strip-anywhere rule deleted it
+    // from the live side and produced desired-vs-undefined false drift.
+    const stmt = {
+      Effect: 'Deny',
+      Condition: { Bool: { 'aws:SecureTransport': 'false' } },
+      StringEquals: { 'aws:PrincipalOrgID': 'o-corpus123' },
+    };
+    expect(stripAwsTagsDeep(stmt)).toEqual(stmt);
+    // a map under Tags nested deeper still strips
+    expect(stripAwsTagsDeep({ Nested: { Tags: { 'aws:cf': '1', Team: 'a' } } })).toEqual({
+      Nested: { Tags: { Team: 'a' } },
+    });
+  });
 });
 
 describe('cc-api strip', () => {

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -91,6 +91,18 @@ describe('SDK overrides', () => {
   it('IAM ManagedPolicy: undefined when physical id is not an ARN', async () => {
     expect(await SDK_OVERRIDES['AWS::IAM::ManagedPolicy'](ctx({}, 'not-an-arn'))).toBeUndefined();
   });
+  it('IAM ManagedPolicy: an OMITTED Description reads as "" — the empty description (R69)', async () => {
+    // GetPolicy omits Description when empty, while CDK declares Description: "";
+    // an undefined-valued key produced desired-vs-undefined false declared drift.
+    iam.on(GetPolicyCommand).resolves({ Policy: { DefaultVersionId: 'v1', Path: '/' } });
+    iam
+      .on(GetPolicyVersionCommand)
+      .resolves({ PolicyVersion: { Document: encodeURIComponent(POLICY) } });
+    const out = await SDK_OVERRIDES['AWS::IAM::ManagedPolicy'](
+      ctx({}, 'arn:aws:iam::123:policy/p')
+    );
+    expect(out!.Description).toBe('');
+  });
 
   it('Lambda Permission: matches statement by Action + Principal', async () => {
     const fnPolicy = JSON.stringify({


### PR DESCRIPTION
## Why

First live run of `policies/verify.sh` (user-authorized) — never executed before — failed at `check CLEAN after accept` with two REAL false positives, plus a latent script bug further in.

## Fixes

1. **`stripAwsTagsDeep` ate IAM condition keys**: the map-form rule deleted every `aws:`-prefixed key at any depth — `Condition.Bool["aws:SecureTransport"]` (the CDK enforceSSL pattern), `aws:SourceArn`, `aws:PrincipalOrgID`… vanished from the LIVE side → `desired="false" actual=undefined` false drift. Map stripping is now scoped to maps under a `Tags` key ({Key,Value}[] lists stay shape-based anywhere). Debugged by replaying the recorded corpus case offline — the harness paid for itself.
2. **ManagedPolicy empty Description**: GetPolicy omits an empty Description; the reader emitted an undefined-valued key → CDK's `Description: ""` reported as drift. Absent now reads as `""`.
3. **Script**: the CFn physical id of `AWS::IAM::Policy` is an opaque string, NOT the role's PolicyName → `list-role-policies` instead.

## Live evidence

Third run = **INTEG PASS end-to-end**: accept → CLEAN → 5 policy injections → `5 drift(s) (declared=5)` → `revert --yes` through **all 5 SDK writers** → CLEAN → direct AWS reads confirm injected statements gone / declared intact. (/tmp/integ-policies{,2,3}.out)

## Corpus

20 → 25 cases (413 tests): wave-2 seeds (CloudFront method-enum sets, QueuePolicy account-id↔root-ARN principals, Glue stringly Map values) + the two recordings imported as **fix proofs** (recorded enforce-SSL policy now expected CLEAN; recorded ManagedPolicy keeps only the honest Roles readGap).

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: ARCHITECTURE pipeline line updated (`docs`)