### PR TITLE
docs(integ): re-run every script after exit-code/baseline semantic changes (R72)

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -43,6 +43,10 @@ These do NOT run in CI (they need credentials and mutate a real account):
   `basic/verify-mutation-matrix.sh` (the drift-direction matrix) before merging.
 - Scripts that share a fixture/stack (`basic`'s four) must run sequentially,
   never concurrently.
+- **After changing exit-code or baseline semantics** (report-only/--fail, the
+  UNRECORDED contract, prompt flows): re-run EVERY script. They assert exit
+  codes and grep output wording, and have now broken on three such changes
+  (R55, R62, R70) — each found only on the next live run.
 
 ## basic
 


### PR DESCRIPTION
Retrospective artifact from the /verify-pr run: this lesson has now recurred three times (R55 grep breaks, R62 guard wording, R70 vs-cdk-drift needing a baseline) — each found only on the next live run. Encoded in the integration README When-to-run list.