### PR TITLE
docs(readme): expand the drift-tool comparison to driftctl + terraform plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,24 @@ $ npx cdkrd check ApiStack
 result: 1 drift(s) (undeclared=1)
 ```
 
-| Capability                                                          | `cdkrd` | `cdk drift` / CFn drift detection |
-| ------------------------------------------------------------------- | :-----: | :-------------------------------: |
-| Detect drift on **declared** properties (incl. out-of-band deletes) |   ✅    |                ✅                 |
-| Detect drift on **undeclared** properties                           |   ✅    |                ❌                 |
-| **Revert** declared drift                                           |   ✅    |  ✅ `cdk deploy --revert-drift`   |
-| **Revert** undeclared drift                                         |   ✅    |                ❌                 |
-| **Accept** drift into a git-committed file, reviewed like any PR    |   ✅    |                ❌                 |
+Every other drift tool compares only the properties that appear in your IaC
+(template / state / provider schema), so a change to a setting you never declared
+is invisible to all of them — that is the row that sets `cdkrd` apart:
+
+| Capability                                                           | `cdkrd` | `cdk drift` / CFn drift | `driftctl` | `terraform plan` |
+| -------------------------------------------------------------------- | :-----: | :---------------------: | :--------: | :--------------: |
+| Detect drift on **declared** properties (incl. out-of-band deletes)  |   ✅    |           ✅            |     ✅     |        ✅        |
+| Detect drift on **undeclared** properties (settings not in your IaC) |   ✅    |           ❌            |     ❌     |        ❌        |
+| **Revert** declared drift                                            |   ✅    |           ✅            |     ❌     |        ✅        |
+| **Revert** undeclared drift                                          |   ✅    |           ❌            |     ❌     |        ❌        |
+| **Accept** drift into a git-committed, reviewable file               |   ✅    |           ❌            |     ⚠️     |        ❌        |
+
+- **Revert**: `cdk deploy --revert-drift` (declared only); `terraform apply`
+  reconciles only attributes Terraform manages, so a setting outside the
+  resource's managed attributes is the same blind spot as the undeclared row.
+- **Accept (⚠️)**: `driftctl` is detect-only and offers ignore-rules rather
+  than a reviewed, committed baseline; it is also no longer actively
+  maintained — listed here as the closest Terraform-side analogue.
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

Expands the "Why" comparison table from `cdkrd` vs `cdk drift` only to the four tools the project positions against (per CLAUDE.md): **`cdk drift`/CFn drift, `driftctl`, `terraform plan`**. The **undeclared-properties** row — ✅ for `cdkrd`, ❌ for all three others — is the differentiator, now shown at a glance.

Cells are bare symbols (clean source alignment); the qualifiers moved to two notes below the table:
- Revert: `--revert-drift` is declared-only; `terraform apply` reconciles only Terraform-managed attributes (same blind spot as the undeclared row).
- Accept (⚠️): `driftctl` is detect-only / ignore-rules (not a reviewed committed baseline) and is no longer actively maintained — listed as the closest Terraform-side analogue.

## ⚠️ Please review the competitor framing

This is launch-facing positioning, so the competitor claims are the part to scrutinize — I did **not** auto-merge it. Open questions for you:
- Keep `driftctl` in the table given it's unmaintained, or drop it / move to prose?
- Is the `terraform plan` "undeclared = ❌" framing how you want to state it?
- Tone/wording of the two notes.

Docs-only change; no code touched.
