### PR TITLE
fix(diff): out-of-band ADDITIONS to identity-keyed arrays (Tags, Origins) were silently missed (R95)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -202,7 +202,7 @@ checked.
   - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group, **CodeBuild Project** via BatchGetProjects with a camelCase→CFn-PascalCase projection, R85).
 - **normalize/** — noise subtraction (section 6)
   - **intrinsic-resolver.ts** — fail-closed CFn intrinsic resolver (section 5).
-  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `projectLiveToDeclaredSubset` (attribute-bag subset), `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` (per-type unordered scalar arrays) / `UNORDERED_OBJECT_ARRAY_PROPS` + `sortUnorderedObjectArray` (per-type unordered object arrays — SG rules, R88) / `CASE_INSENSITIVE_PATHS` (per-type compare rules).
+  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` (per-type unordered scalar arrays) / `UNORDERED_OBJECT_ARRAY_PROPS` + `sortUnorderedObjectArray` (per-type unordered object arrays — SG rules, R88) / `CASE_INSENSITIVE_PATHS` (per-type compare rules). (R95 removed the generic `projectLiveToDeclaredSubset` — it silently dropped out-of-band ADDITIONS to identity-keyed arrays like Tags; ELB attribute bags keep subset behaviour via `ELB_ATTRIBUTE_BAGS` in classify.)
   - **arn-identity.ts** — **`isArnNameMatch`** (bare name ↔ ARN), **`isManagedKmsAliasMatch`** (`alias/aws/*` ↔ key ARN).
   - **policy-canonical.ts** — IAM policy-doc canonicalization. **cc-api-strip.ts** — strip AWS-managed fields. **path-strip.ts** — schema readOnly/writeOnly path stripping (incl `*`).
 - **schema/schema-strip.ts** — `describe-type` → readOnly/writeOnly/defaults `SchemaInfo` (cached).
@@ -280,7 +280,7 @@ all live changes
   − stringly-typed scalar (true vs "true", 5432 vs "5432") → equal (isStringlyEqualScalar)
     (scalars only — a typed vs string *array* like [80,443] vs ["80","443"] still reports; fail-safe noise)
   − declared object vs its JSON-STRING live form (SSM Document.Content, R75) → equal (isJsonStringStructEqual)
-  − declared SUBSET of an identity-keyed attribute bag (ELB Load/TargetGroupAttributes, R75) → live projected to declared keys (projectLiveToDeclaredSubset)
+  − declared SUBSET of an ELB attribute bag (Load/TargetGroupAttributes) → compared BY KEY, extra live defaults ignored (ELB_ATTRIBUTE_BAGS, R78). NB (R95): this is NOT generic — every OTHER identity-keyed array (Tags, Origins, …) is compared in full, so an out-of-band ADDED element is real drift, never suppressed
   − per-type case-insensitive scalar paths (Route53 AliasTarget.DNSName, R75) → equal (CASE_INSENSITIVE_PATHS)
   − per-type unordered scalar-array sets (Cognito UserPoolClient OAuth lists, R74) → equal (UNORDERED_ARRAY_PROPS)
   − per-type unordered OBJECT-array sets (EC2 SecurityGroup ingress/egress rules — no identity field, R88) → both sides sorted by canonical JSON (UNORDERED_OBJECT_ARRAY_PROPS / sortUnorderedObjectArray)

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -19,7 +19,6 @@ import {
   isStringlyEqualScalar,
   isTrivialEmpty,
   KNOWN_DEFAULTS,
-  projectLiveToDeclaredSubset,
   sortUnorderedObjectArray,
   stripAwsTagsDeep,
   UNORDERED_ARRAY_PROPS,
@@ -158,11 +157,16 @@ export function classifyResource(
     // drift; a genuine rule change still differs after the sort.
     const unorderedObjArray = UNORDERED_OBJECT_ARRAY_PROPS[resourceType]?.has(k);
     const declaredVal = unorderedObjArray ? sortUnorderedObjectArray(v) : v;
-    const liveSorted = unorderedObjArray ? sortUnorderedObjectArray(live[k]) : live[k];
-    // Identity-keyed attribute bags (R75: other bag-shaped props) — the template
-    // declares a SUBSET of the keys AWS returns; compare only the declared keys so
-    // the extra live attributes are not false drift on the whole list.
-    const liveVal = projectLiveToDeclaredSubset(declaredVal, liveSorted);
+    const liveVal = unorderedObjArray ? sortUnorderedObjectArray(live[k]) : live[k];
+    // R95: the live side is compared in FULL — no subset projection. An R75
+    // generic `projectLiveToDeclaredSubset` used to drop live elements whose
+    // identity key was not declared, to mute the extra default attributes ELB
+    // returns. But that ALSO silently dropped genuine out-of-band ADDITIONS to any
+    // identity-keyed array — a console-added Tag, an extra CloudFront Origin — which
+    // a drift tool must never hide (fail-closed: report, do not suppress). The ELB
+    // attribute bags are handled above by ELB_ATTRIBUTE_BAGS (R78, compare BY KEY),
+    // which subsumes the projection for the one type that needed it; the corpus
+    // confirms no other type relied on it.
     for (const d of calculateResourceDrift({ [k]: declaredVal }, { [k]: liveVal })) {
       // a bare name declared for a field AWS returns as the full ARN is not drift
       // (account/region-scoped when opts are provided); likewise an AWS-managed-default

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -168,41 +168,15 @@ export function canonicalizeTagListsDeep(v: unknown): unknown {
   return v;
 }
 
-// Identity-keyed ATTRIBUTE BAGS where the template declares only a SUBSET of the
-// keys AWS returns (R75: ELB LoadBalancerAttributes / TargetGroupAttributes —
-// CDK declares the two attrs it set, AWS returns all ~15). A positional diff of
-// the declared 2-element list against the live 15-element list is false drift on
-// the whole property. Project the live side down to ONLY the keys the template
-// declared, recursing through nested bags. Both sides are already identity-sorted
-// by canonicalizeTagListsDeep, so the projected subset stays aligned. A genuine
-// change to a DECLARED attribute's value still differs element-wise after the
-// projection; a never-declared live attribute is simply not compared (it lives
-// inside a declared parent, so it is not undeclared drift either). Returns the
-// live value unchanged when the shapes are not both identity-keyed arrays.
-export function projectLiveToDeclaredSubset(declaredVal: unknown, liveVal: unknown): unknown {
-  if (Array.isArray(declaredVal) && Array.isArray(liveVal)) {
-    const idf = identityField(declaredVal);
-    if (idf && identityField(liveVal) === idf) {
-      const keys = new Set(declaredVal.map((e) => (e as Record<string, unknown>)[idf]));
-      return liveVal
-        .filter((e) => keys.has((e as Record<string, unknown>)[idf]))
-        .map((e) => {
-          const d = declaredVal.find(
-            (x) => (x as Record<string, unknown>)[idf] === (e as Record<string, unknown>)[idf]
-          );
-          return projectLiveToDeclaredSubset(d, e);
-        });
-    }
-    return liveVal;
-  }
-  if (declaredVal && liveVal && typeof declaredVal === 'object' && typeof liveVal === 'object') {
-    const out: Record<string, unknown> = { ...(liveVal as Record<string, unknown>) };
-    for (const [k, dv] of Object.entries(declaredVal as Record<string, unknown>))
-      if (k in out) out[k] = projectLiveToDeclaredSubset(dv, out[k]);
-    return out;
-  }
-  return liveVal;
-}
+// (R95) The generic `projectLiveToDeclaredSubset` was REMOVED. It projected the live
+// side of an identity-keyed array down to only the keys the template declared, to
+// mute the extra default attributes ELB returns (declares 2, AWS returns ~15). But
+// projecting away every undeclared live element ALSO silently dropped genuine
+// out-of-band ADDITIONS to any identity-keyed array — a console-added Tag, an extra
+// CloudFront Origin — a false negative a drift tool must never produce (fail-closed:
+// report, do not suppress). The one type that needed subset behaviour, ELB attribute
+// bags, is handled in classify by ELB_ATTRIBUTE_BAGS (R78, compare BY KEY); the
+// golden corpus confirmed no other type relied on the projection.
 
 // A declared OBJECT/ARRAY whose live counterpart is the same value serialized as a
 // JSON STRING (R75: SSM Document.Content — CDK declares the parsed object, AWS

--- a/tests/_audit.test.ts
+++ b/tests/_audit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+const sc: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+};
+const res = (rt: string, d: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'L',
+  resourceType: rt,
+  physicalId: 'p',
+  declared: d,
+});
+const opts = { accountId: '111111111111', region: 'us-east-1', kmsAliasTargets: {} };
+const probe = (label: string, f: ReturnType<typeof classifyResource>) => {
+  const real = f.filter((x) => x.tier === 'declared' || x.tier === 'undeclared');
+  console.log(
+    `AUDIT ${label}: ${real.length === 0 ? '*** MISSED (BUG) ***' : 'detected'} ${JSON.stringify(real.map((x) => x.tier + ':' + x.path))}`
+  );
+};
+describe('suppression audit: each must still DETECT a real change', () => {
+  it('runs', () => {
+    probe(
+      'json-string(SSM Content changed)',
+      classifyResource(
+        res('AWS::SSM::Document', {
+          Content: { schemaVersion: '2.2', mainSteps: [{ name: 'a' }] },
+        }),
+        { Content: '{"schemaVersion":"2.2","mainSteps":[{"name":"DIFFERENT"}]}' },
+        sc
+      )
+    );
+    probe(
+      'unordered-scalar(Cognito flow changed)',
+      classifyResource(
+        res('AWS::Cognito::UserPoolClient', {
+          ExplicitAuthFlows: ['ALLOW_USER_SRP_AUTH', 'ALLOW_REFRESH_TOKEN_AUTH'],
+        }),
+        { ExplicitAuthFlows: ['ALLOW_USER_SRP_AUTH', 'ALLOW_ADMIN_USER_PASSWORD_AUTH'] },
+        sc
+      )
+    );
+    probe(
+      'case-insensitive(Route53 DNS changed)',
+      classifyResource(
+        res('AWS::Route53::RecordSet', { AliasTarget: { DNSName: 'foo.example.com' } }),
+        { AliasTarget: { DNSName: 'bar.example.com' } },
+        sc
+      )
+    );
+    probe(
+      'stringly(Port 5432->9999)',
+      classifyResource(res('AWS::RDS::DBInstance', { Port: 5432 }), { Port: '9999' }, sc)
+    );
+    probe(
+      'arn-name(role myrole->othername)',
+      classifyResource(
+        res('AWS::IAM::Role', { RoleRef: 'myrole' }),
+        { RoleRef: 'arn:aws:iam::111111111111:role/othername' },
+        sc,
+        opts
+      )
+    );
+    probe(
+      'unordered-obj(SG rule REMOVED)',
+      classifyResource(
+        res('AWS::EC2::SecurityGroup', {
+          SecurityGroupIngress: [
+            { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+            { CidrIp: '10.0.1.0/24', IpProtocol: 'tcp', FromPort: 22, ToPort: 22 },
+          ],
+        }),
+        {
+          SecurityGroupIngress: [
+            { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+          ],
+        },
+        sc
+      )
+    );
+    probe(
+      'atDefault(Lambda Tracing default->Active)',
+      classifyResource(res('AWS::Lambda::Function', {}), { TracingConfig: { Mode: 'Active' } }, sc)
+    );
+    expect(true).toBe(true);
+  });
+});

--- a/tests/_audit2.test.ts
+++ b/tests/_audit2.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+const sc: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+};
+const res = (rt: string, d: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'L',
+  resourceType: rt,
+  physicalId: 'p',
+  declared: d,
+});
+const probe = (label: string, f: ReturnType<typeof classifyResource>, expectDetect = true) => {
+  const real = f.filter((x) => x.tier === 'declared' || x.tier === 'undeclared');
+  const got = real.length > 0;
+  console.log(
+    `AUDIT2 ${label}: ${got === expectDetect ? (got ? 'detected' : 'clean-ok') : '*** ' + (expectDetect ? 'MISSED (BUG)' : 'FALSE-POSITIVE') + ' ***'} ${JSON.stringify(real.map((x) => x.tier + ':' + x.path))}`
+  );
+};
+describe('audit2: removal / nested-undeclared / type-mismatch / deep', () => {
+  it('runs', () => {
+    probe(
+      'tag REMOVED (declared[A,B] live[A])',
+      classifyResource(
+        res('AWS::S3::Bucket', {
+          Tags: [
+            { Key: 'a', Value: '1' },
+            { Key: 'b', Value: '2' },
+          ],
+        }),
+        { Tags: [{ Key: 'a', Value: '1' }] },
+        sc
+      )
+    );
+    probe(
+      'inline-policy stmt REMOVED',
+      classifyResource(
+        res('AWS::IAM::Role', {
+          Policies: [
+            {
+              PolicyName: 'P',
+              PolicyDocument: {
+                Statement: [
+                  { Effect: 'Allow', Action: 's3:Get', Resource: '*' },
+                  { Effect: 'Allow', Action: 's3:Put', Resource: '*' },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          Policies: [
+            {
+              PolicyName: 'P',
+              PolicyDocument: { Statement: [{ Effect: 'Allow', Action: 's3:Get', Resource: '*' }] },
+            },
+          ],
+        },
+        sc
+      )
+    );
+    probe(
+      'NESTED undeclared (declared{A:{x:1}} live{A:{x:1,y:2}})',
+      classifyResource(
+        res('AWS::X::Y', { Conf: { Level: 'INFO' } }),
+        { Conf: { Level: 'INFO', Destination: 's3' } },
+        sc
+      )
+    );
+    probe(
+      'top-level undeclared (sanity)',
+      classifyResource(res('AWS::X::Y', {}), { Extra: 'value' }, sc)
+    );
+    probe(
+      'DEEP nested change (A.B.C 1->2)',
+      classifyResource(res('AWS::X::Y', { A: { B: { C: 1 } } }), { A: { B: { C: 2 } } }, sc)
+    );
+    probe(
+      'type mismatch (declared array, live scalar)',
+      classifyResource(res('AWS::X::Y', { P: [1, 2] }), { P: 'scalar' }, sc)
+    );
+    probe(
+      'declared scalar, live object',
+      classifyResource(res('AWS::X::Y', { P: 'x' }), { P: { nested: 1 } }, sc)
+    );
+    probe(
+      'declared key, live MISSING it (removed/null)',
+      classifyResource(res('AWS::X::Y', { P: 'declared-val' }), {}, sc)
+    );
+    expect(true).toBe(true);
+  });
+});

--- a/tests/_audit3.test.ts
+++ b/tests/_audit3.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+const sc: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+};
+const res = (rt: string, d: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'L',
+  resourceType: rt,
+  physicalId: 'p',
+  declared: d,
+});
+describe('audit3 full tiers', () => {
+  it('runs', () => {
+    console.log(
+      'A3 nested-undeclared ALL=' +
+        JSON.stringify(
+          classifyResource(
+            res('AWS::X::Y', { Conf: { Level: 'INFO' } }),
+            { Conf: { Level: 'INFO', Destination: 's3' } },
+            sc
+          ).map((x) => x.tier + ':' + x.path)
+        )
+    );
+    console.log(
+      'A3 declared-missing ALL=' +
+        JSON.stringify(
+          classifyResource(res('AWS::X::Y', { P: 'declared-val' }), {}, sc).map(
+            (x) => x.tier + ':' + x.path + '/' + (x.note ?? '')
+          )
+        )
+    );
+    console.log(
+      'A3 nested-undeclared-array (declared list of obj, live obj has extra nested key)=' +
+        JSON.stringify(
+          classifyResource(
+            res('AWS::X::Y', { Items: [{ Id: 'a', V: 1 }] }),
+            { Items: [{ Id: 'a', V: 1, Extra: 9 }] },
+            sc
+          ).map((x) => x.tier + ':' + x.path)
+        )
+    );
+    expect(true).toBe(true);
+  });
+});

--- a/tests/_probe.test.ts
+++ b/tests/_probe.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, SchemaInfo } from '../src/types.js';
+const schema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+};
+const res = (rt: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'L',
+  resourceType: rt,
+  physicalId: 'b',
+  declared,
+});
+describe('probe2', () => {
+  it('added tag', () => {
+    const f = classifyResource(
+      res('AWS::S3::Bucket', { Tags: [{ Key: 'team', Value: 'platform' }] }),
+      {
+        Tags: [
+          { Key: 'team', Value: 'platform' },
+          { Key: 'rogue', Value: 'x' },
+        ],
+      },
+      schema
+    );
+    console.log('ADDED2=' + JSON.stringify(f.map((x) => x.tier + ':' + x.path)));
+    expect(f.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -855,3 +855,83 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 });
+
+describe('identity-keyed array ADDITIONS are detected, not subset-projected away (R95)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    physicalId: 'phys',
+    declared,
+  });
+
+  it('a tag ADDED out of band (live has a Key the template does not) is drift, NOT silently dropped', () => {
+    const findings = classifyResource(
+      res('AWS::S3::Bucket', { Tags: [{ Key: 'team', Value: 'platform' }] }),
+      {
+        Tags: [
+          { Key: 'team', Value: 'platform' },
+          { Key: 'rogue', Value: 'x' },
+        ],
+      },
+      emptySchema
+    );
+    // before R95 this returned [] (the rogue tag was projected away) — the bug.
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings.some((f) => f.tier === 'declared' && f.path.startsWith('Tags'))).toBe(true);
+  });
+
+  it('a CHANGED tag value is still detected (regression — changes were always caught)', () => {
+    const findings = classifyResource(
+      res('AWS::S3::Bucket', { Tags: [{ Key: 'team', Value: 'platform' }] }),
+      { Tags: [{ Key: 'team', Value: 'CHANGED' }] },
+      emptySchema
+    );
+    expect(findings.some((f) => f.tier === 'declared' && f.path.startsWith('Tags'))).toBe(true);
+  });
+
+  it('an ADDED Id-keyed element (e.g. a CloudFront Origin) is drift, not dropped', () => {
+    const findings = classifyResource(
+      res('AWS::CloudFront::Distribution', {
+        DistributionConfig: { Origins: [{ Id: 'o1', DomainName: 'a.example' }] },
+      }),
+      {
+        DistributionConfig: {
+          Origins: [
+            { Id: 'o1', DomainName: 'a.example' },
+            { Id: 'o2', DomainName: 'b.example' },
+          ],
+        },
+      },
+      emptySchema
+    );
+    expect(findings.length).toBeGreaterThan(0);
+  });
+
+  it('ELB attribute bags still compare as a SUBSET (declared 2, AWS returns extra defaults) — no false drift', () => {
+    const T = 'AWS::ElasticLoadBalancingV2::LoadBalancer';
+    const declared = {
+      LoadBalancerAttributes: [
+        { Key: 'idle_timeout.timeout_seconds', Value: '120' },
+        { Key: 'deletion_protection.enabled', Value: 'false' },
+      ],
+    };
+    const liveAll = {
+      LoadBalancerAttributes: [
+        { Key: 'access_logs.s3.enabled', Value: 'false' },
+        { Key: 'idle_timeout.timeout_seconds', Value: '120' },
+        { Key: 'deletion_protection.enabled', Value: 'false' },
+        { Key: 'routing.http2.enabled', Value: 'true' },
+      ],
+    };
+    expect(classifyResource(res(T, declared), liveAll, emptySchema)).toEqual([]);
+  });
+});

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -350,6 +350,18 @@ then accept -> `check --fail` CLEAN.
 cd harvest5 && npm install && bash verify-harvest5.sh
 ```
 
+## mutation-tags
+
+Guards the R95 fix (a console-ADDED tag must be DETECTED, not subset-projected
+away). Deploy a bucket with one declared tag, accept CLEAN, ADD a second tag out of
+band (a Key the template never declared, via the Resource Groups Tagging API so the
+aws:* system tags survive), and assert `check --fail` reports it. Before R95 the
+added tag was silently dropped.
+
+```bash
+cd mutation-tags && npm install && bash verify.sh
+```
+
 ## mutation-arrays
 
 The highest-yield false-NEGATIVE hunt: properties whose normalizer sorts or

--- a/tests/integration/mutation-tags/app.ts
+++ b/tests/integration/mutation-tags/app.ts
@@ -1,0 +1,13 @@
+// CDK app for the cdk-real-drift TAG-addition mutation integration test (R95).
+// The live guard for the R95 fix: a console-added tag must be DETECTED, not
+// silently projected away. A tagged S3 bucket whose template declares one tag.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMutationTags");
+
+const bucket = new Bucket(stack, "Bucket", { removalPolicy: RemovalPolicy.DESTROY });
+Tags.of(bucket).add("team", "platform");
+
+app.synth();

--- a/tests/integration/mutation-tags/cdk.json
+++ b/tests/integration/mutation-tags/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/mutation-tags/package.json
+++ b/tests/integration/mutation-tags/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-mutation-tags",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Tag-addition mutation (R95 false-negative fix) integration test for cdk-real-drift. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/mutation-tags/verify.sh
+++ b/tests/integration/mutation-tags/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# cdk-real-drift tag-addition mutation integration test (real AWS, R95).
+# Guards the R95 fix: a console-ADDED tag (a Key the template never declared) must be
+# DETECTED, not silently dropped by subset projection. Deploy a bucket with one
+# declared tag, accept CLEAN, add a second tag out of band, assert check detects it.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegMutationTags; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ---"; npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+echo "=== build + deploy + accept ==="
+(cd "$ROOT" && vp run build) || fail "build"
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+$CLI accept "$STACK" --region "$REGION" --yes || fail "accept"
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after accept"
+echo "=== add a tag out of band (a Key the template never declared) ==="
+B="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
+[ -n "$B" ] || fail "no bucket"
+# ADD a tag without disturbing existing tags (the Resource Groups Tagging API
+# appends; put-bucket-tagging would REPLACE all tags and then refuse to drop the
+# aws:cloudformation:* system tags).
+aws resourcegroupstaggingapi tag-resources --resource-arn-list "arn:aws:s3:::$B" \
+  --tags rogue=injected --region "$REGION" || fail "add tag"
+sleep 5
+echo "=== check must DETECT the added tag (R95: not subset-projected away) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-mut-tags.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1 — the added tag was MISSED (the R95 bug)"
+grep -qi "Tags\|rogue" /tmp/cdkrd-mut-tags.out || fail "the added tag was not named in the report"
+echo "INTEG PASS"


### PR DESCRIPTION
## The bug
A **console-added tag** — or any element added to an identity-keyed array AWS returns (Tags, CloudFront Origins, …) — was **NOT detected**: cdkrd reported CLEAN. A false negative that undermines the core promise.

## Root cause
The R75 generic `projectLiveToDeclaredSubset` projected the live side of every identity-keyed array down to **only the keys the template declared**, to mute the extra default attributes ELB returns. But that also silently dropped genuine out-of-band **additions** (fail-open — wrong for a drift tool).

## Fix
Remove the generic projection; compare the live side in FULL. ELB attribute bags keep their subset behaviour via `ELB_ATTRIBUTE_BAGS` (R78, BY KEY). The **231-case / 128-type golden corpus replays unchanged** — nothing else relied on the projection.

## Verification
- Unit: added-tag detected, added Id-keyed element (Origin) detected, changed-tag still detected, **ELB subset still clean**.
- **Live**: `mutation-tags` fixture (add a tag out of band → detected) INTEG PASS; 6 tag/array/policy regression fixtures (noise/basic/iam/dynamodb/securitygroup/cognito) all PASS — no new false positives.
- typecheck / lint / build / **718 unit tests** green.

Found by a deliberate over-suppression (added-element mutation) hunt.

> NOTE: nested undeclared properties (a live sub-field inside a DECLARED object) are still not detected — deliberate `diffAt` subset semantics (avoids nested-default noise); tracked for a folded-detection design next.