### PR TITLE
test: array/policy mutation fixture — the over-suppression (false-negative) hunt (R94)

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -350,6 +350,20 @@ then accept -> `check --fail` CLEAN.
 cd harvest5 && npm install && bash verify-harvest5.sh
 ```
 
+## mutation-arrays
+
+The highest-yield false-NEGATIVE hunt: properties whose normalizer sorts or
+canonicalizes an array/policy (the class where the R88 bugs lived). Deploy an IAM
+role with a named inline policy, a SecurityGroup with two ingress rules, and a WAFv2
+IPSet with two addresses; accept CLEAN; then ADD one element to each out of band (a
+policy Action, an ingress rule, an IP address) and assert `check --fail` DETECTS
+every one — proving the normalization does not OVER-suppress and silently hide a
+real change. Run after changing `src/normalize/**`.
+
+```bash
+cd mutation-arrays && npm install && bash verify.sh
+```
+
 ## revert-multi
 
 Exercises the one AWS-mutating path across five types via Cloud Control

--- a/tests/integration/mutation-arrays/app.ts
+++ b/tests/integration/mutation-arrays/app.ts
@@ -1,0 +1,47 @@
+// CDK app for the cdk-real-drift array/policy MUTATION integration test (R94).
+//
+// The highest-yield false-negative hunt: every property here is one whose
+// normalizer SORTS or CANONICALIZES an array/policy (the exact class where the R88
+// bugs lived). verify.sh adds an element out of band and asserts `check` DETECTS it
+// — proving the normalization does not OVER-suppress and silently hide a real
+// change. An IAM inline policy (policy canonicalization), a SecurityGroup ingress
+// set (R88 object-array sort), and a WAFv2 IPSet address set (R84 scalar-set).
+import { App, Stack } from "aws-cdk-lib";
+import { Peer, Port, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Effect, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnIPSet } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMutationArrays");
+
+// IAM role with a named inline policy (one action) -> verify.sh adds a second.
+new Role(stack, "Role", {
+  assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
+  inlinePolicies: {
+    P: new PolicyDocument({
+      statements: [
+        new PolicyStatement({ effect: Effect.ALLOW, actions: ["s3:GetObject"], resources: ["*"] }),
+      ],
+    }),
+  },
+});
+
+// SecurityGroup with two ingress rules -> verify.sh adds a third.
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+const sg = new SecurityGroup(stack, "Sg", { vpc, allowAllOutbound: true });
+sg.addIngressRule(Peer.ipv4("10.0.0.0/24"), Port.tcp(443), "https a");
+sg.addIngressRule(Peer.ipv4("10.0.1.0/24"), Port.tcp(443), "https b");
+
+// WAFv2 IPSet with two addresses -> verify.sh adds a third.
+new CfnIPSet(stack, "IpSet", {
+  name: "cdkrd-integ-mut-ipset",
+  scope: "REGIONAL",
+  ipAddressVersion: "IPV4",
+  addresses: ["192.0.2.0/24", "198.51.100.0/24"],
+});
+
+app.synth();

--- a/tests/integration/mutation-arrays/cdk.json
+++ b/tests/integration/mutation-arrays/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/mutation-arrays/package.json
+++ b/tests/integration/mutation-arrays/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-mutation-arrays",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Array/policy mutation (false-negative / over-suppression) integration test for cdk-real-drift (R94). Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/mutation-arrays/verify.sh
+++ b/tests/integration/mutation-arrays/verify.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# cdk-real-drift array/policy MUTATION integration test (real AWS, R94).
+#
+# The highest-yield false-negative hunt: each property's normalizer sorts or
+# canonicalizes an array/policy (the class where the R88 bugs lived). Add an element
+# out of band and assert `check` DETECTS it — proving the normalization does not
+# OVER-suppress and silently hide a real change.
+#   - IAM inline policy: add an Action (policy canonicalization);
+#   - SecurityGroup: add an ingress rule (R88 object-array sort);
+#   - WAFv2 IPSet: add an address (R84 scalar-set).
+# A cleanup trap destroys even on failure.
+#
+# Usage:  cd tests/integration/mutation-arrays && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMutationArrays
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+phys() {
+  aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+    --query "StackResources[?ResourceType=='$1'].PhysicalResourceId" --output text
+}
+
+echo "=== build + deploy + accept (CLEAN baseline) ==="
+(cd "$ROOT" && vp run build) || fail "build"
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after accept"
+
+echo "=== add an element to each array/policy out of band ==="
+ROLE="$(phys AWS::IAM::Role)";          [ -n "$ROLE" ] || fail "no role"
+SGID="$(phys AWS::EC2::SecurityGroup)"; [ -n "$SGID" ] || fail "no sg id"
+IPSET="$(phys AWS::WAFv2::IPSet)";      [ -n "$IPSET" ] || fail "no ipset"
+IPSET_ID="$(echo "$IPSET" | awk -F'|' '{print $2}')"
+IPSET_NAME="$(echo "$IPSET" | awk -F'|' '{print $1}')"
+
+# IAM inline policy: add a second Action
+aws iam put-role-policy --role-name "$ROLE" --policy-name P \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetObject","s3:DeleteObject"],"Resource":"*"}]}' \
+  || fail "mutate iam policy"
+
+# SecurityGroup: add an SSH ingress rule
+aws ec2 authorize-security-group-ingress --group-id "$SGID" \
+  --ip-permissions 'IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=203.0.113.0/24,Description=ssh}]' \
+  --region "$REGION" >/dev/null || fail "mutate sg"
+
+# WAFv2 IPSet: add a third address (needs the current lock token)
+LOCK="$(aws wafv2 get-ip-set --scope REGIONAL --name "$IPSET_NAME" --id "$IPSET_ID" --region "$REGION" --query 'LockToken' --output text)"
+[ -n "$LOCK" ] || fail "no ipset lock token"
+aws wafv2 update-ip-set --scope REGIONAL --name "$IPSET_NAME" --id "$IPSET_ID" --lock-token "$LOCK" \
+  --addresses 192.0.2.0/24 198.51.100.0/24 203.0.113.0/24 --region "$REGION" >/dev/null || fail "mutate ipset"
+sleep 5
+
+echo "=== check must DETECT every array/policy addition (no over-suppression) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-mut-arrays.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc — an array/policy change was MISSED"
+grep -q "Policies" /tmp/cdkrd-mut-arrays.out || fail "IAM inline-policy Action addition NOT detected (policy canon over-suppressed)"
+grep -q "SecurityGroupIngress" /tmp/cdkrd-mut-arrays.out || fail "SG ingress rule addition NOT detected (R88 sort over-suppressed)"
+grep -q "Addresses" /tmp/cdkrd-mut-arrays.out || fail "WAFv2 IPSet address addition NOT detected (R84 set over-suppressed)"
+
+echo "INTEG PASS"


### PR DESCRIPTION
The highest-yield false-negative hunt, targeting the normalizers that sort/canonicalize an array or policy (the class where the R88 bugs lived). Deploy an IAM role with a named inline policy, a SecurityGroup with two ingress rules, a WAFv2 IPSet with two addresses → accept CLEAN → **ADD one element to each out of band** (a policy Action, an ingress rule, an IP address) → assert `check --fail` **DETECTS every one**.

**INTEG PASS**: all three detected (`result: 3 drift(s) (declared=3)`). Proves the array/policy normalization is equality-gated and does **not** over-suppress a real addition — in particular the R88 SecurityGroupIngress sort and the R84 IPSet-set handling never hide an added element. No source change; 710 unit tests green.