### PR TITLE
docs(readme): drop driftctl/terraform-plan columns — focus the comparison on cdk drift / CFn (R82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,13 @@ $ npx cdkrd check ApiStack
 result: 1 drift(s) (undeclared=1)
 ```
 
-| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection | `driftctl` | `terraform plan` |
-| ------------------------------------------------------------------- | :-----: | :-------------------------------: | :--------: | :--------------: |
-| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |     ✅     |        ✅        |
-| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |     ❌     |        ❌        |
-| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |     ❌     |    ✅ `apply`    |
-| **Revert** undeclared drift                                         |   ✅    |                ❌                 |     ❌     |        ❌        |
-| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |     ❌     |        ❌        |
-
-Every tool reads only what's in the template/state — so the **undeclared** rows
-are blank everywhere but `cdkrd`. That row is the whole reason it exists.
+| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection |
+| ------------------------------------------------------------------- | :-----: | :-------------------------------: |
+| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |
+| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |
+| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |
+| **Revert** undeclared drift                                         |   ✅    |                ❌                 |
+| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |
 
 ## Quick start
 


### PR DESCRIPTION
Per user direction: the comparison table should not list driftctl or terraform plan. Reverts the R81 widening back to the focused 2-tool table (`cdkrd` vs `cdk drift` / CFn drift detection) and removes the trailing 'every tool reads only...' sentence that referenced them. The killer demo above the table is unchanged.

Docs-only; `vp run check` passes; check/docs markers set.