### PR TITLE
fix(read): CC identifier adapters + Scheduler SDK override; harvest3 wave with a 5-type revert matrix (R74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,8 @@ covers them. If you scope tighter, the calls are:
   `sns:GetTopicAttributes`, `sqs:GetQueueAttributes`, `iam:GetRolePolicy`,
   `iam:GetUserPolicy`, `iam:GetGroupPolicy`, `iam:GetPolicy`, `iam:GetPolicyVersion`,
   `lambda:GetPolicy`, `budgets:ViewBudget`, `ec2:DescribeAddresses`,
-  `route53:ListResourceRecordSets`, `glue:GetTable`, `logs:DescribeMetricFilters`
+  `route53:ListResourceRecordSets`, `glue:GetTable`, `logs:DescribeMetricFilters`,
+  `scheduler:GetSchedule`
 - Optional: `kms:ListAliases` — enables strict verification that a declared
   `alias/aws/*` key was not swapped for a customer-managed key (without it, that
   case is conservatively suppressed)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,11 +75,16 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    types without per-type code; SDK overrides fill only the gaps. _Does CC API's
    coverage + model fidelity hold up across the breadth users will throw at it, or
    does the SDK-override list grow until the "generic" claim breaks?_ **Tracking
-   (as of the R21 pass):** `SDK_OVERRIDES` holds 11 types, all genuine CC-API gaps
-   (`UnsupportedActionException` / `ValidationException` from GetResource), surfaced
-   across 2 real-app dogfoods + 8 integ fixtures. The bet holds while the count grows
-   only a few types per new dogfood; revisit it if a single new stack adds many
-   overrides at once (= the generic claim is breaking).
+   (as of the R74 pass):** `SDK_OVERRIDES` holds 12 types, all genuine CC-API gaps
+   (`UnsupportedActionException` / `ValidationException` from GetResource — plus
+   Scheduler::Schedule, whose CC read handler only finds schedules in the DEFAULT
+   group), surfaced across 2 real-app dogfoods + 10 integ fixtures. The bet holds
+   while the count grows only a few types per new dogfood; revisit it if a single
+   new stack adds many overrides at once (= the generic claim is breaking). A
+   second, smaller gap class is CC IDENTIFIERS: some types' CFn physical id is not
+   the CC primaryIdentifier (AppSync GraphQLApi ARN vs ApiId, Cognito
+   UserPoolClient composite) — `CC_IDENTIFIER_ADAPTERS` in router.ts maps those
+   without leaving the CC read path.
 4. **The deployed template, not synth, is the declared baseline.** So un-deployed
    code edits never masquerade as drift; `--pre-deploy` is the opt-in inversion.
    _Right call, or do users actually expect code-vs-reality by default?_
@@ -182,8 +187,8 @@ checked.
   - **template-adapter.ts** — `loadDesired()`: deployed (or `--pre-deploy` synth) template + phys-ids + params → resolved `DesiredResource[]`. Builds `ResolverContext`.
   - **yaml-cfn.ts** — CFn-flavored YAML/JSON template parser.
 - **read/** — the "reality" side
-  - **router.ts** — `readLive()`: SDK_OVERRIDES first, else CC API GetResource; classifies skip reasons.
-  - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters).
+  - **router.ts** — `readLive()`: SDK_OVERRIDES first, else CC API GetResource (with `CC_IDENTIFIER_ADAPTERS` deriving the CC identifier when the CFn physical id is not it — AppSync GraphQLApi ARN→ApiId, Cognito UserPoolClient `UserPoolId|ClientId`); classifies skip reasons.
+  - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group).
 - **normalize/** — noise subtraction (section 6)
   - **intrinsic-resolver.ts** — fail-closed CFn intrinsic resolver (section 5).
   - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**.

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@aws-sdk/client-lambda": "^3.1065.0",
     "@aws-sdk/client-route-53": "^3.1066.0",
     "@aws-sdk/client-s3": "^3.1065.0",
+    "@aws-sdk/client-scheduler": "^3.1067.0",
     "@aws-sdk/client-sns": "^3.1065.0",
     "@aws-sdk/client-sqs": "^3.1065.0",
     "@clack/prompts": "^1.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1065.0
         version: 3.1066.0
+      '@aws-sdk/client-scheduler':
+        specifier: ^3.1067.0
+        version: 3.1067.0
       '@aws-sdk/client-sns':
         specifier: ^3.1065.0
         version: 3.1066.0
@@ -274,6 +277,10 @@ packages:
 
   '@aws-sdk/client-s3@3.1066.0':
     resolution: {integrity: sha512-jfJTg6Xbyws8+YF5sVQXgCA01elkenGEYeX6+HQOovu9m/Td1Ln2xcY3lHKetVNltdArp5rykjNd56z7bnA9dw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-scheduler@3.1067.0':
+    resolution: {integrity: sha512-Vco2r3jPEjGBcgKqQZ+QDHkZUPhLHDsGszCQ2/HaJ1HfsPx5+y2EaOTFbwQGDZ+veHuy8sf1tZff9Y+aWBKFeQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-secrets-manager@3.1066.0':
@@ -3662,6 +3669,19 @@ snapshots:
       '@aws-sdk/middleware-flexible-checksums': 3.974.30
       '@aws-sdk/middleware-sdk-s3': 3.972.51
       '@aws-sdk/signature-v4-multi-region': 3.996.34
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-scheduler@3.1067.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-node': 3.972.55
       '@aws-sdk/types': 3.973.12
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -12,10 +12,12 @@ import { stripCcApiAwsManagedFields } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
   isAllAwsTags,
+  isEqualUnorderedScalarSet,
   isStringlyEqualScalar,
   isTrivialEmpty,
   KNOWN_DEFAULTS,
   stripAwsTagsDeep,
+  UNORDERED_ARRAY_PROPS,
 } from '../normalize/noise.js';
 import { deepStripPaths } from '../normalize/path-strip.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
@@ -89,6 +91,7 @@ export function classifyResource(
   // NOTE: no `schema.writeOnly.has(k)` guard here — a top-level write-only key was
   // already emitted as a readGap above AND stripped from `declared` by writeOnlyPaths,
   // so it cannot reach this loop (the old guard was dead code for top-level keys).
+  const knownDef = KNOWN_DEFAULTS[resourceType] ?? {};
   for (const [k, v] of Object.entries(declared)) {
     if (v === UNRESOLVED || hasUnresolved(v)) {
       findings.push({ tier: 'unresolved', logicalId, resourceType, path: k });
@@ -113,6 +116,26 @@ export function classifyResource(
       // CFn stringly-typed scalar (Glue Parameters Map<String,String>, "5432" ports):
       // declared `true`/`5432` vs AWS `"true"`/`"5432"` is not drift.
       if (isStringlyEqualScalar(d.stateValue, d.awsValue)) continue;
+      // Per-type unordered scalar-array sets (R74: Cognito UserPoolClient OAuth
+      // flow/scope lists) — same elements in the service's canonical order is
+      // not drift; a genuine element change still differs after sorting.
+      if (
+        UNORDERED_ARRAY_PROPS[resourceType]?.has(d.path) &&
+        isEqualUnorderedScalarSet(d.stateValue, d.awsValue)
+      )
+        continue;
+      // A declared trivially-EMPTY value that the service materializes as its
+      // documented default is not drift (R74: CDK Trail declares EventSelectors
+      // [] and CloudTrail returns the default management selector). Equality-
+      // gated on BOTH sides: the declared side must be empty (a real declared
+      // value mismatch is never muted) and the live side must EQUAL the listed
+      // default (any out-of-band change still surfaces).
+      if (
+        isTrivialEmpty(d.stateValue) &&
+        d.path in knownDef &&
+        deepEqual(d.awsValue, knownDef[d.path])
+      )
+        continue;
       findings.push({
         tier: 'declared',
         logicalId,
@@ -125,7 +148,6 @@ export function classifyResource(
   }
 
   // undeclared (A1/A2/A4 + identity suppression)
-  const knownDef = KNOWN_DEFAULTS[resourceType] ?? {};
   for (const [k, v] of Object.entries(live)) {
     if (k in declared) continue;
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -37,6 +37,21 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Chatbot::SlackChannelConfiguration': {
     GuardrailPolicies: ['arn:aws:iam::aws:policy/AdministratorAccess'],
   },
+  // CloudTrail materializes the default management-events selector when the
+  // template declares EventSelectors [] or omits it (observed live on the
+  // harvest3 fixture, R74 — CDK's Trail construct synthesizes `EventSelectors:
+  // []` by default, so EVERY default CDK trail otherwise reports declared
+  // drift). Also consulted by the declared loop's trivially-empty rule.
+  'AWS::CloudTrail::Trail': {
+    EventSelectors: [
+      {
+        IncludeManagementEvents: true,
+        ReadWriteType: 'All',
+        ExcludeManagementEventSources: [],
+        DataResources: [],
+      },
+    ],
+  },
 };
 
 // Strip AWS-managed (aws:*) tag ELEMENTS from the live side so a declared tag
@@ -161,6 +176,37 @@ export function canonicalizeIdArraysDeep(v: unknown): unknown {
     return out;
   }
   return v;
+}
+
+// Per-type SCALAR-array props AWS treats as UNORDERED SETS but whose elements
+// match none of the content-shape canonicalizers above (not ids/ARNs, not HTTP
+// verbs, no identity field): the service stores a set and echoes it in ITS
+// canonical order, so a positional diff against the template's order is false
+// drift on every check. Entries are added only when OBSERVED live (R74: a fresh
+// Cognito UserPoolClient deploy reported all three as declared drift with
+// identical elements). Consulted by classify's declared loop, equality-gated:
+// the two sides must be the SAME multiset — a genuine element change still
+// reports.
+export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
+  'AWS::Cognito::UserPoolClient': new Set([
+    'AllowedOAuthFlows',
+    'AllowedOAuthScopes',
+    'ExplicitAuthFlows',
+  ]),
+};
+
+// True when both values are scalar arrays containing the same multiset of
+// primitives (order-insensitive equality). Objects/nested arrays never match —
+// those have their own canonicalizers.
+export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  const scalar = (v: unknown): boolean =>
+    typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+  if (!a.every(scalar) || !b.every(scalar)) return false;
+  const sort = (arr: unknown[]): string[] => arr.map((v) => `${typeof v}:${String(v)}`).sort();
+  const sa = sort(a);
+  const sb = sort(b);
+  return sa.every((v, i) => v === sb[i]);
 }
 
 // CFn has many "stringly-typed" fields: Glue Table `Parameters` is a

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -28,6 +28,7 @@ import {
 } from '@aws-sdk/client-iam';
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
 import { GetBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetScheduleCommand, SchedulerClient } from '@aws-sdk/client-scheduler';
 import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { READ_RETRY } from './client-config.js';
@@ -378,6 +379,44 @@ const readMetricFilter: OverrideReader = async ({ physicalId, declared, region }
   };
 };
 
+// AWS::Scheduler::Schedule — Cloud Control CAN read this type, but its
+// primaryIdentifier is the bare Name and the read handler only looks in the
+// DEFAULT schedule group: a schedule in any other group reads as not-found and
+// falsely reports DELETED (proven live on the harvest3 fixture, R74 — Name-only,
+// "group/name", "group|name", and the full ARN were all tried against CC).
+// Read via Scheduler GetSchedule with the declared GroupName instead. The CFn
+// physical id IS the schedule name.
+const readSchedulerSchedule: OverrideReader = async ({ physicalId, declared, region }) => {
+  const name = str(physicalId) ?? str(declared.Name);
+  if (!name) return undefined;
+  const group = str(declared.GroupName); // omitted -> service default group
+  const c = new SchedulerClient({ region, ...READ_RETRY });
+  // Not-found propagates so the router maps a genuinely deleted schedule to `deleted`.
+  const s = await c.send(
+    new GetScheduleCommand({ Name: name, ...(group && { GroupName: group }) })
+  );
+  // Project ONLY CFn-modeled props — Arn/CreationDate/LastModificationDate are
+  // AWS-managed noise the classifier should never see from an SDK reader.
+  return {
+    Name: s.Name,
+    ...(s.GroupName !== undefined && { GroupName: s.GroupName }),
+    ...(s.ScheduleExpression !== undefined && { ScheduleExpression: s.ScheduleExpression }),
+    ...(s.ScheduleExpressionTimezone !== undefined && {
+      ScheduleExpressionTimezone: s.ScheduleExpressionTimezone,
+    }),
+    ...(s.FlexibleTimeWindow !== undefined && { FlexibleTimeWindow: s.FlexibleTimeWindow }),
+    ...(s.State !== undefined && { State: s.State }),
+    ...(s.Description !== undefined && { Description: s.Description }),
+    ...(s.KmsKeyArn !== undefined && { KmsKeyArn: s.KmsKeyArn }),
+    ...(s.ActionAfterCompletion !== undefined && {
+      ActionAfterCompletion: s.ActionAfterCompletion,
+    }),
+    ...(s.StartDate !== undefined && { StartDate: s.StartDate.toISOString() }),
+    ...(s.EndDate !== undefined && { EndDate: s.EndDate.toISOString() }),
+    ...(s.Target !== undefined && { Target: s.Target }),
+  };
+};
+
 export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::S3::BucketPolicy': readS3BucketPolicy,
   'AWS::SNS::TopicPolicy': readSnsTopicPolicy,
@@ -390,4 +429,5 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::Route53::RecordSet': readRoute53RecordSet,
   'AWS::Glue::Table': readGlueTable,
   'AWS::Logs::MetricFilter': readMetricFilter,
+  'AWS::Scheduler::Schedule': readSchedulerSchedule,
 };

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -12,6 +12,27 @@ export interface ReadResult {
   deleted?: boolean; // the resource was deleted out of band (read returned not-found)
 }
 
+// Cloud Control identifier adapters (R74): for most types the CFn physical id IS
+// the CC primaryIdentifier, but not for all — passing the raw physical id then
+// reads as not-found and falsely reports the resource DELETED (found live on the
+// harvest3 fixture). Each adapter derives the CC identifier; returning undefined
+// falls back to the physical id unchanged.
+export const CC_IDENTIFIER_ADAPTERS: Record<
+  string,
+  (physicalId: string, declared: Record<string, unknown>) => string | undefined
+> = {
+  // physical id = the API ARN (arn:...:apis/<apiId>); CC wants the bare ApiId.
+  'AWS::AppSync::GraphQLApi': (pid) => (pid.startsWith('arn:') ? pid.split('/').pop() : pid),
+  // primaryIdentifier is the composite [UserPoolId, ClientId]; the physical id is
+  // only the ClientId. UserPoolId comes from the resolved declared Ref — when it
+  // did not resolve, keep the physical id (CC then reports ValidationException →
+  // an honest skip, same as before).
+  'AWS::Cognito::UserPoolClient': (pid, declared) =>
+    typeof declared.UserPoolId === 'string' && declared.UserPoolId.length > 0
+      ? `${declared.UserPoolId}|${pid}`
+      : undefined,
+};
+
 export async function readLive(
   cc: CloudControlClient,
   resource: DesiredResource,
@@ -37,8 +58,10 @@ export async function readLive(
     }
   }
   try {
+    const identifier =
+      CC_IDENTIFIER_ADAPTERS[resourceType]?.(physicalId ?? '', declared) ?? physicalId ?? '';
     const g = await cc.send(
-      new GetResourceCommand({ TypeName: resourceType, Identifier: physicalId ?? '' })
+      new GetResourceCommand({ TypeName: resourceType, Identifier: identifier })
     );
     return { live: JSON.parse(g.ResourceDescription?.Properties ?? '{}') };
   } catch (e) {

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -250,7 +250,7 @@ describe('classifyResource post-revert phantom drift (R46)', () => {
     ).toEqual(['VersioningConfiguration']);
   });
 
-  it('DECLARED Enabled vs live Suspended stays declared drift (KNOWN_DEFAULTS never touches the declared loop)', () => {
+  it('DECLARED Enabled vs live Suspended stays declared drift (KNOWN_DEFAULTS never mutes a non-empty declared value)', () => {
     const findings = classifyResource(
       res('AWS::S3::Bucket', { VersioningConfiguration: { Status: 'Enabled' } }),
       { VersioningConfiguration: { Status: 'Suspended' } },
@@ -379,5 +379,109 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
         )
       ).undeclared
     ).toEqual(['GuardrailPolicies']);
+  });
+
+  // R74: the declared loop's trivially-empty rule — CDK Trail synthesizes
+  // `EventSelectors: []`, CloudTrail materializes the default management
+  // selector; that pair must not be drift, but everything around it must stay.
+  describe('declared trivially-empty vs known service default (R74)', () => {
+    const DEFAULT_SELECTOR = {
+      IncludeManagementEvents: true,
+      ReadWriteType: 'All',
+      ExcludeManagementEventSources: [],
+      DataResources: [],
+    };
+    const trail = (declared: Record<string, unknown>): DesiredResource => ({
+      logicalId: 'Audit',
+      resourceType: 'AWS::CloudTrail::Trail',
+      physicalId: 'trail-name',
+      declared,
+    });
+
+    it('declared [] vs the live default selector is NOT drift', () => {
+      const findings = classifyResource(
+        trail({ EventSelectors: [] }),
+        { EventSelectors: [structuredClone(DEFAULT_SELECTOR)] },
+        emptySchema
+      );
+      expect(findings).toEqual([]);
+    });
+
+    it('declared [] vs a MODIFIED selector is still declared drift (equality gate)', () => {
+      const findings = classifyResource(
+        trail({ EventSelectors: [] }),
+        { EventSelectors: [{ ...structuredClone(DEFAULT_SELECTOR), ReadWriteType: 'ReadOnly' }] },
+        emptySchema
+      );
+      expect(tiers(findings).declared).toEqual(['EventSelectors']);
+    });
+
+    it('a NON-empty declared value differing from live is never muted by the rule', () => {
+      const findings = classifyResource(
+        trail({ EventSelectors: [{ ReadWriteType: 'ReadOnly', IncludeManagementEvents: true }] }),
+        { EventSelectors: [structuredClone(DEFAULT_SELECTOR)] },
+        emptySchema
+      );
+      expect(tiers(findings).declared).toEqual(['EventSelectors.0.ReadWriteType']);
+    });
+
+    it('UNORDERED_ARRAY_PROPS: same OAuth enum set in a different order is NOT drift', () => {
+      const client = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'WebClient',
+        resourceType: 'AWS::Cognito::UserPoolClient',
+        physicalId: 'client123',
+        declared,
+      });
+      expect(
+        classifyResource(
+          client({ ExplicitAuthFlows: ['ALLOW_USER_SRP_AUTH', 'ALLOW_REFRESH_TOKEN_AUTH'] }),
+          { ExplicitAuthFlows: ['ALLOW_REFRESH_TOKEN_AUTH', 'ALLOW_USER_SRP_AUTH'] },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine element change still reports
+      expect(
+        tiers(
+          classifyResource(
+            client({ ExplicitAuthFlows: ['ALLOW_USER_SRP_AUTH', 'ALLOW_REFRESH_TOKEN_AUTH'] }),
+            { ExplicitAuthFlows: ['ALLOW_ADMIN_USER_PASSWORD_AUTH', 'ALLOW_USER_SRP_AUTH'] },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['ExplicitAuthFlows']);
+      // the rule is per-type+per-prop: the same shape on an UNLISTED prop still reports
+      expect(
+        tiers(
+          classifyResource(
+            client({ CallbackURLs: ['https://b.example', 'https://a.example'] }),
+            { CallbackURLs: ['https://a.example', 'https://b.example'] },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['CallbackURLs']);
+    });
+
+    it('undeclared EventSelectors equal to the default is suppressed; a changed one surfaces', () => {
+      expect(
+        classifyResource(
+          trail({}),
+          { EventSelectors: [structuredClone(DEFAULT_SELECTOR)] },
+          emptySchema
+        )
+      ).toEqual([]);
+      expect(
+        tiers(
+          classifyResource(
+            trail({}),
+            {
+              EventSelectors: [
+                { ...structuredClone(DEFAULT_SELECTOR), ReadWriteType: 'WriteOnly' },
+              ],
+            },
+            emptySchema
+          )
+        ).undeclared
+      ).toEqual(['EventSelectors']);
+    });
   });
 });

--- a/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
@@ -1,0 +1,122 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::AppSync::GraphQLApi model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Graph",
+    "resourceType": "AWS::AppSync::GraphQLApi",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+    "constructPath": "CdkrdIntegHarvest3/Graph",
+    "declared": {
+      "AuthenticationType": "API_KEY",
+      "Name": "cdkrd-harvest3"
+    }
+  },
+  "liveRaw": {
+    "QueryDepthLimit": 0,
+    "IntrospectionConfig": "ENABLED",
+    "RealtimeDns": "ykqwe6k7g5hcfabiuoypeum55u.appsync-realtime-api.us-east-1.amazonaws.com",
+    "ResolverCountLimit": 0,
+    "Name": "cdkrd-harvest3",
+    "RealtimeUrl": "wss://ykqwe6k7g5hcfabiuoypeum55u.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+    "EnvironmentVariables": {},
+    "GraphQLUrl": "https://ykqwe6k7g5hcfabiuoypeum55u.appsync-api.us-east-1.amazonaws.com/graphql",
+    "GraphQLDns": "ykqwe6k7g5hcfabiuoypeum55u.appsync-api.us-east-1.amazonaws.com",
+    "ApiType": "GRAPHQL",
+    "XrayEnabled": false,
+    "Visibility": "GLOBAL",
+    "Arn": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+    "ApiId": "bb3dolsy4jf4vgdelqzpaojuqq",
+    "Tags": [],
+    "AuthenticationType": "API_KEY",
+    "GraphQLEndpointArn": "arn:aws:appsync:us-east-1:111111111111:endpoints/graphql-api/ykqwe6k7g5hcfabiuoypeum55u"
+  },
+  "schema": {
+    "readOnly": [
+      "ApiId",
+      "Arn",
+      "GraphQLDns",
+      "GraphQLEndpointArn",
+      "GraphQLUrl",
+      "RealtimeDns",
+      "RealtimeUrl"
+    ],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "ApiId",
+      "Arn",
+      "GraphQLDns",
+      "GraphQLEndpointArn",
+      "GraphQLUrl",
+      "RealtimeDns",
+      "RealtimeUrl"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "LambdaAuthorizerConfig.AuthorizerResultTtlInSeconds",
+      "LambdaAuthorizerConfig.AuthorizerUri",
+      "LambdaAuthorizerConfig.IdentityValidationExpression",
+      "OpenIDConnectConfig.AuthTTL",
+      "OpenIDConnectConfig.ClientId",
+      "OpenIDConnectConfig.IatTTL",
+      "OpenIDConnectConfig.Issuer",
+      "UserPoolConfig.AppIdClientRegex",
+      "UserPoolConfig.AwsRegion",
+      "UserPoolConfig.DefaultAction",
+      "UserPoolConfig.UserPoolId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Graph",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "QueryDepthLimit",
+      "actual": 0,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+      "constructPath": "CdkrdIntegHarvest3/Graph"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Graph",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "IntrospectionConfig",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+      "constructPath": "CdkrdIntegHarvest3/Graph"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Graph",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "ResolverCountLimit",
+      "actual": 0,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+      "constructPath": "CdkrdIntegHarvest3/Graph"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Graph",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "ApiType",
+      "actual": "GRAPHQL",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+      "constructPath": "CdkrdIntegHarvest3/Graph"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Graph",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "Visibility",
+      "actual": "GLOBAL",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+      "constructPath": "CdkrdIntegHarvest3/Graph"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Backup__BackupPlan.PlanDAF4E53A.json
+++ b/tests/corpus/AWS__Backup__BackupPlan.PlanDAF4E53A.json
@@ -1,0 +1,72 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Backup::BackupPlan model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "PlanDAF4E53A",
+    "resourceType": "AWS::Backup::BackupPlan",
+    "physicalId": "4e662c50-8d81-4e43-b41d-703cacbe0e34",
+    "constructPath": "CdkrdIntegHarvest3/Plan",
+    "declared": {
+      "BackupPlan": {
+        "BackupPlanName": "Plan",
+        "BackupPlanRule": [
+          {
+            "Lifecycle": {
+              "DeleteAfterDays": 35
+            },
+            "RuleName": "Daily",
+            "ScheduleExpression": "cron(0 5 * * ? *)",
+            "TargetBackupVault": "CdkrdIntegHarvest3Vault1B103709"
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "VersionId": "Mjk0MGIyZWYtZDdmZi00MzQwLTk5OGItODY1ZDA4NmYwNTcz",
+    "BackupPlan": {
+      "BackupPlanName": "Plan",
+      "ScanSettings": [],
+      "AdvancedBackupSettings": [],
+      "BackupPlanRule": [
+        {
+          "CompletionWindowMinutes": 10080,
+          "ScheduleExpression": "cron(0 5 * * ? *)",
+          "RecoveryPointTags": {},
+          "CopyActions": [],
+          "ScanActions": [],
+          "Lifecycle": {
+            "DeleteAfterDays": 35
+          },
+          "IndexActions": [],
+          "TargetBackupVault": "CdkrdIntegHarvest3Vault1B103709",
+          "StartWindowMinutes": 480,
+          "ScheduleExpressionTimezone": "Etc/UTC",
+          "RuleName": "Daily"
+        }
+      ]
+    },
+    "BackupPlanId": "4e662c50-8d81-4e43-b41d-703cacbe0e34",
+    "BackupPlanTags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest3",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+      "aws:cloudformation:logical-id": "PlanDAF4E53A"
+    },
+    "BackupPlanArn": "arn:aws:backup:us-east-1:111111111111:backup-plan:4e662c50-8d81-4e43-b41d-703cacbe0e34"
+  },
+  "schema": {
+    "readOnly": ["BackupPlanArn", "BackupPlanId", "VersionId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["BackupPlanArn", "BackupPlanId", "VersionId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Backup__BackupVault.Vault23237E5B.json
+++ b/tests/corpus/AWS__Backup__BackupVault.Vault23237E5B.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Backup::BackupVault model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Vault23237E5B",
+    "resourceType": "AWS::Backup::BackupVault",
+    "physicalId": "CdkrdIntegHarvest3Vault1B103709",
+    "constructPath": "CdkrdIntegHarvest3/Vault",
+    "declared": {
+      "BackupVaultName": "CdkrdIntegHarvest3Vault1B103709"
+    }
+  },
+  "liveRaw": {
+    "BackupVaultTags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest3",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+      "aws:cloudformation:logical-id": "Vault23237E5B"
+    },
+    "BackupVaultName": "CdkrdIntegHarvest3Vault1B103709",
+    "BackupVaultArn": "arn:aws:backup:us-east-1:111111111111:backup-vault:CdkrdIntegHarvest3Vault1B103709",
+    "EncryptionKeyArn": "arn:aws:kms:us-east-1:111111111111:key/b405e2ab-23b0-48e9-834e-aa3aeeded51d"
+  },
+  "schema": {
+    "readOnly": ["BackupVaultArn"],
+    "writeOnly": [],
+    "createOnly": ["BackupVaultName", "EncryptionKeyArn"],
+    "readOnlyPaths": ["BackupVaultArn"],
+    "writeOnlyPaths": ["LockConfiguration.ChangeableForDays"],
+    "createOnlyPaths": ["BackupVaultName", "EncryptionKeyArn"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Vault23237E5B",
+      "resourceType": "AWS::Backup::BackupVault",
+      "path": "EncryptionKeyArn",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "physicalId": "CdkrdIntegHarvest3Vault1B103709",
+      "constructPath": "CdkrdIntegHarvest3/Vault"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudTrail__Trail.Audit3D8ADE0A.json
+++ b/tests/corpus/AWS__CloudTrail__Trail.Audit3D8ADE0A.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::CloudTrail::Trail model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Audit3D8ADE0A",
+    "resourceType": "AWS::CloudTrail::Trail",
+    "physicalId": "CdkrdIntegHarvest3-Audit3D8ADE0A-CfTL0QAII0QB",
+    "constructPath": "CdkrdIntegHarvest3/Audit",
+    "declared": {
+      "EnableLogFileValidation": true,
+      "EventSelectors": [],
+      "IncludeGlobalServiceEvents": false,
+      "IsLogging": true,
+      "IsMultiRegionTrail": false,
+      "S3BucketName": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte"
+    }
+  },
+  "liveRaw": {
+    "IncludeGlobalServiceEvents": false,
+    "EventSelectors": [
+      {
+        "IncludeManagementEvents": true,
+        "ReadWriteType": "All",
+        "ExcludeManagementEventSources": [],
+        "DataResources": []
+      }
+    ],
+    "AggregationConfigurations": [],
+    "AdvancedEventSelectors": [],
+    "TrailName": "CdkrdIntegHarvest3-Audit3D8ADE0A-CfTL0QAII0QB",
+    "IsOrganizationTrail": false,
+    "InsightSelectors": [],
+    "IsMultiRegionTrail": false,
+    "S3BucketName": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+    "EnableLogFileValidation": true,
+    "Arn": "arn:aws:cloudtrail:us-east-1:111111111111:trail/CdkrdIntegHarvest3-Audit3D8ADE0A-CfTL0QAII0QB",
+    "Tags": [],
+    "IsLogging": true
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnsTopicArn"],
+    "writeOnly": [],
+    "createOnly": ["TrailName"],
+    "readOnlyPaths": ["Arn", "SnsTopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TrailName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -1,0 +1,612 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Cognito::UserPool model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Users0A0EEA89",
+    "resourceType": "AWS::Cognito::UserPool",
+    "physicalId": "us-east-1_Ifea0bzss",
+    "constructPath": "CdkrdIntegHarvest3/Users",
+    "declared": {
+      "AccountRecoverySetting": {
+        "RecoveryMechanisms": [
+          {
+            "Name": "verified_email",
+            "Priority": 1
+          }
+        ]
+      },
+      "AdminCreateUserConfig": {
+        "AllowAdminCreateUserOnly": true
+      },
+      "EmailVerificationMessage": "The verification code to your new account is {####}",
+      "EmailVerificationSubject": "Verify your new account",
+      "Policies": {
+        "PasswordPolicy": {
+          "MinimumLength": 12,
+          "RequireNumbers": true,
+          "RequireSymbols": true,
+          "TemporaryPasswordValidityDays": 3
+        }
+      },
+      "SmsVerificationMessage": "The verification code to your new account is {####}",
+      "VerificationMessageTemplate": {
+        "DefaultEmailOption": "CONFIRM_WITH_CODE",
+        "EmailMessage": "The verification code to your new account is {####}",
+        "EmailSubject": "Verify your new account",
+        "SmsMessage": "The verification code to your new account is {####}"
+      }
+    }
+  },
+  "liveRaw": {
+    "UserPoolTags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest3",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+      "aws:cloudformation:logical-id": "Users0A0EEA89"
+    },
+    "Policies": {
+      "PasswordPolicy": {
+        "RequireNumbers": true,
+        "MinimumLength": 12,
+        "TemporaryPasswordValidityDays": 3,
+        "RequireUppercase": false,
+        "RequireLowercase": false,
+        "RequireSymbols": true
+      },
+      "SignInPolicy": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      }
+    },
+    "VerificationMessageTemplate": {
+      "EmailMessage": "The verification code to your new account is {####}",
+      "SmsMessage": "The verification code to your new account is {####}",
+      "EmailSubject": "Verify your new account",
+      "DefaultEmailOption": "CONFIRM_WITH_CODE"
+    },
+    "ProviderURL": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_Ifea0bzss",
+    "MfaConfiguration": "OFF",
+    "Schema": [
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "profile"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "address"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "10",
+          "MaxLength": "10"
+        },
+        "Required": false,
+        "Name": "birthdate"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "gender"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "preferred_username"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Number",
+        "Required": false,
+        "NumberAttributeConstraints": {
+          "MinValue": "0"
+        },
+        "Name": "updated_at"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "website"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "picture"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {},
+        "Required": false,
+        "Name": "identities"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": false,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "1",
+          "MaxLength": "2048"
+        },
+        "Required": true,
+        "Name": "sub"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "phone_number"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "phone_number_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "zoneinfo"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "locale"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "email"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "email_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "given_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "family_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "middle_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "nickname"
+      }
+    ],
+    "AdminCreateUserConfig": {
+      "UnusedAccountValidityDays": 3,
+      "AllowAdminCreateUserOnly": true
+    },
+    "UserPoolTier": "ESSENTIALS",
+    "DeletionProtection": "INACTIVE",
+    "UserPoolName": "Users0A0EEA89-RYUoEBfJwQHo",
+    "SmsVerificationMessage": "The verification code to your new account is {####}",
+    "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_Ifea0bzss",
+    "UserPoolId": "us-east-1_Ifea0bzss",
+    "UserAttributeUpdateSettings": {
+      "AttributesRequireVerificationBeforeUpdate": []
+    },
+    "EmailConfiguration": {
+      "EmailSendingAccount": "COGNITO_DEFAULT"
+    },
+    "AliasAttributes": [],
+    "EmailVerificationSubject": "Verify your new account",
+    "LambdaConfig": {},
+    "Arn": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_Ifea0bzss",
+    "UsernameAttributes": [],
+    "AutoVerifiedAttributes": [],
+    "EmailVerificationMessage": "The verification code to your new account is {####}",
+    "AccountRecoverySetting": {
+      "RecoveryMechanisms": [
+        {
+          "Priority": 1,
+          "Name": "verified_email"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnly": ["EnabledMfas"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnlyPaths": ["EnabledMfas"],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema",
+      "actual": [
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "profile"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "address"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "10",
+            "MaxLength": "10"
+          },
+          "Required": false,
+          "Name": "birthdate"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "gender"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "preferred_username"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Number",
+          "Required": false,
+          "NumberAttributeConstraints": {
+            "MinValue": "0"
+          },
+          "Name": "updated_at"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "website"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "picture"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {},
+          "Required": false,
+          "Name": "identities"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": false,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "1",
+            "MaxLength": "2048"
+          },
+          "Required": true,
+          "Name": "sub"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "phone_number"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "phone_number_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "zoneinfo"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "locale"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "email"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "email_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "given_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "family_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "middle_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "nickname"
+        }
+      ],
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolName",
+      "actual": "Users0A0EEA89-RYUoEBfJwQHo",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Cognito::UserPoolClient model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "WebClient697086FD",
+    "resourceType": "AWS::Cognito::UserPoolClient",
+    "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
+    "constructPath": "CdkrdIntegHarvest3/WebClient",
+    "declared": {
+      "AllowedOAuthFlows": ["implicit", "code"],
+      "AllowedOAuthFlowsUserPoolClient": true,
+      "AllowedOAuthScopes": [
+        "profile",
+        "phone",
+        "email",
+        "openid",
+        "aws.cognito.signin.user.admin"
+      ],
+      "CallbackURLs": ["https://example.com"],
+      "ExplicitAuthFlows": ["ALLOW_USER_SRP_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+      "GenerateSecret": false,
+      "SupportedIdentityProviders": ["COGNITO"],
+      "UserPoolId": "us-east-1_Ifea0bzss"
+    }
+  },
+  "liveRaw": {
+    "GenerateSecret": false,
+    "CallbackURLs": ["https://example.com"],
+    "EnablePropagateAdditionalUserContextData": false,
+    "AuthSessionValidity": 3,
+    "AllowedOAuthScopes": ["aws.cognito.signin.user.admin", "email", "openid", "phone", "profile"],
+    "TokenValidityUnits": {},
+    "ReadAttributes": [],
+    "AllowedOAuthFlowsUserPoolClient": true,
+    "SupportedIdentityProviders": ["COGNITO"],
+    "Name": "WebClient697086FD-4XOyobXvYCtB",
+    "ClientName": "WebClient697086FD-4XOyobXvYCtB",
+    "UserPoolId": "us-east-1_Ifea0bzss",
+    "AllowedOAuthFlows": ["code", "implicit"],
+    "ExplicitAuthFlows": ["ALLOW_REFRESH_TOKEN_AUTH", "ALLOW_USER_SRP_AUTH"],
+    "LogoutURLs": [],
+    "ClientId": "7d78lu0gfopub8hldk8ogl5asn",
+    "RefreshTokenValidity": 30,
+    "WriteAttributes": [],
+    "EnableTokenRevocation": true
+  },
+  "schema": {
+    "readOnly": ["ClientId", "ClientSecret", "Name"],
+    "writeOnly": [],
+    "createOnly": ["GenerateSecret", "UserPoolId"],
+    "readOnlyPaths": ["ClientId", "ClientSecret", "Name"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GenerateSecret", "UserPoolId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WebClient697086FD",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "AuthSessionValidity",
+      "actual": 3,
+      "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
+      "constructPath": "CdkrdIntegHarvest3/WebClient"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WebClient697086FD",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "ClientName",
+      "actual": "WebClient697086FD-4XOyobXvYCtB",
+      "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
+      "constructPath": "CdkrdIntegHarvest3/WebClient"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WebClient697086FD",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "RefreshTokenValidity",
+      "actual": 30,
+      "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
+      "constructPath": "CdkrdIntegHarvest3/WebClient"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WebClient697086FD",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnableTokenRevocation",
+      "actual": true,
+      "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
+      "constructPath": "CdkrdIntegHarvest3/WebClient"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.drifted.json
+++ b/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.drifted.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 revert matrix, R74): AWS::Events::Rule after an OUT-OF-BAND mutation of a declared value — the declared finding in `expected` is the drift the matrix detects and reverts via Cloud Control. A change here means declared-drift semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixRuleF1E32BBB",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+    "constructPath": "CdkrdIntegHarvest3/MatrixRule",
+    "declared": {
+      "ScheduleExpression": "rate(1 hour)",
+      "State": "ENABLED"
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "ScheduleExpression": "rate(1 hour)",
+    "State": "DISABLED",
+    "Targets": [],
+    "Id": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MatrixRuleF1E32BBB",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "MatrixRuleF1E32BBB",
+      "resourceType": "AWS::Events::Rule",
+      "path": "State",
+      "desired": "ENABLED",
+      "actual": "DISABLED",
+      "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+      "constructPath": "CdkrdIntegHarvest3/MatrixRule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.json
+++ b/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Events::Rule model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixRuleF1E32BBB",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+    "constructPath": "CdkrdIntegHarvest3/MatrixRule",
+    "declared": {
+      "ScheduleExpression": "rate(1 hour)",
+      "State": "ENABLED"
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "ScheduleExpression": "rate(1 hour)",
+    "State": "ENABLED",
+    "Targets": [],
+    "Id": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MatrixRuleF1E32BBB",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Policy.FirehoseRoleDefaultPolicyF034DFF7.json
+++ b/tests/corpus/AWS__IAM__Policy.FirehoseRoleDefaultPolicyF034DFF7.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::IAM::Policy model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FirehoseRoleDefaultPolicyF034DFF7",
+    "resourceType": "AWS::IAM::Policy",
+    "physicalId": "Cdkrd-Fireh-UJiJLhYiaMMu",
+    "constructPath": "CdkrdIntegHarvest3/FirehoseRole/DefaultPolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": [
+              "s3:GetObject*",
+              "s3:GetBucket*",
+              "s3:List*",
+              "s3:DeleteObject*",
+              "s3:PutObject",
+              "s3:PutObjectLegalHold",
+              "s3:PutObjectRetention",
+              "s3:PutObjectTagging",
+              "s3:PutObjectVersionTagging",
+              "s3:Abort*"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+              "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+              "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy/*"
+            ]
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "PolicyName": "FirehoseRoleDefaultPolicyF034DFF7",
+      "Roles": ["CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY"]
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "FirehoseRoleDefaultPolicyF034DFF7",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "s3:GetObject*",
+            "s3:GetBucket*",
+            "s3:List*",
+            "s3:DeleteObject*",
+            "s3:PutObject",
+            "s3:PutObjectLegalHold",
+            "s3:PutObjectRetention",
+            "s3:PutObjectTagging",
+            "s3:PutObjectVersionTagging",
+            "s3:Abort*"
+          ],
+          "Resource": [
+            "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+            "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy/*"
+          ],
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Roles": ["CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY"]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Policy.SchedRoleDefaultPolicy49B7B02E.json
+++ b/tests/corpus/AWS__IAM__Policy.SchedRoleDefaultPolicy49B7B02E.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::IAM::Policy model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "SchedRoleDefaultPolicy49B7B02E",
+    "resourceType": "AWS::IAM::Policy",
+    "physicalId": "Cdkrd-Sched-JT0mG3cH8UEb",
+    "constructPath": "CdkrdIntegHarvest3/SchedRole/DefaultPolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "PolicyName": "SchedRoleDefaultPolicy49B7B02E",
+      "Roles": ["CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx"]
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "SchedRoleDefaultPolicy49B7B02E",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sns:Publish",
+          "Resource": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Roles": ["CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx"]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.FirehoseRoleAA67C190.json
+++ b/tests/corpus/AWS__IAM__Role.FirehoseRoleAA67C190.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FirehoseRoleAA67C190",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+    "constructPath": "CdkrdIntegHarvest3/FirehoseRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "firehose.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    },
+    "siblingPolicyNames": ["FirehoseRoleDefaultPolicyF034DFF7"]
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+    "Description": "",
+    "Policies": [
+      {
+        "PolicyName": "FirehoseRoleDefaultPolicyF034DFF7",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*"
+              ],
+              "Resource": [
+                "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+                "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy/*"
+              ],
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    ],
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "firehose.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+    "RoleId": "AROAXXXJN2LN5FIP7UKJ4"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.MatrixFnServiceRoleF6E55B32.json
+++ b/tests/corpus/AWS__IAM__Role.MatrixFnServiceRoleF6E55B32.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixFnServiceRoleF6E55B32",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+    "constructPath": "CdkrdIntegHarvest3/MatrixFn/ServiceRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+    "RoleId": "AROAXXXJN2LNUD7PGSLJL"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.SchedRole812B2F5C.json
+++ b/tests/corpus/AWS__IAM__Role.SchedRole812B2F5C.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "SchedRole812B2F5C",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+    "constructPath": "CdkrdIntegHarvest3/SchedRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "scheduler.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    },
+    "siblingPolicyNames": ["SchedRoleDefaultPolicy49B7B02E"]
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+    "Description": "",
+    "Policies": [
+      {
+        "PolicyName": "SchedRoleDefaultPolicy49B7B02E",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sns:Publish",
+              "Resource": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    ],
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "scheduler.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+    "RoleId": "AROAXXXJN2LN6X7LGIQU6"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__KMS__Alias.DataKeyAliasD4424CA2.json
+++ b/tests/corpus/AWS__KMS__Alias.DataKeyAliasD4424CA2.json
@@ -1,0 +1,33 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::KMS::Alias model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "DataKeyAliasD4424CA2",
+    "resourceType": "AWS::KMS::Alias",
+    "physicalId": "alias/cdkrd-harvest3",
+    "constructPath": "CdkrdIntegHarvest3/DataKeyAlias",
+    "declared": {
+      "AliasName": "alias/cdkrd-harvest3",
+      "TargetKeyId": "arn:aws:kms:us-east-1:111111111111:key/f989c1f9-fd8b-4a78-a71d-a69a1e096af1"
+    }
+  },
+  "liveRaw": {
+    "TargetKeyId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+    "AliasName": "alias/cdkrd-harvest3"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["AliasName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AliasName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
+++ b/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::KMS::Key model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "DataKey17AFBB84",
+    "resourceType": "AWS::KMS::Key",
+    "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+    "constructPath": "CdkrdIntegHarvest3/DataKey",
+    "declared": {
+      "Description": "cdkrd harvest3 data key",
+      "EnableKeyRotation": true,
+      "KeyPolicy": {
+        "Statement": [
+          {
+            "Action": "kms:*",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Resource": "*"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "PendingWindowInDays": 7
+    }
+  },
+  "liveRaw": {
+    "Origin": "AWS_KMS",
+    "MultiRegion": false,
+    "Description": "cdkrd harvest3 data key",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          }
+        }
+      ]
+    },
+    "KeySpec": "SYMMETRIC_DEFAULT",
+    "Enabled": true,
+    "EnableKeyRotation": true,
+    "KeyUsage": "ENCRYPT_DECRYPT",
+    "KeyId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck", "PendingWindowInDays", "RotationPeriodInDays"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "PendingWindowInDays",
+      "RotationPeriodInDays"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "PendingWindowInDays",
+      "note": "write-only — cannot be read back",
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Tap.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Tap.json
@@ -1,0 +1,154 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::KinesisFirehose::DeliveryStream model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Tap",
+    "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+    "physicalId": "CdkrdIntegHarvest3-Tap-tX2SzyWziKT4",
+    "constructPath": "CdkrdIntegHarvest3/Tap",
+    "declared": {
+      "DeliveryStreamType": "DirectPut",
+      "S3DestinationConfiguration": {
+        "BucketARN": "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+        "BufferingHints": {
+          "IntervalInSeconds": 300,
+          "SizeInMBs": 5
+        },
+        "CompressionFormat": "GZIP",
+        "RoleARN": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY"
+      }
+    }
+  },
+  "liveRaw": {
+    "DeliveryStreamType": "DirectPut",
+    "DeliveryStreamName": "CdkrdIntegHarvest3-Tap-tX2SzyWziKT4",
+    "Arn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/CdkrdIntegHarvest3-Tap-tX2SzyWziKT4",
+    "ExtendedS3DestinationConfiguration": {
+      "BucketARN": "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+      "BufferingHints": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "CompressionFormat": "GZIP",
+      "EncryptionConfiguration": {
+        "NoEncryptionConfig": "NoEncryption"
+      },
+      "CloudWatchLoggingOptions": {
+        "Enabled": false
+      },
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+      "S3BackupMode": "Disabled"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "ElasticsearchDestinationConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration"
+    ],
+    "createOnly": [
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration"
+    ],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "DirectPutSourceConfiguration.ThroughputHintInMBs",
+      "ElasticsearchDestinationConfiguration",
+      "ElasticsearchDestinationConfiguration.CloudWatchLoggingOptions.Enabled",
+      "ExtendedS3DestinationConfiguration.CustomTimeZone",
+      "ExtendedS3DestinationConfiguration.FileExtension",
+      "HttpEndpointDestinationConfiguration.EndpointConfiguration.AccessKey",
+      "HttpEndpointDestinationConfiguration.ProcessingConfiguration",
+      "HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "HttpEndpointDestinationConfiguration.SecretsManagerConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "RedshiftDestinationConfiguration.Password",
+      "RedshiftDestinationConfiguration.ProcessingConfiguration",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3Configuration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.Enabled",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.RoleARN",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.SecretARN",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration",
+      "SplunkDestinationConfiguration.BufferingHints",
+      "SplunkDestinationConfiguration.CloudWatchLoggingOptions",
+      "SplunkDestinationConfiguration.ProcessingConfiguration",
+      "SplunkDestinationConfiguration.S3Configuration.EncryptionConfiguration.NoEncryptionConfig",
+      "SplunkDestinationConfiguration.SecretsManagerConfiguration"
+    ],
+    "createOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration.VpcConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration.VpcConfiguration",
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "ElasticsearchDestinationConfiguration.VpcConfiguration",
+      "IcebergDestinationConfiguration.CatalogConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Tap",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "S3DestinationConfiguration",
+      "note": "write-only — cannot be read back",
+      "physicalId": "CdkrdIntegHarvest3-Tap-tX2SzyWziKT4",
+      "constructPath": "CdkrdIntegHarvest3/Tap"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Tap",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "ExtendedS3DestinationConfiguration",
+      "actual": {
+        "BucketARN": "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+        "BufferingHints": {
+          "IntervalInSeconds": 300,
+          "SizeInMBs": 5
+        },
+        "CompressionFormat": "GZIP",
+        "EncryptionConfiguration": {
+          "NoEncryptionConfig": "NoEncryption"
+        },
+        "CloudWatchLoggingOptions": {
+          "Enabled": false
+        },
+        "RoleARN": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+        "S3BackupMode": "Disabled"
+      },
+      "physicalId": "CdkrdIntegHarvest3-Tap-tX2SzyWziKT4",
+      "constructPath": "CdkrdIntegHarvest3/Tap"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
@@ -1,0 +1,119 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 revert matrix, R74): AWS::Lambda::Function after an OUT-OF-BAND mutation of a declared value — the declared finding in `expected` is the drift the matrix detects and reverts via Cloud Control. A change here means declared-drift semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixFn0598BE1E",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+    "constructPath": "CdkrdIntegHarvest3/MatrixFn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => 'harvest3';"
+      },
+      "Handler": "index.handler",
+      "MemorySize": 256,
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+      "Runtime": "nodejs20.x",
+      "Timeout": 10
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 512,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 10,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "MatrixFn0598BE1E",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "desired": 256,
+      "actual": 512,
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT"
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
@@ -1,0 +1,114 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Lambda::Function model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixFn0598BE1E",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+    "constructPath": "CdkrdIntegHarvest3/MatrixFn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => 'harvest3';"
+      },
+      "Handler": "index.handler",
+      "MemorySize": 256,
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+      "Runtime": "nodejs20.x",
+      "Timeout": 10
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 256,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "VpcConfig": {
+      "Ipv6AllowedForDualStack": false,
+      "SecurityGroupIds": [],
+      "SubnetIds": []
+    },
+    "Timeout": 10,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "MatrixFn0598BE1E",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT"
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.drifted.json
+++ b/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.drifted.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 revert matrix, R74): AWS::Logs::LogGroup after an OUT-OF-BAND mutation of a declared value — the declared finding in `expected` is the drift the matrix detects and reverts via Cloud Control. A change here means declared-drift semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixLogsDDD521D9",
+    "resourceType": "AWS::Logs::LogGroup",
+    "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+    "constructPath": "CdkrdIntegHarvest3/MatrixLogs",
+    "declared": {
+      "RetentionInDays": 7
+    }
+  },
+  "liveRaw": {
+    "FieldIndexPolicies": [],
+    "RetentionInDays": 30,
+    "BearerTokenAuthenticationEnabled": false,
+    "LogGroupClass": "STANDARD",
+    "LogGroupName": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J:*",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "MatrixLogsDDD521D9",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "DataProtectionPolicy": {}
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName"],
+    "defaults": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "RetentionInDays",
+      "desired": 7,
+      "actual": 30,
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.json
+++ b/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Logs::LogGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixLogsDDD521D9",
+    "resourceType": "AWS::Logs::LogGroup",
+    "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+    "constructPath": "CdkrdIntegHarvest3/MatrixLogs",
+    "declared": {
+      "RetentionInDays": 7
+    }
+  },
+  "liveRaw": {
+    "FieldIndexPolicies": [],
+    "RetentionInDays": 7,
+    "BearerTokenAuthenticationEnabled": false,
+    "LogGroupClass": "STANDARD",
+    "LogGroupName": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J:*",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "MatrixLogsDDD521D9",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "DataProtectionPolicy": {}
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName"],
+    "defaults": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__Bucket.AuditLogsB945E340.json
+++ b/tests/corpus/AWS__S3__Bucket.AuditLogsB945E340.json
@@ -1,0 +1,153 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::S3::Bucket model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AuditLogsB945E340",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+    "constructPath": "CdkrdIntegHarvest3/AuditLogs",
+    "declared": {
+      "PublicAccessBlockConfiguration": {
+        "BlockPublicAcls": true,
+        "BlockPublicPolicy": true,
+        "IgnorePublicAcls": true,
+        "RestrictPublicBuckets": true
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+    "RegionalDomainName": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AuditLogsB945E340",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "AuditLogsB945E340",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+      "constructPath": "CdkrdIntegHarvest3/AuditLogs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AuditLogsB945E340",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+      "constructPath": "CdkrdIntegHarvest3/AuditLogs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.FirehoseSinkB757FE18.json
+++ b/tests/corpus/AWS__S3__Bucket.FirehoseSinkB757FE18.json
@@ -1,0 +1,153 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::S3::Bucket model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FirehoseSinkB757FE18",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+    "constructPath": "CdkrdIntegHarvest3/FirehoseSink",
+    "declared": {
+      "PublicAccessBlockConfiguration": {
+        "BlockPublicAcls": true,
+        "BlockPublicPolicy": true,
+        "IgnorePublicAcls": true,
+        "RestrictPublicBuckets": true
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+    "RegionalDomainName": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "FirehoseSinkB757FE18",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FirehoseSinkB757FE18",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseSink"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "FirehoseSinkB757FE18",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseSink"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.AuditLogsPolicyC0AE7983.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.AuditLogsPolicyC0AE7983.json
@@ -1,0 +1,105 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::S3::BucketPolicy model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AuditLogsPolicyC0AE7983",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+    "constructPath": "CdkrdIntegHarvest3/AuditLogs/Policy",
+    "declared": {
+      "Bucket": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-CustomS3AutoDeleteObjectsCustomR-c2vHtPWK4W8e"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+              "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte/*"
+            ]
+          },
+          {
+            "Action": "s3:GetBucketAcl",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Resource": "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte"
+          },
+          {
+            "Action": "s3:PutObject",
+            "Condition": {
+              "StringEquals": {
+                "s3:x-amz-acl": "bucket-owner-full-control"
+              }
+            },
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Resource": "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte/AWSLogs/111111111111/*"
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-CustomS3AutoDeleteObjectsCustomR-c2vHtPWK4W8e"
+          },
+          "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+          "Resource": [
+            "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+            "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte/*"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "cloudtrail.amazonaws.com"
+          },
+          "Action": "s3:GetBucketAcl",
+          "Resource": "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte"
+        },
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "cloudtrail.amazonaws.com"
+          },
+          "Action": "s3:PutObject",
+          "Resource": "arn:aws:s3:::cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte/AWSLogs/111111111111/*",
+          "Condition": {
+            "StringEquals": {
+              "s3:x-amz-acl": "bucket-owner-full-control"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.FirehoseSinkPolicy5EBD7FC2.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.FirehoseSinkPolicy5EBD7FC2.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::S3::BucketPolicy model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FirehoseSinkPolicy5EBD7FC2",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+    "constructPath": "CdkrdIntegHarvest3/FirehoseSink/Policy",
+    "declared": {
+      "Bucket": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-CustomS3AutoDeleteObjectsCustomR-c2vHtPWK4W8e"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+              "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy/*"
+            ]
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-CustomS3AutoDeleteObjectsCustomR-c2vHtPWK4W8e"
+          },
+          "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+          "Resource": [
+            "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+            "arn:aws:s3:::cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy/*"
+          ]
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
+++ b/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
@@ -1,0 +1,74 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::SES::ConfigurationSet model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Mailer",
+    "resourceType": "AWS::SES::ConfigurationSet",
+    "physicalId": "cdkrd-harvest3",
+    "constructPath": "CdkrdIntegHarvest3/Mailer",
+    "declared": {
+      "Name": "cdkrd-harvest3"
+    }
+  },
+  "liveRaw": {
+    "SendingOptions": {
+      "SendingEnabled": true
+    },
+    "ReputationOptions": {
+      "ReputationMetricsEnabled": true
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Mailer",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest3"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Mailer",
+      "resourceType": "AWS::SES::ConfigurationSet",
+      "path": "SendingOptions",
+      "actual": {
+        "SendingEnabled": true
+      },
+      "physicalId": "cdkrd-harvest3",
+      "constructPath": "CdkrdIntegHarvest3/Mailer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Mailer",
+      "resourceType": "AWS::SES::ConfigurationSet",
+      "path": "ReputationOptions",
+      "actual": {
+        "ReputationMetricsEnabled": true
+      },
+      "physicalId": "cdkrd-harvest3",
+      "constructPath": "CdkrdIntegHarvest3/Mailer"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.drifted.json
+++ b/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.drifted.json
@@ -1,0 +1,69 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 revert matrix, R74): AWS::SNS::Topic after an OUT-OF-BAND mutation of a declared value — the declared finding in `expected` is the drift the matrix detects and reverts via Cloud Control. A change here means declared-drift semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixTopic643E8545",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+    "constructPath": "CdkrdIntegHarvest3/MatrixTopic",
+    "declared": {
+      "DisplayName": "cdkrd harvest3 matrix"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+    "DisplayName": "mutated out of band",
+    "FifoTopic": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MatrixTopic643E8545",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "MatrixTopic643E8545",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "DisplayName",
+      "desired": "cdkrd harvest3 matrix",
+      "actual": "mutated out of band",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+      "constructPath": "CdkrdIntegHarvest3/MatrixTopic"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixTopic643E8545",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "TopicName",
+      "actual": "CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+      "constructPath": "CdkrdIntegHarvest3/MatrixTopic"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.json
+++ b/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::SNS::Topic model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixTopic643E8545",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+    "constructPath": "CdkrdIntegHarvest3/MatrixTopic",
+    "declared": {
+      "DisplayName": "cdkrd harvest3 matrix"
+    }
+  },
+  "liveRaw": {
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+    "DisplayName": "cdkrd harvest3 matrix",
+    "FifoTopic": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MatrixTopic643E8545",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixTopic643E8545",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "TopicName",
+      "actual": "CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+      "constructPath": "CdkrdIntegHarvest3/MatrixTopic"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
@@ -1,0 +1,96 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 revert matrix, R74): AWS::SQS::Queue after an OUT-OF-BAND mutation of a declared value — the declared finding in `expected` is the drift the matrix detects and reverts via Cloud Control. A change here means declared-drift semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixQueueEEAE6F08",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+    "constructPath": "CdkrdIntegHarvest3/MatrixQueue",
+    "declared": {
+      "MessageRetentionPeriod": 345600,
+      "VisibilityTimeout": 60
+    }
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 120,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+    "QueueName": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "desired": 60,
+      "actual": 120,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::SQS::Queue model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "MatrixQueueEEAE6F08",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+    "constructPath": "CdkrdIntegHarvest3/MatrixQueue",
+    "declared": {
+      "MessageRetentionPeriod": 345600,
+      "VisibilityTimeout": 60
+    }
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 60,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+    "QueueName": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Scheduler::Schedule model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "HourlyPing",
+    "resourceType": "AWS::Scheduler::Schedule",
+    "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
+    "constructPath": "CdkrdIntegHarvest3/HourlyPing",
+    "declared": {
+      "FlexibleTimeWindow": {
+        "Mode": "OFF"
+      },
+      "GroupName": "cdkrd-harvest3",
+      "ScheduleExpression": "rate(1 hour)",
+      "State": "DISABLED",
+      "Target": {
+        "Arn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+        "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
+    "GroupName": "cdkrd-harvest3",
+    "ScheduleExpression": "rate(1 hour)",
+    "ScheduleExpressionTimezone": "UTC",
+    "FlexibleTimeWindow": {
+      "Mode": "OFF"
+    },
+    "State": "DISABLED",
+    "ActionAfterCompletion": "NONE",
+    "Target": {
+      "Arn": "arn:aws:sns:us-east-1:111111111111:CdkrdIntegHarvest3-MatrixTopic643E8545-sQb9jM5VUINu",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+      "RetryPolicy": {
+        "MaximumEventAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 185
+      }
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "HourlyPing",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "ScheduleExpressionTimezone",
+      "actual": "UTC",
+      "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
+      "constructPath": "CdkrdIntegHarvest3/HourlyPing"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HourlyPing",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "ActionAfterCompletion",
+      "actual": "NONE",
+      "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
+      "constructPath": "CdkrdIntegHarvest3/HourlyPing"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Scheduler__ScheduleGroup.SchedGroup.json
+++ b/tests/corpus/AWS__Scheduler__ScheduleGroup.SchedGroup.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::Scheduler::ScheduleGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "SchedGroup",
+    "resourceType": "AWS::Scheduler::ScheduleGroup",
+    "physicalId": "cdkrd-harvest3",
+    "constructPath": "CdkrdIntegHarvest3/SchedGroup",
+    "declared": {
+      "Name": "cdkrd-harvest3"
+    }
+  },
+  "liveRaw": {
+    "CreationDate": "2026-06-12T17:18:25.472Z",
+    "State": "ACTIVE",
+    "LastModificationDate": "2026-06-12T17:18:25.472Z",
+    "Arn": "arn:aws:scheduler:us-east-1:111111111111:schedule-group/cdkrd-harvest3",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest3",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest3/b01a95f0-6682-11f1-ba13-122419eb6ddf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "SchedGroup",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest3"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreationDate", "LastModificationDate", "State"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "CreationDate", "LastModificationDate", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SecretsManager__Secret.AppSecretFAB5164C.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.AppSecretFAB5164C.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest3 fixture, R74): fresh-deploy AWS::SecretsManager::Secret model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AppSecretFAB5164C",
+    "resourceType": "AWS::SecretsManager::Secret",
+    "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:AppSecretFAB5164C-dJ2LiOENJfDC-AwMLKc",
+    "constructPath": "CdkrdIntegHarvest3/AppSecret",
+    "declared": {
+      "Description": "cdkrd harvest3 secret",
+      "GenerateSecretString": {
+        "ExcludePunctuation": true,
+        "GenerateStringKey": "password",
+        "SecretStringTemplate": "{\"username\":\"app\"}"
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd harvest3 secret",
+    "ReplicaRegions": [],
+    "Id": "arn:aws:secretsmanager:us-east-1:111111111111:secret:AppSecretFAB5164C-dJ2LiOENJfDC-AwMLKc",
+    "Tags": [],
+    "Name": "AppSecretFAB5164C-dJ2LiOENJfDC"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["GenerateSecretString", "SecretString"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["GenerateSecretString", "SecretString"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "AppSecretFAB5164C",
+      "resourceType": "AWS::SecretsManager::Secret",
+      "path": "GenerateSecretString",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:AppSecretFAB5164C-dJ2LiOENJfDC-AwMLKc",
+      "constructPath": "CdkrdIntegHarvest3/AppSecret"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AppSecretFAB5164C",
+      "resourceType": "AWS::SecretsManager::Secret",
+      "path": "Name",
+      "actual": "AppSecretFAB5164C-dJ2LiOENJfDC",
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:AppSecretFAB5164C-dJ2LiOENJfDC-AwMLKc",
+      "constructPath": "CdkrdIntegHarvest3/AppSecret"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -38,7 +38,8 @@ These do NOT run in CI (they need credentials and mutate a real account):
   `verify-mutation-matrix.sh`), `iam`, `lambda`, `revert`, `policies`.
 - **After changing** `src/read/**`, `src/revert/**`, `src/normalize/**`, or
   `src/commands/gather.ts`: run at least `basic` + `revert` (and `policies` if
-  `writers.ts` changed) before merging.
+  `writers.ts` changed; `harvest3` for the multi-type Cloud Control revert
+  matrix) before merging.
 - **After changing** `src/diff/**` or `src/baseline/**`: run
   `basic/verify-mutation-matrix.sh` (the drift-direction matrix) before merging.
 - Scripts that share a fixture/stack (`basic`'s four) must run sequentially,
@@ -169,6 +170,32 @@ accept -> `check --fail` CLEAN.
 
 ```bash
 cd harvest2 && npm install && bash verify-harvest2.sh
+```
+
+## harvest3
+
+Wave 3 of the corpus harvest (R74), two jobs in one deploy:
+
+- **New service families** the corpus had never seen live: Cognito
+  UserPool+Client, KMS Key+Alias, Secrets Manager, EventBridge Scheduler
+  (group + schedule), Firehose delivery stream, SES configuration set,
+  Cloud Map HTTP namespace, AppSync GraphQL API, CloudTrail trail, AWS
+  Backup vault+plan. Same two harvest invariants: fresh deploy = ZERO
+  declared drift, then accept -> `check --fail` CLEAN.
+- **Multi-type revert matrix** — the first live proof of the Cloud Control
+  write path beyond S3. Five CC-routed declared values are mutated
+  out-of-band (Lambda `MemorySize`, SQS `VisibilityTimeout`, Logs
+  `RetentionInDays`, SNS `DisplayName`, Events Rule `State`); ONE `check`
+  must report exactly 5 declared drifts, ONE `revert --yes` must restore
+  all five, verified by `check --fail` CLEAN and direct per-service AWS
+  reads.
+
+With `CDKRD_CORPUS_DIR` set, the drift-state recordings are snapshotted to
+`${CDKRD_CORPUS_DIR}.drifted` before the post-revert check overwrites them —
+one run yields BOTH a clean and a drifted corpus case per matrix type.
+
+```bash
+cd harvest3 && npm install && bash verify-harvest3.sh
 ```
 
 ## revert

--- a/tests/integration/harvest3/app.ts
+++ b/tests/integration/harvest3/app.ts
@@ -1,0 +1,170 @@
+// Corpus-harvest fixture wave 3 (R74): NEW SERVICE FAMILIES + a multi-type
+// REVERT MATRIX. Waves 1-2 covered default-config breadth and deeply-declared
+// structs; this wave adds service families the corpus has never seen live
+// (Cognito, KMS, Secrets Manager, EventBridge Scheduler, Firehose, SES,
+// Cloud Map, AppSync, CloudTrail, AWS Backup) AND five Cloud-Control-routed
+// "matrix" resources (Lambda / SQS / Logs / SNS / Events) whose declared
+// values the verify script mutates out-of-band and reverts in ONE
+// `revert --yes` — the first live proof that CC UpdateResource converges
+// across many types at once (the previous revert integ was S3-only).
+// Everything is cheap, fast to deploy, and self-cleaning.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnGraphQLApi } from "aws-cdk-lib/aws-appsync";
+import { BackupPlan, BackupVault } from "aws-cdk-lib/aws-backup";
+import { Trail } from "aws-cdk-lib/aws-cloudtrail";
+import { AccountRecovery, UserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { Alias, Key } from "aws-cdk-lib/aws-kms";
+import { Code, Function as Fn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnSchedule, CfnScheduleGroup } from "aws-cdk-lib/aws-scheduler";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+import { CfnConfigurationSet } from "aws-cdk-lib/aws-ses";
+import { HttpNamespace } from "aws-cdk-lib/aws-servicediscovery";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegHarvest3");
+
+// ---- revert-matrix targets (all Cloud-Control routed; the verify script
+// ---- mutates each declared value out-of-band, then one revert restores all 5)
+const matrixFn = new Fn(stack, "MatrixFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => 'harvest3';"),
+  memorySize: 256, // matrix M1: out-of-band 512 -> revert -> 256
+  timeout: Duration.seconds(10),
+});
+
+new Queue(stack, "MatrixQueue", {
+  visibilityTimeout: Duration.seconds(60), // matrix M2: out-of-band 120 -> revert -> 60
+  retentionPeriod: Duration.days(4),
+});
+
+new LogGroup(stack, "MatrixLogs", {
+  retention: RetentionDays.ONE_WEEK, // matrix M3: out-of-band 30 -> revert -> 7
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const matrixTopic = new Topic(stack, "MatrixTopic", {
+  displayName: "cdkrd harvest3 matrix", // matrix M4: out-of-band rename -> revert
+});
+
+new Rule(stack, "MatrixRule", {
+  schedule: Schedule.rate(Duration.hours(1)),
+  enabled: true, // matrix M5: out-of-band disable-rule -> revert -> ENABLED
+});
+
+// ---- new service families (harvest-only: deploy -> zero declared drift ->
+// ---- accept -> CLEAN -> record corpus -> destroy)
+const pool = new UserPool(stack, "Users", {
+  selfSignUpEnabled: false,
+  accountRecovery: AccountRecovery.EMAIL_ONLY,
+  passwordPolicy: {
+    minLength: 12,
+    requireDigits: true,
+    requireSymbols: true,
+    tempPasswordValidity: Duration.days(3),
+  },
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+new UserPoolClient(stack, "WebClient", {
+  userPool: pool,
+  authFlows: { userSrp: true },
+  generateSecret: false,
+});
+
+const key = new Key(stack, "DataKey", {
+  description: "cdkrd harvest3 data key",
+  enableKeyRotation: true,
+  pendingWindow: Duration.days(7),
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+new Alias(stack, "DataKeyAlias", { aliasName: "alias/cdkrd-harvest3", targetKey: key });
+
+new Secret(stack, "AppSecret", {
+  description: "cdkrd harvest3 secret",
+  generateSecretString: {
+    secretStringTemplate: JSON.stringify({ username: "app" }),
+    generateStringKey: "password",
+    excludePunctuation: true,
+  },
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const schedGroup = new CfnScheduleGroup(stack, "SchedGroup", {
+  name: "cdkrd-harvest3",
+});
+const schedRole = new Role(stack, "SchedRole", {
+  assumedBy: new ServicePrincipal("scheduler.amazonaws.com"),
+});
+schedRole.addToPolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ["sns:Publish"],
+    resources: [matrixTopic.topicArn],
+  })
+);
+new CfnSchedule(stack, "HourlyPing", {
+  groupName: schedGroup.name,
+  scheduleExpression: "rate(1 hour)",
+  flexibleTimeWindow: { mode: "OFF" },
+  state: "DISABLED", // never actually publish
+  target: { arn: matrixTopic.topicArn, roleArn: schedRole.roleArn },
+}).addDependency(schedGroup);
+
+const sink = new Bucket(stack, "FirehoseSink", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+});
+const firehoseRole = new Role(stack, "FirehoseRole", {
+  assumedBy: new ServicePrincipal("firehose.amazonaws.com"),
+});
+sink.grantReadWrite(firehoseRole);
+new CfnDeliveryStream(stack, "Tap", {
+  deliveryStreamType: "DirectPut",
+  s3DestinationConfiguration: {
+    bucketArn: sink.bucketArn,
+    roleArn: firehoseRole.roleArn,
+    bufferingHints: { intervalInSeconds: 300, sizeInMBs: 5 },
+    compressionFormat: "GZIP",
+  },
+});
+
+new CfnConfigurationSet(stack, "Mailer", { name: "cdkrd-harvest3" });
+
+new HttpNamespace(stack, "Mesh", {
+  name: "cdkrd-harvest3",
+  description: "cdkrd harvest3 http namespace",
+});
+
+new CfnGraphQLApi(stack, "Graph", {
+  name: "cdkrd-harvest3",
+  authenticationType: "API_KEY",
+});
+
+const auditBucket = new Bucket(stack, "AuditLogs", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+});
+new Trail(stack, "Audit", {
+  bucket: auditBucket,
+  isMultiRegionTrail: false,
+  includeGlobalServiceEvents: false,
+});
+
+const vault = new BackupVault(stack, "Vault", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+BackupPlan.daily35DayRetention(stack, "Plan", vault);
+
+// keep the matrix Lambda referenced so oxc/tsgo never flag it unused
+void matrixFn;
+
+app.synth();

--- a/tests/integration/harvest3/cdk.json
+++ b/tests/integration/harvest3/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest3/package.json
+++ b/tests/integration/harvest3/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-harvest3",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest fixture wave 3: new service families + a multi-type Cloud Control revert matrix. Run via verify-harvest3.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@11.17.0"
+}

--- a/tests/integration/harvest3/verify-harvest3.sh
+++ b/tests/integration/harvest3/verify-harvest3.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 3 (real AWS) — R74.
+#
+# Two jobs in one deploy:
+#   A. HARVEST new service families (Cognito, KMS, Secrets Manager, Scheduler,
+#      Firehose, SES, Cloud Map, AppSync, CloudTrail, AWS Backup):
+#      1. baseline-free `check` — a FRESH deploy must classify with ZERO
+#         declared drift across every type, exit 0;
+#      2. `accept --yes` then `check --fail` — CLEAN across every type.
+#   B. MULTI-TYPE REVERT MATRIX (first live proof beyond S3): mutate the
+#      declared value of five Cloud-Control-routed resources out-of-band
+#      (Lambda MemorySize, SQS VisibilityTimeout, Logs RetentionInDays,
+#      SNS DisplayName, Events Rule State), confirm ONE `check` reports all
+#      five as DECLARED drift, then ONE `revert --yes` restores all five via
+#      CC UpdateResource — verified both by `check --fail` CLEAN and by
+#      direct per-service AWS reads.
+#
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases. The script
+# snapshots the drift-state recordings to ${CDKRD_CORPUS_DIR}.drifted before
+# the post-revert check overwrites them — so one run yields BOTH a clean and
+# a drifted corpus case per matrix type.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest3 && npm install && bash verify-harvest3.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegHarvest3
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest3.out
+
+cleanup() {
+  # CDKRD_HARVEST3_KEEP=1 skips the destroy so a corpus/debug session can keep
+  # iterating against the deployed stack. Destroy manually when done:
+  #   npx cdk destroy -f CdkrdIntegHarvest3 && rm -rf .cdkrd cdk.out
+  if [ -n "${CDKRD_HARVEST3_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST3_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+phys() { # phys <ResourceType> <LogicalIdPrefix>
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?ResourceType=='$1' && starts_with(LogicalResourceId,'$2')].PhysicalResourceId" \
+    --output text
+}
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 3: new families + revert-matrix targets) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== A1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== A2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "=== B1. resolve matrix physical ids ==="
+FN_NAME="$(phys AWS::Lambda::Function MatrixFn)"
+QUEUE_URL="$(phys AWS::SQS::Queue MatrixQueue)"
+LOG_GROUP="$(phys AWS::Logs::LogGroup MatrixLogs)"
+TOPIC_ARN="$(phys AWS::SNS::Topic MatrixTopic)"
+RULE_NAME="$(phys AWS::Events::Rule MatrixRule)"
+for v in FN_NAME QUEUE_URL LOG_GROUP TOPIC_ARN RULE_NAME; do
+  [ -n "${!v}" ] || fail "could not resolve $v"
+done
+
+echo "=== B2. inject 5 declared drifts out-of-band (one per type) ==="
+aws lambda update-function-configuration --function-name "$FN_NAME" --memory-size 512 --region "$REGION" >/dev/null || fail "inject lambda"
+aws sqs set-queue-attributes --queue-url "$QUEUE_URL" --attributes VisibilityTimeout=120 --region "$REGION" || fail "inject sqs"
+aws logs put-retention-policy --log-group-name "$LOG_GROUP" --retention-in-days 30 --region "$REGION" || fail "inject logs"
+aws sns set-topic-attributes --topic-arn "$TOPIC_ARN" --attribute-name DisplayName --attribute-value "mutated out of band" --region "$REGION" || fail "inject sns"
+aws events disable-rule --name "$RULE_NAME" --region "$REGION" || fail "inject events"
+sleep 10
+
+echo "=== B3. one check must report ALL FIVE as DECLARED drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
+grep -q "DECLARED DRIFT: 5" "$OUT" || fail "expected exactly 5 declared drifts"
+for needle in MemorySize VisibilityTimeout RetentionInDays DisplayName MatrixRule; do
+  grep -q "$needle" "$OUT" || fail "missing declared drift: $needle"
+done
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== snapshot drift-state corpus recordings ==="
+  rm -rf "${CDKRD_CORPUS_DIR}.drifted"
+  cp -R "$CDKRD_CORPUS_DIR" "${CDKRD_CORPUS_DIR}.drifted" || fail "corpus snapshot"
+fi
+
+echo "=== B4. ONE revert --yes restores all five via Cloud Control ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert returned non-zero"
+sleep 10
+
+echo "=== B5. check CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "drift remains after revert"
+
+echo "=== B6. direct AWS reads confirm every value restored ==="
+MEM="$(aws lambda get-function-configuration --function-name "$FN_NAME" --region "$REGION" --query MemorySize --output text)"
+[ "$MEM" = "256" ] || fail "lambda MemorySize not restored (got $MEM)"
+VIS="$(aws sqs get-queue-attributes --queue-url "$QUEUE_URL" --attribute-names VisibilityTimeout --region "$REGION" --query "Attributes.VisibilityTimeout" --output text)"
+[ "$VIS" = "60" ] || fail "sqs VisibilityTimeout not restored (got $VIS)"
+RET="$(aws logs describe-log-groups --log-group-name-prefix "$LOG_GROUP" --region "$REGION" --query "logGroups[?logGroupName=='$LOG_GROUP'].retentionInDays | [0]" --output text)"
+[ "$RET" = "7" ] || fail "logs retention not restored (got $RET)"
+DISP="$(aws sns get-topic-attributes --topic-arn "$TOPIC_ARN" --region "$REGION" --query "Attributes.DisplayName" --output text)"
+[ "$DISP" = "cdkrd harvest3 matrix" ] || fail "sns DisplayName not restored (got $DISP)"
+STATE="$(aws events describe-rule --name "$RULE_NAME" --region "$REGION" --query State --output text)"
+[ "$STATE" = "ENABLED" ] || fail "events rule State not restored (got $STATE)"
+
+echo "INTEG PASS"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -13,6 +13,7 @@ import {
 import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
 import { GetBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
+import { GetScheduleCommand, SchedulerClient } from '@aws-sdk/client-scheduler';
 import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { mockClient } from 'aws-sdk-client-mock';
@@ -28,6 +29,7 @@ const budgets = mockClient(BudgetsClient);
 const route53 = mockClient(Route53Client);
 const glue = mockClient(GlueClient);
 const logs = mockClient(CloudWatchLogsClient);
+const scheduler = mockClient(SchedulerClient);
 
 const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
   physicalId,
@@ -39,7 +41,7 @@ const POLICY =
   '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:Get","Resource":"*"}]}';
 
 beforeEach(() => {
-  for (const m of [s3, sns, sqs, iam, lambda, budgets, route53, glue, logs]) m.reset();
+  for (const m of [s3, sns, sqs, iam, lambda, budgets, route53, glue, logs, scheduler]) m.reset();
 });
 
 describe('SDK overrides', () => {
@@ -392,6 +394,55 @@ describe('SDK overrides', () => {
       expect(
         await SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'missing'))
       ).toBeUndefined();
+    });
+  });
+
+  describe('Scheduler Schedule (R74)', () => {
+    it('reads by physical-id name + declared GroupName and projects only CFn props', async () => {
+      scheduler.on(GetScheduleCommand).resolves({
+        Arn: 'arn:aws:scheduler:us-east-1:123456789012:schedule/grp/sched',
+        Name: 'sched',
+        GroupName: 'grp',
+        ScheduleExpression: 'rate(1 hour)',
+        FlexibleTimeWindow: { Mode: 'OFF' },
+        State: 'DISABLED',
+        CreationDate: new Date(0),
+        LastModificationDate: new Date(0),
+        Target: {
+          Arn: 'arn:aws:sns:us-east-1:123456789012:t',
+          RoleArn: 'arn:aws:iam::123456789012:role/r',
+        },
+      });
+      const out = await SDK_OVERRIDES['AWS::Scheduler::Schedule'](
+        ctx({ GroupName: 'grp' }, 'sched')
+      );
+      expect(scheduler.commandCalls(GetScheduleCommand)[0]?.args[0].input).toEqual({
+        Name: 'sched',
+        GroupName: 'grp',
+      });
+      expect(out).toEqual({
+        Name: 'sched',
+        GroupName: 'grp',
+        ScheduleExpression: 'rate(1 hour)',
+        FlexibleTimeWindow: { Mode: 'OFF' },
+        State: 'DISABLED',
+        Target: {
+          Arn: 'arn:aws:sns:us-east-1:123456789012:t',
+          RoleArn: 'arn:aws:iam::123456789012:role/r',
+        },
+      });
+    });
+
+    it('omits GroupName from the call when not declared (service default group)', async () => {
+      scheduler.on(GetScheduleCommand).resolves({ Name: 'sched' });
+      await SDK_OVERRIDES['AWS::Scheduler::Schedule'](ctx({}, 'sched'));
+      expect(scheduler.commandCalls(GetScheduleCommand)[0]?.args[0].input).toEqual({
+        Name: 'sched',
+      });
+    });
+
+    it('undefined when no name is resolvable (-> stays skipped)', async () => {
+      expect(await SDK_OVERRIDES['AWS::Scheduler::Schedule'](ctx({}))).toBeUndefined();
     });
   });
 });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -49,6 +49,68 @@ describe('readLive (CC API path)', () => {
   });
 });
 
+describe('readLive (CC identifier adapters, R74)', () => {
+  const sent = (): string =>
+    (cc.commandCalls(GetResourceCommand)[0]?.args[0].input.Identifier ?? '') as string;
+
+  it('AppSync GraphQLApi: the ARN physical id is reduced to the bare ApiId', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::AppSync::GraphQLApi',
+        physicalId: 'arn:aws:appsync:us-east-1:111111111111:apis/abc123xyz',
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('abc123xyz');
+  });
+
+  it('AppSync GraphQLApi: a non-ARN physical id passes through unchanged', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::AppSync::GraphQLApi', physicalId: 'abc123xyz' }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('abc123xyz');
+  });
+
+  it('Cognito UserPoolClient: builds the composite UserPoolId|ClientId identifier', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::Cognito::UserPoolClient',
+        physicalId: 'client123',
+        declared: { UserPoolId: 'us-east-1_AbCdEf' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('us-east-1_AbCdEf|client123');
+  });
+
+  it('Cognito UserPoolClient: an unresolved UserPoolId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Cognito::UserPoolClient', physicalId: 'client123', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('client123');
+  });
+
+  it('types without an adapter keep the physical id as the identifier', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(cc as unknown as CloudControlClient, res(), 'us-east-1', '1');
+    expect(sent()).toBe('phys');
+  });
+});
+
 describe('readLive (custom resources short-circuit, R26)', () => {
   it('returns skipped WITHOUT calling Cloud Control for a Custom:: resource', async () => {
     const r = await readLive(


### PR DESCRIPTION
## Summary

The new **harvest3** integ fixture (10 new service families + a 5-type revert matrix) found **four real false-positive classes** on its first live runs. All fixed, all locked into the offline corpus, third live run = **INTEG PASS** end-to-end.

### False positives found live → fixed

| # | Class | Symptom | Fix |
|---|-------|---------|-----|
| 1 | CC identifier ≠ CFn physical id | AppSync GraphQLApi reported **deleted** on a live API (ARN vs ApiId); Cognito UserPoolClient whole-resource skip (composite `UserPoolId\|ClientId`) | `CC_IDENTIFIER_ADAPTERS` in router.ts |
| 2 | CC group-blind read handler | Scheduler Schedule in any non-default group reported **deleted** (proven live: Name / group/name / group\|name / ARN all fail) | SDK override via `GetSchedule` + declared `GroupName` |
| 3 | Declared-empty vs service default | CDK `Trail` synthesizes `EventSelectors: []`; CloudTrail materializes the default management selector → every default CDK trail = declared drift | declared loop folds trivially-EMPTY declared vs `KNOWN_DEFAULTS` (equality-gated both sides) |
| 4 | Unordered enum sets | Fresh UserPoolClient: `AllowedOAuthFlows` / `AllowedOAuthScopes` / `ExplicitAuthFlows` drift with identical elements, different order | per-type `UNORDERED_ARRAY_PROPS` (observed-only), multiset-equality gated |

### First live proof of multi-type revert (the headline path)

Five Cloud-Control-routed declared values mutated out of band — Lambda `MemorySize`, SQS `VisibilityTimeout`, Logs `RetentionInDays`, SNS `DisplayName`, Events Rule `State` — ONE `check` reports exactly 5 declared drifts, ONE `revert --yes` restores all five, verified by `check --fail` CLEAN **and** direct per-service AWS reads. (The previous revert integ was S3-only.)

### Corpus 95 → 127 (536 unit tests)

- 27 clean fresh-deploy recordings: Cognito UserPool+Client, KMS Key+Alias, Secrets Manager, Scheduler group, Firehose, SES, AppSync, CloudTrail, AWS Backup vault+plan, …
- 5 **drifted** matrix recordings — real declared-drift findings locked from the live mutation state (snapshotted before the post-revert check overwrote them).

## Test plan

- [x] `vp run typecheck` / `vp check --fix` / `vp run build` / `vp run test` (31 files, 536 tests)
- [x] Live: `tests/integration/harvest3/verify-harvest3.sh` → INTEG PASS (deploy → zero declared drift → accept → CLEAN → 5 injections → 5 declared drifts → one revert → CLEAN → direct AWS reads confirm → destroy)
- [x] Stack destroyed; no orphans; recordings sanitized (no real account id in corpus)