### PR TITLE
fix(report): label UNRECORDED 'not drift' and reconcile the shown/folded count (R112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ there is nothing to compare them to yet), then offers to record a baseline:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[UNRECORDED: 2] (not declared in your template; not in the baseline yet — accept to record)
+[UNRECORDED: 2] (not drift — undeclared and not in the baseline yet; accept to record)
   ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
 
-result: CLEAN — 42 unrecorded value(s) await a baseline (run cdkrd accept)
+result: CLEAN — 42 unrecorded value(s) await a baseline (2 shown, 40 folded; run cdkrd accept)
 info:
   - atDefault=40 (undeclared values matching a known AWS default — not drift)
   ...

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -669,10 +669,11 @@ never-snapshot-complete resource has nothing to violate (§8). `applyBaseline`
 tags such findings `unrecorded` — on a no-baseline first run that is every
 undeclared value, and after a cherry-pick accept it is still every value the
 user did not pick. They render as their own `[UNRECORDED: N]` section (note:
-`not in the baseline yet — accept to record`) alongside any real
-`[UNDECLARED DRIFT]` section, are excluded from the verdict and the `--fail`
-exit, and the `result:` line carries the count + the way out
-(`— N unrecorded value(s) await a baseline (run cdkrd accept)`). Declared and
+`not drift — undeclared and not in the baseline yet; accept to record`) alongside
+any real `[UNDECLARED DRIFT]` section, are excluded from the verdict and the
+`--fail` exit, and the `result:` line carries the count + the way out
+(`— N unrecorded value(s) await a baseline (X shown, Y folded; run cdkrd accept)`
+when some fold; R112). Declared and
 deleted drift still report and fail normally. The interactive after-report
 prompt still fires for unrecorded values (`unrecorded values found — what do
 you want to do?`) so "show them first" keeps its promise of a selective accept.

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -181,7 +181,7 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     section(
       unrecordedShown,
       'UNRECORDED',
-      'not declared in your template; not in the baseline yet — accept to record',
+      'not drift — undeclared and not in the baseline yet; accept to record',
       style.undeclaredTier,
       driftSections > 0
     )
@@ -198,11 +198,17 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   const verdict =
     drifted === 0 ? style.clean('CLEAN') : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;
   // unrecorded values are stated NEXT TO the verdict (not as drift): the count
-  // and the way out, in one place (R60).
+  // and the way out, in one place (R60). The total counts ALL unrecorded values
+  // but the [UNRECORDED] section lists only the standout (non-folded) ones, so name
+  // the split (R112) — otherwise "25 await a baseline" reads as a mismatch against a
+  // visible "[UNRECORDED: 2]".
+  const unrecordedFoldedCount = unrecordedItems.length - unrecordedShown.length;
   const unrecordedNote =
     unrecordedItems.length > 0
       ? style.infoTier(
-          ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (run cdkrd accept)`
+          unrecordedFoldedCount > 0
+            ? ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (${unrecordedShown.length} shown, ${unrecordedFoldedCount} folded; run cdkrd accept)`
+            : ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (run cdkrd accept)`
         )
       : '';
   // A blank line before the verdict ONLY when drift sections were printed — it must

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -19,14 +19,24 @@ function run(findings: Finding[], opts: Parameters<typeof report>[2] = {}) {
 const U = (path = 'P'): Finding => ({ ...F('undeclared', path), unrecorded: true });
 
 describe('report unrecorded findings (R60/R62 — per finding: never decided is inventory, not drift)', () => {
-  it('unrecorded findings render as [UNRECORDED: N] and do NOT count as drift', () => {
+  it('unrecorded findings render as [UNRECORDED: N], labelled "not drift", and do NOT count as drift', () => {
     const { code, text } = run([U(), U('Q')]);
     expect(code).toBe(0);
     expect(text).toContain('[UNRECORDED: 2]');
-    expect(text).toContain('not in the baseline yet — accept to record');
+    expect(text).toContain('not drift —'); // R112: the section says so up front
     expect(text).not.toContain('UNDECLARED DRIFT');
     expect(text).toContain(
       'result: CLEAN — 2 unrecorded value(s) await a baseline (run cdkrd accept)'
+    );
+  });
+
+  it('result note names the shown/folded split so the section count and total reconcile (R112)', () => {
+    // 2 standout (shown in [UNRECORDED: 2]) + 3 nested (folded) = 5 total
+    const nested = (p: string): Finding => ({ ...U(p), nested: true });
+    const { text } = run([U(), U('Q'), nested('a'), nested('b'), nested('c')]);
+    expect(text).toContain('[UNRECORDED: 2]'); // only the standout are listed
+    expect(text).toContain(
+      'result: CLEAN — 5 unrecorded value(s) await a baseline (2 shown, 3 folded; run cdkrd accept)'
     );
   });
 


### PR DESCRIPTION
Q2 presentation fixes. A stack with [DECLARED DRIFT: 1] + [UNRECORDED: 2] read as '3 drifts' despite `result: 1 drift(s)`, and 'result: 25 unrecorded await a baseline' mismatched the visible '[UNRECORDED: 2]' (the rest are folded). Now the section note leads with 'not drift —', and the result note names the split: '25 unrecorded value(s) await a baseline (2 shown, 23 folded; run cdkrd accept)'. 777 tests pass.