### PR TITLE
test(corpus): record 19 wave-2 golden cases — locks the R88 fixes offline (R89)

### DIFF
--- a/tests/corpus/AWS__CloudWatch__Alarm.Alarm7103F465.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.Alarm7103F465.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Alarm7103F465",
+    "resourceType": "AWS::CloudWatch::Alarm",
+    "physicalId": "CdkRealDriftIntegAlarm-Alarm7103F465-sZUYbouFngxU",
+    "constructPath": "CdkRealDriftIntegAlarm/Alarm",
+    "declared": {
+      "ComparisonOperator": "GreaterThanThreshold",
+      "Dimensions": [
+        {
+          "Name": "FunctionName",
+          "Value": "cdkrd-integ-fn"
+        },
+        {
+          "Name": "Resource",
+          "Value": "cdkrd-integ-fn:live"
+        }
+      ],
+      "EvaluationPeriods": 2,
+      "MetricName": "Errors",
+      "Namespace": "AWS/Lambda",
+      "Period": 300,
+      "Statistic": "Sum",
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "Threshold": 5
+    }
+  },
+  "liveRaw": {
+    "ComparisonOperator": "GreaterThanThreshold",
+    "Dimensions": [
+      {
+        "Value": "cdkrd-integ-fn",
+        "Name": "FunctionName"
+      },
+      {
+        "Value": "cdkrd-integ-fn:live",
+        "Name": "Resource"
+      }
+    ],
+    "Period": 300,
+    "EvaluationPeriods": 2,
+    "Namespace": "AWS/Lambda",
+    "OKActions": [],
+    "AlarmActions": [],
+    "MetricName": "Errors",
+    "ActionsEnabled": true,
+    "AlarmName": "CdkRealDriftIntegAlarm-Alarm7103F465-sZUYbouFngxU",
+    "Statistic": "Sum",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkRealDriftIntegAlarm-Alarm7103F465-sZUYbouFngxU",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegAlarm",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Alarm7103F465",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAlarm/cd3b1c10-6725-11f1-90f6-0e3526a02887",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Threshold": 5
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {
+      "ActionsEnabled": true
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Alarm7103F465",
+      "resourceType": "AWS::CloudWatch::Alarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkRealDriftIntegAlarm-Alarm7103F465-sZUYbouFngxU",
+      "constructPath": "CdkRealDriftIntegAlarm/Alarm"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Client4A7F64DF",
+    "resourceType": "AWS::Cognito::UserPoolClient",
+    "physicalId": "mr9u1vrva41nona9of2rfctdi",
+    "constructPath": "CdkRealDriftIntegCognito/Client",
+    "declared": {
+      "AllowedOAuthFlows": ["implicit", "code"],
+      "AllowedOAuthFlowsUserPoolClient": true,
+      "AllowedOAuthScopes": ["openid", "email", "profile"],
+      "CallbackURLs": ["https://a.example/cb", "https://b.example/cb"],
+      "ExplicitAuthFlows": [
+        "ALLOW_USER_PASSWORD_AUTH",
+        "ALLOW_USER_SRP_AUTH",
+        "ALLOW_REFRESH_TOKEN_AUTH"
+      ],
+      "GenerateSecret": false,
+      "SupportedIdentityProviders": ["COGNITO"],
+      "UserPoolId": "us-east-1_J7y6AVs3e"
+    }
+  },
+  "liveRaw": {
+    "GenerateSecret": false,
+    "CallbackURLs": ["https://a.example/cb", "https://b.example/cb"],
+    "EnablePropagateAdditionalUserContextData": false,
+    "AuthSessionValidity": 3,
+    "AllowedOAuthScopes": ["email", "openid", "profile"],
+    "TokenValidityUnits": {},
+    "ReadAttributes": [],
+    "AllowedOAuthFlowsUserPoolClient": true,
+    "SupportedIdentityProviders": ["COGNITO"],
+    "Name": "Client4A7F64DF-sygg0gzLDfo0",
+    "ClientName": "Client4A7F64DF-sygg0gzLDfo0",
+    "UserPoolId": "us-east-1_J7y6AVs3e",
+    "AllowedOAuthFlows": ["code", "implicit"],
+    "ExplicitAuthFlows": [
+      "ALLOW_REFRESH_TOKEN_AUTH",
+      "ALLOW_USER_PASSWORD_AUTH",
+      "ALLOW_USER_SRP_AUTH"
+    ],
+    "LogoutURLs": [],
+    "ClientId": "mr9u1vrva41nona9of2rfctdi",
+    "RefreshTokenValidity": 30,
+    "WriteAttributes": [],
+    "EnableTokenRevocation": true
+  },
+  "schema": {
+    "readOnly": ["ClientId", "ClientSecret", "Name"],
+    "writeOnly": [],
+    "createOnly": ["GenerateSecret", "UserPoolId"],
+    "readOnlyPaths": ["ClientId", "ClientSecret", "Name"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GenerateSecret", "UserPoolId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Client4A7F64DF",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "AuthSessionValidity",
+      "actual": 3,
+      "physicalId": "mr9u1vrva41nona9of2rfctdi",
+      "constructPath": "CdkRealDriftIntegCognito/Client"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Client4A7F64DF",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "ClientName",
+      "actual": "Client4A7F64DF-sygg0gzLDfo0",
+      "physicalId": "mr9u1vrva41nona9of2rfctdi",
+      "constructPath": "CdkRealDriftIntegCognito/Client"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Client4A7F64DF",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "RefreshTokenValidity",
+      "actual": 30,
+      "physicalId": "mr9u1vrva41nona9of2rfctdi",
+      "constructPath": "CdkRealDriftIntegCognito/Client"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Client4A7F64DF",
+      "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnableTokenRevocation",
+      "actual": true,
+      "physicalId": "mr9u1vrva41nona9of2rfctdi",
+      "constructPath": "CdkRealDriftIntegCognito/Client"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
@@ -1,0 +1,186 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Data666C94C7",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+    "constructPath": "CdkRealDriftIntegDynamoDB/Data",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "sk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "gsi1pk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "gsi1sk",
+          "AttributeType": "N"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "GlobalSecondaryIndexes": [
+        {
+          "IndexName": "gsi1",
+          "KeySchema": [
+            {
+              "AttributeName": "gsi1pk",
+              "KeyType": "HASH"
+            },
+            {
+              "AttributeName": "gsi1sk",
+              "KeyType": "RANGE"
+            }
+          ],
+          "Projection": {
+            "ProjectionType": "ALL"
+          }
+        }
+      ],
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "PointInTimeRecoverySpecification": {
+        "PointInTimeRecoveryEnabled": true
+      },
+      "Tags": [
+        {
+          "Key": "cost-center",
+          "Value": "1234"
+        },
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SSESpecification": {
+      "SSEEnabled": false
+    },
+    "ContributorInsightsSpecification": {
+      "Enabled": false
+    },
+    "PointInTimeRecoverySpecification": {
+      "PointInTimeRecoveryEnabled": true,
+      "RecoveryPeriodInDays": 35
+    },
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "TableName": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "gsi1pk"
+      },
+      {
+        "AttributeType": "N",
+        "AttributeName": "gsi1sk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "sk"
+      }
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+    "GlobalSecondaryIndexes": [
+      {
+        "IndexName": "gsi1",
+        "ContributorInsightsSpecification": {
+          "Enabled": false
+        },
+        "Projection": {
+          "NonKeyAttributes": [],
+          "ProjectionType": "ALL"
+        },
+        "KeySchema": [
+          {
+            "KeyType": "HASH",
+            "AttributeName": "gsi1pk"
+          },
+          {
+            "KeyType": "RANGE",
+            "AttributeName": "gsi1sk"
+          }
+        ],
+        "WarmThroughput": {
+          "ReadUnitsPerSecond": 12000,
+          "WriteUnitsPerSecond": 4000
+        }
+      }
+    ],
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      },
+      {
+        "KeyType": "RANGE",
+        "AttributeName": "sk"
+      }
+    ],
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "1234",
+        "Key": "cost-center"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      }
+    ],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn"],
+    "writeOnly": ["ImportSourceSpecification"],
+    "createOnly": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn"],
+    "writeOnlyPaths": ["ImportSourceSpecification"],
+    "createOnlyPaths": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+      "constructPath": "CdkRealDriftIntegDynamoDB/Data"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__InternetGateway.VpcIGWD7BA715C.json
+++ b/tests/corpus/AWS__EC2__InternetGateway.VpcIGWD7BA715C.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcIGWD7BA715C",
+    "resourceType": "AWS::EC2::InternetGateway",
+    "physicalId": "igw-09d610db1e1a48943",
+    "constructPath": "CdkRealDriftIntegSg/Vpc/IGW",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegSg/Vpc"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "InternetGatewayId": "igw-09d610db1e1a48943",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegSg/Vpc",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["InternetGatewayId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["InternetGatewayId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__Route.VpcpublicSubnet1DefaultRouteB88F9E93.json
+++ b/tests/corpus/AWS__EC2__Route.VpcpublicSubnet1DefaultRouteB88F9E93.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcpublicSubnet1DefaultRouteB88F9E93",
+    "resourceType": "AWS::EC2::Route",
+    "physicalId": "rtb-09f1f01d82cbfdfcc|0.0.0.0/0",
+    "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/DefaultRoute",
+    "declared": {
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "GatewayId": "igw-09d610db1e1a48943",
+      "RouteTableId": "rtb-09f1f01d82cbfdfcc"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-09f1f01d82cbfdfcc",
+    "CidrBlock": "0.0.0.0/0",
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "GatewayId": "igw-09d610db1e1a48943",
+    "VpcEndpointId": "igw-09d610db1e1a48943"
+  },
+  "schema": {
+    "readOnly": ["CidrBlock"],
+    "writeOnly": [],
+    "createOnly": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "readOnlyPaths": ["CidrBlock"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DestinationCidrBlock",
+      "DestinationIpv6CidrBlock",
+      "DestinationPrefixListId",
+      "RouteTableId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcpublicSubnet1DefaultRouteB88F9E93",
+      "resourceType": "AWS::EC2::Route",
+      "path": "VpcEndpointId",
+      "actual": "igw-09d610db1e1a48943",
+      "physicalId": "rtb-09f1f01d82cbfdfcc|0.0.0.0/0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/DefaultRoute"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__RouteTable.VpcpublicSubnet1RouteTable15C15F8E.json
+++ b/tests/corpus/AWS__EC2__RouteTable.VpcpublicSubnet1RouteTable15C15F8E.json
@@ -1,0 +1,43 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcpublicSubnet1RouteTable15C15F8E",
+    "resourceType": "AWS::EC2::RouteTable",
+    "physicalId": "rtb-09f1f01d82cbfdfcc",
+    "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/RouteTable",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegSg/Vpc/publicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-08f08ab760705a18a"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-09f1f01d82cbfdfcc",
+    "VpcId": "vpc-08f08ab760705a18a",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegSg/Vpc/publicSubnet1",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RouteTableId"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["RouteTableId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SecurityGroup.SgD4954771.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.SgD4954771.json
@@ -1,0 +1,131 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SgD4954771",
+    "resourceType": "AWS::EC2::SecurityGroup",
+    "physicalId": "sg-0f4873d4b3aa50607",
+    "constructPath": "CdkRealDriftIntegSg/Sg",
+    "declared": {
+      "GroupDescription": "CdkRealDriftIntegSg/Sg",
+      "SecurityGroupEgress": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "Allow all outbound traffic by default",
+          "IpProtocol": "-1"
+        }
+      ],
+      "SecurityGroupIngress": [
+        {
+          "CidrIp": "10.0.0.0/24",
+          "Description": "https from a",
+          "FromPort": 443,
+          "IpProtocol": "tcp",
+          "ToPort": 443
+        },
+        {
+          "CidrIp": "10.0.1.0/24",
+          "Description": "https from b",
+          "FromPort": 443,
+          "IpProtocol": "tcp",
+          "ToPort": 443
+        },
+        {
+          "CidrIp": "192.168.0.0/16",
+          "Description": "ssh",
+          "FromPort": 22,
+          "IpProtocol": "tcp",
+          "ToPort": 22
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "VpcId": "vpc-08f08ab760705a18a"
+    }
+  },
+  "liveRaw": {
+    "GroupDescription": "CdkRealDriftIntegSg/Sg",
+    "GroupName": "CdkRealDriftIntegSg-SgD4954771-8qZ9xcu9LOZR",
+    "VpcId": "vpc-08f08ab760705a18a",
+    "Id": "sg-0f4873d4b3aa50607",
+    "SecurityGroupIngress": [
+      {
+        "CidrIp": "192.168.0.0/16",
+        "Description": "ssh",
+        "FromPort": 22,
+        "ToPort": 22,
+        "IpProtocol": "tcp"
+      },
+      {
+        "CidrIp": "10.0.0.0/24",
+        "Description": "https from a",
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
+      },
+      {
+        "CidrIp": "10.0.1.0/24",
+        "Description": "https from b",
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
+      }
+    ],
+    "SecurityGroupEgress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow all outbound traffic by default",
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "-1"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegSg",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSg/93f7af90-6725-11f1-a89d-0e41c8a66b63",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "SgD4954771",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "GroupId": "sg-0f4873d4b3aa50607"
+  },
+  "schema": {
+    "readOnly": ["GroupId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["GroupDescription", "GroupName", "VpcId"],
+    "readOnlyPaths": ["GroupId", "Id"],
+    "writeOnlyPaths": ["SecurityGroupIngress.*.SourceSecurityGroupName"],
+    "createOnlyPaths": ["GroupDescription", "GroupName", "VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "SgD4954771",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "GroupName",
+      "actual": "CdkRealDriftIntegSg-SgD4954771-8qZ9xcu9LOZR",
+      "physicalId": "sg-0f4873d4b3aa50607",
+      "constructPath": "CdkRealDriftIntegSg/Sg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
+++ b/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
@@ -1,0 +1,155 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+    "resourceType": "AWS::EC2::Subnet",
+    "physicalId": "subnet-0a9a838411f55ddb0",
+    "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "CidrBlock": "10.0.0.0/24",
+      "MapPublicIpOnLaunch": true,
+      "Tags": [
+        {
+          "Key": "aws-cdk:subnet-name",
+          "Value": "public"
+        },
+        {
+          "Key": "aws-cdk:subnet-type",
+          "Value": "Public"
+        },
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegSg/Vpc/publicSubnet1"
+        }
+      ],
+      "VpcId": "vpc-08f08ab760705a18a"
+    }
+  },
+  "liveRaw": {
+    "MapPublicIpOnLaunch": true,
+    "EnableDns64": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "CidrBlock": "10.0.0.0/24",
+    "SubnetId": "subnet-0a9a838411f55ddb0",
+    "BlockPublicAccessStates": {
+      "InternetGatewayBlockMode": "off"
+    },
+    "AssignIpv6AddressOnCreation": false,
+    "VpcId": "vpc-08f08ab760705a18a",
+    "NetworkAclAssociationId": "aclassoc-014f7267371e2ec44",
+    "PrivateDnsNameOptionsOnLaunch": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "Ipv6Native": false,
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegSg/Vpc/publicSubnet1",
+        "Key": "Name"
+      },
+      {
+        "Value": "Public",
+        "Key": "aws-cdk:subnet-type"
+      },
+      {
+        "Value": "public",
+        "Key": "aws-cdk:subnet-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnly": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnly": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "BlockPublicAccessStates",
+      "Ipv6CidrBlocks",
+      "NetworkAclAssociationId",
+      "SubnetId"
+    ],
+    "writeOnlyPaths": [
+      "EnableLniAtDeviceIndex",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6IpamPoolId",
+      "Ipv6NetmaskLength"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZone",
+      "AvailabilityZoneId",
+      "CidrBlock",
+      "Ipv4IpamPoolId",
+      "Ipv4NetmaskLength",
+      "Ipv6CidrBlock",
+      "Ipv6IpamPoolId",
+      "Ipv6Native",
+      "Ipv6NetmaskLength",
+      "OutpostArn",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "PrivateDnsNameOptionsOnLaunch",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.VpcpublicSubnet1RouteTableAssociation4E83B6E4.json
+++ b/tests/corpus/AWS__EC2__SubnetRouteTableAssociation.VpcpublicSubnet1RouteTableAssociation4E83B6E4.json
@@ -1,0 +1,33 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcpublicSubnet1RouteTableAssociation4E83B6E4",
+    "resourceType": "AWS::EC2::SubnetRouteTableAssociation",
+    "physicalId": "rtbassoc-0e438ec054aac8cc7",
+    "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/RouteTableAssociation",
+    "declared": {
+      "RouteTableId": "rtb-09f1f01d82cbfdfcc",
+      "SubnetId": "subnet-0a9a838411f55ddb0"
+    }
+  },
+  "liveRaw": {
+    "RouteTableId": "rtb-09f1f01d82cbfdfcc",
+    "Id": "rtbassoc-0e438ec054aac8cc7",
+    "SubnetId": "subnet-0a9a838411f55ddb0"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["RouteTableId", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RouteTableId", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPC.Vpc8378EB38.json
+++ b/tests/corpus/AWS__EC2__VPC.Vpc8378EB38.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Vpc8378EB38",
+    "resourceType": "AWS::EC2::VPC",
+    "physicalId": "vpc-08f08ab760705a18a",
+    "constructPath": "CdkRealDriftIntegSg/Vpc",
+    "declared": {
+      "CidrBlock": "10.0.0.0/16",
+      "EnableDnsHostnames": true,
+      "EnableDnsSupport": true,
+      "InstanceTenancy": "default",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegSg/Vpc"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-08f08ab760705a18a",
+    "InstanceTenancy": "default",
+    "CidrBlockAssociations": ["vpc-cidr-assoc-09f6797051d22a710"],
+    "CidrBlock": "10.0.0.0/16",
+    "DefaultNetworkAcl": "acl-05e56cde864d77687",
+    "EnableDnsSupport": true,
+    "Ipv6CidrBlocks": [],
+    "DefaultSecurityGroup": "sg-0a911c30b680f3c4e",
+    "EnableDnsHostnames": true,
+    "Tags": [
+      {
+        "Value": "Vpc8378EB38",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSg/93f7af90-6725-11f1-a89d-0e41c8a66b63",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSg",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CdkRealDriftIntegSg/Vpc",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnly": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnly": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "readOnlyPaths": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnlyPaths": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPCGatewayAttachment.VpcVPCGWBF912B6E.json
+++ b/tests/corpus/AWS__EC2__VPCGatewayAttachment.VpcVPCGWBF912B6E.json
@@ -1,0 +1,33 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcVPCGWBF912B6E",
+    "resourceType": "AWS::EC2::VPCGatewayAttachment",
+    "physicalId": "IGW|vpc-08f08ab760705a18a",
+    "constructPath": "CdkRealDriftIntegSg/Vpc/VPCGW",
+    "declared": {
+      "InternetGatewayId": "igw-09d610db1e1a48943",
+      "VpcId": "vpc-08f08ab760705a18a"
+    }
+  },
+  "liveRaw": {
+    "InternetGatewayId": "igw-09d610db1e1a48943",
+    "AttachmentType": "IGW",
+    "VpcId": "vpc-08f08ab760705a18a"
+  },
+  "schema": {
+    "readOnly": ["AttachmentType"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["AttachmentType"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Events__Rule.Rule4C995B7F.json
+++ b/tests/corpus/AWS__Events__Rule.Rule4C995B7F.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule4C995B7F",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU",
+    "constructPath": "CdkRealDriftIntegEvents/Rule",
+    "declared": {
+      "EventPattern": {
+        "source": ["cdkrd.integ"],
+        "detail-type": ["test-a", "test-b"]
+      },
+      "State": "ENABLED",
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "Targets": [
+        {
+          "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+          "Id": "Target0"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "EventPattern": {
+      "detail-type": ["test-a", "test-b"],
+      "source": ["cdkrd.integ"]
+    },
+    "State": "ENABLED",
+    "Targets": [
+      {
+        "Id": "Target0",
+        "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe"
+      }
+    ],
+    "Id": "CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegEvents",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Rule4C995B7F",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEvents/70671ce0-6726-11f1-893a-0eacb13db4b5",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Rule4C995B7F",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU",
+      "constructPath": "CdkRealDriftIntegEvents/Rule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__Role.MachineRoleD2D3D395.json
+++ b/tests/corpus/AWS__IAM__Role.MachineRoleD2D3D395.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MachineRoleD2D3D395",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+    "constructPath": "CdkRealDriftIntegSfn/Machine/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "states.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "states.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+    "RoleId": "AROAXXXJN2LN3RULV5VNB",
+    "Tags": [
+      {
+        "Value": "platform",
+        "Key": "team"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MachineRoleD2D3D395",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+      "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MachineRoleD2D3D395",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+      "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MachineRoleD2D3D395",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+      "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
+++ b/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
@@ -1,0 +1,93 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DlqD1FAA4AD",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+    "constructPath": "CdkRealDriftIntegSqs/Dlq",
+    "declared": {
+      "MessageRetentionPeriod": 1209600
+    }
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 1209600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+    "QueueName": "CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
+++ b/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Main54E5BC70",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+    "constructPath": "CdkRealDriftIntegSqs/Main",
+    "declared": {
+      "MessageRetentionPeriod": 345600,
+      "RedrivePolicy": {
+        "deadLetterTargetArn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+        "maxReceiveCount": 5
+      },
+      "Tags": [
+        {
+          "Key": "cost-center",
+          "Value": "1234"
+        },
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "VisibilityTimeout": 45
+    }
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "RedrivePolicy": {
+      "maxReceiveCount": 5,
+      "deadLetterTargetArn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC"
+    },
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 45,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+    "QueueName": "CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+    "Tags": [
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "1234",
+        "Key": "cost-center"
+      }
+    ],
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
+++ b/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Target3191CF44",
+    "resourceType": "AWS::SQS::Queue",
+    "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+    "constructPath": "CdkRealDriftIntegEvents/Target",
+    "declared": {}
+  },
+  "liveRaw": {
+    "SqsManagedSseEnabled": true,
+    "ReceiveMessageWaitTimeSeconds": 0,
+    "DelaySeconds": 0,
+    "MessageRetentionPeriod": 345600,
+    "MaximumMessageSize": 1048576,
+    "VisibilityTimeout": 30,
+    "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+    "QueueName": "CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+    "QueueUrl": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe"
+  },
+  "schema": {
+    "readOnly": ["Arn", "QueueUrl"],
+    "writeOnly": [],
+    "createOnly": ["FifoQueue", "QueueName"],
+    "readOnlyPaths": ["Arn", "QueueUrl"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoQueue", "QueueName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SQS__QueuePolicy.TargetPolicyDC4F1B6B.json
+++ b/tests/corpus/AWS__SQS__QueuePolicy.TargetPolicyDC4F1B6B.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TargetPolicyDC4F1B6B",
+    "resourceType": "AWS::SQS::QueuePolicy",
+    "physicalId": "CdkRealDriftIntegEvents-TargetPolicyDC4F1B6B-BRkWFRS1GXo3",
+    "constructPath": "CdkRealDriftIntegEvents/Target/Policy",
+    "declared": {
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": ["sqs:SendMessage", "sqs:GetQueueAttributes", "sqs:GetQueueUrl"],
+            "Condition": {
+              "ArnEquals": {
+                "aws:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU"
+              }
+            },
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "events.amazonaws.com"
+            },
+            "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "Queues": [
+        "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe"
+      ]
+    }
+  },
+  "liveRaw": {
+    "Queues": [
+      "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe"
+    ],
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "events.amazonaws.com"
+          },
+          "Action": ["sqs:SendMessage", "sqs:GetQueueAttributes", "sqs:GetQueueUrl"],
+          "Resource": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+          "Condition": {
+            "ArnEquals": {
+              "aws:SourceArn": "arn:aws:events:us-east-1:111111111111:rule/CdkRealDriftIntegEvents-Rule4C995B7F-onmWJJClRIjU"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SSM__Document.Doc.json
+++ b/tests/corpus/AWS__SSM__Document.Doc.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Doc",
+    "resourceType": "AWS::SSM::Document",
+    "physicalId": "cdkrd-integ-doc",
+    "constructPath": "CdkRealDriftIntegSsm/Doc",
+    "declared": {
+      "Content": {
+        "schemaVersion": "2.2",
+        "description": "cdk-real-drift integ document",
+        "mainSteps": [
+          {
+            "action": "aws:runShellScript",
+            "name": "run",
+            "inputs": {
+              "runCommand": ["echo hello"]
+            }
+          }
+        ]
+      },
+      "DocumentType": "Command",
+      "Name": "cdkrd-integ-doc"
+    }
+  },
+  "liveRaw": {
+    "DocumentFormat": "JSON",
+    "Content": "{\n  \"schemaVersion\" : \"2.2\",\n  \"description\" : \"cdk-real-drift integ document\",\n  \"mainSteps\" : [ {\n    \"inputs\" : {\n      \"runCommand\" : [ \"echo hello\" ]\n    },\n    \"name\" : \"run\",\n    \"action\" : \"aws:runShellScript\"\n  } ]\n}",
+    "DocumentType": "Command",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSsm/30805150-6726-11f1-9d16-12be47f86c4d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSsm",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Doc",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-doc"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["Attachments", "UpdateMethod"],
+    "createOnly": [
+      "Attachments",
+      "Content",
+      "DocumentFormat",
+      "DocumentType",
+      "Name",
+      "Requires",
+      "TargetType",
+      "VersionName"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["Attachments", "UpdateMethod"],
+    "createOnlyPaths": [
+      "Attachments",
+      "Content",
+      "DocumentFormat",
+      "DocumentType",
+      "Name",
+      "Requires",
+      "TargetType",
+      "VersionName"
+    ],
+    "defaults": {
+      "DocumentFormat": "JSON",
+      "UpdateMethod": "Replace"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Doc",
+      "resourceType": "AWS::SSM::Document",
+      "path": "DocumentFormat",
+      "actual": "JSON",
+      "physicalId": "cdkrd-integ-doc",
+      "constructPath": "CdkRealDriftIntegSsm/Doc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.Machine6FC8AE80.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.Machine6FC8AE80.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Machine6FC8AE80",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:Machine6FC8AE80-rOT2HXO40dQB",
+    "constructPath": "CdkRealDriftIntegSfn/Machine",
+    "declared": {
+      "DefinitionString": "{\"StartAt\":\"Start\",\"States\":{\"Start\":{\"Type\":\"Pass\",\"Comment\":\"a pass state\",\"Next\":\"Done\"},\"Done\":{\"Type\":\"Succeed\"}}}",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "DefinitionString": "{\"StartAt\":\"Start\",\"States\":{\"Start\":{\"Type\":\"Pass\",\"Comment\":\"a pass state\",\"Next\":\"Done\"},\"Done\":{\"Type\":\"Succeed\"}}}",
+    "EncryptionConfiguration": {
+      "Type": "AWS_OWNED_KEY"
+    },
+    "LoggingConfiguration": {
+      "IncludeExecutionData": false,
+      "Level": "OFF"
+    },
+    "StateMachineRevisionId": "INITIAL",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:Machine6FC8AE80-rOT2HXO40dQB",
+    "StateMachineName": "Machine6FC8AE80-rOT2HXO40dQB",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegSfn",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Machine6FC8AE80",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSfn/e7377be0-6725-11f1-b348-0affd2e8cf5d",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "Machine6FC8AE80-rOT2HXO40dQB",
+    "StateMachineType": "STANDARD",
+    "TracingConfiguration": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnly": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnly": ["StateMachineName", "StateMachineType"],
+    "readOnlyPaths": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnlyPaths": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnlyPaths": ["StateMachineName", "StateMachineType"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Machine6FC8AE80",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "Type": "AWS_OWNED_KEY"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:Machine6FC8AE80-rOT2HXO40dQB",
+      "constructPath": "CdkRealDriftIntegSfn/Machine"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Machine6FC8AE80",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "LoggingConfiguration",
+      "actual": {
+        "IncludeExecutionData": false,
+        "Level": "OFF"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:Machine6FC8AE80-rOT2HXO40dQB",
+      "constructPath": "CdkRealDriftIntegSfn/Machine"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Machine6FC8AE80",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineName",
+      "actual": "Machine6FC8AE80-rOT2HXO40dQB",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:Machine6FC8AE80-rOT2HXO40dQB",
+      "constructPath": "CdkRealDriftIntegSfn/Machine"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Machine6FC8AE80",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineType",
+      "actual": "STANDARD",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:Machine6FC8AE80-rOT2HXO40dQB",
+      "constructPath": "CdkRealDriftIntegSfn/Machine"
+    }
+  ]
+}


### PR DESCRIPTION
Captured live from the eight wave-2 false-positive stacks (`CDKRD_CORPUS_DIR`), so their richer configs replay offline forever with **no AWS** — the golden-corpus model: record once via integ, replay every CI run as a unit test.

## Highlights
- **Locks the two R88 fixes offline**: `DynamoDB::Table` with a GSI (4 AttributeDefinitions) and `EC2::SecurityGroup` with 3 ingress rules are both recorded **CLEAN** — reverting the `AttributeName`/`IndexName` identity canonicalization or the `UNORDERED_OBJECT_ARRAY_PROPS` sort would resurface the reorder as declared drift and **fail the replay**, with no deploy needed.
- Also adds the SG fixture's VPC/Subnet/RouteTable infra cases + SQS/SFN/Events resources.
- 3 logicalId collisions with existing harvest6 cases (Cognito UserPool/Group, SSM Parameter) were restored to the committed harvest6 versions — **pure addition, no existing golden case modified**.

## Numbers
- Corpus 212 → 231 (+19). Unit tests 667 → **686**. typecheck / lint / build green. Account ids auto-sanitized to 111111111111.