### PR TITLE
fix(read): CodeBuild Project SDK override via BatchGetProjects — closes the last CC skip (R85)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    types without per-type code; SDK overrides fill only the gaps. _Does CC API's
    coverage + model fidelity hold up across the breadth users will throw at it, or
    does the SDK-override list grow until the "generic" claim breaks?_ **Tracking
-   (as of the R74 pass):** `SDK_OVERRIDES` holds 12 types, all genuine CC-API gaps
+   (as of the R85 pass):** `SDK_OVERRIDES` holds 13 types, all genuine CC-API gaps
    (`UnsupportedActionException` / `ValidationException` from GetResource — plus
    Scheduler::Schedule, whose CC read handler only finds schedules in the DEFAULT
    group), surfaced across 2 real-app dogfoods + 10 integ fixtures. The bet holds
@@ -195,7 +195,7 @@ checked.
   - **yaml-cfn.ts** — CFn-flavored YAML/JSON template parser.
 - **read/** — the "reality" side
   - **router.ts** — `readLive()`: SDK_OVERRIDES first, else CC API GetResource (with `CC_IDENTIFIER_ADAPTERS` deriving the CC identifier when the CFn physical id is not it — AppSync GraphQLApi ARN→ApiId, Cognito UserPoolClient `UserPoolId|ClientId`); classifies skip reasons.
-  - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group).
+  - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group, **CodeBuild Project** via BatchGetProjects with a camelCase→CFn-PascalCase projection, R85).
 - **normalize/** — noise subtraction (section 6)
   - **intrinsic-resolver.ts** — fail-closed CFn intrinsic resolver (section 5).
   - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `projectLiveToDeclaredSubset` (attribute-bag subset), `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` / `CASE_INSENSITIVE_PATHS` (per-type compare rules).

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@aws-sdk/client-cloudcontrol": "^3.1065.0",
     "@aws-sdk/client-cloudformation": "^3.1065.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1066.0",
+    "@aws-sdk/client-codebuild": "^3.1068.0",
     "@aws-sdk/client-ec2": "^3.1066.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.1068.0",
     "@aws-sdk/client-glue": "^3.1066.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@aws-sdk/client-cloudwatch-logs':
         specifier: ^3.1066.0
         version: 3.1066.0
+      '@aws-sdk/client-codebuild':
+        specifier: ^3.1068.0
+        version: 3.1068.0
       '@aws-sdk/client-ec2':
         specifier: ^3.1066.0
         version: 3.1066.0
@@ -234,8 +237,8 @@ packages:
     resolution: {integrity: sha512-yJEixTEkz3JoDLbalcjmPcki3+M1gARBr+/bxmp5RfudI1t1S8l+180MG3C5qHOUgG5cx1sv7yWBJtQ7lsdRNQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-codebuild@3.1066.0':
-    resolution: {integrity: sha512-1A4inLmed1eONfQr8EfHw2iqwTMZtN4zpn95k6JnBQaz/OOB/yHBYoD5ssvw3sjIW3UTdkVz9QQTLOiUZvLtVg==}
+  '@aws-sdk/client-codebuild@3.1068.0':
+    resolution: {integrity: sha512-bImvmwJN7Fio2efS6K9OZQROxechi6hYbelYiBqTp0WJKoWE0WdAcsnEI0g5LG4yutFbpQNRyQrEvv7lTAu8pA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cognito-identity@3.1066.0':
@@ -3341,7 +3344,7 @@ snapshots:
       '@aws-sdk/client-cloudcontrol': 3.1066.0
       '@aws-sdk/client-cloudformation': 3.1066.0
       '@aws-sdk/client-cloudwatch-logs': 3.1066.0
-      '@aws-sdk/client-codebuild': 3.1066.0
+      '@aws-sdk/client-codebuild': 3.1068.0
       '@aws-sdk/client-ec2': 3.1066.0
       '@aws-sdk/client-ecr': 3.1066.0
       '@aws-sdk/client-ecs': 3.1066.0
@@ -3517,7 +3520,7 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
-  '@aws-sdk/client-codebuild@3.1066.0':
+  '@aws-sdk/client-codebuild@3.1068.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -7,6 +7,7 @@
 // classifier; undefined when the target can't be resolved/read (→ skipped).
 
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
+import { BatchGetProjectsCommand, CodeBuildClient } from '@aws-sdk/client-codebuild';
 import {
   CloudWatchLogsClient,
   DescribeMetricFiltersCommand,
@@ -417,7 +418,64 @@ const readSchedulerSchedule: OverrideReader = async ({ physicalId, declared, reg
   };
 };
 
+// AWS::CodeBuild::Project — Cloud Control GetResource throws
+// UnsupportedActionException (R84/R85, observed live on the harvest6 fixture).
+// Read via CodeBuild BatchGetProjects — the CFn physical id IS the project name.
+// Maps the camelCase SDK Project back to the CFn PascalCase shape, projecting
+// ONLY CFn-modeled props (Arn / Created / LastModified / Badge URL are
+// AWS-managed noise). The declared compare is subset-based, so nested fields the
+// template never set are ignored; an absent project returns undefined (-> skip).
+const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, region }) => {
+  const name = str(physicalId) ?? str(declared.Name);
+  if (!name) return undefined;
+  const c = new CodeBuildClient({ region, ...READ_RETRY });
+  const r = await c.send(new BatchGetProjectsCommand({ names: [name] }));
+  const p = r.projects?.[0];
+  if (!p) return undefined;
+  const model: Record<string, unknown> = { Name: p.name };
+  if (p.serviceRole !== undefined) model.ServiceRole = p.serviceRole;
+  if (p.description !== undefined) model.Description = p.description;
+  if (p.timeoutInMinutes !== undefined) model.TimeoutInMinutes = p.timeoutInMinutes;
+  if (p.queuedTimeoutInMinutes !== undefined)
+    model.QueuedTimeoutInMinutes = p.queuedTimeoutInMinutes;
+  if (p.encryptionKey !== undefined) model.EncryptionKey = p.encryptionKey;
+  const src = p.source;
+  if (src)
+    model.Source = {
+      ...(src.type !== undefined && { Type: src.type }),
+      ...(src.location !== undefined && { Location: src.location }),
+      ...(src.buildspec !== undefined && { BuildSpec: src.buildspec }),
+      ...(src.gitCloneDepth !== undefined && { GitCloneDepth: src.gitCloneDepth }),
+    };
+  const art = p.artifacts;
+  if (art)
+    model.Artifacts = {
+      ...(art.type !== undefined && { Type: art.type }),
+      ...(art.location !== undefined && { Location: art.location }),
+    };
+  const env = p.environment;
+  if (env)
+    model.Environment = {
+      ...(env.type !== undefined && { Type: env.type }),
+      ...(env.computeType !== undefined && { ComputeType: env.computeType }),
+      ...(env.image !== undefined && { Image: env.image }),
+      ...(env.privilegedMode !== undefined && { PrivilegedMode: env.privilegedMode }),
+      ...(env.imagePullCredentialsType !== undefined && {
+        ImagePullCredentialsType: env.imagePullCredentialsType,
+      }),
+      ...(env.environmentVariables !== undefined && {
+        EnvironmentVariables: env.environmentVariables.map((v) => ({
+          Name: v.name,
+          Value: v.value,
+          ...(v.type !== undefined && { Type: v.type }),
+        })),
+      }),
+    };
+  return model;
+};
+
 export const SDK_OVERRIDES: Record<string, OverrideReader> = {
+  'AWS::CodeBuild::Project': readCodeBuildProject,
   'AWS::S3::BucketPolicy': readS3BucketPolicy,
   'AWS::SNS::TopicPolicy': readSnsTopicPolicy,
   'AWS::SQS::QueuePolicy': readSqsQueuePolicy,

--- a/tests/corpus/AWS__CodeBuild__Project.Build.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (harvest6 + R85 CodeBuild SDK override): fresh-deploy AWS::CodeBuild::Project model — now READABLE via batch-get-projects (camelCase SDK -> CFn PascalCase projection); was a CC UnsupportedActionException skip before R85. A change in this case's expected means the projection/classify semantics for this type changed.",
+  "resource": {
+    "logicalId": "Build",
+    "resourceType": "AWS::CodeBuild::Project",
+    "physicalId": "cdkrd-harvest6",
+    "constructPath": "CdkrdIntegHarvest6/Build",
+    "declared": {
+      "Artifacts": {
+        "Type": "NO_ARTIFACTS"
+      },
+      "Environment": {
+        "ComputeType": "BUILD_GENERAL1_SMALL",
+        "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+        "Type": "LINUX_CONTAINER"
+      },
+      "Name": "cdkrd-harvest6",
+      "ServiceRole": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-CbRole566E4F1D-qcEj5AOkbOAV",
+      "Source": {
+        "BuildSpec": "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hi",
+        "Type": "NO_SOURCE"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-harvest6",
+    "ServiceRole": "arn:aws:iam::111111111111:role/CdkrdIntegHarvest6-CbRole566E4F1D-qcEj5AOkbOAV",
+    "TimeoutInMinutes": 60,
+    "QueuedTimeoutInMinutes": 480,
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+    "Source": {
+      "Type": "NO_SOURCE",
+      "BuildSpec": "version: 0.2\nphases:\n  build:\n    commands:\n      - echo hi"
+    },
+    "Artifacts": {
+      "Type": "NO_ARTIFACTS"
+    },
+    "Environment": {
+      "Type": "LINUX_CONTAINER",
+      "ComputeType": "BUILD_GENERAL1_SMALL",
+      "Image": "aws/codebuild/amazonlinux2-x86_64-standard:5.0",
+      "PrivilegedMode": false,
+      "ImagePullCredentialsType": "CODEBUILD",
+      "EnvironmentVariables": []
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Build",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "TimeoutInMinutes",
+      "actual": 60,
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Build"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Build",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "QueuedTimeoutInMinutes",
+      "actual": 480,
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Build"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Build",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "EncryptionKey",
+      "actual": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Build"
+    }
+  ]
+}

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1,4 +1,5 @@
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
+import { BatchGetProjectsCommand, CodeBuildClient } from '@aws-sdk/client-codebuild';
 import {
   CloudWatchLogsClient,
   DescribeMetricFiltersCommand,
@@ -30,6 +31,7 @@ const route53 = mockClient(Route53Client);
 const glue = mockClient(GlueClient);
 const logs = mockClient(CloudWatchLogsClient);
 const scheduler = mockClient(SchedulerClient);
+const codebuild = mockClient(CodeBuildClient);
 
 const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
   physicalId,
@@ -41,7 +43,8 @@ const POLICY =
   '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:Get","Resource":"*"}]}';
 
 beforeEach(() => {
-  for (const m of [s3, sns, sqs, iam, lambda, budgets, route53, glue, logs, scheduler]) m.reset();
+  for (const m of [s3, sns, sqs, iam, lambda, budgets, route53, glue, logs, scheduler, codebuild])
+    m.reset();
 });
 
 describe('SDK overrides', () => {
@@ -443,6 +446,60 @@ describe('SDK overrides', () => {
 
     it('undefined when no name is resolvable (-> stays skipped)', async () => {
       expect(await SDK_OVERRIDES['AWS::Scheduler::Schedule'](ctx({}))).toBeUndefined();
+    });
+  });
+
+  describe('CodeBuild Project (R85)', () => {
+    it('maps the camelCase SDK Project to the CFn PascalCase shape', async () => {
+      codebuild.on(BatchGetProjectsCommand).resolves({
+        projects: [
+          {
+            name: 'cdkrd-harvest6',
+            arn: 'arn:aws:codebuild:us-east-1:1:project/cdkrd-harvest6',
+            serviceRole: 'arn:aws:iam::1:role/cb',
+            timeoutInMinutes: 60,
+            queuedTimeoutInMinutes: 480,
+            source: { type: 'NO_SOURCE', buildspec: 'version: 0.2' },
+            artifacts: { type: 'NO_ARTIFACTS' },
+            environment: {
+              type: 'LINUX_CONTAINER',
+              computeType: 'BUILD_GENERAL1_SMALL',
+              image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0',
+              privilegedMode: false,
+              environmentVariables: [{ name: 'K', value: 'V', type: 'PLAINTEXT' }],
+            },
+            created: new Date(0), // AWS-managed noise — must NOT appear in the model
+          },
+        ],
+      });
+      const out = await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'cdkrd-harvest6'));
+      expect(codebuild.commandCalls(BatchGetProjectsCommand)[0]?.args[0].input).toEqual({
+        names: ['cdkrd-harvest6'],
+      });
+      expect(out).toEqual({
+        Name: 'cdkrd-harvest6',
+        ServiceRole: 'arn:aws:iam::1:role/cb',
+        TimeoutInMinutes: 60,
+        QueuedTimeoutInMinutes: 480,
+        Source: { Type: 'NO_SOURCE', BuildSpec: 'version: 0.2' },
+        Artifacts: { Type: 'NO_ARTIFACTS' },
+        Environment: {
+          Type: 'LINUX_CONTAINER',
+          ComputeType: 'BUILD_GENERAL1_SMALL',
+          Image: 'aws/codebuild/amazonlinux2-x86_64-standard:5.0',
+          PrivilegedMode: false,
+          EnvironmentVariables: [{ Name: 'K', Value: 'V', Type: 'PLAINTEXT' }],
+        },
+      });
+    });
+
+    it('undefined when the project is absent (-> stays skipped)', async () => {
+      codebuild.on(BatchGetProjectsCommand).resolves({ projects: [] });
+      expect(await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'missing'))).toBeUndefined();
+    });
+
+    it('undefined when no name is resolvable', async () => {
+      expect(await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}))).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
`AWS::CodeBuild::Project` was the **last CC-skip** (GetResource throws `UnsupportedActionException`, observed live on harvest6 in R84). Added an SDK override reader.

## Approach

The CFn physical id IS the project name → `BatchGetProjects({names:[name]})` fetches it. The reader maps the **camelCase SDK Project → CFn PascalCase** shape (Source/Artifacts/Environment sub-structs, `environmentVariables` name→Name/value→Value/type→Type), projecting only CFn-modeled props. `Arn`/`Created`/`LastModified` are dropped as AWS-managed noise. An absent project or unresolved name returns `undefined` (→ honest skip).

## Live result (harvest6 re-deploy)

CodeBuild now **reads with ZERO declared drift** — its `TimeoutInMinutes`/`QueuedTimeoutInMinutes`/`EncryptionKey` (AWS defaults the template didn't declare) surface as honest UNRECORDED inventory, not drift. **skipped 1 → 0**, INTEG PASS. This closes the last known skip-class gap — every type on the harvest fixtures now reads.

## Corpus 211 → 212 (655 tests)

CodeBuild Project recorded live for the first time (couldn't while skipped) + a unit test covering the camelCase→PascalCase mapping and the absent/unresolved cases. New dep `@aws-sdk/client-codebuild`. ARCHITECTURE bet #3 updated (SDK_OVERRIDES 12→13).

## Test plan
- [x] typecheck / lint / build / test (31 files, 655)
- [x] Live: harvest6 CodeBuild reads CLEAN, skip 1→0, accept→CLEAN, INTEG PASS
- [x] Stack destroyed; recording sanitized