### PR TITLE
feat(schema,check): fold nested schema defaults as atDefault, not undeclared (R103)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -30,8 +30,9 @@ un-deployed code edits would show as false "drift".
      - cc-api strip   (timestamps, revision ids, ...)
      - policy canonical (Action/Resource/Principal scalar-vs-array unify, statement
        sort, account-id<->root-ARN; Version kept only when declared — never fabricated)
-     - aws:* tags (list + map); scalar schema-defaults + per-type known-defaults
-       are NOT dropped but tagged `atDefault` (folded, never drift; R86)
+     - aws:* tags (list + map); schema-defaults (at ANY depth, via $ref-resolved
+       nested `default` extraction; R103) + per-type known-defaults are NOT dropped
+       but tagged `atDefault` (folded, never drift; R86)
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
 5. classify (tag):  declared | undeclared | atDefault | readGap | unresolved | skipped

--- a/README.md
+++ b/README.md
@@ -304,7 +304,10 @@ that folds everything informational.
     `TracingConfig: PassThrough`, a bucket's default Block Public Access). The bulk
     of a first run, folded to a count so the body shows only what actually
     diverges. Equality-gated: a change away from the default still surfaces, and
-    `--show-all` lists them.
+    `--show-all` lists them. Applies at **any depth** — a value nested inside a
+    declared property that equals the schema's `default` for that path folds here
+    too (so config-dense types like CloudFront, whose schema annotates dozens of
+    nested defaults, don't drown the report in `nested` inventory).
   - **`nested`** — undeclared values that live as a **sub-key inside a property
     you _did_ declare** (e.g. you set a cache behavior but never its
     `SmoothStreaming`, which AWS materializes underneath) — including inside the

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -63,6 +63,7 @@ export interface CorpusCase {
     writeOnlyPaths: string[];
     createOnlyPaths: string[];
     defaults: Record<string, unknown>;
+    defaultPaths: Record<string, unknown>;
   };
   opts: {
     accountId: string;
@@ -123,6 +124,7 @@ export function buildCorpusCase(
       writeOnlyPaths: [...schema.writeOnlyPaths].sort(),
       createOnlyPaths: [...schema.createOnlyPaths].sort(),
       defaults: schema.defaults,
+      defaultPaths: schema.defaultPaths,
     },
     opts,
     expected: findings,
@@ -140,6 +142,7 @@ export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
     writeOnlyPaths: [...s.writeOnlyPaths],
     createOnlyPaths: [...s.createOnlyPaths],
     defaults: s.defaults,
+    defaultPaths: s.defaultPaths ?? {},
   };
 }
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -302,18 +302,22 @@ export function classifyResource(
   // machinery, just `nested`-flagged so the report can fold them (the live model
   // carries many nested AWS defaults): folded inventory on a first run, recorded by
   // accept, and a later out-of-band change to one surfaces as drift vs the baseline.
+  // R103: a nested value EQUAL to the schema's `default` at that path is the
+  // `atDefault` tier (mirrors the top-level atDefault), so config-dense types stop
+  // drowning the report in materialized defaults. Live array-element paths carry the
+  // element identity (`Prop[<id>].sub`); the schema keys it with a `*` wildcard, so
+  // normalize `[<id>]` -> `.*` before the lookup. Equality-gated: a value changed
+  // AWAY from its default no longer matches and falls back to `undeclared`.
   for (const [k, dv] of Object.entries(declared)) {
     if (dv === UNRESOLVED || hasUnresolved(dv) || !(k in live)) continue;
     collectNestedUndeclared(dv, live[k], k, (path, value) => {
       if (isAllAwsTags(value) || isTrivialEmpty(value)) return;
-      findings.push({
-        tier: 'undeclared',
-        logicalId,
-        resourceType,
-        path,
-        actual: value,
-        nested: true,
-      });
+      const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');
+      const tier =
+        schemaPath in schema.defaultPaths && deepEqual(value, schema.defaultPaths[schemaPath])
+          ? 'atDefault'
+          : 'undeclared';
+      findings.push({ tier, logicalId, resourceType, path, actual: value, nested: true });
     });
   }
 

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -13,6 +13,7 @@ const EMPTY: SchemaInfo = {
   writeOnlyPaths: [],
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 };
 
 export async function getSchemaInfo(
@@ -42,6 +43,45 @@ function pointerToDotted(p: string): string {
   return p.replace(/^\/properties\//, '').replace(/\//g, '.');
 }
 
+// Unlike readOnly/writeOnly/createOnly (CFn pre-flattens those into pointer
+// arrays), nested `default` annotations live inline on the property schemas
+// (incl. inside `definitions`, reached via `$ref`). Walk the schema resolving
+// local `#/definitions/...` refs and collect every `default` keyed by its dotted
+// path — array `items` contribute a `*` segment, matching the readOnlyPaths
+// convention and the `[id]`->`*`-normalized live finding paths. The per-branch
+// `seen` ref-set breaks recursive definitions (a $ref cannot expand inside its
+// own descent). Best-effort: only `properties` + `items` are descended (not
+// oneOf/anyOf/allOf), so a missed default just stays `undeclared` — never a false
+// positive.
+type SchemaNode = {
+  $ref?: string;
+  default?: unknown;
+  properties?: Record<string, SchemaNode>;
+  items?: SchemaNode;
+};
+function collectDefaultPaths(
+  definitions: Record<string, SchemaNode>,
+  properties: Record<string, SchemaNode>
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const walk = (node: SchemaNode | undefined, path: string, seen: ReadonlySet<string>): void => {
+    if (!node || typeof node !== 'object') return;
+    if (node.$ref) {
+      const name = node.$ref.replace('#/definitions/', '');
+      if (seen.has(name)) return; // recursive definition — stop
+      walk(definitions[name], path, new Set(seen).add(name));
+      return;
+    }
+    if ('default' in node && path) out[path] = node.default;
+    if (node.properties)
+      for (const [k, child] of Object.entries(node.properties))
+        walk(child, path ? `${path}.${k}` : k, seen);
+    if (node.items) walk(node.items, path ? `${path}.*` : '*', seen);
+  };
+  for (const [k, child] of Object.entries(properties)) walk(child, k, new Set());
+  return out;
+}
+
 /** Exported for unit testing without an AWS call. */
 export function parseSchema(schemaJson: string): SchemaInfo {
   const schema = JSON.parse(schemaJson) as {
@@ -49,7 +89,8 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     writeOnlyProperties?: string[];
     createOnlyProperties?: string[];
     conditionalCreateOnlyProperties?: string[];
-    properties?: Record<string, { default?: unknown }>;
+    properties?: Record<string, SchemaNode>;
+    definitions?: Record<string, SchemaNode>;
   };
   const dotted = (arr: string[] | undefined): string[] => (arr ?? []).map(pointerToDotted);
   const topLevel = (paths: string[]): Set<string> => new Set(paths.filter((p) => !p.includes('.')));
@@ -65,6 +106,7 @@ export function parseSchema(schemaJson: string): SchemaInfo {
   for (const [k, def] of Object.entries(schema.properties ?? {})) {
     if (def && typeof def === 'object' && 'default' in def) defaults[k] = def.default;
   }
+  const defaultPaths = collectDefaultPaths(schema.definitions ?? {}, schema.properties ?? {});
   return {
     readOnly: topLevel(readOnlyPaths),
     writeOnly: topLevel(writeOnlyPaths),
@@ -73,5 +115,6 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     writeOnlyPaths,
     createOnlyPaths,
     defaults,
+    defaultPaths,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,7 @@ export interface SchemaInfo {
   writeOnlyPaths: string[]; // full dotted paths incl '*' wildcard (skip from compare, any depth)
   createOnlyPaths: string[]; // full dotted paths incl '*' wildcard (revert is impossible — replacement)
   defaults: Record<string, unknown>; // top-level schema `default` values
+  defaultPaths: Record<string, unknown>; // schema `default` values at ANY depth, dotted-path keyed ('*' for array items)
 }
 
 export interface ResolverContext {

--- a/tests/_audit.test.ts
+++ b/tests/_audit.test.ts
@@ -9,6 +9,7 @@ const sc: SchemaInfo = {
   writeOnlyPaths: [],
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 };
 const res = (rt: string, d: Record<string, unknown>): DesiredResource => ({
   logicalId: 'L',

--- a/tests/_audit2.test.ts
+++ b/tests/_audit2.test.ts
@@ -9,6 +9,7 @@ const sc: SchemaInfo = {
   writeOnlyPaths: [],
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 };
 const res = (rt: string, d: Record<string, unknown>): DesiredResource => ({
   logicalId: 'L',

--- a/tests/_audit3.test.ts
+++ b/tests/_audit3.test.ts
@@ -9,6 +9,7 @@ const sc: SchemaInfo = {
   writeOnlyPaths: [],
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 };
 const res = (rt: string, d: Record<string, unknown>): DesiredResource => ({
   logicalId: 'L',

--- a/tests/_probe.test.ts
+++ b/tests/_probe.test.ts
@@ -9,6 +9,7 @@ const schema: SchemaInfo = {
   writeOnlyPaths: [],
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 };
 const res = (rt: string, declared: Record<string, unknown>): DesiredResource => ({
   logicalId: 'L',

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -28,6 +28,7 @@ describe('classifyResource (the heart)', () => {
     writeOnlyPaths: ['AssumeRolePolicyDocument'],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const resource: DesiredResource = {
     logicalId: 'Role',
@@ -101,6 +102,7 @@ describe('classifyResource account/region-scoped ARN identity (R10)', () => {
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res: DesiredResource = {
     logicalId: 'Fn',
@@ -147,6 +149,7 @@ describe('classifyResource regressions (dogfood false-positive classes)', () => 
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res = (declared: Record<string, unknown>): DesiredResource => ({
     logicalId: 'R',
@@ -213,6 +216,7 @@ describe('classifyResource post-revert phantom drift (R46)', () => {
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
     logicalId: 'R',
@@ -272,6 +276,7 @@ describe('sibling-managed inline Policies (IAM Role)', () => {
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const DOC = {
     Version: '2012-10-17',
@@ -338,6 +343,7 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const bare = (resourceType: string): DesiredResource => ({
     logicalId: 'L',
@@ -530,6 +536,7 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
     logicalId: 'L',
@@ -728,6 +735,7 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
     logicalId: 'L',
@@ -865,6 +873,7 @@ describe('identity-keyed array ADDITIONS are detected, not subset-projected away
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
     logicalId: 'L',
@@ -945,6 +954,7 @@ describe('nested undeclared detection (R96 — the differentiator at depth)', ()
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
     logicalId: 'L',
@@ -1062,6 +1072,7 @@ describe('CloudFront OAI S3 BucketPolicy principal (real-AWS reproduced false po
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const OAI_ID = 'EM4A89W3GHI3';
   const CANON =
@@ -1124,5 +1135,63 @@ describe('CloudFront OAI S3 BucketPolicy principal (real-AWS reproduced false po
       oaiCanonicalIds: { [OAI_ID]: CANON },
     });
     expect(out.some((f) => f.tier === 'declared')).toBe(true);
+  });
+});
+
+describe('nested atDefault folding (R103 — schema defaults at depth)', () => {
+  const schema = (defaultPaths: Record<string, unknown>): SchemaInfo => ({
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths,
+  });
+  const res = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'R',
+    resourceType: 'AWS::X::Y',
+    physicalId: 'p',
+    declared,
+  });
+
+  it('a nested live value EQUAL to its schema default folds as atDefault, not undeclared', () => {
+    const out = classifyResource(
+      res({ Conf: { A: 1 } }),
+      { Conf: { A: 1, Timeout: 30 } },
+      schema({ 'Conf.Timeout': 30 })
+    );
+    const f = out.find((x) => x.path === 'Conf.Timeout');
+    expect(f?.tier).toBe('atDefault');
+    expect(f?.nested).toBe(true);
+  });
+
+  it('a nested value CHANGED away from its schema default stays undeclared (surfaces)', () => {
+    const out = classifyResource(
+      res({ Conf: { A: 1 } }),
+      { Conf: { A: 1, Timeout: 99 } },
+      schema({ 'Conf.Timeout': 30 })
+    );
+    expect(out.find((x) => x.path === 'Conf.Timeout')?.tier).toBe('undeclared');
+  });
+
+  it('an array-element nested default folds: the live [<id>] path normalizes to the schema * key', () => {
+    const out = classifyResource(
+      res({ Origins: [{ Id: 'o1' }] }),
+      { Origins: [{ Id: 'o1', Port: 80 }] },
+      schema({ 'Origins.*.Port': 80 })
+    );
+    const f = out.find((x) => x.path === 'Origins[o1].Port');
+    expect(f?.tier).toBe('atDefault');
+  });
+
+  it('a nested value with NO schema default stays undeclared', () => {
+    const out = classifyResource(
+      res({ Conf: { A: 1 } }),
+      { Conf: { A: 1, Other: 5 } },
+      schema({ 'Conf.Timeout': 30 })
+    );
+    expect(out.find((x) => x.path === 'Conf.Other')?.tier).toBe('undeclared');
   });
 });

--- a/tests/corpus-record.test.ts
+++ b/tests/corpus-record.test.ts
@@ -58,6 +58,7 @@ describe('corpus recording (R63)', () => {
       writeOnlyPaths: [],
       createOnlyPaths: [],
       defaults: {},
+      defaultPaths: {},
     };
     const findings: Finding[] = [
       {

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -87,6 +87,7 @@ describe('regatherTouched (R44 — scoped post-revert convergence re-gather)', (
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   };
   const ctx = (): ResolverContext => ({
     params: {},

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -65,6 +65,12 @@ These do NOT run in CI (they need credentials and mutate a real account):
   still match live Cloud Control output (a shape mismatch would resurface the
   value as real undeclared drift) and that a value changed away from its default
   still surfaces.
+- **After changing** the nested-schema-default extraction (`collectDefaultPaths`
+  in `src/schema/schema-strip.ts`) or the nested `atDefault` fold
+  (`src/diff/classify.ts`): run `cloudfront-atdefault` — it deploys a CloudFront
+  Distribution and asserts its schema-annotated nested defaults
+  (`CustomOriginConfig.HTTPSPort`/`OriginReadTimeout`, `PriceClass`, …) fold as
+  `atDefault` rather than `undeclared` (R103). CloudFront deploy/destroy are slow.
 - Scripts that share a fixture/stack (`basic`'s four) must run sequentially,
   never concurrently.
 - **After changing exit-code or baseline semantics** (report-only/--fail, the

--- a/tests/integration/cloudfront-atdefault/app.ts
+++ b/tests/integration/cloudfront-atdefault/app.ts
@@ -1,0 +1,22 @@
+// R103 fixture: a CloudFront Distribution materializes many NESTED config defaults
+// the template never declared (Origins[].CustomOriginConfig.HTTPPort=80 / HTTPSPort=443
+// / OriginReadTimeout=30, PriceClass, DefaultCacheBehavior.AllowedMethods, ...). The
+// CloudFront CFn schema annotates these as `default`, so cdkrd folds the matching live
+// values as `atDefault` (informational) instead of drowning the report in `undeclared`.
+// HttpOrigin → a CustomOriginConfig carrying the schema-defaulted ports/timeout.
+import { App, Stack } from "aws-cdk-lib";
+import { Distribution, ViewerProtocolPolicy } from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new App();
+const stack = new Stack(app, "CdkrdIntegCfAtDefault");
+
+new Distribution(stack, "Cdn", {
+  defaultBehavior: {
+    origin: new HttpOrigin("example.com"),
+    viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+  },
+  comment: "cdkrd cf atDefault fixture",
+});
+
+app.synth();

--- a/tests/integration/cloudfront-atdefault/cdk.json
+++ b/tests/integration/cloudfront-atdefault/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-atdefault/package.json
+++ b/tests/integration/cloudfront-atdefault/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-atdefault",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture asserting CloudFront nested schema defaults fold as atDefault (R103). Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/cloudfront-atdefault/verify.sh
+++ b/tests/integration/cloudfront-atdefault/verify.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# cdkrd R103 integration test (real AWS, read-only). A CloudFront Distribution
+# materializes nested config defaults the template never set; the CloudFront CFn
+# schema annotates them as `default`, so cdkrd folds the matching live values as
+# `atDefault` (nested) instead of `undeclared`. Asserts that schema-defaulted nested
+# paths (CustomOriginConfig.HTTPSPort=443 / OriginReadTimeout=30, PriceClass) land in
+# the atDefault tier, and that NONE of them are `declared` drift.
+# CloudFront deploy/destroy are slow (minutes each).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkrdIntegCfAtDefault
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup (CloudFront destroy is slow) ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy (slow) ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+echo "=== check: schema-defaulted nested values fold as atDefault, none are drift ==="
+$CLI check "$STACK" --region "$REGION" --show-all --json > /tmp/cdkrd-cfad.json 2>/tmp/cdkrd-cfad.err \
+  || { cat /tmp/cdkrd-cfad.err; fail "check errored"; }
+node -e '
+  const j = require("/tmp/cdkrd-cfad.json");
+  const dist = (j.findings||[]).filter(f => f.resourceType === "AWS::CloudFront::Distribution");
+  const tierOf = (substr) => {
+    const f = dist.find(x => String(x.path).includes(substr));
+    return f ? f.tier : "(absent)";
+  };
+  // these nested paths are schema `default`s — must be atDefault now, never undeclared
+  const checks = [
+    ["CustomOriginConfig.HTTPSPort", 443],
+    ["CustomOriginConfig.OriginReadTimeout", 30],
+    ["PriceClass", null],
+  ];
+  let bad = [];
+  for (const [p] of checks) {
+    const t = tierOf(p);
+    if (t !== "atDefault") bad.push(`${p} -> ${t} (expected atDefault)`);
+  }
+  if (dist.some(f => f.tier === "declared")) bad.push("unexpected declared drift: " + JSON.stringify(dist.filter(f=>f.tier==="declared").map(f=>f.path)));
+  if (bad.length) { console.error("FAIL:\n" + bad.join("\n")); process.exit(1); }
+  const atDefaultCount = dist.filter(f => f.tier === "atDefault").length;
+  console.log(`schema-defaulted nested values folded as atDefault (${atDefaultCount} total) ✓`);
+' || fail "nested schema defaults did not fold as atDefault"
+
+echo "INTEG PASS"

--- a/tests/invariants.test.ts
+++ b/tests/invariants.test.ts
@@ -95,6 +95,7 @@ const EMPTY_SCHEMA: SchemaInfo = {
   writeOnlyPaths: [],
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 };
 
 const SEEDS = Array.from({ length: 200 }, (_, i) => i + 1);

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -249,4 +249,43 @@ describe('parseSchema', () => {
     expect(info.createOnlyPaths).toContain('Nested.Key');
     expect(info.createOnlyPaths).toContain('AvailabilityZone');
   });
+
+  it('R103: extracts nested defaults through $ref + arrays into defaultPaths', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        properties: {
+          TopWithDefault: { default: 7 },
+          Config: { $ref: '#/definitions/Config' },
+        },
+        definitions: {
+          Config: {
+            type: 'object',
+            properties: {
+              Origins: { type: 'array', items: { $ref: '#/definitions/Origin' } },
+              Comment: { type: 'string', default: '' },
+            },
+          },
+          Origin: {
+            type: 'object',
+            properties: {
+              Port: { type: 'integer', default: 80 },
+              Nested: { $ref: '#/definitions/Origin' }, // recursive — must not loop
+            },
+          },
+        },
+      })
+    );
+    // array items contribute a '*' segment, matching readOnlyPaths + live finding paths
+    expect(info.defaultPaths['Config.Origins.*.Port']).toBe(80);
+    expect(info.defaultPaths['Config.Comment']).toBe('');
+    expect(info.defaultPaths['TopWithDefault']).toBe(7);
+    // the self-referential `Nested` ($ref Origin) is already on the descent's seen-set,
+    // so it is NOT expanded — the recursion guard prevents an infinite walk.
+    expect(info.defaultPaths).not.toHaveProperty('Config.Origins.*.Nested.Port');
+  });
+
+  it('R103: a schema with no nested defaults yields an empty defaultPaths (minus top-level)', () => {
+    const info = parseSchema(JSON.stringify({ properties: { A: {}, B: { default: 1 } } }));
+    expect(info.defaultPaths).toEqual({ B: 1 });
+  });
 });

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -12,6 +12,7 @@ const schemaWithWriteOnly = (...names: string[]): SchemaInfo => ({
   writeOnlyPaths: names,
   createOnlyPaths: [],
   defaults: {},
+  defaultPaths: {},
 });
 
 const schemaWithCreateOnly = (type: string, ...names: string[]): Map<string, SchemaInfo> =>
@@ -26,6 +27,7 @@ const schemaWithCreateOnly = (type: string, ...names: string[]): Map<string, Sch
         writeOnlyPaths: [],
         createOnlyPaths: names,
         defaults: {},
+        defaultPaths: {},
       },
     ],
   ]);

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -267,6 +267,7 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     writeOnlyPaths: [],
     createOnlyPaths: [],
     defaults: {},
+    defaultPaths: {},
   } as SchemaInfo;
 
   // One bucket with declared VersioningConfiguration drift (the declared() fixture).


### PR DESCRIPTION
## Summary

Config-dense types (CloudFront, ECS, …) materialize many **nested** config values the template never declared. cdkrd surfaced all of them as `undeclared` (folded under `nested=N`, baseline-able) — a lot of first-run noise that undercuts the "low noise / everything explainable" promise, since the CFn schema **knows** these are defaults. The top-level `atDefault` fold (R86) never reached nested paths.

## How

- Unlike readOnly/writeOnly (CFn pre-flattens those into pointer arrays), nested `default` annotations live inline on the property schemas (incl. inside `definitions`, reached via `$ref`). New `collectDefaultPaths` (`src/schema/schema-strip.ts`) walks the schema resolving local refs and collects every `default` keyed by dotted path — array `items` contribute a `*` segment (matching the readOnlyPaths convention). A per-branch ref-set breaks recursive definitions. Result rides on a new `SchemaInfo.defaultPaths`.
- `classify`'s nested-undeclared emit normalizes the live `Prop[<id>].sub` path to the schema's `Prop.*.sub` key, and when the value equals the schema default tags it `atDefault` (nested) instead of `undeclared`. Equality-gated like the top-level fold: a value changed away from its default falls back to `undeclared` and surfaces.
- **Schema-driven, general across all types** — no per-type defaults table (the cdkd-style hand-coding cdkrd avoids). The remaining schema-gap defaults (values AWS applies but doesn't annotate as schema `default`) stay `undeclared`, exactly as before — never a false positive.

## Downstream

A nested `atDefault` finding flows through the existing tier machinery untouched: `buildAccepted` records only `undeclared` (so atDefault is never baselined), and the report folds it into the `atDefault=N` info line.

## Test plan

- **Real AWS** (`tests/integration/cloudfront-atdefault`, us-east-1): a deployed Distribution folds **7** schema-defaulted nested values (`CustomOriginConfig.HTTPSPort`/`OriginReadTimeout`, `PriceClass`, `DefaultCacheBehavior` methods, …) as `atDefault`, **none** as drift. `INTEG PASS`, clean destroy. (CloudFront deploy/destroy are slow.)
- **Unit** (+6): `parseSchema` defaultPaths extraction through `$ref`/arrays/recursion-guard (`noise-and-strip.test.ts`); classify nested `atDefault` vs `undeclared` gating incl. `[id]`→`*` path normalization (`classify.test.ts`). Full suite green (764); typecheck + lint + build pass.
