### PR TITLE
test: atDefault + false-positive + honest-gap integration fixtures; README polish (R87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,11 @@ want to do?
 ```
 
 The count is the **complete** undeclared inventory, but the report lists only the
-handful that actually diverge — the rest sit at a known AWS default and fold into
-one `info: atDefault=40 (…)` line (`--show-all` expands it to the full list). So a
-first run highlights your real out-of-band edits instead of burying them under
-defaults you never touched. Accept writes
+handful that actually diverge — defaults you never touched fold into a single
+`info: atDefault=40 (…)` line (`--show-all` expands it). Accept writes
 `.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing written to
-AWS** — commit it. From here on `check` reports CLEAN until reality actually
-changes. (Declared drift — template vs reality — is detected from this very first
-run, baseline or not.)
+AWS** — commit it; from here on `check` reports CLEAN until reality changes.
+(Declared drift is detected from the very first run, baseline or not.)
 
 **Day to day** — someone changes something from the console; the next `check`
 reports it and asks right there:
@@ -292,26 +289,28 @@ A **deleted resource is never ignorable**.
 
 ## Output
 
-Drift tiers (`deleted` / `declared` / `undeclared`) are always printed in full —
-they are the point. Undeclared values you have **not yet accepted** (no baseline
-entry, and their resource was never fully snapshot) print as their own
-`[UNRECORDED: N]` section: full detail like a drift section, but they are not
-drift — they never count toward the verdict or the `--fail` exit, and the
-`result:` line names the count with the way out (`run cdkrd accept`). Once a
-resource's snapshot is complete, a value that appears out of band IS undeclared
-drift (`appeared since accept`). Informational tiers (`atDefault` / `readGap` /
-`unresolved` / `skipped` / `ignored`) fold into an `info:` footer with per-reason
-counts; `--verbose` expands them to full lists. **`atDefault`** is the bulk of a
-first run: an undeclared value whose live state EQUALS a known AWS default (e.g. a
-Lambda's `TracingConfig: PassThrough`, an S3 bucket's account-default Block Public
-Access). It is **not dropped** — it is folded to a count so the report states the
-_complete_ undeclared inventory but lists only the values that actually diverge
-(your real out-of-band edits). The match is equality-gated: change one away from
-its default and it re-surfaces as real undeclared drift. `accept` never records an
-`atDefault`; `--show-all` (or `--verbose`) expands the fold to the full list.
-Greppable: `^result:` is the verdict;
-for machine consumption the formal contract is `--json`. Output is colorized on
-a TTY (`NO_COLOR` respected); piped / CI / `--json` output is always plain text.
+Two parts: the **drift sections** in full detail, then a one-line `info:` footer
+that folds everything informational.
+
+- **Drift tiers** — `deleted` / `declared` / `undeclared` — are always listed in
+  full and drive the `--fail` exit. They are the point.
+- **`[UNRECORDED: N]`** — undeclared values you have not accepted yet. Listed in
+  full, but not drift (there is nothing to compare them to): they never fail the
+  build, and `result:` points you at `cdkrd accept`. Once a resource is fully
+  snapshotted, a value that _appears_ later is real drift (`appeared since accept`).
+- **`info:` footer** folds the informational tiers to per-reason counts
+  (`--verbose` expands them):
+  - **`atDefault`** — undeclared values sitting at a known AWS default (a Lambda's
+    `TracingConfig: PassThrough`, a bucket's default Block Public Access). The bulk
+    of a first run, folded to a count so the body shows only what actually
+    diverges. Equality-gated: a change away from the default still surfaces, and
+    `--show-all` lists them.
+  - **`readGap` / `unresolved` / `skipped` / `ignored`** — values cdkrd can't
+    confidently compare, reported honestly rather than guessed (never false drift).
+
+`^result:` is the greppable verdict; `--json` is the formal machine contract.
+Colorized on a TTY (`NO_COLOR` respected); piped / CI / `--json` output is plain
+text.
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -35,13 +35,20 @@ These do NOT run in CI (they need credentials and mutate a real account):
 
 - **Before every release** (the `/verify-pr` gate): run EVERY fixture —
   `basic` (+ `verify-deleted-guards.sh` + `verify-vs-cdk-drift.sh` +
-  `verify-mutation-matrix.sh`), `iam`, `lambda`, `revert`, `policies`.
+  `verify-mutation-matrix.sh`), `iam`, `lambda`, `revert`, `policies`, `atdefault`,
+  `noise`, `readgap`.
 - **After changing** `src/read/**`, `src/revert/**`, `src/normalize/**`, or
-  `src/commands/gather.ts`: run at least `basic` + `revert` (and `policies` if
-  `writers.ts` changed; `harvest3` for the multi-type Cloud Control revert
-  matrix) before merging.
+  `src/commands/gather.ts`: run at least `basic` + `revert` + `noise` (the
+  false-positive guard — `noise` asserts tricky declared values normalize equal to
+  live, never a false declared drift) (and `policies` if `writers.ts` changed;
+  `harvest3` for the multi-type Cloud Control revert matrix) before merging.
 - **After changing** `src/diff/**` or `src/baseline/**`: run
   `basic/verify-mutation-matrix.sh` (the drift-direction matrix) before merging.
+- **After changing** `KNOWN_DEFAULTS` (`src/normalize/noise.ts`) or the
+  `atDefault` fold: run `atdefault` — it asserts the hand-written default shapes
+  still match live Cloud Control output (a shape mismatch would resurface the
+  value as real undeclared drift) and that a value changed away from its default
+  still surfaces.
 - Scripts that share a fixture/stack (`basic`'s four) must run sequentially,
   never concurrently.
 - **After changing exit-code or baseline semantics** (report-only/--fail, the
@@ -136,6 +143,60 @@ sibling `AWS::IAM::Policy`):
 
 ```bash
 cd iam && bash verify-inline-policy.sh
+```
+
+## atdefault
+
+Validates the R86 `atDefault` fold end-to-end (a default-config Lambda + a bare
+L1 S3 bucket, whose undeclared properties all sit at a known AWS default):
+
+1. **before any baseline**, those values FOLD into the `atDefault` tier — they are
+   counted in the `info:` footer but NOT listed in the report body. This proves the
+   hand-written `KNOWN_DEFAULTS` shapes (especially the S3 `BucketEncryption` shape
+   with `BlockedEncryptionTypes`) still match what Cloud Control returns; a mismatch
+   would reclassify the value as real undeclared and surface it in the body.
+2. `--show-all` expands the fold and lists those same values under `AT AWS DEFAULT`.
+3. after `accept`, `check` is CLEAN (the at-default values fold, never recorded).
+4. mutating one at-default value away from its default (Lambda `TracingConfig`
+   `PassThrough` → `Active`) makes `check` surface it as real drift — the fold
+   never blinds cdkrd to an actual change (the equality gate has teeth).
+
+```bash
+cd atdefault && bash verify.sh
+```
+
+## noise
+
+The false-positive guard. Deploys resources that DECLARE properties whose live
+AWS form is textually different from the template but semantically identical —
+exactly what the `normalize/` layer subtracts:
+
+- an IAM inline policy with an `aws:SecureTransport` **Condition** key (R69
+  regression: it must survive the live read, NOT be stripped as an `aws:*` tag),
+  multi-action statements, and a managed policy attached by name (name↔ARN);
+- resource **Tags** AWS augments with `aws:cloudformation:*` and may reorder;
+- an S3 **CorsConfiguration** (ordered array of rules).
+
+The assertion is the strong one: with NO baseline, `check --fail` must exit `0` —
+there is no declared drift, because every declared value normalizes equal to live.
+A normalizer regression turns one of these into a false declared drift and fails.
+
+```bash
+cd noise && bash verify.sh
+```
+
+## readgap
+
+The honest-gap guard (the other direction). Some declared properties genuinely
+cannot be read back — a write-only value is the canonical case. A change to one out
+of band IS real drift cdkrd cannot verify; the promise is to say so honestly
+(`readGap`) rather than silently pass it as CLEAN. Deploys a SecretsManager secret
+with a literal write-only `SecretString` and asserts it surfaces in the `readGap`
+tier (reason: `write-only`), never silently absent; `--fail` still exits `0` (a
+readGap is informational, not drift). The cleanup trap force-deletes the secret.
+
+```bash
+cd readgap && bash verify.sh
 ```
 
 ## harvest

--- a/tests/integration/atdefault/app.ts
+++ b/tests/integration/atdefault/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift `atDefault` integration test (R87).
+//
+// Two resources whose live state carries undeclared properties sitting at a known
+// AWS default — exactly the values R86 folds into the `atDefault` tier:
+//   - a default-config Lambda: TracingConfig=PassThrough, EphemeralStorage=512,
+//     PackageType=Zip, RecursiveLoop=Terminate, RuntimeManagementConfig=Auto,
+//     Architectures=[x86_64], MemorySize=128, Timeout=3 — none declared here.
+//   - a bare L1 S3 bucket (NO Properties): the account-wide 2023 defaults AWS
+//     applies — PublicAccessBlockConfiguration (all true), OwnershipControls
+//     (BucketOwnerEnforced), BucketEncryption (SSE-S3 / AES256) — none declared.
+//     This is the case that validates the hand-written KNOWN_DEFAULTS shapes
+//     actually match what Cloud Control returns today (the R86 fragility risk).
+import { App, CfnResource, Stack } from "aws-cdk-lib";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAtDefault");
+
+new Function(stack, "DefaultFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 });"),
+  description: "cdk-real-drift atDefault integration test function",
+});
+
+// L1 bucket with NO Properties, so the template declares none of the security
+// settings AWS applies by default — they read back live as undeclared-at-default.
+new CfnResource(stack, "BareBucket", { type: "AWS::S3::Bucket" });
+
+app.synth();

--- a/tests/integration/atdefault/cdk.json
+++ b/tests/integration/atdefault/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/atdefault/package.json
+++ b/tests/integration/atdefault/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-atdefault",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift atDefault integration test (R87). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/atdefault/verify.sh
+++ b/tests/integration/atdefault/verify.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# cdk-real-drift `atDefault` integration test (real AWS, R87).
+#
+# Validates the R86 fold end-to-end against a live account:
+#   1. a default-config Lambda + a bare L1 S3 bucket carry undeclared properties
+#      that sit at a known AWS default;
+#   2. BEFORE any baseline, those values FOLD into the atDefault tier (they are
+#      NOT listed in the report body) — this proves the hand-written KNOWN_DEFAULTS
+#      shapes (esp. the S3 BucketEncryption shape with BlockedEncryptionTypes)
+#      actually match what Cloud Control returns today. A shape mismatch would
+#      reclassify the value as real undeclared and surface it in the body — caught
+#      here as a failure;
+#   3. `--show-all` expands the fold and lists those same values under AT AWS DEFAULT;
+#   4. the equality gate has teeth: mutate one at-default value AWAY from its
+#      default out of band and `check` MUST surface it as real drift (the fold
+#      never blinds cdkrd to an actual change).
+#
+# A cleanup trap destroys + removes the baseline even on failure, so a failed run
+# leaves no orphan resources.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit), Docker NOT needed.
+# Usage:  cd tests/integration/atdefault && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAtDefault
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+# ---- 2: before any baseline, at-default values FOLD (not listed in the body) ----
+echo "=== check (no baseline): at-default values must be FOLDED, not in the body ==="
+$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-atdef-fold.out
+grep -q "atDefault=" /tmp/cdkrd-atdef-fold.out || fail "no atDefault fold count in the info: footer"
+# These sit at their AWS default, so they must NOT appear as listed undeclared
+# values. If a KNOWN_DEFAULTS shape no longer matches live, the value reclassifies
+# to real undeclared and shows up here — that is the bug this assertion catches.
+for p in PublicAccessBlockConfiguration BucketEncryption OwnershipControls TracingConfig; do
+  grep -q "$p" /tmp/cdkrd-atdef-fold.out \
+    && fail "$p is at its AWS default but was listed in the body (KNOWN_DEFAULTS shape drift?)"
+done
+
+# ---- 3: --show-all expands the fold and lists them under AT AWS DEFAULT ----
+echo "=== check --show-all: the folded values must appear under AT AWS DEFAULT ==="
+$CLI check "$STACK" --region "$REGION" --show-all | tee /tmp/cdkrd-atdef-showall.out
+grep -q "AT AWS DEFAULT" /tmp/cdkrd-atdef-showall.out || fail "no AT AWS DEFAULT section under --show-all"
+for p in PublicAccessBlockConfiguration BucketEncryption TracingConfig; do
+  grep -q "$p" /tmp/cdkrd-atdef-showall.out || fail "$p missing from the --show-all inventory"
+done
+
+echo "=== accept (write baseline) ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+
+echo "=== check should be CLEAN right after accept (at-default values fold, not drift) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
+
+# ---- 4: the equality gate has teeth — mutate an at-default value away from default ----
+echo "=== mutate Lambda TracingConfig PassThrough -> Active (out of band) ==="
+FN_NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN_NAME" ] || fail "could not resolve function physical id"
+aws lambda update-function-configuration --function-name "$FN_NAME" \
+  --tracing-config Mode=Active --region "$REGION" >/dev/null || fail "inject TracingConfig drift"
+# the update is async; wait for it to settle before reading back
+aws lambda wait function-updated --function-name "$FN_NAME" --region "$REGION" || true
+sleep 5
+
+echo "=== check must now DETECT the changed value (fold never hides a real change) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-atdef-drift.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1 after mutating TracingConfig, got $rc"
+grep -q "TracingConfig" /tmp/cdkrd-atdef-drift.out || fail "TracingConfig change not reported"
+grep -q "Active" /tmp/cdkrd-atdef-drift.out || fail "the changed value (Active) not in the report"
+
+echo "INTEG PASS"

--- a/tests/integration/noise/app.ts
+++ b/tests/integration/noise/app.ts
@@ -1,0 +1,69 @@
+// CDK app for the cdk-real-drift false-positive ("noise") integration test (R87).
+//
+// Every resource here DECLARES properties whose live AWS form is textually
+// different from the template but semantically identical — exactly the cases the
+// normalize/ layer exists to subtract. If any normalizer regresses, the declared
+// value diverges from live and `check` reports a FALSE declared drift. The test
+// deploys this and asserts `check --fail` exits 0 (zero false positives), then
+// `accept` + `check` stays CLEAN.
+//
+// Coverage (historical false-positive bugs in parentheses):
+//   - IAM inline policy with an `aws:SecureTransport` Condition key — must NOT be
+//     stripped as an `aws:*` tag (R69: stripping it turned every enforceSSL policy
+//     into false drift);
+//   - IAM policy Action as a multi-element array + a wildcard Resource — policy
+//     canonicalization (scalar/array unify, statement order);
+//   - a managed policy attached by name/ARN (name<->ARN collapse);
+//   - resource Tags — AWS adds `aws:cloudformation:*` managed tags and may reorder
+//     them; the declared set must still compare equal (aws:* strip + tag-list order);
+//   - S3 CorsConfiguration — an ordered array of rules whose elements must match.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import {
+  Effect,
+  ManagedPolicy,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { Bucket, HttpMethods } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegNoise");
+
+const role = new Role(stack, "NoiseRole", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+  managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("ReadOnlyAccess")],
+  inlinePolicies: {
+    NoisePolicy: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+          resources: ["*"],
+          // R69 regression guard: this aws:* CONDITION key must survive the live
+          // read — it is NOT an aws:* tag. Stripping it would drop the condition
+          // from live and report a false declared drift on the whole policy.
+          conditions: { Bool: { "aws:SecureTransport": "true" } },
+        }),
+      ],
+    }),
+  },
+});
+Tags.of(role).add("team", "platform");
+Tags.of(role).add("cost-center", "1234");
+
+const bucket = new Bucket(stack, "NoiseBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  cors: [
+    {
+      allowedMethods: [HttpMethods.GET, HttpMethods.PUT],
+      allowedOrigins: ["*"],
+      allowedHeaders: ["*"],
+    },
+  ],
+});
+Tags.of(bucket).add("team", "platform");
+Tags.of(bucket).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/noise/cdk.json
+++ b/tests/integration/noise/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/noise/package.json
+++ b/tests/integration/noise/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-noise",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift false-positive (noise) integration test (R87). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/noise/verify.sh
+++ b/tests/integration/noise/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# cdk-real-drift false-positive ("noise") integration test (real AWS, R87).
+#
+# Deploys resources that DECLARE properties whose live AWS form is textually
+# different but semantically equal (IAM policy with an aws:SecureTransport
+# condition, multi-action statements, a managed policy by name; resource tags AWS
+# augments with aws:cloudformation:* and reorders; S3 CORS rules). If any
+# normalizer regresses, one of these declared values diverges from live and is
+# reported as a FALSE declared drift.
+#
+# The assertion is the strong one: WITHOUT any baseline, `check --fail` must exit
+# 0 — there is no declared drift to find, because every declared value normalizes
+# equal to live. (Undeclared/at-default values are not drift and never fail.) Then
+# accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit), Docker NOT needed.
+# Usage:  cd tests/integration/noise && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNoise
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+# The core false-positive guard: with NO baseline, the only thing `--fail` can flag
+# is DECLARED drift, and there must be none — every tricky declared value (policy
+# with aws:SecureTransport, multi-action statements, name<->ARN managed policy,
+# tags AWS augments + reorders, CORS rules) must normalize equal to live.
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-noise-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-noise-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/readgap/app.ts
+++ b/tests/integration/readgap/app.ts
@@ -1,0 +1,28 @@
+// CDK app for the cdk-real-drift "honest gap" integration test (R87).
+//
+// Some declared properties genuinely CANNOT be read back from AWS — a write-only
+// value (a secret, a password) is the canonical case. A change to such a value out
+// of band IS real drift, but cdkrd cannot verify it. The design promise is to say
+// so HONESTLY (report it in the informational `readGap` tier) rather than silently
+// pass it as CLEAN — silently dropping it would make the user blind to a class of
+// drift they think is covered.
+//
+// This fixture declares a SecretsManager secret with a literal `SecretString`
+// (write-only). The test asserts that property surfaces as a `readGap` (note:
+// write-only) — never silently absent. An explicit secret name lets the cleanup
+// trap force-delete it (no 30-day recovery-window residue).
+import { App, RemovalPolicy, SecretValue, Stack } from "aws-cdk-lib";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegReadGap");
+
+new Secret(stack, "GapSecret", {
+  secretName: "cdkrd-integ-readgap",
+  // a literal write-only SecretString in the template — cdkrd declares it but
+  // cannot read it back, so it must be reported as a readGap, not silently CLEAN.
+  secretStringValue: SecretValue.unsafePlainText("integ-write-only-value"),
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+app.synth();

--- a/tests/integration/readgap/cdk.json
+++ b/tests/integration/readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/readgap/package.json
+++ b/tests/integration/readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift honest-gap (readGap) integration test (R87). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/readgap/verify.sh
+++ b/tests/integration/readgap/verify.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# cdk-real-drift "honest gap" integration test (real AWS, R87).
+#
+# A declared write-only property (SecretsManager SecretString) cannot be read back
+# from AWS. A change to it out of band is real drift cdkrd CANNOT verify — and the
+# design promise is to report that honestly as a `readGap`, never to silently pass
+# it as CLEAN (which would make the user blind to it). This asserts the write-only
+# value surfaces in the readGap tier, with a `write-only` reason.
+#
+# The cleanup trap force-deletes the secret (no 30-day recovery-window residue).
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit), Docker NOT needed.
+# Usage:  cd tests/integration/readgap && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegReadGap
+REGION="${AWS_REGION:-us-east-1}"
+SECRET=cdkrd-integ-readgap
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  # purge the secret immediately (cdk destroy only SCHEDULES deletion)
+  aws secretsmanager delete-secret --secret-id "$SECRET" \
+    --force-delete-without-recovery --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+# The write-only SecretString must be reported as a readGap, not silently dropped.
+echo "=== the write-only SecretString must surface as a readGap (honest gap) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee /tmp/cdkrd-readgap.out
+grep -qi "write-only" /tmp/cdkrd-readgap.out \
+  || fail "the write-only SecretString was not surfaced as a readGap — silently dropped?"
+grep -q "SecretString" /tmp/cdkrd-readgap.out \
+  || fail "the readGap does not name the SecretString property"
+
+# A readGap is informational, not drift: --fail must still exit 0 (it is NOT a
+# false positive), and the secret value being unverifiable must NOT read as CLEAN
+# silence — the readGap above is the honest signal.
+echo "=== readGap is informational: --fail exits 0 (not a false positive) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "a write-only readGap must not fail the build (it is not drift)"
+
+echo "INTEG PASS"


### PR DESCRIPTION
Three new real-AWS integration fixtures (all INTEG PASS on the dev account, self-cleaning) + a README readability pass.

## Fixtures
- **atdefault** — validates the R86 atDefault fold live: default-config Lambda + bare L1 S3 bucket. Before any baseline the at-default values FOLD (not in the body) — proving the hand-written `KNOWN_DEFAULTS` shapes (esp. S3 `BucketEncryption` with `BlockedEncryptionTypes`) still match live Cloud Control. `--show-all` lists them under AT AWS DEFAULT. Mutating `TracingConfig` PassThrough→Active makes `check` surface it as real drift (the equality gate has teeth).
- **noise** — false-positive guard: declares properties whose live form is textually different but semantically equal (IAM policy with an `aws:SecureTransport` Condition [R69 regression], multi-action statements, managed policy by name; tags AWS augments + reorders; S3 CORS). With no baseline, `check --fail` must exit 0.
- **readgap** — honest-gap guard: a write-only `SecretString` must surface as a `readGap` (write-only), never silently CLEAN.

## README
Broke the wall-of-text Output section into a scannable tier list; tightened the dense first-run paragraph (both bloated by R86's inline edits). `integration/README.md` documents the three fixtures.

## Verification
- typecheck / lint / build / 663 unit tests green.
- **All 11 integration fixtures INTEG PASS** (the 3 new + the 8 existing re-run against the identical, unchanged dist). No source changes.