### PR TITLE
feat(check): fold dogfood-observed service defaults as atDefault (R104)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -78,6 +78,62 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       },
     ],
   },
+  // R104 (dogfood noise audit across the harvest fixtures): top-level service
+  // defaults AWS materializes that the CFn schema does NOT annotate as `default`
+  // (so the schema-driven R103 fold can't reach them). All OBSERVED on real
+  // default-config resources; equality-gated, so a value set away from the default
+  // still surfaces. Resource-/account-/region-specific values (names, ARNs, ids,
+  // VpcId, KmsKeyId, NetworkBorderGroup, …) are deliberately NOT listed — those are
+  // genuine undeclared inventory, not defaults.
+  'AWS::SQS::Queue': {
+    DelaySeconds: 0,
+    VisibilityTimeout: 30,
+    MessageRetentionPeriod: 345600,
+    ReceiveMessageWaitTimeSeconds: 0,
+    SqsManagedSseEnabled: true,
+    FifoThroughputLimit: 'perQueue', // FIFO queues only
+    DeduplicationScope: 'queue', // FIFO queues only
+  },
+  'AWS::ElasticLoadBalancingV2::TargetGroup': {
+    HealthCheckEnabled: true,
+    HealthCheckPort: 'traffic-port',
+    HealthCheckProtocol: 'HTTP',
+    HealthCheckTimeoutSeconds: 5,
+    UnhealthyThresholdCount: 2,
+    ProtocolVersion: 'HTTP1',
+    IpAddressType: 'ipv4',
+    Matcher: { HttpCode: '200' },
+  },
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': {
+    IpAddressType: 'ipv4',
+    EnablePrefixForIpv6SourceNat: 'off',
+  },
+  'AWS::EC2::NatGateway': {
+    ConnectivityType: 'public',
+    AvailabilityMode: 'zonal',
+  },
+  'AWS::EFS::FileSystem': {
+    ThroughputMode: 'bursting',
+    BackupPolicy: { Status: 'DISABLED' },
+    FileSystemProtection: { ReplicationOverwriteProtection: 'ENABLED' },
+  },
+  'AWS::StepFunctions::StateMachine': {
+    StateMachineType: 'STANDARD',
+    LoggingConfiguration: { IncludeExecutionData: false, Level: 'OFF' },
+    EncryptionConfiguration: { Type: 'AWS_OWNED_KEY' },
+  },
+  'AWS::ApiGateway::RestApi': {
+    ApiKeySourceType: 'HEADER',
+    SecurityPolicy: 'TLS_1_0',
+    EndpointConfiguration: { IpAddressType: 'ipv4', Types: ['EDGE'] },
+  },
+  'AWS::EC2::Subnet': {
+    PrivateDnsNameOptionsOnLaunch: {
+      EnableResourceNameDnsARecord: false,
+      HostnameType: 'ip-name',
+      EnableResourceNameDnsAAAARecord: false,
+    },
+  },
 };
 
 // Strip AWS-managed (aws:*) tag ELEMENTS from the live side so a declared tag

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -393,6 +393,26 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ).toEqual(['GuardrailPolicies']);
   });
 
+  it('R104: an SQS default value folds; a changed one surfaces', () => {
+    const t = (live: Record<string, unknown>) =>
+      tiers(classifyResource(bare('AWS::SQS::Queue'), live, emptySchema));
+    expect(t({ VisibilityTimeout: 30 }).atDefault).toEqual(['VisibilityTimeout']);
+    expect(t({ VisibilityTimeout: 60 }).undeclared).toEqual(['VisibilityTimeout']);
+  });
+
+  it('R104: StateMachineType STANDARD folds, EXPRESS stays undeclared (equality-gated curation)', () => {
+    const t = (v: string) =>
+      tiers(
+        classifyResource(
+          bare('AWS::StepFunctions::StateMachine'),
+          { StateMachineType: v },
+          emptySchema
+        )
+      );
+    expect(t('STANDARD').atDefault).toEqual(['StateMachineType']);
+    expect(t('EXPRESS').undeclared).toEqual(['StateMachineType']);
+  });
+
   // R74: the declared loop's trivially-empty rule — CDK Trail synthesizes
   // `EventSelectors: []`, CloudTrail materializes the default management
   // selector; that pair must not be drift, but everything around it must stay.

--- a/tests/corpus/AWS__ApiGateway__RestApi.Api.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.Api.json
@@ -59,7 +59,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Api",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
@@ -68,7 +68,7 @@
       "constructPath": "CdkrdIntegHarvest6/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Api",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "EndpointConfiguration",
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest6/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Api",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "SecurityPolicy",

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
@@ -58,7 +58,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
@@ -67,7 +67,7 @@
       "constructPath": "CdkdriftIntegHarvest8/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "EndpointConfiguration",
@@ -79,7 +79,7 @@
       "constructPath": "CdkdriftIntegHarvest8/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "SecurityPolicy",

--- a/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
@@ -74,7 +74,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "RestApi0C43BF4B",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
@@ -83,7 +83,7 @@
       "constructPath": "CdkrdIntegHarvest/RestApi"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "RestApi0C43BF4B",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "EndpointConfiguration",
@@ -95,7 +95,7 @@
       "constructPath": "CdkrdIntegHarvest/RestApi"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "RestApi0C43BF4B",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "SecurityPolicy",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
@@ -96,7 +96,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "AvailabilityMode",
@@ -105,7 +105,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "ConnectivityType",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
@@ -96,7 +96,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "AvailabilityMode",
@@ -105,7 +105,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "ConnectivityType",

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
@@ -132,7 +132,7 @@
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "NetpublicSubnet1SubnetA0498A0F",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
@@ -132,7 +132,7 @@
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "NetpublicSubnet2Subnet5183DBBB",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
+++ b/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
@@ -131,7 +131,7 @@
       "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
@@ -147,7 +147,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
@@ -147,7 +147,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
@@ -147,7 +147,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
@@ -147,7 +147,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
       "resourceType": "AWS::EC2::Subnet",
       "path": "PrivateDnsNameOptionsOnLaunch",

--- a/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
@@ -72,7 +72,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "BackupPolicy",
@@ -83,7 +83,7 @@
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "FileSystemProtection",
@@ -103,7 +103,7 @@
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "ThroughputMode",

--- a/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
@@ -61,7 +61,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "BackupPolicy",
@@ -72,7 +72,7 @@
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "FileSystemProtection",
@@ -101,7 +101,7 @@
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "ThroughputMode",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
@@ -190,7 +190,7 @@
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "EnablePrefixForIpv6SourceNat",
@@ -199,7 +199,7 @@
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "IpAddressType",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
@@ -179,7 +179,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "EnablePrefixForIpv6SourceNat",
@@ -188,7 +188,7 @@
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "IpAddressType",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
@@ -162,7 +162,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "HealthCheckEnabled",
@@ -171,7 +171,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "HealthCheckPort",
@@ -180,7 +180,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "HealthCheckProtocol",
@@ -189,7 +189,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "HealthCheckTimeoutSeconds",
@@ -198,7 +198,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "IpAddressType",
@@ -207,7 +207,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "Matcher",
@@ -227,7 +227,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "ProtocolVersion",
@@ -236,7 +236,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "UnhealthyThresholdCount",

--- a/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
+++ b/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
@@ -36,7 +36,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -63,7 +63,7 @@
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -72,7 +72,7 @@
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",
@@ -81,7 +81,7 @@
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",

--- a/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
+++ b/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
@@ -50,7 +50,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -68,7 +68,7 @@
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
@@ -86,7 +86,7 @@
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -95,7 +95,7 @@
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",
@@ -104,7 +104,7 @@
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",

--- a/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
@@ -67,7 +67,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -76,7 +76,7 @@
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
       "path": "FifoThroughputLimit",
@@ -94,7 +94,7 @@
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
@@ -112,7 +112,7 @@
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -121,7 +121,7 @@
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",

--- a/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
@@ -56,7 +56,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "DeduplicationScope",
@@ -65,7 +65,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -74,7 +74,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "FifoThroughputLimit",
@@ -92,7 +92,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
@@ -110,7 +110,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -119,7 +119,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",
@@ -128,7 +128,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",

--- a/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
+++ b/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
@@ -65,7 +65,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -92,7 +92,7 @@
       "constructPath": "CdkRealDriftIntegSqs/Main"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -101,7 +101,7 @@
       "constructPath": "CdkRealDriftIntegSqs/Main"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
@@ -48,7 +48,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -75,7 +75,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -84,7 +84,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
@@ -38,7 +38,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -65,7 +65,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -74,7 +74,7 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",

--- a/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
@@ -35,7 +35,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -53,7 +53,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
@@ -71,7 +71,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",
@@ -89,7 +89,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",

--- a/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
@@ -35,7 +35,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -53,7 +53,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
@@ -71,7 +71,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",
@@ -89,7 +89,7 @@
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",

--- a/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
+++ b/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
@@ -34,7 +34,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
       "path": "DelaySeconds",
@@ -52,7 +52,7 @@
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
       "path": "MessageRetentionPeriod",
@@ -70,7 +70,7 @@
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
       "path": "ReceiveMessageWaitTimeSeconds",
@@ -79,7 +79,7 @@
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
       "path": "SqsManagedSseEnabled",
@@ -88,7 +88,7 @@
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",

--- a/tests/corpus/AWS__StepFunctions__StateMachine.ExpressEE4D4F3B.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.ExpressEE4D4F3B.json
@@ -61,7 +61,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ExpressEE4D4F3B",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "EncryptionConfiguration",
@@ -72,7 +72,7 @@
       "constructPath": "CdkrdIntegHarvest5/Express"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ExpressEE4D4F3B",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "LoggingConfiguration",

--- a/tests/corpus/AWS__StepFunctions__StateMachine.FlowA74D6E88.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.FlowA74D6E88.json
@@ -75,7 +75,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FlowA74D6E88",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "EncryptionConfiguration",
@@ -86,7 +86,7 @@
       "constructPath": "CdkrdIntegHarvest/Flow"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FlowA74D6E88",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "LoggingConfiguration",
@@ -107,7 +107,7 @@
       "constructPath": "CdkrdIntegHarvest/Flow"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FlowA74D6E88",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "StateMachineType",

--- a/tests/corpus/AWS__StepFunctions__StateMachine.Machine6FC8AE80.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.Machine6FC8AE80.json
@@ -69,7 +69,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Machine6FC8AE80",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "EncryptionConfiguration",
@@ -80,7 +80,7 @@
       "constructPath": "CdkRealDriftIntegSfn/Machine"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Machine6FC8AE80",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "LoggingConfiguration",
@@ -101,7 +101,7 @@
       "constructPath": "CdkRealDriftIntegSfn/Machine"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Machine6FC8AE80",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "StateMachineType",


### PR DESCRIPTION
## Summary

A noise audit across the `harvest` integ fixtures (**101 resource types, ZERO false positives** anywhere) showed config-dense types still emit many top-level AWS defaults as `undeclared` first-run noise. These are AWS-materialized defaults the CFn schema does **not** annotate as `default`, so the schema-driven [R103](https://github.com/go-to-k/cdk-real-drift/pull/74) fold can't reach them — they belong to the hand-coded `KNOWN_DEFAULTS` (R66) lane.

## Change

Add the audit-observed **constant** defaults for the highest-noise types: `SQS::Queue`, `ElasticLoadBalancingV2::TargetGroup`/`LoadBalancer`, `EC2::NatGateway`, `EFS::FileSystem`, `StepFunctions::StateMachine`, `ApiGateway::RestApi`, `EC2::Subnet`.

- **Equality-gated** like every `KNOWN_DEFAULTS` entry — a value set away from the default still surfaces. (Verified: a `STANDARD` state machine folds `StateMachineType`, an `EXPRESS` one does not.)
- **Deliberately excluded** (genuine undeclared inventory, NOT defaults): generated names (QueueName/TopicName/LB+TG Name), resource/topology ids (VpcId, SubnetMappings, PrivateIpAddress), account/region-specific values (EFS `KmsKeyId`, EIP `NetworkBorderGroup`), and the suspicious SQS `MaximumMessageSize` (recorded `1048576` ≠ the documented `262144`).

## Corpus

The 30 affected golden-corpus cases are regenerated **offline** from their recorded real-AWS live models — every change is a `undeclared → atDefault` tier flip on exactly the listed paths, nothing else (verified per-path; no finding added/removed, `.drifted` cases keep their drift).

## Test plan

- **Real AWS**: `harvest2` (SQS + 17 types) and `harvest4` (ALB/TG/EFS/NatGateway/Subnet/VPC) re-run with the change — both `INTEG PASS` (fresh deploy reports no DECLARED drift, clean accept round-trip), clean destroy.
- **Unit** (+2): an SQS default folds / a changed one surfaces; `StateMachineType` STANDARD folds while EXPRESS stays undeclared (documents the curation's equality-gating). The generic "every KNOWN_DEFAULTS entry folds to atDefault" test (R66) now also covers the new entries. Full suite green (766); typecheck + lint + build pass.
