### PR TITLE
test(corpus): harvest waves 7 & 8 — 18 more golden cases across ~25 uncovered types (R90)

### DIFF
--- a/tests/corpus/AWS__ApiGateway__Account.ApiAccountA18C9B29.json
+++ b/tests/corpus/AWS__ApiGateway__Account.ApiAccountA18C9B29.json
@@ -1,0 +1,31 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiAccountA18C9B29",
+    "resourceType": "AWS::ApiGateway::Account",
+    "physicalId": "Cdkdri-ApiAc-uSKoF74o8pn9",
+    "constructPath": "CdkdriftIntegHarvest8/Api/Account",
+    "declared": {
+      "CloudWatchRoleArn": "arn:aws:iam::111111111111:role/CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT"
+    }
+  },
+  "liveRaw": {
+    "Id": "Cdkdri-ApiAc-uSKoF74o8pn9",
+    "CloudWatchRoleArn": "arn:aws:iam::111111111111:role/CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__GatewayResponse.GwResponse4E10BA47.json
+++ b/tests/corpus/AWS__ApiGateway__GatewayResponse.GwResponse4E10BA47.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GwResponse4E10BA47",
+    "resourceType": "AWS::ApiGateway::GatewayResponse",
+    "physicalId": "38w1jnsg0j:DEFAULT_4XX",
+    "constructPath": "CdkdriftIntegHarvest8/GwResponse",
+    "declared": {
+      "ResponseType": "DEFAULT_4XX",
+      "RestApiId": "38w1jnsg0j"
+    }
+  },
+  "liveRaw": {
+    "ResponseTemplates": {
+      "application/json": "{\"message\":$context.error.messageString}"
+    },
+    "ResponseParameters": {},
+    "RestApiId": "38w1jnsg0j",
+    "Id": "38w1jnsg0j:DEFAULT_4XX",
+    "ResponseType": "DEFAULT_4XX"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["ResponseType", "RestApiId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResponseType", "RestApiId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "GwResponse4E10BA47",
+      "resourceType": "AWS::ApiGateway::GatewayResponse",
+      "path": "ResponseTemplates",
+      "actual": {
+        "application/json": "{\"message\":$context.error.messageString}"
+      },
+      "physicalId": "38w1jnsg0j:DEFAULT_4XX",
+      "constructPath": "CdkdriftIntegHarvest8/GwResponse"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__Method.ApiGET9257B917.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiGET9257B917.json
@@ -1,0 +1,73 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiGET9257B917",
+    "resourceType": "AWS::ApiGateway::Method",
+    "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+    "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET",
+    "declared": {
+      "AuthorizationType": "NONE",
+      "HttpMethod": "GET",
+      "Integration": {
+        "IntegrationResponses": [
+          {
+            "StatusCode": "200"
+          }
+        ],
+        "RequestTemplates": {
+          "application/json": "{\"statusCode\": 200}"
+        },
+        "Type": "MOCK"
+      },
+      "MethodResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "ResourceId": "1pd9ky6ghl",
+      "RestApiId": "38w1jnsg0j"
+    }
+  },
+  "liveRaw": {
+    "MethodResponses": [
+      {
+        "StatusCode": "200"
+      }
+    ],
+    "Integration": {
+      "CacheNamespace": "1pd9ky6ghl",
+      "Type": "MOCK",
+      "IntegrationResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "RequestTemplates": {
+        "application/json": "{\"statusCode\": 200}"
+      },
+      "ResponseTransferMode": "BUFFERED",
+      "TimeoutInMillis": 29000,
+      "PassthroughBehavior": "WHEN_NO_MATCH"
+    },
+    "ResourceId": "1pd9ky6ghl",
+    "RestApiId": "38w1jnsg0j",
+    "ApiKeyRequired": false,
+    "AuthorizationType": "NONE",
+    "HttpMethod": "GET"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["HttpMethod", "ResourceId", "RestApiId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HttpMethod", "ResourceId", "RestApiId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiF70053CD",
+    "resourceType": "AWS::ApiGateway::RestApi",
+    "physicalId": "38w1jnsg0j",
+    "constructPath": "CdkdriftIntegHarvest8/Api",
+    "declared": {
+      "Name": "cdkrd-integ-api"
+    }
+  },
+  "liveRaw": {
+    "RootResourceId": "1pd9ky6ghl",
+    "SecurityPolicy": "TLS_1_0",
+    "RestApiId": "38w1jnsg0j",
+    "ApiKeySourceType": "HEADER",
+    "EndpointConfiguration": {
+      "IpAddressType": "ipv4",
+      "Types": ["EDGE"]
+    },
+    "DisableExecuteApiEndpoint": false,
+    "Tags": [
+      {
+        "Value": "ApiF70053CD",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest8/19b5c920-6729-11f1-9ba5-0e26a0c940e7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest8",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "cdkrd-integ-api"
+  },
+  "schema": {
+    "readOnly": ["RestApiId", "RootResourceId"],
+    "writeOnly": ["Body", "BodyS3Location", "CloneFrom", "FailOnWarnings", "Mode", "Parameters"],
+    "createOnly": [],
+    "readOnlyPaths": ["RestApiId", "RootResourceId"],
+    "writeOnlyPaths": [
+      "Body",
+      "BodyS3Location",
+      "CloneFrom",
+      "FailOnWarnings",
+      "Mode",
+      "Parameters"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "38w1jnsg0j",
+      "constructPath": "CdkdriftIntegHarvest8/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "ApiKeySourceType",
+      "actual": "HEADER",
+      "physicalId": "38w1jnsg0j",
+      "constructPath": "CdkdriftIntegHarvest8/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "EndpointConfiguration",
+      "actual": {
+        "IpAddressType": "ipv4",
+        "Types": ["EDGE"]
+      },
+      "physicalId": "38w1jnsg0j",
+      "constructPath": "CdkdriftIntegHarvest8/Api"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeDeploy__Application.CodeDeployApp.json
+++ b/tests/corpus/AWS__CodeDeploy__Application.CodeDeployApp.json
@@ -1,0 +1,32 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CodeDeployApp",
+    "resourceType": "AWS::CodeDeploy::Application",
+    "physicalId": "cdkrd-integ-cd",
+    "constructPath": "CdkdriftIntegHarvest7/CodeDeployApp",
+    "declared": {
+      "ApplicationName": "cdkrd-integ-cd",
+      "ComputePlatform": "Lambda"
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "cdkrd-integ-cd",
+    "ComputePlatform": "Lambda"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApplicationName", "ComputePlatform"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApplicationName", "ComputePlatform"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -1,0 +1,632 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Pool88FC4FF9F",
+    "resourceType": "AWS::Cognito::UserPool",
+    "physicalId": "us-east-1_BUaNF3GfH",
+    "constructPath": "CdkdriftIntegHarvest8/Pool8",
+    "declared": {
+      "AccountRecoverySetting": {
+        "RecoveryMechanisms": [
+          {
+            "Name": "verified_phone_number",
+            "Priority": 1
+          },
+          {
+            "Name": "verified_email",
+            "Priority": 2
+          }
+        ]
+      },
+      "AdminCreateUserConfig": {
+        "AllowAdminCreateUserOnly": true
+      },
+      "EmailVerificationMessage": "The verification code to your new account is {####}",
+      "EmailVerificationSubject": "Verify your new account",
+      "SmsVerificationMessage": "The verification code to your new account is {####}",
+      "VerificationMessageTemplate": {
+        "DefaultEmailOption": "CONFIRM_WITH_CODE",
+        "EmailMessage": "The verification code to your new account is {####}",
+        "EmailSubject": "Verify your new account",
+        "SmsMessage": "The verification code to your new account is {####}"
+      }
+    }
+  },
+  "liveRaw": {
+    "UserPoolTags": {
+      "aws:cloudformation:stack-name": "CdkdriftIntegHarvest8",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest8/19b5c920-6729-11f1-9ba5-0e26a0c940e7",
+      "aws:cloudformation:logical-id": "Pool88FC4FF9F"
+    },
+    "Policies": {
+      "PasswordPolicy": {
+        "RequireNumbers": true,
+        "MinimumLength": 8,
+        "TemporaryPasswordValidityDays": 7,
+        "RequireUppercase": true,
+        "RequireLowercase": true,
+        "RequireSymbols": true
+      },
+      "SignInPolicy": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      }
+    },
+    "VerificationMessageTemplate": {
+      "EmailMessage": "The verification code to your new account is {####}",
+      "SmsMessage": "The verification code to your new account is {####}",
+      "EmailSubject": "Verify your new account",
+      "DefaultEmailOption": "CONFIRM_WITH_CODE"
+    },
+    "ProviderURL": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_BUaNF3GfH",
+    "MfaConfiguration": "OFF",
+    "Schema": [
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "profile"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "address"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "10",
+          "MaxLength": "10"
+        },
+        "Required": false,
+        "Name": "birthdate"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "gender"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "preferred_username"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Number",
+        "Required": false,
+        "NumberAttributeConstraints": {
+          "MinValue": "0"
+        },
+        "Name": "updated_at"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "website"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "picture"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {},
+        "Required": false,
+        "Name": "identities"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": false,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "1",
+          "MaxLength": "2048"
+        },
+        "Required": true,
+        "Name": "sub"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "phone_number"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "phone_number_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "zoneinfo"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "locale"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "email"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "email_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "given_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "family_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "middle_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "nickname"
+      }
+    ],
+    "AdminCreateUserConfig": {
+      "UnusedAccountValidityDays": 7,
+      "AllowAdminCreateUserOnly": true
+    },
+    "UserPoolTier": "ESSENTIALS",
+    "DeletionProtection": "INACTIVE",
+    "UserPoolName": "Pool88FC4FF9F-jVGU9rNojAd7",
+    "SmsVerificationMessage": "The verification code to your new account is {####}",
+    "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_BUaNF3GfH",
+    "UserPoolId": "us-east-1_BUaNF3GfH",
+    "UserAttributeUpdateSettings": {
+      "AttributesRequireVerificationBeforeUpdate": []
+    },
+    "EmailConfiguration": {
+      "EmailSendingAccount": "COGNITO_DEFAULT"
+    },
+    "AliasAttributes": [],
+    "EmailVerificationSubject": "Verify your new account",
+    "LambdaConfig": {},
+    "Arn": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_BUaNF3GfH",
+    "UsernameAttributes": [],
+    "AutoVerifiedAttributes": [],
+    "EmailVerificationMessage": "The verification code to your new account is {####}",
+    "AccountRecoverySetting": {
+      "RecoveryMechanisms": [
+        {
+          "Priority": 1,
+          "Name": "verified_phone_number"
+        },
+        {
+          "Priority": 2,
+          "Name": "verified_email"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnly": ["EnabledMfas"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnlyPaths": ["EnabledMfas"],
+    "createOnlyPaths": [],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Policies",
+      "actual": {
+        "PasswordPolicy": {
+          "RequireNumbers": true,
+          "MinimumLength": 8,
+          "TemporaryPasswordValidityDays": 7,
+          "RequireUppercase": true,
+          "RequireLowercase": true,
+          "RequireSymbols": true
+        },
+        "SignInPolicy": {
+          "AllowedFirstAuthFactors": ["PASSWORD"]
+        }
+      },
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema",
+      "actual": [
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "profile"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "address"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "10",
+            "MaxLength": "10"
+          },
+          "Required": false,
+          "Name": "birthdate"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "gender"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "preferred_username"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Number",
+          "Required": false,
+          "NumberAttributeConstraints": {
+            "MinValue": "0"
+          },
+          "Name": "updated_at"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "website"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "picture"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {},
+          "Required": false,
+          "Name": "identities"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": false,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "1",
+            "MaxLength": "2048"
+          },
+          "Required": true,
+          "Name": "sub"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "phone_number"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "phone_number_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "zoneinfo"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "locale"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "email"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "email_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "given_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "family_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "middle_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "nickname"
+        }
+      ],
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolName",
+      "actual": "Pool88FC4FF9F-jVGU9rNojAd7",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECR__PublicRepository.PublicRepo.json
+++ b/tests/corpus/AWS__ECR__PublicRepository.PublicRepo.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PublicRepo",
+    "resourceType": "AWS::ECR::PublicRepository",
+    "physicalId": "cdkrd-integ-pub",
+    "constructPath": "CdkdriftIntegHarvest8/PublicRepo",
+    "declared": {
+      "RepositoryName": "cdkrd-integ-pub"
+    }
+  },
+  "liveRaw": {
+    "RepositoryName": "cdkrd-integ-pub",
+    "Arn": "arn:aws:ecr-public::111111111111:repository/cdkrd-integ-pub",
+    "RepositoryCatalogData": {},
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegHarvest8",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest8/19b5c920-6729-11f1-9ba5-0e26a0c940e7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "PublicRepo",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["RepositoryName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RepositoryName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EventSchemas__Registry.SchemaRegistry.json
+++ b/tests/corpus/AWS__EventSchemas__Registry.SchemaRegistry.json
@@ -1,0 +1,31 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SchemaRegistry",
+    "resourceType": "AWS::EventSchemas::Registry",
+    "physicalId": "arn:aws:schemas:us-east-1:111111111111:registry/cdkrd-integ-registry",
+    "constructPath": "CdkdriftIntegHarvest7/SchemaRegistry",
+    "declared": {
+      "RegistryName": "cdkrd-integ-registry"
+    }
+  },
+  "liveRaw": {
+    "RegistryName": "cdkrd-integ-registry",
+    "RegistryArn": "arn:aws:schemas:us-east-1:111111111111:registry/cdkrd-integ-registry"
+  },
+  "schema": {
+    "readOnly": ["RegistryArn"],
+    "writeOnly": [],
+    "createOnly": ["RegistryName"],
+    "readOnlyPaths": ["RegistryArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RegistryName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EventSchemas__Schema.Schema.json
+++ b/tests/corpus/AWS__EventSchemas__Schema.Schema.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Schema",
+    "resourceType": "AWS::EventSchemas::Schema",
+    "physicalId": "arn:aws:schemas:us-east-1:111111111111:schema/cdkrd-integ-registry/cdkrd-integ-schema",
+    "constructPath": "CdkdriftIntegHarvest7/Schema",
+    "declared": {
+      "Content": "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"e\",\"version\":\"1.0.0\"},\"paths\":{}}",
+      "RegistryName": "cdkrd-integ-registry",
+      "SchemaName": "cdkrd-integ-schema",
+      "Type": "OpenApi3"
+    }
+  },
+  "liveRaw": {
+    "LastModified": "2026-06-13T13:04:28Z",
+    "Type": "OpenApi3",
+    "SchemaVersion": "1",
+    "Content": "{\"openapi\":\"3.0.0\",\"info\":{\"title\":\"e\",\"version\":\"1.0.0\"},\"paths\":{}}",
+    "RegistryName": "cdkrd-integ-registry",
+    "VersionCreatedDate": "2026-06-13T13:04:28Z",
+    "SchemaArn": "arn:aws:schemas:us-east-1:111111111111:schema/cdkrd-integ-registry/cdkrd-integ-schema",
+    "SchemaName": "cdkrd-integ-schema"
+  },
+  "schema": {
+    "readOnly": ["LastModified", "SchemaArn", "SchemaVersion", "VersionCreatedDate"],
+    "writeOnly": [],
+    "createOnly": ["RegistryName", "SchemaName"],
+    "readOnlyPaths": ["LastModified", "SchemaArn", "SchemaVersion", "VersionCreatedDate"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RegistryName", "SchemaName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Group.GroupC77FDACD.json
+++ b/tests/corpus/AWS__IAM__Group.GroupC77FDACD.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GroupC77FDACD",
+    "resourceType": "AWS::IAM::Group",
+    "physicalId": "CdkdriftIntegHarvest7-GroupC77FDACD-FNM4Ze6xlaOA",
+    "constructPath": "CdkdriftIntegHarvest7/Group",
+    "declared": {}
+  },
+  "liveRaw": {
+    "GroupName": "CdkdriftIntegHarvest7-GroupC77FDACD-FNM4Ze6xlaOA",
+    "Path": "/",
+    "Arn": "arn:aws:iam::111111111111:group/CdkdriftIntegHarvest7-GroupC77FDACD-FNM4Ze6xlaOA"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["GroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["GroupName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "GroupC77FDACD",
+      "resourceType": "AWS::IAM::Group",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkdriftIntegHarvest7-GroupC77FDACD-FNM4Ze6xlaOA",
+      "constructPath": "CdkdriftIntegHarvest7/Group"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__OIDCProvider.Oidc.json
+++ b/tests/corpus/AWS__IAM__OIDCProvider.Oidc.json
@@ -1,0 +1,36 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Oidc",
+    "resourceType": "AWS::IAM::OIDCProvider",
+    "physicalId": "arn:aws:iam::111111111111:oidc-provider/oidc.cdkrd-integ-test.example.com",
+    "constructPath": "CdkdriftIntegHarvest8/Oidc",
+    "declared": {
+      "ClientIdList": ["sts.amazonaws.com"],
+      "ThumbprintList": ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"],
+      "Url": "https://oidc.cdkrd-integ-test.example.com"
+    }
+  },
+  "liveRaw": {
+    "ClientIdList": ["sts.amazonaws.com"],
+    "ThumbprintList": ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"],
+    "Arn": "arn:aws:iam::111111111111:oidc-provider/oidc.cdkrd-integ-test.example.com",
+    "Url": "https://oidc.cdkrd-integ-test.example.com",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Url"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Url"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__Role.ApiCloudWatchRole73EC6FC4.json
+++ b/tests/corpus/AWS__IAM__Role.ApiCloudWatchRole73EC6FC4.json
@@ -1,0 +1,94 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiCloudWatchRole73EC6FC4",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
+    "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Statement": [
+          {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "apigateway.amazonaws.com"
+            }
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "ManagedPolicyArns": [
+        "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+      ]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "ManagedPolicyArns": [
+      "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+    ],
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "apigateway.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
+    "RoleId": "AROAXXXJN2LN5AUI4EUCF"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiCloudWatchRole73EC6FC4",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
+      "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiCloudWatchRole73EC6FC4",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
+      "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiCloudWatchRole73EC6FC4",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
+      "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__QueryDefinition.QueryDef.json
+++ b/tests/corpus/AWS__Logs__QueryDefinition.QueryDef.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "QueryDef",
+    "resourceType": "AWS::Logs::QueryDefinition",
+    "physicalId": "83554b47-e42f-4621-a263-5c7441f50ff7",
+    "constructPath": "CdkdriftIntegHarvest7/QueryDef",
+    "declared": {
+      "Name": "cdkrd-integ-query",
+      "QueryString": "fields @timestamp, @message | sort @timestamp desc | limit 20"
+    }
+  },
+  "liveRaw": {
+    "Parameters": [],
+    "QueryString": "fields @timestamp, @message | sort @timestamp desc | limit 20",
+    "LogGroupNames": [],
+    "QueryLanguage": "CWLI",
+    "QueryDefinitionId": "83554b47-e42f-4621-a263-5c7441f50ff7",
+    "Name": "cdkrd-integ-query"
+  },
+  "schema": {
+    "readOnly": ["QueryDefinitionId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["QueryDefinitionId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {
+      "QueryLanguage": "CWLI"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "QueryDef",
+      "resourceType": "AWS::Logs::QueryDefinition",
+      "path": "QueryLanguage",
+      "actual": "CWLI",
+      "physicalId": "83554b47-e42f-4621-a263-5c7441f50ff7",
+      "constructPath": "CdkdriftIntegHarvest7/QueryDef"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53Resolver__FirewallDomainList.FwDomains.json
+++ b/tests/corpus/AWS__Route53Resolver__FirewallDomainList.FwDomains.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FwDomains",
+    "resourceType": "AWS::Route53Resolver::FirewallDomainList",
+    "physicalId": "rslvr-fdl-fae10c927473462b",
+    "constructPath": "CdkdriftIntegHarvest8/FwDomains",
+    "declared": {
+      "Domains": ["example.com", "test.example.org"],
+      "Name": "cdkrd-integ-fw"
+    }
+  },
+  "liveRaw": {
+    "Status": "COMPLETE",
+    "CreationTime": "2026-06-13T13:09:36.559903485Z",
+    "ManagedOwnerName": "NA",
+    "ModificationTime": "2026-06-13T13:10:30.643877921Z",
+    "Id": "rslvr-fdl-fae10c927473462b",
+    "Arn": "arn:aws:route53resolver:us-east-1:111111111111:firewall-domain-list/rslvr-fdl-fae10c927473462b",
+    "CreatorRequestId": "e886f2bf-f35c-4e45-1f4c-eddeb875f054",
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegHarvest8",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest8/19b5c920-6729-11f1-9ba5-0e26a0c940e7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "FwDomains",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-fw",
+    "DomainCount": 2,
+    "StatusMessage": "Finished domain list update"
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CreationTime",
+      "CreatorRequestId",
+      "DomainCount",
+      "Id",
+      "ManagedOwnerName",
+      "ModificationTime",
+      "Status",
+      "StatusMessage"
+    ],
+    "writeOnly": ["DomainFileUrl", "Domains"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "Arn",
+      "CreationTime",
+      "CreatorRequestId",
+      "DomainCount",
+      "Id",
+      "ManagedOwnerName",
+      "ModificationTime",
+      "Status",
+      "StatusMessage"
+    ],
+    "writeOnlyPaths": ["DomainFileUrl", "Domains"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "FwDomains",
+      "resourceType": "AWS::Route53Resolver::FirewallDomainList",
+      "path": "Domains",
+      "note": "write-only — cannot be read back",
+      "physicalId": "rslvr-fdl-fae10c927473462b",
+      "constructPath": "CdkdriftIntegHarvest8/FwDomains"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53Resolver__FirewallRuleGroup.FwRuleGroup.json
+++ b/tests/corpus/AWS__Route53Resolver__FirewallRuleGroup.FwRuleGroup.json
@@ -1,0 +1,95 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FwRuleGroup",
+    "resourceType": "AWS::Route53Resolver::FirewallRuleGroup",
+    "physicalId": "rslvr-frg-4b70eb88fb1c45ef",
+    "constructPath": "CdkdriftIntegHarvest8/FwRuleGroup",
+    "declared": {
+      "FirewallRules": [
+        {
+          "Action": "BLOCK",
+          "BlockResponse": "NODATA",
+          "FirewallDomainListId": "rslvr-fdl-fae10c927473462b",
+          "Priority": 100
+        }
+      ],
+      "Name": "cdkrd-integ-frg"
+    }
+  },
+  "liveRaw": {
+    "RuleCount": 1,
+    "Status": "COMPLETE",
+    "ShareStatus": "NOT_SHARED",
+    "ModificationTime": "2026-06-13T13:10:30.746307457Z",
+    "CreatorRequestId": "466328c8-c1db-e373-5cb4-5e1dfca334bd",
+    "Name": "cdkrd-integ-frg",
+    "StatusMessage": "Finished rule group update",
+    "OwnerId": "111111111111",
+    "CreationTime": "2026-06-13T13:09:38.721431276Z",
+    "Id": "rslvr-frg-4b70eb88fb1c45ef",
+    "Arn": "arn:aws:route53resolver:us-east-1:111111111111:firewall-rule-group/rslvr-frg-4b70eb88fb1c45ef",
+    "FirewallRules": [
+      {
+        "Action": "BLOCK",
+        "Priority": 100,
+        "FirewallDomainListId": "rslvr-fdl-fae10c927473462b",
+        "FirewallThreatProtectionId": "NOT_APPLICABLE",
+        "BlockResponse": "NODATA",
+        "FirewallDomainRedirectionAction": "INSPECT_REDIRECTION_DOMAIN"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegHarvest8",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest8/19b5c920-6729-11f1-9ba5-0e26a0c940e7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "FwRuleGroup",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CreationTime",
+      "CreatorRequestId",
+      "Id",
+      "ModificationTime",
+      "OwnerId",
+      "RuleCount",
+      "ShareStatus",
+      "Status",
+      "StatusMessage"
+    ],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "Arn",
+      "CreationTime",
+      "CreatorRequestId",
+      "FirewallRules.*.FirewallThreatProtectionId",
+      "Id",
+      "ModificationTime",
+      "OwnerId",
+      "RuleCount",
+      "ShareStatus",
+      "Status",
+      "StatusMessage"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53__CidrCollection.CidrColl.json
+++ b/tests/corpus/AWS__Route53__CidrCollection.CidrColl.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CidrColl",
+    "resourceType": "AWS::Route53::CidrCollection",
+    "physicalId": "2acf608a-b4df-8ecd-a13a-bb592f59f11c",
+    "constructPath": "CdkdriftIntegHarvest7/CidrColl",
+    "declared": {
+      "Locations": [
+        {
+          "CidrList": ["10.0.0.0/24"],
+          "LocationName": "loc1"
+        }
+      ],
+      "Name": "cdkrd-integ-cidr"
+    }
+  },
+  "liveRaw": {
+    "Locations": [
+      {
+        "CidrList": ["10.0.0.0/24"],
+        "LocationName": "loc1"
+      }
+    ],
+    "Id": "2acf608a-b4df-8ecd-a13a-bb592f59f11c",
+    "Arn": "arn:aws:route53:::cidrcollection/2acf608a-b4df-8ecd-a13a-bb592f59f11c",
+    "Name": "cdkrd-integ-cidr"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SES__Template.SesTemplate.json
+++ b/tests/corpus/AWS__SES__Template.SesTemplate.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SesTemplate",
+    "resourceType": "AWS::SES::Template",
+    "physicalId": "cdkrd-integ-tmpl",
+    "constructPath": "CdkdriftIntegHarvest7/SesTemplate",
+    "declared": {
+      "Template": {
+        "SubjectPart": "cdk-real-drift integ",
+        "TemplateName": "cdkrd-integ-tmpl",
+        "TextPart": "hello"
+      }
+    }
+  },
+  "liveRaw": {
+    "Id": "cdkrd-integ-tmpl",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest7/60f88ad0-6728-11f1-851e-12bc8aa3685f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest7",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SesTemplate",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Template": {
+      "TextPart": "hello",
+      "TemplateName": "cdkrd-integ-tmpl",
+      "SubjectPart": "cdk-real-drift integ"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Template.TemplateName"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__RegexPatternSet.RegexSet.json
+++ b/tests/corpus/AWS__WAFv2__RegexPatternSet.RegexSet.json
@@ -1,0 +1,60 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RegexSet",
+    "resourceType": "AWS::WAFv2::RegexPatternSet",
+    "physicalId": "RegexSet-CTQHtT5iegpr|86885cf4-7aa6-4169-92a4-c9d9ac32aed5|REGIONAL",
+    "constructPath": "CdkdriftIntegHarvest7/RegexSet",
+    "declared": {
+      "RegularExpressionList": ["^test.*", "admin"],
+      "Scope": "REGIONAL"
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "RegularExpressionList": ["^test.*", "admin"],
+    "Scope": "REGIONAL",
+    "Id": "86885cf4-7aa6-4169-92a4-c9d9ac32aed5",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/regexpatternset/RegexSet-CTQHtT5iegpr/86885cf4-7aa6-4169-92a4-c9d9ac32aed5",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest7/60f88ad0-6728-11f1-851e-12bc8aa3685f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest7",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "RegexSet",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "RegexSet-CTQHtT5iegpr"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "RegexSet",
+      "resourceType": "AWS::WAFv2::RegexPatternSet",
+      "path": "Name",
+      "actual": "RegexSet-CTQHtT5iegpr",
+      "physicalId": "RegexSet-CTQHtT5iegpr|86885cf4-7aa6-4169-92a4-c9d9ac32aed5|REGIONAL",
+      "constructPath": "CdkdriftIntegHarvest7/RegexSet"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -336,6 +336,26 @@ then accept -> `check --fail` CLEAN.
 cd harvest5 && npm install && bash verify-harvest5.sh
 ```
 
+## harvest7 / harvest8
+
+Waves 7 and 8 of the corpus harvest (R90): cheap, low-dependency CFn types that
+were still uncovered after the corpus crossed 115 distinct types. Wave 7 — WAFv2
+RegexPatternSet, Logs QueryDefinition, ServiceDiscovery HttpNamespace + Service,
+Glue SecurityConfiguration + Workflow, IAM Group, Route53 CidrCollection,
+EventSchemas Registry + Schema, CodeDeploy Application, SES Template, CloudWatch
+AnomalyDetector. Wave 8 — ApiGateway Model / RequestValidator / GatewayResponse
+(children of a RestApi), a Cognito UserPoolResourceServer, Route53 Resolver DNS
+firewall (FirewallDomainList + FirewallRuleGroup), an IAM OIDC provider, and a
+public ECR repository. Same two harvest invariants (fresh deploy = ZERO declared
+drift, then accept -> `check --fail` CLEAN); the CC-unreadable types among them are
+honestly `skipped` (not recorded, never false drift). Run with
+`CDKRD_CORPUS_DIR=<dir>` to record the readable types as golden cases.
+
+```bash
+cd harvest7 && npm install && CDKRD_CORPUS_DIR=../../corpus bash verify-harvest7.sh
+cd harvest8 && npm install && CDKRD_CORPUS_DIR=../../corpus bash verify-harvest8.sh
+```
+
 ## revert
 
 A versioned S3 bucket. Enables acceleration, `accept`s (recording it in the

--- a/tests/integration/harvest7/app.ts
+++ b/tests/integration/harvest7/app.ts
@@ -1,0 +1,85 @@
+// cdk-real-drift corpus-harvest wave 7 (real AWS) — R90.
+// Cheap, no-/low-dependency CFn types NOT yet in the golden corpus (the corpus had
+// 115 distinct types before this wave). Deploy once, record one golden case per
+// readable resource (CDKRD_CORPUS_DIR), assert ZERO declared drift on the fresh
+// deploy (the false-positive invariant across many types), then destroy.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnAnomalyDetector } from "aws-cdk-lib/aws-cloudwatch";
+import { CfnApplication } from "aws-cdk-lib/aws-codedeploy";
+import { CfnRegistry, CfnSchema } from "aws-cdk-lib/aws-eventschemas";
+import { CfnSecurityConfiguration, CfnWorkflow } from "aws-cdk-lib/aws-glue";
+import { Group } from "aws-cdk-lib/aws-iam";
+import { CfnQueryDefinition } from "aws-cdk-lib/aws-logs";
+import { CfnCidrCollection } from "aws-cdk-lib/aws-route53";
+import { CfnTemplate } from "aws-cdk-lib/aws-ses";
+import { HttpNamespace } from "aws-cdk-lib/aws-servicediscovery";
+import { CfnRegexPatternSet } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkdriftIntegHarvest7");
+
+new CfnRegexPatternSet(stack, "RegexSet", {
+  scope: "REGIONAL",
+  regularExpressionList: ["^test.*", "admin"],
+});
+
+new CfnQueryDefinition(stack, "QueryDef", {
+  name: "cdkrd-integ-query",
+  queryString: "fields @timestamp, @message | sort @timestamp desc | limit 20",
+});
+
+const ns = new HttpNamespace(stack, "HttpNs", { name: "cdkrd-integ-ns" });
+ns.createService("Svc", { name: "cdkrd-integ-svc" });
+
+new CfnSecurityConfiguration(stack, "GlueSec", {
+  name: "cdkrd-integ-glue-sec",
+  encryptionConfiguration: { s3Encryptions: [{ s3EncryptionMode: "SSE-S3" }] },
+});
+
+new CfnWorkflow(stack, "GlueWf", { name: "cdkrd-integ-wf" });
+
+const group = new Group(stack, "Group");
+Tags.of(group).add("team", "platform");
+
+new CfnCidrCollection(stack, "CidrColl", {
+  name: "cdkrd-integ-cidr",
+  locations: [{ locationName: "loc1", cidrList: ["10.0.0.0/24"] }],
+});
+
+const registry = new CfnRegistry(stack, "SchemaRegistry", {
+  registryName: "cdkrd-integ-registry",
+});
+const schema = new CfnSchema(stack, "Schema", {
+  registryName: "cdkrd-integ-registry",
+  schemaName: "cdkrd-integ-schema",
+  type: "OpenApi3",
+  content: JSON.stringify({
+    openapi: "3.0.0",
+    info: { title: "e", version: "1.0.0" },
+    paths: {},
+  }),
+});
+schema.node.addDependency(registry); // registry must exist before the schema
+
+new CfnApplication(stack, "CodeDeployApp", {
+  applicationName: "cdkrd-integ-cd",
+  computePlatform: "Lambda",
+});
+
+new CfnTemplate(stack, "SesTemplate", {
+  template: {
+    templateName: "cdkrd-integ-tmpl",
+    subjectPart: "cdk-real-drift integ",
+    textPart: "hello",
+  },
+});
+
+new CfnAnomalyDetector(stack, "AnomalyDetector", {
+  singleMetricAnomalyDetector: {
+    namespace: "AWS/EC2",
+    metricName: "CPUUtilization",
+    stat: "Average",
+  },
+});
+
+app.synth();

--- a/tests/integration/harvest7/cdk.json
+++ b/tests/integration/harvest7/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest7/package.json
+++ b/tests/integration/harvest7/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-harvest7",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest CDK app wave 7 (uncovered cheap CFn types) for cdk-real-drift. Run via verify-harvest7.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/harvest7/verify-harvest7.sh
+++ b/tests/integration/harvest7/verify-harvest7.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 7 (real AWS) — R90.
+#
+# Cheap, low-dependency CFn types NOT yet in the golden corpus (115 distinct types
+# before this wave): WAFv2 RegexPatternSet, Logs QueryDefinition, ServiceDiscovery
+# HttpNamespace + Service, Glue SecurityConfiguration + Workflow, IAM Group, Route53
+# CidrCollection, EventSchemas Registry + Schema, CodeDeploy Application, SES
+# Template, CloudWatch AnomalyDetector. Asserts the two harvest invariants:
+#   1. baseline-free `check` — fresh deploy = ZERO declared drift, exit 0;
+#   2. `accept --yes` then `check --fail` — CLEAN across every type.
+#
+# CDKRD_HARVEST7_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest7 && npm install && bash verify-harvest7.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkdriftIntegHarvest7
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest7.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST7_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST7_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 7: uncovered cheap types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"

--- a/tests/integration/harvest8/app.ts
+++ b/tests/integration/harvest8/app.ts
@@ -1,0 +1,79 @@
+// cdk-real-drift corpus-harvest wave 8 (real AWS) — R90.
+// More uncovered CFn types, several as children of a covered parent (ApiGateway
+// RestApi children; a Cognito resource server) plus standalone DNS-firewall, OIDC
+// provider, and public ECR repo. Same harvest invariants as wave 7.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  GatewayResponse,
+  JsonSchemaType,
+  MockIntegration,
+  Model,
+  RequestValidator,
+  ResponseType,
+  RestApi,
+} from "aws-cdk-lib/aws-apigateway";
+import { ResourceServerScope, UserPool, UserPoolResourceServer } from "aws-cdk-lib/aws-cognito";
+import { CfnPublicRepository } from "aws-cdk-lib/aws-ecr";
+import { CfnOIDCProvider } from "aws-cdk-lib/aws-iam";
+import { CfnFirewallDomainList, CfnFirewallRuleGroup } from "aws-cdk-lib/aws-route53resolver";
+
+const app = new App();
+const stack = new Stack(app, "CdkdriftIntegHarvest8");
+
+// ApiGateway RestApi (covered) carrying NEW child types: Model, RequestValidator,
+// GatewayResponse (+ the Deployment/Stage CDK adds for a RestApi).
+const api = new RestApi(stack, "Api", { restApiName: "cdkrd-integ-api" });
+api.root.addMethod(
+  "GET",
+  new MockIntegration({
+    integrationResponses: [{ statusCode: "200" }],
+    requestTemplates: { "application/json": '{"statusCode": 200}' },
+  }),
+  { methodResponses: [{ statusCode: "200" }] },
+);
+new Model(stack, "Model", {
+  restApi: api,
+  contentType: "application/json",
+  modelName: "cdkrdModel",
+  schema: { type: JsonSchemaType.OBJECT },
+});
+new RequestValidator(stack, "Validator", { restApi: api, validateRequestBody: true });
+new GatewayResponse(stack, "GwResponse", { restApi: api, type: ResponseType.DEFAULT_4XX });
+
+// Cognito resource server (the UserPool itself is already covered).
+const pool = new UserPool(stack, "Pool8", { removalPolicy: RemovalPolicy.DESTROY });
+new UserPoolResourceServer(stack, "ResourceServer", {
+  userPool: pool,
+  identifier: "cdkrd-api",
+  scopes: [new ResourceServerScope({ scopeName: "read", scopeDescription: "read access" })],
+});
+
+// Route53 Resolver DNS firewall.
+const fwDomains = new CfnFirewallDomainList(stack, "FwDomains", {
+  name: "cdkrd-integ-fw",
+  domains: ["example.com", "test.example.org"],
+});
+new CfnFirewallRuleGroup(stack, "FwRuleGroup", {
+  name: "cdkrd-integ-frg",
+  firewallRules: [
+    {
+      action: "BLOCK",
+      blockResponse: "NODATA",
+      firewallDomainListId: fwDomains.attrId,
+      priority: 100,
+    },
+  ],
+});
+
+// IAM OIDC provider (L1 with an explicit thumbprint, so no network fetch and a
+// fake url that cannot collide with a real provider in the account).
+new CfnOIDCProvider(stack, "Oidc", {
+  url: "https://oidc.cdkrd-integ-test.example.com",
+  clientIdList: ["sts.amazonaws.com"],
+  thumbprintList: ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"],
+});
+
+// Public ECR repository (us-east-1 only).
+new CfnPublicRepository(stack, "PublicRepo", { repositoryName: "cdkrd-integ-pub" });
+
+app.synth();

--- a/tests/integration/harvest8/cdk.json
+++ b/tests/integration/harvest8/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest8/package.json
+++ b/tests/integration/harvest8/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-harvest8",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest CDK app wave 8 (uncovered cheap CFn types) for cdk-real-drift. Run via verify-harvest8.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/harvest8/verify-harvest8.sh
+++ b/tests/integration/harvest8/verify-harvest8.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 8 (real AWS) — R90.
+#
+# Cheap, low-dependency CFn types NOT yet in the golden corpus (115 distinct types
+# before this wave): WAFv2 RegexPatternSet, Logs QueryDefinition, ServiceDiscovery
+# HttpNamespace + Service, Glue SecurityConfiguration + Workflow, IAM Group, Route53
+# CidrCollection, EventSchemas Registry + Schema, CodeDeploy Application, SES
+# Template, CloudWatch AnomalyDetector. Asserts the two harvest invariants:
+#   1. baseline-free `check` — fresh deploy = ZERO declared drift, exit 0;
+#   2. `accept --yes` then `check --fail` — CLEAN across every type.
+#
+# CDKRD_HARVEST8_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest8 && npm install && bash verify-harvest8.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkdriftIntegHarvest8
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest8.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST8_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST8_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 8: uncovered cheap types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"


### PR DESCRIPTION
Two corpus-harvest fixtures of cheap, low-dependency CFn types still uncovered after the corpus crossed 115 distinct types. Deploy once → assert ZERO declared drift on the fresh deploy (the false-positive invariant across many types at once) → record every readable resource as a golden case (`CDKRD_CORPUS_DIR`) → destroy. Recorded once via integ, replayed every CI run as offline unit tests — **no AWS, negligible CI cost**.

## Types
- **harvest7**: WAFv2 RegexPatternSet, Logs QueryDefinition, ServiceDiscovery HttpNamespace + Service, Glue SecurityConfiguration + Workflow, IAM Group, Route53 CidrCollection, EventSchemas Registry + Schema, CodeDeploy Application, SES Template, CloudWatch AnomalyDetector.
- **harvest8**: ApiGateway Model / RequestValidator / GatewayResponse (RestApi children), Cognito UserPoolResourceServer, Route53 Resolver DNS firewall (FirewallDomainList + FirewallRuleGroup), IAM OIDC provider, public ECR repository.

## Verification
- Both fixtures **INTEG PASS** (fresh deploy = zero declared drift, accept → CLEAN). CC-unreadable types among them are honestly `skipped` (not recorded, never false drift).
- Corpus **231 → 249**; unit tests **686 → 704**. typecheck / lint / build green. Account ids auto-sanitized to 111111111111.