### PR TITLE
fix(check): reconcile CloudFront OAI bucket-policy principals (R101)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -47,6 +47,27 @@ interface ClassifyOpts {
   accountId: string;
   region: string;
   kmsAliasTargets: Record<string, string>;
+  oaiCanonicalIds: Record<string, string>;
+}
+
+// CloudFront legacy OAI id -> S3CanonicalUserId, harvested from the stack's own
+// OAI resources' live attributes (both are readOnly attrs the CC-API read already
+// returned — no extra AWS call). Lets classify reconcile the two equivalent OAI
+// principal forms in a resource policy (see rewriteOaiPrincipalsDeep). Empty when
+// the stack declares no OAI.
+const OAI_TYPE = 'AWS::CloudFront::CloudFrontOriginAccessIdentity';
+function buildOaiCanonicalIds(desired: Desired): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== OAI_TYPE) continue;
+    const live = desired.ctx.liveAttrs[r.logicalId];
+    const id = live?.Id;
+    const canonical = live?.S3CanonicalUserId;
+    if (typeof id === 'string' && id && typeof canonical === 'string' && canonical) {
+      map[id] = canonical;
+    }
+  }
+  return map;
 }
 
 // Turn ONE resource's read into findings: no-physical-id / deleted / skipped
@@ -152,7 +173,8 @@ export async function gatherFindings(
   const kmsAliasTargets = desired.resources.some((r) => usesManagedKmsAlias(r.declared))
     ? await fetchManagedAliasTargets(region)
     : {};
-  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets };
+  const oaiCanonicalIds = buildOaiCanonicalIds(desired);
+  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets, oaiCanonicalIds };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
   // CDKRD_CORPUS_DIR records every readable resource as a golden-corpus case
@@ -224,7 +246,10 @@ export async function regatherTouched(
   const kmsAliasTargets = targets.some((r) => usesManagedKmsAlias(r.declared))
     ? await fetchManagedAliasTargets(region)
     : {};
-  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets };
+  // Built from desired.ctx.liveAttrs (populated by the original gather), so the OAI
+  // map is complete even though regather only re-reads the touched resources.
+  const oaiCanonicalIds = buildOaiCanonicalIds(desired);
+  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets, oaiCanonicalIds };
 
   const fresh: Finding[] = [];
   for (const r of targets) {

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -64,7 +64,12 @@ export interface CorpusCase {
     createOnlyPaths: string[];
     defaults: Record<string, unknown>;
   };
-  opts: { accountId: string; region: string; kmsAliasTargets: Record<string, string> };
+  opts: {
+    accountId: string;
+    region: string;
+    kmsAliasTargets: Record<string, string>;
+    oaiCanonicalIds: Record<string, string>;
+  };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
 
@@ -89,7 +94,12 @@ export function buildCorpusCase(
   resource: DesiredResource,
   liveRaw: Record<string, unknown>,
   schema: SchemaInfo,
-  opts: { accountId: string; region: string; kmsAliasTargets: Record<string, string> },
+  opts: {
+    accountId: string;
+    region: string;
+    kmsAliasTargets: Record<string, string>;
+    oaiCanonicalIds: Record<string, string>;
+  },
   findings: Finding[]
 ): CorpusCase {
   const c: CorpusCase = {

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -27,6 +27,7 @@ import {
 } from '../normalize/noise.js';
 import { deepStripPaths } from '../normalize/path-strip.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
+import { rewriteOaiPrincipalsDeep } from '../normalize/policy-canonical.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
 import { calculateResourceDrift, deepEqual } from './drift-calculator.js';
 
@@ -94,19 +95,26 @@ export function classifyResource(
     accountId?: string;
     region?: string;
     kmsAliasTargets?: Record<string, string>; // alias/aws/* -> target key id, for strict KMS match
+    oaiCanonicalIds?: Record<string, string>; // OAI id -> S3CanonicalUserId, for CloudFront OAI principal match
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
   const findings: Finding[] = [];
 
-  // strip AWS-managed fields + drop aws:* tag elements (live-only), then run the
-  // shared canonicalization pipeline (policy docs + tag lists + id arrays) on both
-  // sides so reordering / scalar-vs-array is not false drift. The pipeline is shared
-  // with baseline-file.ts so baseline values normalize identically (see pipeline.ts).
+  // strip AWS-managed fields + drop aws:* tag elements (live-only), then reconcile
+  // CloudFront OAI principals (cloudfront:user ARN <-> CanonicalUser; no-op without
+  // a resolved map) on BOTH sides, then run the shared canonicalization pipeline
+  // (policy docs + tag lists + id arrays) so reordering / scalar-vs-array / OAI
+  // principal-form is not false drift. The pipeline is shared with baseline-file.ts
+  // so baseline values normalize identically (see pipeline.ts).
+  const oaiMap = opts.oaiCanonicalIds ?? {};
   const live = canonicalizeForCompare(
-    stripAwsTagsDeep(stripCcApiAwsManagedFields(liveRaw))
+    rewriteOaiPrincipalsDeep(stripAwsTagsDeep(stripCcApiAwsManagedFields(liveRaw)), oaiMap)
   ) as Record<string, unknown>;
-  const declared = canonicalizeForCompare(declaredIn) as Record<string, unknown>;
+  const declared = canonicalizeForCompare(rewriteOaiPrincipalsDeep(declaredIn, oaiMap)) as Record<
+    string,
+    unknown
+  >;
   // R11: a declared TOP-LEVEL write-only key is about to be stripped from `declared`
   // (below). Surface it as ONE readGap finding FIRST so it is never silently dropped
   // — the informational tier exists precisely for "declared but unreadable" props.

--- a/src/normalize/policy-canonical.ts
+++ b/src/normalize/policy-canonical.ts
@@ -96,6 +96,76 @@ export function canonicalizePolicy(doc: Record<string, unknown>): Record<string,
   return out;
 }
 
+// A CloudFront legacy Origin Access Identity (OAI) grant can be written two
+// equivalent ways in a resource policy principal:
+//   declared (CDK `grantRead(oai)`): { CanonicalUser: <oai S3CanonicalUserId> }
+//   live (S3 GetBucketPolicy / SNS / SQS read-back): AWS normalizes it to
+//     { AWS: "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity <oaiId>" }
+// The two carry DIFFERENT tokens — the S3 canonical-user-id hex vs the OAI id —
+// so a string diff fires a false declared drift on the bucket policy. We reconcile
+// them by rewriting the `cloudfront:user` ARN form to the CanonicalUser form, using
+// a resolved `oaiId -> S3CanonicalUserId` map (built in gather.ts from the stack's
+// own OAI resources' live attributes — no extra AWS call). Applied to BOTH sides so
+// either declaration style normalizes to the same canonical token; an empty/missing
+// map is a no-op (the false positive simply remains rather than hiding real drift).
+// An OAI id we cannot resolve is left as-is — never silently equated, so repointing
+// a bucket policy to a DIFFERENT, unknown OAI is still reported.
+const OAI_USER_ARN_RE =
+  /^arn:aws[a-z-]*:iam::cloudfront:user\/CloudFront Origin Access Identity (.+)$/;
+
+function rewriteOaiPrincipal(
+  principal: Record<string, unknown>,
+  oaiCanonicalIds: Record<string, string>
+): Record<string, unknown> {
+  const awsRaw = principal.AWS;
+  if (awsRaw === undefined) return principal;
+  const awsArr = Array.isArray(awsRaw) ? awsRaw : [awsRaw];
+  const remainingAws: unknown[] = [];
+  const resolvedCanonical: string[] = [];
+  for (const entry of awsArr) {
+    const oaiId = typeof entry === 'string' ? OAI_USER_ARN_RE.exec(entry)?.[1] : undefined;
+    const canonical = oaiId ? oaiCanonicalIds[oaiId] : undefined;
+    if (canonical) resolvedCanonical.push(canonical);
+    else remainingAws.push(entry);
+  }
+  if (resolvedCanonical.length === 0) return principal; // nothing matched/resolved
+  const out: Record<string, unknown> = { ...principal };
+  if (remainingAws.length === 0) delete out.AWS;
+  else out.AWS = remainingAws.length === 1 ? remainingAws[0] : remainingAws;
+  const existing =
+    out.CanonicalUser === undefined
+      ? []
+      : Array.isArray(out.CanonicalUser)
+        ? out.CanonicalUser
+        : [out.CanonicalUser];
+  const merged = [...existing, ...resolvedCanonical];
+  out.CanonicalUser = merged.length === 1 ? merged[0] : merged;
+  return out;
+}
+
+/** Walk a value, rewriting every policy-statement `Principal`/`NotPrincipal` that
+ *  grants a CloudFront OAI via its `cloudfront:user` ARN into the equivalent
+ *  `CanonicalUser` form (see `rewriteOaiPrincipal`). No-op when the map is empty. */
+export function rewriteOaiPrincipalsDeep(
+  v: unknown,
+  oaiCanonicalIds: Record<string, string>
+): unknown {
+  if (oaiCanonicalIds === undefined || Object.keys(oaiCanonicalIds).length === 0) return v;
+  if (Array.isArray(v)) return v.map((x) => rewriteOaiPrincipalsDeep(x, oaiCanonicalIds));
+  if (isObj(v)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) {
+      if ((k === 'Principal' || k === 'NotPrincipal') && isObj(val)) {
+        out[k] = rewriteOaiPrincipal(val, oaiCanonicalIds);
+      } else {
+        out[k] = rewriteOaiPrincipalsDeep(val, oaiCanonicalIds);
+      }
+    }
+    return out;
+  }
+  return v;
+}
+
 // Canonicalize an embedded JSON string (e.g. ECR LifecyclePolicyText) so that
 // pretty-printed vs minified vs key-reordered forms compare equal.
 function canonicalizeJsonText(s: string): string {

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1052,3 +1052,77 @@ describe('nested undeclared detection (R96 — the differentiator at depth)', ()
     expect(out.filter((x) => x.nested)).toEqual([]);
   });
 });
+
+describe('CloudFront OAI S3 BucketPolicy principal (real-AWS reproduced false positive)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+  };
+  const OAI_ID = 'EM4A89W3GHI3';
+  const CANON =
+    '9f136d368cf2e7a1231ec86b0e9fba1753e7182eda536b6294f93d5667ce29f71f5d58bb774dbb93d4a89e7b2c1a3c4e';
+  const userArn = `arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${OAI_ID}`;
+  // declared = CDK grantRead(oai): CanonicalUser carries the resolved S3CanonicalUserId
+  const declared: DesiredResource = {
+    logicalId: 'AssetsPolicy',
+    resourceType: 'AWS::S3::BucketPolicy',
+    physicalId: 'bucket',
+    declared: {
+      Bucket: 'bucket',
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          { Effect: 'Allow', Action: 's3:GetObject', Principal: { CanonicalUser: CANON } },
+        ],
+      },
+    },
+  };
+  // live = GetBucketPolicy: S3 returns the equivalent cloudfront:user ARN form
+  const liveRaw = {
+    Bucket: 'bucket',
+    PolicyDocument: {
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Principal: { AWS: userArn } }],
+    },
+  };
+
+  it('fires a false declared drift WITHOUT the resolved OAI map (documents the bug)', () => {
+    const out = classifyResource(declared, liveRaw, bare);
+    expect(out.some((f) => f.tier === 'declared')).toBe(true);
+  });
+
+  it('is CLEAN with the resolved OAI map (the fix)', () => {
+    const out = classifyResource(declared, liveRaw, bare, {
+      oaiCanonicalIds: { [OAI_ID]: CANON },
+    });
+    expect(out.filter((f) => f.tier === 'declared')).toEqual([]);
+    expect(out.filter((f) => f.tier === 'undeclared')).toEqual([]);
+  });
+
+  it('still reports a repoint to a DIFFERENT OAI even with a map', () => {
+    const otherLive = {
+      Bucket: 'bucket',
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: 's3:GetObject',
+            Principal: {
+              AWS: 'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity OTHEROAI999',
+            },
+          },
+        ],
+      },
+    };
+    const out = classifyResource(declared, otherLive, bare, {
+      oaiCanonicalIds: { [OAI_ID]: CANON },
+    });
+    expect(out.some((f) => f.tier === 'declared')).toBe(true);
+  });
+});

--- a/tests/corpus-record.test.ts
+++ b/tests/corpus-record.test.ts
@@ -73,7 +73,7 @@ describe('corpus recording (R63)', () => {
       resource,
       { A: 'arn:aws:iam::123456789012:role/r' },
       schema,
-      { accountId: '123456789012', region: 'us-east-1', kmsAliasTargets: {} },
+      { accountId: '123456789012', region: 'us-east-1', kmsAliasTargets: {}, oaiCanonicalIds: {} },
       findings
     );
     // sanitized EVERYWHERE, consistently (inputs, opts, and expected findings)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -38,7 +38,7 @@ These do NOT run in CI (they need credentials and mutate a real account):
   `verify-mutation-matrix.sh`), `iam`, `lambda`, `revert`, `policies`, `atdefault`,
   `noise`, `readgap`, and the false-positive matrix (`dynamodb`, `sqs`,
   `securitygroup`, `cloudwatch-alarm`, `stepfunctions`, `ssm`, `eventbridge`,
-  `cognito`).
+  `cognito`, `cloudfront-oai`).
 - **After changing** `src/read/**`, `src/revert/**`, `src/normalize/**`, or
   `src/commands/gather.ts`: run at least `basic` + `revert` + `noise` + the
   false-positive matrix (below — each asserts tricky declared values normalize
@@ -224,10 +224,10 @@ cd mutation-multi && npm install && bash verify.sh
 
 ## false-positive matrix
 
-Eight focused fixtures (R88), each the same shape as `noise`: deploy a resource that
+Nine focused fixtures (R88), each the same shape as `noise`: deploy a resource that
 DECLARES a property whose live AWS form is textually different but semantically
-equal, then assert `check --fail` exits `0` with no baseline — zero false declared
-drift. They target the specific normalization classes most likely to regress:
+equal, then assert `check` reports no false declared drift. They target the specific
+normalization classes most likely to regress:
 
 | fixture            | resource             | noise-prone declared property (class)                                  |
 | ------------------ | -------------------- | ---------------------------------------------------------------------- |
@@ -239,6 +239,7 @@ drift. They target the specific normalization classes most likely to regress:
 | `ssm`              | SSM Document + Param | Document Content (object↔JSON-string, R75)                             |
 | `eventbridge`      | EventBridge Rule     | EventPattern (object↔JSON-string), Targets array + queue policy        |
 | `cognito`          | Cognito Pool/Client  | OAuth/ExplicitAuthFlows (unordered enums, R74), UserPoolGroup id (R84) |
+| `cloudfront-oai`   | S3 BucketPolicy/OAI  | OAI principal (`CanonicalUser` hex vs `cloudfront:user` ARN) (R101)     |
 
 ```bash
 cd dynamodb && bash verify.sh   # …and likewise for each fixture above

--- a/tests/integration/cloudfront-oai/app.ts
+++ b/tests/integration/cloudfront-oai/app.ts
@@ -1,0 +1,33 @@
+// CloudFront LEGACY Origin Access Identity (OAI) fixture — reproduces the S3
+// BucketPolicy principal-form false positive (ported concern from cdkd #871).
+//
+// `bucket.grantRead(oai)` writes a BucketPolicy whose statement Principal is
+// `{ CanonicalUser: <oai S3CanonicalUserId> }`. The open question this fixture
+// answers against REAL AWS: what does `GetBucketPolicy` return on read-back —
+// the same `CanonicalUser` form, or the equivalent
+// `{ AWS: "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity <id>" }`
+// form? If the two differ, cdkrd's declared(template)-vs-live(GetBucketPolicy)
+// compare fires a false declared drift on the bucket policy.
+//
+// No Distribution is created — the principal-form divergence lives entirely on
+// the BucketPolicy, so this stays a fast deploy (seconds, no CF propagation).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { OriginAccessIdentity } from "aws-cdk-lib/aws-cloudfront";
+import { BlockPublicAccess, Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegCloudfrontOai");
+
+const assets = new Bucket(stack, "Assets", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+});
+
+const oai = new OriginAccessIdentity(stack, "Oai", {
+  comment: "cdkrd oai fixture",
+});
+
+// Adds AWS::S3::BucketPolicy at Assets/Policy with a CanonicalUser principal.
+assets.grantRead(oai);
+
+app.synth();

--- a/tests/integration/cloudfront-oai/cdk.json
+++ b/tests/integration/cloudfront-oai/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-oai/package.json
+++ b/tests/integration/cloudfront-oai/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-oai",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app reproducing the CloudFront OAI S3 BucketPolicy principal-form false positive. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudfront-oai/verify.sh
+++ b/tests/integration/cloudfront-oai/verify.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# cdkrd CloudFront legacy OAI integration test (real AWS, read-only mutation of an
+# S3 bucket policy out of band). Reproduces — and pins the fix for — the S3
+# BucketPolicy principal-form false positive (ported concern from cdkd #871):
+#   declared (CDK grantRead(oai)):  Principal = { CanonicalUser: <S3CanonicalUserId> }
+#   live (GetBucketPolicy returns): Principal = { AWS: "arn:aws:iam::cloudfront:user/
+#                                                  CloudFront Origin Access Identity <oaiId>" }
+# The two are equivalent; before the fix cdkrd reported a false declared drift on
+# the bucket policy. The fix resolves the OAI id -> S3CanonicalUserId from the
+# stack's own OAI resource and reconciles the two principal forms.
+#
+# Flow: deploy -> check (bucket policy CLEAN, no false declared drift) -> repoint the
+# bucket policy to a DIFFERENT (fictional) OAI principal out of band -> check DETECTS
+# a declared drift on the policy (the fix does NOT blanket-suppress) -> destroy.
+# Self-cleaning trap; no orphans on failure. No Distribution → fast deploy.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdIntegCloudfrontOai
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
+[ -n "$BUCKET" ] || fail "could not resolve bucket"
+
+echo "=== check CLEAN (no false declared drift on the OAI bucket policy) ==="
+$CLI check "$STACK" --region "$REGION" --json > /tmp/cdkrd-oai-clean.json 2>/tmp/cdkrd-oai-clean.err \
+  || { cat /tmp/cdkrd-oai-clean.err; fail "check errored"; }
+node -e '
+  const j = require("/tmp/cdkrd-oai-clean.json");
+  const bad = (j.findings||[]).filter(f =>
+    f.resourceType === "AWS::S3::BucketPolicy" &&
+    (f.tier === "declared" || f.tier === "undeclared"));
+  if (bad.length) { console.error("UNEXPECTED bucket-policy drift:\n"+JSON.stringify(bad,null,2)); process.exit(1); }
+  console.log("bucket policy clean ✓");
+' || fail "false positive on the OAI bucket policy (the bug this fixes)"
+
+echo "=== inject a real out-of-band statement, KEEPING the OAI grant ==="
+# S3 rejects a fictional cloudfront:user principal (MalformedPolicy), so we cannot
+# repoint to a fake OAI. Instead append a second, valid statement to the LIVE policy
+# (which still carries the genuine OAI grant). The OAI statement reconciles to clean;
+# the appended one must surface — proving the fix does NOT blanket-suppress the policy.
+DOC="$(aws s3api get-bucket-policy --bucket "$BUCKET" --region "$REGION" --query Policy --output text)"
+aws s3api put-bucket-policy --bucket "$BUCKET" --region "$REGION" --policy "$(node -e '
+  const doc = JSON.parse(process.argv[1]);
+  doc.Statement.push({ Sid: "CdkrdInjected", Effect: "Deny", Principal: "*",
+    Action: "s3:GetBucketTagging", Resource: "arn:aws:s3:::'"$BUCKET"'" });
+  process.stdout.write(JSON.stringify(doc));
+' "$DOC")" || fail "could not inject extra statement"
+sleep 3
+
+echo "=== check DETECTS the injected statement (no blanket suppression) ==="
+$CLI check "$STACK" --region "$REGION" --json > /tmp/cdkrd-oai-drift.json 2>/dev/null
+node -e '
+  const j = require("/tmp/cdkrd-oai-drift.json");
+  const hit = (j.findings||[]).some(f => f.resourceType === "AWS::S3::BucketPolicy");
+  if (!hit) { console.error("injected bucket-policy statement was NOT detected"); process.exit(1); }
+  console.log("injected statement detected ✓");
+' || fail "out-of-band bucket-policy change was not reported"
+
+echo "INTEG PASS"

--- a/tests/policy-canonical.test.ts
+++ b/tests/policy-canonical.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { deepEqual } from '../src/diff/drift-calculator.js';
-import { canonicalizePolicy, normalizePoliciesDeep } from '../src/normalize/policy-canonical.js';
+import {
+  canonicalizePolicy,
+  normalizePoliciesDeep,
+  rewriteOaiPrincipalsDeep,
+} from '../src/normalize/policy-canonical.js';
 
 describe('policy canonicalization', () => {
   it('unifies scalar vs array Action; does not fabricate Version when absent', () => {
@@ -85,5 +89,87 @@ describe('policy canonicalization', () => {
     const pretty = '{\n  "rules": [ { "a": 1, "b": 2 } ]\n}';
     const mini = '{"rules":[{"b":2,"a":1}]}';
     expect(normalizePoliciesDeep(pretty)).toBe(normalizePoliciesDeep(mini));
+  });
+});
+
+describe('CloudFront OAI principal reconciliation (rewriteOaiPrincipalsDeep)', () => {
+  const OAI_ID = 'EM4A89W3GHI3';
+  const CANON =
+    '9f136d368cf2e7a1231ec86b0e9fba1753e7182eda536b6294f93d5667ce29f71f5d58bb774dbb93d4a89e7b2c1a3c4e';
+  const map = { [OAI_ID]: CANON };
+  const userArn = `arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity ${OAI_ID}`;
+
+  // the declared (CDK grantRead) side and the live (GetBucketPolicy) side, the exact
+  // two forms the real-AWS probe produced for the same OAI grant
+  const declaredDoc = {
+    Version: '2012-10-17',
+    Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Principal: { CanonicalUser: CANON } }],
+  };
+  const liveDoc = {
+    Version: '2012-10-17',
+    Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Principal: { AWS: userArn } }],
+  };
+
+  it('reconciles the cloudfront:user ARN form to the declared CanonicalUser form', () => {
+    const live = canonicalizePolicy(
+      rewriteOaiPrincipalsDeep(liveDoc, map) as Record<string, unknown>
+    );
+    const declared = canonicalizePolicy(
+      rewriteOaiPrincipalsDeep(declaredDoc, map) as Record<string, unknown>
+    );
+    expect(deepEqual(live, declared)).toBe(true);
+  });
+
+  it('is a no-op when the OAI id is not in the map (no false equivalence)', () => {
+    const live = canonicalizePolicy(
+      rewriteOaiPrincipalsDeep(liveDoc, {}) as Record<string, unknown>
+    );
+    const declared = canonicalizePolicy(declaredDoc);
+    // unresolved → forms still differ, so a real repoint to an unknown OAI is NOT hidden
+    expect(deepEqual(live, declared)).toBe(false);
+  });
+
+  it('does NOT equate two DIFFERENT OAIs', () => {
+    const otherArn = 'arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity OTHEROAI123';
+    const otherLive = {
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Principal: { AWS: otherArn } }],
+    };
+    const live = canonicalizePolicy(
+      rewriteOaiPrincipalsDeep(otherLive, map) as Record<string, unknown>
+    );
+    const declared = canonicalizePolicy(declaredDoc);
+    expect(deepEqual(live, declared)).toBe(false);
+  });
+
+  it('splits a mixed AWS principal, keeping non-OAI ARNs and hoisting the OAI to CanonicalUser', () => {
+    const out = rewriteOaiPrincipalsDeep(
+      {
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: 's3:GetObject',
+            Principal: { AWS: ['arn:aws:iam::123456789012:role/r', userArn] },
+          },
+        ],
+      },
+      map
+    ) as any;
+    const p = out.Statement[0].Principal;
+    expect(p.AWS).toBe('arn:aws:iam::123456789012:role/r');
+    expect(p.CanonicalUser).toBe(CANON);
+  });
+
+  it('leaves a non-OAI policy entirely untouched', () => {
+    const doc = {
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 'sts:AssumeRole',
+          Principal: { Service: 'lambda.amazonaws.com' },
+        },
+      ],
+    };
+    expect(rewriteOaiPrincipalsDeep(doc, map)).toEqual(doc);
   });
 });


### PR DESCRIPTION
## Summary

A freshly-deployed `AWS::S3::BucketPolicy` granting a CloudFront **legacy Origin Access Identity (OAI)** reported a **false declared drift** on every `check`. CDK's `grantRead(oai)` declares the principal as `{ CanonicalUser: <oai S3CanonicalUserId> }`, but `GetBucketPolicy` returns the equivalent `{ AWS: "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity <oaiId>" }`. The two are the same principal but carry **different tokens** (the S3 canonical-user-id hex vs the OAI id), so the diff fired.

Same root cause as cdkd [#872](https://github.com/go-to-k/cdkd/issues/872). Modern OAC grants use a `cloudfront.amazonaws.com` service principal and are unaffected.

## Fix

- `rewriteOaiPrincipalsDeep` (`src/normalize/policy-canonical.ts`) rewrites the `cloudfront:user` ARN principal form to the `CanonicalUser` form using a resolved `oaiId -> S3CanonicalUserId` map. Applied to **both** sides; runs before the shared canonicalization pipeline.
- The map is built in `gather.ts` (`buildOaiCanonicalIds`) from the stack's **own** OAI resources' live attributes (`Id` + `S3CanonicalUserId` — both readOnly attrs the CC-API read already returned). **No extra AWS call, no extra IAM grant.** Threaded into `classifyResource` via `oaiCanonicalIds` (mirrors the KMS `kmsAliasTargets` opt), and rebuilt in `regatherTouched` from `ctx.liveAttrs` so the post-revert re-check stays consistent.
- **Strict**: an OAI id that cannot be resolved is left as-is — never silently equated — so repointing a policy to a *different* OAI is still reported.

## Test plan

- **Real AWS** (`tests/integration/cloudfront-oai`, us-east-1): a fast OAI-only fixture (bucket + OAI + `grantRead`, no distribution). Reproduced the bug, then with the fix the OAI bucket policy reports **clean**, and a real out-of-band statement added to the same policy is still **detected** (no blanket suppression). `INTEG PASS`, clean destroy.
- **Regression** (`tests/integration/policies`, us-east-1): full revert round-trip across S3/SNS/SQS/IAM policy types — `INTEG PASS` (policy canonicalization unaffected).
- **Unit**: `tests/policy-canonical.test.ts` (reconcile / no-op without map / different-OAI / mixed-AWS split / non-OAI untouched) + `tests/classify.test.ts` (false positive without map, clean with map, repoint still reported). Full suite green; typecheck + lint + build pass.
