### PR TITLE
feat: detect nested undeclared properties (R96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ that folds everything informational.
     of a first run, folded to a count so the body shows only what actually
     diverges. Equality-gated: a change away from the default still surfaces, and
     `--show-all` lists them.
+  - **`nested`** — undeclared values that live as a **sub-key inside a property
+    you _did_ declare** (e.g. you set a cache behavior but never its
+    `SmoothStreaming`, which AWS materializes underneath). The live model carries
+    many of these, so they fold to a count; `accept` records them like any
+    undeclared value (so a later out-of-band change to one surfaces), and
+    `--show-all` / `--verbose` list them.
   - **`readGap` / `unresolved` / `skipped` / `ignored`** — values cdkrd can't
     confidently compare, reported honestly rather than guessed (never false drift).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -167,12 +167,15 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
 5. classify (tier)       deleted | declared | undeclared | atDefault | readGap | unresolved | skipped
                          (atDefault = undeclared but EQUAL to a known AWS default —
                          folded, never drift, never recorded; R86)
+                         (undeclared also carries a nested:true flag for a live
+                         sub-key inside a declared object the template never set; R96)
 6. baseline filter       applyBaseline(): undeclared findings already accepted → drop;
                          atDefault reconciled too (an accepted value now at-default is
                          suppressed, not a false "removed since accept")
 7. report + exit code    report.ts: drift tiers in full + info: footer (1 line;
                          1 bullet/tier when 2+; --verbose expands, --show-all expands
-                         atDefault only); --json carries all findings; worst exit across stacks
+                         atDefault + nested undeclared); --json carries all findings;
+                         worst exit across stacks
 ```
 
 The two-pass structure (PR "resolve Fn::GetAtt against live attributes") is what
@@ -286,6 +289,12 @@ all live changes
   − per-type unordered OBJECT-array sets (EC2 SecurityGroup ingress/egress rules — no identity field, R88) → both sides sorted by canonical JSON (UNORDERED_OBJECT_ARRAY_PROPS / sortUnorderedObjectArray)
   − sibling AWS::IAM::Policy entries in a role's Policies → filtered BY NAME (see below)
   = undeclared residual                → the unique signal
+      ├─ top-level: a live property the template never declared
+      └─ nested (R96): a live SUB-key inside a DECLARED object never set by it
+         (recursed by classify's collectNestedUndeclared, dotted path, flagged
+         nested:true) — folded in the report by default (the live model carries many
+         nested AWS defaults), expanded by --show-all/--verbose, recorded by accept
+         like any undeclared value so a later out-of-band change to it surfaces
 ```
 
 **The four false-positive classes found by dogfooding** (8 real cdkd fixtures —

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -44,6 +44,27 @@ const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
   typeof (t as { Key?: unknown }).Key === 'string' &&
   'Value' in (t as object);
 
+// R96: recurse two plain objects (the declared and live sides of a property) and
+// emit each LIVE-only nested key — a sub-key present in live but never declared, at
+// any depth. Arrays are not descended (their element identity/order is handled by the
+// declared compare + canonicalizers); only nested OBJECTS are walked. Pure: the
+// caller decides suppression and finding shape.
+const isNestedObject = (x: unknown): x is Record<string, unknown> =>
+  x !== null && typeof x === 'object' && !Array.isArray(x);
+function collectNestedUndeclared(
+  declaredVal: unknown,
+  liveVal: unknown,
+  path: string,
+  emit: (path: string, value: unknown) => void
+): void {
+  if (!isNestedObject(declaredVal) || !isNestedObject(liveVal)) return;
+  for (const [k, val] of Object.entries(liveVal)) {
+    const childPath = `${path}.${k}`;
+    if (k in declaredVal) collectNestedUndeclared(declaredVal[k], val, childPath, emit);
+    else emit(childPath, val);
+  }
+}
+
 export function classifyResource(
   resource: DesiredResource,
   liveRaw: Record<string, unknown>,
@@ -242,6 +263,29 @@ export function classifyResource(
     if (physicalId !== undefined && v === physicalId) continue;
     if (isTrivialEmpty(v)) continue;
     findings.push({ tier: 'undeclared', logicalId, resourceType, path: k, actual: v });
+  }
+
+  // Nested undeclared (R96): the Cloud Control read returns the FULL live model, so a
+  // live SUB-key inside a DECLARED object that the template never set is just as
+  // undeclared as a top-level one — recurse the declared∩live objects and emit each
+  // live-only nested key (dotted path). Same noise suppression as the top-level loop
+  // (trivially-empty / aws:* tags). These flow through the usual undeclared→baseline
+  // machinery, just `nested`-flagged so the report can fold them (the live model
+  // carries many nested AWS defaults): folded inventory on a first run, recorded by
+  // accept, and a later out-of-band change to one surfaces as drift vs the baseline.
+  for (const [k, dv] of Object.entries(declared)) {
+    if (dv === UNRESOLVED || hasUnresolved(dv) || !(k in live)) continue;
+    collectNestedUndeclared(dv, live[k], k, (path, value) => {
+      if (isAllAwsTags(value) || isTrivialEmpty(value)) return;
+      findings.push({
+        tier: 'undeclared',
+        logicalId,
+        resourceType,
+        path,
+        actual: value,
+        nested: true,
+      });
+    });
   }
 
   // attach physicalId (for revert) + construct path (display) onto every finding

--- a/src/diff/drift-calculator.ts
+++ b/src/diff/drift-calculator.ts
@@ -38,8 +38,10 @@ function diffAt(
 ): void {
   if (deepEqual(sv, av)) return;
   if (isPlainObject(sv) && isPlainObject(av) && !Array.isArray(sv) && !Array.isArray(av)) {
-    // Subset semantics: only walk keys present in the desired (state) side, so
-    // AWS-added keys the template never set are not reported as drift.
+    // Subset semantics: only walk keys present in the desired (state) side, so an
+    // AWS-added nested key the template never set is not a DECLARED-side change here.
+    // (R96: such live-only nested keys are instead caught by classify's
+    // `collectNestedUndeclared` as nested UNDECLARED findings — folded, baseline-able.)
     for (const key of Object.keys(sv)) {
       const childPath = `${path}.${key}`;
       if (isIgnoredPath(childPath, ignorePaths)) continue;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -129,6 +129,15 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
 
   const byTier = (t: Tier) => findings.filter((f) => f.tier === t && !f.unrecorded);
   const unrecordedItems = findings.filter((f) => f.unrecorded === true);
+  // R96: a NESTED unrecorded value (a live sub-key inside a DECLARED object the
+  // template never set) folds by default — the live model carries many nested AWS
+  // defaults, so listing them all would re-flood the first run R86 worked to quiet.
+  // Top-level unrecorded values still list in full in [UNRECORDED]; the nested ones
+  // collapse to one `info:` count, expanded by --verbose or --show-all. Either way
+  // accept records them, so a later out-of-band change to one surfaces as drift.
+  const expandNested = !!opts.verbose || !!opts.expandAtDefault;
+  const unrecordedShown = expandNested ? unrecordedItems : unrecordedItems.filter((f) => !f.nested);
+  const nestedFolded = expandNested ? [] : unrecordedItems.filter((f) => f.nested === true);
   // Count inside the brackets (`[NAME: N]`), explanation outside (dim) — see the
   // layout comment at the top (R48). `leadingBlank` separates a section from
   // whatever precedes it; the FIRST drift section sits directly under the header.
@@ -161,7 +170,7 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // hiding them would defeat the differentiator), but kept OUT of the verdict.
   if (
     section(
-      unrecordedItems,
+      unrecordedShown,
       'UNRECORDED',
       'not declared in your template; not in the baseline yet — accept to record',
       style.undeclaredTier,
@@ -210,6 +219,11 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
       return items.length ? summaryFor(t, items) : null;
     })
     .filter((s): s is string => s !== null);
+  // R96: the folded nested-unrecorded count joins the info: footer (--show-all lists them).
+  if (nestedFolded.length > 0)
+    summaries.push(
+      `nested=${nestedFolded.length} (undeclared values nested in a declared object — accept to record; --show-all to list)`
+    );
   if (summaries.length === 1) {
     log(style.infoTier(`info: ${summaries[0]} — run with --verbose for the list`));
   } else if (summaries.length > 1) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,12 @@ export interface Finding {
   // this Key=Value via ModifyLoadBalancerAttributes (a Cloud Control index patch
   // would misalign against the full live bag and exceed ELB's 20-attribute cap).
   attributeKey?: string;
+  // undeclared tier only (R96): the value is a live SUB-key inside a DECLARED object
+  // that the template never set (a nested undeclared property, dotted path). Detected
+  // by recursing the declared/live objects. Reported folded by default (the live
+  // model carries many nested AWS defaults), expanded by --show-all; recorded by
+  // accept like any undeclared value, so a later out-of-band change to it surfaces.
+  nested?: boolean;
 }
 
 export interface SchemaInfo {

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -509,3 +509,29 @@ describe('baseline', () => {
     });
   });
 });
+
+describe('nested undeclared through the baseline (R96)', () => {
+  const nf = (path: string, val: unknown): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'L',
+    resourceType: 'T',
+    path,
+    actual: val,
+    nested: true,
+  });
+  it('no baseline -> nested undeclared is unrecorded inventory (folded downstream)', () => {
+    const out = applyBaseline([nf('Conf.X', 'default')], undefined);
+    expect(out[0]).toMatchObject({ tier: 'undeclared', path: 'Conf.X', unrecorded: true });
+  });
+  it('accepted + unchanged -> suppressed (CLEAN)', () => {
+    const b = baseline([{ logicalId: 'L', resourceType: 'T', path: 'Conf.X', value: 'default' }]);
+    expect(applyBaseline([nf('Conf.X', 'default')], b)).toEqual([]);
+  });
+  it('accepted then a nested value CHANGES out of band -> drift (the depth differentiator)', () => {
+    const b = baseline([{ logicalId: 'L', resourceType: 'T', path: 'Conf.X', value: 'default' }]);
+    const out = applyBaseline([nf('Conf.X', 'EDITED')], b);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'undeclared', path: 'Conf.X' });
+    expect(out[0]!.unrecorded).toBeUndefined(); // it is drift, not unrecorded
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -935,3 +935,64 @@ describe('identity-keyed array ADDITIONS are detected, not subset-projected away
     expect(classifyResource(res(T, declared), liveAll, emptySchema)).toEqual([]);
   });
 });
+
+describe('nested undeclared detection (R96 — the differentiator at depth)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    physicalId: 'phys',
+    declared,
+  });
+  const f = (rt: string, d: Record<string, unknown>, l: Record<string, unknown>) =>
+    classifyResource(res(rt, d), l, emptySchema);
+
+  it('a live sub-key inside a DECLARED object the template never set is nested undeclared', () => {
+    const out = f(
+      'AWS::X::Y',
+      { Conf: { Level: 'INFO' } },
+      { Conf: { Level: 'INFO', Destination: 's3' } }
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'undeclared', path: 'Conf.Destination', nested: true });
+  });
+
+  it('detects nested undeclared at ANY depth (A.B.D)', () => {
+    const out = f('AWS::X::Y', { A: { B: { C: 1 } } }, { A: { B: { C: 1, D: 2 } } });
+    expect(out.some((x) => x.tier === 'undeclared' && x.path === 'A.B.D' && x.nested)).toBe(true);
+  });
+
+  it('a CHANGE to a declared nested field is DECLARED drift, not nested-undeclared', () => {
+    const out = f('AWS::X::Y', { Conf: { Level: 'INFO' } }, { Conf: { Level: 'CHANGED' } });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      tier: 'declared',
+      path: 'Conf.Level',
+      desired: 'INFO',
+      actual: 'CHANGED',
+    });
+    expect(out[0]!.nested).toBeUndefined();
+  });
+
+  it('does NOT descend arrays (element identity/order handled elsewhere)', () => {
+    const out = f('AWS::X::Y', { Items: [{ Id: 'a' }] }, { Items: [{ Id: 'a', Extra: 9 }] });
+    expect(out.filter((x) => x.nested)).toEqual([]);
+  });
+
+  it('nested trivially-empty / aws:* values are suppressed like top-level', () => {
+    const out = f('AWS::X::Y', { Conf: { A: 1 } }, { Conf: { A: 1, EmptyList: [], EmptyObj: {} } });
+    expect(out.filter((x) => x.nested)).toEqual([]);
+  });
+
+  it('no nested findings when the live object adds nothing beyond declared', () => {
+    expect(f('AWS::X::Y', { Conf: { A: 1 } }, { Conf: { A: 1 } })).toEqual([]);
+  });
+});

--- a/tests/corpus/AWS__ApiGateway__Method.ApiGET9257B917.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiGET9257B917.json
@@ -69,5 +69,46 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiGET9257B917",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.CacheNamespace",
+      "actual": "1pd9ky6ghl",
+      "nested": true,
+      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiGET9257B917",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.PassthroughBehavior",
+      "actual": "WHEN_NO_MATCH",
+      "nested": true,
+      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiGET9257B917",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.ResponseTransferMode",
+      "actual": "BUFFERED",
+      "nested": true,
+      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiGET9257B917",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.TimeoutInMillis",
+      "actual": 29000,
+      "nested": true,
+      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
+    }
+  ]
 }

--- a/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
+++ b/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
@@ -86,5 +86,36 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApiGET0F59260B",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.CacheNamespace",
+      "actual": "6pva1vasg4",
+      "nested": true,
+      "physicalId": "84xvb60zri|6pva1vasg4|GET",
+      "constructPath": "CdkrdIntegHarvest/RestApi/Default/GET"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApiGET0F59260B",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.ResponseTransferMode",
+      "actual": "BUFFERED",
+      "nested": true,
+      "physicalId": "84xvb60zri|6pva1vasg4|GET",
+      "constructPath": "CdkrdIntegHarvest/RestApi/Default/GET"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "RestApiGET0F59260B",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.TimeoutInMillis",
+      "actual": 29000,
+      "nested": true,
+      "physicalId": "84xvb60zri|6pva1vasg4|GET",
+      "constructPath": "CdkrdIntegHarvest/RestApi/Default/GET"
+    }
+  ]
 }

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
@@ -61,15 +61,6 @@
       "tier": "undeclared",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
-      "path": "SecurityPolicy",
-      "actual": "TLS_1_0",
-      "physicalId": "38w1jnsg0j",
-      "constructPath": "CdkdriftIntegHarvest8/Api"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "ApiF70053CD",
-      "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
       "actual": "HEADER",
       "physicalId": "38w1jnsg0j",
@@ -84,6 +75,15 @@
         "IpAddressType": "ipv4",
         "Types": ["EDGE"]
       },
+      "physicalId": "38w1jnsg0j",
+      "constructPath": "CdkdriftIntegHarvest8/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
       "physicalId": "38w1jnsg0j",
       "constructPath": "CdkdriftIntegHarvest8/Api"
     }

--- a/tests/corpus/AWS__ApiGateway__UsagePlan.Plan.json
+++ b/tests/corpus/AWS__ApiGateway__UsagePlan.Plan.json
@@ -60,5 +60,16 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Plan",
+      "resourceType": "AWS::ApiGateway::UsagePlan",
+      "path": "Quota.Offset",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "6aiqlx",
+      "constructPath": "CdkrdIntegHarvest6/Plan"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Budgets__Budget.CfnBudgetCostForDaily.json
+++ b/tests/corpus/AWS__Budgets__Budget.CfnBudgetCostForDaily.json
@@ -67,6 +67,16 @@
       "note": "declared but not returned by live read",
       "physicalId": "CfnBudgetCostForDaily-us-east-1-1679810595264-2BgFDrBokvWD",
       "constructPath": "main-CostCheck/CfnBudgetCostForDaily"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "CfnBudgetCostForDaily",
+      "resourceType": "AWS::Budgets::Budget",
+      "path": "Budget.BudgetName",
+      "actual": "CfnBudgetCostForDaily-us-east-1-1679810595264-2BgFDrBokvWD",
+      "nested": true,
+      "physicalId": "CfnBudgetCostForDaily-us-east-1-1679810595264-2BgFDrBokvWD",
+      "constructPath": "main-CostCheck/CfnBudgetCostForDaily"
     }
   ]
 }

--- a/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
+++ b/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
@@ -64,6 +64,15 @@
       "path": "NotificationsWithSubscribers",
       "note": "declared but not returned by live read",
       "physicalId": "MonthlyCost-us-east-1-1679810595490-abcDEFghij"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "MonthlyCost",
+      "resourceType": "AWS::Budgets::Budget",
+      "path": "Budget.BudgetName",
+      "actual": "MonthlyCost-us-east-1-1679810595490-abcDEFghij",
+      "nested": true,
+      "physicalId": "MonthlyCost-us-east-1-1679810595490-abcDEFghij"
     }
   ]
 }

--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD.json
@@ -196,5 +196,48 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.OriginGroups",
+      "actual": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Restrictions",
+      "actual": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CodeBuild__Project.Build.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build.json
@@ -73,6 +73,16 @@
       "tier": "undeclared",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
+      "path": "Environment.ImagePullCredentialsType",
+      "actual": "CODEBUILD",
+      "nested": true,
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Build"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Build",
+      "resourceType": "AWS::CodeBuild::Project",
       "path": "QueuedTimeoutInMinutes",
       "actual": 480,
       "physicalId": "cdkrd-harvest6",

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -335,6 +335,45 @@
       "tier": "undeclared",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 7,
+      "nested": true,
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
       "path": "Policies",
       "actual": {
         "PasswordPolicy": {
@@ -349,15 +388,6 @@
           "AllowedFirstAuthFactors": ["PASSWORD"]
         }
       },
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "MfaConfiguration",
-      "actual": "OFF",
       "physicalId": "us-east-1_BUaNF3GfH",
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
@@ -594,24 +624,6 @@
       "tier": "undeclared",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "UserPoolTier",
-      "actual": "ESSENTIALS",
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "DeletionProtection",
-      "actual": "INACTIVE",
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",
       "actual": "Pool88FC4FF9F-jVGU9rNojAd7",
       "physicalId": "us-east-1_BUaNF3GfH",
@@ -621,10 +633,8 @@
       "tier": "undeclared",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "EmailConfiguration",
-      "actual": {
-        "EmailSendingAccount": "COGNITO_DEFAULT"
-      },
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
       "physicalId": "us-east-1_BUaNF3GfH",
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     }

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -336,6 +336,16 @@
       "tier": "undeclared",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 7,
+      "nested": true,
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
       "path": "DeletionProtection",
       "actual": "INACTIVE",
       "physicalId": "us-east-1_4tB3jYmmc",

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -336,6 +336,16 @@
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
       "path": "DeletionProtection",
       "actual": "INACTIVE",
       "physicalId": "us-east-1_Ifea0bzss",
@@ -358,6 +368,18 @@
       "resourceType": "AWS::Cognito::UserPool",
       "path": "MfaConfiguration",
       "actual": "OFF",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Policies.SignInPolicy",
+      "actual": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      },
+      "nested": true,
       "physicalId": "us-east-1_Ifea0bzss",
       "constructPath": "CdkrdIntegHarvest3/Users"
     },

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
@@ -82,8 +82,8 @@
       "tier": "undeclared",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "RefreshTokenValidity",
-      "actual": 30,
+      "path": "EnableTokenRevocation",
+      "actual": true,
       "physicalId": "mr9u1vrva41nona9of2rfctdi",
       "constructPath": "CdkRealDriftIntegCognito/Client"
     },
@@ -91,8 +91,8 @@
       "tier": "undeclared",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "EnableTokenRevocation",
-      "actual": true,
+      "path": "RefreshTokenValidity",
+      "actual": 30,
       "physicalId": "mr9u1vrva41nona9of2rfctdi",
       "constructPath": "CdkRealDriftIntegCognito/Client"
     }

--- a/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
@@ -174,6 +174,16 @@
       "tier": "undeclared",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::DynamoDB::Table",
+      "path": "PointInTimeRecoverySpecification.RecoveryPeriodInDays",
+      "actual": 35,
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+      "constructPath": "CdkRealDriftIntegDynamoDB/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",
       "actual": {
         "ReadUnitsPerSecond": 12000,

--- a/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
+++ b/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
@@ -122,14 +122,6 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
-      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
-      "physicalId": "subnet-0a9a838411f55ddb0",
-      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
       "resourceType": "AWS::EC2::Subnet",
@@ -148,6 +140,14 @@
         "HostnameType": "ip-name",
         "EnableResourceNameDnsAAAARecord": false
       },
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
       "physicalId": "subnet-0a9a838411f55ddb0",
       "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
@@ -105,24 +105,6 @@
       "tier": "undeclared",
       "logicalId": "VpcS3Endpoint4A3DE4B5",
       "resourceType": "AWS::EC2::VPCEndpoint",
-      "path": "IpAddressType",
-      "actual": "ipv4",
-      "physicalId": "vpce-010c0956e4433b47b",
-      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "VpcS3Endpoint4A3DE4B5",
-      "resourceType": "AWS::EC2::VPCEndpoint",
-      "path": "ServiceRegion",
-      "actual": "us-east-1",
-      "physicalId": "vpce-010c0956e4433b47b",
-      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "VpcS3Endpoint4A3DE4B5",
-      "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "DnsOptions",
       "actual": {
         "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
@@ -130,6 +112,15 @@
         "DnsRecordIpType": "service-defined",
         "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
       },
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "IpAddressType",
+      "actual": "ipv4",
       "physicalId": "vpce-010c0956e4433b47b",
       "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
     },
@@ -149,6 +140,15 @@
         ],
         "Version": "2008-10-17"
       },
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "ServiceRegion",
+      "actual": "us-east-1",
       "physicalId": "vpce-010c0956e4433b47b",
       "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
     }

--- a/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
@@ -64,17 +64,10 @@
       "tier": "undeclared",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "KmsKeyId",
-      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
-      "physicalId": "fs-0d81f40b7a880b7ae",
-      "constructPath": "CdkdriftIntegHarvest9/Fs"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Fs6C1AF03C",
-      "resourceType": "AWS::EFS::FileSystem",
-      "path": "PerformanceMode",
-      "actual": "generalPurpose",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
       "physicalId": "fs-0d81f40b7a880b7ae",
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     },
@@ -93,8 +86,8 @@
       "tier": "undeclared",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "ThroughputMode",
-      "actual": "bursting",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
       "physicalId": "fs-0d81f40b7a880b7ae",
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     },
@@ -102,10 +95,17 @@
       "tier": "undeclared",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "BackupPolicy",
-      "actual": {
-        "Status": "DISABLED"
-      },
+      "path": "PerformanceMode",
+      "actual": "generalPurpose",
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "ThroughputMode",
+      "actual": "bursting",
       "physicalId": "fs-0d81f40b7a880b7ae",
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     }

--- a/tests/corpus/AWS__Glue__Database.Catalog.json
+++ b/tests/corpus/AWS__Glue__Database.Catalog.json
@@ -58,5 +58,23 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Catalog",
+      "resourceType": "AWS::Glue::Database",
+      "path": "DatabaseInput.CreateTableDefaultPermissions",
+      "actual": [
+        {
+          "Permissions": ["ALL"],
+          "Principal": {
+            "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
+          }
+        }
+      ],
+      "nested": true,
+      "physicalId": "cdkrd_harvest_db",
+      "constructPath": "CdkrdIntegHarvest/Catalog"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Glue__Table.Events.json
+++ b/tests/corpus/AWS__Glue__Table.Events.json
@@ -79,5 +79,26 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Events",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.Retention",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_harvest_events",
+      "constructPath": "CdkrdIntegHarvest/Events"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Events",
+      "resourceType": "AWS::Glue::Table",
+      "path": "TableInput.StorageDescriptor.NumberOfBuckets",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "cdkrd_harvest_events",
+      "constructPath": "CdkrdIntegHarvest/Events"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.ApiCloudWatchRole73EC6FC4.json
+++ b/tests/corpus/AWS__IAM__Role.ApiCloudWatchRole73EC6FC4.json
@@ -67,8 +67,8 @@
       "tier": "atDefault",
       "logicalId": "ApiCloudWatchRole73EC6FC4",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
       "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
     },
@@ -85,8 +85,8 @@
       "tier": "atDefault",
       "logicalId": "ApiCloudWatchRole73EC6FC4",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
       "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
     }

--- a/tests/corpus/AWS__IAM__Role.MachineRoleD2D3D395.json
+++ b/tests/corpus/AWS__IAM__Role.MachineRoleD2D3D395.json
@@ -73,8 +73,8 @@
       "tier": "atDefault",
       "logicalId": "MachineRoleD2D3D395",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
       "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
     },
@@ -91,8 +91,8 @@
       "tier": "atDefault",
       "logicalId": "MachineRoleD2D3D395",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
       "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
     }

--- a/tests/corpus/AWS__Route53__HealthCheck.Health.json
+++ b/tests/corpus/AWS__Route53__HealthCheck.Health.json
@@ -47,5 +47,16 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Health",
+      "resourceType": "AWS::Route53::HealthCheck",
+      "path": "HealthCheckConfig.EnableSNI",
+      "actual": true,
+      "nested": true,
+      "physicalId": "fc5f8fb0-4e1a-49d2-9491-17730c70f226",
+      "constructPath": "CdkrdIntegHarvest5/Health"
+    }
+  ]
 }

--- a/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
+++ b/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
@@ -248,6 +248,16 @@
       },
       "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
       "constructPath": "CdkrdIntegHarvest2/Archive"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ArchiveDA4CB258",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "LifecycleConfiguration.TransitionDefaultMinimumObjectSize",
+      "actual": "all_storage_classes_128K",
+      "nested": true,
+      "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+      "constructPath": "CdkrdIntegHarvest2/Archive"
     }
   ]
 }

--- a/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
+++ b/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
@@ -39,24 +39,6 @@
       "tier": "undeclared",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
-      "constructPath": "CdkRealDriftIntegSqs/Dlq"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "DlqD1FAA4AD",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
-      "constructPath": "CdkRealDriftIntegSqs/Dlq"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "DlqD1FAA4AD",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
@@ -75,8 +57,8 @@
       "tier": "undeclared",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     },
@@ -84,8 +66,26 @@
       "tier": "undeclared",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     }

--- a/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
+++ b/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
@@ -68,24 +68,6 @@
       "tier": "undeclared",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
-      "constructPath": "CdkRealDriftIntegSqs/Main"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Main54E5BC70",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
-      "constructPath": "CdkRealDriftIntegSqs/Main"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Main54E5BC70",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
@@ -106,6 +88,24 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
       "constructPath": "CdkRealDriftIntegSqs/Main"
     }

--- a/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
+++ b/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
@@ -37,35 +37,8 @@
       "tier": "undeclared",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
-      "constructPath": "CdkRealDriftIntegEvents/Target"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Target3191CF44",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
-      "constructPath": "CdkRealDriftIntegEvents/Target"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Target3191CF44",
-      "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
       "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
-      "constructPath": "CdkRealDriftIntegEvents/Target"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Target3191CF44",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
@@ -82,8 +55,8 @@
       "tier": "undeclared",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
@@ -93,6 +66,33 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "ReceiveMessageWaitTimeSeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "constructPath": "CdkRealDriftIntegEvents/Target"
     }

--- a/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
@@ -70,6 +70,19 @@
       "actual": "UTC",
       "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
       "constructPath": "CdkrdIntegHarvest3/HourlyPing"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HourlyPing",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "Target.RetryPolicy",
+      "actual": {
+        "MaximumEventAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 185
+      },
+      "nested": true,
+      "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
+      "constructPath": "CdkrdIntegHarvest3/HourlyPing"
     }
   ]
 }

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -358,3 +358,31 @@ describe('report', () => {
     });
   });
 });
+
+describe('R96 nested unrecorded folding', () => {
+  const NU = (path: string, nested?: boolean): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'L',
+    resourceType: 'T',
+    path,
+    actual: 1,
+    unrecorded: true,
+    ...(nested ? { nested: true } : {}),
+  });
+  it('nested unrecorded folds into info:, top-level lists in [UNRECORDED]', () => {
+    const { text } = run([NU('TopLevel'), NU('Conf.A', true), NU('Conf.B', true)]);
+    expect(text).toContain('[UNRECORDED: 1]');
+    expect(text).toContain('L.TopLevel');
+    expect(text).toContain('nested=2');
+    expect(text).not.toContain('Conf.A');
+  });
+  it('--show-all expands nested into the body (no fold line)', () => {
+    const { text } = run([NU('Conf.A', true)], { expandAtDefault: true });
+    expect(text).toContain('L.Conf.A');
+    expect(text).not.toContain('nested=1');
+  });
+  it('--verbose also expands nested', () => {
+    const { text } = run([NU('Conf.A', true)], { verbose: true });
+    expect(text).toContain('L.Conf.A');
+  });
+});


### PR DESCRIPTION
## What

Detect **nested undeclared** properties — a live sub-key inside a property you *did* declare, that the template never set. e.g. you declare a CloudFront cache behavior but never its `SmoothStreaming`; you declare an ApiGateway `Integration` but never its `CacheNamespace`. AWS materializes these underneath, and until now cdkrd only looked at top-level undeclared properties, so they were invisible.

This extends the undeclared differentiator **to depth**.

## How

- **classify** recurses the declared/live object pair (`collectNestedUndeclared`), emitting a finding for every live sub-key with no declared counterpart — dotted path, flagged `nested: true`. Arrays are not descended (they keep their existing identity-keyed / unordered handling); trivially-empty and all-`aws:*`-tag values are skipped.
- **report** folds nested findings into the `info:` footer as a count by default (the live model carries many nested AWS defaults); `--show-all` / `--verbose` expand them.
- **accept** records them like any undeclared value — so a later out-of-band change to one surfaces as drift. No hand-maintained nested-default tables (baseline-based, consistent with the subtractive noise model).

## Tests

- `classify.test.ts` — 6: detected / deep / array-not-descended / trivially-empty-skipped / nested-change-is-declared / no-false-positive.
- `report.test.ts` — 3: folds by default / `--show-all` expands / `--verbose` expands.
- `baseline.test.ts` — 3: no-baseline→unrecorded / accepted+unchanged→suppressed / accepted+changed→drift.
- Golden corpus regenerated (26 files gained nested findings, all AWS defaults). Replay green.
- Full gates: typecheck / lint+format / build / 730 unit tests pass.

## Docs

README `info:` footer + ARCHITECTURE noise model / pipeline updated to describe the nested tier flag.