### PR TITLE
feat(check): reframe the first-run prompt as baseline setup; count only standout edits (R105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,21 @@ UNRECORDED values (they are not drift — there is nothing to compare them to
 yet):
 
 ```console
-ApiStack: no baseline yet — found 42 live value(s) not declared in your
-template (40 sit at a known AWS default (folded below); 2 look like real
-out-of-band edits). Declared-side drift is reported either way. What do you
-want to do?
+ApiStack: no baseline yet — this first run SETS UP your baseline (without one,
+check can't tell deploy-state from a later drift). Found 42 live value(s) not
+declared in your template: 2 stand out as possible out-of-band edits, the other
+40 fold as AWS defaults / auto-generated / nested sub-keys. Declared-side drift
+is reported either way. Accept records the current state (2 value(s)) as your
+baseline — from the next run, check reports only what changes. What do you want
+to do?
   ❯ Accept ALL 2 into the baseline now, without reviewing them
     Show them first — you can still accept (selectively) right after the report
 ```
 
-The count is the **complete** undeclared inventory, but the report lists only the
-handful that actually diverge — defaults you never touched fold into a single
-`info: atDefault=40 (…)` line (`--show-all` expands it). Accept writes
+The count is the **complete** undeclared inventory, but only the handful that
+**stand out** are listed — AWS defaults, auto-generated names/identifiers, and
+nested sub-keys you never touched fold into the `info:` footer (`atDefault=` /
+`generated=` / `nested=`, `--show-all` expands them). Accept writes
 `.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing written to
 AWS** — commit it; from here on `check` reports CLEAN until reality changes.
 (Declared drift is detected from the very first run, baseline or not.)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -54,47 +54,66 @@ export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
   );
 }
 
-// The first-run (no-baseline) prompt (R45). The old Yes/No confirm hid the two
-// facts the decision hinges on: HOW MANY values "Yes" would accept sight-unseen,
-// and that "No" is not a dead end (the report prints first and a selective
-// accept is offered right after it). A select carries both in the option labels
-// themselves; Accept-ALL is first/default since R52 (see the options comment).
-// Exported (pure) so the wording contract is unit-tested.
+// The first-run (no-baseline) prompt (R45, reframed R105). The decision the user
+// is making is "record the current reality as my baseline?" — NOT "fix N problems".
+// Two facts the choice hinges on: how many values Accept-ALL records sight-unseen,
+// and that "Show first" is not a dead end (the report prints and a selective accept
+// follows). Accept-ALL is first/default since R52. Exported (pure) so the wording
+// contract is unit-tested.
 //
-// Wording (R49): "undeclared" must be anchored — it means "not declared in YOUR
-// deployed (CDK/CloudFormation) template"; there is no cdkrd-side template, and
-// the baseline only filters which of these get REPORTED. The count is also NOT
-// a drift count: on a first run these are typically AWS defaults the template
-// never pinned (with any real out-of-band edits hiding among them), so the
-// message says so instead of reading as "N problems found".
+// Wording (R49): "undeclared" is anchored to YOUR deployed (CDK/CloudFormation)
+// template; there is no cdkrd-side template, the baseline only filters what gets
+// REPORTED. The count is NOT a drift verdict.
 //
-// declaredDriftCount (R51): a user whose out-of-band edit hit a DECLARED
-// property sees a prompt that only talks about NOT-declared values and reads it
-// as "the tool missed my change". When declared-side drift exists (declared or
-// deleted tier — both are reported regardless of the baseline decision), say so
-// explicitly instead of the generic "either way" clause.
+// STANDOUT vs FOLDED (R105): the live model carries far more not-declared values
+// than the user ever edited — AWS defaults (atDefault), auto-generated identifiers
+// (generated, R104), and nested sub-keys (nested, R96) all FOLD in the report;
+// only the top-level diverging values (`standout`) list as [UNRECORDED]. The old
+// prompt called the whole recordable set "real out-of-band edits", which counted
+// the 50+ folded nested values as edits — overstating wildly (the bug that
+// confused the first-run user). Now the prompt names `standout` as what stands
+// out, states the folded remainder separately, and frames the run as baseline
+// SETUP rather than a findings list.
+//
+// declaredDrift (R51): declared-side drift (declared/deleted tier) is reported
+// regardless of the baseline choice; when present, say so explicitly.
+export interface FirstRunCounts {
+  standout: number; // top-level undeclared — listed in [UNRECORDED]; the values that stand out
+  nested?: number; // nested undeclared — folded in the report, but recorded by accept
+  atDefault?: number; // undeclared at a known AWS default — folded, never recorded
+  generated?: number; // AWS/CDK auto-generated identifier — folded, never recorded
+  declaredDrift?: number; // declared/deleted drift — reported either way
+}
 export function firstRunPrompt(
   stackName: string,
-  recordableCount: number,
-  atDefaultCount = 0,
-  declaredDriftCount = 0
+  counts: FirstRunCounts
 ): { message: string; options: { value: 'show' | 'acceptAll'; label: string }[] } {
+  const { standout, nested = 0, atDefault = 0, generated = 0, declaredDrift = 0 } = counts;
+  const recordable = standout + nested; // what Accept records (atDefault/generated never are)
+  const folded = nested + atDefault + generated; // not listed in the report by default
+  const total = standout + folded;
   const declaredNote =
-    declaredDriftCount > 0
-      ? `Also found ${declaredDriftCount} declared-side drift(s) — reported below whichever you choose.`
+    declaredDrift > 0
+      ? `Also found ${declaredDrift} declared-side drift(s) — reported below whichever you choose.`
       : 'Declared-side drift is reported either way.';
-  // The "found N" count is the COMPLETE undeclared inventory (R86): the values that
-  // actually diverge PLUS the ones sitting at a known AWS default. The at-default
-  // remainder is folded in the report, so name it here too instead of letting the
-  // user wonder why "found 113" but only a couple are listed. Accept records only the
-  // recordable (diverging) ones — at-default values are held by the equality gate.
-  const total = recordableCount + atDefaultCount;
-  const split =
-    atDefaultCount > 0
-      ? `${atDefaultCount} sit at a known AWS default (folded below); ${recordableCount} look like real out-of-band edits`
-      : 'typically AWS defaults, but out-of-band edits hide among them';
+  // The "stand out" number is the one the user should react to — it matches the
+  // [UNRECORDED: N] section. The folded remainder is named so "found N" never reads
+  // as "N problems found".
+  const standoutClause =
+    standout > 0
+      ? `${standout} stand out as possible out-of-band edits`
+      : 'none stand out as out-of-band edits';
+  const foldedClause =
+    folded > 0
+      ? `, the other ${folded} fold as AWS defaults / auto-generated / nested sub-keys`
+      : '';
   return {
-    message: `${stackName}: no baseline yet — found ${total} live value(s) not declared in your template (${split}). ${declaredNote} What do you want to do?`,
+    message:
+      `${stackName}: no baseline yet — this first run SETS UP your baseline ` +
+      `(without one, check can't tell deploy-state from a later drift). Found ${total} ` +
+      `live value(s) not declared in your template: ${standoutClause}${foldedClause}. ` +
+      `${declaredNote} Accept records the current state (${recordable} value(s)) as your ` +
+      `baseline — from the next run, check reports only what changes. What do you want to do?`,
     // Accept-ALL first (R52, user decision): it is the overwhelmingly common
     // first-run choice, and the cost of an accidental Enter is one git-tracked
     // file — reviewable and revertible, nothing written to AWS. "Show first"
@@ -102,7 +121,7 @@ export function firstRunPrompt(
     options: [
       {
         value: 'acceptAll',
-        label: `Accept ALL ${recordableCount} into the baseline now, without reviewing them`,
+        label: `Accept ALL ${recordable} into the baseline now, without reviewing them`,
       },
       {
         value: 'show',
@@ -272,22 +291,27 @@ export async function runCheck(args: string[]): Promise<number> {
       // no prompt (`cdkrd accept` still writes a baseline for a clean stack).
       if (!baseline && !a.showAll && !a.json && !a.fail && isInteractive()) {
         const acceptable = applyIgnores(findings, stackName, config);
-        // recordable = real diverging undeclared values (what accept records); the
-        // atDefault tier is folded inventory, never recorded (R86). Prompt only when
+        // recordable = undeclared values accept would record (top-level + nested).
+        // atDefault/generated are folded inventory, never recorded. Prompt only when
         // there is something to record — a stack whose only undeclared values are at
-        // their AWS default is reported (CLEAN + folded info), not interrupted.
-        const recordableCount = acceptable.filter((f) => f.tier === 'undeclared').length;
-        const atDefaultCount = acceptable.filter((f) => f.tier === 'atDefault').length;
+        // an AWS default / auto-generated is reported (CLEAN + folded info), not
+        // interrupted. The prompt splits `standout` (top-level, listed) from `nested`
+        // (folded) so it never calls the 50+ folded nested values "edits" (R105).
+        const undeclared = acceptable.filter((f) => f.tier === 'undeclared');
+        const standoutCount = undeclared.filter((f) => !f.nested).length;
+        const nestedCount = undeclared.length - standoutCount;
+        const recordableCount = undeclared.length;
         const declaredDriftCount = acceptable.filter(
           (f) => f.tier === 'declared' || f.tier === 'deleted'
         ).length;
         if (recordableCount > 0) {
-          const prompt = firstRunPrompt(
-            stackName,
-            recordableCount,
-            atDefaultCount,
-            declaredDriftCount
-          );
+          const prompt = firstRunPrompt(stackName, {
+            standout: standoutCount,
+            nested: nestedCount,
+            atDefault: acceptable.filter((f) => f.tier === 'atDefault').length,
+            generated: acceptable.filter((f) => f.tier === 'generated').length,
+            declaredDrift: declaredDriftCount,
+          });
           const choice = await select({
             message: prompt.message,
             options: prompt.options,

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -51,59 +51,81 @@ describe('undeclaredOnlyFindings (R59 — pair-with-cdk-drift scope)', () => {
   });
 });
 
-describe('firstRunPrompt (R45 — the no-baseline decision must be informed)', () => {
-  it('the message anchors "undeclared" to the template and does not read as a drift count (R49)', () => {
-    const { message } = firstRunPrompt('ApiStack', 113);
+describe('firstRunPrompt (R45/R105 — the no-baseline decision must be informed, framed as baseline setup)', () => {
+  it('frames the run as baseline SETUP and does not read as a drift count (R49/R105)', () => {
+    const { message } = firstRunPrompt('ApiStack', { standout: 113 });
     expect(message).toContain('ApiStack: no baseline yet');
-    expect(message).toContain('found 113 live value(s) not declared in your template');
-    expect(message).toContain('typically AWS defaults'); // first-run framing, not "113 problems"
+    expect(message).toContain('this first run SETS UP your baseline');
+    expect(message).toContain('Found 113 live value(s) not declared in your template');
+    expect(message).toContain('113 stand out as possible out-of-band edits');
     expect(message).toContain('Declared-side drift is reported either way');
     expect(message).not.toContain('drift(s) found'); // it must never read as a drift verdict
   });
 
   it('declared-side drift present → the prompt says it was FOUND, with its count (R51)', () => {
-    const { message } = firstRunPrompt('ApiStack', 113, 0, 3);
+    const { message } = firstRunPrompt('ApiStack', { standout: 113, declaredDrift: 3 });
     expect(message).toContain(
       'Also found 3 declared-side drift(s) — reported below whichever you choose.'
     );
     expect(message).not.toContain('either way'); // the generic clause is replaced, not appended
   });
 
-  it('the "found N" count is the COMPLETE inventory; at-default values are named + folded, Accept ALL records only the diverging ones (R86)', () => {
-    const { message, options } = firstRunPrompt('ApiStack', 7, 152);
-    // total = recordable + atDefault, the user-meaningful "everything not in your template"
-    expect(message).toContain('found 159 live value(s) not declared in your template');
-    expect(message).toContain('152 sit at a known AWS default (folded below)');
-    expect(message).toContain('7 look like real out-of-band edits');
-    expect(message).not.toContain('typically AWS defaults'); // the generic clause is replaced when we know the split
-    // accept records the diverging ones only — the at-default remainder is held by the equality gate
+  it('the "found N" total is the COMPLETE inventory; only STANDOUT is called an edit, folded remainder named separately (R86/R104/R105)', () => {
+    // 7 top-level edits + 50 nested (folded) + 152 atDefault + 5 generated = 214 not-declared
+    const { message, options } = firstRunPrompt('ApiStack', {
+      standout: 7,
+      nested: 50,
+      atDefault: 152,
+      generated: 5,
+    });
+    expect(message).toContain('Found 214 live value(s) not declared in your template');
+    // ONLY the 7 top-level values are called edits — the 50 nested are NOT (the R105 fix)
+    expect(message).toContain('7 stand out as possible out-of-band edits');
+    expect(message).toContain(
+      'the other 207 fold as AWS defaults / auto-generated / nested sub-keys'
+    );
+    expect(message).not.toContain('57 stand out'); // nested must NOT be counted as edits
+    // accept records standout + nested (atDefault/generated never) = 57
     const bulk = options.find((o) => o.value === 'acceptAll')!;
-    expect(bulk.label).toContain('Accept ALL 7');
+    expect(bulk.label).toContain('Accept ALL 57');
+    expect(message).toContain('Accept records the current state (57 value(s)) as your baseline');
+  });
+
+  it('zero standout (only nested/folded) → says nothing stands out, still offers the baseline (R105)', () => {
+    const { message, options } = firstRunPrompt('ApiStack', {
+      standout: 0,
+      nested: 50,
+      generated: 5,
+    });
+    expect(message).toContain('none stand out as out-of-band edits');
+    expect(message).toContain('Found 55 live value(s) not declared');
+    // accept still records the 50 nested (generated is not recorded)
+    expect(options.find((o) => o.value === 'acceptAll')!.label).toContain('Accept ALL 50');
   });
 
   it('no declared-side drift → the generic either-way clause (R51)', () => {
-    const { message } = firstRunPrompt('ApiStack', 113, 0);
+    const { message } = firstRunPrompt('ApiStack', { standout: 113 });
     expect(message).toContain('Declared-side drift is reported either way.');
     expect(message).not.toContain('Also found');
   });
 
   it('"Accept ALL" is the FIRST option (the common first-run choice — R52); show-first follows', () => {
-    const { options } = firstRunPrompt('S', 5);
+    const { options } = firstRunPrompt('S', { standout: 5 });
     expect(options[0]!.value).toBe('acceptAll');
     expect(options[1]!.value).toBe('show');
     expect(options[1]!.label).toContain('Show them first');
     expect(options[1]!.label).toContain('accept (selectively) right after');
   });
 
-  it('the bulk option states the count and that values have NOT been reviewed', () => {
-    const { options } = firstRunPrompt('S', 113);
+  it('the bulk option states the recordable count and that values have NOT been reviewed', () => {
+    const { options } = firstRunPrompt('S', { standout: 113 });
     const bulk = options.find((o) => o.value === 'acceptAll')!;
     expect(bulk.label).toContain('Accept ALL 113');
     expect(bulk.label).toContain('without reviewing them');
   });
 
   it('prompts speak the command vocabulary (accept) — no retired jargon', () => {
-    const p = firstRunPrompt('S', 3);
+    const p = firstRunPrompt('S', { standout: 3 });
     const all = [p.message, ...p.options.map((o) => o.label)].join(' ');
     // the retired word is assembled at runtime so this file itself stays free of it (R46)
     expect(all.toLowerCase()).not.toContain(['b', 'less'].join(''));


### PR DESCRIPTION
## What & why

The no-baseline **first-run prompt** called the entire recordable set "real out-of-band edits". That set is top-level undeclared **plus** the 50+ nested sub-keys that fold in the report and are mostly AWS-materialized values the user never touched. So a stack with 2 genuine edits announced "**57 look like real out-of-band edits**" — burying the signal. This is the exact confusion a first-run user hit (the same session that produced R104).

This is the ② follow-up to R104: with auto-generated values now folded as `generated`, the remaining first-run noise was the *prompt wording* itself.

## Change

`firstRunPrompt` now takes a counts object and separates:
- **standout** = top-level undeclared (the values listed as `[UNRECORDED: N]`) — the only ones described as "stand out as possible out-of-band edits"
- **nested / atDefault / generated** = folded inventory, named as the folded remainder

And the message is reframed as **baseline setup** rather than a findings list.

Rendered with the real ai-api counts (verified live, read-only):

```
# original scenario (2 manual edits + 5 generated + 50 nested + 175 atDefault)
BEFORE: ...found 232 ... (175 sit at a known AWS default (folded below);
        57 look like real out-of-band edits)...
AFTER:  ...this first run SETS UP your baseline... Found 232 live value(s) not
        declared in your template: 2 stand out as possible out-of-band edits,
        the other 230 fold as AWS defaults / auto-generated / nested sub-keys.
        ... Accept records the current state (52 value(s)) as your baseline —
        from the next run, check reports only what changes.

# current state (edits reverted)
AFTER:  ...Found 230 ... none stand out as out-of-band edits, the other 230
        fold ... Accept records the current state (50 value(s)) ...
```

## Notes

- Behavior unchanged: the prompt still fires only when there is recordable inventory; Accept-ALL still records `standout + nested` (atDefault/generated are never recorded).
- The prompt is TTY-only (clack `select`), so it was verified by unit tests at the real-data counts rather than driven non-interactively against the user's repo (an accidental Enter would write a baseline file).

## Tests

`tests/check.test.ts` rewritten to the object signature: asserts the baseline-setup framing, that nested is **not** counted as an edit, the folded-remainder clause, and a zero-standout case. 773 unit tests pass; typecheck / lint / build green.
