### PR TITLE
fix(noise): unordered object-array false positives (DynamoDB attrs, SG rules) + 8 false-positive integ fixtures (R88)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,7 +202,7 @@ checked.
   - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group, **CodeBuild Project** via BatchGetProjects with a camelCase→CFn-PascalCase projection, R85).
 - **normalize/** — noise subtraction (section 6)
   - **intrinsic-resolver.ts** — fail-closed CFn intrinsic resolver (section 5).
-  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `projectLiveToDeclaredSubset` (attribute-bag subset), `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` / `CASE_INSENSITIVE_PATHS` (per-type compare rules).
+  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `projectLiveToDeclaredSubset` (attribute-bag subset), `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` (per-type unordered scalar arrays) / `UNORDERED_OBJECT_ARRAY_PROPS` + `sortUnorderedObjectArray` (per-type unordered object arrays — SG rules, R88) / `CASE_INSENSITIVE_PATHS` (per-type compare rules).
   - **arn-identity.ts** — **`isArnNameMatch`** (bare name ↔ ARN), **`isManagedKmsAliasMatch`** (`alias/aws/*` ↔ key ARN).
   - **policy-canonical.ts** — IAM policy-doc canonicalization. **cc-api-strip.ts** — strip AWS-managed fields. **path-strip.ts** — schema readOnly/writeOnly path stripping (incl `*`).
 - **schema/schema-strip.ts** — `describe-type` → readOnly/writeOnly/defaults `SchemaInfo` (cached).
@@ -283,6 +283,7 @@ all live changes
   − declared SUBSET of an identity-keyed attribute bag (ELB Load/TargetGroupAttributes, R75) → live projected to declared keys (projectLiveToDeclaredSubset)
   − per-type case-insensitive scalar paths (Route53 AliasTarget.DNSName, R75) → equal (CASE_INSENSITIVE_PATHS)
   − per-type unordered scalar-array sets (Cognito UserPoolClient OAuth lists, R74) → equal (UNORDERED_ARRAY_PROPS)
+  − per-type unordered OBJECT-array sets (EC2 SecurityGroup ingress/egress rules — no identity field, R88) → both sides sorted by canonical JSON (UNORDERED_OBJECT_ARRAY_PROPS / sortUnorderedObjectArray)
   − sibling AWS::IAM::Policy entries in a role's Policies → filtered BY NAME (see below)
   = undeclared residual                → the unique signal
 ```
@@ -296,7 +297,10 @@ _real change still detected_ ([tests/classify.test.ts](../tests/classify.test.ts
    `DistributionConfig.Origins` (`{Id,...}[]`) are unordered sets; a positional diff
    flagged every CDK-tagged resource (and every field of every swapped origin on a
    multi-origin distribution). Fix: `canonicalizeTagListsDeep` sorts arrays whose every
-   element is an object with a string identity field (`Key` preferred, else `Id`).
+   element is an object with a string identity field (`Key`, `Id`, or — R88 — DynamoDB's
+   `AttributeName` / `IndexName`). Identity-LESS unordered object arrays (EC2
+   SecurityGroup ingress/egress rules) have no such field and are instead sorted by
+   canonical JSON per-type (`UNORDERED_OBJECT_ARRAY_PROPS`, R88) in the classify loop.
 2. **resource-id/ARN/HTTP-method array order** — `SubnetIds` / `SecurityGroupIds` and
    HTTP-method enum sets (CloudFront `AllowedMethods` / `CachedMethods`) are unordered;
    positional diff flagged them. Fix: `canonicalizeIdArraysDeep` (sort arrays whose

--- a/docs/redesign-notes.md
+++ b/docs/redesign-notes.md
@@ -85,6 +85,51 @@ core thesis is unchanged.
 
 ## Considered and rejected
 
+- **Delegating DECLARED-property drift to CloudFormation's native drift detection
+  (`DetectStackDrift`), and keeping only the undeclared detection in cdkrd.**
+  Tempting: CFn drift detection is AWS-authoritative for declared properties, so
+  it would remove cdkrd's _reimplemented_ declared comparison — a genuine
+  false-positive surface (it is exactly what the `noise` / false-positive-matrix
+  integ fixtures exist to guard). Rejected as a runtime default, for reasons that
+  mostly do NOT depend on coverage:
+  - **The normalization is SHARED, so delegation does not remove the
+    false-positive surface.** Policy canonicalization, ARN↔name collapse, array
+    ordering, object↔JSON-string equality, `aws:*`-tag stripping, etc. are all
+    still required for the UNDECLARED comparison (an undeclared policy / tag set /
+    ordered array needs the identical subtraction). Handing the declared half to
+    CFn leaves every normalizer in place, still running on the undeclared half —
+    which is the differentiator, the part that matters most. The bug class is
+    halved in exposure, not eliminated.
+  - **`--pre-deploy` cannot be delegated.** It compares live state against the
+    LOCAL synth template; CFn drift detection only knows the DEPLOYED template, so
+    cdkrd must own the declared comparison for that feature regardless.
+  - **Coverage gap.** CFn drift detection returns `NOT_CHECKED` for unsupported
+    resource types (and does not check every property even on supported ones).
+    Coverage is broad and has grown a lot (core services are covered) — it is NOT
+    "about half", an earlier overstatement — but it is still incomplete; delegating
+    would make declared drift invisible on the unchecked tail, against the
+    fail-closed "honest about what it cannot check" promise. cdkrd's full live read
+    (Cloud Control + SDK overrides) reaches further.
+  - **Runtime cost + two diff models.** `DetectStackDrift` is asynchronous
+    (start + poll, minutes on large stacks) and throttled; reconciling its
+    `PropertyDifferences` with cdkrd's findings into one report / exit / revert plan
+    adds complexity and a second failure mode, and the declared comparison would no
+    longer be offline-replayable (the golden corpus).
+  - **CFn drift has its own quirks** — a _different_ false-positive set, not
+    strictly fewer; `cdk drift` is built on it. cdkrd keeps a deliberately
+    conservative, self-controlled normalization (zero false drift).
+
+  Where the instinct lands instead: `--undeclared-only` lets a user who WANTS this
+  split suppress cdkrd's declared output and run `cdk drift` themselves for the
+  declared side. It is a pure OUTPUT FILTER (`undeclaredOnlyFindings` in
+  `commands/check.ts`) — cdkrd never calls the CFn drift API, and the declared
+  detection logic is identical with or without the flag; the flag only drops the
+  declared / readGap / unresolved tiers from the report. CFn drift detection IS
+  used, but as a differential TEST ORACLE (`basic/verify-vs-cdk-drift.sh`), not a
+  runtime dependency. A future enhancement could use it to cross-validate cdkrd's
+  declared findings in CI (catch cdkrd false positives); as a runtime engine the
+  trade is net-negative.
+
 - **Skipping `isTrivialEmpty` under `--show-all`.** `isTrivialEmpty` suppresses
   undeclared `false` / `''` / `[]` / `{}` values (AWS returns an "off/empty" value
   for nearly every unset option). One could argue inventory (`--show-all`) should

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -20,8 +20,10 @@ import {
   isTrivialEmpty,
   KNOWN_DEFAULTS,
   projectLiveToDeclaredSubset,
+  sortUnorderedObjectArray,
   stripAwsTagsDeep,
   UNORDERED_ARRAY_PROPS,
+  UNORDERED_OBJECT_ARRAY_PROPS,
 } from '../normalize/noise.js';
 import { deepStripPaths } from '../normalize/path-strip.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
@@ -150,11 +152,18 @@ export function classifyResource(
       }
       continue;
     }
+    // Per-type unordered OBJECT-array sets (R88: EC2 SecurityGroup ingress/egress) —
+    // rule objects with no single identity field that AWS returns reordered. Sort BOTH
+    // sides by canonical JSON before the positional diff so a reorder is not false
+    // drift; a genuine rule change still differs after the sort.
+    const unorderedObjArray = UNORDERED_OBJECT_ARRAY_PROPS[resourceType]?.has(k);
+    const declaredVal = unorderedObjArray ? sortUnorderedObjectArray(v) : v;
+    const liveSorted = unorderedObjArray ? sortUnorderedObjectArray(live[k]) : live[k];
     // Identity-keyed attribute bags (R75: other bag-shaped props) — the template
     // declares a SUBSET of the keys AWS returns; compare only the declared keys so
     // the extra live attributes are not false drift on the whole list.
-    const liveVal = projectLiveToDeclaredSubset(v, live[k]);
-    for (const d of calculateResourceDrift({ [k]: v }, { [k]: liveVal })) {
+    const liveVal = projectLiveToDeclaredSubset(declaredVal, liveSorted);
+    for (const d of calculateResourceDrift({ [k]: declaredVal }, { [k]: liveVal })) {
       // a bare name declared for a field AWS returns as the full ARN is not drift
       // (account/region-scoped when opts are provided); likewise an AWS-managed-default
       // KMS alias vs its resolved key ARN

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -132,7 +132,12 @@ function stripTagsWalk(v: unknown, underTagsKey: boolean): unknown {
 // Recurses so nested bags (LaunchTemplate TagSpecifications, Origins, ...) are covered.
 // ASSUMPTION: no `Key`- or `Id`-keyed AWS array is known to be order-significant, so
 // sorting is safe (same conservative bet as the scalar id-array canonicalizer).
-const IDENTITY_FIELDS = ['Key', 'Id'] as const;
+// R88: `AttributeName` and `IndexName` extend this to DynamoDB's identity-keyed
+// arrays — AttributeDefinitions / KeySchema (keyed by AttributeName) and
+// GlobalSecondaryIndexes (keyed by IndexName), which AWS returns in a different order
+// than the template declares them (a positional diff otherwise reports false drift on
+// every element). Both are set-like identities, not order-significant.
+const IDENTITY_FIELDS = ['Key', 'Id', 'AttributeName', 'IndexName'] as const;
 function identityField(arr: unknown[]): string | undefined {
   return IDENTITY_FIELDS.find((f) =>
     arr.every(
@@ -331,6 +336,48 @@ export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
   const sa = sort(a);
   const sb = sort(b);
   return sa.every((v, i) => v === sb[i]);
+}
+
+// Per-type OBJECT-array props AWS treats as UNORDERED SETS whose element objects
+// carry NO single identity field (so canonicalizeTagListsDeep cannot key them) and
+// are NOT scalar (so isEqualUnorderedScalarSet does not apply): EC2 SecurityGroup
+// ingress/egress rules are the case (R88) — a set of {CidrIp,IpProtocol,FromPort,
+// ToPort,Description,...} rules AWS returns in a different order than declared, which
+// a positional diff reports as false drift on every field of every shifted rule.
+// A blanket "sort every identity-less object array" is unsafe (some object arrays ARE
+// order-significant — CloudFront cache behaviors by precedence, etc.), so this stays a
+// per-type opt-in. Consulted by classify's declared loop, which sorts BOTH sides by
+// canonical JSON before the positional diff — a genuine rule change still differs.
+export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
+  'AWS::EC2::SecurityGroup': new Set(['SecurityGroupIngress', 'SecurityGroupEgress']),
+};
+
+// Stable, key-order-insensitive JSON of a value (objects emit keys sorted), used as a
+// total order to sort an unordered object array deterministically on both sides.
+function canonicalJson(v: unknown): string {
+  if (Array.isArray(v)) return `[${v.map(canonicalJson).join(',')}]`;
+  if (v && typeof v === 'object') {
+    const o = v as Record<string, unknown>;
+    return `{${Object.keys(o)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonicalJson(o[k])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(v) ?? 'null';
+}
+
+// Sort an array by each element's canonical JSON (a no-op on non-arrays). Applied to
+// BOTH the declared and live side of an UNORDERED_OBJECT_ARRAY_PROPS property so a
+// reordered-but-equal rule set aligns positionally; equal elements (modulo key order)
+// land in the same slot, so the subsequent element-wise diff sees no drift, while a
+// genuinely changed rule still differs.
+export function sortUnorderedObjectArray(v: unknown): unknown {
+  if (!Array.isArray(v)) return v;
+  return [...v].sort((a, b) => {
+    const ka = canonicalJson(a);
+    const kb = canonicalJson(b);
+    return ka < kb ? -1 : ka > kb ? 1 : 0;
+  });
 }
 
 // CFn has many "stringly-typed" fields: Glue Table `Parameters` is a

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -718,3 +718,140 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 });
+
+describe('unordered-array declared false positives (R88, found by the wave-2 integ fixtures)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    physicalId: 'phys',
+    declared,
+  });
+  const declaredTiers = (
+    rt: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    classifyResource(res(rt, declared), live, emptySchema)
+      .filter((f) => f.tier === 'declared')
+      .map((f) => f.path);
+
+  describe('DynamoDB AttributeDefinitions / KeySchema (AttributeName identity, R88)', () => {
+    const T = 'AWS::DynamoDB::Table';
+    const declared = {
+      AttributeDefinitions: [
+        { AttributeName: 'pk', AttributeType: 'S' },
+        { AttributeName: 'sk', AttributeType: 'S' },
+        { AttributeName: 'gsi1pk', AttributeType: 'S' },
+        { AttributeName: 'gsi1sk', AttributeType: 'N' },
+      ],
+    };
+
+    it('AWS returning the attributes in a different order is NOT drift', () => {
+      const live = {
+        AttributeDefinitions: [
+          { AttributeName: 'gsi1pk', AttributeType: 'S' },
+          { AttributeName: 'gsi1sk', AttributeType: 'N' },
+          { AttributeName: 'pk', AttributeType: 'S' },
+          { AttributeName: 'sk', AttributeType: 'S' },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine attribute TYPE change still surfaces', () => {
+      const live = {
+        AttributeDefinitions: [
+          { AttributeName: 'pk', AttributeType: 'N' }, // S -> N
+          { AttributeName: 'sk', AttributeType: 'S' },
+          { AttributeName: 'gsi1pk', AttributeType: 'S' },
+          { AttributeName: 'gsi1sk', AttributeType: 'N' },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('EC2 SecurityGroup ingress (identity-less object array, R88)', () => {
+    const T = 'AWS::EC2::SecurityGroup';
+    const declared = {
+      SecurityGroupIngress: [
+        { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443, Description: 'a' },
+        { CidrIp: '10.0.1.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443, Description: 'b' },
+        {
+          CidrIp: '192.168.0.0/16',
+          IpProtocol: 'tcp',
+          FromPort: 22,
+          ToPort: 22,
+          Description: 'ssh',
+        },
+      ],
+    };
+
+    it('AWS returning the same rules in a different order is NOT drift', () => {
+      const live = {
+        SecurityGroupIngress: [
+          {
+            CidrIp: '192.168.0.0/16',
+            IpProtocol: 'tcp',
+            FromPort: 22,
+            ToPort: 22,
+            Description: 'ssh',
+          },
+          {
+            CidrIp: '10.0.0.0/24',
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            Description: 'a',
+          },
+          {
+            CidrIp: '10.0.1.0/24',
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            Description: 'b',
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine rule change (a port) still surfaces', () => {
+      const live = {
+        SecurityGroupIngress: [
+          {
+            CidrIp: '10.0.0.0/24',
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+            Description: 'a',
+          },
+          {
+            CidrIp: '10.0.1.0/24',
+            IpProtocol: 'tcp',
+            FromPort: 8443,
+            ToPort: 8443,
+            Description: 'b',
+          }, // 443 -> 8443
+          {
+            CidrIp: '192.168.0.0/16',
+            IpProtocol: 'tcp',
+            FromPort: 22,
+            ToPort: 22,
+            Description: 'ssh',
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -36,12 +36,14 @@ These do NOT run in CI (they need credentials and mutate a real account):
 - **Before every release** (the `/verify-pr` gate): run EVERY fixture —
   `basic` (+ `verify-deleted-guards.sh` + `verify-vs-cdk-drift.sh` +
   `verify-mutation-matrix.sh`), `iam`, `lambda`, `revert`, `policies`, `atdefault`,
-  `noise`, `readgap`.
+  `noise`, `readgap`, and the false-positive matrix (`dynamodb`, `sqs`,
+  `securitygroup`, `cloudwatch-alarm`, `stepfunctions`, `ssm`, `eventbridge`,
+  `cognito`).
 - **After changing** `src/read/**`, `src/revert/**`, `src/normalize/**`, or
-  `src/commands/gather.ts`: run at least `basic` + `revert` + `noise` (the
-  false-positive guard — `noise` asserts tricky declared values normalize equal to
-  live, never a false declared drift) (and `policies` if `writers.ts` changed;
-  `harvest3` for the multi-type Cloud Control revert matrix) before merging.
+  `src/commands/gather.ts`: run at least `basic` + `revert` + `noise` + the
+  false-positive matrix (below — each asserts tricky declared values normalize
+  equal to live, never a false declared drift) (and `policies` if `writers.ts`
+  changed; `harvest3` for the multi-type Cloud Control revert matrix) before merging.
 - **After changing** `src/diff/**` or `src/baseline/**`: run
   `basic/verify-mutation-matrix.sh` (the drift-direction matrix) before merging.
 - **After changing** `KNOWN_DEFAULTS` (`src/normalize/noise.ts`) or the
@@ -197,6 +199,28 @@ readGap is informational, not drift). The cleanup trap force-deletes the secret.
 
 ```bash
 cd readgap && bash verify.sh
+```
+
+## false-positive matrix
+
+Eight focused fixtures (R88), each the same shape as `noise`: deploy a resource that
+DECLARES a property whose live AWS form is textually different but semantically
+equal, then assert `check --fail` exits `0` with no baseline — zero false declared
+drift. They target the specific normalization classes most likely to regress:
+
+| fixture            | resource             | noise-prone declared property (class)                                  |
+| ------------------ | -------------------- | ---------------------------------------------------------------------- |
+| `dynamodb`         | DynamoDB Table       | KeySchema / AttributeDefinitions / GSIs (ordered arrays), tags         |
+| `sqs`              | SQS Queue + DLQ      | RedrivePolicy (object↔JSON-string, R75), numeric attributes            |
+| `securitygroup`    | EC2 SecurityGroup    | ingress/egress rules (unordered arrays of CIDR rule objects)           |
+| `cloudwatch-alarm` | CloudWatch Alarm     | Dimensions (unordered `{Name,Value}` array — NOT Key/Id-keyed)         |
+| `stepfunctions`    | Step Functions SM    | DefinitionString (JSON string, R75) + auto-role policy                 |
+| `ssm`              | SSM Document + Param | Document Content (object↔JSON-string, R75)                             |
+| `eventbridge`      | EventBridge Rule     | EventPattern (object↔JSON-string), Targets array + queue policy        |
+| `cognito`          | Cognito Pool/Client  | OAuth/ExplicitAuthFlows (unordered enums, R74), UserPoolGroup id (R84) |
+
+```bash
+cd dynamodb && bash verify.sh   # …and likewise for each fixture above
 ```
 
 ## harvest

--- a/tests/integration/cloudwatch-alarm/app.ts
+++ b/tests/integration/cloudwatch-alarm/app.ts
@@ -1,0 +1,27 @@
+// CDK app for the cdk-real-drift CloudWatch Alarm false-positive integration test
+// (R88). Tricky declared property: Dimensions — an unordered array of {Name,Value}
+// objects (NOT Key/Id-keyed), which AWS may return reordered. If the identity-keyed
+// array canonicalization does not cover Name-keyed arrays, a reorder surfaces as a
+// false declared drift — exactly the kind of gap this fixture is here to catch.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Alarm, ComparisonOperator, Metric } from "aws-cdk-lib/aws-cloudwatch";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAlarm");
+
+const metric = new Metric({
+  namespace: "AWS/Lambda",
+  metricName: "Errors",
+  dimensionsMap: { FunctionName: "cdkrd-integ-fn", Resource: "cdkrd-integ-fn:live" },
+  statistic: "Sum",
+});
+
+const alarm = new Alarm(stack, "Alarm", {
+  metric,
+  threshold: 5,
+  evaluationPeriods: 2,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+});
+Tags.of(alarm).add("team", "platform");
+
+app.synth();

--- a/tests/integration/cloudwatch-alarm/cdk.json
+++ b/tests/integration/cloudwatch-alarm/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudwatch-alarm/package.json
+++ b/tests/integration/cloudwatch-alarm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudwatch-alarm",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift CloudWatch Alarm false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudwatch-alarm/verify.sh
+++ b/tests/integration/cloudwatch-alarm/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift CloudWatch Alarm false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/cloudwatch-alarm && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAlarm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cloudwatch-alarm-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-cloudwatch-alarm-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/cognito/app.ts
+++ b/tests/integration/cognito/app.ts
@@ -1,0 +1,34 @@
+// CDK app for the cdk-real-drift Cognito false-positive integration test (R88).
+// Tricky declared properties: a UserPoolClient's ExplicitAuthFlows,
+// AllowedOAuthFlows / AllowedOAuthScopes and CallbackURLs are UNORDERED enum/string
+// arrays AWS may return reordered (R74 unordered-set handling); a UserPoolGroup uses
+// a COMPOSITE Cloud Control identifier (UserPoolId|GroupName, R84).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnUserPoolGroup, OAuthScope, UserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCognito");
+
+const pool = new UserPool(stack, "Pool", {
+  selfSignUpEnabled: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new UserPoolClient(stack, "Client", {
+  userPool: pool,
+  generateSecret: false,
+  authFlows: { userSrp: true, userPassword: true },
+  oAuth: {
+    flows: { authorizationCodeGrant: true, implicitCodeGrant: true },
+    scopes: [OAuthScope.OPENID, OAuthScope.EMAIL, OAuthScope.PROFILE],
+    callbackUrls: ["https://a.example/cb", "https://b.example/cb"],
+  },
+});
+
+new CfnUserPoolGroup(stack, "Group", {
+  userPoolId: pool.userPoolId,
+  groupName: "cdkrd-integ-group",
+  description: "cdk-real-drift integ group",
+});
+
+app.synth();

--- a/tests/integration/cognito/cdk.json
+++ b/tests/integration/cognito/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cognito/package.json
+++ b/tests/integration/cognito/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cognito",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift Cognito false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift Cognito false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/cognito && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCognito
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cognito-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-cognito-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/dynamodb/app.ts
+++ b/tests/integration/dynamodb/app.ts
@@ -1,0 +1,25 @@
+// CDK app for the cdk-real-drift DynamoDB false-positive integration test (R88).
+// Tricky declared properties: KeySchema / AttributeDefinitions (ordered arrays AWS
+// may return in a different order), a GlobalSecondaryIndexes array, and tags.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegDynamoDB");
+
+const table = new Table(stack, "Data", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  sortKey: { name: "sk", type: AttributeType.STRING },
+  billingMode: BillingMode.PAY_PER_REQUEST,
+  pointInTimeRecovery: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+table.addGlobalSecondaryIndex({
+  indexName: "gsi1",
+  partitionKey: { name: "gsi1pk", type: AttributeType.STRING },
+  sortKey: { name: "gsi1sk", type: AttributeType.NUMBER },
+});
+Tags.of(table).add("team", "platform");
+Tags.of(table).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/dynamodb/cdk.json
+++ b/tests/integration/dynamodb/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dynamodb/package.json
+++ b/tests/integration/dynamodb/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dynamodb",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift DynamoDB false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dynamodb/verify.sh
+++ b/tests/integration/dynamodb/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift DynamoDB false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/dynamodb && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDynamoDB
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-dynamodb-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-dynamodb-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/eventbridge/app.ts
+++ b/tests/integration/eventbridge/app.ts
@@ -1,0 +1,24 @@
+// CDK app for the cdk-real-drift EventBridge false-positive integration test (R88).
+// Tricky declared properties: EventPattern — declared as an OBJECT, returned by AWS
+// as a JSON STRING (R75); and Targets — an array. Adding the SQS target also creates
+// a queue policy (policy canonicalization).
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Rule } from "aws-cdk-lib/aws-events";
+import { SqsQueue } from "aws-cdk-lib/aws-events-targets";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEvents");
+
+const target = new Queue(stack, "Target");
+
+const rule = new Rule(stack, "Rule", {
+  eventPattern: {
+    source: ["cdkrd.integ"],
+    detailType: ["test-a", "test-b"],
+  },
+});
+rule.addTarget(new SqsQueue(target));
+Tags.of(rule).add("team", "platform");
+
+app.synth();

--- a/tests/integration/eventbridge/cdk.json
+++ b/tests/integration/eventbridge/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eventbridge/package.json
+++ b/tests/integration/eventbridge/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eventbridge",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift EventBridge false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift EventBridge false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/eventbridge && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEvents
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-eventbridge-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-eventbridge-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/securitygroup/app.ts
+++ b/tests/integration/securitygroup/app.ts
@@ -1,0 +1,24 @@
+// CDK app for the cdk-real-drift SecurityGroup false-positive integration test (R88).
+// Tricky declared property: SecurityGroupIngress / SecurityGroupEgress — unordered
+// arrays of rule objects (AWS may return them in a different order than declared)
+// carrying CIDR strings. A minimal single-AZ VPC with no NAT keeps it cheap and
+// self-cleaning.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Peer, Port, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSg");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc, allowAllOutbound: true });
+sg.addIngressRule(Peer.ipv4("10.0.0.0/24"), Port.tcp(443), "https from a");
+sg.addIngressRule(Peer.ipv4("10.0.1.0/24"), Port.tcp(443), "https from b");
+sg.addIngressRule(Peer.ipv4("192.168.0.0/16"), Port.tcp(22), "ssh");
+Tags.of(sg).add("team", "platform");
+
+app.synth();

--- a/tests/integration/securitygroup/cdk.json
+++ b/tests/integration/securitygroup/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/securitygroup/package.json
+++ b/tests/integration/securitygroup/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-securitygroup",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift SecurityGroup false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/securitygroup/verify.sh
+++ b/tests/integration/securitygroup/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift SecurityGroup false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/securitygroup && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSg
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-securitygroup-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-securitygroup-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/sqs/app.ts
+++ b/tests/integration/sqs/app.ts
@@ -1,0 +1,22 @@
+// CDK app for the cdk-real-drift SQS false-positive integration test (R88).
+// Tricky declared property: RedrivePolicy — CDK declares it as an OBJECT (with an
+// intrinsic ref to the DLQ ARN), but SQS returns it as a JSON STRING (R75
+// object<->JSON-string equality). Plus numeric attributes (VisibilityTimeout, etc.)
+// and tags. The `policies` fixture covers the queue ACCESS policy; this covers the
+// queue ATTRIBUTES.
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSqs");
+
+const dlq = new Queue(stack, "Dlq", { retentionPeriod: Duration.days(14) });
+const queue = new Queue(stack, "Main", {
+  visibilityTimeout: Duration.seconds(45),
+  retentionPeriod: Duration.days(4),
+  deadLetterQueue: { queue: dlq, maxReceiveCount: 5 },
+});
+Tags.of(queue).add("team", "platform");
+Tags.of(queue).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/sqs/cdk.json
+++ b/tests/integration/sqs/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sqs/package.json
+++ b/tests/integration/sqs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sqs",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift SQS false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sqs/verify.sh
+++ b/tests/integration/sqs/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift SQS false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/sqs && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSqs
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sqs-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-sqs-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/ssm/app.ts
+++ b/tests/integration/ssm/app.ts
@@ -1,0 +1,32 @@
+// CDK app for the cdk-real-drift SSM false-positive integration test (R88).
+// Tricky declared property: SSM Document Content — declared as an OBJECT in the
+// template, but AWS returns it as a JSON STRING with keys in a different order
+// (R75 object<->JSON-string structural equality). Plus a plain StringParameter.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnDocument, StringParameter } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSsm");
+
+new StringParameter(stack, "Param", {
+  parameterName: "/cdkrd-integ/ssm/p1",
+  stringValue: "hello-world",
+});
+
+new CfnDocument(stack, "Doc", {
+  name: "cdkrd-integ-doc",
+  documentType: "Command",
+  content: {
+    schemaVersion: "2.2",
+    description: "cdk-real-drift integ document",
+    mainSteps: [
+      {
+        action: "aws:runShellScript",
+        name: "run",
+        inputs: { runCommand: ["echo hello"] },
+      },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/ssm/cdk.json
+++ b/tests/integration/ssm/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ssm/package.json
+++ b/tests/integration/ssm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ssm",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift SSM false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ssm/verify.sh
+++ b/tests/integration/ssm/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift SSM false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/ssm && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSsm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ssm-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-ssm-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/stepfunctions/app.ts
+++ b/tests/integration/stepfunctions/app.ts
@@ -1,0 +1,19 @@
+// CDK app for the cdk-real-drift Step Functions false-positive integration test
+// (R88). Tricky declared property: DefinitionString — a (large) JSON string whose
+// live form may differ in key order / whitespace (R75 JSON-string handling). The
+// auto-created execution role also exercises policy canonicalization.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { DefinitionBody, Pass, StateMachine, Succeed } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSfn");
+
+const start = new Pass(stack, "Start", { comment: "a pass state" });
+const done = new Succeed(stack, "Done");
+
+const sm = new StateMachine(stack, "Machine", {
+  definitionBody: DefinitionBody.fromChainable(start.next(done)),
+});
+Tags.of(sm).add("team", "platform");
+
+app.synth();

--- a/tests/integration/stepfunctions/cdk.json
+++ b/tests/integration/stepfunctions/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/stepfunctions/package.json
+++ b/tests/integration/stepfunctions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-stepfunctions",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift Step Functions false-positive integration test (R88). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/stepfunctions/verify.sh
+++ b/tests/integration/stepfunctions/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift Step Functions false-positive integration test (real AWS, R88).
+#
+# Deploys resources that DECLARE noise-prone properties (see app.ts) whose live AWS
+# form is textually different but semantically equal. The strong assertion: with NO
+# baseline, `check --fail` must exit 0 — there is no declared drift, because every
+# declared value normalizes equal to live. A normalizer regression turns one into a
+# false declared drift and fails here. Then accept + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/stepfunctions && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSfn
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-stepfunctions-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-stepfunctions-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== accept then check must stay CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after accept"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## What

A second wave of real-AWS false-positive integration fixtures — and the two real bugs they caught.

### 8 new "false-positive matrix" fixtures
Each declares a property whose live AWS form is textually different but semantically equal, then asserts `check --fail` exits `0` with no baseline (zero false declared drift): `dynamodb`, `sqs`, `securitygroup`, `cloudwatch-alarm`, `stepfunctions`, `ssm`, `eventbridge`, `cognito`. They target the normalization classes most likely to regress (ordered/unordered arrays, object↔JSON-string, composite identifiers).

### 2 real false-positive bugs found + fixed
- **DynamoDB `AttributeDefinitions` / `KeySchema`** — identity-keyed by `AttributeName` (GSIs by `IndexName`); AWS returns them reordered → positional diff reported false drift on every element. **Fix:** add `AttributeName` / `IndexName` to `IDENTITY_FIELDS` (the identity-array canonicalizer sorts both sides).
- **EC2 `SecurityGroupIngress` / `SecurityGroupEgress`** — rule objects with NO single identity field, returned reordered. **Fix:** per-type `UNORDERED_OBJECT_ARRAY_PROPS` + `sortUnorderedObjectArray` (sort both sides by canonical JSON) in classify. Per-type opt-in because a blanket sort of identity-less object arrays would break order-significant ones (CloudFront cache-behavior precedence, etc.).

Both fixes are equality-gated — a genuine attribute/rule change still surfaces (new unit tests cover reorder-is-clean **and** genuine-change-still-drifts for both classes).

### Docs
`docs/redesign-notes.md` "Considered and rejected" now documents **why declared-side drift is not delegated to CloudFormation's native drift detection** (normalization is shared with the undeclared side so delegation wouldn't remove the false-positive surface; `--pre-deploy` can't be delegated; coverage gap; async cost; CFn drift's own quirks) — with `--undeclared-only` as the user-side split and `verify-vs-cdk-drift` as the test oracle. `ARCHITECTURE.md` notes the new canonicalizers.

## Verification
- typecheck / lint / build / **667 unit tests** green (+4 new for the two fix classes).
- **All 8 wave-2 fixtures INTEG PASS** on the dev account (incl. the 2 that drove the fix, re-run after the fix → CLEAN).
- The **212-case golden corpus replay** still passes — the offline regression net for the normalization change; its blast radius is provably isolated (only `AttributeName`/`IndexName`-keyed arrays and SG ingress/egress), so existing fixtures' types are unaffected.
