### PR TITLE
feat(check): fold more dogfood-observed service defaults as atDefault (R105)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -134,6 +134,38 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       EnableResourceNameDnsAAAARecord: false,
     },
   },
+  // R105 (second dogfood-audit wave): more top-level constant service defaults
+  // (same exclusions as R104 — no names/ids/ARNs, no region-/account-specific
+  // values, no large/evolving config blobs like Athena WorkGroupConfiguration).
+  'AWS::ApiGatewayV2::Api': {
+    RouteSelectionExpression: '$request.method $request.path',
+  },
+  'AWS::ApiGatewayV2::Integration': {
+    ConnectionType: 'INTERNET',
+    TimeoutInMillis: 30000,
+  },
+  'AWS::CodeBuild::Project': {
+    TimeoutInMinutes: 60,
+    QueuedTimeoutInMinutes: 480,
+  },
+  'AWS::DynamoDB::Table': {
+    BillingMode: 'PROVISIONED',
+  },
+  'AWS::ECR::Repository': {
+    EncryptionConfiguration: { EncryptionType: 'AES256' },
+  },
+  'AWS::Kinesis::Stream': {
+    MaxRecordSizeInKiB: 1024,
+  },
+  'AWS::SSM::Parameter': {
+    DataType: 'text',
+  },
+  'AWS::StepFunctions::Activity': {
+    EncryptionConfiguration: { Type: 'AWS_OWNED_KEY' },
+  },
+  'AWS::SNS::Subscription': {
+    FilterPolicyScope: 'MessageAttributes',
+  },
 };
 
 // AWS/CDK auto-GENERATED values keyed by the resource's CFn-assigned physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -414,6 +414,13 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t('EXPRESS').undeclared).toEqual(['StateMachineType']);
   });
 
+  it('R105: DynamoDB BillingMode PROVISIONED folds, PAY_PER_REQUEST surfaces', () => {
+    const t = (v: string) =>
+      tiers(classifyResource(bare('AWS::DynamoDB::Table'), { BillingMode: v }, emptySchema));
+    expect(t('PROVISIONED').atDefault).toEqual(['BillingMode']);
+    expect(t('PAY_PER_REQUEST').undeclared).toEqual(['BillingMode']);
+  });
+
   // R74: the declared loop's trivially-empty rule — CDK Trail synthesizes
   // `EventSelectors: []`, CloudTrail materializes the default management
   // selector; that pair must not be drift, but everything around it must stay.

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
@@ -72,7 +72,7 @@
       "constructPath": "CdkrdIntegHarvest4/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGatewayV2::Api",
       "path": "RouteSelectionExpression",

--- a/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
@@ -87,7 +87,7 @@
       "constructPath": "CdkrdIntegHarvest/HttpApi"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HttpApi",
       "resourceType": "AWS::ApiGatewayV2::Api",
       "path": "RouteSelectionExpression",

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
@@ -41,7 +41,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiANYpingPingA3011524",
       "resourceType": "AWS::ApiGatewayV2::Integration",
       "path": "ConnectionType",
@@ -59,7 +59,7 @@
       "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiANYpingPingA3011524",
       "resourceType": "AWS::ApiGatewayV2::Integration",
       "path": "TimeoutInMillis",

--- a/tests/corpus/AWS__CodeBuild__Project.Build.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build.json
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest6/Build"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
       "path": "QueuedTimeoutInMinutes",
@@ -89,7 +89,7 @@
       "constructPath": "CdkrdIntegHarvest6/Build"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
       "path": "TimeoutInMinutes",

--- a/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
+++ b/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
@@ -81,7 +81,7 @@
       "constructPath": "CdkrdIntegHarvest/Images"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Images2D38C313",
       "resourceType": "AWS::ECR::Repository",
       "path": "EncryptionConfiguration",

--- a/tests/corpus/AWS__Kinesis__Stream.EventsD32975C2.json
+++ b/tests/corpus/AWS__Kinesis__Stream.EventsD32975C2.json
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest2/Events"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EventsD32975C2",
       "resourceType": "AWS::Kinesis::Stream",
       "path": "MaxRecordSizeInKiB",

--- a/tests/corpus/AWS__SNS__Subscription.InboxCdkrdIntegHarvest2Alerts473B90C08943AC11.json
+++ b/tests/corpus/AWS__SNS__Subscription.InboxCdkrdIntegHarvest2Alerts473B90C08943AC11.json
@@ -58,7 +58,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "InboxCdkrdIntegHarvest2Alerts473B90C08943AC11",
       "resourceType": "AWS::SNS::Subscription",
       "path": "FilterPolicyScope",

--- a/tests/corpus/AWS__SSM__Parameter.FlagC3248847.json
+++ b/tests/corpus/AWS__SSM__Parameter.FlagC3248847.json
@@ -53,7 +53,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FlagC3248847",
       "resourceType": "AWS::SSM::Parameter",
       "path": "DataType",

--- a/tests/corpus/AWS__SSM__Parameter.Param165332EC.json
+++ b/tests/corpus/AWS__SSM__Parameter.Param165332EC.json
@@ -49,7 +49,7 @@
       "constructPath": "CdkrdIntegHarvest5/Param"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Param165332EC",
       "resourceType": "AWS::SSM::Parameter",
       "path": "DataType",

--- a/tests/corpus/AWS__StepFunctions__Activity.Act869B7EB7.json
+++ b/tests/corpus/AWS__StepFunctions__Activity.Act869B7EB7.json
@@ -62,7 +62,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Act869B7EB7",
       "resourceType": "AWS::StepFunctions::Activity",
       "path": "EncryptionConfiguration",


### PR DESCRIPTION
## Summary

Second wave of the pre-release noise audit (follow-up to [R104](https://github.com/go-to-k/cdk-real-drift/pull/76)). Folds the remaining **top-level** constant service defaults the CFn schema does not annotate as `default`, so the report stops showing them as first-run `undeclared` noise.

Types: `ApiGatewayV2::Api`/`Integration`, `CodeBuild::Project`, `DynamoDB::Table` (BillingMode), `ECR::Repository`, `Kinesis::Stream`, `SSM::Parameter`, `StepFunctions::Activity`, `SNS::Subscription`.

- **Equality-gated**: a DynamoDB table set to `PAY_PER_REQUEST` still surfaces; only the `PROVISIONED` default folds (unit-tested).
- **Same exclusions as R104**: no names/ids/ARNs, no region/account-specific values (EIP `NetworkBorderGroup`, ScalingPolicy namespace/dimension), no large/evolving config blobs (Athena `WorkGroupConfiguration`, ELBv2 Listener attributes, WAFv2 DDoS config).
- **Nested** defaults (ApiGateway::Method `Integration.*`, Glue `TableInput.*`, S3 `LifecycleConfiguration.*`, DynamoDB `WarmThroughput`) are **not** folded — `KNOWN_DEFAULTS` is top-level only; folding those would need a nested-defaults mechanism (future work).

## Test plan

- **Corpus**: 10 golden cases regenerated offline from their recorded real-AWS live models — every change is a `undeclared → atDefault` flip on exactly the listed paths (verified per-path; nothing else changed).
- **Real AWS**: `harvest` + `harvest4` re-run with the change — both `INTEG PASS`, clean destroy.
- **Unit**: BillingMode `PROVISIONED` folds / `PAY_PER_REQUEST` surfaces; the generic "every KNOWN_DEFAULTS entry folds to atDefault" test now covers the new entries. Full suite green (775); typecheck + lint + build pass.
