### PR TITLE
chore(hooks): port cdkd branch-protection + verify-pr-merge gates, add English-only gate (R83)

### DIFF
--- a/.claude/hooks/branch-gate.sh
+++ b/.claude/hooks/branch-gate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# branch-gate.sh
+#
+# PreToolUse hook. Blocks `git commit` and `git push` when the working
+# tree the command will actually act on is on `main` / `master`. All
+# changes to cdkd must land via PR from a feature branch — direct
+# commits/pushes to main are not allowed.
+#
+# WHY the cwd-aware resolution matters: this repo is regularly worked
+# in via `git worktree`. The previous implementation derived the repo
+# root from `BASH_SOURCE` (the hook script's location), which in a
+# worktree-copy invocation pointed at the worktree itself — so the
+# hook checked the worktree's branch (a feature branch) and allowed
+# the commit, even when the user's actual command did
+# `cd /path/to/parent && git commit` and the commit landed on the
+# parent worktree's `main`. Real-world incident: 2026-05-04 lambda fix
+# session, see memory feedback_git_use_C_in_worktree.md.
+#
+# Resolution order for "where will the git command actually run":
+#   1. Explicit `git -C <path> commit/push` — last `-C` wins.
+#   2. Leading `cd <path> && ...` — the cd target.
+#   3. The hook input's `cwd` field (the Bash tool's persisted cwd).
+#   4. The hook process's own $PWD (fallback, almost never reached).
+
+set -u
+
+# Read the entire stdin payload once; we need both .tool_input.command
+# and .cwd from it. Reading via two separate jq invocations would
+# consume stdin twice and the second read would see nothing.
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate git commit / git push — any other command passes through.
+# The regex matches `git` + optional global flags (e.g. `-C <path>`,
+# `-c <key>=<value>`, `--no-pager`, `--git-dir=<path>`) + the literal
+# subcommand `commit` or `push`, anchored so that `commit` / `push`
+# must appear in the GIT SUBCOMMAND POSITION — not as a substring of
+# a refspec (`<sha>^{commit}`), a pathspec (`-- '*push*.md'`), or a
+# `--grep=push` query.
+#
+# Anchors:
+#   `^[[:space:]]*(cd[[:space:]]+...&&[[:space:]]*)?git`
+#                             — line-start anchored (per memory rule
+#                               feedback_hook_command_match_line_start.md)
+#                               so `git commit` / `git push` substrings
+#                               inside quoted argument bodies
+#                               (`gh issue create --body "we should add
+#                               git commit hook later"`) do NOT
+#                               false-positive into a hard block. The
+#                               optional leading `cd <path> &&` prefix
+#                               preserves the worktree-aware
+#                               `cd <side> && git commit` chain shape —
+#                               `cd ... &&` at the literal line-start
+#                               cannot match inside a JSON literal
+#                               containing `&&` because the line-start
+#                               anchor requires no leading characters
+#                               except whitespace. Mirrors check-gate.sh
+#                               (PR #562 fix pattern).
+#   `([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*`
+#                             — zero or more "flag tokens": each flag
+#                               (`-X` or `--foo[=val]`) optionally
+#                               followed by a separate non-flag value
+#                               token (covers `-C <path>` /
+#                               `-c <key>=<val>`).
+#   `[[:space:]]+(commit|push)` — the subcommand position.
+#   `([[:space:]]|$|[|;&`)])` — must end at a token boundary so
+#                               `commit.gpgSign=false` (a `-c` value)
+#                               is NOT counted as the subcommand;
+#                               also recognizes pipeline / subshell
+#                               separators so `git status; git commit`,
+#                               `` `git push` `` all match.
+#                               `$(git commit)` / backtick-wrapped
+#                               forms are an accepted false-negative
+#                               of the line-start tightening (per the
+#                               memory rule's trade-off).
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+(commit|push)([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+# Start from the Bash session's persisted cwd; fall back to the hook
+# process's own cwd if the payload did not include a `cwd` field.
+target_dir="${hook_cwd:-$PWD}"
+
+# `cd <path>` at the start of the command shifts the target dir. We
+# look at the FIRST `cd` and stop — chained `cd` patterns are rare
+# enough that handling only the leading one covers the realistic
+# foot-gun (the "cd into parent for tooling" case) without parsing
+# arbitrary shell.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  # Strip surrounding single or double quotes if present.
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  # Resolve relative paths against the inherited cwd.
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# `git -C <path>` is git's own "run as if from <path>" flag and beats
+# any earlier cd. Find the LAST occurrence so a chained
+# `git -C /a foo && git -C /b commit` resolves to /b.
+if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  # Use a pattern that captures the last occurrence by greedy-skipping.
+  # bash regex doesn't support lookbehind, so re-scan from the end.
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# Read the branch from the resolved target dir. `-C` lets git operate
+# on a directory that isn't our cwd; if the dir doesn't exist or isn't
+# inside a git repo, symbolic-ref returns empty and we fall through to
+# the safe `exit 0` below (we can't gate what we can't see).
+branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+
+case "$branch" in
+  main|master)
+    echo "Blocked by branch-gate: target git working tree is on branch '$branch'." >&2
+    echo "  resolved target dir: $target_dir" >&2
+    echo "  command: $cmd" >&2
+    echo "Create a feature branch and open a PR instead (e.g. 'git -C \"$target_dir\" switch -c fix/xxx')." >&2
+    echo "Direct commits/pushes to main are not allowed in this repo." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/hooks/branch-gate.test.sh
+++ b/.claude/hooks/branch-gate.test.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# Smoke test for branch-gate.sh.
+#
+# Exercises the cwd-aware branch resolution against fixture git
+# worktrees, asserting both the BLOCK (exit 2) and ALLOW (exit 0)
+# outcomes. Run from the repo root: `bash .claude/hooks/branch-gate.test.sh`.
+#
+# Why a shell script and not a vitest test: the hook IS a shell
+# script, the contract IS the stdin JSON payload + exit code. A
+# TypeScript wrapper would test the wrapper, not the hook.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/branch-gate.sh"
+
+# Per-run scratch dir; cleaned on EXIT.
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Two fixture git working trees: one on `main`, one on a feature branch.
+# Both have a config user so commit works if we ever exercise it.
+main_repo="$TMPDIR/main-repo"
+feature_repo="$TMPDIR/feature-repo"
+git init -q -b main "$main_repo"
+git -C "$main_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git init -q -b feature/x "$feature_repo"
+git -C "$feature_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+pass=0
+fail=0
+fail_log=""
+
+# run_case <name> <expect_exit> <stdin_json>
+run_case() {
+  local name="$1"; local want="$2"; local payload="$3"
+  local got out
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) || true
+  got=$?
+  # The above always evaluates to 0 (`|| true`), so capture status
+  # via a separate run.
+  printf '%s' "$payload" | "$HOOK" >/dev/null 2>&1
+  got=$?
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1))
+    printf 'OK   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: want exit $want, got $got\n"
+    fail_log+="  payload: $payload\n"
+    fail_log+="  output : $out\n"
+    printf 'FAIL %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# --- ALLOW cases ---
+
+# 1. Non-git command always passes through.
+run_case "non-git command always allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"ls -la"}}' "$main_repo")"
+
+# 2. git command other than commit/push (e.g. status) is allowed even on main.
+run_case "git status on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$main_repo")"
+
+# 3. git commit on a feature branch — the happy path.
+run_case "git commit on feature branch allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$feature_repo")"
+
+# 4. git -C <feature> commit, even when cwd is on main → ALLOW
+#    (the actual git operation targets the feature working tree).
+run_case "git -C <feature> commit from main-cwd allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s commit -m wip"}}' "$main_repo" "$feature_repo")"
+
+# 5. cd <feature> && git commit, even when payload cwd is main.
+run_case "cd <feature> && git commit from main-cwd allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"cd %s && git commit -m wip"}}' "$main_repo" "$feature_repo")"
+
+# 6. Detached HEAD / non-git dir → symbolic-ref empty → allow (we can't
+#    gate what we can't see).
+run_case "non-git target dir allowed (silent pass)" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m wip"}}' "$TMPDIR")"
+
+# --- ALLOW cases for read-only `git` commands that contain the literal
+# words `commit` / `push` in args or refspecs (issue #281).
+#
+# Pre-fix the regex `\bgit[^|;&]*\b(commit|push)\b` matched any git
+# invocation that mentioned `commit` / `push` anywhere on the line —
+# blocking legitimate read-only ops like `git rev-parse <sha>^{commit}`
+# even on `main`. The tightened regex requires `commit` / `push` to
+# appear in the GIT SUBCOMMAND POSITION.
+
+# 7a. `git rev-parse <sha>^{commit}` — `^{commit}` is git's peel-to-commit
+#     syntax, NOT the commit subcommand. Must pass-through even on main.
+run_case "git rev-parse <sha>^{commit} on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git rev-parse abc123^{commit}"}}' "$main_repo")"
+
+# 7b. `git cat-file -e <sha>^{commit}` — same peel-to-commit; this is the
+#     exact repro from the issue body.
+run_case "git cat-file -e <sha>^{commit} on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git cat-file -e abc^{commit}"}}' "$main_repo")"
+
+# 7c. `git log --grep=commit` — `commit` is a literal in a search query,
+#     not the subcommand.
+run_case "git log --grep=commit on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git log --grep=commit"}}' "$main_repo")"
+
+# 7d. `git log --grep=push` — same shape for the `push` keyword.
+run_case "git log --grep=push on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git log --grep=push"}}' "$main_repo")"
+
+# 7e. `git diff <range> -- '*push*.md'` — `push` is part of a pathspec.
+run_case "git diff with push pathspec on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git diff abc def -- '\''*push*.md'\''"}}' "$main_repo")"
+
+# 7f. `git diff <range> -- '*commit*.md'` — same shape for `commit`.
+run_case "git diff with commit pathspec on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git diff abc def -- '\''*commit*.md'\''"}}' "$main_repo")"
+
+# 7g. `git rev-list HEAD..main --oneline | head -5` — read-only revlist
+#     that pipes into another command; no commit/push subcommand.
+run_case "git rev-list piped on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git rev-list HEAD..main --oneline | head -5"}}' "$main_repo")"
+
+# 7h. `git symbolic-ref HEAD` — pure read; trivially shouldn't trigger.
+run_case "git symbolic-ref HEAD on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git symbolic-ref HEAD"}}' "$main_repo")"
+
+# --- BLOCK cases ---
+
+# 7. Plain git commit when cwd is on main.
+run_case "git commit on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git commit -m oops"}}' "$main_repo")"
+
+# 8. git push on main blocked too.
+run_case "git push on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin main"}}' "$main_repo")"
+
+# 9. cd <main> && git commit from a feature-branch cwd. The cd target
+#    is what matters, not the inherited cwd. THIS is the regression
+#    case the rewrite fixes.
+run_case "cd <main> && git commit from feature-cwd blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"cd %s && git commit -m oops"}}' "$feature_repo" "$main_repo")"
+
+# 10. git -C <main> commit. Same logic via -C.
+run_case "git -C <main> commit blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s commit -m oops"}}' "$feature_repo" "$main_repo")"
+
+# 11. Single-line `git -C <a> status; git -C <b> commit` — chained
+#     shape where the second `git` is NOT at line-start. With the
+#     line-start anchored matcher (per memory rule
+#     feedback_hook_command_match_line_start.md, issue #563), the
+#     matcher fires on the FIRST `git -C <feature> status` token
+#     (the line-start one), which is not a commit/push subcommand,
+#     so the hook short-circuits at the matcher (exit 0). This is
+#     an ACCEPTED FALSE-NEGATIVE of the line-start tightening — the
+#     trade-off we make to eliminate quoted-body false-positives
+#     (see Part C false-positive cases below). For the agent
+#     workflow this is fine: chained-on-one-line commits to main
+#     are rare; the dominant shape is `cd <repo> && git commit ...`,
+#     which IS line-start matched.
+run_case "single-line chained git -C status; git -C commit (accepted false-negative)" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -C %s status; git -C %s commit -m oops"}}' "$feature_repo" "$feature_repo" "$main_repo")"
+
+# 11b. `git -c <key>=<val> commit` — global `-c` flag before commit
+#      subcommand. The tightened regex must not get confused by the
+#      `<key>=<val>` token (which can contain the literal substring
+#      `commit`, e.g. `commit.gpgSign=false`).
+run_case "git -c commit.gpgSign=false commit on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git -c commit.gpgSign=false commit -m oops"}}' "$main_repo")"
+
+# 11c. `git push --force` on main — `--force` after the subcommand.
+run_case "git push --force on main blocked" 2 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git push origin --force"}}' "$main_repo")"
+
+# --- Edge cases ---
+
+# 12. Missing .cwd in payload → fall back to hook process $PWD.
+#    Not exercised end-to-end (we'd need to control $PWD); just
+#    confirm the hook does not crash on missing cwd.
+run_case "missing .cwd does not crash" 0 \
+  '{"tool_input":{"command":"git status"}}'
+
+# 13. Empty stdin payload → cmd empty → allowed (nothing to gate).
+run_case "empty stdin allowed" 0 \
+  ''
+
+# --- LINE-START ANCHORING cases (issue #563) ---
+#
+# The matcher MUST NOT fire when the literal substrings `git commit` /
+# `git push` appear inside a quoted argument body of an unrelated
+# command. Per memory rule feedback_hook_command_match_line_start.md,
+# applied to branch-gate.sh in issue #563 (mirroring the PR #562 fix
+# to check-gate.sh).
+
+# 14. `gh issue create --body "...git commit..."` on main: the body
+#     mentions `git commit` but the command itself starts with `gh`.
+#     MUST pass through (would otherwise block routine issue creation).
+run_case "gh issue body quoting 'git commit' on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh issue create --body \"we should add a git commit hook later\""}}' "$main_repo")"
+
+# 15. `echo "...git push..."` on main: the body mentions `git push`
+#     but the command starts with `echo`. MUST pass through.
+run_case "echo body quoting 'git push' on main allowed" 0 \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"echo \"reminder: git push origin main later\""}}' "$main_repo")"
+
+echo
+echo "Pass: $pass  Fail: $fail"
+if [[ "$fail" -gt 0 ]]; then
+  echo
+  printf '%b' "$fail_log"
+  exit 1
+fi

--- a/.claude/hooks/non-english-text-gate.sh
+++ b/.claude/hooks/non-english-text-gate.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# non-english-text-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr create` / `gh pr edit` / `gh pr merge`
+# when the PR diff contains non-ASCII writing-system characters:
+# hiragana, katakana, CJK ideographs (kanji / Chinese), Hangul, or CJK
+# punctuation. The repo is OSS and the workflow rule "English-only for
+# committed files" forbids those.
+#
+# WHY: PR #521 (integ-schema-migration gate) shipped with verbatim
+# Japanese session quotes embedded in `.markgate.yml` and the hook
+# header comment. The English-only rule (memory
+# `feedback_oss_english_only.md`) was honor-system at the time; nothing
+# structural caught the violation, so the user had to spot it
+# post-merge and we had to open PR #523 as a fix-up. This hook closes
+# the gap.
+#
+# Why PR-level (not per-commit):
+#   - Empirically violations are 1-2 files (PR #521 was 2). The pattern
+#     is "verbatim paste of a session quote" or "intentional non-ASCII
+#     text" — not the kind of mistake that accumulates across N commits.
+#   - Per-commit scanning is also viable (~30-150ms / commit on
+#     measured shapes) but compounds: a 30-commit PR pays the cost 30x.
+#     PR-level scanning runs once (~234ms on PR #522's 29-file diff),
+#     so the user-visible overhead is zero in the steady state.
+#   - Strength-wise the gate is equivalent to a per-commit hook because
+#     it blocks `gh pr merge` itself — every code path that lands a
+#     commit on main goes through that one call.
+#
+# Scope:
+#   - Triggers on `gh pr create` / `gh pr edit` / `gh pr merge` (and
+#     their `gh -C <path> ...` forms). Everything else passes through.
+#   - Detects the PR by `gh pr view --json number` from the resolved
+#     target working tree (same cwd-resolution shape as branch-gate.sh
+#     / internal-pr-labels-gate.sh).
+#   - Walks every file in the PR diff (added or modified, not deleted)
+#     via `gh pr diff <N> --name-only`. The post-PR file content is
+#     fetched via `gh api repos/<owner>/<repo>/contents/<file>?ref=<sha>`
+#     so the gate works even before the branch is checked out locally.
+#   - Skips known binary / lockfile / asset extensions where the bytes
+#     can legitimately carry non-ASCII content (PNGs / fonts / lockfile
+#     author names / etc.).
+#
+# Detection: a single `grep -nP` run per touched file against the
+# combined character class of:
+#   U+3000-U+303F   CJK Symbols and Punctuation (Japanese quotes etc.)
+#   U+3040-U+309F   Hiragana
+#   U+30A0-U+30FF   Katakana
+#   U+4E00-U+9FFF   CJK Unified Ideographs (kanji / Chinese)
+#   U+AC00-U+D7AF   Hangul Syllables
+# The ranges deliberately exclude general-purpose Unicode that the repo
+# already uses (em-dashes, curly quotes, box-drawing chars in CLAUDE.md
+# ASCII art, arrow glyphs in docs).
+#
+# Fails open when `gh` is missing or the PR cannot be resolved (matches
+# post-merge-orphan-push-gate.sh's contract so a fresh machine still
+# works).
+#
+# No bypass marker — the fix is trivial (translate the text). If a test
+# fixture ever genuinely needs Japanese content (Unicode-handling
+# tests), add a sidecar allow-list file like the integ-coverage gate
+# uses; v1 ships without that mechanism.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate gh pr create / edit / merge — anything else passes through.
+if ! printf '%s' "$cmd" | grep -qE '\bgh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|edit|merge)\b'; then
+  exit 0
+fi
+
+target_dir="${hook_cwd:-$PWD}"
+
+# Leading `cd <path> && ...` shifts the target dir.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# Last `gh -C <path>` wins.
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# If the resolved target dir is not a git repo, silently pass.
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+# gh missing or unauthenticated — fail open.
+if ! command -v "${GH_BIN:-gh}" >/dev/null 2>&1; then
+  exit 0
+fi
+GH="${GH_BIN:-gh}"
+if ! "$GH" -C "$target_dir" auth status >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Resolve target PR number.
+#
+#   `gh pr merge <N>` / `gh pr edit <N>` — N is the explicit arg.
+#   `gh pr create` / `gh pr merge` (no arg) — current branch's PR.
+pr_number=""
+if [[ "$cmd" =~ gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(merge|edit)[[:space:]]+([0-9]+) ]]; then
+  pr_number="${BASH_REMATCH[3]}"
+fi
+
+if [[ -z "$pr_number" ]]; then
+  pr_number=$("$GH" -C "$target_dir" pr view --json number -q .number 2>/dev/null || true)
+fi
+
+# No PR yet (typical `gh pr create` on a fresh branch) — fall back to
+# scanning the local diff against the default base branch.
+use_local_diff=0
+if [[ -z "$pr_number" ]]; then
+  use_local_diff=1
+fi
+
+# File-list resolution.
+if [[ "$use_local_diff" -eq 1 ]]; then
+  base_ref=$(git -C "$target_dir" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
+  base_ref="${base_ref:-main}"
+  merge_base=$(git -C "$target_dir" merge-base "origin/$base_ref" HEAD 2>/dev/null || true)
+  if [[ -z "$merge_base" ]]; then
+    # Can't establish a base — silently pass (CI / detached HEAD).
+    exit 0
+  fi
+  changed_files=$(git -C "$target_dir" diff "$merge_base..HEAD" --name-only --diff-filter=AM 2>/dev/null || true)
+else
+  changed_files=$("$GH" -C "$target_dir" pr diff "$pr_number" --name-only 2>/dev/null || true)
+fi
+
+if [[ -z "$changed_files" ]]; then
+  exit 0
+fi
+
+# Skip binary / lockfile / asset extensions.
+should_scan() {
+  local f="$1"
+  case "$f" in
+    *.png|*.jpg|*.jpeg|*.gif|*.svg|*.ico|*.webp|*.pdf) return 1 ;;
+    *.woff|*.woff2|*.ttf|*.eot|*.otf) return 1 ;;
+    *.zip|*.tar|*.gz|*.tgz|*.bz2|*.7z|*.xz) return 1 ;;
+    *.mp3|*.mp4|*.wav|*.ogg|*.webm|*.mov) return 1 ;;
+    pnpm-lock.yaml|package-lock.json|yarn.lock|Cargo.lock|go.sum) return 1 ;;
+    *.lock) return 1 ;;
+  esac
+  return 0
+}
+
+# Matcher implemented in perl (not `grep -P`) because BSD `grep` on
+# macOS does not support PCRE / `-P`. `perl -CSD` reads STDIN as UTF-8
+# and writes STDOUT as UTF-8, so the Unicode ranges below work in
+# either system.
+NON_ENGLISH_PERL='print "$.:$_" if /[\x{3000}-\x{303F}\x{3040}-\x{309F}\x{30A0}-\x{30FF}\x{4E00}-\x{9FFF}\x{AC00}-\x{D7AF}]/'
+
+declare -a OFFENDERS=()
+MAX_REPORT=20
+
+# For PR-mode we need each file's content at the PR HEAD sha. Fetch the
+# sha once.
+pr_head_sha=""
+if [[ "$use_local_diff" -eq 0 ]]; then
+  pr_head_sha=$("$GH" -C "$target_dir" pr view "$pr_number" --json headRefOid -q .headRefOid 2>/dev/null || true)
+fi
+
+read_file_content() {
+  local f="$1"
+  if [[ "$use_local_diff" -eq 1 ]]; then
+    git -C "$target_dir" show "HEAD:$f" 2>/dev/null
+  else
+    if [[ -n "$pr_head_sha" ]]; then
+      # Prefer local git when the PR sha is present locally — avoids a
+      # network call per file.
+      git -C "$target_dir" show "$pr_head_sha:$f" 2>/dev/null && return 0
+    fi
+    # Fall back to fetching from the API.
+    "$GH" -C "$target_dir" api "repos/{owner}/{repo}/contents/$f?ref=${pr_head_sha:-HEAD}" -q .content 2>/dev/null | base64 -d 2>/dev/null
+  fi
+}
+
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  if ! should_scan "$f"; then
+    continue
+  fi
+
+  while IFS=: read -r ln content; do
+    [[ -z "$ln" ]] && continue
+    OFFENDERS+=("$f:$ln:$content")
+    if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
+      break 2
+    fi
+  done < <(read_file_content "$f" | perl -CSD -ne "$NON_ENGLISH_PERL" 2>/dev/null || true)
+done <<< "$changed_files"
+
+if [[ "${#OFFENDERS[@]}" -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ -t 2 ]]; then
+  RED_BOLD=$'\033[1;31m'
+  RESET=$'\033[0m'
+else
+  RED_BOLD=""
+  RESET=""
+fi
+
+scope_label="PR #$pr_number"
+[[ "$use_local_diff" -eq 1 ]] && scope_label="local diff (origin/$base_ref..HEAD)"
+
+{
+  echo "${RED_BOLD}Blocked by non-english-text-gate:${RESET}"
+  echo
+  echo "$scope_label contains non-English writing-system characters"
+  echo "(hiragana / katakana / kanji / Chinese / hangul / CJK punctuation)."
+  echo
+  echo "This is an OSS repo. Every committed artifact must be English-only"
+  echo "per the workflow rule: source code, shell scripts, hook messages,"
+  echo "config files, docs, comments, commit messages, PR titles/bodies."
+  echo "Conversation in chat may be in any language — this rule applies"
+  echo "only to files that land in the repository."
+  echo
+  echo "Found:"
+  for entry in "${OFFENDERS[@]}"; do
+    file="${entry%%:*}"
+    rest="${entry#*:}"
+    ln="${rest%%:*}"
+    content="${rest#*:}"
+    echo "  $file:$ln: $content"
+  done
+  echo
+  echo "Fix:"
+  echo "  - Translate the offending text to English."
+  echo "  - For docstrings / comments: rewrite in English."
+  echo "  - For verbatim session quotes (PR #521 trap): rewrite as a"
+  echo "    project-level contract statement, not as a quote."
+  echo "  - Open a follow-up commit on the same branch and push; this"
+  echo "    hook re-runs against the new HEAD."
+  echo
+  echo "Rule: CLAUDE.md > Workflow Rules > 'English-only for all committed files'."
+} >&2
+
+exit 2

--- a/.claude/hooks/non-english-text-gate.test.sh
+++ b/.claude/hooks/non-english-text-gate.test.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Smoke test for non-english-text-gate.sh.
+#
+# Verifies the hook's trigger surface and Unicode-range matcher
+# against fixture git repos. The PR-mode path is exercised via a
+# stub `gh` injected through $GH_BIN — same pattern as
+# post-merge-orphan-push-gate.test.sh.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/non-english-text-gate.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+init_repo() {
+  local dir="$1"
+  git init -q -b main "$dir"
+  mkdir -p "$dir/src" "$dir/docs" "$dir/.claude/hooks"
+  cat > "$dir/README.md" <<'EOF'
+# project
+Baseline.
+EOF
+  cat > "$dir/src/foo.ts" <<'EOF'
+export const foo = 1;
+EOF
+  git -C "$dir" add -A
+  git -C "$dir" -c user.email=t@t -c user.name=t commit -q -m baseline
+  # Mock origin/main so the local-diff fallback (`merge-base
+  # origin/main HEAD`) has a base. We use a non-tracking ref to keep
+  # the fixture self-contained.
+  git -C "$dir" update-ref refs/remotes/origin/main HEAD
+  git -C "$dir" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+}
+
+commit_all() {
+  local dir="$1"
+  git -C "$dir" add -A
+  git -C "$dir" -c user.email=t@t -c user.name=t commit -q -m wip
+}
+
+# Stub `gh`. The hook calls:
+#   gh -C <dir> auth status            -> rc 0 = authed
+#   gh -C <dir> pr view --json number  -> "" (no PR; local-diff fallback)
+#   gh -C <dir> pr view <N> --json...  -> rejects (we use local-diff)
+#   gh -C <dir> pr diff <N> --name-only -> N/A here
+make_gh_stub() {
+  local out="$TMPDIR/gh-stub"
+  cat > "$out" <<'EOF'
+#!/usr/bin/env bash
+# Strip optional `-C <dir>` so we can pattern-match against the
+# remaining args.
+args=()
+i=1
+while [[ $i -le $# ]]; do
+  if [[ "${!i}" == "-C" ]]; then
+    i=$((i + 2))
+    continue
+  fi
+  args+=("${!i}")
+  i=$((i + 1))
+done
+
+case "${args[*]}" in
+  "auth status") exit 0 ;;
+  "pr view --json number -q .number") echo "" ;;
+  *) echo "" ;;
+esac
+EOF
+  chmod +x "$out"
+  echo "$out"
+}
+
+run_hook() {
+  local dir="$1"
+  local cmd="${2:-gh -C $dir pr create}"
+  local payload
+  payload=$(jq -n --arg cmd "$cmd" --arg cwd "$dir" \
+    '{"tool_input":{"command":$cmd},"cwd":$cwd}')
+  printf '%s' "$payload" | GH_BIN="$(make_gh_stub)" bash "$HOOK" >/dev/null 2>&1
+}
+
+PASS=0
+FAIL=0
+case_label() { printf '  case: %s\n' "$1"; }
+ok() { PASS=$((PASS + 1)); printf '    PASS\n'; }
+ng() { FAIL=$((FAIL + 1)); printf '    FAIL: expected exit %s, got %s\n' "$1" "$2"; }
+
+# --- Case 1: ASCII-only diff --> pass ---
+case_label "ASCII-only diff --> pass"
+D="$TMPDIR/case1"; init_repo "$D"
+printf '\nNew line.\n' >> "$D/README.md"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 2: hiragana --> block ---
+case_label "Hiragana in diff --> block"
+D="$TMPDIR/case2"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\201\223\343\202\223\343\201\253\343\201\241\343\201\257')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 3: katakana --> block ---
+case_label "Katakana in diff --> block"
+D="$TMPDIR/case3"; init_repo "$D"
+printf '\nNote: %s\n' "$(printf '\343\202\271\343\202\261\343\202\270\343\203\245\343\203\274\343\203\253')" > "$D/docs/notes.md"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 4: kanji --> block ---
+case_label "Kanji in diff --> block"
+D="$TMPDIR/case4"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\344\277\235\350\250\274')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 5: hangul --> block ---
+case_label "Hangul in diff --> block"
+D="$TMPDIR/case5"; init_repo "$D"
+printf '\n# %s\n' "$(printf '\354\225\210\353\205\225')" >> "$D/README.md"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 6: CJK punctuation --> block ---
+case_label "CJK punctuation in diff --> block"
+D="$TMPDIR/case6"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\200\214label\343\200\215')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 7: em-dash + box-drawing + curly quotes --> pass ---
+case_label "Em-dash + box-drawing + curly quotes --> pass"
+D="$TMPDIR/case7"; init_repo "$D"
+cat >> "$D/README.md" <<'EOF'
+
+Em-dash here — followed by "smart quotes" and 'curly apostrophes'.
+
+```
+┌─────────────────────────────────────────────┐
+│ 1. Layer (src/cli/)                         │ → entry
+└─────────────────────────────────────────────┘
+```
+EOF
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 8: PNG with non-ASCII bytes --> skip ---
+case_label "PNG binary --> skip"
+D="$TMPDIR/case8"; init_repo "$D"
+mkdir -p "$D/docs"
+printf '\x89PNG\r\n\x1a\n%s' "$(printf '\343\201\202')" > "$D/docs/image.png"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 9: pnpm-lock.yaml --> skip ---
+case_label "pnpm-lock.yaml with hiragana --> skip"
+D="$TMPDIR/case9"; init_repo "$D"
+printf '# %s\n' "$(printf '\343\201\202')" > "$D/pnpm-lock.yaml"
+commit_all "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 10: git commit (not gh pr) --> pass-through ---
+case_label "git commit --> pass-through"
+D="$TMPDIR/case10"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\201\202')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D" "git -C $D commit -m test"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 11: gh pr merge <N> --> block ---
+case_label "gh pr merge --> block"
+D="$TMPDIR/case11"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\201\202')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D" "gh -C $D pr merge --squash --delete-branch"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 12: gh pr edit --> block ---
+case_label "gh pr edit --> block"
+D="$TMPDIR/case12"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\201\202')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D" "gh -C $D pr edit --add-label test"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 13: cd <path> && gh pr create routing --> block ---
+case_label "cd <path> && gh pr create routing --> block"
+D="$TMPDIR/case13"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\201\202')" >> "$D/src/foo.ts"
+commit_all "$D"
+run_hook "$D" "cd $D && gh pr create --fill"; rc=$?
+if [[ $rc -eq 2 ]]; then ok; else ng 2 "$rc"; fi
+
+# --- Case 14: non-git directory --> pass ---
+case_label "non-git directory --> pass"
+D="$TMPDIR/case14"; mkdir -p "$D"
+run_hook "$D"; rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+# --- Case 15: gh missing --> pass (fail-open) ---
+case_label "gh missing --> fail-open pass"
+D="$TMPDIR/case15"; init_repo "$D"
+printf '\n// %s\n' "$(printf '\343\201\202')" >> "$D/src/foo.ts"
+commit_all "$D"
+# Override GH_BIN to a non-existent binary.
+payload=$(jq -n --arg cmd "gh -C $D pr create" --arg cwd "$D" \
+  '{"tool_input":{"command":$cmd},"cwd":$cwd}')
+printf '%s' "$payload" | GH_BIN="/nonexistent/gh" bash "$HOOK" >/dev/null 2>&1
+rc=$?
+if [[ $rc -eq 0 ]]; then ok; else ng 0 "$rc"; fi
+
+echo
+printf 'Total: %d pass, %d fail\n' "$PASS" "$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# verify-pr-gate.sh
+#
+# PreToolUse hook. Blocks `gh pr create` and `gh pr merge` (including
+# --auto) unless the `verify-pr` markgate marker is fresh for the
+# current content state. The gate's scope (see .markgate.yml) covers
+# every code/test/doc path the /verify-pr skill inspects, so editing
+# any of them invalidates the marker and forces a successful
+# /verify-pr run before the PR can be opened or merged.
+#
+# This is the structural enforcement of the "PR readiness checklist"
+# rule: live-test the changed behavior, walk all shared-utility
+# callers, refresh PR title + body, and run the session retrospective
+# (proposing new rules/hooks/skills for recurring patterns) BEFORE
+# `gh pr create` / `gh pr merge`. The skill said it; the hook
+# enforces it.
+#
+# WHY the cwd-aware resolution matters (cdkd #559): this repo is
+# regularly worked in via `git worktree`, and markgate stores marker
+# state per-worktree at `<git rev-parse --absolute-git-dir>/markgate/`.
+# The pre-#559 implementation derived REPO from `BASH_SOURCE` and
+# always landed on the main working tree, defeating markgate's
+# per-worktree isolation and forcing every parallel agent to converge
+# on the main tree's view (see memory rule
+# feedback_cross_agent_main_tree_contention.md). We now resolve the
+# target working tree from the PreToolUse payload's `cwd` field +
+# leading `cd <path>` + last `gh -C <path>` flag.
+
+set -u
+
+# Read the entire stdin payload once; we need both .tool_input.command
+# and .cwd from it.
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `gh pr create` and `gh pr merge` invocations -- any other
+# command passes through. Match both `gh pr merge` and
+# `gh pr merge --auto`. Tolerate an optional `gh -C <path>` between
+# `gh` and `pr` so `gh -C <path> pr create` is also recognised.
+# Line-start anchored (per memory rule
+# feedback_hook_command_match_line_start.md) so `gh pr create` /
+# `gh pr merge` substrings inside quoted argument bodies
+# (`echo "next step: gh pr create"`) do NOT false-positive into a
+# hard block. The optional leading `cd <path> &&` prefix preserves
+# the worktree-aware `cd <side> && gh pr create` chain shape,
+# mirroring check-gate.sh (PR #562 fix pattern).
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+# Resolve where the gh command will actually run (cwd-aware; mirrors
+# non-english-text-gate.sh / integ-local-gate.sh).
+target_dir="${hook_cwd:-$PWD}"
+
+# `cd <path>` at the start of the command shifts the target dir.
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  if [[ "$cd_target" != /* ]]; then
+    cd_target="$target_dir/$cd_target"
+  fi
+  target_dir="$cd_target"
+fi
+
+# Last `gh -C <path>` wins.
+if [[ "$cmd" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""
+  remaining="$cmd"
+  while [[ "$remaining" =~ gh[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  if [[ "$c_target" != /* ]]; then
+    c_target="$target_dir/$c_target"
+  fi
+  target_dir="$c_target"
+fi
+
+# If the resolved target dir is not a git repo, silently pass — we
+# can't audit what we can't see.
+if ! git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
+
+cd "$target_dir" 2>/dev/null || exit 0
+
+# Prefer the `.mise.toml`-pinned version via `mise exec --` so the repo's
+# canonical markgate wins over an older PATH binary; see check-gate.sh for
+# the schema-bump rationale (0.3.0 markers are silently invisible to 0.3.1).
+if command -v mise >/dev/null 2>&1; then
+  markgate=(mise exec -- markgate)
+elif command -v markgate >/dev/null 2>&1; then
+  markgate=(markgate)
+else
+  echo "Blocked by verify-pr-gate: markgate is not installed. Run 'mise install' at the repo root (see CONTRIBUTING.md)." >&2
+  exit 2
+fi
+
+"${markgate[@]}" verify verify-pr >/dev/null 2>&1
+status=$?
+
+if [ "$status" -eq 0 ]; then
+  exit 0
+fi
+
+# Extract the parenthesized reason from `markgate status verify-pr` so the
+# error message tells the user *why* the gate is stale. With markgate 0.3+
+# `requires: [check, docs]` the reason often names the failing child
+# (e.g. "(child docs is stale)"), pointing the user straight at /check or
+# /check-docs without forcing them to re-run /verify-pr blindly. Fails open
+# to the static heredoc body when extraction fails.
+reason=$("${markgate[@]}" status verify-pr 2>/dev/null \
+  | awk '/^state:/ { if (match($0, /\([^)]+\)/)) print substr($0, RSTART, RLENGTH); exit }')
+
+if [ -n "$reason" ]; then
+  printf "Blocked by verify-pr-gate: the \`verify-pr\` marker is stale %s.\n\n" "$reason" >&2
+else
+  echo "Blocked by verify-pr-gate: the \`verify-pr\` marker is stale (or missing)." >&2
+  echo >&2
+fi
+
+cat >&2 <<'EOF'
+Required action — no exceptions:
+  /verify-pr [PR-number]
+
+The skill walks the full PR-readiness checklist:
+  - typecheck / lint / build / unit tests
+  - test coverage for the diff
+  - CI status / working tree / docs consistency / leftover AWS resources
+  - code review (incl. shared-utility caller verification)
+  - live-test the changed behavior against real or fixture input
+  - retrospective + proposals for new rules / hooks / skills
+  - PR title + body freshness vs the actual diff
+
+It is the ONLY legitimate setter of this marker. Do NOT call
+`markgate set verify-pr` directly from a shell to bypass this hook —
+the whole point of the gate is that an unverified PR cannot be opened
+or merged. If a check legitimately cannot pass right now (e.g. no
+AWS credentials for live-test), say so explicitly in the report; the
+gate stays red so a human can decide whether to override.
+EOF
+exit 2

--- a/.claude/hooks/verify-pr-gate.test.sh
+++ b/.claude/hooks/verify-pr-gate.test.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Smoke test for verify-pr-gate.sh.
+#
+# Exercises the cwd-aware command-matching against fixture git
+# working trees and asserts that the markgate verify runs against
+# the RESOLVED target directory — not the script's location. This
+# is the post-#559 contract: markers land in the worktree where
+# `gh pr create` / `gh pr merge` actually runs, not always in the
+# main tree.
+#
+# Run from the repo root: `bash .claude/hooks/verify-pr-gate.test.sh`.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/verify-pr-gate.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+side_repo="$TMPDIR/side-repo"
+main_repo="$TMPDIR/main-repo"
+git init -q -b feature/x "$side_repo"
+git -C "$side_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git init -q -b main "$main_repo"
+git -C "$main_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+
+SHIM_DIR="$TMPDIR/bin"
+mkdir -p "$SHIM_DIR"
+CWD_TRACE_FILE="$TMPDIR/cwd-trace"
+
+cat > "$SHIM_DIR/mise" <<'MISE_EOF'
+#!/usr/bin/env bash
+if [ "$1" = "exec" ] && [ "$2" = "--" ]; then
+  shift 2
+  exec "$@"
+fi
+exit 1
+MISE_EOF
+chmod +x "$SHIM_DIR/mise"
+
+cat > "$SHIM_DIR/markgate" <<MARKGATE_EOF
+#!/usr/bin/env bash
+echo "\$PWD" >> "$CWD_TRACE_FILE"
+verdict="\${MARKGATE_MOCK_VERDICT:-stale}"
+case "\$1" in
+  verify)
+    [ "\$verdict" = "fresh" ] && exit 0
+    exit 1
+    ;;
+  status)
+    if [ "\$verdict" = "fresh" ]; then
+      printf 'key:        %s\nstate:      match\n' "\$2"
+    else
+      printf 'key:        %s\nstate:      stale (digest differs)\n' "\$2"
+    fi
+    exit 0
+    ;;
+esac
+exit 1
+MARKGATE_EOF
+chmod +x "$SHIM_DIR/markgate"
+
+export PATH="$SHIM_DIR:$PATH"
+
+pass=0
+fail=0
+fail_log=""
+
+# run_case <name> <expect_exit> <mg_verdict> <expect_cwd> <stdin_json>
+run_case() {
+  local name="$1"; local want="$2"; local verdict="$3"; local expect_cwd="$4"; local payload="$5"
+  : > "$CWD_TRACE_FILE"
+  local got
+  printf '%s' "$payload" | MARKGATE_MOCK_VERDICT="$verdict" "$HOOK" >/dev/null 2>&1
+  got=$?
+
+  local cwd_ok=1
+  if [ -n "$expect_cwd" ]; then
+    if ! grep -qFx "$expect_cwd" "$CWD_TRACE_FILE" 2>/dev/null; then
+      cwd_ok=0
+    fi
+  fi
+
+  if [[ "$got" == "$want" ]] && [ "$cwd_ok" -eq 1 ]; then
+    pass=$((pass + 1))
+    printf 'OK   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: want exit $want, got $got"
+    if [ "$cwd_ok" -eq 0 ]; then
+      fail_log+="; cwd mismatch (want '$expect_cwd', trace: $(cat "$CWD_TRACE_FILE" 2>/dev/null | tr '\n' '|'))"
+    fi
+    fail_log+="\n  payload: $payload\n"
+    printf 'FAIL %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# --- PASS-THROUGH cases (matcher must NOT fire) ---
+
+# 1. Non-PR-create/merge command always passes through.
+run_case "git status passes through" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"git status"}}' "$side_repo")"
+
+# 2. `gh pr view` not gated.
+run_case "gh pr view passes through" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr view 42"}}' "$side_repo")"
+
+# 3. `gh pr edit` not gated.
+run_case "gh pr edit passes through" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr edit 42"}}' "$side_repo")"
+
+# 4. Non-git target dir → silent pass.
+run_case "non-git target dir allowed" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create --title x"}}' "$TMPDIR")"
+
+# 5. Empty stdin.
+run_case "empty stdin passes through" 0 stale "" ''
+
+# --- CWD-AWARE cases ---
+
+# 6. `gh pr create` from side worktree → markgate runs in side.
+#    Load-bearing #559 case.
+run_case "gh pr create in side worktree → markgate runs there" 2 stale "$side_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create --title x"}}' "$side_repo")"
+
+# 7. `gh pr merge` from main worktree → markgate runs in main.
+run_case "gh pr merge in main worktree → markgate runs there" 2 stale "$main_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge 42 --squash"}}' "$main_repo")"
+
+# 8. `cd <side> && gh pr merge` from main cwd → markgate in side.
+run_case "cd <side> && gh pr merge from main cwd → side wins" 2 stale "$side_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"cd %s && gh pr merge 42 --auto"}}' "$main_repo" "$side_repo")"
+
+# 9. `gh -C <side> pr merge` from main cwd → markgate in side.
+run_case "gh -C <side> pr merge from main cwd → side wins" 2 stale "$side_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh -C %s pr merge 42 --squash"}}' "$main_repo" "$side_repo")"
+
+# 10. Fresh marker in side worktree → pass.
+run_case "fresh marker in side worktree passes" 0 fresh "$side_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create"}}' "$side_repo")"
+
+# 11. `gh pr merge --auto` shape matches.
+run_case "gh pr merge --auto matches" 2 stale "$side_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr merge --auto"}}' "$side_repo")"
+
+# --- LINE-START ANCHORING cases (issue #563) ---
+#
+# The matcher MUST NOT fire when the literal substrings `gh pr create`
+# / `gh pr merge` appear inside a quoted argument body of an unrelated
+# command. Per memory rule feedback_hook_command_match_line_start.md,
+# applied to verify-pr-gate.sh in issue #563 (mirroring the PR #562
+# fix to check-gate.sh).
+
+# 12. `gh issue create --body "...gh pr create..."`: the body mentions
+#     `gh pr create` but the line starts with `gh issue create`, not
+#     `gh pr create`. MUST pass through.
+run_case "gh issue body quoting 'gh pr create' passes through" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh issue create --body \"next step: gh pr create from this branch\""}}' "$side_repo")"
+
+# 13. `echo "...gh pr merge..."`: the body mentions `gh pr merge` but
+#     the command starts with `echo`. MUST pass through.
+run_case "echo body quoting 'gh pr merge' passes through" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"echo \"after CI green: gh pr merge --squash\""}}' "$side_repo")"
+
+echo
+echo "Pass: $pass  Fail: $fail"
+if [[ "$fail" -gt 0 ]]; then
+  echo
+  printf '%b' "$fail_log"
+  exit 1
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "//": "PreToolUse hooks for cdk-real-drift. Only the check-gate is wired: cdkrd is a solo, local-only repo with no GitHub remote yet, so branch-protection / verify-pr-merge / pr-review / integ-* gates are deferred until Phase 4 (when the repo gets a remote). check-gate blocks `git commit` unless both the `check` and `docs` markgate markers are fresh.",
+  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh; non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule). NOT wired: pr-review and integ-* — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
   "hooks": {
     "PreToolUse": [
       {
@@ -11,6 +11,27 @@
             "if": "Bash(git commit*) or Bash(git -C * commit*)",
             "timeout": 10,
             "statusMessage": "Checking /check + /check-docs markers..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/branch-gate.sh",
+            "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*) or Bash(cd * && git commit*) or Bash(cd * && git push*)",
+            "timeout": 10,
+            "statusMessage": "Checking target branch is not main..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/verify-pr-gate.sh",
+            "if": "Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*)",
+            "timeout": 15,
+            "statusMessage": "Checking /verify-pr marker is fresh..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/non-english-text-gate.sh",
+            "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*)",
+            "timeout": 20,
+            "statusMessage": "Scanning PR diff for non-English text..."
           }
         ]
       }

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -30,9 +30,11 @@
 #               (AWS-side wire-format + Cloud Control behavior drift over time).
 #
 # NOTE: the commit/PR-blocking ENFORCEMENT (the .claude hooks that call markgate)
-# is intentionally not installed yet. CI (.github/workflows/ci.yml) enforces
-# typecheck/lint/build/test on every push in the meantime. When hooks are added,
-# wire them ONLY to check / docs / verify-pr (the gates with companion skills).
+# is now installed (R83): check-gate (commit), verify-pr-gate (gh pr create/merge),
+# plus the marker-free branch-gate and non-english-text-gate. Hooks are wired ONLY
+# to check / docs / verify-pr — the gates with companion skills. pr-review and integ
+# remain INERT and UNWIRED (no companion skill) so they cannot brick the flow.
+# CI (.github/workflows/ci.yml) still enforces typecheck/lint/build/test on push.
 
 gates:
   check:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,12 @@ detail:
   only.
 - **All changes go through a pull request — never commit directly to `main`.**
   Branch (or worktree branch) → run the gates + set markers → commit → push →
-  `gh pr create`. The reviewer re-reviews the PR diff before merge. cdkd's heavier
-  branch-protection / verify-pr-merge / pr-review / integ-\* gates are still not
-  ported — revisit at Phase 4.
+  `gh pr create`. The reviewer re-reviews the PR diff before merge. cdkd's
+  branch-protection (`branch-gate`) and verify-pr-merge (`verify-pr-gate`) gates
+  ARE now ported and wired (R83), plus the OSS English-only
+  `non-english-text-gate`. pr-review and integ-\* stay UNPORTED on purpose:
+  pr-review is multi-agent (cdkrd is solo); integ-\* depends on cdkd's
+  providers/state/destroy paths cdkrd lacks (see `.markgate.yml`).
 
 ## Dependencies
 


### PR DESCRIPTION
The repo now has a GitHub remote and a PR-based flow, so the two cdkd-derived gate families cdkrd's CLAUDE.md named are ported and wired.

## Ported gates (each with its `.test.sh`)

- **branch-gate.sh** (branch-protection): blocks `git commit`/`git push` when the target tree is on main/master — enforces the worktree+PR workflow. cwd-aware (`git -C`, leading `cd`, hook cwd). Tests: 25/25.
- **verify-pr-gate.sh** (verify-pr-merge): blocks `gh pr create`/`gh pr merge` unless the `verify-pr` marker is fresh. Tests: 13/13.
- **non-english-text-gate.sh** (OSS English-only rule cdkrd already states): blocks `gh pr create/edit/merge` when the PR diff has CJK/hiragana/katakana/hangul text. The one cdkd-specific memory-path line was retargeted to cdkrd's CLAUDE.md rule. Tests: 15/15.

Wired in `.claude/settings.json` **only** to gates with companion skills, per `.markgate.yml`.

## Deliberately NOT ported

- **pr-review** — multi-agent reviewer dispatch; cdkrd is solo-authored.
- **integ-*** (destroy / broad / local / schema-migration / provider) — depend on cdkd's providers/state/destroy architecture, which cdkrd (read-only via Cloud Control) lacks. `.markgate.yml` already marks these inert.

Updated `.markgate.yml`'s NOTE and CLAUDE.md's stale 'not ported — revisit at Phase 4' line to match reality.

`.claude/**` is in no marker scope, so this PR doesn't stale any gate.