### PR TITLE
fix(revert): nested undeclared values are not revertable (R99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,10 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
     so `revert` refuses: accept them if the live values are right, or opt into
     removal with `--remove-unaccepted`;
   - a `deleted` resource (recreate it with `cdk deploy`);
+  - **nested undeclared values** (a sub-key inside a property you declared, incl.
+    inside an identity-keyed array element) — detect/accept-only: a flat patch
+    can't safely target a deep sub-field, so fix any real divergence in your IaC
+    or re-accept the live value;
   - **create-only** properties (changing them requires resource replacement);
   - toggle-style properties with no "absent" state (e.g. S3 transfer acceleration
     is only `Enabled`/`Suspended`);

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -101,6 +101,28 @@ export function buildRevertPlan(
       });
       continue;
     }
+    // Nested undeclared values (R96/R98) are detect/accept-only, NOT revertable. Their
+    // path addresses a sub-key INSIDE a declared object or array element — dotted
+    // (`Conf.Destination`) or, for an identity-keyed array element, `Prop[<id>].sub`.
+    // `toPointer` builds a flat RFC6902 pointer by splitting on '.', so the bracket
+    // form yields the malformed `/Prop[<id>]/sub` (the bracket is not RFC6902 and the
+    // CC patch would target a literal key, not the array element). Even the dotted form
+    // is a fragile deep patch (the same reason R78 abandoned index-based array patches).
+    // These are overwhelmingly AWS-materialized defaults — report + baseline them, and
+    // fix any real divergence in your IaC or by re-accepting the live value. Detect by
+    // PATH SHAPE, not Finding.nested: a baseline value REMOVED since accept is
+    // reconstructed (baseline-file.ts) WITHOUT the flag, but keeps its nested path. A
+    // top-level undeclared path is a single key (never contains '.'/'['), and declared
+    // drift is a different tier — so this never blocks a top-level revert.
+    if (f.tier === 'undeclared' && (f.nested || f.path.includes('.') || f.path.includes('['))) {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason: 'nested undeclared value — detect/accept only, not revertable',
+      });
+      continue;
+    }
     if (!DRIFT_TIERS.has(f.tier)) continue; // only declared/undeclared are drift to revert
     if (!f.physicalId) {
       notRevertable.push({

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -406,3 +406,101 @@ describe('property-scoped SDK writer routing (IAM Role inline Policies)', () => 
     );
   });
 });
+
+describe('buildRevertPlan — nested undeclared is not revertable (R99)', () => {
+  it('R98 identity-keyed array-element nested value (accepted then changed) -> notRevertable, never a malformed pointer', () => {
+    // path `Origins[id].ConnectionTimeout` would become the bogus pointer
+    // `/Origins[id]/ConnectionTimeout` (bracket is not RFC6902) if it reached revertOp.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::CloudFront::Distribution',
+      path: 'DistributionConfig.Origins[o1].ConnectionTimeout',
+      actual: 60,
+      nested: true,
+    });
+    const b = baseline([
+      {
+        logicalId: 'R',
+        resourceType: 'AWS::CloudFront::Distribution',
+        path: 'DistributionConfig.Origins[o1].ConnectionTimeout',
+        value: 10,
+      },
+    ]);
+    const plan = buildRevertPlan([f], b);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
+  });
+
+  it('R96 dotted object-nested value -> notRevertable (fragile deep patch)', () => {
+    const f = F({ tier: 'undeclared', path: 'Conf.Destination', actual: 's3', nested: true });
+    const b = baseline([
+      { logicalId: 'R', resourceType: 'AWS::S3::Bucket', path: 'Conf.Destination', value: 'old' },
+    ]);
+    const plan = buildRevertPlan([f], b);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
+  });
+
+  it('nested guard fires by PATH SHAPE even without the flag (baseline value removed since accept)', () => {
+    // applyBaseline reconstructs a "removed since accept" finding WITHOUT Finding.nested
+    // (baseline-file.ts), but it keeps the nested path — the path-shape guard still catches it.
+    const f = F({
+      tier: 'undeclared',
+      path: 'DistributionConfig.Origins[o1].ConnectionTimeout',
+      desired: 10,
+      actual: undefined,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
+  });
+
+  it('--remove-unaccepted does NOT override the nested guard', () => {
+    const f = F({
+      tier: 'undeclared',
+      path: 'Conf.Destination',
+      actual: 's3',
+      nested: true,
+      unrecorded: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]), { removeUnaccepted: true });
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
+  });
+
+  it('a TOP-LEVEL undeclared value (single-key path) is still revertable — guard does not over-fire', () => {
+    const f = F({
+      tier: 'undeclared',
+      path: 'AccelerateConfiguration',
+      actual: { AccelerationStatus: 'Enabled' },
+    });
+    const b = baseline([
+      {
+        logicalId: 'R',
+        resourceType: 'AWS::S3::Bucket',
+        path: 'AccelerateConfiguration',
+        value: { AccelerationStatus: 'Suspended' },
+      },
+    ]);
+    const plan = buildRevertPlan([f], b);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.notRevertable).toHaveLength(0);
+  });
+
+  it('a DECLARED drift with a dotted path is still revertable (guard is scoped to undeclared)', () => {
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'declared',
+          path: 'VersioningConfiguration.Status',
+          desired: 'Enabled',
+          actual: 'Suspended',
+        }),
+      ],
+      undefined
+    );
+    expect(plan.items).toHaveLength(1);
+    expect(plan.notRevertable).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## The bug

R98 added array-element nested undeclared findings with paths like `DistributionConfig.Origins[o1].ConnectionTimeout`. `buildRevertPlan`'s `toPointer` builds a flat RFC6902 pointer by splitting on `.`, so that bracketed path became the **malformed** `/DistributionConfig/Origins[o1]/ConnectionTimeout` (the bracket is not RFC6902 — a Cloud Control patch would target a literal key, not the array element). An **accepted-then-changed** nested value flows past the unrecorded guard straight to `revertOp`, so reverting it would fail or mis-patch. No test covered the revert path for nested findings.

Found by auditing "does every behavior R96/R98 changed have a test?" — the answer was no for the revert leg.

## The fix

Guard `buildRevertPlan` so any **nested undeclared** value is reported `notRevertable` (detect/accept-only). Fix a real divergence in your IaC or by re-accepting the live value — consistent with R78 abandoning fragile deep/array index patches, and with the tool's stance that detection (not surgical deep revert) is the differentiator.

Key detail: the guard keys on **path shape** (`path` contains `.`/`[`), **not** `Finding.nested` — a baseline value *removed since accept* is reconstructed (baseline-file.ts) **without** the flag but keeps its nested path, so a flag-only guard would miss it. Scoped to `tier === 'undeclared'`, so a top-level undeclared value (single-key path) and declared drift (dotted, different tier) stay revertable.

## Tests

`revert-plan.test.ts` +6:
- R98 identity-keyed array-element value (accepted→changed) → notRevertable, never a malformed pointer
- R96 dotted object-nested → notRevertable
- path-shape guard fires WITHOUT the flag (removed-since-accept case)
- `--remove-unaccepted` does not override the guard
- top-level undeclared (single-key) still revertable (no over-fire)
- declared dotted-path drift still revertable (guard scoped to undeclared)

Full gates: typecheck / lint+format / build / **742** unit tests pass. README known-limitations updated.