### PR TITLE
fix(noise): WAFv2 IPSet Addresses unordered set; Cognito UserPoolGroup CC adapter; harvest6 wave (R84)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -287,6 +287,10 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
     'AllowedOAuthScopes',
     'ExplicitAuthFlows',
   ]),
+  // R84 (observed live on a fresh harvest6 deploy): WAFv2 stores the IP address
+  // set and echoes it in its own canonical order, so a fresh deploy reports the
+  // declared CIDR list as drift with identical elements in a different order.
+  'AWS::WAFv2::IPSet': new Set(['Addresses']),
 };
 
 // True when both values are scalar arrays containing the same multiset of

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -29,6 +29,7 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // ApiGatewayV2, R77 AppConfig). An unresolved parent → fall back to the bare
   // physical id (CC then reports an honest ValidationException skip).
   'AWS::Cognito::UserPoolClient': compositeWith('UserPoolId'),
+  'AWS::Cognito::UserPoolGroup': compositeWith('UserPoolId'),
   'AWS::ApiGatewayV2::Stage': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Route': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Integration': compositeWith('ApiId'),

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -461,6 +461,33 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['CallbackURLs']);
     });
 
+    it('UNORDERED_ARRAY_PROPS: WAFv2 IPSet Addresses in a different order is NOT drift (R84)', () => {
+      const ipset = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'IpSet',
+        resourceType: 'AWS::WAFv2::IPSet',
+        physicalId: 'ipset-1',
+        declared,
+      });
+      // same CIDR set, reversed order — WAFv2 echoes its own canonical order
+      expect(
+        classifyResource(
+          ipset({ Addresses: ['192.0.2.0/24', '198.51.100.0/24'] }),
+          { Addresses: ['198.51.100.0/24', '192.0.2.0/24'] },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine CIDR change still reports
+      expect(
+        tiers(
+          classifyResource(
+            ipset({ Addresses: ['192.0.2.0/24', '198.51.100.0/24'] }),
+            { Addresses: ['203.0.113.0/24', '192.0.2.0/24'] },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['Addresses']);
+    });
+
     it('undeclared EventSelectors equal to the default is suppressed; a changed one surfaces', () => {
       expect(
         classifyResource(

--- a/tests/corpus/AWS__ApiGateway__ApiKey.ApiKey.json
+++ b/tests/corpus/AWS__ApiGateway__ApiKey.ApiKey.json
@@ -1,0 +1,62 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::ApiGateway::ApiKey model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "ApiKey",
+    "resourceType": "AWS::ApiGateway::ApiKey",
+    "physicalId": "6r6yg8wk4j",
+    "constructPath": "CdkrdIntegHarvest6/ApiKey",
+    "declared": {
+      "Enabled": true,
+      "Name": "cdkrd-harvest6"
+    }
+  },
+  "liveRaw": {
+    "APIKeyId": "6r6yg8wk4j",
+    "StageKeys": [],
+    "Value": "OL2cc3xWoX85uZuwBZpvO311UM7TN5ke2SyXoEYD",
+    "Enabled": true,
+    "Tags": [
+      {
+        "Value": "ApiKey",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["APIKeyId"],
+    "writeOnly": ["GenerateDistinctId"],
+    "createOnly": ["GenerateDistinctId", "Name", "Value"],
+    "readOnlyPaths": ["APIKeyId"],
+    "writeOnlyPaths": ["GenerateDistinctId"],
+    "createOnlyPaths": ["GenerateDistinctId", "Name", "Value"],
+    "defaults": {
+      "Enabled": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiKey",
+      "resourceType": "AWS::ApiGateway::ApiKey",
+      "path": "Value",
+      "actual": "OL2cc3xWoX85uZuwBZpvO311UM7TN5ke2SyXoEYD",
+      "physicalId": "6r6yg8wk4j",
+      "constructPath": "CdkrdIntegHarvest6/ApiKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__RestApi.Api.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.Api.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::ApiGateway::RestApi model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Api",
+    "resourceType": "AWS::ApiGateway::RestApi",
+    "physicalId": "plg2s0yj0k",
+    "constructPath": "CdkrdIntegHarvest6/Api",
+    "declared": {
+      "Name": "cdkrd-harvest6"
+    }
+  },
+  "liveRaw": {
+    "RootResourceId": "gjwltve1fj",
+    "SecurityPolicy": "TLS_1_0",
+    "RestApiId": "plg2s0yj0k",
+    "ApiKeySourceType": "HEADER",
+    "EndpointConfiguration": {
+      "IpAddressType": "ipv4",
+      "Types": ["EDGE"]
+    },
+    "DisableExecuteApiEndpoint": false,
+    "Tags": [
+      {
+        "Value": "Api",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["RestApiId", "RootResourceId"],
+    "writeOnly": ["Body", "BodyS3Location", "CloneFrom", "FailOnWarnings", "Mode", "Parameters"],
+    "createOnly": [],
+    "readOnlyPaths": ["RestApiId", "RootResourceId"],
+    "writeOnlyPaths": [
+      "Body",
+      "BodyS3Location",
+      "CloneFrom",
+      "FailOnWarnings",
+      "Mode",
+      "Parameters"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Api",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "plg2s0yj0k",
+      "constructPath": "CdkrdIntegHarvest6/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Api",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "ApiKeySourceType",
+      "actual": "HEADER",
+      "physicalId": "plg2s0yj0k",
+      "constructPath": "CdkrdIntegHarvest6/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Api",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "EndpointConfiguration",
+      "actual": {
+        "IpAddressType": "ipv4",
+        "Types": ["EDGE"]
+      },
+      "physicalId": "plg2s0yj0k",
+      "constructPath": "CdkrdIntegHarvest6/Api"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__UsagePlan.Plan.json
+++ b/tests/corpus/AWS__ApiGateway__UsagePlan.Plan.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::ApiGateway::UsagePlan model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Plan",
+    "resourceType": "AWS::ApiGateway::UsagePlan",
+    "physicalId": "6aiqlx",
+    "constructPath": "CdkrdIntegHarvest6/Plan",
+    "declared": {
+      "Quota": {
+        "Limit": 1000,
+        "Period": "MONTH"
+      },
+      "Throttle": {
+        "BurstLimit": 5,
+        "RateLimit": 10
+      },
+      "UsagePlanName": "cdkrd-harvest6"
+    }
+  },
+  "liveRaw": {
+    "Quota": {
+      "Period": "MONTH",
+      "Limit": 1000,
+      "Offset": 0
+    },
+    "Id": "6aiqlx",
+    "ApiStages": [],
+    "Tags": [
+      {
+        "Value": "Plan",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Throttle": {
+      "BurstLimit": 5,
+      "RateLimit": 10
+    },
+    "UsagePlanName": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -1,0 +1,633 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::Cognito::UserPool model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "PoolD3F588B8",
+    "resourceType": "AWS::Cognito::UserPool",
+    "physicalId": "us-east-1_4tB3jYmmc",
+    "constructPath": "CdkrdIntegHarvest6/Pool",
+    "declared": {
+      "AccountRecoverySetting": {
+        "RecoveryMechanisms": [
+          {
+            "Name": "verified_phone_number",
+            "Priority": 1
+          },
+          {
+            "Name": "verified_email",
+            "Priority": 2
+          }
+        ]
+      },
+      "AdminCreateUserConfig": {
+        "AllowAdminCreateUserOnly": true
+      },
+      "EmailVerificationMessage": "The verification code to your new account is {####}",
+      "EmailVerificationSubject": "Verify your new account",
+      "SmsVerificationMessage": "The verification code to your new account is {####}",
+      "VerificationMessageTemplate": {
+        "DefaultEmailOption": "CONFIRM_WITH_CODE",
+        "EmailMessage": "The verification code to your new account is {####}",
+        "EmailSubject": "Verify your new account",
+        "SmsMessage": "The verification code to your new account is {####}"
+      }
+    }
+  },
+  "liveRaw": {
+    "UserPoolTags": {
+      "aws:cloudformation:stack-name": "CdkrdIntegHarvest6",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+      "aws:cloudformation:logical-id": "PoolD3F588B8"
+    },
+    "Policies": {
+      "PasswordPolicy": {
+        "RequireNumbers": true,
+        "MinimumLength": 8,
+        "TemporaryPasswordValidityDays": 7,
+        "RequireUppercase": true,
+        "RequireLowercase": true,
+        "RequireSymbols": true
+      },
+      "SignInPolicy": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      }
+    },
+    "VerificationMessageTemplate": {
+      "EmailMessage": "The verification code to your new account is {####}",
+      "SmsMessage": "The verification code to your new account is {####}",
+      "EmailSubject": "Verify your new account",
+      "DefaultEmailOption": "CONFIRM_WITH_CODE"
+    },
+    "ProviderURL": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_4tB3jYmmc",
+    "MfaConfiguration": "OFF",
+    "Schema": [
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "profile"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "address"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "10",
+          "MaxLength": "10"
+        },
+        "Required": false,
+        "Name": "birthdate"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "gender"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "preferred_username"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Number",
+        "Required": false,
+        "NumberAttributeConstraints": {
+          "MinValue": "0"
+        },
+        "Name": "updated_at"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "website"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "picture"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {},
+        "Required": false,
+        "Name": "identities"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": false,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "1",
+          "MaxLength": "2048"
+        },
+        "Required": true,
+        "Name": "sub"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "phone_number"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "phone_number_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "zoneinfo"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "locale"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "email"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "email_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "given_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "family_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "middle_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "nickname"
+      }
+    ],
+    "AdminCreateUserConfig": {
+      "UnusedAccountValidityDays": 7,
+      "AllowAdminCreateUserOnly": true
+    },
+    "UserPoolTier": "ESSENTIALS",
+    "DeletionProtection": "INACTIVE",
+    "UserPoolName": "PoolD3F588B8-x2yLeeWNu9OW",
+    "SmsVerificationMessage": "The verification code to your new account is {####}",
+    "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_4tB3jYmmc",
+    "UserPoolId": "us-east-1_4tB3jYmmc",
+    "UserAttributeUpdateSettings": {
+      "AttributesRequireVerificationBeforeUpdate": []
+    },
+    "EmailConfiguration": {
+      "EmailSendingAccount": "COGNITO_DEFAULT"
+    },
+    "AliasAttributes": [],
+    "EmailVerificationSubject": "Verify your new account",
+    "LambdaConfig": {},
+    "Arn": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_4tB3jYmmc",
+    "UsernameAttributes": [],
+    "AutoVerifiedAttributes": [],
+    "EmailVerificationMessage": "The verification code to your new account is {####}",
+    "AccountRecoverySetting": {
+      "RecoveryMechanisms": [
+        {
+          "Priority": 1,
+          "Name": "verified_phone_number"
+        },
+        {
+          "Priority": 2,
+          "Name": "verified_email"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnly": ["EnabledMfas"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnlyPaths": ["EnabledMfas"],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Policies",
+      "actual": {
+        "PasswordPolicy": {
+          "RequireNumbers": true,
+          "MinimumLength": 8,
+          "TemporaryPasswordValidityDays": 7,
+          "RequireUppercase": true,
+          "RequireLowercase": true,
+          "RequireSymbols": true
+        },
+        "SignInPolicy": {
+          "AllowedFirstAuthFactors": ["PASSWORD"]
+        }
+      },
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema",
+      "actual": [
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "profile"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "address"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "10",
+            "MaxLength": "10"
+          },
+          "Required": false,
+          "Name": "birthdate"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "gender"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "preferred_username"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Number",
+          "Required": false,
+          "NumberAttributeConstraints": {
+            "MinValue": "0"
+          },
+          "Name": "updated_at"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "website"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "picture"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {},
+          "Required": false,
+          "Name": "identities"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": false,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "1",
+            "MaxLength": "2048"
+          },
+          "Required": true,
+          "Name": "sub"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "phone_number"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "phone_number_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "zoneinfo"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "locale"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "email"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "email_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "given_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "family_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "middle_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "nickname"
+        }
+      ],
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolName",
+      "actual": "PoolD3F588B8-x2yLeeWNu9OW",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__UserPoolGroup.Group.json
+++ b/tests/corpus/AWS__Cognito__UserPoolGroup.Group.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::Cognito::UserPoolGroup model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Group",
+    "resourceType": "AWS::Cognito::UserPoolGroup",
+    "physicalId": "cdkrd-harvest6",
+    "constructPath": "CdkrdIntegHarvest6/Group",
+    "declared": {
+      "Description": "harvest6 group",
+      "GroupName": "cdkrd-harvest6",
+      "Precedence": 10,
+      "UserPoolId": "us-east-1_4tB3jYmmc"
+    }
+  },
+  "liveRaw": {
+    "GroupName": "cdkrd-harvest6",
+    "Description": "harvest6 group",
+    "UserPoolId": "us-east-1_4tB3jYmmc",
+    "Precedence": 10
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["GroupName", "UserPoolId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GroupName", "UserPoolId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__LaunchTemplate.LaunchTpl.json
+++ b/tests/corpus/AWS__EC2__LaunchTemplate.LaunchTpl.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::EC2::LaunchTemplate model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "LaunchTpl",
+    "resourceType": "AWS::EC2::LaunchTemplate",
+    "physicalId": "lt-07d78df03ff0277ba",
+    "constructPath": "CdkrdIntegHarvest6/LaunchTpl",
+    "declared": {
+      "LaunchTemplateData": {
+        "InstanceType": "t3.micro",
+        "MetadataOptions": {
+          "HttpTokens": "required"
+        },
+        "Monitoring": {
+          "Enabled": false
+        }
+      },
+      "LaunchTemplateName": "cdkrd-harvest6"
+    }
+  },
+  "liveRaw": {
+    "LaunchTemplateName": "cdkrd-harvest6",
+    "LatestVersionNumber": "1",
+    "LaunchTemplateId": "lt-07d78df03ff0277ba",
+    "DefaultVersionNumber": "1"
+  },
+  "schema": {
+    "readOnly": ["DefaultVersionNumber", "LatestVersionNumber", "LaunchTemplateId"],
+    "writeOnly": ["LaunchTemplateData", "TagSpecifications", "VersionDescription"],
+    "createOnly": ["LaunchTemplateName"],
+    "readOnlyPaths": ["DefaultVersionNumber", "LatestVersionNumber", "LaunchTemplateId"],
+    "writeOnlyPaths": ["LaunchTemplateData", "TagSpecifications", "VersionDescription"],
+    "createOnlyPaths": ["LaunchTemplateName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "LaunchTpl",
+      "resourceType": "AWS::EC2::LaunchTemplate",
+      "path": "LaunchTemplateData",
+      "note": "write-only — cannot be read back",
+      "physicalId": "lt-07d78df03ff0277ba",
+      "constructPath": "CdkrdIntegHarvest6/LaunchTpl"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__PrefixList.PrefixList.json
+++ b/tests/corpus/AWS__EC2__PrefixList.PrefixList.json
@@ -1,0 +1,65 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::EC2::PrefixList model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "PrefixList",
+    "resourceType": "AWS::EC2::PrefixList",
+    "physicalId": "pl-09cc92c7a277bdc87",
+    "constructPath": "CdkrdIntegHarvest6/PrefixList",
+    "declared": {
+      "AddressFamily": "IPv4",
+      "Entries": [
+        {
+          "Cidr": "10.0.0.0/16",
+          "Description": "vpc-a"
+        }
+      ],
+      "MaxEntries": 5,
+      "PrefixListName": "cdkrd-harvest6"
+    }
+  },
+  "liveRaw": {
+    "MaxEntries": 5,
+    "OwnerId": "111111111111",
+    "PrefixListId": "pl-09cc92c7a277bdc87",
+    "Version": 1,
+    "PrefixListName": "cdkrd-harvest6",
+    "Entries": [
+      {
+        "Description": "vpc-a",
+        "Cidr": "10.0.0.0/16"
+      }
+    ],
+    "AddressFamily": "IPv4",
+    "Arn": "arn:aws:ec2:us-east-1:111111111111:prefix-list/pl-09cc92c7a277bdc87",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "PrefixList",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "OwnerId", "PrefixListId", "Version"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "OwnerId", "PrefixListId", "Version"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ECS__TaskDefinition.Task.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.Task.json
@@ -1,0 +1,117 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::ECS::TaskDefinition model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Task",
+    "resourceType": "AWS::ECS::TaskDefinition",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-harvest6:1",
+    "constructPath": "CdkrdIntegHarvest6/Task",
+    "declared": {
+      "ContainerDefinitions": [
+        {
+          "Command": ["sleep", "3600"],
+          "Essential": true,
+          "Image": "public.ecr.aws/amazonlinux/amazonlinux:2",
+          "Name": "app"
+        }
+      ],
+      "Cpu": "256",
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+      "Family": "cdkrd-harvest6",
+      "Memory": "512",
+      "NetworkMode": "awsvpc",
+      "RequiresCompatibilities": ["FARGATE"]
+    }
+  },
+  "liveRaw": {
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+    "Volumes": [],
+    "InferenceAccelerators": [],
+    "Memory": "512",
+    "PlacementConstraints": [],
+    "ContainerDefinitions": [
+      {
+        "ExtraHosts": [],
+        "Secrets": [],
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": [],
+        "Image": "public.ecr.aws/amazonlinux/amazonlinux:2",
+        "Essential": true,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "app",
+        "MountPoints": [],
+        "DependsOn": [],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": [],
+        "SystemControls": [],
+        "Command": ["sleep", "3600"],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": [],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      }
+    ],
+    "Family": "cdkrd-harvest6",
+    "Cpu": "256",
+    "RequiresCompatibilities": ["FARGATE"],
+    "NetworkMode": "awsvpc",
+    "Tags": [],
+    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-harvest6:1"
+  },
+  "schema": {
+    "readOnly": ["TaskDefinitionArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "readOnlyPaths": ["TaskDefinitionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Policy.PipeRoleDefaultPolicy84F54597.json
+++ b/tests/corpus/AWS__IAM__Policy.PipeRoleDefaultPolicy84F54597.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::IAM::Policy model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "PipeRoleDefaultPolicy84F54597",
+    "resourceType": "AWS::IAM::Policy",
+    "physicalId": "Cdkrd-PipeR-5STgDF94FHik",
+    "constructPath": "CdkrdIntegHarvest6/PipeRole/DefaultPolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+            "Effect": "Allow",
+            "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V"
+          },
+          {
+            "Action": "sqs:SendMessage",
+            "Effect": "Allow",
+            "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "PolicyName": "PipeRoleDefaultPolicy84F54597",
+      "Roles": ["CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc"]
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "PipeRoleDefaultPolicy84F54597",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+          "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+          "Effect": "Allow"
+        },
+        {
+          "Action": "sqs:SendMessage",
+          "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Roles": ["CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc"]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.CbRole566E4F1D.json
+++ b/tests/corpus/AWS__IAM__Role.CbRole566E4F1D.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::IAM::Role model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "CbRole566E4F1D",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
+    "constructPath": "CdkrdIntegHarvest6/CbRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "codebuild.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "codebuild.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
+    "RoleId": "AROAXXXJN2LNSFXCUPTOJ"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.PipeRole4D7B8476.json
+++ b/tests/corpus/AWS__IAM__Role.PipeRole4D7B8476.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::IAM::Role model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "PipeRole4D7B8476",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+    "constructPath": "CdkrdIntegHarvest6/PipeRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "pipes.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    },
+    "siblingPolicyNames": ["PipeRoleDefaultPolicy84F54597"]
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+    "Description": "",
+    "Policies": [
+      {
+        "PolicyName": "PipeRoleDefaultPolicy84F54597",
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+              "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+              "Effect": "Allow"
+            },
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+              "Effect": "Allow"
+            }
+          ]
+        }
+      }
+    ],
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "pipes.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+    "RoleId": "AROAXXXJN2LNS3H5AO65W"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.TaskExecRoleA2BBB60C.json
+++ b/tests/corpus/AWS__IAM__Role.TaskExecRoleA2BBB60C.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::IAM::Role model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "TaskExecRoleA2BBB60C",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+    "constructPath": "CdkrdIntegHarvest6/TaskExecRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ecs-tasks.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "ecs-tasks.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+    "RoleId": "AROAXXXJN2LNVPHEQX6KP"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.UrlFnServiceRole8FBBFD8A.json
+++ b/tests/corpus/AWS__IAM__Role.UrlFnServiceRole8FBBFD8A.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::IAM::Role model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "UrlFnServiceRole8FBBFD8A",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+    "constructPath": "CdkrdIntegHarvest6/UrlFn/ServiceRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+    "RoleId": "AROAXXXJN2LN3EOS4R5LG"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
+++ b/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::Lambda::Function model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "UrlFnE068003E",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+    "constructPath": "CdkrdIntegHarvest6/UrlFn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => ({ statusCode: 200, body: 'ok' });"
+      },
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+      "Runtime": "nodejs20.x"
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "UrlFnE068003E",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz"
+      },
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Url.FnUrl.json
+++ b/tests/corpus/AWS__Lambda__Url.FnUrl.json
@@ -1,0 +1,36 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::Lambda::Url model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "FnUrl",
+    "resourceType": "AWS::Lambda::Url",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+    "constructPath": "CdkrdIntegHarvest6/FnUrl",
+    "declared": {
+      "AuthType": "NONE",
+      "TargetFunctionArn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz"
+    }
+  },
+  "liveRaw": {
+    "FunctionArn": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+    "FunctionUrl": "https://fw3rloqogc22w2u4n2vrdv3qhu0plkgj.lambda-url.us-east-1.on.aws/",
+    "InvokeMode": "BUFFERED",
+    "AuthType": "NONE",
+    "TargetFunctionArn": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz"
+  },
+  "schema": {
+    "readOnly": ["FunctionArn", "FunctionUrl"],
+    "writeOnly": [],
+    "createOnly": ["Qualifier", "TargetFunctionArn"],
+    "readOnlyPaths": ["FunctionArn", "FunctionUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Qualifier", "TargetFunctionArn"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Pipes__Pipe.Pipe.json
+++ b/tests/corpus/AWS__Pipes__Pipe.Pipe.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::Pipes::Pipe model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Pipe",
+    "resourceType": "AWS::Pipes::Pipe",
+    "physicalId": "cdkrd-harvest6",
+    "constructPath": "CdkrdIntegHarvest6/Pipe",
+    "declared": {
+      "Name": "cdkrd-harvest6",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+      "Source": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "SourceParameters": {
+        "SqsQueueParameters": {
+          "BatchSize": 1
+        }
+      },
+      "Target": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT"
+    }
+  },
+  "liveRaw": {
+    "Target": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+    "DesiredState": "RUNNING",
+    "StateReason": "USER_INITIATED",
+    "CurrentState": "RUNNING",
+    "CreationTime": "2026-06-13T09:30:56Z",
+    "LastModifiedTime": "2026-06-13T09:31:25Z",
+    "Arn": "arn:aws:pipes:us-east-1:111111111111:pipe/cdkrd-harvest6",
+    "EnrichmentParameters": {},
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+    "Source": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreationTime", "CurrentState", "LastModifiedTime", "StateReason"],
+    "writeOnly": ["SourceParameters", "TargetParameters"],
+    "createOnly": ["Name", "Source"],
+    "readOnlyPaths": ["Arn", "CreationTime", "CurrentState", "LastModifiedTime", "StateReason"],
+    "writeOnlyPaths": ["SourceParameters", "TargetParameters"],
+    "createOnlyPaths": [
+      "Name",
+      "Source",
+      "SourceParameters.ActiveMQBrokerParameters.QueueName",
+      "SourceParameters.DynamoDBStreamParameters.StartingPosition",
+      "SourceParameters.KinesisStreamParameters.StartingPosition",
+      "SourceParameters.KinesisStreamParameters.StartingPositionTimestamp",
+      "SourceParameters.ManagedStreamingKafkaParameters.ConsumerGroupID",
+      "SourceParameters.ManagedStreamingKafkaParameters.StartingPosition",
+      "SourceParameters.ManagedStreamingKafkaParameters.TopicName",
+      "SourceParameters.RabbitMQBrokerParameters.QueueName",
+      "SourceParameters.RabbitMQBrokerParameters.VirtualHost",
+      "SourceParameters.SelfManagedKafkaParameters.AdditionalBootstrapServers",
+      "SourceParameters.SelfManagedKafkaParameters.ConsumerGroupID",
+      "SourceParameters.SelfManagedKafkaParameters.StartingPosition",
+      "SourceParameters.SelfManagedKafkaParameters.TopicName"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Pipe",
+      "resourceType": "AWS::Pipes::Pipe",
+      "path": "SourceParameters",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Pipe"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pipe",
+      "resourceType": "AWS::Pipes::Pipe",
+      "path": "DesiredState",
+      "actual": "RUNNING",
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Pipe"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
@@ -1,0 +1,101 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::SQS::Queue model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "PipeDstD49C8EAB",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+    "constructPath": "CdkrdIntegHarvest6/PipeDst",
+    "declared": {}
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+    "QueueName": "CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
@@ -1,0 +1,101 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::SQS::Queue model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "PipeSrc0E082391",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+    "constructPath": "CdkrdIntegHarvest6/PipeSrc",
+    "declared": {}
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+    "QueueName": "CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SSM__MaintenanceWindow.Window.json
+++ b/tests/corpus/AWS__SSM__MaintenanceWindow.Window.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::SSM::MaintenanceWindow model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Window",
+    "resourceType": "AWS::SSM::MaintenanceWindow",
+    "physicalId": "mw-0b5d2cf6aec29900c",
+    "constructPath": "CdkrdIntegHarvest6/Window",
+    "declared": {
+      "AllowUnassociatedTargets": true,
+      "Cutoff": 1,
+      "Duration": 2,
+      "Name": "cdkrd-harvest6",
+      "Schedule": "rate(7 days)"
+    }
+  },
+  "liveRaw": {
+    "WindowId": "mw-0b5d2cf6aec29900c",
+    "AllowUnassociatedTargets": true,
+    "Cutoff": 1,
+    "Schedule": "rate(7 days)",
+    "Duration": 2,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Window",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["WindowId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["WindowId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__PatchBaseline.Patch.json
+++ b/tests/corpus/AWS__SSM__PatchBaseline.Patch.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::SSM::PatchBaseline model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Patch",
+    "resourceType": "AWS::SSM::PatchBaseline",
+    "physicalId": "pb-0dc7b8f7d8aa1a1a3",
+    "constructPath": "CdkrdIntegHarvest6/Patch",
+    "declared": {
+      "ApprovalRules": {
+        "PatchRules": [
+          {
+            "ApproveAfterDays": 7,
+            "ComplianceLevel": "HIGH",
+            "PatchFilterGroup": {
+              "PatchFilters": [
+                {
+                  "Key": "CLASSIFICATION",
+                  "Values": ["Security"]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "Name": "cdkrd-harvest6",
+      "OperatingSystem": "AMAZON_LINUX_2"
+    }
+  },
+  "liveRaw": {
+    "OperatingSystem": "AMAZON_LINUX_2",
+    "RejectedPatchesAction": "ALLOW_AS_DEPENDENCY",
+    "ApprovedPatchesComplianceLevel": "UNSPECIFIED",
+    "ApprovedPatchesEnableNonSecurity": false,
+    "Id": "pb-0dc7b8f7d8aa1a1a3",
+    "DefaultBaseline": false,
+    "ApprovalRules": {
+      "PatchRules": [
+        {
+          "EnableNonSecurity": false,
+          "PatchFilterGroup": {
+            "PatchFilters": [
+              {
+                "Values": ["Security"],
+                "Key": "CLASSIFICATION"
+              }
+            ]
+          },
+          "ApproveAfterDays": 7,
+          "ComplianceLevel": "HIGH"
+        }
+      ]
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Patch",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["OperatingSystem"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["OperatingSystem"],
+    "defaults": {
+      "DefaultBaseline": false,
+      "OperatingSystem": "WINDOWS",
+      "RejectedPatchesAction": "ALLOW_AS_DEPENDENCY",
+      "ApprovedPatchesComplianceLevel": "UNSPECIFIED",
+      "ApprovedPatchesEnableNonSecurity": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__IPSet.IpSet.json
+++ b/tests/corpus/AWS__WAFv2__IPSet.IpSet.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::WAFv2::IPSet model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "IpSet",
+    "resourceType": "AWS::WAFv2::IPSet",
+    "physicalId": "cdkrd-harvest6|ec032017-71fe-45da-873f-1ee3c130036c|REGIONAL",
+    "constructPath": "CdkrdIntegHarvest6/IpSet",
+    "declared": {
+      "Addresses": ["192.0.2.0/24", "198.51.100.0/24"],
+      "IPAddressVersion": "IPV4",
+      "Name": "cdkrd-harvest6",
+      "Scope": "REGIONAL"
+    }
+  },
+  "liveRaw": {
+    "Addresses": ["198.51.100.0/24", "192.0.2.0/24"],
+    "Description": "",
+    "Scope": "REGIONAL",
+    "Id": "ec032017-71fe-45da-873f-1ee3c130036c",
+    "IPAddressVersion": "IPV4",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/ipset/cdkrd-harvest6/ec032017-71fe-45da-873f-1ee3c130036c",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "IpSet",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__RuleGroup.RuleGroup.json
+++ b/tests/corpus/AWS__WAFv2__RuleGroup.RuleGroup.json
@@ -1,0 +1,130 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 fixture, R84): fresh-deploy AWS::WAFv2::RuleGroup model — a common CFn type the corpus had not seen before R84. A change in this case's expected means the normalize/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "RuleGroup",
+    "resourceType": "AWS::WAFv2::RuleGroup",
+    "physicalId": "cdkrd-harvest6|70aed863-bb66-4369-b0cb-7c3a94f54a37|REGIONAL",
+    "constructPath": "CdkrdIntegHarvest6/RuleGroup",
+    "declared": {
+      "Capacity": 10,
+      "Name": "cdkrd-harvest6",
+      "Rules": [
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "block-large-bodies",
+          "Priority": 1,
+          "Statement": {
+            "SizeConstraintStatement": {
+              "ComparisonOperator": "GT",
+              "FieldToMatch": {
+                "Body": {}
+              },
+              "Size": 8192,
+              "TextTransformations": [
+                {
+                  "Priority": 0,
+                  "Type": "NONE"
+                }
+              ]
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "blockLargeBodies",
+            "SampledRequestsEnabled": true
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "cdkrdHarvest6",
+        "SampledRequestsEnabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "Scope": "REGIONAL",
+    "Capacity": 10,
+    "AvailableLabels": [],
+    "Id": "70aed863-bb66-4369-b0cb-7c3a94f54a37",
+    "ConsumedLabels": [],
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/rulegroup/cdkrd-harvest6/70aed863-bb66-4369-b0cb-7c3a94f54a37",
+    "Rules": [
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 1,
+        "Statement": {
+          "SizeConstraintStatement": {
+            "ComparisonOperator": "GT",
+            "TextTransformations": [
+              {
+                "Type": "NONE",
+                "Priority": 0
+              }
+            ],
+            "Size": 8192,
+            "FieldToMatch": {
+              "Body": {}
+            }
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "blockLargeBodies",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "block-large-bodies"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdHarvest6",
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true
+    },
+    "LabelNamespace": "awswaf:111111111111:rulegroup:cdkrd-harvest6:",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkrdIntegHarvest6/824af380-670a-11f1-bfbb-0e7af627f0fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkrdIntegHarvest6",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "RuleGroup",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-harvest6"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": [
+      "Arn",
+      "AvailableLabels.*.Name",
+      "ConsumedLabels.*.Name",
+      "Id",
+      "LabelNamespace"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/integration/harvest6/app.ts
+++ b/tests/integration/harvest6/app.ts
@@ -1,0 +1,192 @@
+// Corpus-harvest fixture wave 6 (R84): common, cheap, currently-UNCOVERED CFn
+// types the corpus (93 types as of R83) had never seen live — ECS
+// TaskDefinition (Fargate), CodeBuild Project, WAFv2 IPSet + RuleGroup, SSM
+// MaintenanceWindow + PatchBaseline, Lambda FunctionUrl, Cognito UserPoolGroup,
+// EC2 LaunchTemplate + PrefixList, ApiGateway UsagePlan + ApiKey, and an
+// EventBridge Pipes Pipe (SQS -> SQS). All structurally interesting (nested
+// container defs, build configs, WAF rule JSON, patch rules) — exactly the
+// shapes that flush out declared-compare false positives. No VPC, no NAT, no
+// slow resources; everything creates/deletes in seconds.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnApiKey, CfnRestApi, CfnUsagePlan } from "aws-cdk-lib/aws-apigateway";
+import { CfnProject } from "aws-cdk-lib/aws-codebuild";
+import { UserPool } from "aws-cdk-lib/aws-cognito";
+import { CfnUserPoolGroup } from "aws-cdk-lib/aws-cognito";
+import { CfnLaunchTemplate, CfnPrefixList } from "aws-cdk-lib/aws-ec2";
+import { Cluster, CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnUrl, Code, Function as Fn, Runtime } from "aws-cdk-lib/aws-lambda";
+import { CfnPipe } from "aws-cdk-lib/aws-pipes";
+import { RemovalPolicy } from "aws-cdk-lib";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { CfnMaintenanceWindow, CfnPatchBaseline } from "aws-cdk-lib/aws-ssm";
+import { CfnIPSet, CfnRuleGroup } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegHarvest6");
+
+// ---- ECS Fargate TaskDefinition (nested ContainerDefinitions array — FP-prone)
+const execRole = new Role(stack, "TaskExecRole", {
+  assumedBy: new ServicePrincipal("ecs-tasks.amazonaws.com"),
+});
+new CfnTaskDefinition(stack, "Task", {
+  family: "cdkrd-harvest6",
+  requiresCompatibilities: ["FARGATE"],
+  networkMode: "awsvpc",
+  cpu: "256",
+  memory: "512",
+  executionRoleArn: execRole.roleArn,
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/amazonlinux/amazonlinux:2",
+      essential: true,
+      command: ["sleep", "3600"],
+    },
+  ],
+});
+void Cluster; // (intentionally unused — TaskDefinition needs no cluster)
+
+// ---- CodeBuild Project (Source/Artifacts/Environment nested structs)
+const cbRole = new Role(stack, "CbRole", {
+  assumedBy: new ServicePrincipal("codebuild.amazonaws.com"),
+});
+new CfnProject(stack, "Build", {
+  name: "cdkrd-harvest6",
+  serviceRole: cbRole.roleArn,
+  source: { type: "NO_SOURCE", buildSpec: "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hi" },
+  artifacts: { type: "NO_ARTIFACTS" },
+  environment: {
+    type: "LINUX_CONTAINER",
+    computeType: "BUILD_GENERAL1_SMALL",
+    image: "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+  },
+});
+
+// ---- WAFv2 IPSet + RuleGroup (REGIONAL; cheap)
+new CfnIPSet(stack, "IpSet", {
+  name: "cdkrd-harvest6",
+  scope: "REGIONAL",
+  ipAddressVersion: "IPV4",
+  addresses: ["192.0.2.0/24", "198.51.100.0/24"],
+});
+new CfnRuleGroup(stack, "RuleGroup", {
+  name: "cdkrd-harvest6",
+  scope: "REGIONAL",
+  capacity: 10,
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdHarvest6",
+  },
+  rules: [
+    {
+      name: "block-large-bodies",
+      priority: 1,
+      action: { block: {} },
+      statement: { sizeConstraintStatement: {
+        fieldToMatch: { body: {} },
+        comparisonOperator: "GT",
+        size: 8192,
+        textTransformations: [{ priority: 0, type: "NONE" }],
+      } },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "blockLargeBodies",
+      },
+    },
+  ],
+});
+
+// ---- SSM MaintenanceWindow + PatchBaseline
+new CfnMaintenanceWindow(stack, "Window", {
+  name: "cdkrd-harvest6",
+  schedule: "rate(7 days)",
+  duration: 2,
+  cutoff: 1,
+  allowUnassociatedTargets: true,
+});
+new CfnPatchBaseline(stack, "Patch", {
+  name: "cdkrd-harvest6",
+  operatingSystem: "AMAZON_LINUX_2",
+  approvalRules: {
+    patchRules: [
+      {
+        approveAfterDays: 7,
+        complianceLevel: "HIGH",
+        patchFilterGroup: {
+          patchFilters: [{ key: "CLASSIFICATION", values: ["Security"] }],
+        },
+      },
+    ],
+  },
+});
+
+// ---- Lambda Function + FunctionUrl
+const fn = new Fn(stack, "UrlFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ statusCode: 200, body: 'ok' });"),
+});
+new CfnUrl(stack, "FnUrl", { targetFunctionArn: fn.functionArn, authType: "NONE" });
+
+// ---- Cognito UserPoolGroup
+const pool = new UserPool(stack, "Pool", { removalPolicy: RemovalPolicy.DESTROY });
+new CfnUserPoolGroup(stack, "Group", {
+  userPoolId: pool.userPoolId,
+  groupName: "cdkrd-harvest6",
+  description: "harvest6 group",
+  precedence: 10,
+});
+
+// ---- EC2 LaunchTemplate + managed PrefixList (no instances created)
+new CfnLaunchTemplate(stack, "LaunchTpl", {
+  launchTemplateName: "cdkrd-harvest6",
+  launchTemplateData: {
+    instanceType: "t3.micro",
+    monitoring: { enabled: false },
+    metadataOptions: { httpTokens: "required" },
+  },
+});
+new CfnPrefixList(stack, "PrefixList", {
+  prefixListName: "cdkrd-harvest6",
+  addressFamily: "IPv4",
+  maxEntries: 5,
+  entries: [{ cidr: "10.0.0.0/16", description: "vpc-a" }],
+});
+
+// ---- ApiGateway UsagePlan + ApiKey (standalone; no stage binding needed)
+void new CfnRestApi(stack, "Api", { name: "cdkrd-harvest6" });
+new CfnUsagePlan(stack, "Plan", {
+  usagePlanName: "cdkrd-harvest6",
+  throttle: { rateLimit: 10, burstLimit: 5 },
+  quota: { limit: 1000, period: "MONTH" },
+});
+new CfnApiKey(stack, "ApiKey", { name: "cdkrd-harvest6", enabled: true });
+
+// ---- EventBridge Pipes Pipe (SQS source -> SQS target)
+const src = new Queue(stack, "PipeSrc", { removalPolicy: RemovalPolicy.DESTROY });
+const dst = new Queue(stack, "PipeDst", { removalPolicy: RemovalPolicy.DESTROY });
+const pipeRole = new Role(stack, "PipeRole", {
+  assumedBy: new ServicePrincipal("pipes.amazonaws.com"),
+});
+pipeRole.addToPolicy(new PolicyStatement({
+  effect: Effect.ALLOW,
+  actions: ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+  resources: [src.queueArn],
+}));
+pipeRole.addToPolicy(new PolicyStatement({
+  effect: Effect.ALLOW,
+  actions: ["sqs:SendMessage"],
+  resources: [dst.queueArn],
+}));
+new CfnPipe(stack, "Pipe", {
+  name: "cdkrd-harvest6",
+  roleArn: pipeRole.roleArn,
+  source: src.queueArn,
+  target: dst.queueArn,
+  sourceParameters: { sqsQueueParameters: { batchSize: 1 } },
+});
+
+app.synth();

--- a/tests/integration/harvest6/cdk.json
+++ b/tests/integration/harvest6/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest6/package.json
+++ b/tests/integration/harvest6/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cdk-real-drift-integ-harvest6",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest fixture wave 6: ECS TaskDef / CodeBuild / WAFv2 IPSet+RuleGroup / SSM MaintenanceWindow+PatchBaseline / Lambda Url / Cognito UserPoolGroup / EC2 LaunchTemplate+PrefixList / ApiGateway UsagePlan+ApiKey / Pipes Pipe. Run via verify-harvest6.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module",
+  "packageManager": "npm@11.17.0"
+}

--- a/tests/integration/harvest6/verify-harvest6.sh
+++ b/tests/integration/harvest6/verify-harvest6.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 6 (real AWS) — R84.
+#
+# Common, cheap, currently-uncovered CFn types (corpus had 93 distinct types as
+# of R83): ECS TaskDefinition (Fargate), CodeBuild Project, WAFv2 IPSet +
+# RuleGroup, SSM MaintenanceWindow + PatchBaseline, Lambda FunctionUrl, Cognito
+# UserPoolGroup, EC2 LaunchTemplate + PrefixList, ApiGateway UsagePlan + ApiKey,
+# EventBridge Pipes Pipe. Asserts the two harvest invariants:
+#   1. baseline-free `check` — fresh deploy = ZERO declared drift, exit 0;
+#   2. `accept --yes` then `check --fail` — CLEAN across every type.
+#
+# CDKRD_HARVEST6_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest6 && npm install && bash verify-harvest6.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkrdIntegHarvest6
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest6.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST6_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST6_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 6: uncovered common types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -93,6 +93,21 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('us-east-1_AbCdEf|client123');
   });
 
+  it('Cognito UserPoolGroup: builds the composite UserPoolId|GroupName identifier (R84)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::Cognito::UserPoolGroup',
+        physicalId: 'admins',
+        declared: { UserPoolId: 'us-east-1_AbCdEf' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('us-east-1_AbCdEf|admins');
+  });
+
   it('Cognito UserPoolClient: an unresolved UserPoolId falls back to the raw physical id', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(


### PR DESCRIPTION
The harvest6 fixture deploys ~13 common, cheap, previously-uncovered CFn types (ECS TaskDefinition, CodeBuild Project, WAFv2 IPSet+RuleGroup, SSM MaintenanceWindow+PatchBaseline, Lambda Url, Cognito UserPoolGroup, EC2 LaunchTemplate+PrefixList, ApiGateway UsagePlan+ApiKey, EventBridge Pipes Pipe). First live run found a real FP and a skip, both fixed.

## Found + fixed

| Issue | Type | Fix |
|---|---|---|
| Unordered set reported as drift | `AWS::WAFv2::IPSet`.Addresses | WAFv2 echoes the CIDR set in its own order; added to `UNORDERED_ARRAY_PROPS` (R74 mechanism), equality-gated |
| CC ValidationException skip | `AWS::Cognito::UserPoolGroup` | primaryIdentifier `[UserPoolId, GroupName]` → `compositeWith('UserPoolId')` adapter; **skipped 2 → 1** live |

The remaining skip is `AWS::CodeBuild::Project` (CC UnsupportedActionException — needs a full SDK override, deferred).

## Live result

Fresh deploy now CLEAN (was 1 declared FP), accept → check --fail CLEAN, **INTEG PASS**.

## Corpus 189 → 211 (651 tests)

22 harvest6 recordings, including the WAFv2 IPSet case (locks the FP fix) and the newly-readable UserPoolGroup. The harvest6 accept baseline is correctly gitignored (R83 fix working).

## Test plan
- [x] typecheck / lint / build / test (31 files, 651)
- [x] Live: harvest6 fresh deploy zero declared drift after fix, skip 2→1, accept→CLEAN
- [x] Stack destroyed; recordings sanitized (no real account id)