### PR TITLE
test: pin nested read-only/write-only path stripping (R97)

### DIFF
--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -995,4 +995,29 @@ describe('nested undeclared detection (R96 — the differentiator at depth)', ()
   it('no nested findings when the live object adds nothing beyond declared', () => {
     expect(f('AWS::X::Y', { Conf: { A: 1 } }, { Conf: { A: 1 } })).toEqual([]);
   });
+
+  it('a nested READ-ONLY path (stripped from live) is NOT surfaced as nested undeclared', () => {
+    // deepStripPaths(live, readOnlyPaths) runs BEFORE the nested recursion, so a
+    // managed read-only sub-field never reaches collectNestedUndeclared. Pin that
+    // interaction: without the strip this would be a false `Conf.Arn` nested finding.
+    const schema: SchemaInfo = { ...emptySchema, readOnlyPaths: ['Conf.Arn'] };
+    const out = classifyResource(
+      res('AWS::X::Y', { Conf: { A: 1 } }),
+      { Conf: { A: 1, Arn: 'arn:aws:x:::managed' } },
+      schema
+    );
+    expect(out.filter((x) => x.nested)).toEqual([]);
+  });
+
+  it('a nested WRITE-ONLY path (stripped from both sides) is NOT surfaced as nested undeclared', () => {
+    // writeOnly is stripped from BOTH declared and live (cannot be read back), so a
+    // nested secret AWS never returns must not appear as drift on either side.
+    const schema: SchemaInfo = { ...emptySchema, writeOnlyPaths: ['Conf.Secret'] };
+    const out = classifyResource(
+      res('AWS::X::Y', { Conf: { A: 1 } }),
+      { Conf: { A: 1, Secret: 'shh' } },
+      schema
+    );
+    expect(out.filter((x) => x.nested)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## What

Two regression tests pinning a safety property of R96 (nested undeclared detection): a nested **read-only** sub-field (stripped from live) and a nested **write-only** sub-field (stripped from both sides) must NOT surface as nested undeclared findings.

## Why

`classifyResource` runs `deepStripPaths(live, readOnlyPaths)` / `deepStripPaths(live|declared, writeOnlyPaths)` at **any depth** BEFORE the nested recursion (`collectNestedUndeclared`). So a managed read-only nested field, or a nested secret AWS never returns, is already gone before the recursion walks `live`. R96 tested top-level stripping and the nested-detection happy paths, but did not pin this strip↔recursion ordering — these tests lock it so a future refactor that reorders the strip can't silently leak managed/secret nested fields as false drift.

## Tests

- `classify.test.ts` R96 describe +2: nested read-only path not surfaced; nested write-only path not surfaced.
- Full gates: typecheck / lint+format / build / **732** unit tests pass (+2).