### PR TITLE
fix(read): ApiGatewayV2 Stage/Route/Integration CC composite identifiers — cut harvest4 skips 4 to 1 (R76)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -83,8 +83,11 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    new stack adds many overrides at once (= the generic claim is breaking). A
    second, smaller gap class is CC IDENTIFIERS: some types' CFn physical id is not
    the CC primaryIdentifier (AppSync GraphQLApi ARN vs ApiId, Cognito
-   UserPoolClient composite) — `CC_IDENTIFIER_ADAPTERS` in router.ts maps those
-   without leaving the CC read path.
+   UserPoolClient composite, ApiGatewayV2 Stage/Route/Integration `ApiId|<child>`
+   composites — R76) — `CC_IDENTIFIER_ADAPTERS` in router.ts maps those without
+   leaving the CC read path, which is strictly cheaper than an SDK override (no
+   new dependency, no projection). Prefer an adapter over an override whenever the
+   only gap is the identifier shape.
 4. **The deployed template, not synth, is the declared baseline.** So un-deployed
    code edits never masquerade as drift; `--pre-deploy` is the opt-in inversion.
    _Right call, or do users actually expect code-vs-reality by default?_

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -31,7 +31,23 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
     typeof declared.UserPoolId === 'string' && declared.UserPoolId.length > 0
       ? `${declared.UserPoolId}|${pid}`
       : undefined,
+  // ApiGatewayV2 Stage/Route/Integration: primaryIdentifier is the composite
+  // [ApiId, <child id>]; the CFn physical id is only the child id (StageName /
+  // RouteId / IntegrationId). ApiId comes from the resolved declared Ref. CC's
+  // composite-identifier separator is `|` (verified live, R76 — without this
+  // these three common HTTP-API resources read as ValidationException skips).
+  'AWS::ApiGatewayV2::Stage': apiGwV2Composite,
+  'AWS::ApiGatewayV2::Route': apiGwV2Composite,
+  'AWS::ApiGatewayV2::Integration': apiGwV2Composite,
 };
+
+function apiGwV2Composite(pid: string, declared: Record<string, unknown>): string | undefined {
+  // already composite (defensive — never double-prefix) or unresolved ApiId →
+  // fall back to the physical id (CC then reports an honest ValidationException skip).
+  if (pid.includes('|')) return pid;
+  const apiId = declared.ApiId;
+  return typeof apiId === 'string' && apiId.length > 0 ? `${apiId}|${pid}` : undefined;
+}
 
 export async function readLive(
   cc: CloudControlClient,

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 + R76 ApiGatewayV2 CC-identifier adapters): fresh-deploy AWS::ApiGatewayV2::Integration model — now READABLE via the ApiId|<child> composite identifier (was a CC ValidationException skip before R76). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiANYpingPingA3011524",
+    "resourceType": "AWS::ApiGatewayV2::Integration",
+    "physicalId": "qf0uwiu",
+    "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping",
+    "declared": {
+      "ApiId": "w89hrka2nb",
+      "IntegrationType": "AWS_PROXY",
+      "IntegrationUri": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest4-ApiFnE0725F78-It2GXF2ICbSF",
+      "PayloadFormatVersion": "2.0"
+    }
+  },
+  "liveRaw": {
+    "IntegrationUri": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest4-ApiFnE0725F78-It2GXF2ICbSF",
+    "PayloadFormatVersion": "2.0",
+    "ConnectionType": "INTERNET",
+    "RequestTemplates": {},
+    "ResponseParameters": {},
+    "TimeoutInMillis": 30000,
+    "IntegrationId": "qf0uwiu",
+    "ApiId": "w89hrka2nb",
+    "IntegrationMethod": "POST",
+    "IntegrationType": "AWS_PROXY"
+  },
+  "schema": {
+    "readOnly": ["IntegrationId"],
+    "writeOnly": [],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["IntegrationId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiANYpingPingA3011524",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "ConnectionType",
+      "actual": "INTERNET",
+      "physicalId": "qf0uwiu",
+      "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiANYpingPingA3011524",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "TimeoutInMillis",
+      "actual": 30000,
+      "physicalId": "qf0uwiu",
+      "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiANYpingPingA3011524",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "IntegrationMethod",
+      "actual": "POST",
+      "physicalId": "qf0uwiu",
+      "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Route.ApiANYpingF0D17186.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Route.ApiANYpingF0D17186.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 + R76 ApiGatewayV2 CC-identifier adapters): fresh-deploy AWS::ApiGatewayV2::Route model — now READABLE via the ApiId|<child> composite identifier (was a CC ValidationException skip before R76). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiANYpingF0D17186",
+    "resourceType": "AWS::ApiGatewayV2::Route",
+    "physicalId": "lghabc6",
+    "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping",
+    "declared": {
+      "ApiId": "w89hrka2nb",
+      "AuthorizationType": "NONE",
+      "RouteKey": "ANY /ping",
+      "Target": "integrations/qf0uwiu"
+    }
+  },
+  "liveRaw": {
+    "Target": "integrations/qf0uwiu",
+    "RequestModels": {},
+    "AuthorizationScopes": [],
+    "ApiKeyRequired": false,
+    "RouteKey": "ANY /ping",
+    "RouteId": "lghabc6",
+    "AuthorizationType": "NONE",
+    "ApiId": "w89hrka2nb"
+  },
+  "schema": {
+    "readOnly": ["RouteId"],
+    "writeOnly": ["AuthorizerId", "RequestParameters"],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["RouteId"],
+    "writeOnlyPaths": ["AuthorizerId", "RequestParameters"],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Stage.Live.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Stage.Live.json
@@ -1,0 +1,62 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 + R76 ApiGatewayV2 CC-identifier adapters): fresh-deploy AWS::ApiGatewayV2::Stage model — now READABLE via the ApiId|<child> composite identifier (was a CC ValidationException skip before R76). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Live",
+    "resourceType": "AWS::ApiGatewayV2::Stage",
+    "physicalId": "live",
+    "constructPath": "CdkrdIntegHarvest4/Live",
+    "declared": {
+      "ApiId": "w89hrka2nb",
+      "AutoDeploy": true,
+      "DefaultRouteSettings": {
+        "ThrottlingBurstLimit": 10,
+        "ThrottlingRateLimit": 5
+      },
+      "StageName": "live"
+    }
+  },
+  "liveRaw": {
+    "DeploymentId": "yy83cc",
+    "AutoDeploy": true,
+    "RouteSettings": {},
+    "StageName": "live",
+    "StageVariables": {},
+    "ApiId": "w89hrka2nb",
+    "DefaultRouteSettings": {
+      "ThrottlingBurstLimit": 10,
+      "DetailedMetricsEnabled": false,
+      "ThrottlingRateLimit": 5
+    },
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest4",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest4/b3adf870-66db-11f1-ba13-122419eb6ddf",
+      "aws:cloudformation:logical-id": "Live"
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApiId", "StageName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId", "StageName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Live",
+      "resourceType": "AWS::ApiGatewayV2::Stage",
+      "path": "DeploymentId",
+      "actual": "yy83cc",
+      "physicalId": "live",
+      "constructPath": "CdkrdIntegHarvest4/Live"
+    }
+  ]
+}

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -109,6 +109,50 @@ describe('readLive (CC identifier adapters, R74)', () => {
     await readLive(cc as unknown as CloudControlClient, res(), 'us-east-1', '1');
     expect(sent()).toBe('phys');
   });
+
+  // R76: ApiGatewayV2 Stage/Route/Integration composite [ApiId, <child id>].
+  for (const t of [
+    'AWS::ApiGatewayV2::Stage',
+    'AWS::ApiGatewayV2::Route',
+    'AWS::ApiGatewayV2::Integration',
+  ]) {
+    it(`${t}: builds the ApiId|<child> composite identifier`, async () => {
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({ resourceType: t, physicalId: 'child123', declared: { ApiId: 'api456' } }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('api456|child123');
+    });
+  }
+
+  it('ApiGatewayV2 Stage: an unresolved ApiId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::ApiGatewayV2::Stage', physicalId: 'live', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('live');
+  });
+
+  it('ApiGatewayV2 Route: an already-composite physical id is not double-prefixed', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::Route',
+        physicalId: 'api456|route789',
+        declared: { ApiId: 'api456' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('api456|route789');
+  });
 });
 
 describe('readLive (custom resources short-circuit, R26)', () => {


### PR DESCRIPTION
## Summary

ApiGatewayV2 **Stage / Route / Integration** were read with the bare CFn physical id, but their Cloud Control primaryIdentifier is the composite `[ApiId, <child id>]` — so all three read as `ValidationException` **skips**, invisible to drift detection. These are common HTTP-API resources (3 of the 4 skipped resources on the harvest4 fixture).

Each gets a `CC_IDENTIFIER_ADAPTERS` entry building `${ApiId}|${physicalId}` from the resolved declared `ApiId` — the same mechanism R74 added for AppSync GraphQLApi and Cognito UserPoolClient. The `|` separator was verified live against real ApiGatewayV2 resources.

## Result (live re-run of harvest4)

- **skipped 4 → 1** — only `ApplicationAutoScaling::ScalingPolicy` remains (a different `[Arn, ScalableDimension]` composite, a follow-up)
- fresh deploy still **ZERO declared drift** — the newly-readable types introduced no new false positive
- **INTEG PASS** end-to-end

## Corpus 162 → 165 (587 tests)

The three ApiGatewayV2 types recorded live for the first time — they could not be recorded while skipped.

## Notes

- Unresolved `ApiId` → falls back to the raw physical id (honest skip); already-composite id is never double-prefixed.
- ARCHITECTURE bet #3 updated: prefer an identifier adapter over an SDK override when the only gap is the identifier shape (stays on the generic CC read path, no new dependency).

## Test plan

- [x] `vp run typecheck` / `vp check --fix` / `vp run build` / `vp run test` (31 files, 587 tests)
- [x] Live: `harvest4/verify-harvest4.sh` INTEG PASS, skipped 4 → 1, no new declared FP
- [x] Stack destroyed; recordings sanitized (no real account id)
