### PR TITLE
fix(noise): Lambda MemorySize/Timeout defaults; vs-cdk-drift script needs a baseline; 3 corpus cases (R70)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -24,6 +24,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     RecursiveLoop: 'Terminate',
     RuntimeManagementConfig: { UpdateRuntimeOn: 'Auto' },
     Architectures: ['x86_64'],
+    // R70 (observed live on the lambda integ fixture): a never-declared
+    // default-config function otherwise reports both on every first run.
+    MemorySize: 128,
+    Timeout: 3,
   },
   'AWS::Lambda::Url': { InvokeMode: 'BUFFERED' },
   'AWS::Events::Rule': { EventBusName: 'default' },

--- a/tests/corpus/AWS__CloudFront__Distribution.MultiOriginCdn.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.MultiOriginCdn.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "description": "Identity-keyed array sets: a multi-origin distribution returns Origins in a different ORDER (sorted by Id on both sides — not drift), while a REAL change inside one origin (OriginPath) still surfaces as declared drift with the post-sort index path.",
+  "resource": {
+    "logicalId": "MultiOriginCdn",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E7F8G9H0J1K2L3",
+    "declared": {
+      "DistributionConfig": {
+        "Enabled": true,
+        "Origins": [
+          {
+            "Id": "static-assets",
+            "DomainName": "corpus-assets.s3.us-east-1.amazonaws.com",
+            "OriginPath": "/v1"
+          },
+          {
+            "Id": "api-origin",
+            "DomainName": "api.corpus.example.com",
+            "OriginPath": ""
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Id": "E7F8G9H0J1K2L3",
+    "DistributionConfig": {
+      "Enabled": true,
+      "Origins": [
+        {
+          "Id": "api-origin",
+          "DomainName": "api.corpus.example.com",
+          "OriginPath": ""
+        },
+        {
+          "Id": "static-assets",
+          "DomainName": "corpus-assets.s3.us-east-1.amazonaws.com",
+          "OriginPath": "/v2"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Id", "DomainName"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "DomainName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "MultiOriginCdn",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins.1.OriginPath",
+      "desired": "/v1",
+      "actual": "/v2",
+      "physicalId": "E7F8G9H0J1K2L3"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__Role.TestRole.permissions-boundary.json
+++ b/tests/corpus/AWS__IAM__Role.TestRole.permissions-boundary.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (iam integ run): the README headline use case \u2014 an out-of-band PermissionsBoundary attached to a real CDK role surfaces as the ONLY finding, while the sibling DefaultPolicy reflection, trust-policy canonicalization, and IAM KNOWN_DEFAULTS all stay quiet.",
+  "resource": {
+    "logicalId": "TestRole6C9272DF",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
+    "constructPath": "CdkRealDriftIntegIam/TestRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "Description": "cdk-real-drift IAM integration test role"
+    },
+    "siblingPolicyNames": ["TestRoleDefaultPolicyD1C92014"]
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
+    "Description": "cdk-real-drift IAM integration test role",
+    "Policies": [
+      {
+        "PolicyName": "TestRoleDefaultPolicyD1C92014",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "s3:ListAllMyBuckets",
+              "Resource": "*",
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    ],
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "ec2.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
+    "RoleId": "AROAXXXJN2LNRT25RNGI2",
+    "PermissionsBoundary": "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "TestRole6C9272DF",
+      "resourceType": "AWS::IAM::Role",
+      "path": "PermissionsBoundary",
+      "actual": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+      "physicalId": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
+      "constructPath": "CdkRealDriftIntegIam/TestRole"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
+++ b/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
@@ -1,0 +1,118 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (lambda integ run): a real default-config Node Lambda; with the R66+R70 KNOWN_DEFAULTS the only survivors are the deliberately INJECTED ReservedConcurrentExecutions=1 and the per-function LoggingConfig (LogGroup name is function-specific \u2014 deliberately not blanket-suppressed).",
+  "resource": {
+    "logicalId": "TestFn04335C60",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+    "constructPath": "CdkRealDriftIntegLambda/TestFn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => ({ statusCode: 200 });"
+      },
+      "Description": "cdk-real-drift Lambda integration test function",
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambda-TestFnServiceRoleEED02BF3-InAoIu1VgMxY",
+      "Runtime": "nodejs20.x"
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "cdk-real-drift Lambda integration test function",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "ReservedConcurrentExecutions": 1,
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambda-TestFnServiceRoleEED02BF3-InAoIu1VgMxY",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegLambda",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambda/80e23f30-666f-11f1-ad72-0afffb3bb7ff",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "TestFn04335C60",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "ReservedConcurrentExecutions",
+      "actual": 1,
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92"
+      },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    }
+  ]
+}

--- a/tests/integration/basic/verify-vs-cdk-drift.sh
+++ b/tests/integration/basic/verify-vs-cdk-drift.sh
@@ -36,6 +36,12 @@ BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --re
   --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
 [ -n "$BUCKET" ] || fail "no bucket physical id"
 
+# Undeclared DRIFT is defined against an accepted baseline (R60/R62): without
+# one, an injected value is UNRECORDED — reported, but exit 0 even with --fail.
+# The first live run (R70) failed exactly here; the script predated R60.
+echo "=== accept (snapshot-complete baseline) ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail accept
+
 echo "=== inject UNDECLARED drift (enable transfer acceleration) ==="
 aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" \
   --accelerate-configuration Status=Enabled --region "$REGION" || fail "inject accel"


### PR DESCRIPTION
## Integ campaign — every remaining script run live (user-authorized)

| script | result |
|---|---|
| basic/verify.sh | PASS |
| basic/verify-deleted-guards.sh | PASS |
| basic/verify-vs-cdk-drift.sh | FAIL → script fix → **PASS** |
| iam/verify.sh | PASS |
| iam/verify-inline-policy.sh | PASS |
| lambda/verify.sh | PASS |
| revert/verify.sh | PASS |

The one failure was the script predating R60/R62 (no `accept` → the injected value was UNRECORDED → exit 0 by design, with the value visibly reported). With a snapshot-complete baseline first, the re-run **proves the README comparison-table claim live**: `cdk drift --fail` exits 0 on the undeclared change while cdkrd exits 1 and names it; both see the declared change.

## Fixes / additions

- KNOWN_DEFAULTS: Lambda `MemorySize: 128` / `Timeout: 3` (observed live — every never-declared default-config function reported both).
- Corpus 25 → 28 (416 tests): multi-origin CloudFront Origins identity-sort seed (real per-origin change survives at the post-sort index) + 2 live recordings: **the README headline use case** (out-of-band PermissionsBoundary as the only finding on a real role) and a real Lambda model where only the injected concurrency + per-function LoggingConfig survive.

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: no documented surface changed (`docs`)
- [x] live evidence: /tmp/integ-campaign-results.txt + /tmp/integ-vsdrift2.out