### PR TITLE
fix(read): ApplicationAutoScaling ScalingPolicy CC composite identifier — harvest4 skips 1 to 0 (R79)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,11 +85,13 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    the CC primaryIdentifier (AppSync GraphQLApi ARN vs ApiId; and the
    `${parent}|${child}` composites — Cognito UserPoolClient, ApiGatewayV2
    Stage/Route/Integration (R76), AppConfig Environment/ConfigurationProfile (R77)
-   — all built by the shared `compositeWith(parentKey)` helper) —
-   `CC_IDENTIFIER_ADAPTERS` in router.ts maps those without leaving the CC read
-   path, which is strictly cheaper than an SDK override (no new dependency, no
-   projection). Prefer an adapter over an override whenever the only gap is the
-   identifier shape.
+   — all built by the shared `compositeWith(parentKey)` helper; plus
+   ApplicationAutoScaling ScalingPolicy (R79), whose `${PolicyARN}|${dimension}`
+   identifier needs the ScalableDimension parsed out of the resolved
+   ScalingTargetId — `CC_IDENTIFIER_ADAPTERS` in router.ts maps those without
+   leaving the CC read path, which is strictly cheaper than an SDK override (no
+   new dependency, no projection). Prefer an adapter over an override whenever the
+   only gap is the identifier shape.
 4. **The deployed template, not synth, is the declared baseline.** So un-deployed
    code edits never masquerade as drift; `--pre-deploy` is the opt-in inversion.
    _Right call, or do users actually expect code-vs-reality by default?_

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -34,7 +34,28 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   'AWS::ApiGatewayV2::Integration': compositeWith('ApiId'),
   'AWS::AppConfig::Environment': compositeWith('ApplicationId'),
   'AWS::AppConfig::ConfigurationProfile': compositeWith('ApplicationId'),
+  // ApplicationAutoScaling ScalingPolicy: primaryIdentifier is [Arn,
+  // ScalableDimension]. The CFn physical id IS the PolicyARN, but ScalableDimension
+  // is not a direct ScalingPolicy property — it rides on the resolved
+  // `ScalingTargetId` (= the ScalableTarget physical id, formatted
+  // `resourceId|scalableDimension|serviceNamespace`). Verified live (R79): the
+  // PolicyARN was a CC ValidationException skip until paired with its dimension.
+  'AWS::ApplicationAutoScaling::ScalingPolicy': scalingPolicyComposite,
 };
+
+// `${PolicyARN}|${ScalableDimension}` for a ScalingPolicy, extracting the
+// dimension from the resolved ScalingTargetId (`resourceId|dimension|namespace`).
+// undefined when the target ref did not resolve (→ honest skip).
+function scalingPolicyComposite(
+  pid: string,
+  declared: Record<string, unknown>
+): string | undefined {
+  if (pid.includes('|')) return pid; // already composite — never double-suffix
+  const targetId = declared.ScalingTargetId;
+  if (typeof targetId !== 'string') return undefined;
+  const dimension = targetId.split('|')[1];
+  return dimension ? `${pid}|${dimension}` : undefined;
+}
 
 // Build a `${declared[parentKey]}|${physicalId}` composite CC identifier, or
 // undefined when the parent ref did not resolve (→ honest skip). Never

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
@@ -1,0 +1,106 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest4 + R79 AutoScaling CC-identifier adapter): fresh-deploy AWS::ApplicationAutoScaling::ScalingPolicy model — now READABLE via the PolicyARN|ScalableDimension composite (ScalableDimension parsed from ScalingTargetId; was a CC ValidationException skip before R79). ScalingTargetId is a readGap; ResourceId/ScalableDimension/ServiceNamespace are honest UNRECORDED inventory. A change in this case's expected means normalize/classify semantics for this type changed — review it.",
+  "resource": {
+    "logicalId": "ReadTargetReadUtil26E9C51F",
+    "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
+    "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+    "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil",
+    "declared": {
+      "PolicyName": "CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+      "PolicyType": "TargetTrackingScaling",
+      "ScalingTargetId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G|dynamodb:table:ReadCapacityUnits|dynamodb",
+      "TargetTrackingScalingPolicyConfiguration": {
+        "PredefinedMetricSpecification": {
+          "PredefinedMetricType": "DynamoDBReadCapacityUtilization"
+        },
+        "ScaleInCooldown": 60,
+        "ScaleOutCooldown": 60,
+        "TargetValue": 70
+      }
+    }
+  },
+  "liveRaw": {
+    "PolicyType": "TargetTrackingScaling",
+    "ResourceId": "table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G",
+    "PolicyName": "CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+    "ServiceNamespace": "dynamodb",
+    "ScalableDimension": "dynamodb:table:ReadCapacityUnits",
+    "TargetTrackingScalingPolicyConfiguration": {
+      "ScaleOutCooldown": 60,
+      "TargetValue": 70,
+      "ScaleInCooldown": 60,
+      "PredefinedMetricSpecification": {
+        "PredefinedMetricType": "DynamoDBReadCapacityUtilization"
+      }
+    },
+    "Arn": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["ScalingTargetId"],
+    "createOnly": [
+      "PolicyName",
+      "ResourceId",
+      "ScalableDimension",
+      "ScalingTargetId",
+      "ServiceNamespace"
+    ],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [
+      "ScalingTargetId",
+      "TargetTrackingScalingPolicyConfiguration.PredefinedMetricSpecification.ResourceLabel"
+    ],
+    "createOnlyPaths": [
+      "PolicyName",
+      "ResourceId",
+      "ScalableDimension",
+      "ScalingTargetId",
+      "ServiceNamespace"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "ReadTargetReadUtil26E9C51F",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
+      "path": "ScalingTargetId",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReadTargetReadUtil26E9C51F",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
+      "path": "ResourceId",
+      "actual": "table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G",
+      "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReadTargetReadUtil26E9C51F",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
+      "path": "ServiceNamespace",
+      "actual": "dynamodb",
+      "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReadTargetReadUtil26E9C51F",
+      "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
+      "path": "ScalableDimension",
+      "actual": "dynamodb:table:ReadCapacityUnits",
+      "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
+    }
+  ]
+}

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -178,6 +178,41 @@ describe('readLive (CC identifier adapters, R74)', () => {
     );
     expect(sent()).toBe('env1');
   });
+
+  // R79: ApplicationAutoScaling ScalingPolicy [Arn, ScalableDimension] — the
+  // dimension is parsed from the resolved ScalingTargetId (the ScalableTarget
+  // physical id `resourceId|scalableDimension|serviceNamespace`).
+  it('ScalingPolicy: composes PolicyARN|ScalableDimension from ScalingTargetId', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    const policyArn =
+      'arn:aws:autoscaling:us-east-1:1:scalingPolicy:abc:resource/dynamodb/table/T:policyName/p';
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+        physicalId: policyArn,
+        declared: { ScalingTargetId: 'table/T|dynamodb:table:ReadCapacityUnits|dynamodb' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe(`${policyArn}|dynamodb:table:ReadCapacityUnits`);
+  });
+
+  it('ScalingPolicy: an unresolved ScalingTargetId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+        physicalId: 'arn:x',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('arn:x');
+  });
 });
 
 describe('readLive (custom resources short-circuit, R26)', () => {


### PR DESCRIPTION
## Summary

`ApplicationAutoScaling::ScalingPolicy` was the **last CC-skip** on the harvest4 fixture (`ValidationException`): its CC primaryIdentifier is `[Arn, ScalableDimension]`, but read used the bare physical id.

Unlike the `compositeWith` cases, `ScalableDimension` is **not** a direct ScalingPolicy property — it rides on the resolved `ScalingTargetId` (= the ScalableTarget physical id, formatted `resourceId|scalableDimension|serviceNamespace`). The adapter parses the dimension from `segment[1]` and builds `${PolicyARN}|${dimension}`. The CFn physical id IS the PolicyARN (verified live via a probe stack + direct CC `get-resource`).

## Result (live re-run of harvest4)

- ScalingPolicy is now **read** — its `ResourceId`/`ScalableDimension`/`ServiceNamespace` surface as honest UNRECORDED inventory, `ScalingTargetId` as a readGap; the last skip-class gap is closed
- fresh deploy still **ZERO declared drift** (no new FP from the newly-readable type)
- **INTEG PASS** (incl. the R78 ELB attribute revert: mutate → Key-named detect → SDK-writer revert → CLEAN → direct read 120)

## Corpus 188 → 189 (626 tests)

ScalingPolicy recorded live for the first time. Unresolved `ScalingTargetId` → bare physical id (honest skip); already-composite id never double-suffixed.

## Test plan

- [x] `vp run typecheck` / `vp check --fix` / `vp run build` / `vp run test` (31 files, 626 tests)
- [x] Live: `harvest4/verify-harvest4.sh` INTEG PASS — ScalingPolicy now read, no new declared FP, ELB revert still green
- [x] Probe stack + manual test resources cleaned up; recording sanitized (no real account id)
