### PR TITLE
test(corpus): harvest wave 9 — VPC-dependent types (NetworkAcl, VPCEndpoint, EFS AccessPoint) (R93)

### DIFF
--- a/tests/corpus/AWS__EC2__NetworkAcl.Nacl00B1FA37.json
+++ b/tests/corpus/AWS__EC2__NetworkAcl.Nacl00B1FA37.json
@@ -1,0 +1,43 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Nacl00B1FA37",
+    "resourceType": "AWS::EC2::NetworkAcl",
+    "physicalId": "acl-0b09fb918deeb6d6b",
+    "constructPath": "CdkdriftIntegHarvest9/Nacl",
+    "declared": {
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkdriftIntegHarvest9/Nacl"
+        }
+      ],
+      "VpcId": "vpc-0a787ce59de137b49"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-0a787ce59de137b49",
+    "Id": "acl-0b09fb918deeb6d6b",
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegHarvest9/Nacl",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SecurityGroup.FsEfsSecurityGroup7575D9A7.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.FsEfsSecurityGroup7575D9A7.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FsEfsSecurityGroup7575D9A7",
+    "resourceType": "AWS::EC2::SecurityGroup",
+    "physicalId": "sg-07181dc5cc63319cd",
+    "constructPath": "CdkdriftIntegHarvest9/Fs/EfsSecurityGroup",
+    "declared": {
+      "GroupDescription": "CdkdriftIntegHarvest9/Fs/EfsSecurityGroup",
+      "SecurityGroupEgress": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "Allow all outbound traffic by default",
+          "IpProtocol": "-1"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkdriftIntegHarvest9/Fs"
+        }
+      ],
+      "VpcId": "vpc-0a787ce59de137b49"
+    }
+  },
+  "liveRaw": {
+    "GroupDescription": "CdkdriftIntegHarvest9/Fs/EfsSecurityGroup",
+    "GroupName": "CdkdriftIntegHarvest9-FsEfsSecurityGroup7575D9A7-Vmu0w7lGgXbJ",
+    "VpcId": "vpc-0a787ce59de137b49",
+    "Id": "sg-07181dc5cc63319cd",
+    "SecurityGroupEgress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow all outbound traffic by default",
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "-1"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "FsEfsSecurityGroup7575D9A7",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest9/Fs",
+        "Key": "Name"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest9",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest9/1230bfd0-672d-11f1-8375-12f04685a5d7",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "GroupId": "sg-07181dc5cc63319cd"
+  },
+  "schema": {
+    "readOnly": ["GroupId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["GroupDescription", "GroupName", "VpcId"],
+    "readOnlyPaths": ["GroupId", "Id"],
+    "writeOnlyPaths": ["SecurityGroupIngress.*.SourceSecurityGroupName"],
+    "createOnlyPaths": ["GroupDescription", "GroupName", "VpcId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FsEfsSecurityGroup7575D9A7",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "GroupName",
+      "actual": "CdkdriftIntegHarvest9-FsEfsSecurityGroup7575D9A7-Vmu0w7lGgXbJ",
+      "physicalId": "sg-07181dc5cc63319cd",
+      "constructPath": "CdkdriftIntegHarvest9/Fs/EfsSecurityGroup"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
@@ -1,0 +1,156 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcS3Endpoint4A3DE4B5",
+    "resourceType": "AWS::EC2::VPCEndpoint",
+    "physicalId": "vpce-010c0956e4433b47b",
+    "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint",
+    "declared": {
+      "RouteTableIds": ["rtb-039add7b1c659e51a"],
+      "ServiceName": "com.amazonaws.us-east-1.s3",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkdriftIntegHarvest9/Vpc"
+        }
+      ],
+      "VpcEndpointType": "Gateway",
+      "VpcId": "vpc-0a787ce59de137b49"
+    }
+  },
+  "liveRaw": {
+    "PrivateDnsEnabled": false,
+    "IpAddressType": "ipv4",
+    "ServiceRegion": "us-east-1",
+    "CreationTimestamp": "Sat 6 13 13:38:18 UTC 2026",
+    "DnsOptions": {
+      "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
+      "PrivateDnsSpecifiedDomains": ["*"],
+      "DnsRecordIpType": "service-defined",
+      "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
+    },
+    "NetworkInterfaceIds": [],
+    "DnsEntries": [],
+    "ResourceConfigurationArn": "",
+    "SecurityGroupIds": [],
+    "SubnetIds": [],
+    "ServiceNetworkArn": "",
+    "VpcId": "vpc-0a787ce59de137b49",
+    "RouteTableIds": ["rtb-039add7b1c659e51a"],
+    "ServiceName": "com.amazonaws.us-east-1.s3",
+    "PolicyDocument": {
+      "Version": "2008-10-17",
+      "Statement": [
+        {
+          "Action": "*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": "*"
+        }
+      ]
+    },
+    "VpcEndpointType": "Gateway",
+    "Id": "vpce-010c0956e4433b47b",
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegHarvest9",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "VpcS3Endpoint4A3DE4B5",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest9/1230bfd0-672d-11f1-8375-12f04685a5d7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest9/Vpc",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreationTimestamp", "DnsEntries", "Id", "NetworkInterfaceIds"],
+    "writeOnly": [],
+    "createOnly": [
+      "ResourceConfigurationArn",
+      "ServiceName",
+      "ServiceNetworkArn",
+      "ServiceRegion",
+      "VpcEndpointType",
+      "VpcId"
+    ],
+    "readOnlyPaths": ["CreationTimestamp", "DnsEntries", "Id", "NetworkInterfaceIds"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DnsOptions.PrivateDnsPreference",
+      "DnsOptions.PrivateDnsSpecifiedDomains",
+      "ResourceConfigurationArn",
+      "ServiceName",
+      "ServiceNetworkArn",
+      "ServiceRegion",
+      "VpcEndpointType",
+      "VpcId"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "ServiceRegion",
+      "actual": "us-east-1",
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "DnsOptions",
+      "actual": {
+        "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
+        "PrivateDnsSpecifiedDomains": ["*"],
+        "DnsRecordIpType": "service-defined",
+        "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
+      },
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "PolicyDocument",
+      "actual": {
+        "Statement": [
+          {
+            "Action": ["*"],
+            "Effect": "Allow",
+            "Principal": "*",
+            "Resource": ["*"]
+          }
+        ],
+        "Version": "2008-10-17"
+      },
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EFS__AccessPoint.FsApCFF9572D.json
+++ b/tests/corpus/AWS__EFS__AccessPoint.FsApCFF9572D.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FsApCFF9572D",
+    "resourceType": "AWS::EFS::AccessPoint",
+    "physicalId": "fsap-0fc842a4c443a343d",
+    "constructPath": "CdkdriftIntegHarvest9/Fs/Ap",
+    "declared": {
+      "AccessPointTags": [
+        {
+          "Key": "Name",
+          "Value": "CdkdriftIntegHarvest9/Fs/Ap"
+        }
+      ],
+      "FileSystemId": "fs-0d81f40b7a880b7ae",
+      "RootDirectory": {
+        "Path": "/cdkrd"
+      }
+    }
+  },
+  "liveRaw": {
+    "AccessPointId": "fsap-0fc842a4c443a343d",
+    "FileSystemId": "fs-0d81f40b7a880b7ae",
+    "RootDirectory": {
+      "Path": "/cdkrd"
+    },
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:access-point/fsap-0fc842a4c443a343d",
+    "ClientToken": "FsApCFF9572D-dRkYh637cpxN",
+    "AccessPointTags": [
+      {
+        "Value": "CdkdriftIntegHarvest9/Fs/Ap",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AccessPointId", "Arn"],
+    "writeOnly": [],
+    "createOnly": ["ClientToken", "CreationInfo", "FileSystemId", "PosixUser", "RootDirectory"],
+    "readOnlyPaths": ["AccessPointId", "Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ClientToken",
+      "CreationInfo",
+      "CreationInfo.OwnerGid",
+      "CreationInfo.OwnerUid",
+      "CreationInfo.Permissions",
+      "FileSystemId",
+      "PosixUser",
+      "PosixUser.Gid",
+      "PosixUser.SecondaryGids",
+      "PosixUser.Uid",
+      "RootDirectory",
+      "RootDirectory.CreationInfo",
+      "RootDirectory.Path"
+    ],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FsApCFF9572D",
+      "resourceType": "AWS::EFS::AccessPoint",
+      "path": "ClientToken",
+      "actual": "FsApCFF9572D-dRkYh637cpxN",
+      "physicalId": "fsap-0fc842a4c443a343d",
+      "constructPath": "CdkdriftIntegHarvest9/Fs/Ap"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Fs6C1AF03C",
+    "resourceType": "AWS::EFS::FileSystem",
+    "physicalId": "fs-0d81f40b7a880b7ae",
+    "constructPath": "CdkdriftIntegHarvest9/Fs",
+    "declared": {
+      "Encrypted": true,
+      "FileSystemTags": [
+        {
+          "Key": "Name",
+          "Value": "CdkdriftIntegHarvest9/Fs"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
+    "PerformanceMode": "generalPurpose",
+    "Encrypted": true,
+    "FileSystemTags": [
+      {
+        "Value": "CdkdriftIntegHarvest9/Fs",
+        "Key": "Name"
+      }
+    ],
+    "FileSystemId": "fs-0d81f40b7a880b7ae",
+    "FileSystemProtection": {
+      "ReplicationOverwriteProtection": "ENABLED"
+    },
+    "LifecyclePolicies": [],
+    "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:file-system/fs-0d81f40b7a880b7ae",
+    "ThroughputMode": "bursting",
+    "BackupPolicy": {
+      "Status": "DISABLED"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "FileSystemId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck"],
+    "createOnly": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "readOnlyPaths": [
+      "Arn",
+      "FileSystemId",
+      "ReplicationConfiguration.Destinations.*.Status",
+      "ReplicationConfiguration.Destinations.*.StatusMessage"
+    ],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "ReplicationConfiguration.Destinations.0.AvailabilityZoneName",
+      "ReplicationConfiguration.Destinations.0.KmsKeyId"
+    ],
+    "createOnlyPaths": ["AvailabilityZoneName", "Encrypted", "KmsKeyId", "PerformanceMode"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "PerformanceMode",
+      "actual": "generalPurpose",
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "FileSystemProtection",
+      "actual": {
+        "ReplicationOverwriteProtection": "ENABLED"
+      },
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "ThroughputMode",
+      "actual": "bursting",
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EFS__MountTarget.FsEfsMountTarget11EC3BF7C.json
+++ b/tests/corpus/AWS__EFS__MountTarget.FsEfsMountTarget11EC3BF7C.json
@@ -1,0 +1,46 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FsEfsMountTarget11EC3BF7C",
+    "resourceType": "AWS::EFS::MountTarget",
+    "physicalId": "fsmt-03133bb006f34d15f",
+    "constructPath": "CdkdriftIntegHarvest9/Fs/EfsMountTarget1",
+    "declared": {
+      "FileSystemId": "fs-0d81f40b7a880b7ae",
+      "SecurityGroups": ["sg-07181dc5cc63319cd"],
+      "SubnetId": "subnet-09e3c8678a25f92bd"
+    }
+  },
+  "liveRaw": {
+    "SecurityGroups": ["sg-07181dc5cc63319cd"],
+    "FileSystemId": "fs-0d81f40b7a880b7ae",
+    "IpAddress": "10.0.0.242",
+    "Id": "fsmt-03133bb006f34d15f",
+    "SubnetId": "subnet-09e3c8678a25f92bd"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["IpAddressType"],
+    "createOnly": ["FileSystemId", "IpAddress", "IpAddressType", "Ipv6Address", "SubnetId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["IpAddressType"],
+    "createOnlyPaths": ["FileSystemId", "IpAddress", "IpAddressType", "Ipv6Address", "SubnetId"],
+    "defaults": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FsEfsMountTarget11EC3BF7C",
+      "resourceType": "AWS::EFS::MountTarget",
+      "path": "IpAddress",
+      "actual": "10.0.0.242",
+      "physicalId": "fsmt-03133bb006f34d15f",
+      "constructPath": "CdkdriftIntegHarvest9/Fs/EfsMountTarget1"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -363,7 +363,7 @@ ImageTagMutability IMMUTABLE). Run after changing `src/revert/**`.
 cd revert-multi && npm install && bash verify.sh
 ```
 
-## harvest7 / harvest8
+## harvest7 / harvest8 / harvest9
 
 Waves 7 and 8 of the corpus harvest (R90): cheap, low-dependency CFn types that
 were still uncovered after the corpus crossed 115 distinct types. Wave 7 — WAFv2
@@ -373,7 +373,7 @@ EventSchemas Registry + Schema, CodeDeploy Application, SES Template, CloudWatch
 AnomalyDetector. Wave 8 — ApiGateway Model / RequestValidator / GatewayResponse
 (children of a RestApi), a Cognito UserPoolResourceServer, Route53 Resolver DNS
 firewall (FirewallDomainList + FirewallRuleGroup), an IAM OIDC provider, and a
-public ECR repository. Same two harvest invariants (fresh deploy = ZERO declared
+public ECR repository. Wave 9 — a single-AZ VPC carrying a NetworkAcl + entry, an S3 gateway VPC endpoint, and an EFS file system + access point. Same two harvest invariants (fresh deploy = ZERO declared
 drift, then accept -> `check --fail` CLEAN); the CC-unreadable types among them are
 honestly `skipped` (not recorded, never false drift). Run with
 `CDKRD_CORPUS_DIR=<dir>` to record the readable types as golden cases.

--- a/tests/integration/harvest9/app.ts
+++ b/tests/integration/harvest9/app.ts
@@ -1,0 +1,41 @@
+// cdk-real-drift corpus-harvest wave 9 (real AWS) — R93.
+// VPC-dependent uncovered CFn types: a minimal single-AZ VPC (no NAT) carrying a
+// NetworkAcl + NetworkAclEntry, an S3 gateway VPC endpoint, and an EFS file system
+// with an access point. Same harvest invariants as the earlier waves.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  AclCidr,
+  AclTraffic,
+  Action,
+  GatewayVpcEndpointAwsService,
+  NetworkAcl,
+  SubnetType,
+  TrafficDirection,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import { FileSystem } from "aws-cdk-lib/aws-efs";
+
+const app = new App();
+const stack = new Stack(app, "CdkdriftIntegHarvest9");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const nacl = new NetworkAcl(stack, "Nacl", { vpc });
+nacl.addEntry("AllowHttps", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.tcpPort(443),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 100,
+  ruleAction: Action.ALLOW,
+});
+
+vpc.addGatewayEndpoint("S3Endpoint", { service: GatewayVpcEndpointAwsService.S3 });
+
+const fs = new FileSystem(stack, "Fs", { vpc, removalPolicy: RemovalPolicy.DESTROY });
+fs.addAccessPoint("Ap", { path: "/cdkrd" });
+
+app.synth();

--- a/tests/integration/harvest9/cdk.json
+++ b/tests/integration/harvest9/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest9/package.json
+++ b/tests/integration/harvest9/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-harvest9",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest CDK app wave 9 (uncovered cheap CFn types) for cdk-real-drift. Run via verify-harvest9.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/harvest9/verify-harvest9.sh
+++ b/tests/integration/harvest9/verify-harvest9.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 9 (real AWS) — R90.
+#
+# Cheap, low-dependency CFn types NOT yet in the golden corpus (115 distinct types
+# before this wave): WAFv2 RegexPatternSet, Logs QueryDefinition, ServiceDiscovery
+# HttpNamespace + Service, Glue SecurityConfiguration + Workflow, IAM Group, Route53
+# CidrCollection, EventSchemas Registry + Schema, CodeDeploy Application, SES
+# Template, CloudWatch AnomalyDetector. Asserts the two harvest invariants:
+#   1. baseline-free `check` — fresh deploy = ZERO declared drift, exit 0;
+#   2. `accept --yes` then `check --fail` — CLEAN across every type.
+#
+# CDKRD_HARVEST9_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest9 && npm install && bash verify-harvest9.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkdriftIntegHarvest9
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest9.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST9_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST9_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 9: uncovered cheap types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. accept + check --fail must be CLEAN across every type ==="
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "INTEG PASS"


### PR DESCRIPTION
A single-AZ VPC (no NAT) carrying a NetworkAcl + entry, an S3 gateway VPC endpoint, and an EFS file system + access point. Deploy once → assert ZERO declared drift on the fresh deploy → record every readable resource as a golden case → destroy. **INTEG PASS**.

New types now replay offline with no AWS: **EC2 NetworkAcl, EC2 VPCEndpoint, EFS AccessPoint** (plus fresh cases of EC2 SecurityGroup / EFS FileSystem + MountTarget). VPC-infra cases whose logicalIds collided with existing captures were restored to their committed versions — pure addition. Corpus 249 → 255; unit tests 704 → **710**.