### PR TITLE
feat: detect nested undeclared inside identity-keyed array elements (R98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,10 +307,12 @@ that folds everything informational.
     `--show-all` lists them.
   - **`nested`** — undeclared values that live as a **sub-key inside a property
     you _did_ declare** (e.g. you set a cache behavior but never its
-    `SmoothStreaming`, which AWS materializes underneath). The live model carries
-    many of these, so they fold to a count; `accept` records them like any
-    undeclared value (so a later out-of-band change to one surfaces), and
-    `--show-all` / `--verbose` list them.
+    `SmoothStreaming`, which AWS materializes underneath) — including inside the
+    elements of an identity-keyed array you declared (a CloudFront `Origins[<id>]`
+    gaining a `ConnectionTimeout`, a DynamoDB GSI gaining `WarmThroughput`). The
+    live model carries many of these, so they fold to a count; `accept` records
+    them like any undeclared value (so a later out-of-band change to one surfaces),
+    and `--show-all` / `--verbose` list them.
   - **`readGap` / `unresolved` / `skipped` / `ignored`** — values cdkrd can't
     confidently compare, reported honestly rather than guessed (never false drift).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -290,11 +290,15 @@ all live changes
   − sibling AWS::IAM::Policy entries in a role's Policies → filtered BY NAME (see below)
   = undeclared residual                → the unique signal
       ├─ top-level: a live property the template never declared
-      └─ nested (R96): a live SUB-key inside a DECLARED object never set by it
+      └─ nested (R96/R98): a live SUB-key inside a DECLARED object not set by it
          (recursed by classify's collectNestedUndeclared, dotted path, flagged
          nested:true) — folded in the report by default (the live model carries many
          nested AWS defaults), expanded by --show-all/--verbose, recorded by accept
-         like any undeclared value so a later out-of-band change to it surfaces
+         like any undeclared value so a later out-of-band change to it surfaces.
+         R98 extends the recursion into the MATCHED elements of identity-keyed object
+         arrays (Tags/Origins/AttributeDefinitions/…): elements are aligned by identity
+         value and a live-only sub-field inside a declared element is caught too
+         (path `Prop[<id>].sub`). Identity-LESS arrays (SG rules) are not descended
 ```
 
 **The four false-positive classes found by dogfooding** (8 real cdkd fixtures —

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -13,6 +13,7 @@ import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
   CASE_INSENSITIVE_PATHS,
   isAllAwsTags,
+  identityField,
   isCaseInsensitiveScalarEqual,
   isEqualUnorderedScalarSet,
   isJsonStringStructEqual,
@@ -44,11 +45,18 @@ const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
   typeof (t as { Key?: unknown }).Key === 'string' &&
   'Value' in (t as object);
 
-// R96: recurse two plain objects (the declared and live sides of a property) and
-// emit each LIVE-only nested key — a sub-key present in live but never declared, at
-// any depth. Arrays are not descended (their element identity/order is handled by the
-// declared compare + canonicalizers); only nested OBJECTS are walked. Pure: the
-// caller decides suppression and finding shape.
+// R96/R98: recurse the declared and live sides of a property and emit each LIVE-only
+// nested key — a sub-key present in live but never declared, at any depth.
+//   - Plain objects (R96): walk every live key; recurse where declared, emit otherwise.
+//   - Identity-keyed object arrays (R98: Tags/Origins/AttributeDefinitions/…): align
+//     elements BY identity value (not position — canonicalization may sort the side
+//     with an extra sub-key elsewhere) and recurse into each MATCHED pair, so a
+//     live-only sub-field inside a declared element is caught (path `Prop[<id>].sub`).
+//     A whole live-only ELEMENT (no declared match) is left to the declared compare,
+//     not emitted here. Identity-LESS arrays (no shared Key/Id/AttributeName/IndexName,
+//     e.g. SecurityGroup rules) are NOT descended — their elements can't be matched
+//     reliably, so descending risks false positives.
+// Pure: the caller decides suppression and finding shape.
 const isNestedObject = (x: unknown): x is Record<string, unknown> =>
   x !== null && typeof x === 'object' && !Array.isArray(x);
 function collectNestedUndeclared(
@@ -57,6 +65,19 @@ function collectNestedUndeclared(
   path: string,
   emit: (path: string, value: unknown) => void
 ): void {
+  if (Array.isArray(declaredVal) && Array.isArray(liveVal)) {
+    if (declaredVal.length === 0 || liveVal.length === 0) return;
+    const idf = identityField(declaredVal);
+    if (!idf || identityField(liveVal) !== idf) return;
+    const liveById = new Map<string, Record<string, unknown>>();
+    for (const el of liveVal) if (isNestedObject(el)) liveById.set(String(el[idf]), el);
+    for (const dEl of declaredVal) {
+      if (!isNestedObject(dEl)) continue;
+      const match = liveById.get(String(dEl[idf]));
+      if (match) collectNestedUndeclared(dEl, match, `${path}[${String(dEl[idf])}]`, emit);
+    }
+    return;
+  }
   if (!isNestedObject(declaredVal) || !isNestedObject(liveVal)) return;
   for (const [k, val] of Object.entries(liveVal)) {
     const childPath = `${path}.${k}`;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -138,7 +138,10 @@ function stripTagsWalk(v: unknown, underTagsKey: boolean): unknown {
 // than the template declares them (a positional diff otherwise reports false drift on
 // every element). Both are set-like identities, not order-significant.
 const IDENTITY_FIELDS = ['Key', 'Id', 'AttributeName', 'IndexName'] as const;
-function identityField(arr: unknown[]): string | undefined {
+// Exported for classify's nested-undeclared array descent (R98): an identity-keyed
+// object array (Tags/Origins/AttributeDefinitions/…) can be aligned element-by-element
+// by its identity value, so a live-only SUB-key inside a declared element is detected.
+export function identityField(arr: unknown[]): string | undefined {
   return IDENTITY_FIELDS.find((f) =>
     arr.every(
       (t) => t && typeof t === 'object' && typeof (t as Record<string, unknown>)[f] === 'string'

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,11 +32,14 @@ export interface Finding {
   // this Key=Value via ModifyLoadBalancerAttributes (a Cloud Control index patch
   // would misalign against the full live bag and exceed ELB's 20-attribute cap).
   attributeKey?: string;
-  // undeclared tier only (R96): the value is a live SUB-key inside a DECLARED object
-  // that the template never set (a nested undeclared property, dotted path). Detected
-  // by recursing the declared/live objects. Reported folded by default (the live
-  // model carries many nested AWS defaults), expanded by --show-all; recorded by
-  // accept like any undeclared value, so a later out-of-band change to it surfaces.
+  // undeclared tier only (R96/R98): the value is a live SUB-key inside a DECLARED
+  // object that the template never set (a nested undeclared property, dotted path).
+  // Detected by recursing the declared/live objects — and, since R98, into the
+  // MATCHED elements of identity-keyed object arrays (path `Prop[<id>].sub`), so a
+  // live-only sub-field inside a declared Tags/Origins/… element is caught too.
+  // Reported folded by default (the live model carries many nested AWS defaults),
+  // expanded by --show-all; recorded by accept like any undeclared value, so a later
+  // out-of-band change to it surfaces.
   nested?: boolean;
 }
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -982,9 +982,40 @@ describe('nested undeclared detection (R96 — the differentiator at depth)', ()
     expect(out[0]!.nested).toBeUndefined();
   });
 
-  it('does NOT descend arrays (element identity/order handled elsewhere)', () => {
+  it('descends identity-keyed array elements (R98): a live sub-field in a declared element is nested undeclared', () => {
     const out = f('AWS::X::Y', { Items: [{ Id: 'a' }] }, { Items: [{ Id: 'a', Extra: 9 }] });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'undeclared', path: 'Items[a].Extra', nested: true });
+  });
+
+  it('R98: matches array elements BY identity, not position (order differs after canonicalization)', () => {
+    const out = f(
+      'AWS::X::Y',
+      { Items: [{ Id: 'a' }, { Id: 'b' }] },
+      { Items: [{ Id: 'b' }, { Id: 'a', Extra: 9 }] }
+    );
+    expect(out.filter((x) => x.nested).map((x) => x.path)).toEqual(['Items[a].Extra']);
+  });
+
+  it('R98: a whole live-only ELEMENT is NOT emitted as nested (left to the declared compare)', () => {
+    const out = f('AWS::X::Y', { Items: [{ Id: 'a' }] }, { Items: [{ Id: 'a' }, { Id: 'b' }] });
     expect(out.filter((x) => x.nested)).toEqual([]);
+  });
+
+  it('R98: identity-LESS object arrays are NOT descended (elements cannot be matched)', () => {
+    // No Key/Id/AttributeName/IndexName on the elements → no reliable alignment.
+    const out = f(
+      'AWS::X::Y',
+      { Rules: [{ Port: 80 }] },
+      { Rules: [{ Port: 80, Description: 'added' }] }
+    );
+    expect(out.filter((x) => x.nested)).toEqual([]);
+  });
+
+  it('R98: a CHANGE to a declared field inside an array element is declared drift, not nested', () => {
+    const out = f('AWS::X::Y', { Items: [{ Id: 'a', V: 1 }] }, { Items: [{ Id: 'a', V: 2 }] });
+    expect(out.filter((x) => x.nested)).toEqual([]);
+    expect(out.some((x) => x.tier === 'declared')).toBe(true);
   });
 
   it('nested trivially-empty / aws:* values are suppressed like top-level', () => {

--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD.json
@@ -201,6 +201,100 @@
       "tier": "undeclared",
       "logicalId": "Cdn9963B1AD",
       "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin1117C92F8].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin1117C92F8].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin1117C92F8].S3OriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin2499A636E].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin2499A636E].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin2499A636E].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin2499A636E].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkrdIntegCloudfrontCdnOrigin2499A636E].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "E2WBGYTS0T0BVH",
+      "constructPath": "CdkrdIntegCloudfront/Cdn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
       "path": "DistributionConfig.OriginGroups",
       "actual": {
         "Quantity": 0,
@@ -220,20 +314,6 @@
           "Locations": [],
           "RestrictionType": "none"
         }
-      },
-      "nested": true,
-      "physicalId": "E2WBGYTS0T0BVH",
-      "constructPath": "CdkrdIntegCloudfront/Cdn"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Cdn9963B1AD",
-      "resourceType": "AWS::CloudFront::Distribution",
-      "path": "DistributionConfig.ViewerCertificate",
-      "actual": {
-        "SslSupportMethod": "vip",
-        "MinimumProtocolVersion": "TLSv1",
-        "CloudFrontDefaultCertificate": true
       },
       "nested": true,
       "physicalId": "E2WBGYTS0T0BVH",

--- a/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
@@ -174,8 +174,23 @@
       "tier": "undeclared",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::DynamoDB::Table",
-      "path": "PointInTimeRecoverySpecification.RecoveryPeriodInDays",
-      "actual": 35,
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+      "constructPath": "CdkRealDriftIntegDynamoDB/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "GlobalSecondaryIndexes[gsi1].WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
       "nested": true,
       "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
       "constructPath": "CdkRealDriftIntegDynamoDB/Data"
@@ -184,11 +199,9 @@
       "tier": "undeclared",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::DynamoDB::Table",
-      "path": "WarmThroughput",
-      "actual": {
-        "ReadUnitsPerSecond": 12000,
-        "WriteUnitsPerSecond": 4000
-      },
+      "path": "PointInTimeRecoverySpecification.RecoveryPeriodInDays",
+      "actual": 35,
+      "nested": true,
       "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
       "constructPath": "CdkRealDriftIntegDynamoDB/Data"
     }

--- a/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
+++ b/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
@@ -170,6 +170,19 @@
       },
       "physicalId": "CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
       "constructPath": "CdkrdIntegHarvest2/Orders"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "OrdersA9B65338",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "GlobalSecondaryIndexes[byStatus].WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "nested": true,
+      "physicalId": "CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
+      "constructPath": "CdkrdIntegHarvest2/Orders"
     }
   ]
 }


### PR DESCRIPTION
## What

Extends R96 (nested undeclared detection) **into declared array elements**. Before R98, `collectNestedUndeclared` recursed declared objects but bailed on arrays, so a live-only sub-field inside a declared array element (e.g. a CloudFront `Origins[<id>]` gaining `ConnectionTimeout`, a DynamoDB GSI gaining `WarmThroughput`) was invisible — the last gap in the undeclared differentiator at depth.

## How

- Descend **identity-keyed** object arrays only (`Tags`/`Origins`/`AttributeDefinitions`/`GlobalSecondaryIndexes`/… — anything whose elements share a `Key`/`Id`/`AttributeName`/`IndexName`). Elements are aligned **by identity value, not position** (canonicalization may sort the side carrying an extra sub-key elsewhere), and each matched pair is recursed. Path is `Prop[<id>].sub`, flagged `nested: true` — folds, baselines, and surfaces on later change exactly like R96.
- A whole live-only **element** (no declared match) is left to the declared compare, not emitted as nested.
- **Identity-less** object arrays (SecurityGroup ingress/egress rules — no shared identity field) are **not** descended; their elements can't be matched reliably, so descending would risk false positives.
- `identityField` is now exported from `noise.ts` (single source of truth, shared with `canonicalizeTagListsDeep`).

## Tests

- `classify.test.ts` +5: identity-keyed descent / match-by-identity-not-position / whole-new-element-not-nested / identity-less-not-descended / declared-field-change-not-nested.
- **Corpus regen — 3 real cases** gained nested findings, all AWS defaults materialized inside declared array elements (verified net-new, all `nested:true`, zero top-level findings changed):
  - CloudFront `Origins[<id>].ConnectionTimeout/ConnectionAttempts/S3OriginConfig.OriginReadTimeout/CustomOriginConfig.{HTTPPort,HTTPSPort,OriginKeepaliveTimeout}`
  - DynamoDB `GlobalSecondaryIndexes[<id>].WarmThroughput`
- Full gates: typecheck / lint+format / build / **736** unit tests pass.

## Docs

README `nested` bullet + ARCHITECTURE noise-model residual updated for the array-element case.