### PR TITLE
test: generative invariants + harvest2 (richly-declared wave) — corpus 55 → 95 (R73)

### DIFF
--- a/tests/corpus/AWS__CloudWatch__Alarm.Latency2EF2A010.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.Latency2EF2A010.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::CloudWatch::Alarm with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "Latency2EF2A010",
+    "resourceType": "AWS::CloudWatch::Alarm",
+    "physicalId": "CdkrdIntegHarvest2-Latency2EF2A010-Ao1nIA9jxW7i",
+    "constructPath": "CdkrdIntegHarvest2/Latency",
+    "declared": {
+      "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+      "DatapointsToAlarm": 2,
+      "EvaluationPeriods": 3,
+      "MetricName": "Latency",
+      "Namespace": "CdkrdHarvest2",
+      "Period": 300,
+      "Statistic": "Average",
+      "Threshold": 250,
+      "TreatMissingData": "notBreaching"
+    }
+  },
+  "liveRaw": {
+    "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    "TreatMissingData": "notBreaching",
+    "Period": 300,
+    "EvaluationPeriods": 3,
+    "Namespace": "CdkrdHarvest2",
+    "OKActions": [],
+    "AlarmActions": [],
+    "MetricName": "Latency",
+    "ActionsEnabled": true,
+    "AlarmName": "CdkrdIntegHarvest2-Latency2EF2A010-Ao1nIA9jxW7i",
+    "Statistic": "Average",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest2-Latency2EF2A010-Ao1nIA9jxW7i",
+    "DatapointsToAlarm": 2,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Latency2EF2A010",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Threshold": 250
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {
+      "ActionsEnabled": true
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
+++ b/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
@@ -1,0 +1,175 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::DynamoDB::Table with deep declared config classifies as recorded (undeclared:WarmThroughput). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "OrdersA9B65338",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
+    "constructPath": "CdkrdIntegHarvest2/Orders",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "sk",
+          "AttributeType": "N"
+        },
+        {
+          "AttributeName": "status",
+          "AttributeType": "S"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "GlobalSecondaryIndexes": [
+        {
+          "IndexName": "byStatus",
+          "KeySchema": [
+            {
+              "AttributeName": "status",
+              "KeyType": "HASH"
+            }
+          ],
+          "Projection": {
+            "ProjectionType": "KEYS_ONLY"
+          }
+        }
+      ],
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "StreamSpecification": {
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "TimeToLiveSpecification": {
+        "AttributeName": "expiresAt",
+        "Enabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "SSESpecification": {
+      "SSEEnabled": false
+    },
+    "StreamSpecification": {
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    },
+    "ContributorInsightsSpecification": {
+      "Enabled": false
+    },
+    "PointInTimeRecoverySpecification": {
+      "PointInTimeRecoveryEnabled": false
+    },
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "TableName": "CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      },
+      {
+        "AttributeType": "N",
+        "AttributeName": "sk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "status"
+      }
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+    "GlobalSecondaryIndexes": [
+      {
+        "IndexName": "byStatus",
+        "ContributorInsightsSpecification": {
+          "Enabled": false
+        },
+        "Projection": {
+          "NonKeyAttributes": [],
+          "ProjectionType": "KEYS_ONLY"
+        },
+        "KeySchema": [
+          {
+            "KeyType": "HASH",
+            "AttributeName": "status"
+          }
+        ],
+        "WarmThroughput": {
+          "ReadUnitsPerSecond": 12000,
+          "WriteUnitsPerSecond": 4000
+        }
+      }
+    ],
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      },
+      {
+        "KeyType": "RANGE",
+        "AttributeName": "sk"
+      }
+    ],
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
+    "StreamArn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0/stream/2026-06-12T15:52:38.563",
+    "DeletionProtectionEnabled": false,
+    "Tags": [],
+    "TimeToLiveSpecification": {
+      "Enabled": true,
+      "AttributeName": "expiresAt"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn"],
+    "writeOnly": ["ImportSourceSpecification"],
+    "createOnly": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn"],
+    "writeOnlyPaths": ["ImportSourceSpecification"],
+    "createOnlyPaths": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "OrdersA9B65338",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
+      "constructPath": "CdkrdIntegHarvest2/Orders"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
+    "resourceType": "AWS::EC2::EIP",
+    "physicalId": "107.22.107.4",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/EIP",
+    "declared": {
+      "Domain": "vpc",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Domain": "vpc",
+    "NetworkBorderGroup": "us-east-1",
+    "PublicIp": "107.22.107.4",
+    "NetworkInterfaceId": "eni-0f1c51db64ee88129",
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "WorkersVpcPublicSubnet1EIP1A313755"
+      },
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdIntegHarvest2"
+      },
+      {
+        "Key": "Name",
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AllocationId", "PublicIp"],
+    "writeOnly": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnly": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "readOnlyPaths": ["AllocationId", "PublicIp"],
+    "writeOnlyPaths": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnlyPaths": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "107.22.107.4",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/EIP"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkInterfaceId",
+      "actual": "eni-0f1c51db64ee88129",
+      "physicalId": "107.22.107.4",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/EIP"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
+    "resourceType": "AWS::EC2::EIP",
+    "physicalId": "35.171.223.35",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/EIP",
+    "declared": {
+      "Domain": "vpc",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Domain": "vpc",
+    "NetworkBorderGroup": "us-east-1",
+    "PublicIp": "35.171.223.35",
+    "NetworkInterfaceId": "eni-09d601326197ac598",
+    "Tags": [
+      {
+        "Key": "Name",
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2"
+      },
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkrdIntegHarvest2"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "WorkersVpcPublicSubnet2EIP6DA9CDC1"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AllocationId", "PublicIp"],
+    "writeOnly": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnly": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "readOnlyPaths": ["AllocationId", "PublicIp"],
+    "writeOnlyPaths": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnlyPaths": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "35.171.223.35",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/EIP"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkInterfaceId",
+      "actual": "eni-09d601326197ac598",
+      "physicalId": "35.171.223.35",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/EIP"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__InternetGateway.WorkersVpcIGW91E7A5A0.json
+++ b/tests/corpus/AWS__EC2__InternetGateway.WorkersVpcIGW91E7A5A0.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::InternetGateway with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcIGW91E7A5A0",
+    "resourceType": "AWS::EC2::InternetGateway",
+    "physicalId": "igw-06facc81e0936ee08",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/IGW",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "InternetGatewayId": "igw-06facc81e0936ee08",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["InternetGatewayId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["InternetGatewayId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
@@ -1,0 +1,143 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::NatGateway with deep declared config classifies as recorded (undeclared:AvailabilityMode, undeclared:ConnectivityType, undeclared:PrivateIpAddress, undeclared:VpcId, unresolved:AllocationId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+    "resourceType": "AWS::EC2::NatGateway",
+    "physicalId": "nat-07e873bd1eb79666a",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway",
+    "declared": {
+      "AllocationId": "__cdkrd_corpus_unresolved__",
+      "SubnetId": "subnet-0434e5718302e4709",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PrivateIpAddress": "10.0.0.62",
+    "ConnectivityType": "public",
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "EniId": "eni-0f1c51db64ee88129",
+    "AvailabilityMode": "zonal",
+    "AllocationId": "eipalloc-01af7b46fa28e0498",
+    "SubnetId": "subnet-0434e5718302e4709",
+    "NatGatewayId": "nat-07e873bd1eb79666a",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AutoProvisionZones", "AutoScalingIps", "EniId", "NatGatewayId", "RouteTableId"],
+    "writeOnly": ["MaxDrainDurationSeconds"],
+    "createOnly": [
+      "AllocationId",
+      "AvailabilityMode",
+      "ConnectivityType",
+      "PrivateIpAddress",
+      "SubnetId",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "AutoProvisionZones",
+      "AutoScalingIps",
+      "EniId",
+      "NatGatewayId",
+      "RouteTableId"
+    ],
+    "writeOnlyPaths": ["MaxDrainDurationSeconds"],
+    "createOnlyPaths": [
+      "AllocationId",
+      "AvailabilityMode",
+      "ConnectivityType",
+      "PrivateIpAddress",
+      "SubnetId",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "AllocationId",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.62",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "ConnectivityType",
+      "actual": "public",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "VpcId",
+      "actual": "vpc-0b4c09b4fa46530e9",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "AvailabilityMode",
+      "actual": "zonal",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
@@ -1,0 +1,143 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::NatGateway with deep declared config classifies as recorded (undeclared:AvailabilityMode, undeclared:ConnectivityType, undeclared:PrivateIpAddress, undeclared:VpcId, unresolved:AllocationId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+    "resourceType": "AWS::EC2::NatGateway",
+    "physicalId": "nat-029bbcd7fb6e239a7",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway",
+    "declared": {
+      "AllocationId": "__cdkrd_corpus_unresolved__",
+      "SubnetId": "subnet-0433dc95b5f60dbbc",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PrivateIpAddress": "10.0.69.104",
+    "ConnectivityType": "public",
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "EniId": "eni-09d601326197ac598",
+    "AvailabilityMode": "zonal",
+    "AllocationId": "eipalloc-0163727bddacb6156",
+    "SubnetId": "subnet-0433dc95b5f60dbbc",
+    "NatGatewayId": "nat-029bbcd7fb6e239a7",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AutoProvisionZones", "AutoScalingIps", "EniId", "NatGatewayId", "RouteTableId"],
+    "writeOnly": ["MaxDrainDurationSeconds"],
+    "createOnly": [
+      "AllocationId",
+      "AvailabilityMode",
+      "ConnectivityType",
+      "PrivateIpAddress",
+      "SubnetId",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "AutoProvisionZones",
+      "AutoScalingIps",
+      "EniId",
+      "NatGatewayId",
+      "RouteTableId"
+    ],
+    "writeOnlyPaths": ["MaxDrainDurationSeconds"],
+    "createOnlyPaths": [
+      "AllocationId",
+      "AvailabilityMode",
+      "ConnectivityType",
+      "PrivateIpAddress",
+      "SubnetId",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "AllocationId",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.69.104",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "ConnectivityType",
+      "actual": "public",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "VpcId",
+      "actual": "vpc-0b4c09b4fa46530e9",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "AvailabilityMode",
+      "actual": "zonal",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet1DefaultRouteAA29480A.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet1DefaultRouteAA29480A.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet1DefaultRouteAA29480A",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-05e4a92459e2a1258|0.0.0.0/0",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "NatGatewayId": "nat-07e873bd1eb79666a",
+      "RouteTableId": "rtb-05e4a92459e2a1258"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-05e4a92459e2a1258",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "NatGatewayId": "nat-07e873bd1eb79666a"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet2DefaultRoute3AD15157.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet2DefaultRoute3AD15157.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet2DefaultRoute3AD15157",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-0b3f2a65e3c729a4e|0.0.0.0/0",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "NatGatewayId": "nat-029bbcd7fb6e239a7",
+      "RouteTableId": "rtb-0b3f2a65e3c729a4e"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-0b3f2a65e3c729a4e",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "NatGatewayId": "nat-029bbcd7fb6e239a7"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet1DefaultRoute10E419CD.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet1DefaultRoute10E419CD.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (undeclared:VpcEndpointId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet1DefaultRoute10E419CD",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-01daf7af05f3a8d19|0.0.0.0/0",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": "igw-06facc81e0936ee08",
+      "RouteTableId": "rtb-01daf7af05f3a8d19"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-01daf7af05f3a8d19",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": "igw-06facc81e0936ee08",
+    "VpcEndpointId": "igw-06facc81e0936ee08"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1DefaultRoute10E419CD",
+      "resourceType": "AWS::EC2::Route",
+      "path": "VpcEndpointId",
+      "actual": "igw-06facc81e0936ee08",
+      "physicalId": "rtb-01daf7af05f3a8d19|0.0.0.0/0",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/DefaultRoute"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet2DefaultRoute27847E35.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet2DefaultRoute27847E35.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (undeclared:VpcEndpointId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet2DefaultRoute27847E35",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-03ec6bc9b1e2562e5|0.0.0.0/0",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": "igw-06facc81e0936ee08",
+      "RouteTableId": "rtb-03ec6bc9b1e2562e5"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-03ec6bc9b1e2562e5",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": "igw-06facc81e0936ee08",
+    "VpcEndpointId": "igw-06facc81e0936ee08"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2DefaultRoute27847E35",
+      "resourceType": "AWS::EC2::Route",
+      "path": "VpcEndpointId",
+      "actual": "igw-06facc81e0936ee08",
+      "physicalId": "rtb-03ec6bc9b1e2562e5|0.0.0.0/0",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/DefaultRoute"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet1RouteTable14508C3D.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet1RouteTable14508C3D.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet1RouteTable14508C3D",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-05e4a92459e2a1258",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-05e4a92459e2a1258",
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet2RouteTable132F039E.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet2RouteTable132F039E.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet2RouteTable132F039E",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-0b3f2a65e3c729a4e",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-0b3f2a65e3c729a4e",
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet1RouteTableAC7905D6.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet1RouteTableAC7905D6.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet1RouteTableAC7905D6",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-01daf7af05f3a8d19",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-01daf7af05f3a8d19",
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet2RouteTable7E94D522.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet2RouteTable7E94D522.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet2RouteTable7E94D522",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-03ec6bc9b1e2562e5",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-03ec6bc9b1e2562e5",
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
@@ -1,0 +1,171 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-011f0a2e9cbd7ebab",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.128.0/18",
+      "MapPublicIpOnLaunch": false,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "Private"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Private"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": false,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "CidrBlock": "10.0.128.0/18",
+    "SubnetId": "subnet-011f0a2e9cbd7ebab",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "NetworkAclAssociationId": "aclassoc-01d062a56f537bd0d",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1",
+        "Key": "Name"
+      },
+      {
+        "Value": "Private",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "Private",
+        "Key": "aws-cdk:subnet-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
@@ -1,0 +1,171 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-0b456bc01025cb129",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.192.0/18",
+      "MapPublicIpOnLaunch": false,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "Private"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Private"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": false,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az2",
+    "AvailabilityZone": "us-east-1b",
+    "CidrBlock": "10.0.192.0/18",
+    "SubnetId": "subnet-0b456bc01025cb129",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "NetworkAclAssociationId": "aclassoc-0464465b8ffc9a575",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "Private",
+        "Key": "aws-cdk:subnet-name"
+      },
+      {
+        "Value": "Private",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az2",
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
@@ -1,0 +1,171 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-0434e5718302e4709",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.0.0/18",
+      "MapPublicIpOnLaunch": true,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "Public"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Public"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": true,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "CidrBlock": "10.0.0.0/18",
+    "SubnetId": "subnet-0434e5718302e4709",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "NetworkAclAssociationId": "aclassoc-0bccdb1b6846092f4",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-name"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
@@ -1,0 +1,171 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-0433dc95b5f60dbbc",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.64.0/18",
+      "MapPublicIpOnLaunch": true,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "Public"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Public"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2"
+        }
+      ],
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": true,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az2",
+    "AvailabilityZone": "us-east-1b",
+    "CidrBlock": "10.0.64.0/18",
+    "SubnetId": "subnet-0433dc95b5f60dbbc",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "NetworkAclAssociationId": "aclassoc-0a94f65d2119ed284",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-name"
+      },
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az2",
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet1RouteTableAssociation70862F8D.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet1RouteTableAssociation70862F8D.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet1RouteTableAssociation70862F8D",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-0b4706e18e70e6b4e",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-05e4a92459e2a1258",
+      "SubnetId": "subnet-011f0a2e9cbd7ebab"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-05e4a92459e2a1258",
+    "Id": "rtbassoc-0b4706e18e70e6b4e",
+    "SubnetId": "subnet-011f0a2e9cbd7ebab"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet2RouteTableAssociationA174BE42.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet2RouteTableAssociationA174BE42.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPrivateSubnet2RouteTableAssociationA174BE42",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-0976e7af955161b65",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-0b3f2a65e3c729a4e",
+      "SubnetId": "subnet-0b456bc01025cb129"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-0b3f2a65e3c729a4e",
+    "Id": "rtbassoc-0976e7af955161b65",
+    "SubnetId": "subnet-0b456bc01025cb129"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet1RouteTableAssociationF5003E3E.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet1RouteTableAssociationF5003E3E.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet1RouteTableAssociationF5003E3E",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-02fc826361978f21f",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-01daf7af05f3a8d19",
+      "SubnetId": "subnet-0434e5718302e4709"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-01daf7af05f3a8d19",
+    "Id": "rtbassoc-02fc826361978f21f",
+    "SubnetId": "subnet-0434e5718302e4709"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet2RouteTableAssociationC0116C4D.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet2RouteTableAssociationC0116C4D.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcPublicSubnet2RouteTableAssociationC0116C4D",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-00fb61747af272894",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-03ec6bc9b1e2562e5",
+      "SubnetId": "subnet-0433dc95b5f60dbbc"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-03ec6bc9b1e2562e5",
+    "Id": "rtbassoc-00fb61747af272894",
+    "SubnetId": "subnet-0433dc95b5f60dbbc"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPC.WorkersVpcA828E13A.json
+++ b/tests/corpus/AWS__EC2__VPC.WorkersVpcA828E13A.json
@@ -1,0 +1,93 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::VPC with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcA828E13A",
+    "resourceType": "AWS::EC2::VPC",
+    "physicalId": "vpc-0b4c09b4fa46530e9",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc",
+    "declared": {
+      "CidrBlock": "10.0.0.0/16",
+      "EnableDnsHostnames": true,
+      "EnableDnsSupport": true,
+      "InstanceTenancy": "default",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest2/Workers/Vpc"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-0b4c09b4fa46530e9",
+    "InstanceTenancy": "default",
+    "CidrBlockAssociations": ["vpc-cidr-assoc-076ebb2b081f02051"],
+    "CidrBlock": "10.0.0.0/16",
+    "DefaultNetworkAcl": "acl-003e9fbb719a40eb2",
+    "EnableDnsSupport": true,
+    "Ipv6CidrBlocks": [],
+    "DefaultSecurityGroup": "sg-0bd55c9def73e3c0b",
+    "EnableDnsHostnames": true,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2/Workers/Vpc",
+        "Key": "Name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "WorkersVpcA828E13A",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnly": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnly": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "readOnlyPaths": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnlyPaths": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPCGatewayAttachment.WorkersVpcVPCGWCCE585FA.json
+++ b/tests/corpus/AWS__EC2__VPCGatewayAttachment.WorkersVpcVPCGWCCE585FA.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::VPCGatewayAttachment with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkersVpcVPCGWCCE585FA",
+    "resourceType": "AWS::EC2::VPCGatewayAttachment",
+    "physicalId": "IGW|vpc-0b4c09b4fa46530e9",
+    "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/VPCGW",
+    "declared": {
+      "InternetGatewayId": "igw-06facc81e0936ee08",
+      "VpcId": "vpc-0b4c09b4fa46530e9"
+    }
+  },
+  "liveRaw": {
+    "InternetGatewayId": "igw-06facc81e0936ee08",
+    "AttachmentType": "IGW",
+    "VpcId": "vpc-0b4c09b4fa46530e9"
+  },
+  "schema": {
+    "readOnly": ["AttachmentType"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["AttachmentType"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ECS__Cluster.Workers96E39E36.json
+++ b/tests/corpus/AWS__ECS__Cluster.Workers96E39E36.json
@@ -1,0 +1,74 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::ECS::Cluster with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "Workers96E39E36",
+    "resourceType": "AWS::ECS::Cluster",
+    "physicalId": "CdkrdIntegHarvest2-Workers96E39E36-qNSTxrLl8MB3",
+    "constructPath": "CdkrdIntegHarvest2/Workers",
+    "declared": {
+      "ClusterSettings": [
+        {
+          "Name": "containerInsights",
+          "Value": "enabled"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ClusterSettings": [
+      {
+        "Value": "enabled",
+        "Name": "containerInsights"
+      }
+    ],
+    "DefaultCapacityProviderStrategy": [],
+    "CapacityProviders": [],
+    "ClusterName": "CdkrdIntegHarvest2-Workers96E39E36-qNSTxrLl8MB3",
+    "Arn": "arn:aws:ecs:us-east-1:111111111111:cluster/CdkrdIntegHarvest2-Workers96E39E36-qNSTxrLl8MB3",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Workers96E39E36",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["ServiceConnectDefaults"],
+    "createOnly": ["ClusterName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["ServiceConnectDefaults"],
+    "createOnlyPaths": ["ClusterName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Events__Rule.Forward9800F3B2.json
+++ b/tests/corpus/AWS__Events__Rule.Forward9800F3B2.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::Events::Rule with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "Forward9800F3B2",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy",
+    "constructPath": "CdkrdIntegHarvest2/Forward",
+    "declared": {
+      "ScheduleExpression": "rate(6 hours)",
+      "State": "DISABLED",
+      "Targets": [
+        {
+          "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+          "Id": "Target0",
+          "Input": "{\"source\":\"harvest2\",\"kind\":\"tick\"}"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "ScheduleExpression": "rate(6 hours)",
+    "State": "DISABLED",
+    "Targets": [
+      {
+        "Input": "{\"source\":\"harvest2\",\"kind\":\"tick\"}",
+        "Id": "Target0",
+        "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2"
+      }
+    ],
+    "Id": "CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Forward9800F3B2",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Policy.WorkerServiceRoleDefaultPolicyAE71B5FA.json
+++ b/tests/corpus/AWS__IAM__Policy.WorkerServiceRoleDefaultPolicyAE71B5FA.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::IAM::Policy with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkerServiceRoleDefaultPolicyAE71B5FA",
+    "resourceType": "AWS::IAM::Policy",
+    "physicalId": "Cdkrd-Worke-f6H2n1oWmS1l",
+    "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole/DefaultPolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["xray:PutTraceSegments", "xray:PutTelemetryRecords"],
+            "Effect": "Allow",
+            "Resource": "*"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "PolicyName": "WorkerServiceRoleDefaultPolicyAE71B5FA",
+      "Roles": ["CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk"]
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "WorkerServiceRoleDefaultPolicyAE71B5FA",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["xray:PutTraceSegments", "xray:PutTelemetryRecords"],
+          "Resource": "*",
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Roles": ["CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk"]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.WorkerServiceRole8543584E.json
+++ b/tests/corpus/AWS__IAM__Role.WorkerServiceRole8543584E.json
@@ -1,0 +1,94 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::IAM::Role with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "WorkerServiceRole8543584E",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+    "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    },
+    "siblingPolicyNames": ["WorkerServiceRoleDefaultPolicyAE71B5FA"]
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+    "Description": "",
+    "Policies": [
+      {
+        "PolicyName": "WorkerServiceRoleDefaultPolicyAE71B5FA",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": ["xray:PutTraceSegments", "xray:PutTelemetryRecords"],
+              "Resource": "*",
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    ],
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+    "RoleId": "AROAXXXJN2LN4BJCVIYG2"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Kinesis__Stream.EventsD32975C2.json
+++ b/tests/corpus/AWS__Kinesis__Stream.EventsD32975C2.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::Kinesis::Stream with deep declared config classifies as recorded (undeclared:MaxRecordSizeInKiB). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "EventsD32975C2",
+    "resourceType": "AWS::Kinesis::Stream",
+    "physicalId": "CdkrdIntegHarvest2-EventsD32975C2-IyHLeNv132l2",
+    "constructPath": "CdkrdIntegHarvest2/Events",
+    "declared": {
+      "RetentionPeriodHours": 48,
+      "ShardCount": 1,
+      "StreamEncryption": {
+        "EncryptionType": "KMS",
+        "KeyId": "alias/aws/kinesis"
+      }
+    }
+  },
+  "liveRaw": {
+    "StreamModeDetails": {
+      "StreamMode": "PROVISIONED"
+    },
+    "StreamEncryption": {
+      "EncryptionType": "KMS",
+      "KeyId": "alias/aws/kinesis"
+    },
+    "WarmThroughputObject": {
+      "CurrentMiBps": 0,
+      "TargetMiBps": 0
+    },
+    "Arn": "arn:aws:kinesis:us-east-1:111111111111:stream/CdkrdIntegHarvest2-EventsD32975C2-IyHLeNv132l2",
+    "MaxRecordSizeInKiB": 1024,
+    "RetentionPeriodHours": 48,
+    "DesiredShardLevelMetrics": [],
+    "Name": "CdkrdIntegHarvest2-EventsD32975C2-IyHLeNv132l2",
+    "ShardCount": 1
+  },
+  "schema": {
+    "readOnly": ["Arn", "WarmThroughputObject"],
+    "writeOnly": ["WarmThroughputMiBps"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "WarmThroughputObject"],
+    "writeOnlyPaths": ["WarmThroughputMiBps"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {
+      "StreamModeDetails": {
+        "StreamMode": "PROVISIONED"
+      }
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EventsD32975C2",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "MaxRecordSizeInKiB",
+      "actual": 1024,
+      "physicalId": "CdkrdIntegHarvest2-EventsD32975C2-IyHLeNv132l2",
+      "constructPath": "CdkrdIntegHarvest2/Events"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
+++ b/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
@@ -1,0 +1,140 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::Lambda::Function with deep declared config classifies as recorded (undeclared:LoggingConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "Worker11F36D0F",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+    "constructPath": "CdkrdIntegHarvest2/Worker",
+    "declared": {
+      "Architectures": ["arm64"],
+      "Code": {
+        "ZipFile": "exports.handler = async () => 'harvest2';"
+      },
+      "Environment": {
+        "Variables": {
+          "STAGE": "harvest",
+          "FEATURE_X": "on"
+        }
+      },
+      "Handler": "index.handler",
+      "MemorySize": 256,
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+      "Runtime": "nodejs20.x",
+      "Timeout": 20,
+      "TracingConfig": {
+        "Mode": "Active"
+      }
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 256,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "Active"
+    },
+    "Timeout": 20,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv"
+    },
+    "RecursiveLoop": "Terminate",
+    "Environment": {
+      "Variables": {
+        "STAGE": "harvest",
+        "FEATURE_X": "on"
+      }
+    },
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Worker11F36D0F",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["arm64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Worker11F36D0F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv"
+      },
+      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+      "constructPath": "CdkrdIntegHarvest2/Worker"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
+++ b/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
@@ -1,0 +1,244 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::S3::Bucket with deep declared config classifies as recorded (undeclared:BucketEncryption, undeclared:OwnershipControls). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "ArchiveDA4CB258",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+    "constructPath": "CdkrdIntegHarvest2/Archive",
+    "declared": {
+      "CorsConfiguration": {
+        "CorsRules": [
+          {
+            "AllowedHeaders": ["*"],
+            "AllowedMethods": ["GET", "HEAD"],
+            "AllowedOrigins": ["https://example.com"],
+            "MaxAge": 300
+          }
+        ]
+      },
+      "LifecycleConfiguration": {
+        "Rules": [
+          {
+            "ExpirationInDays": 365,
+            "Id": "tier-then-expire",
+            "Prefix": "logs/",
+            "Status": "Enabled",
+            "Transitions": [
+              {
+                "StorageClass": "STANDARD_IA",
+                "TransitionInDays": 30
+              },
+              {
+                "StorageClass": "GLACIER",
+                "TransitionInDays": 90
+              }
+            ]
+          },
+          {
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 7
+            },
+            "Id": "mpu-cleanup",
+            "Status": "Enabled"
+          }
+        ]
+      },
+      "PublicAccessBlockConfiguration": {
+        "BlockPublicAcls": true,
+        "BlockPublicPolicy": true,
+        "IgnorePublicAcls": true,
+        "RestrictPublicBuckets": true
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi.s3-website-us-east-1.amazonaws.com",
+    "LifecycleConfiguration": {
+      "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+      "Rules": [
+        {
+          "Status": "Enabled",
+          "Transitions": [
+            {
+              "StorageClass": "STANDARD_IA",
+              "TransitionInDays": 30
+            },
+            {
+              "StorageClass": "GLACIER",
+              "TransitionInDays": 90
+            }
+          ],
+          "ExpirationInDays": 365,
+          "Id": "tier-then-expire",
+          "Prefix": "logs/"
+        },
+        {
+          "Status": "Enabled",
+          "Id": "mpu-cleanup",
+          "Prefix": "",
+          "AbortIncompleteMultipartUpload": {
+            "DaysAfterInitiation": 7
+          }
+        }
+      ]
+    },
+    "DualStackDomainName": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi.s3.dualstack.us-east-1.amazonaws.com",
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+    "CorsConfiguration": {
+      "CorsRules": [
+        {
+          "AllowedMethods": ["GET", "HEAD"],
+          "AllowedOrigins": ["https://example.com"],
+          "AllowedHeaders": ["*"],
+          "MaxAge": 300
+        }
+      ]
+    },
+    "RegionalDomainName": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "ArchiveDA4CB258",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ArchiveDA4CB258",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+      "constructPath": "CdkrdIntegHarvest2/Archive"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ArchiveDA4CB258",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+      "constructPath": "CdkrdIntegHarvest2/Archive"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.ArchivePolicyC780D5C8.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.ArchivePolicyC780D5C8.json
@@ -1,0 +1,78 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::S3::BucketPolicy with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "ArchivePolicyC780D5C8",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+    "constructPath": "CdkrdIntegHarvest2/Archive/Policy",
+    "declared": {
+      "Bucket": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest2-CustomS3AutoDeleteObjectsCustomR-o9ElgsId3d6f"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+              "arn:aws:s3:::cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi/*"
+            ]
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest2-CustomS3AutoDeleteObjectsCustomR-o9ElgsId3d6f"
+          },
+          "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+          "Resource": [
+            "arn:aws:s3:::cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+            "arn:aws:s3:::cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi/*"
+          ]
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SNS__Subscription.InboxCdkrdIntegHarvest2Alerts473B90C08943AC11.json
+++ b/tests/corpus/AWS__SNS__Subscription.InboxCdkrdIntegHarvest2Alerts473B90C08943AC11.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SNS::Subscription with deep declared config classifies as recorded (undeclared:FilterPolicyScope). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "InboxCdkrdIntegHarvest2Alerts473B90C08943AC11",
+    "resourceType": "AWS::SNS::Subscription",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR:9720c67e-9d2a-484b-bb7b-2b9fe8e5234d",
+    "constructPath": "CdkrdIntegHarvest2/Inbox/CdkrdIntegHarvest2Alerts473B90C0",
+    "declared": {
+      "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "FilterPolicy": {
+        "severity": ["high", "critical"]
+      },
+      "Protocol": "sqs",
+      "RawMessageDelivery": true,
+      "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR"
+    }
+  },
+  "liveRaw": {
+    "RawMessageDelivery": true,
+    "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+    "FilterPolicy": {
+      "severity": ["high", "critical"]
+    },
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR",
+    "FilterPolicyScope": "MessageAttributes",
+    "Arn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR:9720c67e-9d2a-484b-bb7b-2b9fe8e5234d",
+    "Protocol": "sqs"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["Region"],
+    "createOnly": ["Endpoint", "Protocol", "Region", "TopicArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["Region"],
+    "createOnlyPaths": ["Endpoint", "Protocol", "Region", "TopicArn"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxCdkrdIntegHarvest2Alerts473B90C08943AC11",
+      "resourceType": "AWS::SNS::Subscription",
+      "path": "FilterPolicyScope",
+      "actual": "MessageAttributes",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR:9720c67e-9d2a-484b-bb7b-2b9fe8e5234d",
+      "constructPath": "CdkrdIntegHarvest2/Inbox/CdkrdIntegHarvest2Alerts473B90C0"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.Alerts91F83244.json
+++ b/tests/corpus/AWS__SNS__Topic.Alerts91F83244.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SNS::Topic with deep declared config classifies as recorded (undeclared:Subscription, undeclared:TopicName). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "Alerts91F83244",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR",
+    "constructPath": "CdkrdIntegHarvest2/Alerts",
+    "declared": {}
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR",
+    "FifoTopic": false,
+    "Subscription": [
+      {
+        "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+        "Protocol": "sqs"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Alerts91F83244",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Alerts91F83244",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "Subscription",
+      "actual": [
+        {
+          "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+          "Protocol": "sqs"
+        }
+      ],
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR",
+      "constructPath": "CdkrdIntegHarvest2/Alerts"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Alerts91F83244",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "TopicName",
+      "actual": "CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR",
+      "constructPath": "CdkrdIntegHarvest2/Alerts"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
+++ b/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
@@ -1,0 +1,116 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DelaySeconds, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled, undeclared:VisibilityTimeout). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "InboxA8E05DC3",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+    "constructPath": "CdkrdIntegHarvest2/Inbox",
+    "declared": {}
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+    "QueueName": "CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
@@ -1,0 +1,133 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DelaySeconds, undeclared:FifoThroughputLimit, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "JobsDF1CC2D4",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+    "constructPath": "CdkrdIntegHarvest2/Jobs",
+    "declared": {
+      "ContentBasedDeduplication": true,
+      "DeduplicationScope": "messageGroup",
+      "FifoQueue": true,
+      "RedrivePolicy": {
+        "deadLetterTargetArn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+        "maxReceiveCount": 3
+      },
+      "VisibilityTimeout": 45
+    }
+  },
+  "liveRaw": {
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "FifoThroughputLimit": "perQueue",
+    "FifoQueue": true,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 45,
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+    "SqsManagedSseEnabled": true,
+    "DelaySeconds": 0,
+    "RedrivePolicy": {
+      "maxReceiveCount": 3,
+      "deadLetterTargetArn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo"
+    },
+    "MessageRetentionPeriod": 345600,
+    "DeduplicationScope": "messageGroup",
+    "ContentBasedDeduplication": true,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+    "QueueName": "CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "FifoThroughputLimit",
+      "actual": "perQueue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
@@ -1,0 +1,140 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DeduplicationScope, undeclared:DelaySeconds, undeclared:FifoThroughputLimit, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled, undeclared:VisibilityTimeout). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "JobsDlqB53173A1",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+    "constructPath": "CdkrdIntegHarvest2/JobsDlq",
+    "declared": {
+      "FifoQueue": true
+    }
+  },
+  "liveRaw": {
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "FifoThroughputLimit": "perQueue",
+    "FifoQueue": true,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+    "SqsManagedSseEnabled": true,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "DeduplicationScope": "queue",
+    "ContentBasedDeduplication": false,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+    "QueueName": "CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "FifoThroughputLimit",
+      "actual": "perQueue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DeduplicationScope",
+      "actual": "queue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__QueuePolicy.InboxPolicy63A7501F.json
+++ b/tests/corpus/AWS__SQS__QueuePolicy.InboxPolicy63A7501F.json
@@ -1,0 +1,112 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::QueuePolicy with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "InboxPolicy63A7501F",
+    "resourceType": "AWS::SQS::QueuePolicy",
+    "physicalId": "CdkrdIntegHarvest2-InboxPolicy63A7501F-EhOBUSqDuIno",
+    "constructPath": "CdkrdIntegHarvest2/Inbox/Policy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sqs:SendMessage",
+            "Condition": {
+              "ArnEquals": {
+                "aws:SourceArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR"
+              }
+            },
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "sns.amazonaws.com"
+            },
+            "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2"
+          },
+          {
+            "Action": ["sqs:SendMessage", "sqs:GetQueueAttributes", "sqs:GetQueueUrl"],
+            "Condition": {
+              "ArnEquals": {
+                "aws:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy"
+              }
+            },
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "events.amazonaws.com"
+            },
+            "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "Queues": [
+        "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2"
+      ]
+    }
+  },
+  "liveRaw": {
+    "Queues": [
+      "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2"
+    ],
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "sns.amazonaws.com"
+          },
+          "Action": "sqs:SendMessage",
+          "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+          "Condition": {
+            "ArnEquals": {
+              "aws:SourceArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest2-Alerts91F83244-1ZnyAF9edmoR"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "events.amazonaws.com"
+          },
+          "Action": ["sqs:SendMessage", "sqs:GetQueueAttributes", "sqs:GetQueueUrl"],
+          "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+          "Condition": {
+            "ArnEquals": {
+              "aws:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.Edge.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.Edge.json
@@ -1,0 +1,150 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::WAFv2::WebACL with deep declared config classifies as recorded (undeclared:Name, undeclared:OnSourceDDoSProtectionConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "resource": {
+    "logicalId": "Edge",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
+    "constructPath": "CdkrdIntegHarvest2/Edge",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Rules": [
+        {
+          "Name": "common",
+          "OverrideAction": {
+            "None": {}
+          },
+          "Priority": 0,
+          "Statement": {
+            "ManagedRuleGroupStatement": {
+              "Name": "AWSManagedRulesCommonRuleSet",
+              "VendorName": "AWS"
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "common",
+            "SampledRequestsEnabled": false
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "harvest2",
+        "SampledRequestsEnabled": false
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "REGIONAL",
+    "Capacity": 700,
+    "Id": "8db5286a-695e-41b6-beba-f4207a727afc",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/Edge-iCCoPGcllLnA/8db5286a-695e-41b6-beba-f4207a727afc",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [
+      {
+        "Priority": 0,
+        "Statement": {
+          "ManagedRuleGroupStatement": {
+            "VendorName": "AWS",
+            "RuleActionOverrides": [],
+            "ManagedRuleGroupConfigs": [],
+            "ExcludedRules": [],
+            "Name": "AWSManagedRulesCommonRuleSet"
+          }
+        },
+        "OverrideAction": {
+          "None": {}
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "common",
+          "SampledRequestsEnabled": false,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "common"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "harvest2",
+      "SampledRequestsEnabled": false,
+      "CloudWatchMetricsEnabled": true
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:Edge-iCCoPGcllLnA:",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest2/afbe1480-6676-11f1-9003-1221defe289b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Edge",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "Edge-iCCoPGcllLnA"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    }
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
+      "constructPath": "CdkrdIntegHarvest2/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "Name",
+      "actual": "Edge-iCCoPGcllLnA",
+      "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
+      "constructPath": "CdkrdIntegHarvest2/Edge"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -155,6 +155,22 @@ fixture exists to convert one AWS round trip into permanent offline coverage.
 cd harvest && npm install && bash verify-harvest.sh
 ```
 
+## harvest2
+
+Wave 2 of the corpus harvest (R73): RICHLY-DECLARED configurations — S3
+lifecycle+CORS, DynamoDB GSI+TTL+stream, Lambda with non-default
+memory/timeout/arch/tracing/env, FIFO queues with redrive, SNS->SQS
+subscription with a filter policy, EventBridge input transformer, WAFv2
+WebACL with a managed rule group, ECS cluster (pulls in a full VPC: subnets,
+routes, NAT, IGW — all recorded), Kinesis with the aws-managed KMS alias
+(exercises the strict alias<->key-ARN match live). Asserts the same two
+invariants as `harvest`: fresh deploy = ZERO declared drift, then
+accept -> `check --fail` CLEAN.
+
+```bash
+cd harvest2 && npm install && bash verify-harvest2.sh
+```
+
 ## revert
 
 A versioned S3 bucket. Enables acceleration, `accept`s (recording it in the

--- a/tests/integration/harvest2/app.ts
+++ b/tests/integration/harvest2/app.ts
@@ -1,0 +1,154 @@
+// Corpus-harvest fixture wave 2 (R73): RICHLY-DECLARED configurations. Wave 1
+// (harvest/) covered fresh default-config types; the remaining declared-compare
+// false-positive surface is DEEPLY NESTED declared structs (lifecycle rules,
+// GSIs, redrive policies, input transformers, WAF statements) — a fresh deploy
+// of THIS stack must classify with zero declared drift, which stresses the
+// canonicalization pipeline on every shape at once. Also deliberately declares
+// NON-default values for properties that KNOWN_DEFAULTS suppresses (tracing,
+// memory, timeout, architectures) so the declared loop sees them, and a KMS
+// managed alias (alias/aws/kinesis) so the strict alias<->key-ARN match runs
+// against real ListAliases data. Everything cheap and self-cleaning.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Alarm, ComparisonOperator, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { AttributeType, BillingMode, ProjectionType, StreamViewType, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Cluster } from "aws-cdk-lib/aws-ecs";
+import { Rule, RuleTargetInput, Schedule } from "aws-cdk-lib/aws-events";
+import { SqsQueue } from "aws-cdk-lib/aws-events-targets";
+import { Stream, StreamEncryption } from "aws-cdk-lib/aws-kinesis";
+import { Architecture, Code, Function as Fn, Runtime, Tracing } from "aws-cdk-lib/aws-lambda";
+import { BlockPublicAccess, Bucket, HttpMethods, StorageClass } from "aws-cdk-lib/aws-s3";
+import { SubscriptionFilter, Topic } from "aws-cdk-lib/aws-sns";
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+import { DeduplicationScope, Queue } from "aws-cdk-lib/aws-sqs";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegHarvest2");
+
+new Bucket(stack, "Archive", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+  lifecycleRules: [
+    {
+      id: "tier-then-expire",
+      prefix: "logs/",
+      transitions: [
+        { storageClass: StorageClass.INFREQUENT_ACCESS, transitionAfter: Duration.days(30) },
+        { storageClass: StorageClass.GLACIER, transitionAfter: Duration.days(90) },
+      ],
+      expiration: Duration.days(365),
+    },
+    { id: "mpu-cleanup", abortIncompleteMultipartUploadAfter: Duration.days(7) },
+  ],
+  cors: [
+    {
+      allowedMethods: [HttpMethods.GET, HttpMethods.HEAD],
+      allowedOrigins: ["https://example.com"],
+      allowedHeaders: ["*"],
+      maxAge: 300,
+    },
+  ],
+});
+
+new Table(stack, "Orders", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  sortKey: { name: "sk", type: AttributeType.NUMBER },
+  billingMode: BillingMode.PAY_PER_REQUEST,
+  timeToLiveAttribute: "expiresAt",
+  stream: StreamViewType.NEW_AND_OLD_IMAGES,
+  removalPolicy: RemovalPolicy.DESTROY,
+}).addGlobalSecondaryIndex({
+  indexName: "byStatus",
+  partitionKey: { name: "status", type: AttributeType.STRING },
+  projectionType: ProjectionType.KEYS_ONLY,
+});
+
+new Fn(stack, "Worker", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => 'harvest2';"),
+  memorySize: 256,
+  timeout: Duration.seconds(20),
+  architecture: Architecture.ARM_64,
+  tracing: Tracing.ACTIVE,
+  environment: { STAGE: "harvest", FEATURE_X: "on" },
+});
+
+const dlq = new Queue(stack, "JobsDlq", { fifo: true });
+new Queue(stack, "Jobs", {
+  fifo: true,
+  contentBasedDeduplication: true,
+  deduplicationScope: DeduplicationScope.MESSAGE_GROUP,
+  visibilityTimeout: Duration.seconds(45),
+  deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
+});
+
+const alerts = new Topic(stack, "Alerts"); // standard topic so SQS sub + filter policy work
+const inbox = new Queue(stack, "Inbox");
+alerts.addSubscription(
+  new SqsSubscription(inbox, {
+    rawMessageDelivery: true,
+    filterPolicy: {
+      severity: SubscriptionFilter.stringFilter({ allowlist: ["high", "critical"] }),
+    },
+  })
+);
+
+new Rule(stack, "Forward", {
+  schedule: Schedule.rate(Duration.hours(6)),
+  enabled: false,
+  targets: [
+    new SqsQueue(inbox, {
+      message: RuleTargetInput.fromObject({ source: "harvest2", kind: "tick" }),
+    }),
+  ],
+});
+
+new CfnWebACL(stack, "Edge", {
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: true,
+    metricName: "harvest2",
+    sampledRequestsEnabled: false,
+  },
+  rules: [
+    {
+      name: "common",
+      priority: 0,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: { vendorName: "AWS", name: "AWSManagedRulesCommonRuleSet" },
+      },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: "common",
+        sampledRequestsEnabled: false,
+      },
+    },
+  ],
+});
+
+new Alarm(stack, "Latency", {
+  metric: new Metric({
+    namespace: "CdkrdHarvest2",
+    metricName: "Latency",
+    period: Duration.minutes(5),
+  }),
+  threshold: 250,
+  evaluationPeriods: 3,
+  datapointsToAlarm: 2,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+  treatMissingData: TreatMissingData.NOT_BREACHING,
+});
+
+new Cluster(stack, "Workers", { containerInsights: true });
+
+new Stream(stack, "Events", {
+  shardCount: 1,
+  retentionPeriod: Duration.hours(48),
+  encryption: StreamEncryption.MANAGED, // alias/aws/kinesis -> strict alias<->key-ARN match, live
+});
+
+app.synth();

--- a/tests/integration/harvest2/cdk.json
+++ b/tests/integration/harvest2/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest2/package.json
+++ b/tests/integration/harvest2/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-harvest2",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest fixture: many cheap types deployed once to record golden-corpus cases. Run via verify-harvest2.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@11.17.0"
+}

--- a/tests/integration/harvest2/verify-harvest2.sh
+++ b/tests/integration/harvest2/verify-harvest2.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test (real AWS) — R73.
+#
+# Deploys RICHLY-DECLARED configs (wave 2) the corpus had never seen live, then:
+#   1. baseline-free `check` — a FRESH deploy must classify with ZERO declared
+#      drift across every type (the cross-type false-positive test), exit 0
+#      (everything undeclared is UNRECORDED);
+#   2. `accept --yes` then `check --fail` — the baseline round trip must land
+#      CLEAN (exit 0) across every type;
+#   3. destroy. Nothing lingers (no KMS keys, secrets, or hosted zones).
+#
+# Run with CDKRD_CORPUS_DIR=<dir> to record one golden-corpus case per type —
+# the whole point: one AWS round trip becomes permanent offline coverage.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest && npm install && bash verify-harvest2.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegHarvest2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest2.out
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 2: deep declared structs) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"

--- a/tests/invariants.test.ts
+++ b/tests/invariants.test.ts
@@ -1,0 +1,199 @@
+// Generative INVARIANT tests (R73): instead of hand-picking inputs, generate
+// hundreds of pseudo-random property models (seeded LCG — fully deterministic,
+// no Math.random) and assert properties that must hold for EVERY input. These
+// catch whole CLASSES of bugs the example-based tests can't enumerate:
+//   1. self-compare is CLEAN     — classify(declared=X, live=X) yields nothing
+//   2. accept-all suppresses all — applyBaseline after a full accept leaves no
+//                                  undeclared survivors (and no removals)
+//   3. canonicalization is IDEMPOTENT and never throws on weird shapes
+//   4. the strips never throw and never INVENT keys
+//   5. sanitizeAccountId is idempotent and shape-preserving
+import { describe, expect, it } from 'vite-plus/test';
+import { applyBaseline, buildAccepted } from '../src/baseline/baseline-file.js';
+import { sanitizeAccountId } from '../src/corpus/record.js';
+import { classifyResource } from '../src/diff/classify.js';
+import { deepEqual } from '../src/diff/drift-calculator.js';
+import { stripCcApiAwsManagedFields } from '../src/normalize/cc-api-strip.js';
+import { stripAwsTagsDeep } from '../src/normalize/noise.js';
+import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
+import type { Finding, SchemaInfo } from '../src/types.js';
+
+// ---- deterministic pseudo-random model generator (seeded LCG) ----
+
+function lcg(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+}
+
+const WORDS = [
+  'Status',
+  'Enabled',
+  'Name',
+  'Arn',
+  'Tags',
+  'Policy',
+  'Config',
+  'Rules',
+  'Key',
+  'Value',
+  'Action',
+  'Statement',
+  'Type',
+  'Size',
+  'Mode',
+  'Port',
+  'aws:SecureTransport',
+  'Condition',
+  'Principal',
+  'Resource',
+  'Id',
+];
+
+function genValue(rnd: () => number, depth: number): unknown {
+  const r = rnd();
+  if (depth <= 0 || r < 0.35) {
+    // scalar
+    const k = rnd();
+    if (k < 0.25) return Math.floor(rnd() * 1000);
+    if (k < 0.45) return rnd() < 0.5;
+    if (k < 0.55) return '';
+    if (k < 0.7) return `arn:aws:s3:::bucket-${Math.floor(rnd() * 99)}`;
+    return WORDS[Math.floor(rnd() * WORDS.length)];
+  }
+  if (r < 0.6) {
+    // array (may be heterogeneous, nested, or empty)
+    const n = Math.floor(rnd() * 4);
+    return Array.from({ length: n }, () => genValue(rnd, depth - 1));
+  }
+  // object
+  const n = 1 + Math.floor(rnd() * 4);
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < n; i++) {
+    out[WORDS[Math.floor(rnd() * WORDS.length)]!] = genValue(rnd, depth - 1);
+  }
+  return out;
+}
+
+function genModel(seed: number): Record<string, unknown> {
+  const rnd = lcg(seed);
+  const n = 1 + Math.floor(rnd() * 6);
+  const out: Record<string, unknown> = {};
+  for (let i = 0; i < n; i++) {
+    out[`P${i}_${WORDS[Math.floor(rnd() * WORDS.length)]}`] = genValue(rnd, 4);
+  }
+  return out;
+}
+
+const EMPTY_SCHEMA: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+};
+
+const SEEDS = Array.from({ length: 200 }, (_, i) => i + 1);
+
+describe('generative invariants (R73)', () => {
+  it('1. self-compare is CLEAN: classify(template-form X, aws-augmented X) yields no findings', () => {
+    // The realizable input space: a template can never declare aws:* TAG
+    // entries (CFn rejects the reserved prefix), but the LIVE model carries
+    // them — so declared = stripAwsTagsDeep(X) and live = X must compare
+    // CLEAN for every X. aws:* keys NOT under a Tags key (IAM condition keys)
+    // appear identically on BOTH sides and must also be clean — this exact
+    // property would have caught the R69 condition-key-stripping bug.
+    for (const seed of SEEDS) {
+      const model = genModel(seed);
+      const findings = classifyResource(
+        {
+          logicalId: 'L',
+          resourceType: 'AWS::X::Y',
+          physicalId: 'phys',
+          declared: stripAwsTagsDeep(structuredClone(model)) as Record<string, unknown>,
+        },
+        structuredClone(model),
+        EMPTY_SCHEMA,
+        { accountId: '111111111111', region: 'us-east-1', kmsAliasTargets: {} }
+      );
+      expect(findings, `seed ${seed}`).toEqual([]);
+    }
+  });
+
+  it('2. accept-all suppresses ALL undeclared findings (and synthesizes no removals)', () => {
+    for (const seed of SEEDS) {
+      const model = genModel(seed);
+      // every top-level key as an undeclared finding, values canonicalized the
+      // way classify produces them (actual is post-pipeline canonical)
+      const findings: Finding[] = Object.entries(model).map(([path, v]) => {
+        // canonicalize the way classify does (actual is post-pipeline canonical)
+        const canonical = canonicalizeForCompare(
+          stripAwsTagsDeep(stripCcApiAwsManagedFields({ [path]: v }))
+        ) as Record<string, unknown>;
+        return {
+          tier: 'undeclared' as const,
+          logicalId: 'L',
+          resourceType: 'AWS::X::Y',
+          path,
+          actual: canonical[path],
+        };
+      });
+      const baseline = {
+        schemaVersion: 2 as const,
+        stackName: 's',
+        region: 'r',
+        accountId: 'a',
+        capturedAt: '',
+        templateHash: '',
+        accepted: buildAccepted(findings),
+        completeResources: ['L'],
+      };
+      const out = applyBaseline(structuredClone(findings), baseline);
+      expect(out, `seed ${seed}`).toEqual([]);
+    }
+  });
+
+  it('3. canonicalizeForCompare is idempotent and total (never throws)', () => {
+    for (const seed of SEEDS) {
+      const model = genModel(seed);
+      const once = canonicalizeForCompare(structuredClone(model));
+      const twice = canonicalizeForCompare(structuredClone(once));
+      expect(deepEqual(once, twice), `seed ${seed}: canon(canon(x)) != canon(x)`).toBe(true);
+    }
+    // hostile shapes
+    for (const v of [null, undefined, 0, '', false, [], {}, [[]], [null], { a: undefined }]) {
+      expect(() => canonicalizeForCompare(v)).not.toThrow();
+    }
+  });
+
+  it('4. strips are total and never INVENT keys', () => {
+    for (const seed of SEEDS) {
+      const model = genModel(seed);
+      const stripped = stripAwsTagsDeep(
+        stripCcApiAwsManagedFields(structuredClone(model))
+      ) as Record<string, unknown>;
+      for (const k of Object.keys(stripped)) {
+        expect(k in model, `seed ${seed}: invented key ${k}`).toBe(true);
+      }
+    }
+    for (const v of [null, undefined, 0, '', false, [], [[]], [null]]) {
+      expect(() => stripAwsTagsDeep(v)).not.toThrow();
+    }
+  });
+
+  it('5. sanitizeAccountId is idempotent and shape-preserving', () => {
+    for (const seed of SEEDS) {
+      const model = genModel(seed);
+      const withAcct = { ...model, Arn: `arn:aws:iam::123456789012:role/x-${seed}` };
+      const once = sanitizeAccountId(structuredClone(withAcct), '123456789012');
+      const twice = sanitizeAccountId(structuredClone(once), '123456789012');
+      expect(deepEqual(once, twice), `seed ${seed}`).toBe(true);
+      expect(JSON.stringify(once)).not.toContain('123456789012');
+      expect(Object.keys(once as object).sort()).toEqual(Object.keys(withAcct).sort());
+    }
+  });
+});


### PR DESCRIPTION
## What

**1. Generative invariant tests** (200 seeded pseudo-random models per property, deterministic):
- self-compare CLEAN: `classify(stripAwsTags(X), X) == []` for every X — **its very first run reproduced the R69 condition-key bug class**, then was tightened to the realizable input space (templates can't declare aws:* tags)
- accept-all suppresses everything (no survivors, no synthesized removals)
- canonicalization idempotent + total; strips never throw / never invent keys; sanitizer idempotent + shape-preserving

**2. `harvest2` fixture — the richly-DECLARED wave** (deep nested structs: S3 lifecycle+CORS, DynamoDB GSI+TTL+stream, non-default Lambda, FIFO+redrive, SNS filter policy, EventBridge input transformer, WAFv2 managed rule group, ECS→full VPC, Kinesis with aws-managed KMS alias). First live run = **INTEG PASS**: fresh deploy = **zero declared drift across every deep struct** + accept→`check --fail` CLEAN.

**3. Corpus 55 → 95 cases / 491 tests**: 40 reviewed recordings incl. 9 EC2 networking types (VPC/Subnet/Route/RouteTable/IGW/NAT/EIP/assoc/attachment), SNS Subscription with FilterPolicy, WAFv2, Kinesis, FIFO queues — plus real `unresolved`-tier fail-closed behavior (GetAZs, GetAtt AllocationId) locked on live data.

## Gates
- [x] typecheck / lint+format / build / unit tests (`check`)
- [x] docs: integration README harvest2 section (`docs`)
- [x] live evidence: /tmp/integ-harvest2.out INTEG PASS