### PR TITLE
feat(check): collapse the first-run prompt to one terse line (R106)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,9 @@ UNRECORDED values (they are not drift — there is nothing to compare them to
 yet):
 
 ```console
-ApiStack: no baseline yet — this first run SETS UP your baseline (without one,
-check can't tell deploy-state from a later drift). Found 42 live value(s) not
-declared in your template: 2 stand out as possible out-of-band edits, the other
-40 fold as AWS defaults / auto-generated / nested sub-keys. Declared-side drift
-is reported either way. Accept records the current state (2 value(s)) as your
-baseline — from the next run, check reports only what changes. What do you want
-to do?
-  ❯ Accept ALL 2 into the baseline now, without reviewing them
-    Show them first — you can still accept (selectively) right after the report
+ApiStack: no baseline yet — 2 value(s) stand out as possible out-of-band edits (40 fold as defaults/generated/nested).
+  ❯ Accept all 2 into the baseline now (no review)
+    Show first, then accept selectively
 ```
 
 The count is the **complete** undeclared inventory, but only the handful that

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -71,12 +71,16 @@ export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
 // only the top-level diverging values (`standout`) list as [UNRECORDED]. The old
 // prompt called the whole recordable set "real out-of-band edits", which counted
 // the 50+ folded nested values as edits — overstating wildly (the bug that
-// confused the first-run user). Now the prompt names `standout` as what stands
-// out, states the folded remainder separately, and frames the run as baseline
-// SETUP rather than a findings list.
+// confused the first-run user). The prompt names `standout` as what stands out
+// and states the folded remainder in one parenthetical.
+//
+// Terse (R106): kept to a SINGLE line — the old multi-sentence framing ("this run
+// SETS UP your baseline … from the next run check reports only what changes") was
+// a wall nobody read. That context now lives in the option labels + the README.
 //
 // declaredDrift (R51): declared-side drift (declared/deleted tier) is reported
-// regardless of the baseline choice; when present, say so explicitly.
+// regardless of the baseline choice; mention it only when present (R106 dropped
+// the generic "reported either way" clause from the common no-declared-drift path).
 export interface FirstRunCounts {
   standout: number; // top-level undeclared — listed in [UNRECORDED]; the values that stand out
   nested?: number; // nested undeclared — folded in the report, but recorded by accept
@@ -91,29 +95,21 @@ export function firstRunPrompt(
   const { standout, nested = 0, atDefault = 0, generated = 0, declaredDrift = 0 } = counts;
   const recordable = standout + nested; // what Accept records (atDefault/generated never are)
   const folded = nested + atDefault + generated; // not listed in the report by default
-  const total = standout + folded;
-  const declaredNote =
-    declaredDrift > 0
-      ? `Also found ${declaredDrift} declared-side drift(s) — reported below whichever you choose.`
-      : 'Declared-side drift is reported either way.';
-  // The "stand out" number is the one the user should react to — it matches the
-  // [UNRECORDED: N] section. The folded remainder is named so "found N" never reads
-  // as "N problems found".
+  // Terse (R106): the old message was a 5-sentence wall the user wouldn't read.
+  // Keep ONE line — the signal (`standout`, matching [UNRECORDED]) + the folded
+  // remainder in a parenthetical; the "what a baseline is / what accept does"
+  // context lives in the option labels and the README, not here.
   const standoutClause =
     standout > 0
-      ? `${standout} stand out as possible out-of-band edits`
-      : 'none stand out as out-of-band edits';
-  const foldedClause =
-    folded > 0
-      ? `, the other ${folded} fold as AWS defaults / auto-generated / nested sub-keys`
-      : '';
+      ? `${standout} value(s) stand out as possible out-of-band edits`
+      : 'nothing stands out as an out-of-band edit';
+  const foldedClause = folded > 0 ? ` (${folded} fold as defaults/generated/nested)` : '';
+  // declared-side drift is reported regardless of the choice; mention it ONLY when
+  // present (the old generic "reported either way" was noise on the common path).
+  const declaredClause =
+    declaredDrift > 0 ? ` — plus ${declaredDrift} declared-side drift(s), reported below` : '';
   return {
-    message:
-      `${stackName}: no baseline yet — this first run SETS UP your baseline ` +
-      `(without one, check can't tell deploy-state from a later drift). Found ${total} ` +
-      `live value(s) not declared in your template: ${standoutClause}${foldedClause}. ` +
-      `${declaredNote} Accept records the current state (${recordable} value(s)) as your ` +
-      `baseline — from the next run, check reports only what changes. What do you want to do?`,
+    message: `${stackName}: no baseline yet — ${standoutClause}${foldedClause}${declaredClause}.`,
     // Accept-ALL first (R52, user decision): it is the overwhelmingly common
     // first-run choice, and the cost of an accidental Enter is one git-tracked
     // file — reviewable and revertible, nothing written to AWS. "Show first"
@@ -121,11 +117,11 @@ export function firstRunPrompt(
     options: [
       {
         value: 'acceptAll',
-        label: `Accept ALL ${recordable} into the baseline now, without reviewing them`,
+        label: `Accept all ${recordable} into the baseline now (no review)`,
       },
       {
         value: 'show',
-        label: 'Show them first — you can still accept (selectively) right after the report',
+        label: 'Show first, then accept selectively',
       },
     ],
   };

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -51,77 +51,68 @@ describe('undeclaredOnlyFindings (R59 — pair-with-cdk-drift scope)', () => {
   });
 });
 
-describe('firstRunPrompt (R45/R105 — the no-baseline decision must be informed, framed as baseline setup)', () => {
-  it('frames the run as baseline SETUP and does not read as a drift count (R49/R105)', () => {
+describe('firstRunPrompt (R45/R105/R106 — informed, but ONE terse line)', () => {
+  it('is a single line: no baseline + the standout signal, no multi-sentence framing (R106)', () => {
     const { message } = firstRunPrompt('ApiStack', { standout: 113 });
     expect(message).toContain('ApiStack: no baseline yet');
-    expect(message).toContain('this first run SETS UP your baseline');
-    expect(message).toContain('Found 113 live value(s) not declared in your template');
-    expect(message).toContain('113 stand out as possible out-of-band edits');
-    expect(message).toContain('Declared-side drift is reported either way');
-    expect(message).not.toContain('drift(s) found'); // it must never read as a drift verdict
+    expect(message).toContain('113 value(s) stand out as possible out-of-band edits');
+    expect(message).not.toContain('SETS UP your baseline'); // the R105 prose wall is gone
+    expect(message).not.toContain('from the next run');
+    expect(message).not.toContain('\n'); // genuinely one line
+    expect(message).not.toContain('drift(s) found'); // never reads as a drift verdict
   });
 
-  it('declared-side drift present → the prompt says it was FOUND, with its count (R51)', () => {
+  it('declared-side drift present → mentioned inline with its count (R51/R106)', () => {
     const { message } = firstRunPrompt('ApiStack', { standout: 113, declaredDrift: 3 });
-    expect(message).toContain(
-      'Also found 3 declared-side drift(s) — reported below whichever you choose.'
-    );
-    expect(message).not.toContain('either way'); // the generic clause is replaced, not appended
+    expect(message).toContain('plus 3 declared-side drift(s), reported below');
   });
 
-  it('the "found N" total is the COMPLETE inventory; only STANDOUT is called an edit, folded remainder named separately (R86/R104/R105)', () => {
-    // 7 top-level edits + 50 nested (folded) + 152 atDefault + 5 generated = 214 not-declared
+  it('no declared-side drift → the declared clause is OMITTED entirely (R106)', () => {
+    const { message } = firstRunPrompt('ApiStack', { standout: 113 });
+    expect(message).not.toContain('declared-side drift');
+    expect(message).not.toContain('either way'); // the old generic clause is dropped
+  });
+
+  it('only STANDOUT is called an edit; the folded remainder is one parenthetical (R86/R104/R105/R106)', () => {
+    // 7 top-level edits + 50 nested (folded) + 152 atDefault + 5 generated → folded 207
     const { message, options } = firstRunPrompt('ApiStack', {
       standout: 7,
       nested: 50,
       atDefault: 152,
       generated: 5,
     });
-    expect(message).toContain('Found 214 live value(s) not declared in your template');
-    // ONLY the 7 top-level values are called edits — the 50 nested are NOT (the R105 fix)
-    expect(message).toContain('7 stand out as possible out-of-band edits');
-    expect(message).toContain(
-      'the other 207 fold as AWS defaults / auto-generated / nested sub-keys'
-    );
-    expect(message).not.toContain('57 stand out'); // nested must NOT be counted as edits
+    expect(message).toContain('7 value(s) stand out as possible out-of-band edits');
+    expect(message).toContain('(207 fold as defaults/generated/nested)');
+    expect(message).not.toContain('57 value(s) stand out'); // nested must NOT count as edits
     // accept records standout + nested (atDefault/generated never) = 57
-    const bulk = options.find((o) => o.value === 'acceptAll')!;
-    expect(bulk.label).toContain('Accept ALL 57');
-    expect(message).toContain('Accept records the current state (57 value(s)) as your baseline');
+    expect(options.find((o) => o.value === 'acceptAll')!.label).toContain('Accept all 57');
   });
 
-  it('zero standout (only nested/folded) → says nothing stands out, still offers the baseline (R105)', () => {
+  it('zero standout (only nested/folded) → says nothing stands out, still offers the baseline (R105/R106)', () => {
     const { message, options } = firstRunPrompt('ApiStack', {
       standout: 0,
       nested: 50,
       generated: 5,
     });
-    expect(message).toContain('none stand out as out-of-band edits');
-    expect(message).toContain('Found 55 live value(s) not declared');
+    expect(message).toContain('nothing stands out as an out-of-band edit');
+    expect(message).toContain('(55 fold as defaults/generated/nested)');
     // accept still records the 50 nested (generated is not recorded)
-    expect(options.find((o) => o.value === 'acceptAll')!.label).toContain('Accept ALL 50');
+    expect(options.find((o) => o.value === 'acceptAll')!.label).toContain('Accept all 50');
   });
 
-  it('no declared-side drift → the generic either-way clause (R51)', () => {
-    const { message } = firstRunPrompt('ApiStack', { standout: 113 });
-    expect(message).toContain('Declared-side drift is reported either way.');
-    expect(message).not.toContain('Also found');
-  });
-
-  it('"Accept ALL" is the FIRST option (the common first-run choice — R52); show-first follows', () => {
+  it('"Accept all" is the FIRST option (the common first-run choice — R52); show-first follows', () => {
     const { options } = firstRunPrompt('S', { standout: 5 });
     expect(options[0]!.value).toBe('acceptAll');
     expect(options[1]!.value).toBe('show');
-    expect(options[1]!.label).toContain('Show them first');
-    expect(options[1]!.label).toContain('accept (selectively) right after');
+    expect(options[1]!.label).toContain('Show first');
+    expect(options[1]!.label).toContain('accept selectively');
   });
 
-  it('the bulk option states the recordable count and that values have NOT been reviewed', () => {
+  it('the bulk option states the recordable count and that values are NOT reviewed', () => {
     const { options } = firstRunPrompt('S', { standout: 113 });
     const bulk = options.find((o) => o.value === 'acceptAll')!;
-    expect(bulk.label).toContain('Accept ALL 113');
-    expect(bulk.label).toContain('without reviewing them');
+    expect(bulk.label).toContain('Accept all 113');
+    expect(bulk.label).toContain('no review');
   });
 
   it('prompts speak the command vocabulary (accept) — no retired jargon', () => {


### PR DESCRIPTION
The R105 first-run prompt was a five-sentence wall nobody reads. Collapse it to **one line** — stack + `no baseline yet` + the standout signal + the folded remainder in one parenthetical. The baseline/accept explanation moves to the option labels and README; the generic "declared-side drift either way" clause is dropped from the common path.

**Before** (5 sentences) → **After** (rendered with real ai-api counts):
```
dev-goto-tokyo-AiApi: no baseline yet — nothing stands out as an out-of-band edit (230 fold as defaults/generated/nested).
  ❯ Accept all 50 into the baseline now (no review)
    Show first, then accept selectively
```
With edits + declared drift:
```
...: no baseline yet — 2 value(s) stand out as possible out-of-band edits (230 fold as defaults/generated/nested) — plus 1 declared-side drift(s), reported below.
```

Tests rewritten to assert the one-line contract (no prose wall, no newline). README example shortened. 775 tests pass; typecheck/lint/build green.