### PR TITLE
test(report): cover ELB attributeKey display + gitignore integ-fixture baselines (R80)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,12 @@ cdk.out/
 # ignored only inside this repo's own scratch dirs)
 /tmp-dogfood/
 
+# Integration-fixture baselines are transient — written by the verify scripts
+# during a live run, never committed. Without this, `git add -A` repeatedly swept
+# a fixture baseline into a commit (R69/R75/R78/R79). The top-level project
+# .cdkrd/ stays committed; only the fixtures' own .cdkrd dirs are ignored.
+tests/integration/**/.cdkrd/
+
 # Temporary README-example generator: `vp check`/README-gen drops this self-deleting
 # test in tests/; it is explicitly "Not committed" but is easy to sweep up via
 # `git add -A`. Ignore it so it can never be accidentally committed.

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -288,5 +288,22 @@ describe('report', () => {
         'result: CLEAN',
       ]);
     });
+
+    // R78: an ELB attribute-bag drift names the changed attribute by Key
+    // (LoadBalancerAttributes[idle_timeout.timeout_seconds]) instead of a bare path.
+    it('declared drift with attributeKey names the attribute by Key', () => {
+      const finding: Finding = {
+        tier: 'declared',
+        logicalId: 'Edge',
+        resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+        path: 'LoadBalancerAttributes',
+        attributeKey: 'idle_timeout.timeout_seconds',
+        desired: '120',
+        actual: '300',
+      };
+      const { text } = run([finding]);
+      expect(text).toContain('LoadBalancerAttributes[idle_timeout.timeout_seconds]');
+      expect(text).toContain('desired=');
+    });
   });
 });


### PR DESCRIPTION
Two real gaps surfaced by the **/verify-pr** release-readiness gate (run genuinely on main R79):

- **report.ts attributeKey display** (R78's `LoadBalancerAttributes[idle_timeout.timeout_seconds]`) had no unit test — added one to `report.test.ts` (627 tests).
- **`tests/integration/**/.cdkrd` baselines** are transient (written by verify scripts during a live run) but weren't gitignored, so `git add -A` repeatedly swept a fixture baseline into a commit (R69/R75/R78/R79 each needed a manual restore / git-secrets block). Now ignored; the top-level project `.cdkrd/` stays committed.

## /verify-pr result (main R79, f7ffc74)

| Check | Result |
|---|---|
| typecheck / lint / build | pass |
| tests (31 files, 627) | pass |
| coverage for changes | pass (this PR closes the report.ts gap) |
| docs consistency | pass (CLI surface unchanged since R73; SDK_WRITERS ↔ README ELB perms consistent) |
| code review | pass (R74-R79 each PR-reviewed + CI'd) |
| live-test changed behavior | pass (attributeKey display, new CC reads, ELB revert all verified live in harvest4) |
| **integration fixtures** | **all INTEG PASS** — basic x4, iam x2, lambda, revert, policies (this session) + harvest3/4/5 + cloudfront (R74-R79; harvest4 re-run for R79) |
| retrospective | done (this PR is the artifact) |

**Ready to release.**

> Note: an earlier terminal-output-corruption stretch falsely reported R79/R80/R81 as already merged. The real state was reconstructed from `git log`/`gh pr list`: R79 is now genuinely merged (#50), and this is the genuine R80.
