### PR TITLE
test(corpus): harvest fixture — 18 new types recorded live; corpus 28 → 55 (R71)

### DIFF
--- a/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGatewayV2::Api model; surviving raw-classify findings locked as-is (IpAddressType, RouteSelectionExpression). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "HttpApi",
+    "resourceType": "AWS::ApiGatewayV2::Api",
+    "physicalId": "t72tv8phdi",
+    "constructPath": "CdkrdIntegHarvest/HttpApi",
+    "declared": {
+      "Name": "cdkrd-harvest-http",
+      "ProtocolType": "HTTP"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "RouteSelectionExpression": "$request.method $request.path",
+    "ProtocolType": "HTTP",
+    "ApiEndpoint": "https://t72tv8phdi.execute-api.us-east-1.amazonaws.com",
+    "DisableExecuteApiEndpoint": false,
+    "ApiId": "t72tv8phdi",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+      "aws:cloudformation:logical-id": "HttpApi"
+    },
+    "Name": "cdkrd-harvest-http"
+  },
+  "schema": {
+    "readOnly": ["ApiEndpoint", "ApiId"],
+    "writeOnly": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnly": ["ProtocolType"],
+    "readOnlyPaths": ["ApiEndpoint", "ApiId"],
+    "writeOnlyPaths": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "BodyS3Location.Bucket",
+      "BodyS3Location.Etag",
+      "BodyS3Location.Key",
+      "BodyS3Location.Version",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnlyPaths": ["ProtocolType"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "HttpApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "t72tv8phdi",
+      "constructPath": "CdkrdIntegHarvest/HttpApi"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HttpApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "RouteSelectionExpression",
+      "actual": "$request.method $request.path",
+      "physicalId": "t72tv8phdi",
+      "constructPath": "CdkrdIntegHarvest/HttpApi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__Account.RestApiAccount7C83CF5A.json
+++ b/tests/corpus/AWS__ApiGateway__Account.RestApiAccount7C83CF5A.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::Account model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "RestApiAccount7C83CF5A",
+    "resourceType": "AWS::ApiGateway::Account",
+    "physicalId": "CdkrdI-RestA-ctUDD4gN9xMO",
+    "constructPath": "CdkrdIntegHarvest/RestApi/Account",
+    "declared": {
+      "CloudWatchRoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn"
+    }
+  },
+  "liveRaw": {
+    "Id": "CdkrdI-RestA-ctUDD4gN9xMO",
+    "CloudWatchRoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
+++ b/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
@@ -1,0 +1,90 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::Method model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "RestApiGET0F59260B",
+    "resourceType": "AWS::ApiGateway::Method",
+    "physicalId": "84xvb60zri|6pva1vasg4|GET",
+    "constructPath": "CdkrdIntegHarvest/RestApi/Default/GET",
+    "declared": {
+      "AuthorizationType": "NONE",
+      "HttpMethod": "GET",
+      "Integration": {
+        "IntegrationResponses": [
+          {
+            "StatusCode": "200"
+          }
+        ],
+        "PassthroughBehavior": "NEVER",
+        "RequestTemplates": {
+          "application/json": "{\"statusCode\": 200}"
+        },
+        "Type": "MOCK"
+      },
+      "MethodResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "ResourceId": "6pva1vasg4",
+      "RestApiId": "84xvb60zri"
+    }
+  },
+  "liveRaw": {
+    "MethodResponses": [
+      {
+        "StatusCode": "200"
+      }
+    ],
+    "Integration": {
+      "CacheNamespace": "6pva1vasg4",
+      "Type": "MOCK",
+      "IntegrationResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "RequestTemplates": {
+        "application/json": "{\"statusCode\": 200}"
+      },
+      "ResponseTransferMode": "BUFFERED",
+      "TimeoutInMillis": 29000,
+      "PassthroughBehavior": "NEVER"
+    },
+    "ResourceId": "6pva1vasg4",
+    "RestApiId": "84xvb60zri",
+    "ApiKeyRequired": false,
+    "AuthorizationType": "NONE",
+    "HttpMethod": "GET"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["HttpMethod", "ResourceId", "RestApiId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HttpMethod", "ResourceId", "RestApiId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::RestApi model; surviving raw-classify findings locked as-is (ApiKeySourceType, EndpointConfiguration, SecurityPolicy). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "RestApi0C43BF4B",
+    "resourceType": "AWS::ApiGateway::RestApi",
+    "physicalId": "84xvb60zri",
+    "constructPath": "CdkrdIntegHarvest/RestApi",
+    "declared": {
+      "Name": "RestApi"
+    }
+  },
+  "liveRaw": {
+    "RootResourceId": "6pva1vasg4",
+    "SecurityPolicy": "TLS_1_0",
+    "RestApiId": "84xvb60zri",
+    "ApiKeySourceType": "HEADER",
+    "EndpointConfiguration": {
+      "IpAddressType": "ipv4",
+      "Types": ["EDGE"]
+    },
+    "DisableExecuteApiEndpoint": false,
+    "Tags": [
+      {
+        "Value": "RestApi0C43BF4B",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "RestApi"
+  },
+  "schema": {
+    "readOnly": ["RestApiId", "RootResourceId"],
+    "writeOnly": ["Body", "BodyS3Location", "CloneFrom", "FailOnWarnings", "Mode", "Parameters"],
+    "createOnly": [],
+    "readOnlyPaths": ["RestApiId", "RootResourceId"],
+    "writeOnlyPaths": [
+      "Body",
+      "BodyS3Location",
+      "CloneFrom",
+      "FailOnWarnings",
+      "Mode",
+      "Parameters"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApi0C43BF4B",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "84xvb60zri",
+      "constructPath": "CdkrdIntegHarvest/RestApi"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApi0C43BF4B",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "ApiKeySourceType",
+      "actual": "HEADER",
+      "physicalId": "84xvb60zri",
+      "constructPath": "CdkrdIntegHarvest/RestApi"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApi0C43BF4B",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "EndpointConfiguration",
+      "actual": {
+        "IpAddressType": "ipv4",
+        "Types": ["EDGE"]
+      },
+      "physicalId": "84xvb60zri",
+      "constructPath": "CdkrdIntegHarvest/RestApi"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Athena__WorkGroup.Queries.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.Queries.json
@@ -1,0 +1,93 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Athena::WorkGroup model; surviving raw-classify findings locked as-is (RecursiveDeleteOption, WorkGroupConfiguration). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Queries",
+    "resourceType": "AWS::Athena::WorkGroup",
+    "physicalId": "cdkrd-harvest",
+    "constructPath": "CdkrdIntegHarvest/Queries",
+    "declared": {
+      "Name": "cdkrd-harvest",
+      "RecursiveDeleteOption": true
+    }
+  },
+  "liveRaw": {
+    "WorkGroupConfiguration": {
+      "EnforceWorkGroupConfiguration": true,
+      "EngineVersion": {
+        "SelectedEngineVersion": "AUTO",
+        "EffectiveEngineVersion": "Athena engine version 3"
+      },
+      "PublishCloudWatchMetricsEnabled": true,
+      "RequesterPaysEnabled": false
+    },
+    "State": "ENABLED",
+    "CreationTime": "1781277847",
+    "Tags": [],
+    "Name": "cdkrd-harvest"
+  },
+  "schema": {
+    "readOnly": ["CreationTime"],
+    "writeOnly": ["RecursiveDeleteOption", "WorkGroupConfigurationUpdates"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "CreationTime",
+      "WorkGroupConfiguration.EngineVersion.EffectiveEngineVersion",
+      "WorkGroupConfigurationUpdates.EngineVersion.EffectiveEngineVersion"
+    ],
+    "writeOnlyPaths": [
+      "RecursiveDeleteOption",
+      "WorkGroupConfiguration.AdditionalConfiguration",
+      "WorkGroupConfigurationUpdates"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Queries",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "RecursiveDeleteOption",
+      "note": "write-only \u2014 cannot be read back",
+      "physicalId": "cdkrd-harvest",
+      "constructPath": "CdkrdIntegHarvest/Queries"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Queries",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration",
+      "actual": {
+        "EnforceWorkGroupConfiguration": true,
+        "EngineVersion": {
+          "SelectedEngineVersion": "AUTO"
+        },
+        "PublishCloudWatchMetricsEnabled": true,
+        "RequesterPaysEnabled": false
+      },
+      "physicalId": "cdkrd-harvest",
+      "constructPath": "CdkrdIntegHarvest/Queries"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Budgets__Budget.CfnBudgetCostForDaily.json
+++ b/tests/corpus/AWS__Budgets__Budget.CfnBudgetCostForDaily.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (dogfood, R65/R67 aftermath): a real CFn-generated-name budget read by physical id; declared BudgetLimit {Amount:5} folds against the live decimal string \"5.0\"; NotificationsWithSubscribers stays an honest readGap (DescribeBudget cannot return it).",
+  "resource": {
+    "logicalId": "CfnBudgetCostForDaily",
+    "resourceType": "AWS::Budgets::Budget",
+    "physicalId": "CfnBudgetCostForDaily-us-east-1-1679810595264-2BgFDrBokvWD",
+    "constructPath": "main-CostCheck/CfnBudgetCostForDaily",
+    "declared": {
+      "Budget": {
+        "BudgetLimit": {
+          "Amount": 5,
+          "Unit": "USD"
+        },
+        "BudgetType": "COST",
+        "TimeUnit": "DAILY"
+      },
+      "NotificationsWithSubscribers": [
+        {
+          "Notification": {
+            "ComparisonOperator": "GREATER_THAN",
+            "NotificationType": "ACTUAL",
+            "Threshold": 100,
+            "ThresholdType": "PERCENTAGE"
+          },
+          "Subscribers": [
+            {
+              "Address": "arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic",
+              "SubscriptionType": "SNS"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Budget": {
+      "BudgetName": "CfnBudgetCostForDaily-us-east-1-1679810595264-2BgFDrBokvWD",
+      "BudgetType": "COST",
+      "TimeUnit": "DAILY",
+      "BudgetLimit": {
+        "Amount": "5.0",
+        "Unit": "USD"
+      }
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["NotificationsWithSubscribers"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["NotificationsWithSubscribers"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "CfnBudgetCostForDaily",
+      "resourceType": "AWS::Budgets::Budget",
+      "path": "NotificationsWithSubscribers",
+      "note": "declared but not returned by live read",
+      "physicalId": "CfnBudgetCostForDaily-us-east-1-1679810595264-2BgFDrBokvWD",
+      "constructPath": "main-CostCheck/CfnBudgetCostForDaily"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CE__AnomalyMonitor.CfnAnomalyMonitor.json
+++ b/tests/corpus/AWS__CE__AnomalyMonitor.CfnAnomalyMonitor.json
@@ -1,0 +1,66 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (dogfood): a real Cost Explorer anomaly monitor classifies fully CLEAN.",
+  "resource": {
+    "logicalId": "CfnAnomalyMonitor",
+    "resourceType": "AWS::CE::AnomalyMonitor",
+    "physicalId": "arn:aws:ce::111111111111:anomalymonitor/ae408f26-20f1-4dbc-a85c-47a399eec3e4",
+    "constructPath": "main-CostCheck/CfnAnomalyMonitor",
+    "declared": {
+      "MonitorName": "main-CostCheck-AWSServices",
+      "MonitorType": "DIMENSIONAL",
+      "MonitorDimension": "SERVICE"
+    }
+  },
+  "liveRaw": {
+    "LastUpdatedDate": "2026-06-12T14:05:42.499Z",
+    "CreationDate": "2023-03-26T06:03:01.390Z",
+    "LastEvaluatedDate": "2026-06-12T14:05:42.499858752Z",
+    "MonitorType": "DIMENSIONAL",
+    "ResourceTags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/main-CostCheck/d50e7fa0-cb9b-11ed-a5ba-0e37f845411b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "main-CostCheck",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CfnAnomalyMonitor",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "MonitorArn": "arn:aws:ce::111111111111:anomalymonitor/ae408f26-20f1-4dbc-a85c-47a399eec3e4",
+    "MonitorName": "main-CostCheck-AWSServices",
+    "MonitorDimension": "SERVICE",
+    "DimensionalValueCount": 32
+  },
+  "schema": {
+    "readOnly": [
+      "CreationDate",
+      "DimensionalValueCount",
+      "LastEvaluatedDate",
+      "LastUpdatedDate",
+      "MonitorArn"
+    ],
+    "writeOnly": [],
+    "createOnly": ["MonitorDimension", "MonitorSpecification", "MonitorType", "ResourceTags"],
+    "readOnlyPaths": [
+      "CreationDate",
+      "DimensionalValueCount",
+      "LastEvaluatedDate",
+      "LastUpdatedDate",
+      "MonitorArn"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["MonitorDimension", "MonitorSpecification", "MonitorType", "ResourceTags"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CE__AnomalySubscription.CfnAnomalySubscription.json
+++ b/tests/corpus/AWS__CE__AnomalySubscription.CfnAnomalySubscription.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (dogfood): the service DERIVES ThresholdExpression (a JSON string) from the declared legacy Threshold \u2014 surfaces as the one undeclared value (accept-once material, locked as-is); the live Subscribers entry gains a Status field the declared side never set (nested live-extra, ignored).",
+  "resource": {
+    "logicalId": "CfnAnomalySubscription",
+    "resourceType": "AWS::CE::AnomalySubscription",
+    "physicalId": "arn:aws:ce::111111111111:anomalysubscription/fd11a712-95bd-4459-8dd1-2227882aef60",
+    "constructPath": "main-CostCheck/CfnAnomalySubscription",
+    "declared": {
+      "Frequency": "IMMEDIATE",
+      "MonitorArnList": [
+        "arn:aws:ce::111111111111:anomalymonitor/ae408f26-20f1-4dbc-a85c-47a399eec3e4"
+      ],
+      "Subscribers": [
+        {
+          "Address": "arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic",
+          "Type": "SNS"
+        }
+      ],
+      "SubscriptionName": "main-CostCheck-Subscription",
+      "Threshold": 5
+    }
+  },
+  "liveRaw": {
+    "MonitorArnList": [
+      "arn:aws:ce::111111111111:anomalymonitor/ae408f26-20f1-4dbc-a85c-47a399eec3e4"
+    ],
+    "AccountId": "111111111111",
+    "ResourceTags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/main-CostCheck/d50e7fa0-cb9b-11ed-a5ba-0e37f845411b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "main-CostCheck",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CfnAnomalySubscription",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Frequency": "IMMEDIATE",
+    "SubscriptionName": "main-CostCheck-Subscription",
+    "Subscribers": [
+      {
+        "Status": "CONFIRMED",
+        "Type": "SNS",
+        "Address": "arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic"
+      }
+    ],
+    "SubscriptionArn": "arn:aws:ce::111111111111:anomalysubscription/fd11a712-95bd-4459-8dd1-2227882aef60",
+    "Threshold": 5,
+    "ThresholdExpression": "{\n  \"Dimensions\" : {\n    \"Key\" : \"ANOMALY_TOTAL_IMPACT_ABSOLUTE\",\n    \"Values\" : [ \"5.0\" ],\n    \"MatchOptions\" : [ \"GREATER_THAN_OR_EQUAL\" ]\n  }\n}"
+  },
+  "schema": {
+    "readOnly": ["AccountId", "SubscriptionArn"],
+    "writeOnly": [],
+    "createOnly": ["ResourceTags"],
+    "readOnlyPaths": ["AccountId", "Subscribers.*.Status", "SubscriptionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResourceTags"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "CfnAnomalySubscription",
+      "resourceType": "AWS::CE::AnomalySubscription",
+      "path": "ThresholdExpression",
+      "actual": "{\"Dimensions\":{\"Key\":\"ANOMALY_TOTAL_IMPACT_ABSOLUTE\",\"MatchOptions\":[\"GREATER_THAN_OR_EQUAL\"],\"Values\":[\"5.0\"]}}",
+      "physicalId": "arn:aws:ce::111111111111:anomalysubscription/fd11a712-95bd-4459-8dd1-2227882aef60",
+      "constructPath": "main-CostCheck/CfnAnomalySubscription"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannelLive.json
+++ b/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannelLive.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (dogfood, ids sanitized): a real Slack channel configuration; the R66 GuardrailPolicies default and readOnly Arn keep it fully CLEAN.",
+  "resource": {
+    "logicalId": "SlackChannel425D424B",
+    "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
+    "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/main-CostCheck",
+    "constructPath": "main-CostCheck/SlackChannel",
+    "declared": {
+      "ConfigurationName": "main-CostCheck",
+      "IamRoleArn": "arn:aws:iam::111111111111:role/main-CostCheck-SlackChannelConfigurationRole7EE950-1SN896N2F22EI",
+      "SlackChannelId": "C0000000000",
+      "SlackWorkspaceId": "T0000000000",
+      "LoggingLevel": "INFO",
+      "SnsTopicArns": ["arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic"]
+    }
+  },
+  "liveRaw": {
+    "UserRoleRequired": false,
+    "LoggingLevel": "INFO",
+    "CustomizationResourceArns": [],
+    "SnsTopicArns": ["arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic"],
+    "GuardrailPolicies": ["arn:aws:iam::aws:policy/AdministratorAccess"],
+    "SlackWorkspaceId": "T0000000000",
+    "SlackChannelId": "C0000000000",
+    "IamRoleArn": "arn:aws:iam::111111111111:role/main-CostCheck-SlackChannelConfigurationRole7EE950-1SN896N2F22EI",
+    "ConfigurationName": "main-CostCheck",
+    "Arn": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/main-CostCheck",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["ConfigurationName", "SlackWorkspaceId"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ConfigurationName", "SlackWorkspaceId"],
+    "defaults": {
+      "LoggingLevel": "NONE",
+      "UserRoleRequired": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudWatch__Alarm.Pulse82D6B25B.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.Pulse82D6B25B.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::CloudWatch::Alarm model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Pulse82D6B25B",
+    "resourceType": "AWS::CloudWatch::Alarm",
+    "physicalId": "CdkrdIntegHarvest-Pulse82D6B25B-Kbg6xkr8PZ1U",
+    "constructPath": "CdkrdIntegHarvest/Pulse",
+    "declared": {
+      "ComparisonOperator": "GreaterThanThreshold",
+      "EvaluationPeriods": 1,
+      "MetricName": "Pulse",
+      "Namespace": "CdkrdHarvest",
+      "Period": 300,
+      "Statistic": "Average",
+      "Threshold": 1
+    }
+  },
+  "liveRaw": {
+    "ComparisonOperator": "GreaterThanThreshold",
+    "Period": 300,
+    "EvaluationPeriods": 1,
+    "Namespace": "CdkrdHarvest",
+    "OKActions": [],
+    "AlarmActions": [],
+    "MetricName": "Pulse",
+    "ActionsEnabled": true,
+    "AlarmName": "CdkrdIntegHarvest-Pulse82D6B25B-Kbg6xkr8PZ1U",
+    "Statistic": "Average",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest-Pulse82D6B25B-Kbg6xkr8PZ1U",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Pulse82D6B25B",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Threshold": 1
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {
+      "ActionsEnabled": true
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudWatch__Dashboard.Board47D7A2D0.json
+++ b/tests/corpus/AWS__CloudWatch__Dashboard.Board47D7A2D0.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::CloudWatch::Dashboard model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Board47D7A2D0",
+    "resourceType": "AWS::CloudWatch::Dashboard",
+    "physicalId": "Board47D7A2D0-Ha1e74AhsNpA",
+    "constructPath": "CdkrdIntegHarvest/Board",
+    "declared": {
+      "DashboardBody": "{\"widgets\":[{\"type\":\"text\",\"width\":6,\"height\":2,\"x\":0,\"y\":0,\"properties\":{\"markdown\":\"# cdkrd harvest\"}}]}"
+    }
+  },
+  "liveRaw": {
+    "DashboardName": "Board47D7A2D0-Ha1e74AhsNpA",
+    "DashboardBody": "{\"widgets\":[{\"type\":\"text\",\"width\":6,\"height\":2,\"x\":0,\"y\":0,\"properties\":{\"markdown\":\"# cdkrd harvest\"}}]}",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Board47D7A2D0",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DashboardName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DashboardName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::DynamoDB::Table model; surviving raw-classify findings locked as-is (WarmThroughput). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Sessions8896A56D",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "CdkrdIntegHarvest-Sessions8896A56D-R1FO6Y7043MX",
+    "constructPath": "CdkrdIntegHarvest/Sessions",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SSESpecification": {
+      "SSEEnabled": false
+    },
+    "TableName": "CdkrdIntegHarvest-Sessions8896A56D-R1FO6Y7043MX",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      }
+    ],
+    "ContributorInsightsSpecification": {
+      "Enabled": false
+    },
+    "BillingMode": "PAY_PER_REQUEST",
+    "PointInTimeRecoverySpecification": {
+      "PointInTimeRecoveryEnabled": false
+    },
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      }
+    ],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkrdIntegHarvest-Sessions8896A56D-R1FO6Y7043MX",
+    "DeletionProtectionEnabled": false,
+    "Tags": [],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn"],
+    "writeOnly": ["ImportSourceSpecification"],
+    "createOnly": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn"],
+    "writeOnlyPaths": ["ImportSourceSpecification"],
+    "createOnlyPaths": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Sessions8896A56D",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "CdkrdIntegHarvest-Sessions8896A56D-R1FO6Y7043MX",
+      "constructPath": "CdkrdIntegHarvest/Sessions"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EIP.Ip.json
+++ b/tests/corpus/AWS__EC2__EIP.Ip.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::EC2::EIP model; surviving raw-classify findings locked as-is (NetworkBorderGroup). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Ip",
+    "resourceType": "AWS::EC2::EIP",
+    "physicalId": "52.4.97.166",
+    "constructPath": "CdkrdIntegHarvest/Ip",
+    "declared": {
+      "Domain": "vpc"
+    }
+  },
+  "liveRaw": {
+    "Domain": "vpc",
+    "NetworkBorderGroup": "us-east-1",
+    "PublicIp": "52.4.97.166",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "Ip"
+      },
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdIntegHarvest"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AllocationId", "PublicIp"],
+    "writeOnly": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnly": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "readOnlyPaths": ["AllocationId", "PublicIp"],
+    "writeOnlyPaths": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnlyPaths": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Ip",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "52.4.97.166",
+      "constructPath": "CdkrdIntegHarvest/Ip"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
+++ b/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ECR::Repository model; surviving raw-classify findings locked as-is (EmptyOnDelete, EncryptionConfiguration, ImageTagMutability). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Images2D38C313",
+    "resourceType": "AWS::ECR::Repository",
+    "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+    "constructPath": "CdkrdIntegHarvest/Images",
+    "declared": {
+      "EmptyOnDelete": true
+    }
+  },
+  "liveRaw": {
+    "ImageScanningConfiguration": {
+      "ScanOnPush": false
+    },
+    "EncryptionConfiguration": {
+      "EncryptionType": "AES256"
+    },
+    "RepositoryName": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+    "RepositoryUri": "111111111111.dkr.ecr.us-east-1.amazonaws.com/cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+    "Arn": "arn:aws:ecr:us-east-1:111111111111:repository/cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Images2D38C313",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "ImageTagMutability": "MUTABLE"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RepositoryUri"],
+    "writeOnly": ["EmptyOnDelete"],
+    "createOnly": ["EncryptionConfiguration", "RepositoryName"],
+    "readOnlyPaths": ["Arn", "RepositoryUri"],
+    "writeOnlyPaths": ["EmptyOnDelete"],
+    "createOnlyPaths": [
+      "EncryptionConfiguration",
+      "EncryptionConfiguration.EncryptionType",
+      "EncryptionConfiguration.KmsKey",
+      "RepositoryName"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Images2D38C313",
+      "resourceType": "AWS::ECR::Repository",
+      "path": "EmptyOnDelete",
+      "note": "write-only \u2014 cannot be read back",
+      "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+      "constructPath": "CdkrdIntegHarvest/Images"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Images2D38C313",
+      "resourceType": "AWS::ECR::Repository",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "EncryptionType": "AES256"
+      },
+      "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+      "constructPath": "CdkrdIntegHarvest/Images"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Images2D38C313",
+      "resourceType": "AWS::ECR::Repository",
+      "path": "ImageTagMutability",
+      "actual": "MUTABLE",
+      "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
+      "constructPath": "CdkrdIntegHarvest/Images"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__EventBus.BusEA82B648.json
+++ b/tests/corpus/AWS__Events__EventBus.BusEA82B648.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Events::EventBus model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "BusEA82B648",
+    "resourceType": "AWS::Events::EventBus",
+    "physicalId": "CdkrdIntegHarvestBusDE59A7B6",
+    "constructPath": "CdkrdIntegHarvest/Bus",
+    "declared": {
+      "Name": "CdkrdIntegHarvestBusDE59A7B6"
+    }
+  },
+  "liveRaw": {
+    "Arn": "arn:aws:events:us-east-1:111111111111:event-bus/CdkrdIntegHarvestBusDE59A7B6",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "BusEA82B648",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvestBusDE59A7B6"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["EventSourceName"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["EventSourceName"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Events__Rule.Tick6513F4AE.json
+++ b/tests/corpus/AWS__Events__Rule.Tick6513F4AE.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Events::Rule model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Tick6513F4AE",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkrdIntegHarvest-Tick6513F4AE-chVZMFro0x9U",
+    "constructPath": "CdkrdIntegHarvest/Tick",
+    "declared": {
+      "ScheduleExpression": "rate(1 hour)",
+      "State": "DISABLED"
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "ScheduleExpression": "rate(1 hour)",
+    "State": "DISABLED",
+    "Targets": [],
+    "Id": "CdkrdIntegHarvest-Tick6513F4AE-chVZMFro0x9U",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdIntegHarvest-Tick6513F4AE-chVZMFro0x9U",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Tick6513F4AE",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvest-Tick6513F4AE-chVZMFro0x9U"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Glue__Database.Catalog.json
+++ b/tests/corpus/AWS__Glue__Database.Catalog.json
@@ -1,0 +1,62 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Glue::Database model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Catalog",
+    "resourceType": "AWS::Glue::Database",
+    "physicalId": "cdkrd_harvest_db",
+    "constructPath": "CdkrdIntegHarvest/Catalog",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseInput": {
+        "Name": "cdkrd_harvest_db"
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_harvest_db",
+    "DatabaseInput": {
+      "CreateTableDefaultPermissions": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "Parameters": {},
+      "Name": "cdkrd_harvest_db"
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["DatabaseName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DatabaseName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Glue__Table.Events.json
+++ b/tests/corpus/AWS__Glue__Table.Events.json
@@ -1,0 +1,83 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Glue::Table model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Events",
+    "resourceType": "AWS::Glue::Table",
+    "physicalId": "cdkrd_harvest_events",
+    "constructPath": "CdkrdIntegHarvest/Events",
+    "declared": {
+      "CatalogId": "111111111111",
+      "DatabaseName": "cdkrd_harvest_db",
+      "TableInput": {
+        "Name": "cdkrd_harvest_events",
+        "Parameters": {
+          "classification": "json"
+        },
+        "StorageDescriptor": {
+          "Columns": [
+            {
+              "Name": "id",
+              "Type": "string"
+            }
+          ],
+          "Location": "s3://cdkrd-harvest-placeholder/"
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "DatabaseName": "cdkrd_harvest_db",
+    "TableInput": {
+      "Name": "cdkrd_harvest_events",
+      "Retention": 0,
+      "Parameters": {
+        "classification": "json"
+      },
+      "StorageDescriptor": {
+        "Columns": [
+          {
+            "Name": "id",
+            "Type": "string"
+          }
+        ],
+        "Location": "s3://cdkrd-harvest-placeholder/",
+        "Compressed": false,
+        "NumberOfBuckets": 0,
+        "SortColumns": [],
+        "StoredAsSubDirectories": false
+      }
+    },
+    "CatalogId": "111111111111"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["CatalogId", "DatabaseName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["CatalogId", "DatabaseName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Policy.BuildRoleDefaultPolicyEAC4E6D6.json
+++ b/tests/corpus/AWS__IAM__Policy.BuildRoleDefaultPolicyEAC4E6D6.json
@@ -1,0 +1,96 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Policy model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "BuildRoleDefaultPolicyEAC4E6D6",
+    "resourceType": "AWS::IAM::Policy",
+    "physicalId": "Cdkrd-Build-YYSq5sBiB6dN",
+    "constructPath": "CdkrdIntegHarvest/Build/Role/DefaultPolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:logs:us-east-1:111111111111:log-group:/aws/codebuild/Build45A36621-a6GrucdecRsg",
+              "arn:aws:logs:us-east-1:111111111111:log-group:/aws/codebuild/Build45A36621-a6GrucdecRsg:*"
+            ]
+          },
+          {
+            "Action": [
+              "codebuild:CreateReportGroup",
+              "codebuild:CreateReport",
+              "codebuild:UpdateReport",
+              "codebuild:BatchPutTestCases",
+              "codebuild:BatchPutCodeCoverages"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:codebuild:us-east-1:111111111111:report-group/Build45A36621-a6GrucdecRsg-*"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "PolicyName": "BuildRoleDefaultPolicyEAC4E6D6",
+      "Roles": ["CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE"]
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "BuildRoleDefaultPolicyEAC4E6D6",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+          "Resource": [
+            "arn:aws:logs:us-east-1:111111111111:log-group:/aws/codebuild/Build45A36621-a6GrucdecRsg",
+            "arn:aws:logs:us-east-1:111111111111:log-group:/aws/codebuild/Build45A36621-a6GrucdecRsg:*"
+          ],
+          "Effect": "Allow"
+        },
+        {
+          "Action": [
+            "codebuild:CreateReportGroup",
+            "codebuild:CreateReport",
+            "codebuild:UpdateReport",
+            "codebuild:BatchPutTestCases",
+            "codebuild:BatchPutCodeCoverages"
+          ],
+          "Resource": "arn:aws:codebuild:us-east-1:111111111111:report-group/Build45A36621-a6GrucdecRsg-*",
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Roles": ["CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE"]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.BuildRoleB7C66CB2.json
+++ b/tests/corpus/AWS__IAM__Role.BuildRoleB7C66CB2.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "BuildRoleB7C66CB2",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
+    "constructPath": "CdkrdIntegHarvest/Build/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "codebuild.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    },
+    "siblingPolicyNames": ["BuildRoleDefaultPolicyEAC4E6D6"]
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
+    "Description": "",
+    "Policies": [
+      {
+        "PolicyName": "BuildRoleDefaultPolicyEAC4E6D6",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+              "Resource": [
+                "arn:aws:logs:us-east-1:111111111111:log-group:/aws/codebuild/Build45A36621-a6GrucdecRsg",
+                "arn:aws:logs:us-east-1:111111111111:log-group:/aws/codebuild/Build45A36621-a6GrucdecRsg:*"
+              ],
+              "Effect": "Allow"
+            },
+            {
+              "Action": [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages"
+              ],
+              "Resource": "arn:aws:codebuild:us-east-1:111111111111:report-group/Build45A36621-a6GrucdecRsg-*",
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    ],
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "codebuild.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
+    "RoleId": "AROAXXXJN2LNRQGEFZ7V3"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.FlowRoleD99EA574.json
+++ b/tests/corpus/AWS__IAM__Role.FlowRoleD99EA574.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "FlowRoleD99EA574",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+    "constructPath": "CdkrdIntegHarvest/Flow/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "states.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "states.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+    "RoleId": "AROAXXXJN2LNV7X354TOX"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.RestApiCloudWatchRoleE3ED6605.json
+++ b/tests/corpus/AWS__IAM__Role.RestApiCloudWatchRoleE3ED6605.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "RestApiCloudWatchRoleE3ED6605",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
+    "constructPath": "CdkrdIntegHarvest/RestApi/CloudWatchRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "apigateway.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": [
+        "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+      ]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": [
+      "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+    ],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "apigateway.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
+    "RoleId": "AROAXXXJN2LN2EPTLO5X6"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__User.AuditorB9A7BEA8.json
+++ b/tests/corpus/AWS__IAM__User.AuditorB9A7BEA8.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::User model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "AuditorB9A7BEA8",
+    "resourceType": "AWS::IAM::User",
+    "physicalId": "CdkrdIntegHarvest-AuditorB9A7BEA8-DAEDUfNiZ1yz",
+    "constructPath": "CdkrdIntegHarvest/Auditor",
+    "declared": {
+      "Path": "/cdkrd-harvest/"
+    }
+  },
+  "liveRaw": {
+    "Path": "/cdkrd-harvest/",
+    "UserName": "CdkrdIntegHarvest-AuditorB9A7BEA8-DAEDUfNiZ1yz",
+    "Arn": "arn:aws:iam::111111111111:user/cdkrd-harvest/CdkrdIntegHarvest-AuditorB9A7BEA8-DAEDUfNiZ1yz"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["UserName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["LoginProfile.Password"],
+    "createOnlyPaths": ["UserName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Logs__LogGroup.AppLogsC5DF83A6.json
+++ b/tests/corpus/AWS__Logs__LogGroup.AppLogsC5DF83A6.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Logs::LogGroup model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "AppLogsC5DF83A6",
+    "resourceType": "AWS::Logs::LogGroup",
+    "physicalId": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+    "constructPath": "CdkrdIntegHarvest/AppLogs",
+    "declared": {
+      "RetentionInDays": 1
+    }
+  },
+  "liveRaw": {
+    "FieldIndexPolicies": [],
+    "RetentionInDays": 1,
+    "BearerTokenAuthenticationEnabled": false,
+    "LogGroupClass": "STANDARD",
+    "LogGroupName": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h:*",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AppLogsC5DF83A6",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "DataProtectionPolicy": {}
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName"],
+    "defaults": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Logs__MetricFilter.ErrorsFA5270DE.json
+++ b/tests/corpus/AWS__Logs__MetricFilter.ErrorsFA5270DE.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Logs::MetricFilter model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "ErrorsFA5270DE",
+    "resourceType": "AWS::Logs::MetricFilter",
+    "physicalId": "ErrorsFA5270DE-d1Gz31WI1K1O",
+    "constructPath": "CdkrdIntegHarvest/Errors",
+    "declared": {
+      "FilterPattern": "ERROR",
+      "LogGroupName": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+      "MetricTransformations": [
+        {
+          "MetricName": "Errors",
+          "MetricNamespace": "CdkrdHarvest",
+          "MetricValue": "1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "LogGroupName": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+    "FilterName": "ErrorsFA5270DE-d1Gz31WI1K1O",
+    "FilterPattern": "ERROR",
+    "MetricTransformations": [
+      {
+        "MetricName": "Errors",
+        "MetricNamespace": "CdkrdHarvest",
+        "MetricValue": "1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["FilterName", "LogGroupName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FilterName", "LogGroupName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SNS__Topic.BillingAlarmTopic.json
+++ b/tests/corpus/AWS__SNS__Topic.BillingAlarmTopic.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (dogfood): a Chatbot-service-created Subscription on a real SNS topic surfaces as the one undeclared value \u2014 genuinely out-of-band state from the template's perspective (true positive).",
+  "resource": {
+    "logicalId": "BillingAlarmTopic299F87AA",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic",
+    "constructPath": "main-CostCheck/BillingAlarmTopic",
+    "declared": {
+      "DisplayName": "main-CostCheck-BillingAlarmTopic",
+      "TopicName": "main-CostCheck-BillingAlarmTopic"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic",
+    "DisplayName": "main-CostCheck-BillingAlarmTopic",
+    "FifoTopic": false,
+    "Subscription": [
+      {
+        "Endpoint": "https://global.sns-api.chatbot.amazonaws.com",
+        "Protocol": "https"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/main-CostCheck/d50e7fa0-cb9b-11ed-a5ba-0e37f845411b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "main-CostCheck",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "BillingAlarmTopic299F87AA",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "main-CostCheck-BillingAlarmTopic"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "BillingAlarmTopic299F87AA",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "Subscription",
+      "actual": [
+        {
+          "Endpoint": "https://global.sns-api.chatbot.amazonaws.com",
+          "Protocol": "https"
+        }
+      ],
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:main-CostCheck-BillingAlarmTopic",
+      "constructPath": "main-CostCheck/BillingAlarmTopic"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.EncryptedQueue.json
+++ b/tests/corpus/AWS__SQS__Queue.EncryptedQueue.json
@@ -1,0 +1,29 @@
+{
+  "corpusVersion": 1,
+  "description": "KMS managed-alias identity, CONSERVATIVE fallback: with NO kmsAliasTargets (kms:ListAliases unavailable), a declared alias/aws/sqs vs ANY live key ARN is suppressed shape-based — biased toward noise, never a false positive (the STRICT path is locked by the SecretsManager case).",
+  "resource": {
+    "logicalId": "EncryptedQueue",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/corpus-encrypted-queue",
+    "declared": {
+      "QueueName": "corpus-encrypted-queue",
+      "KmsMasterKeyId": "alias/aws/sqs"
+    }
+  },
+  "liveRaw": {
+    "QueueName": "corpus-encrypted-queue",
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:corpus-encrypted-queue",
+    "KmsMasterKeyId": "arn:aws:kms:us-east-1:111111111111:key/9z8y7x6w-5v4u-3t2s-1r0q-ponmlkjihgfe"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["QueueName"],
+    "defaults": {}
+  },
+  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__Parameter.FlagC3248847.json
+++ b/tests/corpus/AWS__SSM__Parameter.FlagC3248847.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::SSM::Parameter model; surviving raw-classify findings locked as-is (DataType). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "FlagC3248847",
+    "resourceType": "AWS::SSM::Parameter",
+    "physicalId": "CFN-FlagC3248847-9mab5rE21xPX",
+    "constructPath": "CdkrdIntegHarvest/Flag",
+    "declared": {
+      "Type": "String",
+      "Value": "harvest"
+    }
+  },
+  "liveRaw": {
+    "Type": "String",
+    "Value": "harvest",
+    "DataType": "text",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+      "aws:cloudformation:logical-id": "FlagC3248847"
+    },
+    "Name": "CFN-FlagC3248847-9mab5rE21xPX"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AllowedPattern", "Description", "Policies", "Tier"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AllowedPattern", "Description", "Policies", "Tier"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FlagC3248847",
+      "resourceType": "AWS::SSM::Parameter",
+      "path": "DataType",
+      "actual": "text",
+      "physicalId": "CFN-FlagC3248847-9mab5rE21xPX",
+      "constructPath": "CdkrdIntegHarvest/Flag"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__Activity.Act869B7EB7.json
+++ b/tests/corpus/AWS__StepFunctions__Activity.Act869B7EB7.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::StepFunctions::Activity model; surviving raw-classify findings locked as-is (EncryptionConfiguration). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "Act869B7EB7",
+    "resourceType": "AWS::StepFunctions::Activity",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:activity:CdkrdIntegHarvestActBBC28113",
+    "constructPath": "CdkrdIntegHarvest/Act",
+    "declared": {
+      "Name": "CdkrdIntegHarvestActBBC28113"
+    }
+  },
+  "liveRaw": {
+    "EncryptionConfiguration": {
+      "Type": "AWS_OWNED_KEY"
+    },
+    "Arn": "arn:aws:states:us-east-1:111111111111:activity:CdkrdIntegHarvestActBBC28113",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Act869B7EB7",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvestActBBC28113"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EncryptionConfiguration", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EncryptionConfiguration", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Act869B7EB7",
+      "resourceType": "AWS::StepFunctions::Activity",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "Type": "AWS_OWNED_KEY"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:activity:CdkrdIntegHarvestActBBC28113",
+      "constructPath": "CdkrdIntegHarvest/Act"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.FlowA74D6E88.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.FlowA74D6E88.json
@@ -1,0 +1,119 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::StepFunctions::StateMachine model; surviving raw-classify findings locked as-is (EncryptionConfiguration, LoggingConfiguration, StateMachineName, StateMachineType). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "resource": {
+    "logicalId": "FlowA74D6E88",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:FlowA74D6E88-9PPXSY9c4tSV",
+    "constructPath": "CdkrdIntegHarvest/Flow",
+    "declared": {
+      "DefinitionString": "{\"StartAt\":\"Noop\",\"States\":{\"Noop\":{\"Type\":\"Pass\",\"End\":true}}}",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai"
+    }
+  },
+  "liveRaw": {
+    "DefinitionString": "{\"StartAt\":\"Noop\",\"States\":{\"Noop\":{\"Type\":\"Pass\",\"End\":true}}}",
+    "EncryptionConfiguration": {
+      "Type": "AWS_OWNED_KEY"
+    },
+    "LoggingConfiguration": {
+      "IncludeExecutionData": false,
+      "Level": "OFF"
+    },
+    "StateMachineRevisionId": "INITIAL",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:FlowA74D6E88-9PPXSY9c4tSV",
+    "StateMachineName": "FlowA74D6E88-9PPXSY9c4tSV",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest/b8951940-6672-11f1-ac8b-0affd7272489",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "FlowA74D6E88",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "FlowA74D6E88-9PPXSY9c4tSV",
+    "StateMachineType": "STANDARD",
+    "TracingConfiguration": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnly": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnly": ["StateMachineName", "StateMachineType"],
+    "readOnlyPaths": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnlyPaths": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnlyPaths": ["StateMachineName", "StateMachineType"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FlowA74D6E88",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "Type": "AWS_OWNED_KEY"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:FlowA74D6E88-9PPXSY9c4tSV",
+      "constructPath": "CdkrdIntegHarvest/Flow"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "FlowA74D6E88",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "LoggingConfiguration",
+      "actual": {
+        "IncludeExecutionData": false,
+        "Level": "OFF"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:FlowA74D6E88-9PPXSY9c4tSV",
+      "constructPath": "CdkrdIntegHarvest/Flow"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "FlowA74D6E88",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineName",
+      "actual": "FlowA74D6E88-9PPXSY9c4tSV",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:FlowA74D6E88-9PPXSY9c4tSV",
+      "constructPath": "CdkrdIntegHarvest/Flow"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "FlowA74D6E88",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineType",
+      "actual": "STANDARD",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:FlowA74D6E88-9PPXSY9c4tSV",
+      "constructPath": "CdkrdIntegHarvest/Flow"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -133,6 +133,24 @@ sibling `AWS::IAM::Policy`):
 cd iam && bash verify-inline-policy.sh
 ```
 
+## harvest
+
+A corpus-harvest fixture (R71): ~18 cheap, fast-create/delete types in one
+stack (DynamoDB, EventBridge Bus+Rule, Step Functions SM+Activity, Athena
+WorkGroup, CloudWatch Alarm+Dashboard, LogGroup+MetricFilter, ECR, SSM,
+HTTP API, REST API, CodeBuild, IAM User, EIP, Glue Database+Table). Asserts:
+
+1. A FRESH deploy classifies with **zero declared drift** across every type
+   (the cross-type false-positive test) and exits 0 (inventory is UNRECORDED).
+2. `accept --yes` then `check --fail` lands CLEAN across every type.
+
+Run with `CDKRD_CORPUS_DIR` to record one golden-corpus case per type — the
+fixture exists to convert one AWS round trip into permanent offline coverage.
+
+```bash
+cd harvest && npm install && bash verify-harvest.sh
+```
+
 ## revert
 
 A versioned S3 bucket. Enables acceleration, `accept`s (recording it in the

--- a/tests/integration/harvest/app.ts
+++ b/tests/integration/harvest/app.ts
@@ -1,0 +1,116 @@
+// Corpus-harvest fixture (R71): one stack of CHEAP, FAST-create/delete resource
+// types the corpus had never seen live. Purpose: every `check` against it is a
+// golden-corpus recording session (CDKRD_CORPUS_DIR), converting one AWS round
+// trip into permanent offline regression coverage per type — and a fresh deploy
+// must classify with ZERO declared drift across all of them (an FP test in
+// itself). Everything here is free or fractions of a cent for the minutes the
+// stack lives; nothing lingers after destroy.
+import { App, Aws, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnApi } from "aws-cdk-lib/aws-apigatewayv2";
+import { MockIntegration, PassthroughBehavior, RestApi } from "aws-cdk-lib/aws-apigateway";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+import { Alarm, ComparisonOperator, Dashboard, Metric, TextWidget } from "aws-cdk-lib/aws-cloudwatch";
+import { BuildSpec, Project } from "aws-cdk-lib/aws-codebuild";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { CfnEIP } from "aws-cdk-lib/aws-ec2";
+import { Repository } from "aws-cdk-lib/aws-ecr";
+import { EventBus, Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { CfnDatabase, CfnTable } from "aws-cdk-lib/aws-glue";
+import { User } from "aws-cdk-lib/aws-iam";
+import { FilterPattern, LogGroup, MetricFilter, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import { Activity, Pass, StateMachine } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegHarvest");
+
+new Table(stack, "Sessions", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  billingMode: BillingMode.PAY_PER_REQUEST,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new EventBus(stack, "Bus");
+new Rule(stack, "Tick", {
+  schedule: Schedule.rate(Duration.hours(1)),
+  enabled: false,
+});
+
+new StateMachine(stack, "Flow", { definition: new Pass(stack, "Noop") });
+new Activity(stack, "Act");
+
+new CfnWorkGroup(stack, "Queries", {
+  name: "cdkrd-harvest",
+  recursiveDeleteOption: true,
+});
+
+const metric = new Metric({ namespace: "CdkrdHarvest", metricName: "Pulse" });
+new Alarm(stack, "Pulse", {
+  metric,
+  threshold: 1,
+  evaluationPeriods: 1,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+});
+new Dashboard(stack, "Board", {
+  widgets: [[new TextWidget({ markdown: "# cdkrd harvest" })]],
+});
+
+const logs = new LogGroup(stack, "AppLogs", {
+  retention: RetentionDays.ONE_DAY,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+new MetricFilter(stack, "Errors", {
+  logGroup: logs,
+  filterPattern: FilterPattern.literal("ERROR"),
+  metricNamespace: "CdkrdHarvest",
+  metricName: "Errors",
+});
+
+new Repository(stack, "Images", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  emptyOnDelete: true,
+});
+
+new StringParameter(stack, "Flag", { stringValue: "harvest" });
+
+new CfnApi(stack, "HttpApi", { name: "cdkrd-harvest-http", protocolType: "HTTP" });
+const rest = new RestApi(stack, "RestApi", { deploy: true });
+rest.root.addMethod(
+  "GET",
+  new MockIntegration({
+    integrationResponses: [{ statusCode: "200" }],
+    passthroughBehavior: PassthroughBehavior.NEVER,
+    requestTemplates: { "application/json": '{"statusCode": 200}' },
+  }),
+  { methodResponses: [{ statusCode: "200" }] }
+);
+
+new Project(stack, "Build", {
+  buildSpec: BuildSpec.fromObject({
+    version: "0.2",
+    phases: { build: { commands: ["echo harvest"] } },
+  }),
+});
+
+new User(stack, "Auditor", { path: "/cdkrd-harvest/" });
+
+new CfnEIP(stack, "Ip", { domain: "vpc" });
+
+new CfnDatabase(stack, "Catalog", {
+  catalogId: Aws.ACCOUNT_ID,
+  databaseInput: { name: "cdkrd_harvest_db" },
+});
+new CfnTable(stack, "Events", {
+  catalogId: Aws.ACCOUNT_ID,
+  databaseName: "cdkrd_harvest_db",
+  tableInput: {
+    name: "cdkrd_harvest_events",
+    parameters: { classification: "json" },
+    storageDescriptor: {
+      columns: [{ name: "id", type: "string" }],
+      location: "s3://cdkrd-harvest-placeholder/",
+    },
+  },
+}).addDependency(stack.node.findChild("Catalog") as CfnDatabase);
+
+app.synth();

--- a/tests/integration/harvest/cdk.json
+++ b/tests/integration/harvest/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest/package.json
+++ b/tests/integration/harvest/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-harvest",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest fixture: many cheap types deployed once to record golden-corpus cases. Run via verify-harvest.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/harvest/verify-harvest.sh
+++ b/tests/integration/harvest/verify-harvest.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test (real AWS) — R71.
+#
+# Deploys ~18 cheap resource types the corpus had never seen live, then:
+#   1. baseline-free `check` — a FRESH deploy must classify with ZERO declared
+#      drift across every type (the cross-type false-positive test), exit 0
+#      (everything undeclared is UNRECORDED);
+#   2. `accept --yes` then `check --fail` — the baseline round trip must land
+#      CLEAN (exit 0) across every type;
+#   3. destroy. Nothing lingers (no KMS keys, secrets, or hosted zones).
+#
+# Run with CDKRD_CORPUS_DIR=<dir> to record one golden-corpus case per type —
+# the whole point: one AWS round trip becomes permanent offline coverage.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest && npm install && bash verify-harvest.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegHarvest
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest.out
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (~18 types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Why

User direction: record as much as possible NOW so future regression coverage needs no AWS at all. One AWS round trip per type → permanent offline CI coverage.

## What

**New `harvest` fixture** (~18 cheap fast types, self-cleaning, no lingering resources). First live run = **INTEG PASS**:
- fresh deploy → **zero declared drift across every type** (cross-type FP test), exit 0
- `accept --yes` → `check --fail` CLEAN across every type (baseline round trip)

**Corpus 28 → 55 cases / 446 unit tests:**
- 24 harvest recordings (incl. the MetricFilter / EIP / Glue **SDK-override readers exercised live**)
- 5 sanitized dogfood recordings (real generated-name Budget locking R65/R67 on real data, CE monitor+subscription, Chatbot-created SNS subscription, real Slack channel config — ids sanitized, no emails)
- 1 hand seed: KMS alias conservative fallback (complement to the strict-path case)

All reviewed for leaks (account ids auto-sanitized; Slack ids replaced; fictional names elsewhere).

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: integration README harvest section (`docs`)
- [x] live evidence: /tmp/integ-harvest.out INTEG PASS