### PR TITLE
feat(check): always show the report before accepting on a first run; drop blind bulk-accept (R110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,20 +53,32 @@ npx cdkrd check                 # checks every stack your app defines
 ```
 
 **First run** — your template never pins every live value (AWS defaults,
-generated names), so `check` first asks you to record a baseline of those
-UNRECORDED values (they are not drift — there is nothing to compare them to
-yet):
+generated names), so the report lists the UNRECORDED values (they are not drift —
+there is nothing to compare them to yet), then offers to record a baseline:
 
 ```console
-ApiStack: no baseline yet — 2 value(s) stand out as possible out-of-band edits (40 fold as defaults/generated/nested).
-  ❯ Accept all 2 into the baseline now (no review)
-    Show first, then accept selectively
+=== cdkrd check: ApiStack (us-east-1) ===
+[UNRECORDED: 2] (not declared in your template; not in the baseline yet — accept to record)
+  ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
+  ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
+
+result: CLEAN — 42 unrecorded value(s) await a baseline (run cdkrd accept)
+info:
+  - atDefault=40 (undeclared values matching a known AWS default — not drift)
+  ...
+
+ApiStack: unrecorded values found — what do you want to do?
+  ❯ Nothing (decide later)
+    Accept — record current state into the baseline
 ```
 
-The count is the **complete** undeclared inventory, but only the handful that
-**stand out** are listed — AWS defaults, auto-generated names/identifiers, and
-nested sub-keys you never touched fold into the `info:` footer (`atDefault=` /
-`generated=` / `nested=`, `--show-all` expands them). Accept writes
+The report always prints **first**, so you see the standout values before deciding
+(no blind bulk-accept). The count is the **complete** undeclared inventory, but
+only the handful that **stand out** are listed — AWS defaults, auto-generated
+names/identifiers, and nested sub-keys you never touched fold into the `info:`
+footer (`atDefault=` / `generated=` / `nested=`, `--show-all` expands them).
+Choosing Accept opens a checklist (everything pre-selected — Enter to accept all,
+or deselect what you want to keep visible) and writes
 `.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing written to
 AWS** — commit it; from here on `check` reports CLEAN until reality changes.
 (Declared drift is detected from the very first run, baseline or not.)

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -10,13 +10,11 @@ import { isCancel, select } from '@clack/prompts';
 import { isStackNotDeployed } from '../aws-errors.js';
 import {
   applyBaseline,
-  buildAccepted,
   checkBaselineAccount,
   declaredKeysByLogical,
   loadBaseline,
   warnBaselineSchemaV1,
   warnTemplateHashDrift,
-  writeBaseline,
 } from '../baseline/baseline-file.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
@@ -52,79 +50,6 @@ export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
   return findings.filter(
     (f) => f.tier !== 'declared' && f.tier !== 'readGap' && f.tier !== 'unresolved'
   );
-}
-
-// The first-run (no-baseline) prompt (R45, reframed R105). The decision the user
-// is making is "record the current reality as my baseline?" — NOT "fix N problems".
-// Two facts the choice hinges on: how many values Accept-ALL records sight-unseen,
-// and that "Show first" is not a dead end (the report prints and a selective accept
-// follows). Accept-ALL is first/default since R52. Exported (pure) so the wording
-// contract is unit-tested.
-//
-// Wording (R49): "undeclared" is anchored to YOUR deployed (CDK/CloudFormation)
-// template; there is no cdkrd-side template, the baseline only filters what gets
-// REPORTED. The count is NOT a drift verdict.
-//
-// STANDOUT vs FOLDED (R105): the live model carries far more not-declared values
-// than the user ever edited — AWS defaults (atDefault), auto-generated identifiers
-// (generated, R104), and nested sub-keys (nested, R96) all FOLD in the report;
-// only the top-level diverging values (`standout`) list as [UNRECORDED]. The old
-// prompt called the whole recordable set "real out-of-band edits", which counted
-// the 50+ folded nested values as edits — overstating wildly (the bug that
-// confused the first-run user). The prompt names `standout` as what stands out
-// and states the folded remainder in one parenthetical.
-//
-// Terse (R106): kept to a SINGLE line — the old multi-sentence framing ("this run
-// SETS UP your baseline … from the next run check reports only what changes") was
-// a wall nobody read. That context now lives in the option labels + the README.
-//
-// declaredDrift (R51): declared-side drift (declared/deleted tier) is reported
-// regardless of the baseline choice; mention it only when present (R106 dropped
-// the generic "reported either way" clause from the common no-declared-drift path).
-export interface FirstRunCounts {
-  standout: number; // top-level undeclared — listed in [UNRECORDED]; the values that stand out
-  nested?: number; // nested undeclared — folded in the report, but recorded by accept
-  atDefault?: number; // undeclared at a known AWS default — folded, never recorded
-  generated?: number; // AWS/CDK auto-generated identifier — folded, never recorded
-  declaredDrift?: number; // declared/deleted drift — reported either way
-}
-export function firstRunPrompt(
-  stackName: string,
-  counts: FirstRunCounts
-): { message: string; options: { value: 'show' | 'acceptAll'; label: string }[] } {
-  const { standout, nested = 0, atDefault = 0, generated = 0, declaredDrift = 0 } = counts;
-  const recordable = standout + nested; // what Accept records (atDefault/generated never are)
-  const folded = nested + atDefault + generated; // not listed in the report by default
-  // Terse (R106): the old message was a 5-sentence wall the user wouldn't read.
-  // Keep ONE line — the signal (`standout`, matching [UNRECORDED]) + the folded
-  // remainder in a parenthetical; the "what a baseline is / what accept does"
-  // context lives in the option labels and the README, not here.
-  const standoutClause =
-    standout > 0
-      ? `${standout} value(s) stand out as possible out-of-band edits`
-      : 'nothing stands out as an out-of-band edit';
-  const foldedClause = folded > 0 ? ` (${folded} fold as defaults/generated/nested)` : '';
-  // declared-side drift is reported regardless of the choice; mention it ONLY when
-  // present (the old generic "reported either way" was noise on the common path).
-  const declaredClause =
-    declaredDrift > 0 ? ` — plus ${declaredDrift} declared-side drift(s), reported below` : '';
-  return {
-    message: `${stackName}: no baseline yet — ${standoutClause}${foldedClause}${declaredClause}.`,
-    // Accept-ALL first (R52, user decision): it is the overwhelmingly common
-    // first-run choice, and the cost of an accidental Enter is one git-tracked
-    // file — reviewable and revertible, nothing written to AWS. "Show first"
-    // stays one arrow away for the careful path.
-    options: [
-      {
-        value: 'acceptAll',
-        label: `Accept all ${recordable} into the baseline now (no review)`,
-      },
-      {
-        value: 'show',
-        label: 'Show first, then accept selectively',
-      },
-    ],
-  };
 }
 
 /**
@@ -268,7 +193,7 @@ export async function runCheck(args: string[]): Promise<number> {
         continue;
       }
 
-      let baseline = a.showAll
+      const baseline = a.showAll
         ? undefined
         : await loadBaseline(stackName, desired.accountId, region);
       // per-account guard: a baseline captured in a different account is wrong here
@@ -278,58 +203,15 @@ export async function runCheck(args: string[]): Promise<number> {
       // schema-v1 baseline: no completeResources — appeared-since-accept values
       // read as unrecorded until the next accept upgrades the file (R62)
       if (baseline && !a.json) warnBaselineSchemaV1(baseline, stackName);
-      // First run: no baseline yet → choose between "report first" (the safe
-      // default — a selective accept is offered again right after the report) and
-      // a bulk accept of everything sight-unseen (R45). Ignore rules are applied
-      // BEFORE counting/accepting so the bulk path can never accept values the
-      // report would have re-tagged as ignored (same as the post-report accept).
-      // With ZERO undeclared values there is no decision worth interrupting for —
-      // no prompt (`cdkrd accept` still writes a baseline for a clean stack).
-      if (!baseline && !a.showAll && !a.json && !a.fail && isInteractive()) {
-        const acceptable = applyIgnores(findings, stackName, config);
-        // The pre-report bulk-accept prompt fires ONLY when something STANDS OUT
-        // (R108): a top-level undeclared value the report would list as [UNRECORDED].
-        // When standout = 0 the only undeclared values are folded (nested) or pure
-        // inventory (atDefault/generated), so "Show first" would reveal an empty body
-        // — confusing. We skip straight to the report; the post-report "unrecorded
-        // values found — Accept/Nothing" prompt still offers to baseline the folded
-        // nested values, so nothing is lost. `standout` splits from `nested` so the
-        // prompt never calls the 50+ folded nested values "edits" (R105).
-        const undeclared = acceptable.filter((f) => f.tier === 'undeclared');
-        const standoutCount = undeclared.filter((f) => !f.nested).length;
-        const nestedCount = undeclared.length - standoutCount;
-        const declaredDriftCount = acceptable.filter(
-          (f) => f.tier === 'declared' || f.tier === 'deleted'
-        ).length;
-        if (standoutCount > 0) {
-          const prompt = firstRunPrompt(stackName, {
-            standout: standoutCount,
-            nested: nestedCount,
-            atDefault: acceptable.filter((f) => f.tier === 'atDefault').length,
-            generated: acceptable.filter((f) => f.tier === 'generated').length,
-            declaredDrift: declaredDriftCount,
-          });
-          const choice = await select({
-            message: prompt.message,
-            options: prompt.options,
-            initialValue: 'acceptAll' as const,
-          });
-          if (!isCancel(choice) && choice === 'acceptAll') {
-            const { count } = await writeBaseline(
-              stackName,
-              region,
-              desired.accountId,
-              acceptable,
-              desired.rawTemplate,
-              buildAccepted(acceptable),
-              // full resource list so read-clean resources are snapshot-complete too (R62)
-              { allLogicalIds: desired.resources.map((r) => r.logicalId) }
-            );
-            console.error(`baseline written (${count} undeclared value(s) accepted) — commit it.`);
-            baseline = await loadBaseline(stackName, desired.accountId, region);
-          }
-        }
-      }
+      // First run (no baseline): R110 removed the pre-report "Accept ALL sight-unseen"
+      // prompt (R45/R52). It buried the very values it flagged as possible out-of-band
+      // edits — pressing Enter recorded them into the baseline BEFORE the user ever saw
+      // them, and the report then suppressed them, so a real edit could vanish in one
+      // keystroke. Now the report ALWAYS prints first; the post-report prompt below
+      // ("unrecorded values found — Accept/Revert/Nothing") offers a SELECTIVE accept
+      // after the user has seen the standout values. Folding (atDefault/generated/
+      // nested) keeps that list short, so the old bulk-accept-to-avoid-scrolling
+      // rationale no longer applies. `cdkrd accept` still writes a baseline directly.
       // applyBaseline classifies per ENTRY (R62): matching entries are suppressed,
       // changed values are drift, entry-less values are drift only on a
       // snapshot-complete resource (appeared since accept) and UNRECORDED

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   finalCheckExit,
-  firstRunPrompt,
   postAcceptNote,
   preDeployFindings,
   undeclaredOnlyFindings,
@@ -48,78 +47,6 @@ describe('undeclaredOnlyFindings (R59 — pair-with-cdk-drift scope)', () => {
     const kept: Finding['tier'][] = ['deleted', 'undeclared', 'skipped'];
     const out = undeclaredOnlyFindings(kept.map((t) => F(t)));
     expect(out.map((f) => f.tier)).toEqual(kept);
-  });
-});
-
-describe('firstRunPrompt (R45/R105/R106 — informed, but ONE terse line)', () => {
-  it('is a single line: no baseline + the standout signal, no multi-sentence framing (R106)', () => {
-    const { message } = firstRunPrompt('ApiStack', { standout: 113 });
-    expect(message).toContain('ApiStack: no baseline yet');
-    expect(message).toContain('113 value(s) stand out as possible out-of-band edits');
-    expect(message).not.toContain('SETS UP your baseline'); // the R105 prose wall is gone
-    expect(message).not.toContain('from the next run');
-    expect(message).not.toContain('\n'); // genuinely one line
-    expect(message).not.toContain('drift(s) found'); // never reads as a drift verdict
-  });
-
-  it('declared-side drift present → mentioned inline with its count (R51/R106)', () => {
-    const { message } = firstRunPrompt('ApiStack', { standout: 113, declaredDrift: 3 });
-    expect(message).toContain('plus 3 declared-side drift(s), reported below');
-  });
-
-  it('no declared-side drift → the declared clause is OMITTED entirely (R106)', () => {
-    const { message } = firstRunPrompt('ApiStack', { standout: 113 });
-    expect(message).not.toContain('declared-side drift');
-    expect(message).not.toContain('either way'); // the old generic clause is dropped
-  });
-
-  it('only STANDOUT is called an edit; the folded remainder is one parenthetical (R86/R104/R105/R106)', () => {
-    // 7 top-level edits + 50 nested (folded) + 152 atDefault + 5 generated → folded 207
-    const { message, options } = firstRunPrompt('ApiStack', {
-      standout: 7,
-      nested: 50,
-      atDefault: 152,
-      generated: 5,
-    });
-    expect(message).toContain('7 value(s) stand out as possible out-of-band edits');
-    expect(message).toContain('(207 fold as defaults/generated/nested)');
-    expect(message).not.toContain('57 value(s) stand out'); // nested must NOT count as edits
-    // accept records standout + nested (atDefault/generated never) = 57
-    expect(options.find((o) => o.value === 'acceptAll')!.label).toContain('Accept all 57');
-  });
-
-  it('zero standout (only nested/folded) → says nothing stands out, still offers the baseline (R105/R106)', () => {
-    const { message, options } = firstRunPrompt('ApiStack', {
-      standout: 0,
-      nested: 50,
-      generated: 5,
-    });
-    expect(message).toContain('nothing stands out as an out-of-band edit');
-    expect(message).toContain('(55 fold as defaults/generated/nested)');
-    // accept still records the 50 nested (generated is not recorded)
-    expect(options.find((o) => o.value === 'acceptAll')!.label).toContain('Accept all 50');
-  });
-
-  it('"Accept all" is the FIRST option (the common first-run choice — R52); show-first follows', () => {
-    const { options } = firstRunPrompt('S', { standout: 5 });
-    expect(options[0]!.value).toBe('acceptAll');
-    expect(options[1]!.value).toBe('show');
-    expect(options[1]!.label).toContain('Show first');
-    expect(options[1]!.label).toContain('accept selectively');
-  });
-
-  it('the bulk option states the recordable count and that values are NOT reviewed', () => {
-    const { options } = firstRunPrompt('S', { standout: 113 });
-    const bulk = options.find((o) => o.value === 'acceptAll')!;
-    expect(bulk.label).toContain('Accept all 113');
-    expect(bulk.label).toContain('no review');
-  });
-
-  it('prompts speak the command vocabulary (accept) — no retired jargon', () => {
-    const p = firstRunPrompt('S', { standout: 3 });
-    const all = [p.message, ...p.options.map((o) => o.label)].join(' ');
-    // the retired word is assembled at runtime so this file itself stays free of it (R46)
-    expect(all.toLowerCase()).not.toContain(['b', 'less'].join(''));
   });
 });
 


### PR DESCRIPTION
Part (a) of the first-run UX fixes. The pre-report "Accept ALL sight-unseen" prompt let a user **bury the very values it flagged** as possible out-of-band edits — one Enter recorded every undeclared value into the baseline *before* the report rendered, then the report suppressed them. That's why "Accept all" showed only declared drift while "Show first" showed [UNRECORDED] (the Q1 inconsistency), and how an added inline IAM policy could vanish in a keystroke (the footgun).

**Fix:** remove the pre-report prompt. The report ALWAYS prints first; the existing post-report "unrecorded values found — Accept/Revert/Nothing" prompt offers a selective accept (checklist pre-selected to all — Enter still accepts everything, but after you've *seen* it). Folding already keeps the standout list short, so the old bulk-accept rationale is moot.

Removes the now-dead `firstRunPrompt`/`FirstRunCounts` + their tests; README first-run walkthrough updated. 776 tests pass.

Follow-ups in this series: (b) sibling-policy fail-open, (c) KMS fail-open + the report presentation tweak (Q2: [UNRECORDED] vs the drift count).