### PR TITLE
test: multi-type revert fixture — Cloud Control UpdateResource convergence (R92)

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -350,6 +350,19 @@ then accept -> `check --fail` CLEAN.
 cd harvest5 && npm install && bash verify-harvest5.sh
 ```
 
+## revert-multi
+
+Exercises the one AWS-mutating path across five types via Cloud Control
+UpdateResource. Deploy SQS / SNS / Lambda / S3 / ECR, accept a CLEAN baseline,
+change one declared property on each out of band, then `revert --yes` and assert the
+stack converges to CLEAN AND every live value is restored to its template value
+(VisibilityTimeout 30, DisplayName, Timeout 10, VersioningConfiguration Enabled,
+ImageTagMutability IMMUTABLE). Run after changing `src/revert/**`.
+
+```bash
+cd revert-multi && npm install && bash verify.sh
+```
+
 ## harvest7 / harvest8
 
 Waves 7 and 8 of the corpus harvest (R90): cheap, low-dependency CFn types that

--- a/tests/integration/revert-multi/app.ts
+++ b/tests/integration/revert-multi/app.ts
@@ -1,0 +1,38 @@
+// CDK app for the cdk-real-drift multi-type REVERT integration test (R92).
+//
+// The false-NEGATIVE guard (the opposite of the noise/false-positive fixtures):
+// each resource DECLARES a property with a known value; verify.sh changes that
+// value out of band and asserts `check` DETECTS it. A normalizer that is too
+// aggressive (e.g. collapsing a real change) would make cdkrd miss the drift and
+// silently report CLEAN — this catches that. Every mutated property is one cdkrd
+// reads back via Cloud Control, so detection is the correct expectation.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Repository, TagMutability } from "aws-cdk-lib/aws-ecr";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRevertMulti");
+
+new Queue(stack, "Queue", { visibilityTimeout: Duration.seconds(30) }); // -> mutate to 60
+
+new Topic(stack, "Topic", { displayName: "original-name" }); // -> mutate DisplayName
+
+new Function(stack, "Fn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 });"),
+  timeout: Duration.seconds(10), // -> mutate to 30
+});
+
+new Bucket(stack, "Bucket", { versioned: true, removalPolicy: RemovalPolicy.DESTROY }); // -> suspend
+
+new Repository(stack, "Repo", {
+  imageTagMutability: TagMutability.IMMUTABLE, // -> mutate to MUTABLE
+  removalPolicy: RemovalPolicy.DESTROY,
+  emptyOnDelete: true,
+});
+
+app.synth();

--- a/tests/integration/revert-multi/cdk.json
+++ b/tests/integration/revert-multi/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revert-multi/package.json
+++ b/tests/integration/revert-multi/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-revert-multi",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Multi-type revert (Cloud Control UpdateResource convergence) integration test for cdk-real-drift (R92). Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/revert-multi/verify.sh
+++ b/tests/integration/revert-multi/verify.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# cdk-real-drift multi-type REVERT integration test (real AWS, R92).
+#
+# Exercises the one AWS-mutating path across five types via Cloud Control
+# UpdateResource: deploy, accept (CLEAN baseline), change one declared property on
+# each out of band, then `revert --yes` and assert the stack converges to CLEAN AND
+# every live value is restored to its template value. A cleanup trap destroys even
+# on failure.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/revert-multi && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRevertMulti
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?ResourceType=='$1'].PhysicalResourceId" --output text
+}
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy + accept (baseline CLEAN) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN right after accept"
+
+echo "=== mutate one declared property on each type out of band ==="
+Q="$(phys AWS::SQS::Queue)";        [ -n "$Q" ] || fail "no queue url"
+T="$(phys AWS::SNS::Topic)";        [ -n "$T" ] || fail "no topic arn"
+FN="$(phys AWS::Lambda::Function)"; [ -n "$FN" ] || fail "no function name"
+B="$(phys AWS::S3::Bucket)";        [ -n "$B" ] || fail "no bucket name"
+R="$(phys AWS::ECR::Repository)";   [ -n "$R" ] || fail "no repo name"
+
+aws sqs set-queue-attributes --queue-url "$Q" --attributes VisibilityTimeout=60 --region "$REGION" || fail "mutate sqs"
+aws sns set-topic-attributes --topic-arn "$T" --attribute-name DisplayName --attribute-value changed-name --region "$REGION" || fail "mutate sns"
+aws lambda update-function-configuration --function-name "$FN" --timeout 30 --region "$REGION" >/dev/null || fail "mutate lambda"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION" || true
+aws s3api put-bucket-versioning --bucket "$B" --versioning-configuration Status=Suspended --region "$REGION" || fail "mutate s3"
+aws ecr put-image-tag-mutability --repository-name "$R" --image-tag-mutability MUTABLE --region "$REGION" >/dev/null || fail "mutate ecr"
+sleep 5
+
+echo "=== drift must be present before revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 1 ] || fail "expected drift exit 1 before revert"
+
+echo "=== revert --yes must write the template values back to AWS ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert returned non-zero"
+
+echo "=== check must be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "drift remains after revert"
+
+echo "=== verify every live value was restored to the template value ==="
+v="$(aws sqs get-queue-attributes --queue-url "$Q" --attribute-names VisibilityTimeout --region "$REGION" --query 'Attributes.VisibilityTimeout' --output text)"
+[ "$v" = "30" ] || fail "SQS VisibilityTimeout not restored (got $v)"
+v="$(aws sns get-topic-attributes --topic-arn "$T" --region "$REGION" --query 'Attributes.DisplayName' --output text)"
+[ "$v" = "original-name" ] || fail "SNS DisplayName not restored (got $v)"
+v="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" --query 'Timeout' --output text)"
+[ "$v" = "10" ] || fail "Lambda Timeout not restored (got $v)"
+v="$(aws s3api get-bucket-versioning --bucket "$B" --region "$REGION" --query 'Status' --output text)"
+[ "$v" = "Enabled" ] || fail "S3 versioning not restored (got $v)"
+v="$(aws ecr describe-repositories --repository-names "$R" --region "$REGION" --query 'repositories[0].imageTagMutability' --output text)"
+[ "$v" = "IMMUTABLE" ] || fail "ECR ImageTagMutability not restored (got $v)"
+
+echo "INTEG PASS"


### PR DESCRIPTION
Exercises the one AWS-mutating path across five types. Deploy SQS/SNS/Lambda/S3/ECR → accept CLEAN baseline → change one declared property on each out of band → `revert --yes` → assert the stack converges to CLEAN **and every live value is restored to its template value** (VisibilityTimeout 30, DisplayName, Timeout 10, VersioningConfiguration Enabled, ImageTagMutability IMMUTABLE).

**INTEG PASS**: all 5 reverted via Cloud Control UpdateResource, CLEAN after revert, every value verified restored. No source change; 704 unit tests green.