### PR TITLE
feat(diff,report): fold AWS/CDK auto-generated values as the `generated` tier (R104)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,10 +32,12 @@ un-deployed code edits would show as false "drift".
        sort, account-id<->root-ARN; Version kept only when declared — never fabricated)
      - aws:* tags (list + map); schema-defaults (at ANY depth, via $ref-resolved
        nested `default` extraction; R103) + per-type known-defaults are NOT dropped
-       but tagged `atDefault` (folded, never drift; R86)
+       but tagged `atDefault` (folded, never drift; R86); AWS/CDK auto-generated
+       values keyed by the resource's physical id (a topic's minted TopicName, a
+       Lambda's default LoggingConfig log group) are tagged `generated` (R104)
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
-5. classify (tag):  declared | undeclared | atDefault | readGap | unresolved | skipped
+5. classify (tag):  declared | undeclared | atDefault | generated | readGap | unresolved | skipped
 6. report + exit code (report-only by default; --fail → 1 on drift; 2 error)
 ```
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,14 @@ that folds everything informational.
     declared property that equals the schema's `default` for that path folds here
     too (so config-dense types like CloudFront, whose schema annotates dozens of
     nested defaults, don't drown the report in `nested` inventory).
+  - **`generated`** — undeclared values that are the **name or identifier AWS/CDK
+    minted for the resource**, not anything you set: a topic's auto-generated
+    `TopicName`, a Lambda's default `LoggingConfig` whose `LogGroup` is named after
+    the generated function name. Keyed off the resource's physical id, so they
+    appear on every first run yet you never chose (and often cannot edit) them.
+    Folded to a count like `atDefault`, equality-gated against the physical-id
+    template (change one out of band — say a `LogFormat: JSON` — and it re-surfaces
+    as real undeclared drift); never recorded by `accept`. `--verbose` lists them.
   - **`nested`** — undeclared values that live as a **sub-key inside a property
     you _did_ declare** (e.g. you set a cache behavior but never its
     `SmoothStreaming`, which AWS materializes underneath) — including inside the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -174,9 +174,13 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
                  Permission.FunctionName = GetAtt[fn, Arn]) — concurrent, once
    --- PASS 2:   classify
 4. normalize / subtract  classify.ts orchestrates the normalizers (section 6)
-5. classify (tier)       deleted | declared | undeclared | atDefault | readGap | unresolved | skipped
+5. classify (tier)       deleted | declared | undeclared | atDefault | generated | readGap | unresolved | skipped
                          (atDefault = undeclared but EQUAL to a known AWS default —
                          folded, never drift, never recorded; R86)
+                         (generated = undeclared but EQUAL to the AWS/CDK auto-generated
+                         value for THIS resource — its minted physical name, or a
+                         default LoggingConfig log group derived from the physical id;
+                         folded like atDefault, never drift, never recorded; R104)
                          (undeclared also carries a nested:true flag for a live
                          sub-key inside a declared object the template never set; R96)
 6. baseline filter       applyBaseline(): undeclared findings already accepted → drop;
@@ -215,7 +219,7 @@ checked.
   - **overrides.ts** — `SDK_OVERRIDES` readers for CC-gap types (S3/SNS/SQS BucketPolicy/TopicPolicy/QueuePolicy, IAM Policy/ManagedPolicy, Lambda Permission, Budgets, **EC2 EIP** via DescribeAddresses, **Route53 RecordSet** via ListResourceRecordSets, **Glue Table** via GetTable, **Logs MetricFilter** via DescribeMetricFilters, **Scheduler Schedule** via GetSchedule — CC only reads the default group, **CodeBuild Project** via BatchGetProjects with a camelCase→CFn-PascalCase projection, R85).
 - **normalize/** — noise subtraction (section 6)
   - **intrinsic-resolver.ts** — fail-closed CFn intrinsic resolver (section 5).
-  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` (per-type unordered scalar arrays) / `UNORDERED_OBJECT_ARRAY_PROPS` + `sortUnorderedObjectArray` (per-type unordered object arrays — SG rules, R88) / `CASE_INSENSITIVE_PATHS` (per-type compare rules). (R95 removed the generic `projectLiveToDeclaredSubset` — it silently dropped out-of-band ADDITIONS to identity-keyed arrays like Tags; ELB attribute bags keep subset behaviour via `ELB_ATTRIBUTE_BAGS` in classify.)
+  - **noise.ts** — `isTrivialEmpty`, `isAllAwsTags`, `stripAwsTagsDeep`, `KNOWN_DEFAULTS`, `GENERATED_DEFAULTS` + `resolveGeneratedDefault` (per-type auto-generated values templated on the physical id → `generated` tier; R104), **`canonicalizeTagListsDeep`**, **`canonicalizeIdArraysDeep`**, `isJsonStringStructEqual` (object↔JSON-string), `UNORDERED_ARRAY_PROPS` (per-type unordered scalar arrays) / `UNORDERED_OBJECT_ARRAY_PROPS` + `sortUnorderedObjectArray` (per-type unordered object arrays — SG rules, R88) / `CASE_INSENSITIVE_PATHS` (per-type compare rules). (R95 removed the generic `projectLiveToDeclaredSubset` — it silently dropped out-of-band ADDITIONS to identity-keyed arrays like Tags; ELB attribute bags keep subset behaviour via `ELB_ATTRIBUTE_BAGS` in classify.)
   - **arn-identity.ts** — **`isArnNameMatch`** (bare name ↔ ARN), **`isManagedKmsAliasMatch`** (`alias/aws/*` ↔ key ARN).
   - **policy-canonical.ts** — IAM policy-doc canonicalization. **cc-api-strip.ts** — strip AWS-managed fields. **path-strip.ts** — schema readOnly/writeOnly path stripping (incl `*`).
 - **schema/schema-strip.ts** — `describe-type` → readOnly/writeOnly/defaults `SchemaInfo` (cached).
@@ -287,6 +291,10 @@ all live changes
     inventory but lists only the values that actually diverge. Equality-gated: change
     one away from its default and it re-tags as real undeclared drift. (`--show-all` /
     `--verbose` expand the fold to the full list; accept never records an atDefault.)
+  − AWS/CDK auto-generated values (a topic's minted TopicName, a Lambda's default
+    LoggingConfig log group) → tagged "generated" (R104): folded into the info: footer
+    like atDefault, equality-gated against the physical-id-substituted template; never
+    drift, never recorded by accept. (`GENERATED_DEFAULTS` / `resolveGeneratedDefault`.)
   − pure structural noise (aws:* tags, physical-id echo, trivially-empty {}/[]) → dropped
   − tag-list / id-array / method-set ORDER → canonicalized (see below)
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -34,11 +34,12 @@ import {
 } from './stack-actions.js';
 
 // --pre-deploy reports declared-side drift the next deploy would clobber; the
-// undeclared tier is meaningless against a synth (not deployed) declared set, so
-// it is excluded. --declared-only reuses the same filter against the DEPLOYED
-// template (R59). Exported (pure) so the contract is unit-tested.
+// undeclared tier (and its `generated` sibling — an undeclared-side classification)
+// is meaningless against a synth (not deployed) declared set, so it is excluded.
+// --declared-only reuses the same filter against the DEPLOYED template (R59).
+// Exported (pure) so the contract is unit-tested.
 export function preDeployFindings(findings: Finding[]): Finding[] {
-  return findings.filter((f) => f.tier !== 'undeclared');
+  return findings.filter((f) => f.tier !== 'undeclared' && f.tier !== 'generated');
 }
 
 // --undeclared-only (R59): the declared-side comparison is delegated to

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -20,6 +20,7 @@ import {
   isStringlyEqualScalar,
   isTrivialEmpty,
   KNOWN_DEFAULTS,
+  resolveGeneratedDefault,
   sortUnorderedObjectArray,
   stripAwsTagsDeep,
   UNORDERED_ARRAY_PROPS,
@@ -162,6 +163,11 @@ export function classifyResource(
   // already emitted as a readGap above AND stripped from `declared` by writeOnlyPaths,
   // so it cannot reach this loop (the old guard was dead code for top-level keys).
   const knownDef = KNOWN_DEFAULTS[resourceType] ?? {};
+  // AWS/CDK-generated values for THIS resource (its minted name, a default log group
+  // derived from the physical id), with the live physical id substituted in — keyed
+  // by property, consulted by the undeclared loop below. Empty when the type has no
+  // template or the physical id is unknown.
+  const genDef = resolveGeneratedDefault(resourceType, physicalId) ?? {};
   for (const [k, v] of Object.entries(declared)) {
     if (v === UNRESOLVED || hasUnresolved(v)) {
       findings.push({ tier: 'unresolved', logicalId, resourceType, path: k });
@@ -283,6 +289,15 @@ export function classifyResource(
       (k in knownDef && deepEqual(v, knownDef[k]))
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // A live value EQUAL to the AWS/CDK-generated value for this resource (its minted
+    // physical name, a default-named log group) is the `generated` tier: folded
+    // inventory like atDefault, never drift, never recorded. Equality-gated against
+    // the physical-id-substituted template, so an out-of-band edit (a different
+    // LogFormat, say) no longer matches and falls through to `undeclared` below.
+    if (k in genDef && deepEqual(v, genDef[k])) {
+      findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
       continue;
     }
     // Pure structural noise (NOT a config value at default) — dropped outright: AWS

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -80,6 +80,63 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
 };
 
+// AWS/CDK auto-GENERATED values keyed by the resource's CFn-assigned physical id.
+// Unlike KNOWN_DEFAULTS (static values), each entry may interpolate the live
+// physical id via two placeholders, substituted by resolveGeneratedDefault before
+// the equality gate:
+//   ${PHYSICAL_ID}   - the PhysicalResourceId verbatim (an ARN or a bare name,
+//                      depending on the resource type)
+//   ${PHYSICAL_NAME} - its trailing name segment (after the last ':' or '/'); for
+//                      an ARN physical id this is the bare resource name
+// These are the identifiers AWS minted for the resource, not user intent: a topic's
+// generated TopicName, a function's default LoggingConfig whose LogGroup is named
+// after the generated function name. They flood a first run as "undeclared" yet the
+// user never set and cannot meaningfully edit them. Classified as the `generated`
+// tier (folded inventory like atDefault), equality-gated exactly like KNOWN_DEFAULTS:
+// an out-of-band edit (a JSON LogFormat, say) no longer matches the substituted
+// template and falls through to a real `undeclared` finding. Never recorded by accept.
+export const GENERATED_DEFAULTS: Record<string, Record<string, unknown>> = {
+  'AWS::SNS::Topic': { TopicName: '${PHYSICAL_NAME}' },
+  'AWS::Lambda::Function': {
+    LoggingConfig: { LogFormat: 'Text', LogGroup: '/aws/lambda/${PHYSICAL_NAME}' },
+  },
+};
+
+function physicalNameOf(physicalId: string): string {
+  const segs = physicalId.split(/[:/]/);
+  return segs[segs.length - 1] || physicalId;
+}
+
+function substitutePhysical(value: unknown, id: string, name: string): unknown {
+  if (typeof value === 'string')
+    return value.split('${PHYSICAL_ID}').join(id).split('${PHYSICAL_NAME}').join(name);
+  if (Array.isArray(value)) return value.map((v) => substitutePhysical(v, id, name));
+  if (value && typeof value === 'object')
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        k,
+        substitutePhysical(v, id, name),
+      ])
+    );
+  return value;
+}
+
+// Resolve the GENERATED_DEFAULTS template for a resource type against its live
+// physical id, returning the per-property expected values (placeholders filled) or
+// undefined when the type has no template / the physical id is unknown. The classify
+// undeclared loop then equality-gates a live value against `result[key]`.
+export function resolveGeneratedDefault(
+  resourceType: string,
+  physicalId: string | undefined
+): Record<string, unknown> | undefined {
+  const tmpl = GENERATED_DEFAULTS[resourceType];
+  if (!tmpl || physicalId === undefined) return undefined;
+  return substitutePhysical(tmpl, physicalId, physicalNameOf(physicalId)) as Record<
+    string,
+    unknown
+  >;
+}
+
 // Strip AWS-managed (aws:*) tag ELEMENTS from the live side so a declared tag
 // set (which never contains aws:* tags) compares equal to the live set (which
 // AWS augments with aws:cloudformation:* etc.). Handles {Key,Value}[] lists at

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -25,6 +25,7 @@ const TIER_NAMES: Record<Tier, string> = {
   declared: 'DECLARED DRIFT',
   undeclared: 'UNDECLARED DRIFT',
   atDefault: 'AT AWS DEFAULT',
+  generated: 'AWS GENERATED',
   ignored: 'IGNORED',
   readGap: 'READ GAP',
   unresolved: 'UNRESOLVED',
@@ -35,6 +36,7 @@ const TIER_NOTES: Partial<Record<Tier, string>> = {
   deleted: 'resource deleted out of band — always drift',
   undeclared: 'not declared in your template — the differentiator',
   atDefault: 'undeclared, but the live value matches a known AWS default — not drift',
+  generated: 'undeclared, but an AWS/CDK auto-generated name or identifier — not drift',
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
   readGap: 'declared but not returned by live read — not drift',
   unresolved: 'declared paths needing GetAtt — skipped, not drift',
@@ -46,7 +48,14 @@ const DRIFT_TIERS: Tier[] = ['deleted', 'declared', 'undeclared'];
 // report states the complete undeclared count but lists only the values that actually
 // diverge, with the at-default remainder collapsed to a count (expanded by --verbose
 // or --show-all).
-const INFO_TIERS: Tier[] = ['atDefault', 'ignored', 'readGap', 'unresolved', 'skipped'];
+const INFO_TIERS: Tier[] = [
+  'atDefault',
+  'generated',
+  'ignored',
+  'readGap',
+  'unresolved',
+  'skipped',
+];
 
 export interface ReportOptions {
   json?: boolean;
@@ -76,7 +85,7 @@ export function formatFinding(f: Finding): string {
   if (f.note) s += ` — ${f.note}`;
   if (f.tier === 'declared')
     s += `\n      desired=${style.desired(j(f.desired))}\n      actual =${style.actual(j(f.actual))}`;
-  else if (f.tier === 'undeclared' || f.tier === 'atDefault')
+  else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
     s += ` = ${style.actual(j(f.actual))}`;
   return s;
 }
@@ -207,12 +216,15 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   const isExpanded = (t: Tier): boolean =>
     !!opts.verbose || (t === 'atDefault' && !!opts.expandAtDefault);
   for (const tier of INFO_TIERS) if (isExpanded(tier)) tierSection(tier, true);
-  const summaryFor = (t: Tier, items: Finding[]): string =>
-    // atDefault has a single cause (matches an AWS default), so the generic
-    // reason-breakdown would just echo the count — give it a plain-English label.
-    t === 'atDefault'
-      ? `atDefault=${items.length} (undeclared values matching a known AWS default — not drift)`
-      : `${t}=${items.length} (${groupReasons(items)})`;
+  const summaryFor = (t: Tier, items: Finding[]): string => {
+    // atDefault / generated each have a single cause, so the generic reason-breakdown
+    // would just echo the count — give them a plain-English label instead.
+    if (t === 'atDefault')
+      return `atDefault=${items.length} (undeclared values matching a known AWS default — not drift)`;
+    if (t === 'generated')
+      return `generated=${items.length} (undeclared AWS/CDK auto-generated names or identifiers — not drift)`;
+    return `${t}=${items.length} (${groupReasons(items)})`;
+  };
   const summaries = INFO_TIERS.filter((t) => !isExpanded(t))
     .map((t) => {
       const items = byTier(t);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type Tier =
   | 'declared'
   | 'undeclared'
   | 'atDefault' // undeclared, but the live value EQUALS a known AWS default (schema `default` or KNOWN_DEFAULTS) — informational inventory, folded in the report (R86); never drift, never recorded by accept. An out-of-band change AWAY from the default no longer matches, so it re-surfaces as a real `undeclared` finding.
+  | 'generated' // undeclared, but the live value EQUALS the AWS/CDK auto-generated value for THIS resource (its minted physical name, or a default-named log group derived from the physical id) — informational inventory, folded like atDefault; never drift, never recorded by accept (it carries no intent, only the identity AWS minted). Equality-gated against the physical-id-substituted template, so an out-of-band edit no longer matches and re-surfaces as `undeclared`.
   | 'ignored' // re-tagged from declared/undeclared by a .cdkrd/config.json ignore rule (informational)
   | 'readGap'
   | 'unresolved'

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -14,6 +14,7 @@ function tiers(findings: Finding[]) {
     declared: by('declared'),
     undeclared: by('undeclared'),
     atDefault: by('atDefault'),
+    generated: by('generated'),
     readGap: by('readGap'),
     unresolved: by('unresolved'),
   };
@@ -1193,5 +1194,90 @@ describe('nested atDefault folding (R103 — schema defaults at depth)', () => {
       schema({ 'Conf.Timeout': 30 })
     );
     expect(out.find((x) => x.path === 'Conf.Other')?.tier).toBe('undeclared');
+  });
+});
+
+// GENERATED_DEFAULTS: an undeclared live value equal to the AWS/CDK auto-generated
+// value for THIS resource (its minted physical name, or a default-named log group
+// derived from the physical id) folds to the `generated` tier — never undeclared,
+// never drift. Equality-gated against the physical-id-substituted template.
+describe('GENERATED_DEFAULTS — physical-id-derived auto values fold to `generated`', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const res = (
+    resourceType: string,
+    physicalId: string | undefined,
+    declared: Record<string, unknown> = {}
+  ): DesiredResource => ({ logicalId: 'L', resourceType, physicalId, declared });
+
+  it('SNS TopicName equal to the generated name segment of the ARN physical id folds', () => {
+    const arn = 'arn:aws:sns:ap-northeast-1:111122223333:Stack-TopicABC123-9F16VRgpExOs';
+    const out = classifyResource(
+      res('AWS::SNS::Topic', arn),
+      { TopicName: 'Stack-TopicABC123-9F16VRgpExOs' },
+      emptySchema
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'generated', path: 'TopicName' });
+  });
+
+  it('Lambda default LoggingConfig whose LogGroup is named after the function physical id folds', () => {
+    const fn = 'Stack-HandlerABC123-d8tC4w62HoBi';
+    const out = classifyResource(
+      res('AWS::Lambda::Function', fn),
+      { LoggingConfig: { LogFormat: 'Text', LogGroup: `/aws/lambda/${fn}` } },
+      emptySchema
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'generated', path: 'LoggingConfig' });
+  });
+
+  it('an out-of-band edit inside the generated value (LogFormat → JSON) no longer matches → undeclared', () => {
+    const fn = 'Stack-HandlerABC123-d8tC4w62HoBi';
+    const out = classifyResource(
+      res('AWS::Lambda::Function', fn),
+      { LoggingConfig: { LogFormat: 'JSON', LogGroup: `/aws/lambda/${fn}` } },
+      emptySchema
+    );
+    expect(tiers(out).undeclared).toEqual(['LoggingConfig']);
+    expect(tiers(out).generated).toEqual([]);
+  });
+
+  it('a TopicName NOT matching the physical id stays undeclared (a real out-of-band name)', () => {
+    const out = classifyResource(
+      res('AWS::SNS::Topic', 'arn:aws:sns:us-east-1:111122223333:Stack-TopicABC123-xyz'),
+      { TopicName: 'totally-different-name' },
+      emptySchema
+    );
+    expect(tiers(out).undeclared).toEqual(['TopicName']);
+  });
+
+  it('with no physical id the template cannot resolve, so the value stays undeclared', () => {
+    const out = classifyResource(
+      res('AWS::SNS::Topic', undefined),
+      { TopicName: 'Stack-TopicABC123-9F16VRgpExOs' },
+      emptySchema
+    );
+    expect(tiers(out).undeclared).toEqual(['TopicName']);
+    expect(tiers(out).generated).toEqual([]);
+  });
+
+  it('a declared property is never reclassified as generated (declared side wins)', () => {
+    const arn = 'arn:aws:sns:us-east-1:111122223333:Stack-TopicABC123-9F16VRgpExOs';
+    const out = classifyResource(
+      res('AWS::SNS::Topic', arn, { TopicName: 'Stack-TopicABC123-9F16VRgpExOs' }),
+      { TopicName: 'Stack-TopicABC123-9F16VRgpExOs' },
+      emptySchema
+    );
+    // declared + equal live → no finding at all (not generated, not drift)
+    expect(out).toEqual([]);
   });
 });

--- a/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
+++ b/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
@@ -170,7 +170,7 @@
       "constructPath": "CdkrdIntegHarvest5/AliasedFn"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "AliasedFn19257E6A",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
+++ b/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
@@ -170,7 +170,7 @@
       "constructPath": "CdkrdIntegHarvest4/ApiFn"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "ApiFnE0725F78",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
+++ b/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
@@ -156,7 +156,7 @@
       "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
@@ -164,7 +164,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
@@ -159,7 +159,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
+++ b/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
@@ -172,7 +172,7 @@
       "constructPath": "CdkRealDriftIntegLambda/TestFn"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "TestFn04335C60",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
+++ b/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
@@ -170,7 +170,7 @@
       "constructPath": "CdkrdIntegHarvest6/UrlFn"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "UrlFnE068003E",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
+++ b/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::Lambda::Function with deep declared config classifies as recorded (undeclared:LoggingConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::Lambda::Function with deep declared config classifies as recorded (generated:LoggingConfig). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Worker11F36D0F",
     "resourceType": "AWS::Lambda::Function",
@@ -165,7 +165,7 @@
       "constructPath": "CdkrdIntegHarvest2/Worker"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Worker11F36D0F",
       "resourceType": "AWS::Lambda::Function",
       "path": "LoggingConfig",

--- a/tests/corpus/AWS__SNS__Topic.Alerts91F83244.json
+++ b/tests/corpus/AWS__SNS__Topic.Alerts91F83244.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SNS::Topic with deep declared config classifies as recorded (undeclared:Subscription, undeclared:TopicName). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
+  "description": "RECORDED LIVE (harvest2 fixture, R73 — richly-declared wave): AWS::SNS::Topic with deep declared config classifies as recorded (undeclared:Subscription, generated:TopicName). Fresh-deploy declared drift was ZERO across the whole stack; a change in this expected means the semantics for this type changed.",
   "resource": {
     "logicalId": "Alerts91F83244",
     "resourceType": "AWS::SNS::Topic",
@@ -79,7 +79,7 @@
       "constructPath": "CdkrdIntegHarvest2/Alerts"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Alerts91F83244",
       "resourceType": "AWS::SNS::Topic",
       "path": "TopicName",

--- a/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.drifted.json
+++ b/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.drifted.json
@@ -57,7 +57,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixTopic"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "MatrixTopic643E8545",
       "resourceType": "AWS::SNS::Topic",
       "path": "TopicName",

--- a/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.json
+++ b/tests/corpus/AWS__SNS__Topic.MatrixTopic643E8545.json
@@ -47,7 +47,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "MatrixTopic643E8545",
       "resourceType": "AWS::SNS::Topic",
       "path": "TopicName",

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -289,6 +289,34 @@ describe('report', () => {
     });
   });
 
+  describe('generated tier (AWS/CDK auto-generated names/identifiers — folded, never drift)', () => {
+    const G = (path = 'TopicName'): Finding => ({
+      tier: 'generated',
+      logicalId: 'L',
+      resourceType: 'AWS::SNS::Topic',
+      path,
+      actual: 'Stack-TopicABC123-9F16VRgpExOs',
+    });
+
+    it('folds into the info: footer with a plain-English label and never sets exit 1', () => {
+      const { code, text } = run([G('TopicName'), G('LoggingConfig')]);
+      expect(code).toBe(0);
+      expect(text).toMatch(/^result: CLEAN$/m);
+      expect(text).toContain(
+        'info: generated=2 (undeclared AWS/CDK auto-generated names or identifiers — not drift)'
+      );
+      expect(text).not.toContain('[AWS GENERATED');
+      expect(text).not.toContain('TopicName =');
+    });
+
+    it('--verbose expands generated to a full section showing each value', () => {
+      const { text } = run([G('TopicName')], { verbose: true });
+      expect(text).toContain('[AWS GENERATED: 1]');
+      expect(text).toContain('L.TopicName (AWS::SNS::Topic) = "Stack-TopicABC123-9F16VRgpExOs"');
+      expect(text).not.toContain('info:');
+    });
+  });
+
   describe('R37 spacing', () => {
     const skipped: Finding = {
       tier: 'skipped',


### PR DESCRIPTION
## What & why

On a first run, `check` listed a resource's **auto-generated names/identifiers** as plain `undeclared` values — an SNS `TopicName`, a Lambda default `LoggingConfig` whose `LogGroup` is named after the generated function name. The user never set these and often cannot edit them, yet they inflated the `[UNRECORDED: N]` headline and got mixed in with values that actually look like out-of-band edits.

Concretely, on a real stack the headline read `[UNRECORDED: 7]` where only 2 were genuine manual edits — the other 5 were a generated `TopicName` + four default `LoggingConfig`s. And with **no** manual changes the headline still showed `5`, which reads as "5 things to worry about".

## Change

Add a `generated` tier. A top-level undeclared value EQUAL to the AWS/CDK auto-generated value for **this** resource (keyed off its physical id) folds into the `info:` footer like `atDefault` — never drift, never recorded by `accept`.

Recognition is a physical-id-templated table, equality-gated exactly like `KNOWN_DEFAULTS`:

```ts
GENERATED_DEFAULTS = {
  'AWS::SNS::Topic': { TopicName: '${PHYSICAL_NAME}' },
  'AWS::Lambda::Function': {
    LoggingConfig: { LogFormat: 'Text', LogGroup: '/aws/lambda/${PHYSICAL_NAME}' },
  },
}
```

`${PHYSICAL_NAME}` is the trailing name segment of the physical id (the bare name for an ARN physical id). An out-of-band edit (a `LogFormat: JSON`, a different name) no longer matches the substituted template and falls through to a real `undeclared` finding.

**Effect:** the `[UNRECORDED]` headline drops to the values that genuinely look like edits — `7 → 2` on the example stack, and `0` when nothing was changed. The auto-generated values are still surfaced honestly as `info: generated=N (...)`, just not as headline inventory.

## Scope / safety

- `accept` never records `generated` (it is not `undeclared`/`atDefault`); verdict/exit unaffected (not a `DRIFT_TIER`); `revert` never touches it.
- Excluded from `--pre-deploy` / `--declared-only` alongside `undeclared` (it is an undeclared-side classification).
- Equality-gated and physical-id-anchored — conservative, mirrors the `KNOWN_DEFAULTS`/`atDefault` ethos.

## Tests

- `tests/classify.test.ts`: SNS TopicName (ARN-segment), Lambda LoggingConfig (name-derived log group), the out-of-band-edit-falls-through-to-undeclared case, no-physical-id, and declared-side-wins.
- `tests/report.test.ts`: folds into `info: generated=N (...)`, `--verbose` expands it.
- Corpus fixtures: 11 real recorded SNS `TopicName` / Lambda `LoggingConfig` cases now classify as `generated` (verified the only diff is the `undeclared → generated` flip — no other findings moved).

## Follow-ups (not in this PR)

- First-run "baseline setup" framing of the no-baseline output (the ② of the discussion) — separate PR.
- Nested generated values and a confidence-tiered presentation for the imperfect recognition tail.
