### PR TITLE
test(corpus): harvest5 long-tail wave + AppConfig CC composite identifiers (R77)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -82,12 +82,14 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    while the count grows only a few types per new dogfood; revisit it if a single
    new stack adds many overrides at once (= the generic claim is breaking). A
    second, smaller gap class is CC IDENTIFIERS: some types' CFn physical id is not
-   the CC primaryIdentifier (AppSync GraphQLApi ARN vs ApiId, Cognito
-   UserPoolClient composite, ApiGatewayV2 Stage/Route/Integration `ApiId|<child>`
-   composites — R76) — `CC_IDENTIFIER_ADAPTERS` in router.ts maps those without
-   leaving the CC read path, which is strictly cheaper than an SDK override (no
-   new dependency, no projection). Prefer an adapter over an override whenever the
-   only gap is the identifier shape.
+   the CC primaryIdentifier (AppSync GraphQLApi ARN vs ApiId; and the
+   `${parent}|${child}` composites — Cognito UserPoolClient, ApiGatewayV2
+   Stage/Route/Integration (R76), AppConfig Environment/ConfigurationProfile (R77)
+   — all built by the shared `compositeWith(parentKey)` helper) —
+   `CC_IDENTIFIER_ADAPTERS` in router.ts maps those without leaving the CC read
+   path, which is strictly cheaper than an SDK override (no new dependency, no
+   projection). Prefer an adapter over an override whenever the only gap is the
+   identifier shape.
 4. **The deployed template, not synth, is the declared baseline.** So un-deployed
    code edits never masquerade as drift; `--pre-deploy` is the opt-in inversion.
    _Right call, or do users actually expect code-vs-reality by default?_

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -23,30 +23,30 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
 > = {
   // physical id = the API ARN (arn:...:apis/<apiId>); CC wants the bare ApiId.
   'AWS::AppSync::GraphQLApi': (pid) => (pid.startsWith('arn:') ? pid.split('/').pop() : pid),
-  // primaryIdentifier is the composite [UserPoolId, ClientId]; the physical id is
-  // only the ClientId. UserPoolId comes from the resolved declared Ref — when it
-  // did not resolve, keep the physical id (CC then reports ValidationException →
-  // an honest skip, same as before).
-  'AWS::Cognito::UserPoolClient': (pid, declared) =>
-    typeof declared.UserPoolId === 'string' && declared.UserPoolId.length > 0
-      ? `${declared.UserPoolId}|${pid}`
-      : undefined,
-  // ApiGatewayV2 Stage/Route/Integration: primaryIdentifier is the composite
-  // [ApiId, <child id>]; the CFn physical id is only the child id (StageName /
-  // RouteId / IntegrationId). ApiId comes from the resolved declared Ref. CC's
-  // composite-identifier separator is `|` (verified live, R76 — without this
-  // these three common HTTP-API resources read as ValidationException skips).
-  'AWS::ApiGatewayV2::Stage': apiGwV2Composite,
-  'AWS::ApiGatewayV2::Route': apiGwV2Composite,
-  'AWS::ApiGatewayV2::Integration': apiGwV2Composite,
+  // The rest are `[<parent ref>, <child id>]` composites: the CFn physical id is
+  // only the child id; the parent id comes from the resolved declared Ref. CC's
+  // composite-identifier separator is `|` (verified live — R74 Cognito, R76
+  // ApiGatewayV2, R77 AppConfig). An unresolved parent → fall back to the bare
+  // physical id (CC then reports an honest ValidationException skip).
+  'AWS::Cognito::UserPoolClient': compositeWith('UserPoolId'),
+  'AWS::ApiGatewayV2::Stage': compositeWith('ApiId'),
+  'AWS::ApiGatewayV2::Route': compositeWith('ApiId'),
+  'AWS::ApiGatewayV2::Integration': compositeWith('ApiId'),
+  'AWS::AppConfig::Environment': compositeWith('ApplicationId'),
+  'AWS::AppConfig::ConfigurationProfile': compositeWith('ApplicationId'),
 };
 
-function apiGwV2Composite(pid: string, declared: Record<string, unknown>): string | undefined {
-  // already composite (defensive — never double-prefix) or unresolved ApiId →
-  // fall back to the physical id (CC then reports an honest ValidationException skip).
-  if (pid.includes('|')) return pid;
-  const apiId = declared.ApiId;
-  return typeof apiId === 'string' && apiId.length > 0 ? `${apiId}|${pid}` : undefined;
+// Build a `${declared[parentKey]}|${physicalId}` composite CC identifier, or
+// undefined when the parent ref did not resolve (→ honest skip). Never
+// double-prefixes an id that is already composite.
+function compositeWith(
+  parentKey: string
+): (pid: string, declared: Record<string, unknown>) => string | undefined {
+  return (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const parent = declared[parentKey];
+    return typeof parent === 'string' && parent.length > 0 ? `${parent}|${pid}` : undefined;
+  };
 }
 
 export async function readLive(

--- a/tests/corpus/AWS__AppConfig__Application.Cfg.json
+++ b/tests/corpus/AWS__AppConfig__Application.Cfg.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::AppConfig::Application model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Cfg",
+    "resourceType": "AWS::AppConfig::Application",
+    "physicalId": "h0s9fpf",
+    "constructPath": "CdkrdIntegHarvest5/Cfg",
+    "declared": {
+      "Name": "cdkrd-harvest5"
+    }
+  },
+  "liveRaw": {
+    "ApplicationId": "h0s9fpf",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Cfg",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest5"
+  },
+  "schema": {
+    "readOnly": ["ApplicationId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["ApplicationId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppConfig__ConfigurationProfile.CfgProfile.json
+++ b/tests/corpus/AWS__AppConfig__ConfigurationProfile.CfgProfile.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::AppConfig::ConfigurationProfile model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "CfgProfile",
+    "resourceType": "AWS::AppConfig::ConfigurationProfile",
+    "physicalId": "77exss1",
+    "constructPath": "CdkrdIntegHarvest5/CfgProfile",
+    "declared": {
+      "ApplicationId": "h0s9fpf",
+      "LocationUri": "hosted",
+      "Name": "flags",
+      "Type": "AWS.AppConfig.FeatureFlags"
+    }
+  },
+  "liveRaw": {
+    "ConfigurationProfileId": "77exss1",
+    "LocationUri": "hosted",
+    "Type": "AWS.AppConfig.FeatureFlags",
+    "ApplicationId": "h0s9fpf",
+    "Tags": [
+      {
+        "Value": "CfgProfile",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "flags"
+  },
+  "schema": {
+    "readOnly": ["ConfigurationProfileId", "KmsKeyArn"],
+    "writeOnly": ["DeletionProtectionCheck"],
+    "createOnly": ["ApplicationId", "LocationUri", "Type"],
+    "readOnlyPaths": ["ConfigurationProfileId", "KmsKeyArn"],
+    "writeOnlyPaths": ["DeletionProtectionCheck"],
+    "createOnlyPaths": ["ApplicationId", "LocationUri", "Type"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppConfig__DeploymentStrategy.CfgStrategy.json
+++ b/tests/corpus/AWS__AppConfig__DeploymentStrategy.CfgStrategy.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::AppConfig::DeploymentStrategy model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "CfgStrategy",
+    "resourceType": "AWS::AppConfig::DeploymentStrategy",
+    "physicalId": "un5ebiu",
+    "constructPath": "CdkrdIntegHarvest5/CfgStrategy",
+    "declared": {
+      "DeploymentDurationInMinutes": 10,
+      "FinalBakeTimeInMinutes": 5,
+      "GrowthFactor": 25,
+      "GrowthType": "LINEAR",
+      "Name": "cdkrd-harvest5-canary",
+      "ReplicateTo": "NONE"
+    }
+  },
+  "liveRaw": {
+    "ReplicateTo": "NONE",
+    "GrowthType": "LINEAR",
+    "DeploymentDurationInMinutes": 10,
+    "GrowthFactor": 25,
+    "Id": "un5ebiu",
+    "FinalBakeTimeInMinutes": 5,
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CfgStrategy",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest5-canary"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "ReplicateTo"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "ReplicateTo"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppConfig__Environment.CfgEnv.json
+++ b/tests/corpus/AWS__AppConfig__Environment.CfgEnv.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::AppConfig::Environment model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "CfgEnv",
+    "resourceType": "AWS::AppConfig::Environment",
+    "physicalId": "935m375",
+    "constructPath": "CdkrdIntegHarvest5/CfgEnv",
+    "declared": {
+      "ApplicationId": "h0s9fpf",
+      "Description": "cdkrd harvest5 env",
+      "Name": "prod"
+    }
+  },
+  "liveRaw": {
+    "EnvironmentId": "935m375",
+    "Description": "cdkrd harvest5 env",
+    "ApplicationId": "h0s9fpf",
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CfgEnv",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "prod"
+  },
+  "schema": {
+    "readOnly": ["EnvironmentId"],
+    "writeOnly": ["DeletionProtectionCheck"],
+    "createOnly": ["ApplicationId"],
+    "readOnlyPaths": ["EnvironmentId"],
+    "writeOnlyPaths": ["DeletionProtectionCheck"],
+    "createOnlyPaths": ["ApplicationId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudWatch__Alarm.AlarmA529EB095.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.AlarmA529EB095.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::CloudWatch::Alarm model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AlarmA529EB095",
+    "resourceType": "AWS::CloudWatch::Alarm",
+    "physicalId": "CdkrdIntegHarvest5-AlarmA529EB095-04aR0ogtAti0",
+    "constructPath": "CdkrdIntegHarvest5/AlarmA",
+    "declared": {
+      "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+      "EvaluationPeriods": 1,
+      "MetricName": "Errors",
+      "Namespace": "cdkrd/harvest5/a",
+      "Period": 300,
+      "Statistic": "Average",
+      "Threshold": 1,
+      "TreatMissingData": "notBreaching"
+    }
+  },
+  "liveRaw": {
+    "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    "TreatMissingData": "notBreaching",
+    "Period": 300,
+    "EvaluationPeriods": 1,
+    "Namespace": "cdkrd/harvest5/a",
+    "OKActions": [],
+    "AlarmActions": [],
+    "MetricName": "Errors",
+    "ActionsEnabled": true,
+    "AlarmName": "CdkrdIntegHarvest5-AlarmA529EB095-04aR0ogtAti0",
+    "Statistic": "Average",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5-AlarmA529EB095-04aR0ogtAti0",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AlarmA529EB095",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Threshold": 1
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {
+      "ActionsEnabled": true
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudWatch__Alarm.AlarmB163AF7E7.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.AlarmB163AF7E7.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::CloudWatch::Alarm model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AlarmB163AF7E7",
+    "resourceType": "AWS::CloudWatch::Alarm",
+    "physicalId": "CdkrdIntegHarvest5-AlarmB163AF7E7-1S6WkdFYC6eR",
+    "constructPath": "CdkrdIntegHarvest5/AlarmB",
+    "declared": {
+      "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+      "EvaluationPeriods": 1,
+      "MetricName": "Errors",
+      "Namespace": "cdkrd/harvest5/b",
+      "Period": 300,
+      "Statistic": "Average",
+      "Threshold": 1,
+      "TreatMissingData": "notBreaching"
+    }
+  },
+  "liveRaw": {
+    "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+    "TreatMissingData": "notBreaching",
+    "Period": 300,
+    "EvaluationPeriods": 1,
+    "Namespace": "cdkrd/harvest5/b",
+    "OKActions": [],
+    "AlarmActions": [],
+    "MetricName": "Errors",
+    "ActionsEnabled": true,
+    "AlarmName": "CdkrdIntegHarvest5-AlarmB163AF7E7-1S6WkdFYC6eR",
+    "Statistic": "Average",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5-AlarmB163AF7E7-1S6WkdFYC6eR",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "AlarmB163AF7E7",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Threshold": 1
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {
+      "ActionsEnabled": true
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudWatch__CompositeAlarm.Composite0B9667B9.json
+++ b/tests/corpus/AWS__CloudWatch__CompositeAlarm.Composite0B9667B9.json
@@ -1,0 +1,62 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::CloudWatch::CompositeAlarm model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Composite0B9667B9",
+    "resourceType": "AWS::CloudWatch::CompositeAlarm",
+    "physicalId": "CdkrdIntegHarvest5Composite92749298",
+    "constructPath": "CdkrdIntegHarvest5/Composite",
+    "declared": {
+      "AlarmName": "CdkrdIntegHarvest5Composite92749298",
+      "AlarmRule": "(ALARM(\"arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5-AlarmA529EB095-04aR0ogtAti0\") OR ALARM(\"arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5-AlarmB163AF7E7-1S6WkdFYC6eR\"))"
+    }
+  },
+  "liveRaw": {
+    "AlarmActions": [],
+    "ActionsEnabled": true,
+    "AlarmName": "CdkrdIntegHarvest5Composite92749298",
+    "AlarmRule": "(ALARM(\"arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5-AlarmA529EB095-04aR0ogtAti0\") OR ALARM(\"arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5-AlarmB163AF7E7-1S6WkdFYC6eR\"))",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkrdIntegHarvest5Composite92749298",
+    "OKActions": [],
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Composite0B9667B9",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Composite0B9667B9",
+      "resourceType": "AWS::CloudWatch::CompositeAlarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkrdIntegHarvest5Composite92749298",
+      "constructPath": "CdkrdIntegHarvest5/Composite"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__ApiDestination.ApiDest.json
+++ b/tests/corpus/AWS__Events__ApiDestination.ApiDest.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Events::ApiDestination model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ApiDest",
+    "resourceType": "AWS::Events::ApiDestination",
+    "physicalId": "ApiDest-5oBdTeq27GBi",
+    "constructPath": "CdkrdIntegHarvest5/ApiDest",
+    "declared": {
+      "ConnectionArn": "arn:aws:events:us-east-1:111111111111:connection/Conn-L4BxGdJVCL8Z/3f826775-e72f-4e64-8ccf-f25357750c6a",
+      "HttpMethod": "POST",
+      "InvocationEndpoint": "https://example.com/webhook",
+      "InvocationRateLimitPerSecond": 10
+    }
+  },
+  "liveRaw": {
+    "ConnectionArn": "arn:aws:events:us-east-1:111111111111:connection/Conn-L4BxGdJVCL8Z/3f826775-e72f-4e64-8ccf-f25357750c6a",
+    "InvocationEndpoint": "https://example.com/webhook",
+    "Arn": "arn:aws:events:us-east-1:111111111111:api-destination/ApiDest-5oBdTeq27GBi/ff602157-2c7a-41e5-9bce-ee9d11e069d4",
+    "ArnForPolicy": "arn:aws:events:us-east-1:111111111111:api-destination/ApiDest-5oBdTeq27GBi",
+    "HttpMethod": "POST",
+    "Name": "ApiDest-5oBdTeq27GBi",
+    "InvocationRateLimitPerSecond": 10
+  },
+  "schema": {
+    "readOnly": ["Arn", "ArnForPolicy"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "ArnForPolicy"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Events__Archive.Archive.json
+++ b/tests/corpus/AWS__Events__Archive.Archive.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Events::Archive model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Archive",
+    "resourceType": "AWS::Events::Archive",
+    "physicalId": "Archive-nfIRYcKHPQ9i",
+    "constructPath": "CdkrdIntegHarvest5/Archive",
+    "declared": {
+      "Description": "cdkrd harvest5 archive",
+      "RetentionDays": 1,
+      "SourceArn": "arn:aws:events:us-east-1:111111111111:event-bus/default"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd harvest5 archive",
+    "SourceArn": "arn:aws:events:us-east-1:111111111111:event-bus/default",
+    "ArchiveName": "Archive-nfIRYcKHPQ9i",
+    "RetentionDays": 1,
+    "Arn": "arn:aws:events:us-east-1:111111111111:archive/Archive-nfIRYcKHPQ9i"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["ArchiveName", "SourceArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ArchiveName", "SourceArn"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Events__Connection.Conn.json
+++ b/tests/corpus/AWS__Events__Connection.Conn.json
@@ -1,0 +1,60 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Events::Connection model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Conn",
+    "resourceType": "AWS::Events::Connection",
+    "physicalId": "Conn-L4BxGdJVCL8Z",
+    "constructPath": "CdkrdIntegHarvest5/Conn",
+    "declared": {
+      "AuthParameters": {
+        "ApiKeyAuthParameters": {
+          "ApiKeyName": "x-api-key",
+          "ApiKeyValue": "cdkrd-harvest5-key"
+        }
+      },
+      "AuthorizationType": "API_KEY"
+    }
+  },
+  "liveRaw": {
+    "SecretArn": "arn:aws:secretsmanager:us-east-1:111111111111:secret:events!connection/Conn-L4BxGdJVCL8Z/9005698e-2b50-4522-b629-31f4f8897768-DmqVmO",
+    "AuthParameters": {
+      "ApiKeyAuthParameters": {
+        "ApiKeyName": "x-api-key"
+      }
+    },
+    "Arn": "arn:aws:events:us-east-1:111111111111:connection/Conn-L4BxGdJVCL8Z/3f826775-e72f-4e64-8ccf-f25357750c6a",
+    "ArnForPolicy": "arn:aws:events:us-east-1:111111111111:connection/Conn-L4BxGdJVCL8Z",
+    "AuthorizationType": "API_KEY",
+    "Name": "Conn-L4BxGdJVCL8Z"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ArnForPolicy", "SecretArn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "Arn",
+      "ArnForPolicy",
+      "AuthParameters.ConnectivityParameters.ResourceParameters.ResourceAssociationArn",
+      "InvocationConnectivityParameters.ResourceParameters.ResourceAssociationArn",
+      "SecretArn"
+    ],
+    "writeOnlyPaths": [
+      "AuthParameters.ApiKeyAuthParameters.ApiKeyValue",
+      "AuthParameters.BasicAuthParameters.Password",
+      "AuthParameters.InvocationHttpParameters",
+      "AuthParameters.OAuthParameters.ClientParameters.ClientSecret",
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.BodyParameters",
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.HeaderParameters",
+      "AuthParameters.OAuthParameters.OAuthHttpParameters.QueryStringParameters"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Glue__Job.GlueJob.json
+++ b/tests/corpus/AWS__Glue__Job.GlueJob.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Glue::Job model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "GlueJob",
+    "resourceType": "AWS::Glue::Job",
+    "physicalId": "cdkrd-harvest5",
+    "constructPath": "CdkrdIntegHarvest5/GlueJob",
+    "declared": {
+      "Command": {
+        "Name": "pythonshell",
+        "PythonVersion": "3.9",
+        "ScriptLocation": "s3://aws-glue-scripts/noop.py"
+      },
+      "GlueVersion": "4.0",
+      "MaxCapacity": 0.0625,
+      "Name": "cdkrd-harvest5",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp"
+    }
+  },
+  "liveRaw": {
+    "MaxRetries": 0,
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+    "JobMode": "SCRIPT",
+    "Command": {
+      "PythonVersion": "3.9",
+      "ScriptLocation": "s3://aws-glue-scripts/noop.py",
+      "Name": "pythonshell"
+    },
+    "Timeout": 2880,
+    "AllocatedCapacity": 0,
+    "GlueVersion": "4.0",
+    "ExecutionProperty": {
+      "MaxConcurrentRuns": 1
+    },
+    "JobRunQueuingEnabled": false,
+    "Name": "cdkrd-harvest5",
+    "MaxCapacity": 0.0625
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "MaxRetries",
+      "actual": 0,
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "JobMode",
+      "actual": "SCRIPT",
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "Timeout",
+      "actual": 2880,
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "AllocatedCapacity",
+      "actual": 0,
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "ExecutionProperty",
+      "actual": {
+        "MaxConcurrentRuns": 1
+      },
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Trigger.GlueTrigger.json
+++ b/tests/corpus/AWS__Glue__Trigger.GlueTrigger.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Glue::Trigger model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "GlueTrigger",
+    "resourceType": "AWS::Glue::Trigger",
+    "physicalId": "GlueTrigger-9t6zHnu1aOIa",
+    "constructPath": "CdkrdIntegHarvest5/GlueTrigger",
+    "declared": {
+      "Actions": [
+        {
+          "JobName": "cdkrd-harvest5"
+        }
+      ],
+      "Type": "ON_DEMAND"
+    }
+  },
+  "liveRaw": {
+    "Type": "ON_DEMAND",
+    "Actions": [
+      {
+        "JobName": "cdkrd-harvest5",
+        "Arguments": {}
+      }
+    ],
+    "Tags": {},
+    "Name": "GlueTrigger-9t6zHnu1aOIa"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["StartOnCreation"],
+    "createOnly": ["Name", "Type", "WorkflowName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["StartOnCreation"],
+    "createOnlyPaths": ["Name", "Type", "WorkflowName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__InstanceProfile.Profile6F32097C.json
+++ b/tests/corpus/AWS__IAM__InstanceProfile.Profile6F32097C.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::IAM::InstanceProfile model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Profile6F32097C",
+    "resourceType": "AWS::IAM::InstanceProfile",
+    "physicalId": "CdkrdIntegHarvest5-Profile6F32097C-4qYS2ADwUrG5",
+    "constructPath": "CdkrdIntegHarvest5/Profile",
+    "declared": {
+      "Roles": ["CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "InstanceProfileName": "CdkrdIntegHarvest5-Profile6F32097C-4qYS2ADwUrG5",
+    "Roles": ["CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK"],
+    "Arn": "arn:aws:iam::111111111111:instance-profile/CdkrdIntegHarvest5-Profile6F32097C-4qYS2ADwUrG5"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["InstanceProfileName", "Path"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["InstanceProfileName", "Path"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Profile6F32097C",
+      "resourceType": "AWS::IAM::InstanceProfile",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest5-Profile6F32097C-4qYS2ADwUrG5",
+      "constructPath": "CdkrdIntegHarvest5/Profile"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__Role.AliasedFnServiceRole4A9555AA.json
+++ b/tests/corpus/AWS__IAM__Role.AliasedFnServiceRole4A9555AA.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AliasedFnServiceRole4A9555AA",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+    "constructPath": "CdkrdIntegHarvest5/AliasedFn/ServiceRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+    "RoleId": "AROAXXXJN2LNTJNGF6PF5"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.Ec2Role2FD9A272.json
+++ b/tests/corpus/AWS__IAM__Role.Ec2Role2FD9A272.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Ec2Role2FD9A272",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
+    "constructPath": "CdkrdIntegHarvest5/Ec2Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "ec2.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
+    "RoleId": "AROAXXXJN2LNZ4QV7DOW6"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.ExpressRole9F822A77.json
+++ b/tests/corpus/AWS__IAM__Role.ExpressRole9F822A77.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ExpressRole9F822A77",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+    "constructPath": "CdkrdIntegHarvest5/Express/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "states.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "states.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+    "RoleId": "AROAXXXJN2LNU5EP4VLZX"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.GlueRoleDEDFFD2C.json
+++ b/tests/corpus/AWS__IAM__Role.GlueRoleDEDFFD2C.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "GlueRoleDEDFFD2C",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+    "constructPath": "CdkrdIntegHarvest5/GlueRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "glue.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "glue.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+    "RoleId": "AROAXXXJN2LN5TM7RCP52"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__Alias.AliasedFnAliasliveC3F00BE1.json
+++ b/tests/corpus/AWS__Lambda__Alias.AliasedFnAliasliveC3F00BE1.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Lambda::Alias model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AliasedFnAliasliveC3F00BE1",
+    "resourceType": "AWS::Lambda::Alias",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:live",
+    "constructPath": "CdkrdIntegHarvest5/AliasedFn/Aliaslive",
+    "declared": {
+      "Description": "cdkrd harvest5 alias",
+      "FunctionName": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "FunctionVersion": "1",
+      "Name": "live"
+    }
+  },
+  "liveRaw": {
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+    "Description": "cdkrd harvest5 alias",
+    "FunctionVersion": "1",
+    "AliasArn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:live",
+    "RoutingConfig": {},
+    "Name": "live"
+  },
+  "schema": {
+    "readOnly": ["AliasArn"],
+    "writeOnly": [],
+    "createOnly": ["FunctionName", "Name"],
+    "readOnlyPaths": ["AliasArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FunctionName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
+++ b/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Lambda::Function model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AliasedFn19257E6A",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+    "constructPath": "CdkrdIntegHarvest5/AliasedFn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => 'ok';"
+      },
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+      "Runtime": "nodejs20.x"
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "AliasedFn19257E6A",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye"
+      },
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Version.AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df.json
+++ b/tests/corpus/AWS__Lambda__Version.AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Lambda::Version model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
+    "resourceType": "AWS::Lambda::Version",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
+    "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion",
+    "declared": {
+      "FunctionName": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye"
+    }
+  },
+  "liveRaw": {
+    "FunctionArn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
+    "FunctionName": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+    "Description": "",
+    "RuntimePolicy": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Version": "1",
+    "CodeSha256": "pYaOwiRWhhzD/erZKRp1WZbhCcuhmh7CovRZdCS9P3w="
+  },
+  "schema": {
+    "readOnly": ["FunctionArn", "Version"],
+    "writeOnly": [],
+    "createOnly": [
+      "CodeSha256",
+      "Description",
+      "FunctionName",
+      "ProvisionedConcurrencyConfig",
+      "RuntimePolicy"
+    ],
+    "readOnlyPaths": ["FunctionArn", "Version"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "CodeSha256",
+      "Description",
+      "FunctionName",
+      "ProvisionedConcurrencyConfig",
+      "RuntimePolicy"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
+      "resourceType": "AWS::Lambda::Version",
+      "path": "RuntimePolicy",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
+      "resourceType": "AWS::Lambda::Version",
+      "path": "CodeSha256",
+      "actual": "pYaOwiRWhhzD/erZKRp1WZbhCcuhmh7CovRZdCS9P3w=",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53__HealthCheck.Health.json
+++ b/tests/corpus/AWS__Route53__HealthCheck.Health.json
@@ -1,0 +1,51 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::Route53::HealthCheck model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Health",
+    "resourceType": "AWS::Route53::HealthCheck",
+    "physicalId": "fc5f8fb0-4e1a-49d2-9491-17730c70f226",
+    "constructPath": "CdkrdIntegHarvest5/Health",
+    "declared": {
+      "HealthCheckConfig": {
+        "FailureThreshold": 3,
+        "FullyQualifiedDomainName": "example.com",
+        "Port": 443,
+        "RequestInterval": 30,
+        "Type": "HTTPS"
+      }
+    }
+  },
+  "liveRaw": {
+    "HealthCheckId": "fc5f8fb0-4e1a-49d2-9491-17730c70f226",
+    "HealthCheckConfig": {
+      "EnableSNI": true,
+      "Type": "HTTPS",
+      "FullyQualifiedDomainName": "example.com",
+      "MeasureLatency": false,
+      "Inverted": false,
+      "Port": 443,
+      "RequestInterval": 30,
+      "FailureThreshold": 3
+    }
+  },
+  "schema": {
+    "readOnly": ["HealthCheckId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["HealthCheckId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "HealthCheckConfig.MeasureLatency",
+      "HealthCheckConfig.RequestInterval",
+      "HealthCheckConfig.Type"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__Parameter.Param165332EC.json
+++ b/tests/corpus/AWS__SSM__Parameter.Param165332EC.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::SSM::Parameter model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "Param165332EC",
+    "resourceType": "AWS::SSM::Parameter",
+    "physicalId": "/cdkrd/harvest5/config",
+    "constructPath": "CdkrdIntegHarvest5/Param",
+    "declared": {
+      "Description": "cdkrd harvest5 parameter",
+      "Name": "/cdkrd/harvest5/config",
+      "Type": "String",
+      "Value": "enabled"
+    }
+  },
+  "liveRaw": {
+    "Type": "String",
+    "Value": "enabled",
+    "DataType": "text",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest5",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+      "aws:cloudformation:logical-id": "Param165332EC"
+    },
+    "Name": "/cdkrd/harvest5/config"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AllowedPattern", "Description", "Policies", "Tier"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AllowedPattern", "Description", "Policies", "Tier"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Param165332EC",
+      "resourceType": "AWS::SSM::Parameter",
+      "path": "Description",
+      "note": "write-only — cannot be read back",
+      "physicalId": "/cdkrd/harvest5/config",
+      "constructPath": "CdkrdIntegHarvest5/Param"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Param165332EC",
+      "resourceType": "AWS::SSM::Parameter",
+      "path": "DataType",
+      "actual": "text",
+      "physicalId": "/cdkrd/harvest5/config",
+      "constructPath": "CdkrdIntegHarvest5/Param"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.ExpressEE4D4F3B.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.ExpressEE4D4F3B.json
@@ -1,0 +1,96 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest5 fixture, R77): fresh-deploy AWS::StepFunctions::StateMachine model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ExpressEE4D4F3B",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:ExpressEE4D4F3B-STsbmWDm37Ea",
+    "constructPath": "CdkrdIntegHarvest5/Express",
+    "declared": {
+      "DefinitionString": "{\"StartAt\":\"Noop\",\"States\":{\"Noop\":{\"Type\":\"Pass\",\"End\":true}}}",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+      "StateMachineType": "EXPRESS"
+    }
+  },
+  "liveRaw": {
+    "DefinitionString": "{\"StartAt\":\"Noop\",\"States\":{\"Noop\":{\"Type\":\"Pass\",\"End\":true}}}",
+    "EncryptionConfiguration": {
+      "Type": "AWS_OWNED_KEY"
+    },
+    "LoggingConfiguration": {
+      "IncludeExecutionData": false,
+      "Level": "OFF"
+    },
+    "StateMachineRevisionId": "INITIAL",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:ExpressEE4D4F3B-STsbmWDm37Ea",
+    "StateMachineName": "ExpressEE4D4F3B-STsbmWDm37Ea",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest5/631b6a70-66de-11f1-9f71-12359b386d2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest5",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "ExpressEE4D4F3B",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "ExpressEE4D4F3B-STsbmWDm37Ea",
+    "StateMachineType": "EXPRESS",
+    "TracingConfiguration": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnly": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnly": ["StateMachineName", "StateMachineType"],
+    "readOnlyPaths": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnlyPaths": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnlyPaths": ["StateMachineName", "StateMachineType"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ExpressEE4D4F3B",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "Type": "AWS_OWNED_KEY"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:ExpressEE4D4F3B-STsbmWDm37Ea",
+      "constructPath": "CdkrdIntegHarvest5/Express"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ExpressEE4D4F3B",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "LoggingConfiguration",
+      "actual": {
+        "IncludeExecutionData": false,
+        "Level": "OFF"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:ExpressEE4D4F3B-STsbmWDm37Ea",
+      "constructPath": "CdkrdIntegHarvest5/Express"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ExpressEE4D4F3B",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineName",
+      "actual": "ExpressEE4D4F3B-STsbmWDm37Ea",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:ExpressEE4D4F3B-STsbmWDm37Ea",
+      "constructPath": "CdkrdIntegHarvest5/Express"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -235,6 +235,21 @@ destroy each take minutes. `CDKRD_CLOUDFRONT_KEEP=1` keeps the stack.
 cd cloudfront && npm install && bash verify-cloudfront.sh
 ```
 
+## harvest5
+
+Wave 5 of the corpus harvest (R77): long-tail family breadth — AppConfig
+(application + environment + configuration profile + deployment strategy),
+EventBridge Connection + ApiDestination + Archive, Glue Job + Trigger,
+Lambda Function + Alias, IAM InstanceProfile, Route53 HealthCheck, a
+CloudWatch CompositeAlarm over two child alarms, an EXPRESS StateMachine,
+and an SSM Parameter. All cheap and fast — no VPC, no NAT, no slow
+resources. Same two harvest invariants: fresh deploy = ZERO declared drift,
+then accept -> `check --fail` CLEAN.
+
+```bash
+cd harvest5 && npm install && bash verify-harvest5.sh
+```
+
 ## revert
 
 A versioned S3 bucket. Enables acceleration, `accept`s (recording it in the

--- a/tests/integration/harvest5/app.ts
+++ b/tests/integration/harvest5/app.ts
@@ -1,0 +1,139 @@
+// Corpus-harvest fixture wave 5 (R77): more cheap, fast-create families the
+// corpus has never seen live, chosen for BREADTH over the long tail of CFn
+// types real apps use — AppConfig (app/env/profile/strategy), EventBridge
+// Connection+ApiDestination+Archive, Glue Job+Trigger, Lambda LayerVersion+
+// Alias, IAM InstanceProfile, Route53 HealthCheck, a CloudWatch CompositeAlarm,
+// an EXPRESS StateMachine, and SSM Parameter variants. Everything is cheap and
+// fast to create/delete; no VPC, no NAT, no slow resources (no RDS/ES/CF).
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnConfigurationProfile,
+  CfnDeploymentStrategy,
+  CfnEnvironment,
+} from "aws-cdk-lib/aws-appconfig";
+import { Alarm, AlarmRule, ComparisonOperator, CompositeAlarm, Metric, TreatMissingData } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnApiDestination, CfnArchive, CfnConnection } from "aws-cdk-lib/aws-events";
+import { CfnJob, CfnTrigger } from "aws-cdk-lib/aws-glue";
+import { InstanceProfile, ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Code, Function as Fn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { CfnHealthCheck } from "aws-cdk-lib/aws-route53";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import { DefinitionBody, StateMachine, StateMachineType, Pass } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegHarvest5");
+
+// ---- AppConfig (4 cheap types, deeply enum/number-typed)
+const cfgApp = new CfnApplication(stack, "Cfg", { name: "cdkrd-harvest5" });
+new CfnEnvironment(stack, "CfgEnv", {
+  applicationId: cfgApp.ref,
+  name: "prod",
+  description: "cdkrd harvest5 env",
+});
+new CfnConfigurationProfile(stack, "CfgProfile", {
+  applicationId: cfgApp.ref,
+  name: "flags",
+  locationUri: "hosted",
+  type: "AWS.AppConfig.FeatureFlags",
+});
+new CfnDeploymentStrategy(stack, "CfgStrategy", {
+  name: "cdkrd-harvest5-canary",
+  deploymentDurationInMinutes: 10,
+  growthFactor: 25,
+  finalBakeTimeInMinutes: 5,
+  growthType: "LINEAR",
+  replicateTo: "NONE",
+});
+
+// ---- EventBridge Connection + ApiDestination + Archive
+const conn = new CfnConnection(stack, "Conn", {
+  authorizationType: "API_KEY",
+  authParameters: {
+    apiKeyAuthParameters: { apiKeyName: "x-api-key", apiKeyValue: "cdkrd-harvest5-key" },
+  },
+});
+new CfnApiDestination(stack, "ApiDest", {
+  connectionArn: conn.attrArn,
+  httpMethod: "POST",
+  invocationEndpoint: "https://example.com/webhook",
+  invocationRateLimitPerSecond: 10,
+});
+new CfnArchive(stack, "Archive", {
+  sourceArn: `arn:aws:events:${stack.region}:${stack.account}:event-bus/default`,
+  retentionDays: 1,
+  description: "cdkrd harvest5 archive",
+});
+
+// ---- Glue Job + Trigger (no Crawler: needs a data store)
+const glueRole = new Role(stack, "GlueRole", {
+  assumedBy: new ServicePrincipal("glue.amazonaws.com"),
+  managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSGlueServiceRole")],
+});
+const job = new CfnJob(stack, "GlueJob", {
+  name: "cdkrd-harvest5",
+  role: glueRole.roleArn,
+  glueVersion: "4.0",
+  command: { name: "pythonshell", pythonVersion: "3.9", scriptLocation: "s3://aws-glue-scripts/noop.py" },
+  maxCapacity: 0.0625,
+});
+new CfnTrigger(stack, "GlueTrigger", {
+  type: "ON_DEMAND",
+  actions: [{ jobName: job.ref }],
+});
+
+// ---- Lambda Function + Version + Alias
+const fn = new Fn(stack, "AliasedFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => 'ok';"),
+});
+fn.addAlias("live", { description: "cdkrd harvest5 alias" });
+
+// ---- IAM InstanceProfile
+const ec2Role = new Role(stack, "Ec2Role", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+});
+new InstanceProfile(stack, "Profile", { role: ec2Role });
+
+// ---- Route53 HealthCheck (cheap; pings a public host)
+new CfnHealthCheck(stack, "Health", {
+  healthCheckConfig: {
+    type: "HTTPS",
+    fullyQualifiedDomainName: "example.com",
+    port: 443,
+    requestInterval: 30,
+    failureThreshold: 3,
+  },
+});
+
+// ---- CloudWatch CompositeAlarm over two child alarms
+const mkAlarm = (id: string, ns: string) =>
+  new Alarm(stack, id, {
+    metric: new Metric({ namespace: ns, metricName: "Errors", period: Duration.minutes(5) }),
+    threshold: 1,
+    evaluationPeriods: 1,
+    comparisonOperator: ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    treatMissingData: TreatMissingData.NOT_BREACHING,
+  });
+const a1 = mkAlarm("AlarmA", "cdkrd/harvest5/a");
+const a2 = mkAlarm("AlarmB", "cdkrd/harvest5/b");
+new CompositeAlarm(stack, "Composite", {
+  alarmRule: AlarmRule.anyOf(a1, a2),
+});
+
+// ---- EXPRESS StateMachine
+new StateMachine(stack, "Express", {
+  stateMachineType: StateMachineType.EXPRESS,
+  definitionBody: DefinitionBody.fromChainable(new Pass(stack, "Noop")),
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+// ---- SSM Parameter (String + StringList)
+new StringParameter(stack, "Param", {
+  parameterName: "/cdkrd/harvest5/config",
+  stringValue: "enabled",
+  description: "cdkrd harvest5 parameter",
+});
+
+app.synth();

--- a/tests/integration/harvest5/cdk.json
+++ b/tests/integration/harvest5/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest5/package.json
+++ b/tests/integration/harvest5/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-harvest5",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest fixture wave 5: AppConfig/EventBridge/Glue/Lambda-layer/IAM/Route53/CloudWatch/StepFunctions long-tail types. Run via verify-harvest5.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@11.17.0"
+}

--- a/tests/integration/harvest5/verify-harvest5.sh
+++ b/tests/integration/harvest5/verify-harvest5.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 5 (real AWS) — R77.
+#
+# Long-tail family breadth: AppConfig (app/env/profile/strategy), EventBridge
+# Connection+ApiDestination+Archive, Glue Job+Trigger, Lambda LayerVersion+
+# Alias, IAM InstanceProfile, Route53 HealthCheck, CloudWatch CompositeAlarm,
+# EXPRESS StateMachine, SSM Parameter. Asserts the two harvest invariants:
+#   1. baseline-free `check` — fresh deploy = ZERO declared drift, exit 0;
+#   2. `accept --yes` then `check --fail` — CLEAN across every type.
+#
+# CDKRD_HARVEST5_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest5 && npm install && bash verify-harvest5.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegHarvest5
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest5.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST5_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST5_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 5: long-tail families) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -153,6 +153,31 @@ describe('readLive (CC identifier adapters, R74)', () => {
     );
     expect(sent()).toBe('api456|route789');
   });
+
+  // R77: AppConfig Environment/ConfigurationProfile composite [ApplicationId, <child id>].
+  for (const t of ['AWS::AppConfig::Environment', 'AWS::AppConfig::ConfigurationProfile']) {
+    it(`${t}: builds the ApplicationId|<child> composite identifier`, async () => {
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({ resourceType: t, physicalId: 'envOrProfile1', declared: { ApplicationId: 'app99' } }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('app99|envOrProfile1');
+    });
+  }
+
+  it('AppConfig Environment: an unresolved ApplicationId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::AppConfig::Environment', physicalId: 'env1', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('env1');
+  });
 });
 
 describe('readLive (custom resources short-circuit, R26)', () => {


### PR DESCRIPTION
## Summary

The **harvest5** fixture deploys a broad long-tail of cheap, fast families the corpus had never seen live — AppConfig (application / environment / configuration profile / deployment strategy), EventBridge Connection + ApiDestination + Archive, Glue Job + Trigger, Lambda Function + Version + Alias, IAM InstanceProfile, Route53 HealthCheck, a CloudWatch CompositeAlarm over two child alarms, an EXPRESS StateMachine, and an SSM Parameter.

It is the **first harvest wave to find ZERO declared false positives** on the first live run — direct evidence the normalization is maturing (every earlier wave R71–R75 surfaced at least one FP).

## AppConfig CC composite identifiers

AppConfig `Environment` and `ConfigurationProfile` were CC `ValidationException` skips — their primaryIdentifier is the composite `[ApplicationId, <child id>]` but read used the bare physical id. Generalized the R76 ApiGatewayV2 fix into a shared `compositeWith(parentKey)` helper and added both AppConfig types (Cognito UserPoolClient + the three ApiGatewayV2 types now share it).

Re-checked live: **skipped 2 → 0**, still ZERO declared drift, INTEG PASS.

## Corpus 165 → 188 (613 tests)

23 long-tail types recorded live, including the two newly-readable AppConfig composites. No source behavior change beyond the identifier helper — this wave is mostly permanent offline regression coverage.

## Test plan

- [x] `vp run typecheck` / `vp check --fix` / `vp run build` / `vp run test` (31 files, 613 tests)
- [x] Live: `harvest5/verify-harvest5.sh` INTEG PASS — fresh deploy ZERO declared drift, skipped 2 → 0 after the AppConfig adapters, accept → CLEAN
- [x] Stack destroyed; recordings sanitized (no real account id)
