### PR TITLE
fix(diff): fail open when a role's sibling policy names are unresolvable (R111)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -384,8 +384,12 @@ sibling **PolicyNames** (`collectRolesWithSiblingPolicies`,
 [template-adapter.ts](../src/desired/template-adapter.ts)) and classify drops only
 the live entries matching those names — the residual (rogue inline policies)
 surfaces as undeclared drift. A sibling `PolicyName` the resolver can't evaluate
-statically falls back to suppressing the whole property for that role (fail-safe:
-no false positives over an unidentifiable sibling entry).
+statically (an `Fn::Sub`/`Fn::Join` name, or none) now **fails OPEN** (R111): the
+role keeps its whole live `Policies`, so a rogue out-of-band policy is never hidden
+— the sibling-managed entries merely surface as undeclared (baseline-able once).
+The old fallback DELETED the property, which also hid out-of-band additions on a
+security-relevant resource (the dangerous DROP class, R95); a visible one-time
+false positive is the right trade against a silent false negative.
 
 **The `isTrivialEmpty` asymmetry (intentional trade-off).** An undeclared value that
 is `false`, `''`, `[]`, or an object whose every value is itself trivially empty

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -145,19 +145,22 @@ export function classifyResource(
   // AWS::IAM::Policy resource, which reflects into the role's live Policies). Drop
   // ONLY the live entries owned by a sibling — their content drift is the sibling
   // resource's own finding — so an out-of-band inline policy added to the role
-  // still surfaces (as undeclared, or inside the declared compare). 'unresolved'
-  // (a sibling PolicyName we cannot resolve statically) falls back to suppressing
-  // the whole property: no false positives over an unidentifiable sibling entry.
+  // still surfaces (as undeclared, or inside the declared compare).
+  //
+  // R111 fail-open: when a sibling PolicyName cannot be resolved statically (an
+  // Fn::Sub/Fn::Join name, or none), `siblingPolicyNames` is 'unresolved' and we
+  // do NOT filter at all. The old fallback DELETED the whole live Policies — which
+  // also hid any out-of-band inline policy added directly to the role: a silent
+  // false negative on a security-relevant resource (the dangerous DROP class, R95).
+  // Now the unresolved role keeps its live Policies, so a rogue policy is NEVER
+  // hidden; the sibling-managed entries surface as undeclared (baseline-able once).
+  // We trade a one-time, VISIBLE false positive for never hiding a real change.
   const sibling = resource.siblingPolicyNames;
-  if (sibling !== undefined && 'Policies' in live) {
-    if (sibling === 'unresolved') {
-      if (!('Policies' in declared)) delete live.Policies;
-    } else if (Array.isArray(live.Policies)) {
-      const names = new Set<unknown>(sibling);
-      live.Policies = live.Policies.filter(
-        (p) => !(p && typeof p === 'object' && names.has((p as Record<string, unknown>).PolicyName))
-      );
-    }
+  if (sibling !== undefined && sibling !== 'unresolved' && Array.isArray(live.Policies)) {
+    const names = new Set<unknown>(sibling);
+    live.Policies = live.Policies.filter(
+      (p) => !(p && typeof p === 'object' && names.has((p as Record<string, unknown>).PolicyName))
+    );
   }
 
   // declared drift (A3: declared key absent in live = read gap, not drift).

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -322,9 +322,16 @@ describe('sibling-managed inline Policies (IAM Role)', () => {
     expect(tiers(findings).undeclared).toEqual(['Policies']);
   });
 
-  it("'unresolved' sibling names fall back to suppressing the whole property", () => {
+  it("'unresolved' sibling names FAIL OPEN: live Policies surface (a rogue policy is never hidden) (R111)", () => {
+    // the old behavior deleted the whole property, which also hid an out-of-band
+    // inline policy on the role — a silent false negative. Now the Policies surface
+    // as undeclared (the sibling-managed entries are baseline-able once, but the
+    // rogue one is reported), so a security-relevant change is never dropped.
     const findings = classifyResource(role('unresolved'), { Policies: [sibling, rogue] }, noSchema);
-    expect(findings).toEqual([]);
+    expect(tiers(findings).undeclared).toEqual(['Policies']);
+    const f = findings.find((x) => x.path === 'Policies')!;
+    // the rogue entry must be present in the surfaced value
+    expect(JSON.stringify(f.actual)).toContain('rogue');
   });
 
   it('declared role Policies + sibling entries in live: the sibling entry is not false declared drift', () => {


### PR DESCRIPTION
Audit Finding 2 (the highest-confidence false-negative, same family as the inline-policy bug). When a role's inline policies come from sibling `AWS::IAM::Policy` resources and a sibling `PolicyName` can't be resolved statically (`Fn::Sub`/`Fn::Join`, or none), the role was marked `unresolved` and the old fallback **deleted the role's entire live `Policies`** — hiding any out-of-band inline policy added directly to the role. A silent false negative on a security-relevant resource, strictly worse than the bug you originally hit.

**Fix:** fail open — when unresolved, don't filter. Sibling-managed entries surface as undeclared (baseline-able once), but a rogue policy is **never hidden**. One-time visible false positive >> silent false negative (the R95 principle).

776 tests pass; the `unresolved` test now asserts the rogue policy surfaces.