### PR TITLE
test: multi-type mutation fixture — the false-negative (missed-detection) guard (R91)

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -201,6 +201,20 @@ readGap is informational, not drift). The cleanup trap force-deletes the secret.
 cd readgap && bash verify.sh
 ```
 
+## mutation-multi
+
+The false-NEGATIVE guard (the opposite of `noise` / the false-positive matrix).
+Deploys five types, accepts a CLEAN baseline, then changes one declared property on
+each out of band (SQS VisibilityTimeout, SNS DisplayName, Lambda Timeout, S3
+VersioningConfiguration, ECR ImageTagMutability) and asserts `check --fail` DETECTS
+every one. A normalizer that wrongly collapses a real change would make cdkrd miss
+it and report CLEAN — this catches that (it also guards the R88 array-sort fixes
+against over-suppression). Run after changing `src/normalize/**` or `src/diff/**`.
+
+```bash
+cd mutation-multi && npm install && bash verify.sh
+```
+
 ## false-positive matrix
 
 Eight focused fixtures (R88), each the same shape as `noise`: deploy a resource that

--- a/tests/integration/mutation-multi/app.ts
+++ b/tests/integration/mutation-multi/app.ts
@@ -1,0 +1,38 @@
+// CDK app for the cdk-real-drift multi-type MUTATION integration test (R91).
+//
+// The false-NEGATIVE guard (the opposite of the noise/false-positive fixtures):
+// each resource DECLARES a property with a known value; verify.sh changes that
+// value out of band and asserts `check` DETECTS it. A normalizer that is too
+// aggressive (e.g. collapsing a real change) would make cdkrd miss the drift and
+// silently report CLEAN — this catches that. Every mutated property is one cdkrd
+// reads back via Cloud Control, so detection is the correct expectation.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Repository, TagMutability } from "aws-cdk-lib/aws-ecr";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMutation");
+
+new Queue(stack, "Queue", { visibilityTimeout: Duration.seconds(30) }); // -> mutate to 60
+
+new Topic(stack, "Topic", { displayName: "original-name" }); // -> mutate DisplayName
+
+new Function(stack, "Fn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 });"),
+  timeout: Duration.seconds(10), // -> mutate to 30
+});
+
+new Bucket(stack, "Bucket", { versioned: true, removalPolicy: RemovalPolicy.DESTROY }); // -> suspend
+
+new Repository(stack, "Repo", {
+  imageTagMutability: TagMutability.IMMUTABLE, // -> mutate to MUTABLE
+  removalPolicy: RemovalPolicy.DESTROY,
+  emptyOnDelete: true,
+});
+
+app.synth();

--- a/tests/integration/mutation-multi/cdk.json
+++ b/tests/integration/mutation-multi/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/mutation-multi/package.json
+++ b/tests/integration/mutation-multi/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-mutation-multi",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Multi-type mutation (false-negative) integration test for cdk-real-drift (R91). Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/mutation-multi/verify.sh
+++ b/tests/integration/mutation-multi/verify.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# cdk-real-drift multi-type MUTATION integration test (real AWS, R91).
+#
+# The false-NEGATIVE guard: deploy 5 types, accept (baseline CLEAN), then change one
+# declared property on each out of band and assert `check --fail` DETECTS every one.
+# A normalizer that wrongly collapses a real change would make cdkrd miss it and
+# report CLEAN — this catches that. A cleanup trap destroys even on failure.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/mutation-multi && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMutation
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?ResourceType=='$1'].PhysicalResourceId" --output text
+}
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== accept then check must be CLEAN ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after accept"
+
+echo "=== mutate one declared property on each type out of band ==="
+Q="$(phys AWS::SQS::Queue)";        [ -n "$Q" ] || fail "no queue url"
+T="$(phys AWS::SNS::Topic)";        [ -n "$T" ] || fail "no topic arn"
+FN="$(phys AWS::Lambda::Function)"; [ -n "$FN" ] || fail "no function name"
+B="$(phys AWS::S3::Bucket)";        [ -n "$B" ] || fail "no bucket name"
+R="$(phys AWS::ECR::Repository)";   [ -n "$R" ] || fail "no repo name"
+
+aws sqs set-queue-attributes --queue-url "$Q" --attributes VisibilityTimeout=60 --region "$REGION" || fail "mutate sqs"
+aws sns set-topic-attributes --topic-arn "$T" --attribute-name DisplayName --attribute-value changed-name --region "$REGION" || fail "mutate sns"
+aws lambda update-function-configuration --function-name "$FN" --timeout 30 --region "$REGION" >/dev/null || fail "mutate lambda"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION" || true
+aws s3api put-bucket-versioning --bucket "$B" --versioning-configuration Status=Suspended --region "$REGION" || fail "mutate s3"
+aws ecr put-image-tag-mutability --repository-name "$R" --image-tag-mutability MUTABLE --region "$REGION" >/dev/null || fail "mutate ecr"
+sleep 5
+
+echo "=== check must DETECT every mutation (exit 1 + each property named) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-mutation.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc — a mutation was MISSED (false negative)"
+for prop in VisibilityTimeout DisplayName Timeout VersioningConfiguration ImageTagMutability; do
+  grep -q "$prop" /tmp/cdkrd-mutation.out || fail "$prop mutation NOT detected — false negative"
+done
+
+echo "INTEG PASS"


### PR DESCRIPTION
The opposite of the `noise` / false-positive matrix: a live **false-negative guard**. Deploy 5 types, accept a CLEAN baseline, then change one declared property on each out of band (SQS VisibilityTimeout, SNS DisplayName, Lambda Timeout, S3 VersioningConfiguration, ECR ImageTagMutability) and assert `check --fail` **DETECTS every one**. A normalizer that wrongly collapses a real change would make cdkrd miss it and silently report CLEAN — this catches that, and in particular guards the R88 array-sort fixes against over-suppression.

**INTEG PASS**: all 5 detected (`result: 5 drift(s) (declared=5)`), zero false negatives. No source change; 704 unit tests green.