### PR TITLE
fix(diff): three declared-compare FP classes (ELB attr subset, SSM JSON-string, Route53 DNS case); harvest4 + cloudfront waves (R75)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -191,7 +191,7 @@ checked.
   - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group).
 - **normalize/** — noise subtraction (section 6)
   - **intrinsic-resolver.ts** — fail-closed CFn intrinsic resolver (section 5).
-  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**.
+  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `projectLiveToDeclaredSubset` (attribute-bag subset), `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` / `CASE_INSENSITIVE_PATHS` (per-type compare rules).
   - **arn-identity.ts** — **`isArnNameMatch`** (bare name ↔ ARN), **`isManagedKmsAliasMatch`** (`alias/aws/*` ↔ key ARN).
   - **policy-canonical.ts** — IAM policy-doc canonicalization. **cc-api-strip.ts** — strip AWS-managed fields. **path-strip.ts** — schema readOnly/writeOnly path stripping (incl `*`).
 - **schema/schema-strip.ts** — `describe-type` → readOnly/writeOnly/defaults `SchemaInfo` (cached).
@@ -263,6 +263,10 @@ all live changes
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)
   − stringly-typed scalar (true vs "true", 5432 vs "5432") → equal (isStringlyEqualScalar)
     (scalars only — a typed vs string *array* like [80,443] vs ["80","443"] still reports; fail-safe noise)
+  − declared object vs its JSON-STRING live form (SSM Document.Content, R75) → equal (isJsonStringStructEqual)
+  − declared SUBSET of an identity-keyed attribute bag (ELB Load/TargetGroupAttributes, R75) → live projected to declared keys (projectLiveToDeclaredSubset)
+  − per-type case-insensitive scalar paths (Route53 AliasTarget.DNSName, R75) → equal (CASE_INSENSITIVE_PATHS)
+  − per-type unordered scalar-array sets (Cognito UserPoolClient OAuth lists, R74) → equal (UNORDERED_ARRAY_PROPS)
   − sibling AWS::IAM::Policy entries in a role's Policies → filtered BY NAME (see below)
   = undeclared residual                → the unique signal
 ```

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -11,11 +11,15 @@ import { isArnNameMatch, isManagedKmsAliasMatch } from '../normalize/arn-identit
 import { stripCcApiAwsManagedFields } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
+  CASE_INSENSITIVE_PATHS,
   isAllAwsTags,
+  isCaseInsensitiveScalarEqual,
   isEqualUnorderedScalarSet,
+  isJsonStringStructEqual,
   isStringlyEqualScalar,
   isTrivialEmpty,
   KNOWN_DEFAULTS,
+  projectLiveToDeclaredSubset,
   stripAwsTagsDeep,
   UNORDERED_ARRAY_PROPS,
 } from '../normalize/noise.js';
@@ -107,7 +111,12 @@ export function classifyResource(
       });
       continue;
     }
-    for (const d of calculateResourceDrift({ [k]: v }, { [k]: live[k] })) {
+    // Identity-keyed attribute bags (R75: ELB LoadBalancerAttributes /
+    // TargetGroupAttributes) — the template declares a SUBSET of the keys AWS
+    // returns; compare only the declared keys so the extra live attributes are
+    // not false drift on the whole list.
+    const liveVal = projectLiveToDeclaredSubset(v, live[k]);
+    for (const d of calculateResourceDrift({ [k]: v }, { [k]: liveVal })) {
       // a bare name declared for a field AWS returns as the full ARN is not drift
       // (account/region-scoped when opts are provided); likewise an AWS-managed-default
       // KMS alias vs its resolved key ARN
@@ -116,6 +125,16 @@ export function classifyResource(
       // CFn stringly-typed scalar (Glue Parameters Map<String,String>, "5432" ports):
       // declared `true`/`5432` vs AWS `"true"`/`"5432"` is not drift.
       if (isStringlyEqualScalar(d.stateValue, d.awsValue)) continue;
+      // A declared object whose live form is the same value as a JSON STRING
+      // (R75: SSM Document.Content) — equal after parse, key-order-insensitive.
+      if (isJsonStringStructEqual(d.stateValue, d.awsValue)) continue;
+      // Per-type case-insensitive scalar paths (R75: Route53 AliasTarget.DNSName
+      // — the ALB's generated DNS name is mixed-case declared, lowercase live).
+      if (
+        CASE_INSENSITIVE_PATHS[resourceType]?.has(d.path) &&
+        isCaseInsensitiveScalarEqual(d.stateValue, d.awsValue)
+      )
+        continue;
       // Per-type unordered scalar-array sets (R74: Cognito UserPoolClient OAuth
       // flow/scope lists) — same elements in the service's canonical order is
       // not drift; a genuine element change still differs after sorting.

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -137,6 +137,100 @@ export function canonicalizeTagListsDeep(v: unknown): unknown {
   return v;
 }
 
+// Identity-keyed ATTRIBUTE BAGS where the template declares only a SUBSET of the
+// keys AWS returns (R75: ELB LoadBalancerAttributes / TargetGroupAttributes —
+// CDK declares the two attrs it set, AWS returns all ~15). A positional diff of
+// the declared 2-element list against the live 15-element list is false drift on
+// the whole property. Project the live side down to ONLY the keys the template
+// declared, recursing through nested bags. Both sides are already identity-sorted
+// by canonicalizeTagListsDeep, so the projected subset stays aligned. A genuine
+// change to a DECLARED attribute's value still differs element-wise after the
+// projection; a never-declared live attribute is simply not compared (it lives
+// inside a declared parent, so it is not undeclared drift either). Returns the
+// live value unchanged when the shapes are not both identity-keyed arrays.
+export function projectLiveToDeclaredSubset(declaredVal: unknown, liveVal: unknown): unknown {
+  if (Array.isArray(declaredVal) && Array.isArray(liveVal)) {
+    const idf = identityField(declaredVal);
+    if (idf && identityField(liveVal) === idf) {
+      const keys = new Set(declaredVal.map((e) => (e as Record<string, unknown>)[idf]));
+      return liveVal
+        .filter((e) => keys.has((e as Record<string, unknown>)[idf]))
+        .map((e) => {
+          const d = declaredVal.find(
+            (x) => (x as Record<string, unknown>)[idf] === (e as Record<string, unknown>)[idf]
+          );
+          return projectLiveToDeclaredSubset(d, e);
+        });
+    }
+    return liveVal;
+  }
+  if (declaredVal && liveVal && typeof declaredVal === 'object' && typeof liveVal === 'object') {
+    const out: Record<string, unknown> = { ...(liveVal as Record<string, unknown>) };
+    for (const [k, dv] of Object.entries(declaredVal as Record<string, unknown>))
+      if (k in out) out[k] = projectLiveToDeclaredSubset(dv, out[k]);
+    return out;
+  }
+  return liveVal;
+}
+
+// A declared OBJECT/ARRAY whose live counterpart is the same value serialized as a
+// JSON STRING (R75: SSM Document.Content — CDK declares the parsed object, AWS
+// returns a JSON string, with keys in a different order). The compare is
+// key-order-insensitive, so a successful parse + structural equality means
+// equal-not-drift. One side must be a string and the other a non-null object; a
+// genuine content change still differs after the parse.
+const SENTINEL_UNPARSEABLE = Symbol('unparseable');
+function deepCompareUnordered(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+  const aArr = Array.isArray(a);
+  if (aArr !== Array.isArray(b)) return false;
+  if (aArr) {
+    const ba = b as unknown[];
+    return (
+      (a as unknown[]).length === ba.length &&
+      (a as unknown[]).every((v, i) => deepCompareUnordered(v, ba[i]))
+    );
+  }
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const ak = Object.keys(ao);
+  return (
+    ak.length === Object.keys(bo).length &&
+    ak.every((k) => Object.hasOwn(bo, k) && deepCompareUnordered(ao[k], bo[k]))
+  );
+}
+export function isJsonStringStructEqual(a: unknown, b: unknown): boolean {
+  const parse = (s: string): unknown => {
+    try {
+      return JSON.parse(s);
+    } catch {
+      return SENTINEL_UNPARSEABLE;
+    }
+  };
+  if (typeof a === 'string' && b !== null && typeof b === 'object') {
+    const pa = parse(a);
+    return pa !== SENTINEL_UNPARSEABLE && deepCompareUnordered(pa, b);
+  }
+  if (typeof b === 'string' && a !== null && typeof a === 'object') {
+    const pb = parse(b);
+    return pb !== SENTINEL_UNPARSEABLE && deepCompareUnordered(a, pb);
+  }
+  return false;
+}
+
+// Per-type property paths AWS compares CASE-INSENSITIVELY (R75: Route53
+// RecordSet AliasTarget.DNSName — an ALB's generated DNS name is mixed-case in
+// the template's GetAtt and all-lowercase in the live record; DNS hostnames are
+// case-insensitive). Observed-only entries. The drift path is the dotted path
+// from calculateResourceDrift (e.g. `AliasTarget.DNSName`).
+export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::Route53::RecordSet': new Set(['AliasTarget.DNSName']),
+};
+export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
+  return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+}
+
 // AWS resource-id / ARN lists (SubnetIds, SecurityGroupIds, AvailabilityZones,
 // VPCSecurityGroups, ...) are UNORDERED sets too, but unlike tags their elements
 // are bare scalars, so the tag canonicalizer doesn't touch them and a positional

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -485,3 +485,141 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     });
   });
 });
+
+describe('declared-compare false-positive classes from harvest4 (R75)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    physicalId: 'phys',
+    declared,
+  });
+
+  describe('identity-keyed attribute bag subset (ELB)', () => {
+    const T = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
+    const declared = {
+      LoadBalancerAttributes: [
+        { Key: 'idle_timeout.timeout_seconds', Value: '120' },
+        { Key: 'deletion_protection.enabled', Value: 'false' },
+      ],
+    };
+    // AWS returns ~15 attributes; the template declared 2.
+    const liveAll = [
+      { Key: 'access_logs.s3.enabled', Value: 'false' },
+      { Key: 'idle_timeout.timeout_seconds', Value: '120' },
+      { Key: 'routing.http2.enabled', Value: 'true' },
+      { Key: 'deletion_protection.enabled', Value: 'false' },
+      { Key: 'client_keep_alive.seconds', Value: '3600' },
+    ];
+
+    it('a fresh deploy with extra live attributes is NOT drift (subset compared)', () => {
+      expect(
+        classifyResource(res(T, declared), { LoadBalancerAttributes: liveAll }, emptySchema)
+      ).toEqual([]);
+    });
+
+    it('a genuine change to a DECLARED attribute still surfaces', () => {
+      const drifted = liveAll.map((a) =>
+        a.Key === 'idle_timeout.timeout_seconds' ? { ...a, Value: '300' } : a
+      );
+      const findings = classifyResource(
+        res(T, declared),
+        { LoadBalancerAttributes: drifted },
+        emptySchema
+      );
+      expect(findings.filter((f) => f.tier === 'declared')).toHaveLength(1);
+      expect(findings[0]?.path).toContain('LoadBalancerAttributes');
+    });
+  });
+
+  describe('JSON-string vs declared object (SSM Document.Content)', () => {
+    const T = 'AWS::SSM::Document';
+    const content = {
+      schemaVersion: '2.2',
+      description: 'noop',
+      mainSteps: [
+        { action: 'aws:runShellScript', name: 'noop', inputs: { runCommand: ['echo hi'] } },
+      ],
+    };
+
+    it('declared object vs the same value as a key-reordered JSON string is NOT drift', () => {
+      // AWS returns the content as a string with keys in a different order
+      const liveStr = JSON.stringify({
+        description: 'noop',
+        mainSteps: [
+          { action: 'aws:runShellScript', inputs: { runCommand: ['echo hi'] }, name: 'noop' },
+        ],
+        schemaVersion: '2.2',
+      });
+      expect(
+        classifyResource(res(T, { Content: content }), { Content: liveStr }, emptySchema)
+      ).toEqual([]);
+    });
+
+    it('a genuine content change is still declared drift', () => {
+      const liveStr = JSON.stringify({ ...content, description: 'CHANGED' });
+      expect(
+        tiers(classifyResource(res(T, { Content: content }), { Content: liveStr }, emptySchema))
+          .declared
+      ).toEqual(['Content']);
+    });
+
+    it('an unparseable live string is still drift (never silently equal)', () => {
+      expect(
+        tiers(
+          classifyResource(res(T, { Content: content }), { Content: 'not json {' }, emptySchema)
+        ).declared
+      ).toEqual(['Content']);
+    });
+  });
+
+  describe('case-insensitive scalar path (Route53 AliasTarget.DNSName)', () => {
+    const T = 'AWS::Route53::RecordSet';
+    const alias = (dns: string) => ({
+      AliasTarget: { DNSName: dns, HostedZoneId: 'Z123', EvaluateTargetHealth: false },
+    });
+
+    it('mixed-case declared vs lowercase live DNS name is NOT drift', () => {
+      expect(
+        classifyResource(
+          res(T, alias('dualstack.CdkrdI-Edge7-abc.us-east-1.elb.amazonaws.com')),
+          alias('dualstack.cdkrdi-edge7-abc.us-east-1.elb.amazonaws.com'),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a genuinely different DNS name is still drift', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res(T, alias('dualstack.aaa.us-east-1.elb.amazonaws.com')),
+            alias('dualstack.bbb.us-east-1.elb.amazonaws.com'),
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['AliasTarget.DNSName']);
+    });
+
+    it('the case-insensitive rule is scoped per-type+path (other scalars still strict)', () => {
+      // a different type with the same path shape stays strict
+      expect(
+        tiers(
+          classifyResource(
+            res('AWS::S3::Bucket', { Name: 'MyBucket' }),
+            { Name: 'mybucket' },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['Name']);
+    });
+  });
+});

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ApiGatewayV2::Api model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiF70053CD",
+    "resourceType": "AWS::ApiGatewayV2::Api",
+    "physicalId": "rno3u8uv0f",
+    "constructPath": "CdkrdIntegHarvest4/Api",
+    "declared": {
+      "Name": "Api",
+      "ProtocolType": "HTTP"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "RouteSelectionExpression": "$request.method $request.path",
+    "ProtocolType": "HTTP",
+    "ApiEndpoint": "https://rno3u8uv0f.execute-api.us-east-1.amazonaws.com",
+    "DisableExecuteApiEndpoint": false,
+    "ApiId": "rno3u8uv0f",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest4",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+      "aws:cloudformation:logical-id": "ApiF70053CD"
+    },
+    "Name": "Api"
+  },
+  "schema": {
+    "readOnly": ["ApiEndpoint", "ApiId"],
+    "writeOnly": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnly": ["ProtocolType"],
+    "readOnlyPaths": ["ApiEndpoint", "ApiId"],
+    "writeOnlyPaths": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "BodyS3Location.Bucket",
+      "BodyS3Location.Etag",
+      "BodyS3Location.Key",
+      "BodyS3Location.Version",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnlyPaths": ["ProtocolType"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "rno3u8uv0f",
+      "constructPath": "CdkrdIntegHarvest4/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "RouteSelectionExpression",
+      "actual": "$request.method $request.path",
+      "physicalId": "rno3u8uv0f",
+      "constructPath": "CdkrdIntegHarvest4/Api"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.ReadTarget3B84E8CE.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalableTarget.ReadTarget3B84E8CE.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ApplicationAutoScaling::ScalableTarget model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ReadTarget3B84E8CE",
+    "resourceType": "AWS::ApplicationAutoScaling::ScalableTarget",
+    "physicalId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1AME3ENAZ10B2|dynamodb:table:ReadCapacityUnits|dynamodb",
+    "constructPath": "CdkrdIntegHarvest4/ReadTarget",
+    "declared": {
+      "MaxCapacity": 5,
+      "MinCapacity": 1,
+      "ResourceId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1AME3ENAZ10B2",
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+      "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+      "ServiceNamespace": "dynamodb"
+    }
+  },
+  "liveRaw": {
+    "ResourceId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1AME3ENAZ10B2",
+    "ServiceNamespace": "dynamodb",
+    "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+    "SuspendedState": {
+      "DynamicScalingOutSuspended": false,
+      "ScheduledScalingSuspended": false,
+      "DynamicScalingInSuspended": false
+    },
+    "Id": "table/CdkrdIntegHarvest4-Sessions8896A56D-1AME3ENAZ10B2|dynamodb:table:ReadCapacityUnits|dynamodb",
+    "MinCapacity": 1,
+    "MaxCapacity": 5
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["RoleARN"],
+    "createOnly": ["ResourceId", "ScalableDimension", "ServiceNamespace"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["RoleARN"],
+    "createOnlyPaths": ["ResourceId", "ScalableDimension", "ServiceNamespace"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "ReadTarget3B84E8CE",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalableTarget",
+      "path": "RoleARN",
+      "note": "write-only — cannot be read back",
+      "physicalId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1AME3ENAZ10B2|dynamodb:table:ReadCapacityUnits|dynamodb",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD.json
@@ -1,0 +1,200 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (cloudfront fixture, R75): fresh-deploy AWS::CloudFront::Distribution model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Cdn9963B1AD",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E2WBGYTS0T0BVH",
+    "constructPath": "CdkrdIntegCloudfront/Cdn",
+    "declared": {
+      "DistributionConfig": {
+        "CacheBehaviors": [
+          {
+            "AllowedMethods": ["GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
+            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
+            "Compress": true,
+            "PathPattern": "/api/*",
+            "TargetOriginId": "CdkrdIntegCloudfrontCdnOrigin2499A636E",
+            "ViewerProtocolPolicy": "https-only"
+          }
+        ],
+        "Comment": "cdkrd cloudfront corpus fixture",
+        "CustomErrorResponses": [
+          {
+            "ErrorCachingMinTTL": 300,
+            "ErrorCode": 404,
+            "ResponseCode": 200,
+            "ResponsePagePath": "/index.html"
+          }
+        ],
+        "DefaultCacheBehavior": {
+          "AllowedMethods": ["GET", "HEAD", "OPTIONS"],
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+          "CachedMethods": ["GET", "HEAD"],
+          "Compress": true,
+          "TargetOriginId": "CdkrdIntegCloudfrontCdnOrigin1117C92F8",
+          "ViewerProtocolPolicy": "redirect-to-https"
+        },
+        "DefaultRootObject": "index.html",
+        "Enabled": true,
+        "HttpVersion": "http2and3",
+        "IPV6Enabled": true,
+        "Origins": [
+          {
+            "DomainName": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh.s3.us-east-1.amazonaws.com",
+            "Id": "CdkrdIntegCloudfrontCdnOrigin1117C92F8",
+            "OriginAccessControlId": "EGP8LO2Z4DVZ6",
+            "S3OriginConfig": {
+              "OriginAccessIdentity": ""
+            }
+          },
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "OriginReadTimeout": 20,
+              "OriginSSLProtocols": ["TLSv1.2"]
+            },
+            "DomainName": "api.example.com",
+            "Id": "CdkrdIntegCloudfrontCdnOrigin2499A636E"
+          }
+        ],
+        "PriceClass": "PriceClass_100"
+      }
+    }
+  },
+  "liveRaw": {
+    "DistributionConfig": {
+      "Logging": {
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+      },
+      "Comment": "cdkrd cloudfront corpus fixture",
+      "DefaultRootObject": "index.html",
+      "Origins": [
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "EGP8LO2Z4DVZ6",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh.s3.us-east-1.amazonaws.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "S3OriginConfig": {
+            "OriginReadTimeout": 30,
+            "OriginAccessIdentity": ""
+          },
+          "OriginPath": "",
+          "Id": "CdkrdIntegCloudfrontCdnOrigin1117C92F8"
+        },
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "api.example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "CdkrdIntegCloudfrontCdnOrigin2499A636E",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 20,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["TLSv1.2"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        }
+      ],
+      "ViewerCertificate": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "PriceClass": "PriceClass_100",
+      "DefaultCacheBehavior": {
+        "Compress": true,
+        "FunctionAssociations": [],
+        "LambdaFunctionAssociations": [],
+        "TargetOriginId": "CdkrdIntegCloudfrontCdnOrigin1117C92F8",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "GrpcConfig": {
+          "Enabled": false
+        },
+        "TrustedSigners": [],
+        "FieldLevelEncryptionId": "",
+        "TrustedKeyGroups": [],
+        "AllowedMethods": ["HEAD", "GET", "OPTIONS"],
+        "CachedMethods": ["HEAD", "GET"],
+        "SmoothStreaming": false,
+        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+      },
+      "Staging": false,
+      "CustomErrorResponses": [
+        {
+          "ResponseCode": 200,
+          "ErrorCachingMinTTL": 300,
+          "ErrorCode": 404,
+          "ResponsePagePath": "/index.html"
+        }
+      ],
+      "ContinuousDeploymentPolicyId": "",
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "Enabled": true,
+      "Aliases": [],
+      "IPV6Enabled": true,
+      "WebACLId": "",
+      "HttpVersion": "http2and3",
+      "Restrictions": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "CacheBehaviors": [
+        {
+          "Compress": true,
+          "FunctionAssociations": [],
+          "LambdaFunctionAssociations": [],
+          "TargetOriginId": "CdkrdIntegCloudfrontCdnOrigin2499A636E",
+          "ViewerProtocolPolicy": "https-only",
+          "GrpcConfig": {
+            "Enabled": false
+          },
+          "TrustedSigners": [],
+          "FieldLevelEncryptionId": "",
+          "TrustedKeyGroups": [],
+          "AllowedMethods": ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"],
+          "PathPattern": "/api/*",
+          "CachedMethods": ["HEAD", "GET"],
+          "SmoothStreaming": false,
+          "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+        }
+      ]
+    },
+    "DomainName": "d2adwxv8w2e8q.cloudfront.net",
+    "Id": "E2WBGYTS0T0BVH",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["DomainName", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["DomainName", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudFront__OriginAccessControl.CdnOrigin1S3OriginAccessControl6AC0AEFC.json
+++ b/tests/corpus/AWS__CloudFront__OriginAccessControl.CdnOrigin1S3OriginAccessControl6AC0AEFC.json
@@ -1,0 +1,43 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (cloudfront fixture, R75): fresh-deploy AWS::CloudFront::OriginAccessControl model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "CdnOrigin1S3OriginAccessControl6AC0AEFC",
+    "resourceType": "AWS::CloudFront::OriginAccessControl",
+    "physicalId": "EGP8LO2Z4DVZ6",
+    "constructPath": "CdkrdIntegCloudfront/Cdn/Origin1/S3OriginAccessControl",
+    "declared": {
+      "OriginAccessControlConfig": {
+        "Name": "CdkrdIntegCloudfrontCdnOrigin1S3OriginAccessControl72EC851C",
+        "OriginAccessControlOriginType": "s3",
+        "SigningBehavior": "always",
+        "SigningProtocol": "sigv4"
+      }
+    }
+  },
+  "liveRaw": {
+    "OriginAccessControlConfig": {
+      "SigningBehavior": "always",
+      "Description": "",
+      "OriginAccessControlOriginType": "s3",
+      "SigningProtocol": "sigv4",
+      "Name": "CdkrdIntegCloudfrontCdnOrigin1S3OriginAccessControl72EC851C"
+    },
+    "Id": "EGP8LO2Z4DVZ6"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__IdentityPool.Ids.json
+++ b/tests/corpus/AWS__Cognito__IdentityPool.Ids.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::Cognito::IdentityPool model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Ids",
+    "resourceType": "AWS::Cognito::IdentityPool",
+    "physicalId": "us-east-1:86c10d35-8cbb-45b9-ae04-7b0116642efb",
+    "constructPath": "CdkrdIntegHarvest4/Ids",
+    "declared": {
+      "AllowUnauthenticatedIdentities": false,
+      "IdentityPoolName": "cdkrd_harvest4"
+    }
+  },
+  "liveRaw": {
+    "CognitoIdentityProviders": [],
+    "Id": "us-east-1:86c10d35-8cbb-45b9-ae04-7b0116642efb",
+    "IdentityPoolName": "cdkrd_harvest4",
+    "SupportedLoginProviders": {},
+    "AllowUnauthenticatedIdentities": false,
+    "Name": "cdkrd_harvest4",
+    "SamlProviderARNs": [],
+    "OpenIdConnectProviderARNs": [],
+    "AllowClassicFlow": false,
+    "IdentityPoolTags": []
+  },
+  "schema": {
+    "readOnly": ["Id", "Name"],
+    "writeOnly": ["CognitoEvents", "CognitoStreams", "PushSync"],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "Name"],
+    "writeOnlyPaths": ["CognitoEvents", "CognitoStreams", "PushSync"],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__InternetGateway.NetIGW5B03566F.json
+++ b/tests/corpus/AWS__EC2__InternetGateway.NetIGW5B03566F.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::InternetGateway model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetIGW5B03566F",
+    "resourceType": "AWS::EC2::InternetGateway",
+    "physicalId": "igw-0c7816775f3353a51",
+    "constructPath": "CdkrdIntegHarvest4/Net/IGW",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Net"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "InternetGatewayId": "igw-0c7816775f3353a51",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest4/Net",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["InternetGatewayId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["InternetGatewayId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__Route.NetpublicSubnet1DefaultRoute05F98207.json
+++ b/tests/corpus/AWS__EC2__Route.NetpublicSubnet1DefaultRoute05F98207.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::Route model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet1DefaultRoute05F98207",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-0f55fd2a2deab184b|0.0.0.0/0",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": "igw-0c7816775f3353a51",
+      "RouteTableId": "rtb-0f55fd2a2deab184b"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-0f55fd2a2deab184b",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": "igw-0c7816775f3353a51",
+    "VpcEndpointId": "igw-0c7816775f3353a51"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "NetpublicSubnet1DefaultRoute05F98207",
+      "resourceType": "AWS::EC2::Route",
+      "path": "VpcEndpointId",
+      "actual": "igw-0c7816775f3353a51",
+      "physicalId": "rtb-0f55fd2a2deab184b|0.0.0.0/0",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/DefaultRoute"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Route.NetpublicSubnet2DefaultRouteE6C085C4.json
+++ b/tests/corpus/AWS__EC2__Route.NetpublicSubnet2DefaultRouteE6C085C4.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::Route model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet2DefaultRouteE6C085C4",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-09f760c55f4a567d2|0.0.0.0/0",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": "igw-0c7816775f3353a51",
+      "RouteTableId": "rtb-09f760c55f4a567d2"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-09f760c55f4a567d2",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": "igw-0c7816775f3353a51",
+    "VpcEndpointId": "igw-0c7816775f3353a51"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "NetpublicSubnet2DefaultRouteE6C085C4",
+      "resourceType": "AWS::EC2::Route",
+      "path": "VpcEndpointId",
+      "actual": "igw-0c7816775f3353a51",
+      "physicalId": "rtb-09f760c55f4a567d2|0.0.0.0/0",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/DefaultRoute"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__RouteTable.NetpublicSubnet1RouteTable513C44C4.json
+++ b/tests/corpus/AWS__EC2__RouteTable.NetpublicSubnet1RouteTable513C44C4.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::RouteTable model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet1RouteTable513C44C4",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-0f55fd2a2deab184b",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Net/publicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-0f55fd2a2deab184b",
+    "VpcId": "vpc-08521c59b278960ac",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest4/Net/publicSubnet1",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__RouteTable.NetpublicSubnet2RouteTableB428CBA3.json
+++ b/tests/corpus/AWS__EC2__RouteTable.NetpublicSubnet2RouteTableB428CBA3.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::RouteTable model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet2RouteTableB428CBA3",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-09f760c55f4a567d2",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Net/publicSubnet2"
+        }
+      ],
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-09f760c55f4a567d2",
+    "VpcId": "vpc-08521c59b278960ac",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest4/Net/publicSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SecurityGroup.AlbSg1155C1BE.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.AlbSg1155C1BE.json
@@ -1,0 +1,94 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::SecurityGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AlbSg1155C1BE",
+    "resourceType": "AWS::EC2::SecurityGroup",
+    "physicalId": "sg-027baeaf6d1dfcb34",
+    "constructPath": "CdkrdIntegHarvest4/AlbSg",
+    "declared": {
+      "GroupDescription": "cdkrd harvest4 alb",
+      "SecurityGroupEgress": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "Allow all outbound traffic by default",
+          "IpProtocol": "-1"
+        }
+      ],
+      "SecurityGroupIngress": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "http in",
+          "FromPort": 80,
+          "IpProtocol": "tcp",
+          "ToPort": 80
+        }
+      ],
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "GroupDescription": "cdkrd harvest4 alb",
+    "GroupName": "CdkrdIntegHarvest4-AlbSg1155C1BE-xPthhDznw5Ma",
+    "VpcId": "vpc-08521c59b278960ac",
+    "Id": "sg-027baeaf6d1dfcb34",
+    "SecurityGroupIngress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "http in",
+        "FromPort": 80,
+        "ToPort": 80,
+        "IpProtocol": "tcp"
+      }
+    ],
+    "SecurityGroupEgress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow all outbound traffic by default",
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "-1"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AlbSg1155C1BE",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "GroupId": "sg-027baeaf6d1dfcb34"
+  },
+  "schema": {
+    "readOnly": ["GroupId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["GroupDescription", "GroupName", "VpcId"],
+    "readOnlyPaths": ["GroupId", "Id"],
+    "writeOnlyPaths": ["SecurityGroupIngress.*.SourceSecurityGroupName"],
+    "createOnlyPaths": ["GroupDescription", "GroupName", "VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "AlbSg1155C1BE",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "GroupName",
+      "actual": "CdkrdIntegHarvest4-AlbSg1155C1BE-xPthhDznw5Ma",
+      "physicalId": "sg-027baeaf6d1dfcb34",
+      "constructPath": "CdkrdIntegHarvest4/AlbSg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SecurityGroup.FilesEfsSecurityGroup332450AB.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.FilesEfsSecurityGroup332450AB.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::SecurityGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FilesEfsSecurityGroup332450AB",
+    "resourceType": "AWS::EC2::SecurityGroup",
+    "physicalId": "sg-0b45db45b9c237e91",
+    "constructPath": "CdkrdIntegHarvest4/Files/EfsSecurityGroup",
+    "declared": {
+      "GroupDescription": "CdkrdIntegHarvest4/Files/EfsSecurityGroup",
+      "SecurityGroupEgress": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "Allow all outbound traffic by default",
+          "IpProtocol": "-1"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Files"
+        }
+      ],
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "GroupDescription": "CdkrdIntegHarvest4/Files/EfsSecurityGroup",
+    "GroupName": "CdkrdIntegHarvest4-FilesEfsSecurityGroup332450AB-w9HKtZuFvrut",
+    "VpcId": "vpc-08521c59b278960ac",
+    "Id": "sg-0b45db45b9c237e91",
+    "SecurityGroupEgress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow all outbound traffic by default",
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "-1"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest4/Files",
+        "Key": "Name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "FilesEfsSecurityGroup332450AB",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "GroupId": "sg-0b45db45b9c237e91"
+  },
+  "schema": {
+    "readOnly": ["GroupId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["GroupDescription", "GroupName", "VpcId"],
+    "readOnlyPaths": ["GroupId", "Id"],
+    "writeOnlyPaths": ["SecurityGroupIngress.*.SourceSecurityGroupName"],
+    "createOnlyPaths": ["GroupDescription", "GroupName", "VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FilesEfsSecurityGroup332450AB",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "GroupName",
+      "actual": "CdkrdIntegHarvest4-FilesEfsSecurityGroup332450AB-w9HKtZuFvrut",
+      "physicalId": "sg-0b45db45b9c237e91",
+      "constructPath": "CdkrdIntegHarvest4/Files/EfsSecurityGroup"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
@@ -1,0 +1,156 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::Subnet model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-0f3317e0d9ac5df28",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.0.0/17",
+      "MapPublicIpOnLaunch": true,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "public"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Public"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Net/publicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": true,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "CidrBlock": "10.0.0.0/17",
+    "SubnetId": "subnet-0f3317e0d9ac5df28",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-08521c59b278960ac",
+    "NetworkAclAssociationId": "aclassoc-0a337ee9aab287b01",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest4/Net/publicSubnet1",
+        "Key": "Name"
+      },
+      {
+        "Value": "public",
+        "Key": "aws-cdk:subnet-name"
+      },
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-type"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
@@ -1,0 +1,156 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::Subnet model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-0e4bae13856face36",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.128.0/17",
+      "MapPublicIpOnLaunch": true,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "public"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Public"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Net/publicSubnet2"
+        }
+      ],
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": true,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az2",
+    "AvailabilityZone": "us-east-1b",
+    "CidrBlock": "10.0.128.0/17",
+    "SubnetId": "subnet-0e4bae13856face36",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-08521c59b278960ac",
+    "NetworkAclAssociationId": "aclassoc-09429956ed06ced15",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "public",
+        "Key": "aws-cdk:subnet-name"
+      },
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4/Net/publicSubnet2",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az2",
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.NetpublicSubnet1RouteTableAssociation4921F6CF.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.NetpublicSubnet1RouteTableAssociation4921F6CF.json
@@ -1,0 +1,34 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::SubnetRouteTableAssociation model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet1RouteTableAssociation4921F6CF",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-0eba8386644438fed",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-0f55fd2a2deab184b",
+      "SubnetId": "subnet-0f3317e0d9ac5df28"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-0f55fd2a2deab184b",
+    "Id": "rtbassoc-0eba8386644438fed",
+    "SubnetId": "subnet-0f3317e0d9ac5df28"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.NetpublicSubnet2RouteTableAssociation4AD902D3.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.NetpublicSubnet2RouteTableAssociation4AD902D3.json
@@ -1,0 +1,34 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::SubnetRouteTableAssociation model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetpublicSubnet2RouteTableAssociation4AD902D3",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-081ce08c63a8b9ca7",
+    "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-09f760c55f4a567d2",
+      "SubnetId": "subnet-0e4bae13856face36"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-09f760c55f4a567d2",
+    "Id": "rtbassoc-081ce08c63a8b9ca7",
+    "SubnetId": "subnet-0e4bae13856face36"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPC.NetDBED6B57.json
+++ b/tests/corpus/AWS__EC2__VPC.NetDBED6B57.json
@@ -1,0 +1,78 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::VPC model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetDBED6B57",
+    "resourceType": "AWS::EC2::VPC",
+    "physicalId": "vpc-08521c59b278960ac",
+    "constructPath": "CdkrdIntegHarvest4/Net",
+    "declared": {
+      "CidrBlock": "10.0.0.0/16",
+      "EnableDnsHostnames": true,
+      "EnableDnsSupport": true,
+      "InstanceTenancy": "default",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Net"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-08521c59b278960ac",
+    "InstanceTenancy": "default",
+    "CidrBlockAssociations": ["vpc-cidr-assoc-03895c9da8354a701"],
+    "CidrBlock": "10.0.0.0/16",
+    "DefaultNetworkAcl": "acl-0b2de30671549f143",
+    "EnableDnsSupport": true,
+    "Ipv6CidrBlocks": [],
+    "DefaultSecurityGroup": "sg-03b714a63cd355862",
+    "EnableDnsHostnames": true,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "NetDBED6B57",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4/Net",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnly": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnly": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "readOnlyPaths": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnlyPaths": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPCGatewayAttachment.NetVPCGWB4C77F62.json
+++ b/tests/corpus/AWS__EC2__VPCGatewayAttachment.NetVPCGWB4C77F62.json
@@ -1,0 +1,34 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EC2::VPCGatewayAttachment model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "NetVPCGWB4C77F62",
+    "resourceType": "AWS::EC2::VPCGatewayAttachment",
+    "physicalId": "IGW|vpc-08521c59b278960ac",
+    "constructPath": "CdkrdIntegHarvest4/Net/VPCGW",
+    "declared": {
+      "InternetGatewayId": "igw-0c7816775f3353a51",
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "InternetGatewayId": "igw-0c7816775f3353a51",
+    "AttachmentType": "IGW",
+    "VpcId": "vpc-08521c59b278960ac"
+  },
+  "schema": {
+    "readOnly": ["AttachmentType"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["AttachmentType"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
@@ -1,0 +1,115 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EFS::FileSystem model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Files8E6940B8",
+    "resourceType": "AWS::EFS::FileSystem",
+    "physicalId": "fs-0679f705e7e468268",
+    "constructPath": "CdkrdIntegHarvest4/Files",
+    "declared": {
+      "Encrypted": true,
+      "FileSystemTags": [
+        {
+          "Key": "Name",
+          "Value": "CdkrdIntegHarvest4/Files"
+        }
+      ],
+      "LifecyclePolicies": [
+        {
+          "TransitionToIA": "AFTER_14_DAYS"
+        }
+      ],
+      "PerformanceMode": "generalPurpose"
+    }
+  },
+  "liveRaw": {
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
+    "PerformanceMode": "generalPurpose",
+    "Encrypted": true,
+    "FileSystemTags": [
+      {
+        "Value": "CdkrdIntegHarvest4/Files",
+        "Key": "Name"
+      }
+    ],
+    "FileSystemId": "fs-0679f705e7e468268",
+    "FileSystemProtection": {
+      "ReplicationOverwriteProtection": "ENABLED"
+    },
+    "LifecyclePolicies": [
+      {
+        "TransitionToIA": "AFTER_14_DAYS"
+      }
+    ],
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:file-system/fs-0679f705e7e468268",
+    "ThroughputMode": "bursting",
+    "BackupPolicy": {
+      "Status": "DISABLED"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "FileSystemId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck"],
+    "createOnly": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "readOnlyPaths": [
+      "Arn",
+      "FileSystemId",
+      "ReplicationConfiguration.Destinations.*.Status",
+      "ReplicationConfiguration.Destinations.*.StatusMessage"
+    ],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "ReplicationConfiguration.Destinations.0.AvailabilityZoneName",
+      "ReplicationConfiguration.Destinations.0.KmsKeyId"
+    ],
+    "createOnlyPaths": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Files8E6940B8",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "physicalId": "fs-0679f705e7e468268",
+      "constructPath": "CdkrdIntegHarvest4/Files"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Files8E6940B8",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "FileSystemProtection",
+      "actual": {
+        "ReplicationOverwriteProtection": "ENABLED"
+      },
+      "physicalId": "fs-0679f705e7e468268",
+      "constructPath": "CdkrdIntegHarvest4/Files"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Files8E6940B8",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "ThroughputMode",
+      "actual": "bursting",
+      "physicalId": "fs-0679f705e7e468268",
+      "constructPath": "CdkrdIntegHarvest4/Files"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Files8E6940B8",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "fs-0679f705e7e468268",
+      "constructPath": "CdkrdIntegHarvest4/Files"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget1AB817C34.json
+++ b/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget1AB817C34.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EFS::MountTarget model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FilesEfsMountTarget1AB817C34",
+    "resourceType": "AWS::EFS::MountTarget",
+    "physicalId": "fsmt-05f0117bf74a4697e",
+    "constructPath": "CdkrdIntegHarvest4/Files/EfsMountTarget1",
+    "declared": {
+      "FileSystemId": "fs-0679f705e7e468268",
+      "SecurityGroups": ["sg-0b45db45b9c237e91"],
+      "SubnetId": "subnet-0f3317e0d9ac5df28"
+    }
+  },
+  "liveRaw": {
+    "SecurityGroups": ["sg-0b45db45b9c237e91"],
+    "FileSystemId": "fs-0679f705e7e468268",
+    "IpAddress": "10.0.88.116",
+    "Id": "fsmt-05f0117bf74a4697e",
+    "SubnetId": "subnet-0f3317e0d9ac5df28"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["IpAddressType"],
+    "createOnly": ["FileSystemId", "IpAddress", "IpAddressType", "Ipv6Address", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["IpAddressType"],
+    "createOnlyPaths": ["FileSystemId", "IpAddress", "IpAddressType", "Ipv6Address", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FilesEfsMountTarget1AB817C34",
+      "resourceType": "AWS::EFS::MountTarget",
+      "path": "IpAddress",
+      "actual": "10.0.88.116",
+      "physicalId": "fsmt-05f0117bf74a4697e",
+      "constructPath": "CdkrdIntegHarvest4/Files/EfsMountTarget1"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget22C8423FA.json
+++ b/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget22C8423FA.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::EFS::MountTarget model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "FilesEfsMountTarget22C8423FA",
+    "resourceType": "AWS::EFS::MountTarget",
+    "physicalId": "fsmt-015fb98a84dac5c79",
+    "constructPath": "CdkrdIntegHarvest4/Files/EfsMountTarget2",
+    "declared": {
+      "FileSystemId": "fs-0679f705e7e468268",
+      "SecurityGroups": ["sg-0b45db45b9c237e91"],
+      "SubnetId": "subnet-0e4bae13856face36"
+    }
+  },
+  "liveRaw": {
+    "SecurityGroups": ["sg-0b45db45b9c237e91"],
+    "FileSystemId": "fs-0679f705e7e468268",
+    "IpAddress": "10.0.244.232",
+    "Id": "fsmt-015fb98a84dac5c79",
+    "SubnetId": "subnet-0e4bae13856face36"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["IpAddressType"],
+    "createOnly": ["FileSystemId", "IpAddress", "IpAddressType", "Ipv6Address", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["IpAddressType"],
+    "createOnlyPaths": ["FileSystemId", "IpAddress", "IpAddressType", "Ipv6Address", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FilesEfsMountTarget22C8423FA",
+      "resourceType": "AWS::EFS::MountTarget",
+      "path": "IpAddress",
+      "actual": "10.0.244.232",
+      "physicalId": "fsmt-015fb98a84dac5c79",
+      "constructPath": "CdkrdIntegHarvest4/Files/EfsMountTarget2"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.EdgeHttp4128BFC4.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.EdgeHttp4128BFC4.json
@@ -1,0 +1,160 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ElasticLoadBalancingV2::Listener model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "EdgeHttp4128BFC4",
+    "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8/bdc3da920490ea14",
+    "constructPath": "CdkrdIntegHarvest4/Edge/Http",
+    "declared": {
+      "DefaultActions": [
+        {
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+          "Type": "forward"
+        }
+      ],
+      "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "Port": 80,
+      "Protocol": "HTTP"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8/bdc3da920490ea14",
+    "ListenerAttributes": [
+      {
+        "Value": "true",
+        "Key": "routing.http.response.server.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_frame_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_methods.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_origin.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_allow_credentials.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.x_content_type_options.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.content_security_policy.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_expose_headers.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.strict_transport_security.header_value"
+      },
+      {
+        "Value": "",
+        "Key": "routing.http.response.access_control_max_age.header_value"
+      }
+    ],
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "DefaultActions": [
+      {
+        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+        "Type": "forward",
+        "ForwardConfig": {
+          "TargetGroupStickinessConfig": {
+            "Enabled": false
+          },
+          "TargetGroups": [
+            {
+              "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+              "Weight": 1
+            }
+          ]
+        }
+      }
+    ],
+    "Port": 80,
+    "Protocol": "HTTP"
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": ["DefaultActions.*.AuthenticateOidcConfig.ClientSecret"],
+    "createOnlyPaths": ["LoadBalancerArn"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EdgeHttp4128BFC4",
+      "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
+      "path": "ListenerAttributes",
+      "actual": [
+        {
+          "Value": "",
+          "Key": "routing.http.response.access_control_allow_credentials.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.access_control_allow_headers.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.access_control_allow_methods.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.access_control_allow_origin.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.access_control_expose_headers.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.access_control_max_age.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.content_security_policy.header_value"
+        },
+        {
+          "Value": "true",
+          "Key": "routing.http.response.server.enabled"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.strict_transport_security.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.x_content_type_options.header_value"
+        },
+        {
+          "Value": "",
+          "Key": "routing.http.response.x_frame_options.header_value"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8/bdc3da920490ea14",
+      "constructPath": "CdkrdIntegHarvest4/Edge/Http"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
@@ -1,0 +1,235 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 subset-projection check, R75): AWS::ElasticLoadBalancingV2::LoadBalancer after an OUT-OF-BAND change to ONE attribute inside the identity-keyed LoadBalancerAttributes bag — the lone `declared` finding in `expected` is the attribute the R75 subset projection isolates (the template declares 2 of ~23 attributes). A change here means the attribute-bag subset projection changed — review it.",
+  "resource": {
+    "logicalId": "Edge7038544F",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "constructPath": "CdkrdIntegHarvest4/Edge",
+    "declared": {
+      "LoadBalancerAttributes": [
+        {
+          "Key": "deletion_protection.enabled",
+          "Value": "false"
+        },
+        {
+          "Key": "idle_timeout.timeout_seconds",
+          "Value": "120"
+        }
+      ],
+      "Scheme": "internet-facing",
+      "SecurityGroups": ["sg-027baeaf6d1dfcb34"],
+      "Subnets": ["subnet-0f3317e0d9ac5df28", "subnet-0e4bae13856face36"],
+      "Type": "application"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "SecurityGroups": ["sg-027baeaf6d1dfcb34"],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "append",
+        "Key": "routing.http.xff_header_processing.mode"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "waf.fail_open.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "300",
+        "Key": "idle_timeout.timeout_seconds"
+      },
+      {
+        "Value": "defensive",
+        "Key": "routing.http.desync_mitigation_mode"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.prefix"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.preserve_host_header.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "health_check_logs.s3.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.xff_client_port.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "3600",
+        "Key": "client_keep_alive.seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.drop_invalid_header_fields.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "connection_logs.s3.enabled"
+      }
+    ],
+    "Scheme": "internet-facing",
+    "DNSName": "CdkrdI-Edge7-ivPMKfmp3Fts-1275371827.us-east-1.elb.amazonaws.com",
+    "Name": "CdkrdI-Edge7-ivPMKfmp3Fts",
+    "LoadBalancerName": "CdkrdI-Edge7-ivPMKfmp3Fts",
+    "Subnets": ["subnet-0f3317e0d9ac5df28", "subnet-0e4bae13856face36"],
+    "Type": "application",
+    "CanonicalHostedZoneID": "Z35SXDOTRQ7X7K",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Edge7038544F",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "LoadBalancerFullName": "app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-0e4bae13856face36"
+      },
+      {
+        "SubnetId": "subnet-0f3317e0d9ac5df28"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes.1.Value",
+      "desired": "120",
+      "actual": "300",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "Name",
+      "actual": "CdkrdI-Edge7-ivPMKfmp3Fts",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "SubnetMappings",
+      "actual": [
+        {
+          "SubnetId": "subnet-0e4bae13856face36"
+        },
+        {
+          "SubnetId": "subnet-0f3317e0d9ac5df28"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
@@ -1,0 +1,225 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ElasticLoadBalancingV2::LoadBalancer model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Edge7038544F",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "constructPath": "CdkrdIntegHarvest4/Edge",
+    "declared": {
+      "LoadBalancerAttributes": [
+        {
+          "Key": "deletion_protection.enabled",
+          "Value": "false"
+        },
+        {
+          "Key": "idle_timeout.timeout_seconds",
+          "Value": "120"
+        }
+      ],
+      "Scheme": "internet-facing",
+      "SecurityGroups": ["sg-027baeaf6d1dfcb34"],
+      "Subnets": ["subnet-0f3317e0d9ac5df28", "subnet-0e4bae13856face36"],
+      "Type": "application"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "SecurityGroups": ["sg-027baeaf6d1dfcb34"],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "append",
+        "Key": "routing.http.xff_header_processing.mode"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "waf.fail_open.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "defensive",
+        "Key": "routing.http.desync_mitigation_mode"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.prefix"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.preserve_host_header.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "health_check_logs.s3.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.xff_client_port.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "3600",
+        "Key": "client_keep_alive.seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.drop_invalid_header_fields.enabled"
+      },
+      {
+        "Value": "120",
+        "Key": "idle_timeout.timeout_seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "connection_logs.s3.enabled"
+      }
+    ],
+    "Scheme": "internet-facing",
+    "DNSName": "CdkrdI-Edge7-ivPMKfmp3Fts-1275371827.us-east-1.elb.amazonaws.com",
+    "Name": "CdkrdI-Edge7-ivPMKfmp3Fts",
+    "LoadBalancerName": "CdkrdI-Edge7-ivPMKfmp3Fts",
+    "Subnets": ["subnet-0f3317e0d9ac5df28", "subnet-0e4bae13856face36"],
+    "Type": "application",
+    "CanonicalHostedZoneID": "Z35SXDOTRQ7X7K",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Edge7038544F",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "LoadBalancerFullName": "app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-0e4bae13856face36"
+      },
+      {
+        "SubnetId": "subnet-0f3317e0d9ac5df28"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "Name",
+      "actual": "CdkrdI-Edge7-ivPMKfmp3Fts",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "SubnetMappings",
+      "actual": [
+        {
+          "SubnetId": "subnet-0e4bae13856face36"
+        },
+        {
+          "SubnetId": "subnet-0f3317e0d9ac5df28"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
@@ -1,0 +1,248 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::ElasticLoadBalancingV2::TargetGroup model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Web3C8945DB",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+    "constructPath": "CdkrdIntegHarvest4/Web",
+    "declared": {
+      "HealthCheckIntervalSeconds": 30,
+      "HealthCheckPath": "/health",
+      "HealthyThresholdCount": 3,
+      "Port": 8080,
+      "Protocol": "HTTP",
+      "TargetGroupAttributes": [
+        {
+          "Key": "deregistration_delay.timeout_seconds",
+          "Value": "15"
+        },
+        {
+          "Key": "stickiness.enabled",
+          "Value": "false"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-08521c59b278960ac"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [
+      "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8"
+    ],
+    "Matcher": {
+      "HttpCode": "200"
+    },
+    "HealthCheckPath": "/health",
+    "Port": 8080,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "ProtocolVersion": "HTTP1",
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 5,
+    "Name": "CdkrdI-Web3C-B2EBJYBQ0UEJ",
+    "VpcId": "vpc-08521c59b278960ac",
+    "TargetGroupFullName": "targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+    "HealthyThresholdCount": 3,
+    "HealthCheckProtocol": "HTTP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "15",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "lb_cookie",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.app_cookie.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.lb_cookie.duration_seconds"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "slow_start.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "off",
+        "Key": "load_balancing.algorithm.anomaly_mitigation"
+      },
+      {
+        "Value": "",
+        "Key": "stickiness.app_cookie.cookie_name"
+      },
+      {
+        "Value": "round_robin",
+        "Key": "load_balancing.algorithm.type"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "HTTP",
+    "TargetGroupName": "CdkrdI-Web3C-B2EBJYBQ0UEJ",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Web3C8945DB",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Matcher",
+      "actual": {
+        "HttpCode": "200"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "ProtocolVersion",
+      "actual": "HTTP1",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Name",
+      "actual": "CdkrdI-Web3C-B2EBJYBQ0UEJ",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "HTTP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__Role.ApiFnServiceRoleD18AAE0E.json
+++ b/tests/corpus/AWS__IAM__Role.ApiFnServiceRoleD18AAE0E.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiFnServiceRoleD18AAE0E",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+    "constructPath": "CdkrdIntegHarvest4/ApiFn/ServiceRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+    "RoleId": "AROAXXXJN2LNRK4ZOCNDQ"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.ReadTargetRoleA9FE198C.json
+++ b/tests/corpus/AWS__IAM__Role.ReadTargetRoleA9FE198C.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ReadTargetRoleA9FE198C",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+    "constructPath": "CdkrdIntegHarvest4/ReadTarget/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "application-autoscaling.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "application-autoscaling.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+    "RoleId": "AROAXXXJN2LNY3IIGANOL"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
+++ b/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::Lambda::Function model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiFnE0725F78",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+    "constructPath": "CdkrdIntegHarvest4/ApiFn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => ({statusCode: 200, body: 'ok'});"
+      },
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+      "Runtime": "nodejs20.x"
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "ApiFnE0725F78",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo"
+      },
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Permission.ApiANYpingPingPermission3EC4806D.json
+++ b/tests/corpus/AWS__Lambda__Permission.ApiANYpingPingPermission3EC4806D.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::Lambda::Permission model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiANYpingPingPermission3EC4806D",
+    "resourceType": "AWS::Lambda::Permission",
+    "physicalId": "CdkrdIntegHarvest4-ApiANYpingPingPermission3EC4806D-HNjdwPvueJi1",
+    "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping-Permission",
+    "declared": {
+      "Action": "lambda:InvokeFunction",
+      "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "Principal": "apigateway.amazonaws.com",
+      "SourceArn": "arn:aws:execute-api:us-east-1:111111111111:rno3u8uv0f/*/*/ping"
+    }
+  },
+  "liveRaw": {
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+    "Action": "lambda:InvokeFunction",
+    "Principal": "apigateway.amazonaws.com",
+    "SourceArn": "arn:aws:execute-api:us-east-1:111111111111:rno3u8uv0f/*/*/ping"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "Action",
+      "EventSourceToken",
+      "FunctionName",
+      "FunctionUrlAuthType",
+      "InvokedViaFunctionUrl",
+      "Principal",
+      "PrincipalOrgID",
+      "SourceAccount",
+      "SourceArn"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "Action",
+      "EventSourceToken",
+      "FunctionName",
+      "FunctionUrlAuthType",
+      "InvokedViaFunctionUrl",
+      "Principal",
+      "PrincipalOrgID",
+      "SourceAccount",
+      "SourceArn"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__HostedZone.ZoneA5DE4B68.json
+++ b/tests/corpus/AWS__Route53__HostedZone.ZoneA5DE4B68.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::Route53::HostedZone model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ZoneA5DE4B68",
+    "resourceType": "AWS::Route53::HostedZone",
+    "physicalId": "Z04472198DJOBTXYG54D",
+    "constructPath": "CdkrdIntegHarvest4/Zone",
+    "declared": {
+      "Name": "cdkrd-harvest4-integ-fixture.com."
+    }
+  },
+  "liveRaw": {
+    "HostedZoneFeatures": {
+      "EnableAcceleratedRecovery": false
+    },
+    "HostedZoneConfig": {},
+    "Id": "Z04472198DJOBTXYG54D",
+    "NameServers": [
+      "ns-1694.awsdns-19.co.uk",
+      "ns-1031.awsdns-00.org",
+      "ns-104.awsdns-13.com",
+      "ns-606.awsdns-11.net"
+    ],
+    "Name": "cdkrd-harvest4-integ-fixture.com."
+  },
+  "schema": {
+    "readOnly": ["Id", "NameServers"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id", "NameServers"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__RecordSet.Apex7EB71B37.json
+++ b/tests/corpus/AWS__Route53__RecordSet.Apex7EB71B37.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::Route53::RecordSet model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Apex7EB71B37",
+    "resourceType": "AWS::Route53::RecordSet",
+    "physicalId": "cdkrd-harvest4-integ-fixture.com",
+    "constructPath": "CdkrdIntegHarvest4/Apex",
+    "declared": {
+      "AliasTarget": {
+        "DNSName": "dualstack.CdkrdI-Edge7-ivPMKfmp3Fts-1275371827.us-east-1.elb.amazonaws.com",
+        "HostedZoneId": "Z35SXDOTRQ7X7K"
+      },
+      "HostedZoneId": "Z04472198DJOBTXYG54D",
+      "Name": "cdkrd-harvest4-integ-fixture.com.",
+      "Type": "A"
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-harvest4-integ-fixture.com.",
+    "Type": "A",
+    "HostedZoneId": "Z04472198DJOBTXYG54D",
+    "AliasTarget": {
+      "DNSName": "dualstack.cdkrdi-edge7-ivpmkfmp3fts-1275371827.us-east-1.elb.amazonaws.com",
+      "HostedZoneId": "Z35SXDOTRQ7X7K",
+      "EvaluateTargetHealth": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__RecordSet.Verify04AA6CE7.json
+++ b/tests/corpus/AWS__Route53__RecordSet.Verify04AA6CE7.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::Route53::RecordSet model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Verify04AA6CE7",
+    "resourceType": "AWS::Route53::RecordSet",
+    "physicalId": "verify.cdkrd-harvest4-integ-fixture.com",
+    "constructPath": "CdkrdIntegHarvest4/Verify",
+    "declared": {
+      "HostedZoneId": "Z04472198DJOBTXYG54D",
+      "Name": "verify.cdkrd-harvest4-integ-fixture.com.",
+      "ResourceRecords": ["\"cdkrd-harvest4\""],
+      "TTL": "300",
+      "Type": "TXT"
+    }
+  },
+  "liveRaw": {
+    "Name": "verify.cdkrd-harvest4-integ-fixture.com.",
+    "Type": "TXT",
+    "HostedZoneId": "Z04472198DJOBTXYG54D",
+    "TTL": "300",
+    "ResourceRecords": ["\"cdkrd-harvest4\""]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["HostedZoneId", "HostedZoneName", "Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HostedZoneId", "HostedZoneName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__Bucket.Assets9A31D427.json
+++ b/tests/corpus/AWS__S3__Bucket.Assets9A31D427.json
@@ -1,0 +1,153 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (cloudfront fixture, R75): fresh-deploy AWS::S3::Bucket model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Assets9A31D427",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+    "constructPath": "CdkrdIntegCloudfront/Assets",
+    "declared": {
+      "PublicAccessBlockConfiguration": {
+        "BlockPublicAcls": true,
+        "BlockPublicPolicy": true,
+        "IgnorePublicAcls": true,
+        "RestrictPublicBuckets": true
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+    "RegionalDomainName": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegCloudfront",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Assets9A31D427",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegCloudfront/3ffd6290-6685-11f1-a2a5-267280503789",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Assets9A31D427",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+      "constructPath": "CdkrdIntegCloudfront/Assets"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Assets9A31D427",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+      "constructPath": "CdkrdIntegCloudfront/Assets"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.AssetsPolicy206C37E3.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.AssetsPolicy206C37E3.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (cloudfront fixture, R75): fresh-deploy AWS::S3::BucketPolicy model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AssetsPolicy206C37E3",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+    "constructPath": "CdkrdIntegCloudfront/Assets/Policy",
+    "declared": {
+      "Bucket": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegCloudfront-CustomS3AutoDeleteObjectsCusto-8cxy7ReNMQCk"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+              "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh/*"
+            ]
+          },
+          {
+            "Action": "s3:GetObject",
+            "Condition": {
+              "StringEquals": {
+                "AWS:SourceArn": "arn:aws:cloudfront::111111111111:distribution/E2WBGYTS0T0BVH"
+              }
+            },
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudfront.amazonaws.com"
+            },
+            "Resource": "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh/*"
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/CdkrdIntegCloudfront-CustomS3AutoDeleteObjectsCusto-8cxy7ReNMQCk"
+          },
+          "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+          "Resource": [
+            "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+            "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh/*"
+          ]
+        },
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "cloudfront.amazonaws.com"
+          },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh/*",
+          "Condition": {
+            "StringEquals": {
+              "AWS:SourceArn": "arn:aws:cloudfront::111111111111:distribution/E2WBGYTS0T0BVH"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__Document.Runbook.json
+++ b/tests/corpus/AWS__SSM__Document.Runbook.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::SSM::Document model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Runbook",
+    "resourceType": "AWS::SSM::Document",
+    "physicalId": "CdkrdIntegHarvest4-Runbook-EFhGaKUli3ve",
+    "constructPath": "CdkrdIntegHarvest4/Runbook",
+    "declared": {
+      "Content": {
+        "schemaVersion": "2.2",
+        "description": "cdkrd harvest4 noop runbook",
+        "mainSteps": [
+          {
+            "action": "aws:runShellScript",
+            "name": "noop",
+            "inputs": {
+              "runCommand": ["echo cdkrd-harvest4"]
+            }
+          }
+        ]
+      },
+      "DocumentType": "Command"
+    }
+  },
+  "liveRaw": {
+    "DocumentFormat": "JSON",
+    "Content": "{\n  \"schemaVersion\" : \"2.2\",\n  \"description\" : \"cdkrd harvest4 noop runbook\",\n  \"mainSteps\" : [ {\n    \"inputs\" : {\n      \"runCommand\" : [ \"echo cdkrd-harvest4\" ]\n    },\n    \"name\" : \"noop\",\n    \"action\" : \"aws:runShellScript\"\n  } ]\n}",
+    "DocumentType": "Command",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/bd58c130-6685-11f1-9f86-12ace98ca6c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Runbook",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "CdkrdIntegHarvest4-Runbook-EFhGaKUli3ve"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["Attachments", "UpdateMethod"],
+    "createOnly": [
+      "Attachments",
+      "Content",
+      "DocumentFormat",
+      "DocumentType",
+      "Name",
+      "Requires",
+      "TargetType",
+      "VersionName"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["Attachments", "UpdateMethod"],
+    "createOnlyPaths": [
+      "Attachments",
+      "Content",
+      "DocumentFormat",
+      "DocumentType",
+      "Name",
+      "Requires",
+      "TargetType",
+      "VersionName"
+    ],
+    "defaults": {
+      "DocumentFormat": "JSON",
+      "UpdateMethod": "Replace"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -198,6 +198,43 @@ one run yields BOTH a clean and a drifted corpus case per matrix type.
 cd harvest3 && npm install && bash verify-harvest3.sh
 ```
 
+## harvest4
+
+Wave 4 of the corpus harvest (R75): the remaining high-frequency families —
+ALB + target group + listener (1-AZ-pair VPC, no NAT), EFS with mount
+targets, Route53 public zone with an ALIAS record to the ALB (runs the
+Route53 SDK reader's AliasTarget path live) + TXT record, Cognito
+IdentityPool, DynamoDB Application Auto Scaling (ScalableTarget +
+target-tracking policy), SSM Document, HTTP API with an explicit throttled
+stage, ECR with a lifecycle policy. Same two harvest invariants, plus a
+subset-projection detection check: the declared `idle_timeout` lives inside
+the `{Key,Value}[]` LoadBalancerAttributes bag — the template declares 2 of
+~23 attributes — so an out-of-band change to it must surface as exactly ONE
+declared drift (without the R75 projection the whole list reports). This
+fixture does NOT `revert` the bag: reverting an identity-keyed attribute bag
+needs a Key-based Cloud Control patch (the index-based JSON patch misaligns
+and ELB caps a modify at 20 attributes) — tracked separately; the revert
+write path itself is covered by the `revert` / `policies` / `harvest3`
+fixtures. `CDKRD_HARVEST4_KEEP=1` keeps the stack for debug iteration.
+
+```bash
+cd harvest4 && npm install && bash verify-harvest4.sh
+```
+
+## cloudfront
+
+CloudFront Distribution (R75) — the most config-dense type, previously
+covered only by hand-written corpus seeds. Two origins (S3 with OAC + HTTP)
+and two behaviors so the Id-keyed Origins sort, the HTTP-method enum-set
+sort, and the cache-policy reference shapes all run against real data.
+Asserts the two harvest invariants (fresh deploy = ZERO declared drift,
+accept -> CLEAN). Kept separate from the harvest waves because deploy and
+destroy each take minutes. `CDKRD_CLOUDFRONT_KEEP=1` keeps the stack.
+
+```bash
+cd cloudfront && npm install && bash verify-cloudfront.sh
+```
+
 ## revert
 
 A versioned S3 bucket. Enables acceleration, `accept`s (recording it in the

--- a/tests/integration/cloudfront/app.ts
+++ b/tests/integration/cloudfront/app.ts
@@ -1,0 +1,64 @@
+// CloudFront corpus fixture (R75): the single most CONFIG-DENSE resource type
+// — DistributionConfig nests origins, behaviors, cache/origin-request policy
+// refs, restrictions, certificates, HTTP versions, and CloudFront materializes
+// service defaults for most of what a template omits. The corpus has only
+// hand-written CloudFront seeds; this records the real thing. Two behaviors +
+// two origins so the Id-keyed Origins sort and the method enum-set sort both
+// run against live data. Slow type (deploy/destroy minutes each) — kept OUT of
+// the harvest fixtures so their fast loop stays fast.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  AllowedMethods,
+  CachedMethods,
+  CachePolicy,
+  Distribution,
+  HttpVersion,
+  PriceClass,
+  ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin, S3BucketOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegCloudfront");
+
+const assets = new Bucket(stack, "Assets", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+});
+
+new Distribution(stack, "Cdn", {
+  defaultBehavior: {
+    origin: S3BucketOrigin.withOriginAccessControl(assets),
+    viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+    allowedMethods: AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+    cachedMethods: CachedMethods.CACHE_GET_HEAD,
+    cachePolicy: CachePolicy.CACHING_OPTIMIZED,
+    compress: true,
+  },
+  additionalBehaviors: {
+    "/api/*": {
+      origin: new HttpOrigin("api.example.com", {
+        readTimeout: Duration.seconds(20),
+      }),
+      viewerProtocolPolicy: ViewerProtocolPolicy.HTTPS_ONLY,
+      allowedMethods: AllowedMethods.ALLOW_ALL,
+      cachePolicy: CachePolicy.CACHING_DISABLED,
+    },
+  },
+  priceClass: PriceClass.PRICE_CLASS_100,
+  httpVersion: HttpVersion.HTTP2_AND_3,
+  defaultRootObject: "index.html",
+  errorResponses: [
+    {
+      httpStatus: 404,
+      responseHttpStatus: 200,
+      responsePagePath: "/index.html",
+      ttl: Duration.minutes(5),
+    },
+  ],
+  comment: "cdkrd cloudfront corpus fixture",
+});
+
+app.synth();

--- a/tests/integration/cloudfront/cdk.json
+++ b/tests/integration/cloudfront/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront/package.json
+++ b/tests/integration/cloudfront/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront",
+  "private": true,
+  "version": "0.0.0",
+  "description": "CloudFront corpus fixture: the most config-dense type, recorded live. Run via verify-cloudfront.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@11.17.0"
+}

--- a/tests/integration/cloudfront/verify-cloudfront.sh
+++ b/tests/integration/cloudfront/verify-cloudfront.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# cdk-real-drift CloudFront corpus integration test (real AWS) — R75.
+#
+# CloudFront is the most config-dense CFn type and materializes service
+# defaults for nearly everything the template omits — the corpus previously
+# had only hand-written seeds for it. Asserts the two harvest invariants:
+#   1. fresh deploy classifies with ZERO declared drift (exit 0) — this
+#      stresses the Id-keyed Origins sort, the HTTP-method enum-set sort,
+#      and the policy-reference shapes against real data;
+#   2. accept --yes then check --fail lands CLEAN.
+# Slow fixture (deploy/destroy take minutes each) — separate from the
+# harvest waves so their fast loop stays fast.
+#
+# CDKRD_CLOUDFRONT_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/cloudfront && npm install && bash verify-cloudfront.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegCloudfront
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-cloudfront.out
+
+cleanup() {
+  if [ -n "${CDKRD_CLOUDFRONT_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_CLOUDFRONT_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (CloudFront distribution; takes minutes) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. accept + check --fail must be CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/harvest4/app.ts
+++ b/tests/integration/harvest4/app.ts
@@ -1,0 +1,165 @@
+// Corpus-harvest fixture wave 4 (R75): the remaining HIGH-FREQUENCY service
+// families real CDK apps lean on that the corpus has never seen live —
+// ELBv2 (ALB + target group + listener, the single most common web entry
+// point), EFS, Route53 (public zone + an ALIAS record exercising the
+// Route53 SDK-override reader's AliasTarget path against real data), Cognito
+// IdentityPool, Application Auto Scaling on DynamoDB (ScalableTarget +
+// target-tracking policy), SSM Document, an HTTP API with an EXPLICIT stage
+// (throttling), and an ECR repo with a lifecycle policy (stringly nested
+// JSON doc). VPC is 1-AZ with NO NAT gateways: fast and free. The Route53
+// zone is destroyed within minutes (zones deleted within 12h are not
+// billed) and uses a FICTIONAL domain that is never delegated — NOT
+// *.example.com, which Route53 rejects as AWS-reserved (found on the first
+// live run). Everything self-cleaning.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnStage, HttpApi } from "aws-cdk-lib/aws-apigatewayv2";
+import { HttpLambdaIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+import { PredefinedMetric, ScalableTarget, ServiceNamespace } from "aws-cdk-lib/aws-applicationautoscaling";
+import { CfnIdentityPool } from "aws-cdk-lib/aws-cognito";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+import { Peer, Port, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Repository, TagMutability } from "aws-cdk-lib/aws-ecr";
+import { FileSystem, LifecyclePolicy, PerformanceMode } from "aws-cdk-lib/aws-efs";
+import {
+  ApplicationLoadBalancer,
+  ApplicationProtocol,
+  ApplicationTargetGroup,
+  ListenerAction,
+  TargetType,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { Code, Function as Fn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { ARecord, PublicHostedZone, RecordTarget, TxtRecord } from "aws-cdk-lib/aws-route53";
+import { LoadBalancerTarget } from "aws-cdk-lib/aws-route53-targets";
+import { CfnDocument } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegHarvest4");
+
+// ---- networking + ALB family (no NAT: cheap + fast)
+const vpc = new Vpc(stack, "Net", {
+  maxAzs: 2, // ALB requires 2 AZs
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC }],
+});
+
+const albSg = new SecurityGroup(stack, "AlbSg", {
+  vpc,
+  description: "cdkrd harvest4 alb",
+  allowAllOutbound: true,
+});
+albSg.addIngressRule(Peer.anyIpv4(), Port.tcp(80), "http in");
+
+const alb = new ApplicationLoadBalancer(stack, "Edge", {
+  vpc,
+  internetFacing: true,
+  securityGroup: albSg,
+  idleTimeout: Duration.seconds(120),
+});
+
+const tg = new ApplicationTargetGroup(stack, "Web", {
+  vpc,
+  port: 8080,
+  protocol: ApplicationProtocol.HTTP,
+  targetType: TargetType.IP,
+  healthCheck: { path: "/health", healthyThresholdCount: 3, interval: Duration.seconds(30) },
+  deregistrationDelay: Duration.seconds(15),
+});
+
+alb.addListener("Http", {
+  port: 80,
+  defaultAction: ListenerAction.forward([tg]),
+});
+
+// ---- EFS (mount targets in the public subnets; no data = no storage cost)
+new FileSystem(stack, "Files", {
+  vpc,
+  lifecyclePolicy: LifecyclePolicy.AFTER_14_DAYS,
+  performanceMode: PerformanceMode.GENERAL_PURPOSE,
+  encrypted: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+// ---- Route53: public zone + ALIAS record to the ALB + TXT record.
+// The alias record runs the Route53 SDK reader's AliasTarget path live.
+const zone = new PublicHostedZone(stack, "Zone", {
+  zoneName: "cdkrd-harvest4-integ-fixture.com",
+});
+new ARecord(stack, "Apex", {
+  zone,
+  target: RecordTarget.fromAlias(new LoadBalancerTarget(alb)),
+});
+new TxtRecord(stack, "Verify", {
+  zone,
+  recordName: "verify",
+  values: ["cdkrd-harvest4"],
+  ttl: Duration.minutes(5),
+});
+
+// ---- Cognito IdentityPool (bare CFn resource; no providers)
+new CfnIdentityPool(stack, "Ids", {
+  identityPoolName: "cdkrd_harvest4",
+  allowUnauthenticatedIdentities: false,
+});
+
+// ---- DynamoDB + Application Auto Scaling (ScalableTarget + policy)
+const table = new Table(stack, "Sessions", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  billingMode: BillingMode.PROVISIONED,
+  readCapacity: 1,
+  writeCapacity: 1,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const readTarget = new ScalableTarget(stack, "ReadTarget", {
+  serviceNamespace: ServiceNamespace.DYNAMODB,
+  resourceId: `table/${table.tableName}`,
+  scalableDimension: "dynamodb:table:ReadCapacityUnits",
+  minCapacity: 1,
+  maxCapacity: 5,
+});
+readTarget.scaleToTrackMetric("ReadUtil", {
+  predefinedMetric: PredefinedMetric.DYNAMODB_READ_CAPACITY_UTILIZATION,
+  targetValue: 70,
+  scaleInCooldown: Duration.seconds(60),
+  scaleOutCooldown: Duration.seconds(60),
+});
+
+// ---- SSM Document (Command type, YAML-able JSON content)
+new CfnDocument(stack, "Runbook", {
+  documentType: "Command",
+  content: {
+    schemaVersion: "2.2",
+    description: "cdkrd harvest4 noop runbook",
+    mainSteps: [
+      {
+        action: "aws:runShellScript",
+        name: "noop",
+        inputs: { runCommand: ["echo cdkrd-harvest4"] },
+      },
+    ],
+  },
+});
+
+// ---- HTTP API with an EXPLICIT stage (throttling settings)
+const fn = new Fn(stack, "ApiFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({statusCode: 200, body: 'ok'});"),
+});
+const api = new HttpApi(stack, "Api", { createDefaultStage: false });
+api.addRoutes({ path: "/ping", integration: new HttpLambdaIntegration("Ping", fn) });
+new CfnStage(stack, "Live", {
+  apiId: api.apiId,
+  stageName: "live",
+  autoDeploy: true,
+  defaultRouteSettings: { throttlingBurstLimit: 10, throttlingRateLimit: 5 },
+});
+
+// ---- ECR with a lifecycle policy (stringly nested JSON rules doc)
+new Repository(stack, "Images", {
+  imageTagMutability: TagMutability.IMMUTABLE,
+  removalPolicy: RemovalPolicy.DESTROY,
+  emptyOnDelete: true,
+  lifecycleRules: [{ maxImageCount: 10, description: "keep last 10" }],
+});
+
+app.synth();

--- a/tests/integration/harvest4/cdk.json
+++ b/tests/integration/harvest4/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest4/package.json
+++ b/tests/integration/harvest4/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-harvest4",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest fixture wave 4: ELBv2/EFS/Route53/IdentityPool/AutoScaling/SSM/HTTP-stage/ECR-lifecycle. Run via verify-harvest4.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@11.17.0"
+}

--- a/tests/integration/harvest4/verify-harvest4.sh
+++ b/tests/integration/harvest4/verify-harvest4.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 4 (real AWS) — R75.
+#
+#   A. HARVEST the high-frequency families (ALB+TG+Listener, EFS, Route53
+#      zone + ALIAS record, Cognito IdentityPool, DynamoDB Application Auto
+#      Scaling, SSM Document, HTTP API explicit stage, ECR lifecycle policy):
+#      1. baseline-free `check` — fresh deploy must classify with ZERO
+#         declared drift, exit 0;
+#      2. `accept --yes` then `check --fail` — CLEAN across every type.
+#   B. ALB ATTRIBUTE REVERT: the declared idle_timeout lives INSIDE the
+#      {Key,Value}[] LoadBalancerAttributes list — mutate it out of band
+#      (120 -> 300), `check` must name it as DECLARED drift, `revert --yes`
+#      must restore it via Cloud Control, confirmed by a direct ELBv2 read.
+#      (Exercises declared drift + revert through a Key-sorted attribute
+#      bag — a different shape from every earlier matrix type.)
+#
+# CDKRD_HARVEST4_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases; drift-state
+# recordings are snapshotted to ${CDKRD_CORPUS_DIR}.drifted first.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest4 && npm install && bash verify-harvest4.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegHarvest4
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest4.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST4_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST4_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 4: high-frequency families) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== A1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== A2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "=== B1. mutate the declared ALB idle_timeout out of band (120 -> 300) ==="
+ALB_ARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::ElasticLoadBalancingV2::LoadBalancer'].PhysicalResourceId" \
+  --output text)"
+[ -n "$ALB_ARN" ] || fail "could not resolve ALB arn"
+aws elbv2 modify-load-balancer-attributes --load-balancer-arn "$ALB_ARN" \
+  --attributes Key=idle_timeout.timeout_seconds,Value=300 --region "$REGION" >/dev/null || fail "inject alb attribute"
+sleep 10
+
+# DETECTION of an out-of-band change to ONE attribute inside the {Key,Value}[]
+# LoadBalancerAttributes bag must name exactly that attribute — this proves the
+# R75 subset projection live (the template declares 2 of ~23 attributes; without
+# the projection the whole list reports as drift; with it, only idle_timeout).
+# NOTE: this fixture deliberately does NOT revert the ELB attribute. Reverting an
+# identity-keyed attribute bag through Cloud Control needs a Key-based patch (the
+# index-based JSON patch misaligns against the live array AND ELB caps a single
+# ModifyLoadBalancerAttributes at 20 attributes) — tracked as its own work item.
+# The revert WRITE path is already proven live by the revert/policies/harvest3
+# fixtures.
+echo "=== B2. check must name ONLY the mutated attribute (subset projection, live) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
+grep -q "DECLARED DRIFT: 1" "$OUT" || fail "expected exactly 1 declared drift (subset projection failed)"
+grep -q "idle_timeout\|LoadBalancerAttributes" "$OUT" || fail "missing idle_timeout drift"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== snapshot drift-state corpus recordings ==="
+  rm -rf "${CDKRD_CORPUS_DIR}.drifted"
+  cp -R "$CDKRD_CORPUS_DIR" "${CDKRD_CORPUS_DIR}.drifted" || fail "corpus snapshot"
+fi
+
+echo "=== B3. restore the attribute out of band (no cdkrd revert — see note above) ==="
+aws elbv2 modify-load-balancer-attributes --load-balancer-arn "$ALB_ARN" \
+  --attributes Key=idle_timeout.timeout_seconds,Value=120 --region "$REGION" >/dev/null || fail "restore alb attribute"
+sleep 5
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after restore"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Summary

Two new live fixtures — **harvest4** (ALB+TG+Listener, EFS, Route53 zone+ALIAS, Cognito IdentityPool, DynamoDB Application Auto Scaling, SSM Document, HTTP API explicit stage, ECR lifecycle) and a dedicated **CloudFront** fixture — found **three real declared-compare false-positive classes**. All fixed, locked into the corpus, both fixtures **INTEG PASS**.

### False positives found live, then fixed

| # | Class | Symptom | Fix |
|---|-------|---------|-----|
| 1 | Identity-keyed attribute-bag subset | ELB `LoadBalancerAttributes` / `TargetGroupAttributes`: template declares ~2 attrs, AWS returns ~23, so the whole property reported as drift | `projectLiveToDeclaredSubset` projects live down to declared keys, recursively |
| 2 | Declared object vs JSON-string | SSM `Document.Content`: declared object vs the AWS JSON string with reordered keys | `isJsonStringStructEqual` (parse + order-insensitive compare; unparseable stays drift) |
| 3 | Per-type case-insensitive path | Route53 `AliasTarget.DNSName`: ALB DNS name mixed-case declared, lowercase live | `CASE_INSENSITIVE_PATHS` (observed-only; every other scalar stays strict) |

### CloudFront, zero declared drift on the first live run

The most config-dense CFn type (previously only hand-seeded) classified CLEAN on a fresh deploy with two origins (S3 OAC + HTTP) and two behaviors — the Id-keyed Origins sort and HTTP-method enum-set sort held against real data.

### A known revert gap, deliberately scoped out

harvest4 **detects** an out-of-band change to one attribute inside the ELB bag (proving the subset projection live) but does **not** `revert` it. Reverting an identity-keyed attribute bag needs a **Key-based** Cloud Control patch — the current index-based JSON patch misaligns against the live array, and ELB caps a `ModifyLoadBalancerAttributes` at 20 attributes. Fail-closed (revert errors atomically, convergence re-check reports the drift, no silent corruption — verified live). Tracked as a separate work item; the revert **write path** itself is proven by the `revert` / `policies` / `harvest3` fixtures.

### Corpus 127 to 162 (579 unit tests)

34 clean fresh-deploy recordings (CloudFront Distribution, ELBv2 LB/TG/Listener, EFS FileSystem+MountTargets, Route53 zone+records, Cognito IdentityPool, SSM Document, ECR lifecycle, and more) + the drifted ELB attribute-bag record the projection isolates.

## Test plan

- [x] `vp run typecheck` / `vp check --fix` / `vp run build` / `vp run test` (31 files, 579 tests)
- [x] Live: `harvest4/verify-harvest4.sh` INTEG PASS (fresh deploy zero declared drift, accept, CLEAN, ELB attr mutate, exactly 1 declared drift via subset projection, restore, CLEAN)
- [x] Live: `cloudfront/verify-cloudfront.sh` INTEG PASS (fresh deploy zero declared drift, accept, CLEAN)
- [x] Both stacks destroyed; no orphans; recordings sanitized (no real account id)
