### PR TITLE
feat(report)!: fold undeclared-at-default values instead of dropping them (R86)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ detail:
   types (`overrides.ts` / `SDK_OVERRIDES`).
 - `normalize/` — noise subtraction (policy canonicalization, ARN/identity, `aws:*`
   tags, CC-API strip, path strip, intrinsic resolution).
-- `diff/` — drift classification + calculation (declared / undeclared / readGap /
+- `diff/` — drift classification + calculation (declared / undeclared / atDefault / readGap /
   unresolved / skipped).
 - `revert/` — the AWS-mutating path: Cloud Control `UpdateResource` + type-specific
   SDK writers (`writers.ts` / `SDK_WRITERS`).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,10 +30,11 @@ un-deployed code edits would show as false "drift".
      - cc-api strip   (timestamps, revision ids, ...)
      - policy canonical (Action/Resource/Principal scalar-vs-array unify, statement
        sort, account-id<->root-ARN; Version kept only when declared — never fabricated)
-     - aws:* tags (list + map), scalar schema-defaults + per-type known-defaults
+     - aws:* tags (list + map); scalar schema-defaults + per-type known-defaults
+       are NOT dropped but tagged `atDefault` (folded, never drift; R86)
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
-5. classify (tag):  declared | undeclared | readGap | unresolved | skipped
+5. classify (tag):  declared | undeclared | atDefault | readGap | unresolved | skipped
 6. report + exit code (report-only by default; --fail → 1 on drift; 2 error)
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,16 +59,22 @@ yet):
 
 ```console
 ApiStack: no baseline yet — found 42 live value(s) not declared in your
-template (typically AWS defaults, but out-of-band edits hide among them).
-Declared-side drift is reported either way. What do you want to do?
-  ❯ Accept ALL 42 into the baseline now, without reviewing them
+template (40 sit at a known AWS default (folded below); 2 look like real
+out-of-band edits). Declared-side drift is reported either way. What do you
+want to do?
+  ❯ Accept ALL 2 into the baseline now, without reviewing them
     Show them first — you can still accept (selectively) right after the report
 ```
 
-Accept writes `.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing
-written to AWS** — commit it. From here on `check` reports CLEAN until reality
-actually changes. (Declared drift — template vs reality — is detected from this
-very first run, baseline or not.)
+The count is the **complete** undeclared inventory, but the report lists only the
+handful that actually diverge — the rest sit at a known AWS default and fold into
+one `info: atDefault=40 (…)` line (`--show-all` expands it to the full list). So a
+first run highlights your real out-of-band edits instead of burying them under
+defaults you never touched. Accept writes
+`.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing written to
+AWS** — commit it. From here on `check` reports CLEAN until reality actually
+changes. (Declared drift — template vs reality — is detected from this very first
+run, baseline or not.)
 
 **Day to day** — someone changes something from the console; the next `check`
 reports it and asks right there:
@@ -293,9 +299,17 @@ entry, and their resource was never fully snapshot) print as their own
 drift — they never count toward the verdict or the `--fail` exit, and the
 `result:` line names the count with the way out (`run cdkrd accept`). Once a
 resource's snapshot is complete, a value that appears out of band IS undeclared
-drift (`appeared since accept`). Informational tiers (`readGap` / `unresolved` /
-`skipped` / `ignored`) fold into an `info:` footer with per-reason counts;
-`--verbose` expands them to full lists. Greppable: `^result:` is the verdict;
+drift (`appeared since accept`). Informational tiers (`atDefault` / `readGap` /
+`unresolved` / `skipped` / `ignored`) fold into an `info:` footer with per-reason
+counts; `--verbose` expands them to full lists. **`atDefault`** is the bulk of a
+first run: an undeclared value whose live state EQUALS a known AWS default (e.g. a
+Lambda's `TracingConfig: PassThrough`, an S3 bucket's account-default Block Public
+Access). It is **not dropped** — it is folded to a count so the report states the
+_complete_ undeclared inventory but lists only the values that actually diverge
+(your real out-of-band edits). The match is equality-gated: change one away from
+its default and it re-surfaces as real undeclared drift. `accept` never records an
+`atDefault`; `--show-all` (or `--verbose`) expands the fold to the full list.
+Greppable: `^result:` is the verdict;
 for machine consumption the formal contract is `--json`. Output is colorized on
 a TTY (`NO_COLOR` respected); piped / CI / `--json` output is always plain text.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -164,11 +164,15 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
                  Permission.FunctionName = GetAtt[fn, Arn]) — concurrent, once
    --- PASS 2:   classify
 4. normalize / subtract  classify.ts orchestrates the normalizers (section 6)
-5. classify (tier)       deleted | declared | undeclared | readGap | unresolved | skipped
-6. baseline filter       applyBaseline(): undeclared findings already accepted → drop
+5. classify (tier)       deleted | declared | undeclared | atDefault | readGap | unresolved | skipped
+                         (atDefault = undeclared but EQUAL to a known AWS default —
+                         folded, never drift, never recorded; R86)
+6. baseline filter       applyBaseline(): undeclared findings already accepted → drop;
+                         atDefault reconciled too (an accepted value now at-default is
+                         suppressed, not a false "removed since accept")
 7. report + exit code    report.ts: drift tiers in full + info: footer (1 line;
-                         1 bullet/tier when 2+; --verbose expands); --json carries
-                         all findings; worst exit across stacks
+                         1 bullet/tier when 2+; --verbose expands, --show-all expands
+                         atDefault only); --json carries all findings; worst exit across stacks
 ```
 
 The two-pass structure (PR "resolve Fn::GetAtt against live attributes") is what
@@ -265,7 +269,12 @@ all live changes
   − policy-doc representational noise  → canonicalized (scalar/array, stmt order, acct-id↔root-ARN)
   − aws:* tags ({Key,Value}[] anywhere; maps only under a `Tags` key — never
     IAM condition keys like aws:SecureTransport, R69) → stripped
-  − schema defaults + known defaults  → suppressed
+  − schema defaults + known defaults  → tagged "atDefault" (R86): NOT dropped — folded
+    into the info: footer as a count, so the report states the COMPLETE undeclared
+    inventory but lists only the values that actually diverge. Equality-gated: change
+    one away from its default and it re-tags as real undeclared drift. (`--show-all` /
+    `--verbose` expand the fold to the full list; accept never records an atDefault.)
+  − pure structural noise (aws:* tags, physical-id echo, trivially-empty {}/[]) → dropped
   − tag-list / id-array / method-set ORDER → canonicalized (see below)
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)
   − stringly-typed scalar (true vs "true", 5432 vs "5432") → equal (isStringlyEqualScalar)

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -298,7 +298,10 @@ export function applyBaseline(
   const complete = new Set(baseline.completeResources ?? []); // v1 file: nothing complete
   const kept: Finding[] = [];
   for (const f of findings) {
-    if (f.tier !== 'undeclared') {
+    // atDefault is reconciled alongside undeclared (R86): a value the user already
+    // accepted is suppressed whichever tier it lands in today, so a baseline entry
+    // whose live value is now classified at-default does NOT read as "removed".
+    if (f.tier !== 'undeclared' && f.tier !== 'atDefault') {
       kept.push(f);
       continue;
     }
@@ -308,6 +311,14 @@ export function applyBaseline(
     // normalization rules still matches today's live, so a cdkrd version bump alone
     // never resurfaces a suppressed value as false drift.
     if (entry && baselineValueMatches(entry.value, f.actual)) continue; // accepted, unchanged
+    if (f.tier === 'atDefault') {
+      // No (or a non-matching) accepted entry: the value still equals a known AWS
+      // default (the equality gate proved it), so it stays folded inventory — never
+      // drift, never unrecorded. A genuine change away from the default would not
+      // match a default and would arrive as tier 'undeclared', handled below.
+      kept.push(f);
+      continue;
+    }
     if (entry) {
       kept.push(f); // recorded value changed -> drift
     } else if (complete.has(f.logicalId)) {
@@ -320,9 +331,13 @@ export function applyBaseline(
       kept.push({ ...f, unrecorded: true }); // never decided -> not drift
     }
   }
-  // removed: accepted entries whose path is no longer present in any current undeclared finding
+  // removed: accepted entries whose path is no longer present in any current undeclared
+  // OR at-default finding (R86: an accepted value reclassified at-default is still
+  // present, not removed).
   const currentPaths = new Set(
-    findings.filter((f) => f.tier === 'undeclared').map((f) => `${f.logicalId}.${f.path}`)
+    findings
+      .filter((f) => f.tier === 'undeclared' || f.tier === 'atDefault')
+      .map((f) => `${f.logicalId}.${f.path}`)
   );
   for (const a of accepted) {
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -74,15 +74,26 @@ export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
 // explicitly instead of the generic "either way" clause.
 export function firstRunPrompt(
   stackName: string,
-  undeclaredCount: number,
+  recordableCount: number,
+  atDefaultCount = 0,
   declaredDriftCount = 0
 ): { message: string; options: { value: 'show' | 'acceptAll'; label: string }[] } {
   const declaredNote =
     declaredDriftCount > 0
       ? `Also found ${declaredDriftCount} declared-side drift(s) — reported below whichever you choose.`
       : 'Declared-side drift is reported either way.';
+  // The "found N" count is the COMPLETE undeclared inventory (R86): the values that
+  // actually diverge PLUS the ones sitting at a known AWS default. The at-default
+  // remainder is folded in the report, so name it here too instead of letting the
+  // user wonder why "found 113" but only a couple are listed. Accept records only the
+  // recordable (diverging) ones — at-default values are held by the equality gate.
+  const total = recordableCount + atDefaultCount;
+  const split =
+    atDefaultCount > 0
+      ? `${atDefaultCount} sit at a known AWS default (folded below); ${recordableCount} look like real out-of-band edits`
+      : 'typically AWS defaults, but out-of-band edits hide among them';
   return {
-    message: `${stackName}: no baseline yet — found ${undeclaredCount} live value(s) not declared in your template (typically AWS defaults, but out-of-band edits hide among them). ${declaredNote} What do you want to do?`,
+    message: `${stackName}: no baseline yet — found ${total} live value(s) not declared in your template (${split}). ${declaredNote} What do you want to do?`,
     // Accept-ALL first (R52, user decision): it is the overwhelmingly common
     // first-run choice, and the cost of an accidental Enter is one git-tracked
     // file — reviewable and revertible, nothing written to AWS. "Show first"
@@ -90,7 +101,7 @@ export function firstRunPrompt(
     options: [
       {
         value: 'acceptAll',
-        label: `Accept ALL ${undeclaredCount} into the baseline now, without reviewing them`,
+        label: `Accept ALL ${recordableCount} into the baseline now, without reviewing them`,
       },
       {
         value: 'show',
@@ -260,12 +271,22 @@ export async function runCheck(args: string[]): Promise<number> {
       // no prompt (`cdkrd accept` still writes a baseline for a clean stack).
       if (!baseline && !a.showAll && !a.json && !a.fail && isInteractive()) {
         const acceptable = applyIgnores(findings, stackName, config);
-        const undeclaredCount = acceptable.filter((f) => f.tier === 'undeclared').length;
+        // recordable = real diverging undeclared values (what accept records); the
+        // atDefault tier is folded inventory, never recorded (R86). Prompt only when
+        // there is something to record — a stack whose only undeclared values are at
+        // their AWS default is reported (CLEAN + folded info), not interrupted.
+        const recordableCount = acceptable.filter((f) => f.tier === 'undeclared').length;
+        const atDefaultCount = acceptable.filter((f) => f.tier === 'atDefault').length;
         const declaredDriftCount = acceptable.filter(
           (f) => f.tier === 'declared' || f.tier === 'deleted'
         ).length;
-        if (undeclaredCount > 0) {
-          const prompt = firstRunPrompt(stackName, undeclaredCount, declaredDriftCount);
+        if (recordableCount > 0) {
+          const prompt = firstRunPrompt(
+            stackName,
+            recordableCount,
+            atDefaultCount,
+            declaredDriftCount
+          );
           const choice = await select({
             message: prompt.message,
             options: prompt.options,
@@ -314,6 +335,9 @@ export async function runCheck(args: string[]): Promise<number> {
       let code = report(reconciled, `${stackName} (${region})`, {
         json: a.json,
         verbose: a.verbose,
+        // --show-all is inventory mode: list every undeclared value, including the
+        // ones at an AWS default (otherwise folded to a count) (R86).
+        expandAtDefault: a.showAll,
       });
       const hasUnrecorded = reconciled.some((f) => f.unrecorded === true);
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -210,8 +210,21 @@ export function classifyResource(
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was
     // already stripped from `live` by writeOnlyPaths above, so it cannot reach here
     // (the old guard was dead code for top-level keys).
-    if (k in schema.defaults && deepEqual(v, schema.defaults[k])) continue;
-    if (k in knownDef && deepEqual(v, knownDef[k])) continue;
+    // A live value EQUAL to a known AWS default is the `atDefault` tier (R86): still
+    // surfaced (folded, never dropped — the report shows the complete undeclared
+    // count and --show-all/--verbose lists them), but informational, not drift, and
+    // not recorded by accept. The equality gate means an out-of-band change away from
+    // the default no longer matches here and falls through to the `undeclared` tier.
+    if (
+      (k in schema.defaults && deepEqual(v, schema.defaults[k])) ||
+      (k in knownDef && deepEqual(v, knownDef[k]))
+    ) {
+      findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // Pure structural noise (NOT a config value at default) — dropped outright: AWS
+    // managed `aws:*` tags, the resource's own physical id echoed back as a property,
+    // and trivially-empty {}/[]. These carry no inventory value, so they are not folded.
     if (isAllAwsTags(v)) continue;
     if (physicalId !== undefined && v === physicalId) continue;
     if (isTrivialEmpty(v)) continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -15,6 +15,32 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::S3::Bucket': {
     VersioningConfiguration: { Status: 'Suspended' },
     AbacStatus: 'Disabled', // R66
+    // R86 (account-wide S3 defaults AWS has applied to every new bucket since 2023):
+    // Block Public Access fully on (Apr 2023), ACLs disabled / BucketOwnerEnforced
+    // (Apr 2023), and SSE-S3 (AES256) default encryption (Jan 2023). A CDK bucket that
+    // does not declare these reports all three on every first run, yet they are the
+    // (secure) AWS default, not an edit. Equality-gated like every KNOWN_DEFAULTS
+    // entry: weaken any of them out of band (e.g. BlockPublicAcls=false) and the value
+    // no longer matches, so it re-surfaces as real undeclared drift. The encryption
+    // shape mirrors what Cloud Control returns today (incl. the newer
+    // BlockedEncryptionTypes field); if AWS changes the shape the match simply falls
+    // through and the value is shown again — never silently wrong.
+    PublicAccessBlockConfiguration: {
+      RestrictPublicBuckets: true,
+      BlockPublicPolicy: true,
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+    },
+    OwnershipControls: { Rules: [{ ObjectOwnership: 'BucketOwnerEnforced' }] },
+    BucketEncryption: {
+      ServerSideEncryptionConfiguration: [
+        {
+          BucketKeyEnabled: false,
+          BlockedEncryptionTypes: { EncryptionType: ['SSE-C'] },
+          ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' },
+        },
+      ],
+    },
   },
   // R66 (dogfood-observed service defaults):
   'AWS::Lambda::Function': {

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -24,6 +24,7 @@ const TIER_NAMES: Record<Tier, string> = {
   deleted: 'DELETED',
   declared: 'DECLARED DRIFT',
   undeclared: 'UNDECLARED DRIFT',
+  atDefault: 'AT AWS DEFAULT',
   ignored: 'IGNORED',
   readGap: 'READ GAP',
   unresolved: 'UNRESOLVED',
@@ -33,17 +34,24 @@ const TIER_NAMES: Record<Tier, string> = {
 const TIER_NOTES: Partial<Record<Tier, string>> = {
   deleted: 'resource deleted out of band — always drift',
   undeclared: 'not declared in your template — the differentiator',
+  atDefault: 'undeclared, but the live value matches a known AWS default — not drift',
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
   readGap: 'declared but not returned by live read — not drift',
   unresolved: 'declared paths needing GetAtt — skipped, not drift',
   skipped: 'CC API unsupported / no physical id',
 };
 const DRIFT_TIERS: Tier[] = ['deleted', 'declared', 'undeclared'];
-const INFO_TIERS: Tier[] = ['ignored', 'readGap', 'unresolved', 'skipped'];
+// atDefault leads the informational footer: it is the bulk of a first run (undeclared
+// values sitting at their AWS default) and folding it is the whole point of R86 — the
+// report states the complete undeclared count but lists only the values that actually
+// diverge, with the at-default remainder collapsed to a count (expanded by --verbose
+// or --show-all).
+const INFO_TIERS: Tier[] = ['atDefault', 'ignored', 'readGap', 'unresolved', 'skipped'];
 
 export interface ReportOptions {
   json?: boolean;
   verbose?: boolean; // expand informational tiers (readGap/unresolved/skipped) to full lists
+  expandAtDefault?: boolean; // expand ONLY the atDefault tier to a full list (--show-all inventory mode)
   log?: (s: string) => void;
 }
 // Unrecorded values (R60, per finding since R62): an undeclared finding tagged
@@ -68,7 +76,8 @@ export function formatFinding(f: Finding): string {
   if (f.note) s += ` — ${f.note}`;
   if (f.tier === 'declared')
     s += `\n      desired=${style.desired(j(f.desired))}\n      actual =${style.actual(j(f.actual))}`;
-  else if (f.tier === 'undeclared') s += ` = ${style.actual(j(f.actual))}`;
+  else if (f.tier === 'undeclared' || f.tier === 'atDefault')
+    s += ` = ${style.actual(j(f.actual))}`;
   return s;
 }
 
@@ -181,23 +190,32 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // A blank line before the verdict ONLY when drift sections were printed — it must
   // not read as a member of the last section (R48); a CLEAN stack stays 3 lines.
   log((driftSections > 0 ? '\n' : '') + `result: ${verdict}${unrecordedNote}`);
-  // INFORMATIONAL tiers: footer below result — full sections under --verbose, else a
-  // folded summary (counts + reason breakdown): one `info: ...` line for a single
-  // tier, a one-line-per-tier bullet list (with ONE --verbose hint) for 2+ (R37).
-  if (opts.verbose) {
-    for (const tier of INFO_TIERS) tierSection(tier, true);
-  } else {
-    const summaries = INFO_TIERS.map((t) => {
+  // INFORMATIONAL tiers: footer below result. Each tier is either EXPANDED to a full
+  // section or FOLDED into the `info:` summary. --verbose expands all of them;
+  // --show-all expands ONLY atDefault (inventory mode lists every undeclared value but
+  // keeps the read-gap/skip breakdown terse). A tier's count is always stated, so the
+  // "surfaced, never silently dropped" invariant holds whichever way it renders.
+  const isExpanded = (t: Tier): boolean =>
+    !!opts.verbose || (t === 'atDefault' && !!opts.expandAtDefault);
+  for (const tier of INFO_TIERS) if (isExpanded(tier)) tierSection(tier, true);
+  const summaryFor = (t: Tier, items: Finding[]): string =>
+    // atDefault has a single cause (matches an AWS default), so the generic
+    // reason-breakdown would just echo the count — give it a plain-English label.
+    t === 'atDefault'
+      ? `atDefault=${items.length} (undeclared values matching a known AWS default — not drift)`
+      : `${t}=${items.length} (${groupReasons(items)})`;
+  const summaries = INFO_TIERS.filter((t) => !isExpanded(t))
+    .map((t) => {
       const items = byTier(t);
-      return items.length ? `${t}=${items.length} (${groupReasons(items)})` : null;
-    }).filter((s): s is string => s !== null);
-    if (summaries.length === 1) {
-      log(style.infoTier(`info: ${summaries[0]} — run with --verbose for the list`));
-    } else if (summaries.length > 1) {
-      log(style.infoTier('info:'));
-      for (const s of summaries) log(style.infoTier(`  - ${s}`));
-      log(style.infoTier('  run with --verbose for the list'));
-    }
+      return items.length ? summaryFor(t, items) : null;
+    })
+    .filter((s): s is string => s !== null);
+  if (summaries.length === 1) {
+    log(style.infoTier(`info: ${summaries[0]} — run with --verbose for the list`));
+  } else if (summaries.length > 1) {
+    log(style.infoTier('info:'));
+    for (const s of summaries) log(style.infoTier(`  - ${s}`));
+    log(style.infoTier('  run with --verbose for the list'));
   }
   return drifted === 0 ? 0 : 1;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ export type Tier =
   | 'deleted'
   | 'declared'
   | 'undeclared'
+  | 'atDefault' // undeclared, but the live value EQUALS a known AWS default (schema `default` or KNOWN_DEFAULTS) — informational inventory, folded in the report (R86); never drift, never recorded by accept. An out-of-band change AWAY from the default no longer matches, so it re-surfaces as a real `undeclared` finding.
   | 'ignored' // re-tagged from declared/undeclared by a .cdkrd/config.json ignore rule (informational)
   | 'readGap'
   | 'unresolved'

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -171,6 +171,48 @@ describe('baseline', () => {
     expect(applyBaseline([undeclared('A', 'P', ['x'])], b)).toEqual([]);
   });
 
+  describe('atDefault reconciliation (R86 — folded inventory, never drift, never a false removal)', () => {
+    const atDefault = (logicalId: string, path: string, value: unknown): Finding => ({
+      tier: 'atDefault',
+      logicalId,
+      resourceType: 'AWS::Lambda::Function',
+      path,
+      actual: value,
+    });
+
+    it('an at-default value with no baseline entry passes through folded (not unrecorded, not drift)', () => {
+      const out = applyBaseline(
+        [atDefault('A', 'TracingConfig', { Mode: 'PassThrough' })],
+        baseline([])
+      );
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ tier: 'atDefault', path: 'TracingConfig' });
+      expect(out[0]!.unrecorded).toBeUndefined();
+    });
+
+    it('with NO baseline at all, an at-default value stays atDefault (only undeclared is tagged unrecorded)', () => {
+      const out = applyBaseline([atDefault('A', 'PackageType', 'Zip')], undefined);
+      expect(out[0]).toMatchObject({ tier: 'atDefault' });
+      expect(out[0]!.unrecorded).toBeUndefined();
+    });
+
+    it('a value the user accepted that is now classified at-default is SUPPRESSED, not reported as removed (the live regression)', () => {
+      // baseline accepted Encryption=<AES256>; today classify tags it atDefault (it now
+      // matches a known default). It must vanish (already decided), and must NOT appear
+      // as "baseline value removed since accept".
+      const b = baseline([
+        {
+          logicalId: 'Bkt',
+          resourceType: 'AWS::S3::Bucket',
+          path: 'Encryption',
+          value: { alg: 'AES256' },
+        },
+      ]);
+      const out = applyBaseline([atDefault('Bkt', 'Encryption', { alg: 'AES256' })], b);
+      expect(out).toEqual([]);
+    });
+  });
+
   it('re-canonicalizes the baseline value before compare (old unsorted form still matches)', () => {
     // accepted under an OLDER rule set: tag list stored UNSORTED
     const b = baseline([

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -62,11 +62,23 @@ describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', (
   });
 
   it('declared-side drift present → the prompt says it was FOUND, with its count (R51)', () => {
-    const { message } = firstRunPrompt('ApiStack', 113, 3);
+    const { message } = firstRunPrompt('ApiStack', 113, 0, 3);
     expect(message).toContain(
       'Also found 3 declared-side drift(s) — reported below whichever you choose.'
     );
     expect(message).not.toContain('either way'); // the generic clause is replaced, not appended
+  });
+
+  it('the "found N" count is the COMPLETE inventory; at-default values are named + folded, Accept ALL records only the diverging ones (R86)', () => {
+    const { message, options } = firstRunPrompt('ApiStack', 7, 152);
+    // total = recordable + atDefault, the user-meaningful "everything not in your template"
+    expect(message).toContain('found 159 live value(s) not declared in your template');
+    expect(message).toContain('152 sit at a known AWS default (folded below)');
+    expect(message).toContain('7 look like real out-of-band edits');
+    expect(message).not.toContain('typically AWS defaults'); // the generic clause is replaced when we know the split
+    // accept records the diverging ones only — the at-default remainder is held by the equality gate
+    const bulk = options.find((o) => o.value === 'acceptAll')!;
+    expect(bulk.label).toContain('Accept ALL 7');
   });
 
   it('no declared-side drift → the generic either-way clause (R51)', () => {

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -13,6 +13,7 @@ function tiers(findings: Finding[]) {
   return {
     declared: by('declared'),
     undeclared: by('undeclared'),
+    atDefault: by('atDefault'),
     readGap: by('readGap'),
     unresolved: by('unresolved'),
   };
@@ -345,9 +346,10 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     declared: {},
   });
 
-  it('EVERY entry suppresses its exact default value through the full pipeline', () => {
-    // generic: each (type, key, default) must classify to zero findings — this
-    // also catches a canonicalization step mangling the listed default shape.
+  it('EVERY entry FOLDS its exact default value to the atDefault tier (R86), never to drift', () => {
+    // generic: each (type, key, default) must classify to a single atDefault finding
+    // (folded inventory, not drift) — this also catches a canonicalization step
+    // mangling the listed default shape (which would resurface it as undeclared).
     for (const [resourceType, defs] of Object.entries(KNOWN_DEFAULTS)) {
       for (const [key, value] of Object.entries(defs)) {
         const findings = classifyResource(
@@ -355,7 +357,11 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
           { [key]: structuredClone(value) },
           emptySchema
         );
-        expect(findings, `${resourceType}.${key}`).toEqual([]);
+        expect(findings, `${resourceType}.${key}`).toHaveLength(1);
+        expect(findings[0], `${resourceType}.${key}`).toMatchObject({
+          tier: 'atDefault',
+          path: key,
+        });
       }
     }
   });
@@ -488,14 +494,16 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['Addresses']);
     });
 
-    it('undeclared EventSelectors equal to the default is suppressed; a changed one surfaces', () => {
+    it('undeclared EventSelectors equal to the default folds to atDefault; a changed one surfaces', () => {
       expect(
-        classifyResource(
-          trail({}),
-          { EventSelectors: [structuredClone(DEFAULT_SELECTOR)] },
-          emptySchema
-        )
-      ).toEqual([]);
+        tiers(
+          classifyResource(
+            trail({}),
+            { EventSelectors: [structuredClone(DEFAULT_SELECTOR)] },
+            emptySchema
+          )
+        ).atDefault
+      ).toEqual(['EventSelectors']);
       expect(
         tiers(
           classifyResource(

--- a/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGatewayV2::Api model; surviving raw-classify findings locked as-is (IpAddressType, RouteSelectionExpression). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGatewayV2::Api model; surviving raw-classify findings locked as-is (IpAddressType, RouteSelectionExpression). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "HttpApi",
     "resourceType": "AWS::ApiGatewayV2::Api",

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
@@ -53,8 +53,8 @@
       "tier": "undeclared",
       "logicalId": "ApiANYpingPingA3011524",
       "resourceType": "AWS::ApiGatewayV2::Integration",
-      "path": "TimeoutInMillis",
-      "actual": 30000,
+      "path": "IntegrationMethod",
+      "actual": "POST",
       "physicalId": "qf0uwiu",
       "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
     },
@@ -62,8 +62,8 @@
       "tier": "undeclared",
       "logicalId": "ApiANYpingPingA3011524",
       "resourceType": "AWS::ApiGatewayV2::Integration",
-      "path": "IntegrationMethod",
-      "actual": "POST",
+      "path": "TimeoutInMillis",
+      "actual": 30000,
       "physicalId": "qf0uwiu",
       "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
     }

--- a/tests/corpus/AWS__ApiGateway__Account.RestApiAccount7C83CF5A.json
+++ b/tests/corpus/AWS__ApiGateway__Account.RestApiAccount7C83CF5A.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::Account model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::Account model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "RestApiAccount7C83CF5A",
     "resourceType": "AWS::ApiGateway::Account",

--- a/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
+++ b/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::Method model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::Method model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "RestApiGET0F59260B",
     "resourceType": "AWS::ApiGateway::Method",

--- a/tests/corpus/AWS__ApiGateway__RestApi.Api.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.Api.json
@@ -62,15 +62,6 @@
       "tier": "undeclared",
       "logicalId": "Api",
       "resourceType": "AWS::ApiGateway::RestApi",
-      "path": "SecurityPolicy",
-      "actual": "TLS_1_0",
-      "physicalId": "plg2s0yj0k",
-      "constructPath": "CdkrdIntegHarvest6/Api"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Api",
-      "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
       "actual": "HEADER",
       "physicalId": "plg2s0yj0k",
@@ -85,6 +76,15 @@
         "IpAddressType": "ipv4",
         "Types": ["EDGE"]
       },
+      "physicalId": "plg2s0yj0k",
+      "constructPath": "CdkrdIntegHarvest6/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Api",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
       "physicalId": "plg2s0yj0k",
       "constructPath": "CdkrdIntegHarvest6/Api"
     }

--- a/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::RestApi model; surviving raw-classify findings locked as-is (ApiKeySourceType, EndpointConfiguration, SecurityPolicy). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ApiGateway::RestApi model; surviving raw-classify findings locked as-is (ApiKeySourceType, EndpointConfiguration, SecurityPolicy). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "RestApi0C43BF4B",
     "resourceType": "AWS::ApiGateway::RestApi",
@@ -77,15 +77,6 @@
       "tier": "undeclared",
       "logicalId": "RestApi0C43BF4B",
       "resourceType": "AWS::ApiGateway::RestApi",
-      "path": "SecurityPolicy",
-      "actual": "TLS_1_0",
-      "physicalId": "84xvb60zri",
-      "constructPath": "CdkrdIntegHarvest/RestApi"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "RestApi0C43BF4B",
-      "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
       "actual": "HEADER",
       "physicalId": "84xvb60zri",
@@ -100,6 +91,15 @@
         "IpAddressType": "ipv4",
         "Types": ["EDGE"]
       },
+      "physicalId": "84xvb60zri",
+      "constructPath": "CdkrdIntegHarvest/RestApi"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApi0C43BF4B",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
       "physicalId": "84xvb60zri",
       "constructPath": "CdkrdIntegHarvest/RestApi"
     }

--- a/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
@@ -77,8 +77,8 @@
       "tier": "undeclared",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
-      "path": "QueryDepthLimit",
-      "actual": 0,
+      "path": "ApiType",
+      "actual": "GRAPHQL",
       "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
       "constructPath": "CdkrdIntegHarvest3/Graph"
     },
@@ -95,7 +95,7 @@
       "tier": "undeclared",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
-      "path": "ResolverCountLimit",
+      "path": "QueryDepthLimit",
       "actual": 0,
       "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
       "constructPath": "CdkrdIntegHarvest3/Graph"
@@ -104,8 +104,8 @@
       "tier": "undeclared",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
-      "path": "ApiType",
-      "actual": "GRAPHQL",
+      "path": "ResolverCountLimit",
+      "actual": 0,
       "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
       "constructPath": "CdkrdIntegHarvest3/Graph"
     },

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
@@ -88,8 +88,8 @@
       "tier": "undeclared",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
-      "path": "ServiceNamespace",
-      "actual": "dynamodb",
+      "path": "ScalableDimension",
+      "actual": "dynamodb:table:ReadCapacityUnits",
       "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     },
@@ -97,8 +97,8 @@
       "tier": "undeclared",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
-      "path": "ScalableDimension",
-      "actual": "dynamodb:table:ReadCapacityUnits",
+      "path": "ServiceNamespace",
+      "actual": "dynamodb",
       "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     }

--- a/tests/corpus/AWS__Athena__WorkGroup.Queries.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.Queries.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Athena::WorkGroup model; surviving raw-classify findings locked as-is (RecursiveDeleteOption, WorkGroupConfiguration). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Athena::WorkGroup model; surviving raw-classify findings locked as-is (RecursiveDeleteOption, WorkGroupConfiguration). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Queries",
     "resourceType": "AWS::Athena::WorkGroup",
@@ -65,11 +65,20 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "Queries",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "cdkrd-harvest",
+      "constructPath": "CdkrdIntegHarvest/Queries"
+    },
+    {
       "tier": "readGap",
       "logicalId": "Queries",
       "resourceType": "AWS::Athena::WorkGroup",
       "path": "RecursiveDeleteOption",
-      "note": "write-only \u2014 cannot be read back",
+      "note": "write-only — cannot be read back",
       "physicalId": "cdkrd-harvest",
       "constructPath": "CdkrdIntegHarvest/Queries"
     },

--- a/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
+++ b/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
@@ -7,7 +7,10 @@
     "physicalId": "MonthlyCost-us-east-1-1679810595490-abcDEFghij",
     "declared": {
       "Budget": {
-        "BudgetLimit": { "Amount": 40, "Unit": "USD" },
+        "BudgetLimit": {
+          "Amount": 40,
+          "Unit": "USD"
+        },
         "BudgetType": "COST",
         "TimeUnit": "MONTHLY"
       },
@@ -18,7 +21,12 @@
             "NotificationType": "ACTUAL",
             "Threshold": 80
           },
-          "Subscribers": [{ "Address": "corpus@example.com", "SubscriptionType": "EMAIL" }]
+          "Subscribers": [
+            {
+              "Address": "corpus@example.com",
+              "SubscriptionType": "EMAIL"
+            }
+          ]
         }
       ]
     }
@@ -28,7 +36,10 @@
       "BudgetName": "MonthlyCost-us-east-1-1679810595490-abcDEFghij",
       "BudgetType": "COST",
       "TimeUnit": "MONTHLY",
-      "BudgetLimit": { "Amount": "40.0", "Unit": "USD" }
+      "BudgetLimit": {
+        "Amount": "40.0",
+        "Unit": "USD"
+      }
     }
   },
   "schema": {
@@ -40,7 +51,11 @@
     "createOnlyPaths": [],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "readGap",

--- a/tests/corpus/AWS__CE__AnomalySubscription.CfnAnomalySubscription.json
+++ b/tests/corpus/AWS__CE__AnomalySubscription.CfnAnomalySubscription.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (dogfood): the service DERIVES ThresholdExpression (a JSON string) from the declared legacy Threshold \u2014 surfaces as the one undeclared value (accept-once material, locked as-is); the live Subscribers entry gains a Status field the declared side never set (nested live-extra, ignored).",
+  "description": "RECORDED LIVE (dogfood): the service DERIVES ThresholdExpression (a JSON string) from the declared legacy Threshold — surfaces as the one undeclared value (accept-once material, locked as-is); the live Subscribers entry gains a Status field the declared side never set (nested live-extra, ignored).",
   "resource": {
     "logicalId": "CfnAnomalySubscription",
     "resourceType": "AWS::CE::AnomalySubscription",

--- a/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannel.json
+++ b/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannel.json
@@ -33,6 +33,19 @@
     "createOnlyPaths": ["ConfigurationName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
-  "expected": []
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SlackChannel",
+      "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
+      "path": "GuardrailPolicies",
+      "actual": ["arn:aws:iam::aws:policy/AdministratorAccess"],
+      "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/corpus-alerts"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannelLive.json
+++ b/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannelLive.json
@@ -45,5 +45,24 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SlackChannel425D424B",
+      "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
+      "path": "GuardrailPolicies",
+      "actual": ["arn:aws:iam::aws:policy/AdministratorAccess"],
+      "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/main-CostCheck",
+      "constructPath": "main-CostCheck/SlackChannel"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SlackChannel425D424B",
+      "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
+      "path": "UserRoleRequired",
+      "actual": false,
+      "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/main-CostCheck",
+      "constructPath": "main-CostCheck/SlackChannel"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn.json
@@ -39,6 +39,10 @@
     "createOnlyPaths": [],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": []
 }

--- a/tests/corpus/AWS__CloudFront__Distribution.MultiOriginCdn.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.MultiOriginCdn.json
@@ -50,7 +50,11 @@
     "createOnlyPaths": [],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "declared",

--- a/tests/corpus/AWS__CloudWatch__Alarm.AlarmA529EB095.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.AlarmA529EB095.json
@@ -63,5 +63,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AlarmA529EB095",
+      "resourceType": "AWS::CloudWatch::Alarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkrdIntegHarvest5-AlarmA529EB095-04aR0ogtAti0",
+      "constructPath": "CdkrdIntegHarvest5/AlarmA"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CloudWatch__Alarm.AlarmB163AF7E7.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.AlarmB163AF7E7.json
@@ -63,5 +63,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AlarmB163AF7E7",
+      "resourceType": "AWS::CloudWatch::Alarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkrdIntegHarvest5-AlarmB163AF7E7-1S6WkdFYC6eR",
+      "constructPath": "CdkrdIntegHarvest5/AlarmB"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CloudWatch__Alarm.Latency2EF2A010.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.Latency2EF2A010.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::CloudWatch::Alarm with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::CloudWatch::Alarm with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Latency2EF2A010",
     "resourceType": "AWS::CloudWatch::Alarm",
@@ -80,5 +80,15 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Latency2EF2A010",
+      "resourceType": "AWS::CloudWatch::Alarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkrdIntegHarvest2-Latency2EF2A010-Ao1nIA9jxW7i",
+      "constructPath": "CdkrdIntegHarvest2/Latency"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CloudWatch__Alarm.Pulse82D6B25B.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.Pulse82D6B25B.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::CloudWatch::Alarm model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::CloudWatch::Alarm model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Pulse82D6B25B",
     "resourceType": "AWS::CloudWatch::Alarm",
@@ -76,5 +76,15 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Pulse82D6B25B",
+      "resourceType": "AWS::CloudWatch::Alarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkrdIntegHarvest-Pulse82D6B25B-Kbg6xkr8PZ1U",
+      "constructPath": "CdkrdIntegHarvest/Pulse"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CloudWatch__Dashboard.Board47D7A2D0.json
+++ b/tests/corpus/AWS__CloudWatch__Dashboard.Board47D7A2D0.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::CloudWatch::Dashboard model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::CloudWatch::Dashboard model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Board47D7A2D0",
     "resourceType": "AWS::CloudWatch::Dashboard",

--- a/tests/corpus/AWS__CodeBuild__Project.Build.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build.json
@@ -64,8 +64,8 @@
       "tier": "undeclared",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
-      "path": "TimeoutInMinutes",
-      "actual": 60,
+      "path": "EncryptionKey",
+      "actual": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
       "physicalId": "cdkrd-harvest6",
       "constructPath": "CdkrdIntegHarvest6/Build"
     },
@@ -82,8 +82,8 @@
       "tier": "undeclared",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
-      "path": "EncryptionKey",
-      "actual": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+      "path": "TimeoutInMinutes",
+      "actual": 60,
       "physicalId": "cdkrd-harvest6",
       "constructPath": "CdkrdIntegHarvest6/Build"
     }

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -336,6 +336,35 @@
       "tier": "undeclared",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
       "path": "Policies",
       "actual": {
         "PasswordPolicy": {
@@ -350,15 +379,6 @@
           "AllowedFirstAuthFactors": ["PASSWORD"]
         }
       },
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "MfaConfiguration",
-      "actual": "OFF",
       "physicalId": "us-east-1_4tB3jYmmc",
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
@@ -595,24 +615,6 @@
       "tier": "undeclared",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "UserPoolTier",
-      "actual": "ESSENTIALS",
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "DeletionProtection",
-      "actual": "INACTIVE",
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",
       "actual": "PoolD3F588B8-x2yLeeWNu9OW",
       "physicalId": "us-east-1_4tB3jYmmc",
@@ -622,10 +624,8 @@
       "tier": "undeclared",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "EmailConfiguration",
-      "actual": {
-        "EmailSendingAccount": "COGNITO_DEFAULT"
-      },
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
       "physicalId": "us-east-1_4tB3jYmmc",
       "constructPath": "CdkrdIntegHarvest6/Pool"
     }

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -336,6 +336,26 @@
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
       "path": "MfaConfiguration",
       "actual": "OFF",
       "physicalId": "us-east-1_Ifea0bzss",
@@ -574,24 +594,6 @@
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "UserPoolTier",
-      "actual": "ESSENTIALS",
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "DeletionProtection",
-      "actual": "INACTIVE",
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",
       "actual": "Users0A0EEA89-RYUoEBfJwQHo",
       "physicalId": "us-east-1_Ifea0bzss",
@@ -601,10 +603,8 @@
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "EmailConfiguration",
-      "actual": {
-        "EmailSendingAccount": "COGNITO_DEFAULT"
-      },
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
       "physicalId": "us-east-1_Ifea0bzss",
       "constructPath": "CdkrdIntegHarvest3/Users"
     }

--- a/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
@@ -81,8 +81,8 @@
       "tier": "undeclared",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "RefreshTokenValidity",
-      "actual": 30,
+      "path": "EnableTokenRevocation",
+      "actual": true,
       "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
       "constructPath": "CdkrdIntegHarvest3/WebClient"
     },
@@ -90,8 +90,8 @@
       "tier": "undeclared",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "EnableTokenRevocation",
-      "actual": true,
+      "path": "RefreshTokenValidity",
+      "actual": 30,
       "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
       "constructPath": "CdkrdIntegHarvest3/WebClient"
     }

--- a/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
+++ b/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::DynamoDB::Table with deep declared config classifies as recorded (undeclared:WarmThroughput). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::DynamoDB::Table with deep declared config classifies as recorded (undeclared:WarmThroughput). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "OrdersA9B65338",
     "resourceType": "AWS::DynamoDB::Table",

--- a/tests/corpus/AWS__DynamoDB__Table.Sessions.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Sessions.json
@@ -8,8 +8,14 @@
     "declared": {
       "TableName": "corpus-sessions",
       "Tags": [
-        { "Key": "team", "Value": "platform" },
-        { "Key": "env", "Value": "dev" }
+        {
+          "Key": "team",
+          "Value": "platform"
+        },
+        {
+          "Key": "env",
+          "Value": "dev"
+        }
       ]
     }
   },
@@ -17,9 +23,18 @@
     "TableName": "corpus-sessions",
     "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/corpus-sessions",
     "Tags": [
-      { "Key": "aws:cloudformation:stack-name", "Value": "CorpusStack" },
-      { "Key": "env", "Value": "dev" },
-      { "Key": "team", "Value": "platform" }
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CorpusStack"
+      },
+      {
+        "Key": "env",
+        "Value": "dev"
+      },
+      {
+        "Key": "team",
+        "Value": "platform"
+      }
     ],
     "TableClass": "STANDARD_INFREQUENT_ACCESS"
   },
@@ -32,7 +47,11 @@
     "createOnlyPaths": ["TableName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "undeclared",

--- a/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::DynamoDB::Table model; surviving raw-classify findings locked as-is (WarmThroughput). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::DynamoDB::Table model; surviving raw-classify findings locked as-is (WarmThroughput). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Sessions8896A56D",
     "resourceType": "AWS::DynamoDB::Table",

--- a/tests/corpus/AWS__EC2__EIP.Ip.json
+++ b/tests/corpus/AWS__EC2__EIP.Ip.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::EC2::EIP model; surviving raw-classify findings locked as-is (NetworkBorderGroup). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::EC2::EIP model; surviving raw-classify findings locked as-is (NetworkBorderGroup). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Ip",
     "resourceType": "AWS::EC2::EIP",

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
     "resourceType": "AWS::EC2::EIP",

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::EIP with deep declared config classifies as recorded (undeclared:NetworkBorderGroup, undeclared:NetworkInterfaceId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
     "resourceType": "AWS::EC2::EIP",

--- a/tests/corpus/AWS__EC2__InternetGateway.WorkersVpcIGW91E7A5A0.json
+++ b/tests/corpus/AWS__EC2__InternetGateway.WorkersVpcIGW91E7A5A0.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::InternetGateway with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::InternetGateway with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcIGW91E7A5A0",
     "resourceType": "AWS::EC2::InternetGateway",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::NatGateway with deep declared config classifies as recorded (undeclared:AvailabilityMode, undeclared:ConnectivityType, undeclared:PrivateIpAddress, undeclared:VpcId, unresolved:AllocationId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::NatGateway with deep declared config classifies as recorded (undeclared:AvailabilityMode, undeclared:ConnectivityType, undeclared:PrivateIpAddress, undeclared:VpcId, unresolved:AllocationId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
     "resourceType": "AWS::EC2::NatGateway",
@@ -96,19 +96,11 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
-      "resourceType": "AWS::EC2::NatGateway",
-      "path": "AllocationId",
-      "physicalId": "nat-07e873bd1eb79666a",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.0.62",
+      "path": "AvailabilityMode",
+      "actual": "zonal",
       "physicalId": "nat-07e873bd1eb79666a",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
@@ -125,8 +117,8 @@
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "VpcId",
-      "actual": "vpc-0b4c09b4fa46530e9",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.62",
       "physicalId": "nat-07e873bd1eb79666a",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
@@ -134,8 +126,16 @@
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "AvailabilityMode",
-      "actual": "zonal",
+      "path": "VpcId",
+      "actual": "vpc-0b4c09b4fa46530e9",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "AllocationId",
       "physicalId": "nat-07e873bd1eb79666a",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     }

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::NatGateway with deep declared config classifies as recorded (undeclared:AvailabilityMode, undeclared:ConnectivityType, undeclared:PrivateIpAddress, undeclared:VpcId, unresolved:AllocationId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::NatGateway with deep declared config classifies as recorded (undeclared:AvailabilityMode, undeclared:ConnectivityType, undeclared:PrivateIpAddress, undeclared:VpcId, unresolved:AllocationId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
     "resourceType": "AWS::EC2::NatGateway",
@@ -96,19 +96,11 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
-      "resourceType": "AWS::EC2::NatGateway",
-      "path": "AllocationId",
-      "physicalId": "nat-029bbcd7fb6e239a7",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.69.104",
+      "path": "AvailabilityMode",
+      "actual": "zonal",
       "physicalId": "nat-029bbcd7fb6e239a7",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
@@ -125,8 +117,8 @@
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "VpcId",
-      "actual": "vpc-0b4c09b4fa46530e9",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.69.104",
       "physicalId": "nat-029bbcd7fb6e239a7",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
@@ -134,8 +126,16 @@
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "AvailabilityMode",
-      "actual": "zonal",
+      "path": "VpcId",
+      "actual": "vpc-0b4c09b4fa46530e9",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "AllocationId",
       "physicalId": "nat-029bbcd7fb6e239a7",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     }

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet1DefaultRouteAA29480A.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet1DefaultRouteAA29480A.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet1DefaultRouteAA29480A",
     "resourceType": "AWS::EC2::Route",

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet2DefaultRoute3AD15157.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPrivateSubnet2DefaultRoute3AD15157.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet2DefaultRoute3AD15157",
     "resourceType": "AWS::EC2::Route",

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet1DefaultRoute10E419CD.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet1DefaultRoute10E419CD.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (undeclared:VpcEndpointId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (undeclared:VpcEndpointId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1DefaultRoute10E419CD",
     "resourceType": "AWS::EC2::Route",

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet2DefaultRoute27847E35.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet2DefaultRoute27847E35.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (undeclared:VpcEndpointId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Route with deep declared config classifies as recorded (undeclared:VpcEndpointId). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2DefaultRoute27847E35",
     "resourceType": "AWS::EC2::Route",

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet1RouteTable14508C3D.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet1RouteTable14508C3D.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet1RouteTable14508C3D",
     "resourceType": "AWS::EC2::RouteTable",

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet2RouteTable132F039E.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPrivateSubnet2RouteTable132F039E.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet2RouteTable132F039E",
     "resourceType": "AWS::EC2::RouteTable",

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet1RouteTableAC7905D6.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet1RouteTableAC7905D6.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1RouteTableAC7905D6",
     "resourceType": "AWS::EC2::RouteTable",

--- a/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet2RouteTable7E94D522.json
+++ b/tests/corpus/AWS__EC2__RouteTable.WorkersVpcPublicSubnet2RouteTable7E94D522.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::RouteTable with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2RouteTable7E94D522",
     "resourceType": "AWS::EC2::RouteTable",

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
@@ -123,14 +123,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-0f3317e0d9ac5df28",
-      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "NetpublicSubnet1SubnetA0498A0F",
       "resourceType": "AWS::EC2::Subnet",
@@ -149,6 +141,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-0f3317e0d9ac5df28",
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
@@ -123,14 +123,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-0e4bae13856face36",
-      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "NetpublicSubnet2Subnet5183DBBB",
       "resourceType": "AWS::EC2::Subnet",
@@ -149,6 +141,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-0e4bae13856face36",
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
     "resourceType": "AWS::EC2::Subnet",
@@ -138,14 +138,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-011f0a2e9cbd7ebab",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
       "resourceType": "AWS::EC2::Subnet",
@@ -164,6 +156,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-011f0a2e9cbd7ebab",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
     "resourceType": "AWS::EC2::Subnet",
@@ -138,14 +138,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-0b456bc01025cb129",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
       "resourceType": "AWS::EC2::Subnet",
@@ -164,6 +156,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-0b456bc01025cb129",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
     "resourceType": "AWS::EC2::Subnet",
@@ -138,14 +138,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-0434e5718302e4709",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
       "resourceType": "AWS::EC2::Subnet",
@@ -164,6 +156,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-0434e5718302e4709",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::Subnet with deep declared config classifies as recorded (undeclared:AvailabilityZoneId, undeclared:PrivateDnsNameOptionsOnLaunch, unresolved:AvailabilityZone). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
     "resourceType": "AWS::EC2::Subnet",
@@ -138,14 +138,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-0433dc95b5f60dbbc",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
       "resourceType": "AWS::EC2::Subnet",
@@ -164,6 +156,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-0433dc95b5f60dbbc",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
     }

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet1RouteTableAssociation70862F8D.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet1RouteTableAssociation70862F8D.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet1RouteTableAssociation70862F8D",
     "resourceType": "AWS::EC2::SubnetRouteTableAssociation",

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet2RouteTableAssociationA174BE42.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPrivateSubnet2RouteTableAssociationA174BE42.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPrivateSubnet2RouteTableAssociationA174BE42",
     "resourceType": "AWS::EC2::SubnetRouteTableAssociation",

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet1RouteTableAssociationF5003E3E.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet1RouteTableAssociationF5003E3E.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet1RouteTableAssociationF5003E3E",
     "resourceType": "AWS::EC2::SubnetRouteTableAssociation",

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet2RouteTableAssociationC0116C4D.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.WorkersVpcPublicSubnet2RouteTableAssociationC0116C4D.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::SubnetRouteTableAssociation with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcPublicSubnet2RouteTableAssociationC0116C4D",
     "resourceType": "AWS::EC2::SubnetRouteTableAssociation",

--- a/tests/corpus/AWS__EC2__VPC.WorkersVpcA828E13A.json
+++ b/tests/corpus/AWS__EC2__VPC.WorkersVpcA828E13A.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::VPC with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::VPC with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcA828E13A",
     "resourceType": "AWS::EC2::VPC",

--- a/tests/corpus/AWS__EC2__VPCGatewayAttachment.WorkersVpcVPCGWCCE585FA.json
+++ b/tests/corpus/AWS__EC2__VPCGatewayAttachment.WorkersVpcVPCGWCCE585FA.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::EC2::VPCGatewayAttachment with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::EC2::VPCGatewayAttachment with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkersVpcVPCGWCCE585FA",
     "resourceType": "AWS::EC2::VPCGatewayAttachment",

--- a/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
+++ b/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ECR::Repository model; surviving raw-classify findings locked as-is (EmptyOnDelete, EncryptionConfiguration, ImageTagMutability). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::ECR::Repository model; surviving raw-classify findings locked as-is (EmptyOnDelete, EncryptionConfiguration, ImageTagMutability). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Images2D38C313",
     "resourceType": "AWS::ECR::Repository",
@@ -76,7 +76,7 @@
       "logicalId": "Images2D38C313",
       "resourceType": "AWS::ECR::Repository",
       "path": "EmptyOnDelete",
-      "note": "write-only \u2014 cannot be read back",
+      "note": "write-only — cannot be read back",
       "physicalId": "cdkrdintegharvest-images2d38c313-8s5jtwfzwsmg",
       "constructPath": "CdkrdIntegHarvest/Images"
     },

--- a/tests/corpus/AWS__ECS__Cluster.Workers96E39E36.json
+++ b/tests/corpus/AWS__ECS__Cluster.Workers96E39E36.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::ECS::Cluster with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::ECS::Cluster with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Workers96E39E36",
     "resourceType": "AWS::ECS::Cluster",

--- a/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
@@ -75,8 +75,10 @@
       "tier": "undeclared",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "KmsKeyId",
-      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
       "physicalId": "fs-0679f705e7e468268",
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
@@ -95,8 +97,8 @@
       "tier": "undeclared",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "ThroughputMode",
-      "actual": "bursting",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
       "physicalId": "fs-0679f705e7e468268",
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
@@ -104,10 +106,8 @@
       "tier": "undeclared",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "BackupPolicy",
-      "actual": {
-        "Status": "DISABLED"
-      },
+      "path": "ThroughputMode",
+      "actual": "bursting",
       "physicalId": "fs-0679f705e7e468268",
       "constructPath": "CdkrdIntegHarvest4/Files"
     }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
@@ -193,6 +193,15 @@
       "tier": "undeclared",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "IpAddressType",
       "actual": "ipv4",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
@@ -204,15 +213,6 @@
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "Name",
       "actual": "CdkrdI-Edge7-ivPMKfmp3Fts",
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
-      "constructPath": "CdkrdIntegHarvest4/Edge"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Edge7038544F",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "EnablePrefixForIpv6SourceNat",
-      "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
@@ -182,6 +182,15 @@
       "tier": "undeclared",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
+      "constructPath": "CdkrdIntegHarvest4/Edge"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Edge7038544F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "IpAddressType",
       "actual": "ipv4",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
@@ -193,15 +202,6 @@
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "Name",
       "actual": "CdkrdI-Edge7-ivPMKfmp3Fts",
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
-      "constructPath": "CdkrdIntegHarvest4/Edge"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Edge7038544F",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "EnablePrefixForIpv6SourceNat",
-      "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
@@ -165,6 +165,42 @@
       "tier": "undeclared",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "HTTP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "IpAddressType",
       "actual": "ipv4",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
@@ -185,8 +221,8 @@
       "tier": "undeclared",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "HealthCheckEnabled",
-      "actual": true,
+      "path": "Name",
+      "actual": "CdkrdI-Web3C-B2EBJYBQ0UEJ",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
@@ -205,42 +241,6 @@
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "UnhealthyThresholdCount",
       "actual": 2,
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
-      "constructPath": "CdkrdIntegHarvest4/Web"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Web3C8945DB",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "HealthCheckTimeoutSeconds",
-      "actual": 5,
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
-      "constructPath": "CdkrdIntegHarvest4/Web"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Web3C8945DB",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "Name",
-      "actual": "CdkrdI-Web3C-B2EBJYBQ0UEJ",
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
-      "constructPath": "CdkrdIntegHarvest4/Web"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Web3C8945DB",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "HealthCheckProtocol",
-      "actual": "HTTP",
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
-      "constructPath": "CdkrdIntegHarvest4/Web"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Web3C8945DB",
-      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
-      "path": "HealthCheckPort",
-      "actual": "traffic-port",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
       "constructPath": "CdkrdIntegHarvest4/Web"
     }

--- a/tests/corpus/AWS__Events__EventBus.BusEA82B648.json
+++ b/tests/corpus/AWS__Events__EventBus.BusEA82B648.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Events::EventBus model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Events::EventBus model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "BusEA82B648",
     "resourceType": "AWS::Events::EventBus",

--- a/tests/corpus/AWS__Events__Rule.Forward9800F3B2.json
+++ b/tests/corpus/AWS__Events__Rule.Forward9800F3B2.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::Events::Rule with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::Events::Rule with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Forward9800F3B2",
     "resourceType": "AWS::Events::Rule",
@@ -76,5 +76,15 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Forward9800F3B2",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkrdIntegHarvest2-Forward9800F3B2-0WDy4EkYHPmy",
+      "constructPath": "CdkrdIntegHarvest2/Forward"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.drifted.json
+++ b/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.drifted.json
@@ -50,6 +50,15 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "MatrixRuleF1E32BBB",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+      "constructPath": "CdkrdIntegHarvest3/MatrixRule"
+    },
+    {
       "tier": "declared",
       "logicalId": "MatrixRuleF1E32BBB",
       "resourceType": "AWS::Events::Rule",

--- a/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.json
+++ b/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.json
@@ -48,5 +48,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixRuleF1E32BBB",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+      "constructPath": "CdkrdIntegHarvest3/MatrixRule"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Events__Rule.Tick6513F4AE.json
+++ b/tests/corpus/AWS__Events__Rule.Tick6513F4AE.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Events::Rule model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Events::Rule model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Tick6513F4AE",
     "resourceType": "AWS::Events::Rule",
@@ -63,5 +63,15 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Tick6513F4AE",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkrdIntegHarvest-Tick6513F4AE-chVZMFro0x9U",
+      "constructPath": "CdkrdIntegHarvest/Tick"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Glue__Database.Catalog.json
+++ b/tests/corpus/AWS__Glue__Database.Catalog.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Glue::Database model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Glue::Database model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Catalog",
     "resourceType": "AWS::Glue::Database",

--- a/tests/corpus/AWS__Glue__Job.GlueJob.json
+++ b/tests/corpus/AWS__Glue__Job.GlueJob.json
@@ -56,8 +56,19 @@
       "tier": "undeclared",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
-      "path": "MaxRetries",
+      "path": "AllocatedCapacity",
       "actual": 0,
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "ExecutionProperty",
+      "actual": {
+        "MaxConcurrentRuns": 1
+      },
       "physicalId": "cdkrd-harvest5",
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
     },
@@ -74,16 +85,7 @@
       "tier": "undeclared",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
-      "path": "Timeout",
-      "actual": 2880,
-      "physicalId": "cdkrd-harvest5",
-      "constructPath": "CdkrdIntegHarvest5/GlueJob"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "GlueJob",
-      "resourceType": "AWS::Glue::Job",
-      "path": "AllocatedCapacity",
+      "path": "MaxRetries",
       "actual": 0,
       "physicalId": "cdkrd-harvest5",
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
@@ -92,10 +94,8 @@
       "tier": "undeclared",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
-      "path": "ExecutionProperty",
-      "actual": {
-        "MaxConcurrentRuns": 1
-      },
+      "path": "Timeout",
+      "actual": 2880,
       "physicalId": "cdkrd-harvest5",
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
     }

--- a/tests/corpus/AWS__Glue__Table.Events.json
+++ b/tests/corpus/AWS__Glue__Table.Events.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Glue::Table model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Glue::Table model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Events",
     "resourceType": "AWS::Glue::Table",

--- a/tests/corpus/AWS__Glue__Table.EventsTable.json
+++ b/tests/corpus/AWS__Glue__Table.EventsTable.json
@@ -39,7 +39,11 @@
     "createOnlyPaths": ["DatabaseName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "declared",

--- a/tests/corpus/AWS__IAM__Policy.BuildRoleDefaultPolicyEAC4E6D6.json
+++ b/tests/corpus/AWS__IAM__Policy.BuildRoleDefaultPolicyEAC4E6D6.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Policy model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Policy model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "BuildRoleDefaultPolicyEAC4E6D6",
     "resourceType": "AWS::IAM::Policy",

--- a/tests/corpus/AWS__IAM__Policy.WorkerServiceRoleDefaultPolicyAE71B5FA.json
+++ b/tests/corpus/AWS__IAM__Policy.WorkerServiceRoleDefaultPolicyAE71B5FA.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::IAM::Policy with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::IAM::Policy with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkerServiceRoleDefaultPolicyAE71B5FA",
     "resourceType": "AWS::IAM::Policy",

--- a/tests/corpus/AWS__IAM__Role.AliasedFnServiceRole4A9555AA.json
+++ b/tests/corpus/AWS__IAM__Role.AliasedFnServiceRole4A9555AA.json
@@ -59,5 +59,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFnServiceRole4A9555AA",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFnServiceRole4A9555AA",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFnServiceRole4A9555AA",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn/ServiceRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.ApiFnServiceRoleD18AAE0E.json
+++ b/tests/corpus/AWS__IAM__Role.ApiFnServiceRoleD18AAE0E.json
@@ -59,5 +59,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnServiceRoleD18AAE0E",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnServiceRoleD18AAE0E",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnServiceRoleD18AAE0E",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn/ServiceRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.BuildRoleB7C66CB2.json
+++ b/tests/corpus/AWS__IAM__Role.BuildRoleB7C66CB2.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "BuildRoleB7C66CB2",
     "resourceType": "AWS::IAM::Role",
@@ -102,5 +102,33 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "BuildRoleB7C66CB2",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
+      "constructPath": "CdkrdIntegHarvest/Build/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BuildRoleB7C66CB2",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
+      "constructPath": "CdkrdIntegHarvest/Build/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "BuildRoleB7C66CB2",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
+      "constructPath": "CdkrdIntegHarvest/Build/Role"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.CbRole566E4F1D.json
+++ b/tests/corpus/AWS__IAM__Role.CbRole566E4F1D.json
@@ -57,5 +57,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CbRole566E4F1D",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
+      "constructPath": "CdkrdIntegHarvest6/CbRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CbRole566E4F1D",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
+      "constructPath": "CdkrdIntegHarvest6/CbRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CbRole566E4F1D",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
+      "constructPath": "CdkrdIntegHarvest6/CbRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092.json
+++ b/tests/corpus/AWS__IAM__Role.CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK-generated custom-resource provider role classifies fully CLEAN \u2014 KNOWN_DEFAULTS (MaxSessionDuration/Path), readOnly strips, and trust-policy canonicalization are all quiet on a genuine CC GetResource model.",
+  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK-generated custom-resource provider role classifies fully CLEAN — KNOWN_DEFAULTS (MaxSessionDuration/Path), readOnly strips, and trust-policy canonicalization are all quiet on a genuine CC GetResource model.",
   "resource": {
     "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
     "resourceType": "AWS::IAM::Role",
@@ -59,5 +59,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.Ec2Role2FD9A272.json
+++ b/tests/corpus/AWS__IAM__Role.Ec2Role2FD9A272.json
@@ -57,5 +57,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Ec2Role2FD9A272",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
+      "constructPath": "CdkrdIntegHarvest5/Ec2Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Ec2Role2FD9A272",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
+      "constructPath": "CdkrdIntegHarvest5/Ec2Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Ec2Role2FD9A272",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
+      "constructPath": "CdkrdIntegHarvest5/Ec2Role"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.ExpressRole9F822A77.json
+++ b/tests/corpus/AWS__IAM__Role.ExpressRole9F822A77.json
@@ -57,5 +57,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ExpressRole9F822A77",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+      "constructPath": "CdkrdIntegHarvest5/Express/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ExpressRole9F822A77",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+      "constructPath": "CdkrdIntegHarvest5/Express/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ExpressRole9F822A77",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
+      "constructPath": "CdkrdIntegHarvest5/Express/Role"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.FirehoseRoleAA67C190.json
+++ b/tests/corpus/AWS__IAM__Role.FirehoseRoleAA67C190.json
@@ -87,5 +87,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FirehoseRoleAA67C190",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FirehoseRoleAA67C190",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FirehoseRoleAA67C190",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.FlowRoleD99EA574.json
+++ b/tests/corpus/AWS__IAM__Role.FlowRoleD99EA574.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "FlowRoleD99EA574",
     "resourceType": "AWS::IAM::Role",
@@ -72,5 +72,33 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FlowRoleD99EA574",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+      "constructPath": "CdkrdIntegHarvest/Flow/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FlowRoleD99EA574",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+      "constructPath": "CdkrdIntegHarvest/Flow/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FlowRoleD99EA574",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
+      "constructPath": "CdkrdIntegHarvest/Flow/Role"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.GlueRoleDEDFFD2C.json
+++ b/tests/corpus/AWS__IAM__Role.GlueRoleDEDFFD2C.json
@@ -59,5 +59,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueRoleDEDFFD2C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+      "constructPath": "CdkrdIntegHarvest5/GlueRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueRoleDEDFFD2C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+      "constructPath": "CdkrdIntegHarvest5/GlueRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueRoleDEDFFD2C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
+      "constructPath": "CdkrdIntegHarvest5/GlueRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.MatrixFnServiceRoleF6E55B32.json
+++ b/tests/corpus/AWS__IAM__Role.MatrixFnServiceRoleF6E55B32.json
@@ -59,5 +59,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFnServiceRoleF6E55B32",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFnServiceRoleF6E55B32",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFnServiceRoleF6E55B32",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn/ServiceRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.PipeRole4D7B8476.json
+++ b/tests/corpus/AWS__IAM__Role.PipeRole4D7B8476.json
@@ -78,5 +78,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeRole4D7B8476",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+      "constructPath": "CdkrdIntegHarvest6/PipeRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeRole4D7B8476",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+      "constructPath": "CdkrdIntegHarvest6/PipeRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeRole4D7B8476",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
+      "constructPath": "CdkrdIntegHarvest6/PipeRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.ReadTargetRoleA9FE198C.json
+++ b/tests/corpus/AWS__IAM__Role.ReadTargetRoleA9FE198C.json
@@ -57,5 +57,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ReadTargetRoleA9FE198C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReadTargetRoleA9FE198C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ReadTargetRoleA9FE198C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
+      "constructPath": "CdkrdIntegHarvest4/ReadTarget/Role"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.RestApiCloudWatchRoleE3ED6605.json
+++ b/tests/corpus/AWS__IAM__Role.RestApiCloudWatchRoleE3ED6605.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::Role model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "RestApiCloudWatchRoleE3ED6605",
     "resourceType": "AWS::IAM::Role",
@@ -78,5 +78,33 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RestApiCloudWatchRoleE3ED6605",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
+      "constructPath": "CdkrdIntegHarvest/RestApi/CloudWatchRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RestApiCloudWatchRoleE3ED6605",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
+      "constructPath": "CdkrdIntegHarvest/RestApi/CloudWatchRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RestApiCloudWatchRoleE3ED6605",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
+      "constructPath": "CdkrdIntegHarvest/RestApi/CloudWatchRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.SchedRole812B2F5C.json
+++ b/tests/corpus/AWS__IAM__Role.SchedRole812B2F5C.json
@@ -73,5 +73,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SchedRole812B2F5C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+      "constructPath": "CdkrdIntegHarvest3/SchedRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SchedRole812B2F5C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+      "constructPath": "CdkrdIntegHarvest3/SchedRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SchedRole812B2F5C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
+      "constructPath": "CdkrdIntegHarvest3/SchedRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.ServiceRole.json
+++ b/tests/corpus/AWS__IAM__Role.ServiceRole.json
@@ -12,7 +12,9 @@
           {
             "Action": "sts:AssumeRole",
             "Effect": "Allow",
-            "Principal": { "Service": "lambda.amazonaws.com" }
+            "Principal": {
+              "Service": "lambda.amazonaws.com"
+            }
           }
         ],
         "Version": "2012-10-17"
@@ -29,7 +31,9 @@
         {
           "Action": ["sts:AssumeRole"],
           "Effect": "Allow",
-          "Principal": { "Service": "lambda.amazonaws.com" }
+          "Principal": {
+            "Service": "lambda.amazonaws.com"
+          }
         }
       ],
       "Version": "2012-10-17"
@@ -40,14 +44,26 @@
       {
         "PolicyName": "ServiceRoleDefaultPolicy",
         "PolicyDocument": {
-          "Statement": [{ "Action": ["s3:PutObject"], "Effect": "Allow", "Resource": ["*"] }],
+          "Statement": [
+            {
+              "Action": ["s3:PutObject"],
+              "Effect": "Allow",
+              "Resource": ["*"]
+            }
+          ],
           "Version": "2012-10-17"
         }
       },
       {
         "PolicyName": "ttttt",
         "PolicyDocument": {
-          "Statement": [{ "Action": ["s3:GetObject"], "Effect": "Allow", "Resource": ["*"] }],
+          "Statement": [
+            {
+              "Action": ["s3:GetObject"],
+              "Effect": "Allow",
+              "Resource": ["*"]
+            }
+          ],
           "Version": "2012-10-17"
         }
       }
@@ -62,8 +78,30 @@
     "createOnlyPaths": ["RoleName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ServiceRole",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CorpusStack-ServiceRole-ABC123",
+      "constructPath": "CorpusStack/Service/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ServiceRole",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CorpusStack-ServiceRole-ABC123",
+      "constructPath": "CorpusStack/Service/Role"
+    },
     {
       "tier": "undeclared",
       "logicalId": "ServiceRole",
@@ -73,7 +111,13 @@
         {
           "PolicyName": "ttttt",
           "PolicyDocument": {
-            "Statement": [{ "Action": ["s3:GetObject"], "Effect": "Allow", "Resource": ["*"] }],
+            "Statement": [
+              {
+                "Action": ["s3:GetObject"],
+                "Effect": "Allow",
+                "Resource": ["*"]
+              }
+            ],
             "Version": "2012-10-17"
           }
         }

--- a/tests/corpus/AWS__IAM__Role.TaskExecRoleA2BBB60C.json
+++ b/tests/corpus/AWS__IAM__Role.TaskExecRoleA2BBB60C.json
@@ -57,5 +57,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskExecRoleA2BBB60C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+      "constructPath": "CdkrdIntegHarvest6/TaskExecRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskExecRoleA2BBB60C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+      "constructPath": "CdkrdIntegHarvest6/TaskExecRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskExecRoleA2BBB60C",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
+      "constructPath": "CdkrdIntegHarvest6/TaskExecRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.TestRole.permissions-boundary.json
+++ b/tests/corpus/AWS__IAM__Role.TestRole.permissions-boundary.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (iam integ run): the README headline use case \u2014 an out-of-band PermissionsBoundary attached to a real CDK role surfaces as the ONLY finding, while the sibling DefaultPolicy reflection, trust-policy canonicalization, and IAM KNOWN_DEFAULTS all stay quiet.",
+  "description": "RECORDED LIVE (iam integ run): the README headline use case — an out-of-band PermissionsBoundary attached to a real CDK role surfaces as the ONLY finding, while the sibling DefaultPolicy reflection, trust-policy canonicalization, and IAM KNOWN_DEFAULTS all stay quiet.",
   "resource": {
     "logicalId": "TestRole6C9272DF",
     "resourceType": "AWS::IAM::Role",
@@ -76,6 +76,24 @@
     "kmsAliasTargets": {}
   },
   "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TestRole6C9272DF",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
+      "constructPath": "CdkRealDriftIntegIam/TestRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestRole6C9272DF",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
+      "constructPath": "CdkRealDriftIntegIam/TestRole"
+    },
     {
       "tier": "undeclared",
       "logicalId": "TestRole6C9272DF",

--- a/tests/corpus/AWS__IAM__Role.UrlFnServiceRole8FBBFD8A.json
+++ b/tests/corpus/AWS__IAM__Role.UrlFnServiceRole8FBBFD8A.json
@@ -59,5 +59,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnServiceRole8FBBFD8A",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnServiceRole8FBBFD8A",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnServiceRole8FBBFD8A",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn/ServiceRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.WorkerServiceRole8543584E.json
+++ b/tests/corpus/AWS__IAM__Role.WorkerServiceRole8543584E.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::IAM::Role with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::IAM::Role with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "WorkerServiceRole8543584E",
     "resourceType": "AWS::IAM::Role",
@@ -90,5 +90,33 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkerServiceRole8543584E",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+      "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkerServiceRole8543584E",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+      "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkerServiceRole8543584E",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
+      "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__User.AuditorB9A7BEA8.json
+++ b/tests/corpus/AWS__IAM__User.AuditorB9A7BEA8.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::User model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::IAM::User model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "AuditorB9A7BEA8",
     "resourceType": "AWS::IAM::User",

--- a/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
+++ b/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
@@ -78,6 +78,42 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeySpec",
+      "actual": "SYMMETRIC_DEFAULT",
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyUsage",
+      "actual": "ENCRYPT_DECRYPT",
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "MultiRegion",
+      "actual": false,
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Origin",
+      "actual": "AWS_KMS",
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    },
+    {
       "tier": "readGap",
       "logicalId": "DataKey17AFBB84",
       "resourceType": "AWS::KMS::Key",

--- a/tests/corpus/AWS__Kinesis__Stream.EventsD32975C2.json
+++ b/tests/corpus/AWS__Kinesis__Stream.EventsD32975C2.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::Kinesis::Stream with deep declared config classifies as recorded (undeclared:MaxRecordSizeInKiB). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::Kinesis::Stream with deep declared config classifies as recorded (undeclared:MaxRecordSizeInKiB). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "EventsD32975C2",
     "resourceType": "AWS::Kinesis::Stream",
@@ -68,6 +68,17 @@
     }
   },
   "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EventsD32975C2",
+      "resourceType": "AWS::Kinesis::Stream",
+      "path": "StreamModeDetails",
+      "actual": {
+        "StreamMode": "PROVISIONED"
+      },
+      "physicalId": "CdkrdIntegHarvest2-EventsD32975C2-IyHLeNv132l2",
+      "constructPath": "CdkrdIntegHarvest2/Events"
+    },
     {
       "tier": "undeclared",
       "logicalId": "EventsD32975C2",

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.QueueTrigger.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.QueueTrigger.json
@@ -25,7 +25,11 @@
     "createOnlyPaths": ["EventSourceArn"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "declared",

--- a/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
+++ b/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
@@ -92,6 +92,84 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "AliasedFn19257E6A",
       "resourceType": "AWS::Lambda::Function",

--- a/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
+++ b/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
@@ -92,6 +92,84 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "ApiFnE0725F78",
       "resourceType": "AWS::Lambda::Function",

--- a/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
+++ b/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK-generated Lambda; the R66 KNOWN_DEFAULTS keep everything quiet EXCEPT LoggingConfig (per-function LogGroup name \u2014 not a constant, so deliberately not blanket-suppressed; current behavior locked).",
+  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK-generated Lambda; the R66 KNOWN_DEFAULTS keep everything quiet EXCEPT LoggingConfig (per-function LogGroup name — not a constant, so deliberately not blanket-suppressed; current behavior locked).",
   "resource": {
     "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
     "resourceType": "AWS::Lambda::Function",
@@ -95,6 +95,66 @@
     "kmsAliasTargets": {}
   },
   "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
     {
       "tier": "undeclared",
       "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",

--- a/tests/corpus/AWS__Lambda__Function.Handler.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler.json
@@ -26,15 +26,22 @@
     "readOnlyPaths": ["Arn"],
     "writeOnlyPaths": [],
     "createOnlyPaths": ["FunctionName"],
-    "defaults": { "PackageType": "Zip" }
+    "defaults": {
+      "PackageType": "Zip"
+    }
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "Handler",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Role",
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "corpus-handler"
     },
     {
@@ -43,6 +50,13 @@
       "resourceType": "AWS::Lambda::Function",
       "path": "ReservedConcurrentExecutions",
       "actual": 5,
+      "physicalId": "corpus-handler"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "Handler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Role",
       "physicalId": "corpus-handler"
     }
   ]

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
@@ -94,6 +94,66 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
       "tier": "declared",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
@@ -99,6 +99,66 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",

--- a/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
+++ b/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (lambda integ run): a real default-config Node Lambda; with the R66+R70 KNOWN_DEFAULTS the only survivors are the deliberately INJECTED ReservedConcurrentExecutions=1 and the per-function LoggingConfig (LogGroup name is function-specific \u2014 deliberately not blanket-suppressed).",
+  "description": "RECORDED LIVE (lambda integ run): a real default-config Node Lambda; with the R66+R70 KNOWN_DEFAULTS the only survivors are the deliberately INJECTED ReservedConcurrentExecutions=1 and the per-function LoggingConfig (LogGroup name is function-specific — deliberately not blanket-suppressed).",
   "resource": {
     "logicalId": "TestFn04335C60",
     "resourceType": "AWS::Lambda::Function",
@@ -94,11 +94,80 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "TestFn04335C60",
       "resourceType": "AWS::Lambda::Function",
-      "path": "ReservedConcurrentExecutions",
-      "actual": 1,
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
       "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
       "constructPath": "CdkRealDriftIntegLambda/TestFn"
     },
@@ -111,6 +180,15 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92"
       },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "ReservedConcurrentExecutions",
+      "actual": 1,
       "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
       "constructPath": "CdkRealDriftIntegLambda/TestFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
+++ b/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
@@ -92,6 +92,84 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "UrlFnE068003E",
       "resourceType": "AWS::Lambda::Function",

--- a/tests/corpus/AWS__Lambda__Function.VpcHandler.json
+++ b/tests/corpus/AWS__Lambda__Function.VpcHandler.json
@@ -23,8 +23,12 @@
       "SubnetIds": ["subnet-0ccccc333333", "subnet-0ddddd444444"]
     },
     "PackageType": "Zip",
-    "TracingConfig": { "Mode": "PassThrough" },
-    "EphemeralStorage": { "Size": 512 },
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "EphemeralStorage": {
+      "Size": 512
+    },
     "Architectures": ["x86_64"]
   },
   "schema": {
@@ -36,6 +40,47 @@
     "createOnlyPaths": ["FunctionName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
-  "expected": []
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcHandler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "corpus-vpc-handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcHandler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "corpus-vpc-handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcHandler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "corpus-vpc-handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcHandler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "corpus-vpc-handler"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
+++ b/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::Lambda::Function with deep declared config classifies as recorded (undeclared:LoggingConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::Lambda::Function with deep declared config classifies as recorded (undeclared:LoggingConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Worker11F36D0F",
     "resourceType": "AWS::Lambda::Function",
@@ -124,6 +124,46 @@
     }
   },
   "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Worker11F36D0F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+      "constructPath": "CdkrdIntegHarvest2/Worker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Worker11F36D0F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+      "constructPath": "CdkrdIntegHarvest2/Worker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Worker11F36D0F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+      "constructPath": "CdkrdIntegHarvest2/Worker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Worker11F36D0F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+      "constructPath": "CdkrdIntegHarvest2/Worker"
+    },
     {
       "tier": "undeclared",
       "logicalId": "Worker11F36D0F",

--- a/tests/corpus/AWS__Lambda__Url.FnUrl.json
+++ b/tests/corpus/AWS__Lambda__Url.FnUrl.json
@@ -32,5 +32,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FnUrl",
+      "resourceType": "AWS::Lambda::Url",
+      "path": "InvokeMode",
+      "actual": "BUFFERED",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/FnUrl"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Lambda__Version.AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df.json
+++ b/tests/corpus/AWS__Lambda__Version.AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df.json
@@ -51,10 +51,8 @@
       "tier": "undeclared",
       "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
       "resourceType": "AWS::Lambda::Version",
-      "path": "RuntimePolicy",
-      "actual": {
-        "UpdateRuntimeOn": "Auto"
-      },
+      "path": "CodeSha256",
+      "actual": "pYaOwiRWhhzD/erZKRp1WZbhCcuhmh7CovRZdCS9P3w=",
       "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion"
     },
@@ -62,8 +60,10 @@
       "tier": "undeclared",
       "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
       "resourceType": "AWS::Lambda::Version",
-      "path": "CodeSha256",
-      "actual": "pYaOwiRWhhzD/erZKRp1WZbhCcuhmh7CovRZdCS9P3w=",
+      "path": "RuntimePolicy",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
       "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion"
     }

--- a/tests/corpus/AWS__Logs__LogGroup.AppLogsC5DF83A6.json
+++ b/tests/corpus/AWS__Logs__LogGroup.AppLogsC5DF83A6.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Logs::LogGroup model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Logs::LogGroup model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "AppLogsC5DF83A6",
     "resourceType": "AWS::Logs::LogGroup",
@@ -67,5 +67,33 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AppLogsC5DF83A6",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "BearerTokenAuthenticationEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+      "constructPath": "CdkrdIntegHarvest/AppLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AppLogsC5DF83A6",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+      "constructPath": "CdkrdIntegHarvest/AppLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AppLogsC5DF83A6",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
+      "physicalId": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
+      "constructPath": "CdkrdIntegHarvest/AppLogs"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.drifted.json
+++ b/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.drifted.json
@@ -54,6 +54,33 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "BearerTokenAuthenticationEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    },
+    {
       "tier": "declared",
       "logicalId": "MatrixLogsDDD521D9",
       "resourceType": "AWS::Logs::LogGroup",

--- a/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.json
+++ b/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.json
@@ -52,5 +52,33 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "BearerTokenAuthenticationEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixLogsDDD521D9",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
+      "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
+      "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Logs__MetricFilter.ErrorsFA5270DE.json
+++ b/tests/corpus/AWS__Logs__MetricFilter.ErrorsFA5270DE.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Logs::MetricFilter model; surviving raw-classify findings locked as-is (none \u2014 fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::Logs::MetricFilter model; surviving raw-classify findings locked as-is (none — fully CLEAN). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "ErrorsFA5270DE",
     "resourceType": "AWS::Logs::MetricFilter",

--- a/tests/corpus/AWS__Redshift__Cluster.Warehouse.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Warehouse.json
@@ -23,7 +23,11 @@
     "createOnlyPaths": [],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "readGap",

--- a/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
+++ b/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::S3::Bucket with deep declared config classifies as recorded (undeclared:BucketEncryption, undeclared:OwnershipControls). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::S3::Bucket with deep declared config classifies as recorded (undeclared:BucketEncryption, undeclared:OwnershipControls). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "ArchiveDA4CB258",
     "resourceType": "AWS::S3::Bucket",
@@ -205,7 +205,16 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
+      "logicalId": "ArchiveDA4CB258",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+      "constructPath": "CdkrdIntegHarvest2/Archive"
+    },
+    {
+      "tier": "atDefault",
       "logicalId": "ArchiveDA4CB258",
       "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
@@ -226,7 +235,7 @@
       "constructPath": "CdkrdIntegHarvest2/Archive"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ArchiveDA4CB258",
       "resourceType": "AWS::S3::Bucket",
       "path": "OwnershipControls",

--- a/tests/corpus/AWS__S3__Bucket.Assets9A31D427.json
+++ b/tests/corpus/AWS__S3__Bucket.Assets9A31D427.json
@@ -114,22 +114,16 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Assets9A31D427",
       "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
-      "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
-          }
-        ]
-      },
+      "path": "AbacStatus",
+      "actual": "Disabled",
       "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
       "constructPath": "CdkrdIntegCloudfront/Assets"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Assets9A31D427",
       "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
@@ -143,6 +137,21 @@
             "ServerSideEncryptionByDefault": {
               "SSEAlgorithm": "AES256"
             }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+      "constructPath": "CdkrdIntegCloudfront/Assets"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Assets9A31D427",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
           }
         ]
       },

--- a/tests/corpus/AWS__S3__Bucket.AuditLogsB945E340.json
+++ b/tests/corpus/AWS__S3__Bucket.AuditLogsB945E340.json
@@ -114,22 +114,16 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AuditLogsB945E340",
       "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
-      "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
-          }
-        ]
-      },
+      "path": "AbacStatus",
+      "actual": "Disabled",
       "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
       "constructPath": "CdkrdIntegHarvest3/AuditLogs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AuditLogsB945E340",
       "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
@@ -143,6 +137,21 @@
             "ServerSideEncryptionByDefault": {
               "SSEAlgorithm": "AES256"
             }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+      "constructPath": "CdkrdIntegHarvest3/AuditLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AuditLogsB945E340",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
           }
         ]
       },

--- a/tests/corpus/AWS__S3__Bucket.CorpusBucket.json
+++ b/tests/corpus/AWS__S3__Bucket.CorpusBucket.json
@@ -12,10 +12,19 @@
   "liveRaw": {
     "BucketName": "corpus-bucket",
     "Arn": "arn:aws:s3:::corpus-bucket",
-    "AccelerateConfiguration": { "AccelerationStatus": "Enabled" },
-    "VersioningConfiguration": { "Status": "Suspended" },
+    "AccelerateConfiguration": {
+      "AccelerationStatus": "Enabled"
+    },
+    "VersioningConfiguration": {
+      "Status": "Suspended"
+    },
     "AnalyticsConfigurations": [],
-    "Tags": [{ "Key": "aws:cloudformation:stack-name", "Value": "CorpusStack" }]
+    "Tags": [
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CorpusStack"
+      }
+    ]
   },
   "schema": {
     "readOnly": ["Arn"],
@@ -26,14 +35,30 @@
     "createOnlyPaths": ["BucketName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CorpusBucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "VersioningConfiguration",
+      "actual": {
+        "Status": "Suspended"
+      },
+      "physicalId": "corpus-bucket"
+    },
     {
       "tier": "undeclared",
       "logicalId": "CorpusBucket",
       "resourceType": "AWS::S3::Bucket",
       "path": "AccelerateConfiguration",
-      "actual": { "AccelerationStatus": "Enabled" },
+      "actual": {
+        "AccelerationStatus": "Enabled"
+      },
       "physicalId": "corpus-bucket"
     }
   ]

--- a/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
+++ b/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
@@ -126,18 +126,31 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::S3::Bucket",
-      "path": "AccelerateConfiguration",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
+      "constructPath": "CdkdriftIntegBasic/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
       "actual": {
-        "AccelerationStatus": "Suspended"
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
       },
       "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
       "constructPath": "CdkdriftIntegBasic/Data"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::S3::Bucket",
       "path": "PublicAccessBlockConfiguration",
@@ -154,13 +167,9 @@
       "tier": "undeclared",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
+      "path": "AccelerateConfiguration",
       "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
-          }
-        ]
+        "AccelerationStatus": "Suspended"
       },
       "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
       "constructPath": "CdkdriftIntegBasic/Data"

--- a/tests/corpus/AWS__S3__Bucket.FirehoseSinkB757FE18.json
+++ b/tests/corpus/AWS__S3__Bucket.FirehoseSinkB757FE18.json
@@ -114,22 +114,16 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FirehoseSinkB757FE18",
       "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
-      "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
-          }
-        ]
-      },
+      "path": "AbacStatus",
+      "actual": "Disabled",
       "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
       "constructPath": "CdkrdIntegHarvest3/FirehoseSink"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FirehoseSinkB757FE18",
       "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
@@ -143,6 +137,21 @@
             "ServerSideEncryptionByDefault": {
               "SSEAlgorithm": "AES256"
             }
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseSink"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FirehoseSinkB757FE18",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
           }
         ]
       },

--- a/tests/corpus/AWS__S3__BucketPolicy.ArchivePolicyC780D5C8.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.ArchivePolicyC780D5C8.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::S3::BucketPolicy with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::S3::BucketPolicy with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "ArchivePolicyC780D5C8",
     "resourceType": "AWS::S3::BucketPolicy",

--- a/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.enforce-ssl.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.enforce-ssl.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (first policies integ run) \u2014 the R69 regression case: a real CDK enforceSSL-style bucket policy whose Condition.Bool[\"aws:SecureTransport\"] the old strip-any-aws:-map-key rule DELETED from the live side (desired-vs-undefined false drift). With the strip scoped to Tags maps, this classifies CLEAN.",
+  "description": "RECORDED LIVE (first policies integ run) — the R69 regression case: a real CDK enforceSSL-style bucket policy whose Condition.Bool[\"aws:SecureTransport\"] the old strip-any-aws:-map-key rule DELETED from the live side (desired-vs-undefined false drift). With the strip scoped to Tags maps, this classifies CLEAN.",
   "resource": {
     "logicalId": "DataPolicyB80589C3",
     "resourceType": "AWS::S3::BucketPolicy",

--- a/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.DataPolicyB80589C3.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK auto-delete bucket policy read via the SDK override classifies fully CLEAN \u2014 policy canonicalization is quiet on a genuine round-tripped document.",
+  "description": "RECORDED LIVE (mutation-matrix integ run): a real CDK auto-delete bucket policy read via the SDK override classifies fully CLEAN — policy canonicalization is quiet on a genuine round-tripped document.",
   "resource": {
     "logicalId": "DataPolicyB80589C3",
     "resourceType": "AWS::S3::BucketPolicy",

--- a/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
+++ b/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
@@ -52,9 +52,9 @@
       "tier": "undeclared",
       "logicalId": "Mailer",
       "resourceType": "AWS::SES::ConfigurationSet",
-      "path": "SendingOptions",
+      "path": "ReputationOptions",
       "actual": {
-        "SendingEnabled": true
+        "ReputationMetricsEnabled": true
       },
       "physicalId": "cdkrd-harvest3",
       "constructPath": "CdkrdIntegHarvest3/Mailer"
@@ -63,9 +63,9 @@
       "tier": "undeclared",
       "logicalId": "Mailer",
       "resourceType": "AWS::SES::ConfigurationSet",
-      "path": "ReputationOptions",
+      "path": "SendingOptions",
       "actual": {
-        "ReputationMetricsEnabled": true
+        "SendingEnabled": true
       },
       "physicalId": "cdkrd-harvest3",
       "constructPath": "CdkrdIntegHarvest3/Mailer"

--- a/tests/corpus/AWS__SNS__Subscription.InboxCdkrdIntegHarvest2Alerts473B90C08943AC11.json
+++ b/tests/corpus/AWS__SNS__Subscription.InboxCdkrdIntegHarvest2Alerts473B90C08943AC11.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SNS::Subscription with deep declared config classifies as recorded (undeclared:FilterPolicyScope). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SNS::Subscription with deep declared config classifies as recorded (undeclared:FilterPolicyScope). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "InboxCdkrdIntegHarvest2Alerts473B90C08943AC11",
     "resourceType": "AWS::SNS::Subscription",

--- a/tests/corpus/AWS__SNS__Topic.Alerts91F83244.json
+++ b/tests/corpus/AWS__SNS__Topic.Alerts91F83244.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SNS::Topic with deep declared config classifies as recorded (undeclared:Subscription, undeclared:TopicName). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SNS::Topic with deep declared config classifies as recorded (undeclared:Subscription, undeclared:TopicName). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Alerts91F83244",
     "resourceType": "AWS::SNS::Topic",

--- a/tests/corpus/AWS__SNS__Topic.BillingAlarmTopic.json
+++ b/tests/corpus/AWS__SNS__Topic.BillingAlarmTopic.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (dogfood): a Chatbot-service-created Subscription on a real SNS topic surfaces as the one undeclared value \u2014 genuinely out-of-band state from the template's perspective (true positive).",
+  "description": "RECORDED LIVE (dogfood): a Chatbot-service-created Subscription on a real SNS topic surfaces as the one undeclared value — genuinely out-of-band state from the template's perspective (true positive).",
   "resource": {
     "logicalId": "BillingAlarmTopic299F87AA",
     "resourceType": "AWS::SNS::Topic",

--- a/tests/corpus/AWS__SNS__TopicPolicy.AlarmTopicPolicy.json
+++ b/tests/corpus/AWS__SNS__TopicPolicy.AlarmTopicPolicy.json
@@ -13,14 +13,18 @@
           {
             "Sid": "AllowPublish",
             "Effect": "Allow",
-            "Principal": { "Service": "cloudwatch.amazonaws.com" },
+            "Principal": {
+              "Service": "cloudwatch.amazonaws.com"
+            },
             "Action": "sns:Publish",
             "Resource": "arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"
           },
           {
             "Sid": "AllowSubscribe",
             "Effect": "Allow",
-            "Principal": { "Service": "events.amazonaws.com" },
+            "Principal": {
+              "Service": "events.amazonaws.com"
+            },
             "Action": "sns:Subscribe",
             "Resource": "arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"
           }
@@ -36,14 +40,18 @@
         {
           "Sid": "AllowSubscribe",
           "Effect": "Allow",
-          "Principal": { "Service": "events.amazonaws.com" },
+          "Principal": {
+            "Service": "events.amazonaws.com"
+          },
           "Action": ["sns:Subscribe"],
           "Resource": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"]
         },
         {
           "Sid": "AllowPublish",
           "Effect": "Allow",
-          "Principal": { "Service": "cloudwatch.amazonaws.com" },
+          "Principal": {
+            "Service": "cloudwatch.amazonaws.com"
+          },
           "Action": ["sns:Publish"],
           "Resource": ["arn:aws:sns:us-east-1:111111111111:corpus-alarm-topic"]
         }
@@ -59,6 +67,10 @@
     "createOnlyPaths": [],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": []
 }

--- a/tests/corpus/AWS__SQS__Queue.EncryptedQueue.json
+++ b/tests/corpus/AWS__SQS__Queue.EncryptedQueue.json
@@ -24,6 +24,10 @@
     "createOnlyPaths": ["QueueName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": []
 }

--- a/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
+++ b/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DelaySeconds, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled, undeclared:VisibilityTimeout). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DelaySeconds, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled, undeclared:VisibilityTimeout). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "InboxA8E05DC3",
     "resourceType": "AWS::SQS::Queue",
@@ -53,35 +53,8 @@
       "tier": "undeclared",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
-      "constructPath": "CdkrdIntegHarvest2/Inbox"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "InboxA8E05DC3",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
-      "constructPath": "CdkrdIntegHarvest2/Inbox"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "InboxA8E05DC3",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
-      "constructPath": "CdkrdIntegHarvest2/Inbox"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "InboxA8E05DC3",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
@@ -98,8 +71,8 @@
       "tier": "undeclared",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
@@ -109,6 +82,33 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     }

--- a/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DelaySeconds, undeclared:FifoThroughputLimit, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DelaySeconds, undeclared:FifoThroughputLimit, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "JobsDF1CC2D4",
     "resourceType": "AWS::SQS::Queue",
@@ -70,7 +70,7 @@
       "tier": "undeclared",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
+      "path": "DelaySeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
       "constructPath": "CdkrdIntegHarvest2/Jobs"
@@ -97,24 +97,6 @@
       "tier": "undeclared",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
-      "constructPath": "CdkrdIntegHarvest2/Jobs"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "JobsDF1CC2D4",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
-      "constructPath": "CdkrdIntegHarvest2/Jobs"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "JobsDF1CC2D4",
-      "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
       "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
@@ -126,6 +108,24 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     }

--- a/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DeduplicationScope, undeclared:DelaySeconds, undeclared:FifoThroughputLimit, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled, undeclared:VisibilityTimeout). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SQS::Queue with deep declared config classifies as recorded (undeclared:DeduplicationScope, undeclared:DelaySeconds, undeclared:FifoThroughputLimit, undeclared:MaximumMessageSize, undeclared:MessageRetentionPeriod, undeclared:QueueName, undeclared:ReceiveMessageWaitTimeSeconds, undeclared:SqsManagedSseEnabled, undeclared:VisibilityTimeout). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "JobsDlqB53173A1",
     "resourceType": "AWS::SQS::Queue",
@@ -59,7 +59,16 @@
       "tier": "undeclared",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
+      "path": "DeduplicationScope",
+      "actual": "queue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
@@ -86,8 +95,26 @@
       "tier": "undeclared",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
@@ -104,35 +131,8 @@
       "tier": "undeclared",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "JobsDlqB53173A1",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "JobsDlqB53173A1",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "DeduplicationScope",
-      "actual": "queue",
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "JobsDlqB53173A1",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     }

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
@@ -51,24 +51,6 @@
       "tier": "undeclared",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
@@ -89,6 +71,24 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     }

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
@@ -41,24 +41,6 @@
       "tier": "undeclared",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
@@ -79,6 +61,24 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     }

--- a/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
@@ -38,35 +38,8 @@
       "tier": "undeclared",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
-      "constructPath": "CdkrdIntegHarvest6/PipeDst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeDstD49C8EAB",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
-      "constructPath": "CdkrdIntegHarvest6/PipeDst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeDstD49C8EAB",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
-      "constructPath": "CdkrdIntegHarvest6/PipeDst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeDstD49C8EAB",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
@@ -83,8 +56,8 @@
       "tier": "undeclared",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
@@ -94,6 +67,33 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     }

--- a/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
@@ -38,35 +38,8 @@
       "tier": "undeclared",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
-      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeSrc0E082391",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
-      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeSrc0E082391",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
-      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeSrc0E082391",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
@@ -83,8 +56,8 @@
       "tier": "undeclared",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
@@ -94,6 +67,33 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     }

--- a/tests/corpus/AWS__SQS__Queue.WorkQueue.json
+++ b/tests/corpus/AWS__SQS__Queue.WorkQueue.json
@@ -27,7 +27,11 @@
     "createOnlyPaths": ["QueueName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "declared",

--- a/tests/corpus/AWS__SQS__QueuePolicy.InboxPolicy63A7501F.json
+++ b/tests/corpus/AWS__SQS__QueuePolicy.InboxPolicy63A7501F.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::SQS::QueuePolicy with deep declared config classifies as recorded (none \u2014 fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SQS::QueuePolicy with deep declared config classifies as recorded (none — fully CLEAN). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "InboxPolicy63A7501F",
     "resourceType": "AWS::SQS::QueuePolicy",

--- a/tests/corpus/AWS__SQS__QueuePolicy.WorkQueuePolicy.json
+++ b/tests/corpus/AWS__SQS__QueuePolicy.WorkQueuePolicy.json
@@ -12,7 +12,9 @@
         "Statement": [
           {
             "Effect": "Allow",
-            "Principal": { "AWS": "arn:aws:iam::111111111111:root" },
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
             "Action": ["sqs:SendMessage"],
             "Resource": ["arn:aws:sqs:us-east-1:111111111111:corpus-work-queue"]
           },
@@ -49,7 +51,9 @@
         },
         {
           "Effect": "Allow",
-          "Principal": { "AWS": "111111111111" },
+          "Principal": {
+            "AWS": "111111111111"
+          },
           "Action": ["sqs:SendMessage"],
           "Resource": ["arn:aws:sqs:us-east-1:111111111111:corpus-work-queue"]
         }
@@ -65,6 +69,10 @@
     "createOnlyPaths": [],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": []
 }

--- a/tests/corpus/AWS__SSM__Document.Runbook.json
+++ b/tests/corpus/AWS__SSM__Document.Runbook.json
@@ -78,5 +78,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Runbook",
+      "resourceType": "AWS::SSM::Document",
+      "path": "DocumentFormat",
+      "actual": "JSON",
+      "physicalId": "CdkrdIntegHarvest4-Runbook-EFhGaKUli3ve",
+      "constructPath": "CdkrdIntegHarvest4/Runbook"
+    }
+  ]
 }

--- a/tests/corpus/AWS__SSM__Parameter.FlagC3248847.json
+++ b/tests/corpus/AWS__SSM__Parameter.FlagC3248847.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::SSM::Parameter model; surviving raw-classify findings locked as-is (DataType). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::SSM::Parameter model; surviving raw-classify findings locked as-is (DataType). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "FlagC3248847",
     "resourceType": "AWS::SSM::Parameter",

--- a/tests/corpus/AWS__SSM__PatchBaseline.Patch.json
+++ b/tests/corpus/AWS__SSM__PatchBaseline.Patch.json
@@ -87,5 +87,42 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Patch",
+      "resourceType": "AWS::SSM::PatchBaseline",
+      "path": "ApprovedPatchesComplianceLevel",
+      "actual": "UNSPECIFIED",
+      "physicalId": "pb-0dc7b8f7d8aa1a1a3",
+      "constructPath": "CdkrdIntegHarvest6/Patch"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Patch",
+      "resourceType": "AWS::SSM::PatchBaseline",
+      "path": "ApprovedPatchesEnableNonSecurity",
+      "actual": false,
+      "physicalId": "pb-0dc7b8f7d8aa1a1a3",
+      "constructPath": "CdkrdIntegHarvest6/Patch"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Patch",
+      "resourceType": "AWS::SSM::PatchBaseline",
+      "path": "DefaultBaseline",
+      "actual": false,
+      "physicalId": "pb-0dc7b8f7d8aa1a1a3",
+      "constructPath": "CdkrdIntegHarvest6/Patch"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Patch",
+      "resourceType": "AWS::SSM::PatchBaseline",
+      "path": "RejectedPatchesAction",
+      "actual": "ALLOW_AS_DEPENDENCY",
+      "physicalId": "pb-0dc7b8f7d8aa1a1a3",
+      "constructPath": "CdkrdIntegHarvest6/Patch"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
@@ -57,8 +57,8 @@
       "tier": "undeclared",
       "logicalId": "HourlyPing",
       "resourceType": "AWS::Scheduler::Schedule",
-      "path": "ScheduleExpressionTimezone",
-      "actual": "UTC",
+      "path": "ActionAfterCompletion",
+      "actual": "NONE",
       "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
       "constructPath": "CdkrdIntegHarvest3/HourlyPing"
     },
@@ -66,8 +66,8 @@
       "tier": "undeclared",
       "logicalId": "HourlyPing",
       "resourceType": "AWS::Scheduler::Schedule",
-      "path": "ActionAfterCompletion",
-      "actual": "NONE",
+      "path": "ScheduleExpressionTimezone",
+      "actual": "UTC",
       "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
       "constructPath": "CdkrdIntegHarvest3/HourlyPing"
     }

--- a/tests/corpus/AWS__StepFunctions__Activity.Act869B7EB7.json
+++ b/tests/corpus/AWS__StepFunctions__Activity.Act869B7EB7.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::StepFunctions::Activity model; surviving raw-classify findings locked as-is (EncryptionConfiguration). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::StepFunctions::Activity model; surviving raw-classify findings locked as-is (EncryptionConfiguration). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "Act869B7EB7",
     "resourceType": "AWS::StepFunctions::Activity",

--- a/tests/corpus/AWS__StepFunctions__StateMachine.Flow.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.Flow.json
@@ -30,14 +30,20 @@
     "createOnlyPaths": ["StateMachineName"],
     "defaults": {}
   },
-  "opts": { "accountId": "111111111111", "region": "us-east-1", "kmsAliasTargets": {} },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
   "expected": [
     {
       "tier": "undeclared",
       "logicalId": "Flow",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "LoggingConfiguration",
-      "actual": { "Level": "OFF" },
+      "actual": {
+        "Level": "OFF"
+      },
       "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:corpus-flow"
     }
   ]

--- a/tests/corpus/AWS__StepFunctions__StateMachine.FlowA74D6E88.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.FlowA74D6E88.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::StepFunctions::StateMachine model; surviving raw-classify findings locked as-is (EncryptionConfiguration, LoggingConfiguration, StateMachineName, StateMachineType). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
+  "description": "RECORDED LIVE (harvest fixture, R71): fresh-deploy AWS::StepFunctions::StateMachine model; surviving raw-classify findings locked as-is (EncryptionConfiguration, LoggingConfiguration, StateMachineName, StateMachineType). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
   "resource": {
     "logicalId": "FlowA74D6E88",
     "resourceType": "AWS::StepFunctions::StateMachine",

--- a/tests/corpus/AWS__WAFv2__WebACL.Edge.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.Edge.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 \u2014 richly-declared wave): AWS::WAFv2::WebACL with deep declared config classifies as recorded (undeclared:Name, undeclared:OnSourceDDoSProtectionConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::WAFv2::WebACL with deep declared config classifies as recorded (undeclared:Name, undeclared:OnSourceDDoSProtectionConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Edge",
     "resourceType": "AWS::WAFv2::WebACL",
@@ -130,10 +130,8 @@
       "tier": "undeclared",
       "logicalId": "Edge",
       "resourceType": "AWS::WAFv2::WebACL",
-      "path": "OnSourceDDoSProtectionConfig",
-      "actual": {
-        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
-      },
+      "path": "Name",
+      "actual": "Edge-iCCoPGcllLnA",
       "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
       "constructPath": "CdkrdIntegHarvest2/Edge"
     },
@@ -141,8 +139,10 @@
       "tier": "undeclared",
       "logicalId": "Edge",
       "resourceType": "AWS::WAFv2::WebACL",
-      "path": "Name",
-      "actual": "Edge-iCCoPGcllLnA",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
       "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
       "constructPath": "CdkrdIntegHarvest2/Edge"
     }

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -238,6 +238,57 @@ describe('report', () => {
     });
   });
 
+  describe('R86 atDefault tier (undeclared values at a known AWS default — folded, never drift)', () => {
+    const AD = (path = 'P'): Finding => ({
+      tier: 'atDefault',
+      logicalId: 'L',
+      resourceType: 'AWS::Lambda::Function',
+      path,
+      actual: { Mode: 'PassThrough' },
+    });
+
+    it('folds into the info: footer and never sets exit 1 (CLEAN)', () => {
+      const { code, text } = run([AD('TracingConfig'), AD('PackageType')]);
+      expect(code).toBe(0);
+      expect(text).toMatch(/^result: CLEAN$/m);
+      expect(text).toContain(
+        'info: atDefault=2 (undeclared values matching a known AWS default — not drift)'
+      );
+      // never listed in the body by default, and never a drift section
+      expect(text).not.toContain('[AT AWS DEFAULT');
+      expect(text).not.toContain('TracingConfig =');
+    });
+
+    it('a real undeclared value is listed in the body while at-default values stay folded', () => {
+      const { code, text } = run([U('RealEdit'), AD('TracingConfig'), AD('PackageType')]);
+      // U() is unrecorded (not drift) → CLEAN, but the real value is shown; defaults fold
+      expect(code).toBe(0);
+      expect(text).toContain('[UNRECORDED: 1]');
+      expect(text).toContain('L.RealEdit');
+      expect(text).toContain('atDefault=2');
+      expect(text).not.toContain('[AT AWS DEFAULT');
+    });
+
+    it('--verbose expands atDefault to a full section with each value shown', () => {
+      const { text } = run([AD('TracingConfig')], { verbose: true });
+      expect(text).toContain('[AT AWS DEFAULT: 1]');
+      expect(text).toContain('L.TracingConfig (AWS::Lambda::Function) = {"Mode":"PassThrough"}');
+      expect(text).not.toContain('info:');
+    });
+
+    it('--show-all (expandAtDefault) expands ONLY atDefault; other info tiers stay folded', () => {
+      const { text } = run(
+        [
+          AD('TracingConfig'),
+          { ...F('skipped'), note: 'custom resource', resourceType: 'Custom::X' },
+        ],
+        { expandAtDefault: true }
+      );
+      expect(text).toContain('[AT AWS DEFAULT: 1]'); // expanded
+      expect(text).toContain('info: skipped=1'); // still folded
+    });
+  });
+
   describe('R37 spacing', () => {
     const skipped: Finding = {
       tier: 'skipped',


### PR DESCRIPTION
## What & why

A first `check` used to **drop** every undeclared value that equalled a known AWS
default, so the reported count was *"everything live not in your template, minus
whatever defaults we happened to hardcode"* — a number with no user-meaningful
definition that silently shrank as the default tables grew.

R86 stops dropping them. A live value equal to a known default now classifies to a
new **`atDefault`** tier: folded into the `info:` footer as a count (never listed in
the body, never drift, never recorded by `accept`), so the report states the
**complete** undeclared inventory while the body shows only the values that actually
diverge — the real out-of-band edits. The fold expands under `--show-all` /
`--verbose`. Equality-gated as before: change one away from its default and it
re-surfaces as real `undeclared` drift.

## Changes
- **types/classify**: new `atDefault` tier; default-equal undeclared routes to it.
  Pure structural noise (aws:* tags, physical-id echo, trivially-empty) still dropped.
- **report**: `atDefault` leads `INFO_TIERS`; folds with a plain count; new
  `expandAtDefault` opt (wired to `--show-all`) expands only this tier.
- **check**: first-run prompt's "found N" is the complete inventory (recordable +
  at-default, named in the message); "Accept ALL N" records only the diverging ones;
  no prompt when a stack's only undeclared values are at their default.
- **baseline**: `applyBaseline` reconciles `atDefault` — an accepted value now
  classified at-default is suppressed, NOT a false "removed since accept".
- **noise**: `KNOWN_DEFAULTS` gains the account-wide S3 defaults AWS has applied
  since 2023 (Block Public Access on, BucketOwnerEnforced, SSE-S3) so they fold.
- **corpus**: every case's `expected` regenerated to carry the atDefault findings.

## Verification
- typecheck / lint / build / **663 unit tests** green (+ new classify/report/check/
  baseline coverage for the fold, the count split, `--show-all` expansion, and the
  accepted-now-at-default reconciliation).
- **Live integ (real AWS, dev acct)**: basic, basic/deleted-guards, basic/vs-cdk-drift,
  iam, iam/inline-policy, lambda, revert, policies — **all INTEG PASS**. The
  applyBaseline regression above was caught by a live dogfood check and fixed.
