### PR TITLE
docs(readme): broaden the comparison table to the full drift-tool landscape (R81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,16 @@ $ npx cdkrd check ApiStack
 result: 1 drift(s) (undeclared=1)
 ```
 
-| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection |
-| ------------------------------------------------------------------- | :-----: | :-------------------------------: |
-| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |
-| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |
-| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |
-| **Revert** undeclared drift                                         |   ✅    |                ❌                 |
-| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |
+| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection | `driftctl` | `terraform plan` |
+| ------------------------------------------------------------------- | :-----: | :-------------------------------: | :--------: | :--------------: |
+| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |     ✅     |        ✅        |
+| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |     ❌     |        ❌        |
+| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |     ❌     |  ✅ `apply`      |
+| **Revert** undeclared drift                                         |   ✅    |                ❌                 |     ❌     |        ❌        |
+| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |     ❌     |        ❌        |
+
+Every tool reads only what's in the template/state — so the **undeclared** rows
+are blank everywhere but `cdkrd`. That row is the whole reason it exists.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ result: 1 drift(s) (undeclared=1)
 | ------------------------------------------------------------------- | :-----: | :-------------------------------: | :--------: | :--------------: |
 | Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |     ✅     |        ✅        |
 | Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |     ❌     |        ❌        |
-| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |     ❌     |  ✅ `apply`      |
+| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |     ❌     |    ✅ `apply`    |
 | **Revert** undeclared drift                                         |   ✅    |                ❌                 |     ❌     |        ❌        |
 | **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |     ❌     |        ❌        |
 


### PR DESCRIPTION
Phase 4 launch polish.

The README already leads with the differentiator demo (`cdk drift` says "0 drift" → `cdkrd check` finds the undeclared change) and a comparison table. This widens the table from 2 tools to the **4 the project's own positioning names** — `cdk drift`/CFn drift detection, `driftctl`, and `terraform plan`:

| Capability | `cdkrd` | cdk drift / CFn | driftctl | terraform plan |
|---|:-:|:-:|:-:|:-:|
| Detect **declared** drift | ✅ | ✅ | ✅ | ✅ |
| Detect **undeclared** drift | ✅ | ❌ | ❌ | ❌ |
| **Revert** declared | ✅ | ✅ | ❌ | ✅ |
| **Revert** undeclared | ✅ | ❌ | ❌ | ❌ |
| **Accept** into a git file | ✅ | ❌ | ❌ | ❌ |

Cell values are conservative and fact-based: driftctl is detection-only (no revert); terraform reverts declared drift via `apply`; none of them read undeclared properties. The result makes the "only cdkrd catches undeclared drift" claim visually complete — the undeclared rows are blank for every tool but cdkrd.

Docs-only; `docs` + `check` markers set. The killer demo itself is unchanged (it's already strong); the remaining launch items (npm badges, demo GIF) are "on publish" tasks tracked by the placeholders already in the README.
