### PR TITLE
feat(report): combined findings verdict + plainer generated/readGap labels (R114)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -32,9 +32,10 @@ un-deployed code edits would show as false "drift".
        sort, account-id<->root-ARN; Version kept only when declared — never fabricated)
      - aws:* tags (list + map); schema-defaults (at ANY depth, via $ref-resolved
        nested `default` extraction; R103) + per-type known-defaults are NOT dropped
-       but tagged `atDefault` (folded, never drift; R86); AWS/CDK auto-generated
-       values keyed by the resource's physical id (a topic's minted TopicName, a
-       Lambda's default LoggingConfig log group) are tagged `generated` (R104)
+       but tagged `atDefault` (folded, never drift; R86); auto-generated identifiers
+       AWS assigns at deploy and absent from the template, keyed by the resource's
+       physical id (a topic's minted TopicName, a Lambda's default LoggingConfig log
+       group) are tagged `generated` (R104)
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
 5. classify (tag):  declared | undeclared | atDefault | generated | readGap | unresolved | skipped

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ text.
 
 result: 1 drift(s) (declared=1)
 info:
-  - readGap=1 (write-only 1)
+  - readGap=1 (declared but unverifiable — AWS doesn't return them on read, not drift: 1 write-only)
   - skipped=2 (custom resource 2)
   run with --verbose for the list
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,9 +177,11 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
 5. classify (tier)       deleted | declared | undeclared | atDefault | generated | readGap | unresolved | skipped
                          (atDefault = undeclared but EQUAL to a known AWS default —
                          folded, never drift, never recorded; R86)
-                         (generated = undeclared but EQUAL to the AWS/CDK auto-generated
-                         value for THIS resource — its minted physical name, or a
-                         default LoggingConfig log group derived from the physical id;
+                         (generated = undeclared (absent from the template) but EQUAL to the
+                         identifier AWS auto-assigns for THIS resource at deploy — its minted
+                         physical name, or a default LoggingConfig log group derived from the
+                         physical id. NOT "CDK generated it into the template" — that would be
+                         declared; this tier is precisely the values your template never set;
                          folded like atDefault, never drift, never recorded; R104)
                          (undeclared also carries a nested:true flag for a live
                          sub-key inside a declared object the template never set; R96)
@@ -291,8 +293,10 @@ all live changes
     inventory but lists only the values that actually diverge. Equality-gated: change
     one away from its default and it re-tags as real undeclared drift. (`--show-all` /
     `--verbose` expand the fold to the full list; accept never records an atDefault.)
-  − AWS/CDK auto-generated values (a topic's minted TopicName, a Lambda's default
-    LoggingConfig log group) → tagged "generated" (R104): folded into the info: footer
+  − auto-generated identifiers AWS assigns at deploy and absent from the template
+    (a topic's minted TopicName, a Lambda's default LoggingConfig log group; if a name
+    were in the template it would be declared, never reaching here) → tagged "generated"
+    (R104): folded into the info: footer
     like atDefault, equality-gated against the physical-id-substituted template; never
     drift, never recorded by accept. (`GENERATED_DEFAULTS` / `resolveGeneratedDefault`.)
   − pure structural noise (aws:* tags, physical-id echo, trivially-empty {}/[]) → dropped
@@ -676,8 +680,13 @@ user did not pick. They render as their own `[UNRECORDED: N]` section (note:
 any real `[UNDECLARED DRIFT]` section, are excluded from the verdict and the
 `--fail` exit, and the `result:` line carries the count + the way out
 (`— N unrecorded value(s) await a baseline (X shown, Y folded; run cdkrd accept)`
-when some fold; R112). Declared and
-deleted drift still report and fail normally. The interactive after-report
+when some fold; R112). When BOTH a drift section and a standout `[UNRECORDED]`
+section print, a lone `N drift(s)` verdict reads as a mismatch against the 2+
+visible blocks, so the line switches to a combined findings count counting only
+what is SHOWN — `result: 3 findings — 1 drift (declared=1) + 2 undeclared to
+review (23 folded; run cdkrd accept)` — keeping the red drift verdict intact
+(R114); single-category runs keep their plain `CLEAN` / `N drift(s)` verdict.
+Declared and deleted drift still report and fail normally. The interactive after-report
 prompt still fires for unrecorded values (`unrecorded values found — what do
 you want to do?`) so "show them first" keeps its promise of a selective accept.
 In `--json` the findings keep `tier: "undeclared"` (the documented enum) plus

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -36,9 +36,9 @@ const TIER_NOTES: Partial<Record<Tier, string>> = {
   deleted: 'resource deleted out of band — always drift',
   undeclared: 'not declared in your template — the differentiator',
   atDefault: 'undeclared, but the live value matches a known AWS default — not drift',
-  generated: 'undeclared, but an AWS/CDK auto-generated name or identifier — not drift',
+  generated: 'auto-generated identifier not in your template (AWS-assigned at deploy) — not drift',
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
-  readGap: 'declared but not returned by live read — not drift',
+  readGap: "declared, but AWS doesn't return it on read so cdkrd can't verify it — not drift",
   unresolved: 'declared paths needing GetAtt — skipped, not drift',
   skipped: 'CC API unsupported / no physical id',
 };
@@ -194,26 +194,50 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   const driftCounts = DRIFT_TIERS.filter((t) => byTier(t).length > 0)
     .map((t) => `${t}=${byTier(t).length}`)
     .join(' ');
-  // the verdict is the one line that must stand out: green CLEAN / red drift count
-  const verdict =
-    drifted === 0 ? style.clean('CLEAN') : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;
-  // unrecorded values are stated NEXT TO the verdict (not as drift): the count
-  // and the way out, in one place (R60). The total counts ALL unrecorded values
-  // but the [UNRECORDED] section lists only the standout (non-folded) ones, so name
-  // the split (R112) — otherwise "25 await a baseline" reads as a mismatch against a
-  // visible "[UNRECORDED: 2]".
   const unrecordedFoldedCount = unrecordedItems.length - unrecordedShown.length;
-  const unrecordedNote =
-    unrecordedItems.length > 0
-      ? style.infoTier(
-          unrecordedFoldedCount > 0
-            ? ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (${unrecordedShown.length} shown, ${unrecordedFoldedCount} folded; run cdkrd accept)`
-            : ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (run cdkrd accept)`
-        )
-      : '';
+  // R114: when DRIFT and standout UNRECORDED values are BOTH visible, a lone
+  // "1 drift(s)" verdict reads as a mismatch against the 2+ printed blocks (the user
+  // sees [DECLARED DRIFT: 1] + [UNRECORDED: 2] but a single "1 drift"). Combine them
+  // under one findings count — `N findings — X drift (...) + Y undeclared to review` —
+  // keeping the red drift verdict and its breakdown so exit-1 stays legible, and
+  // counting only what is SHOWN (folded values are not findings, just a parenthetical).
+  // The combined framing fires ONLY in this mixed case; single-category runs keep their
+  // natural verdict (CLEAN / N drift / inventory note) — the mismatch can't arise there.
+  const mixed = drifted > 0 && unrecordedShown.length > 0;
+  let resultBody: string;
+  if (mixed) {
+    const foldedHint =
+      unrecordedFoldedCount > 0
+        ? `${unrecordedFoldedCount} folded; run cdkrd accept`
+        : 'run cdkrd accept';
+    resultBody =
+      `${drifted + unrecordedShown.length} findings — ${style.drift(`${drifted} drift`)} (${driftCounts})` +
+      ` + ${unrecordedShown.length} undeclared to review` +
+      style.infoTier(` (${foldedHint})`);
+  } else {
+    // the verdict is the one line that must stand out: green CLEAN / red drift count
+    const verdict =
+      drifted === 0
+        ? style.clean('CLEAN')
+        : `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`;
+    // unrecorded values are stated NEXT TO the verdict (not as drift): the count
+    // and the way out, in one place (R60). The total counts ALL unrecorded values
+    // but the [UNRECORDED] section lists only the standout (non-folded) ones, so name
+    // the split (R112) — otherwise "25 await a baseline" reads as a mismatch against a
+    // visible "[UNRECORDED: 2]".
+    const unrecordedNote =
+      unrecordedItems.length > 0
+        ? style.infoTier(
+            unrecordedFoldedCount > 0
+              ? ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (${unrecordedShown.length} shown, ${unrecordedFoldedCount} folded; run cdkrd accept)`
+              : ` — ${unrecordedItems.length} unrecorded value(s) await a baseline (run cdkrd accept)`
+          )
+        : '';
+    resultBody = `${verdict}${unrecordedNote}`;
+  }
   // A blank line before the verdict ONLY when drift sections were printed — it must
   // not read as a member of the last section (R48); a CLEAN stack stays 3 lines.
-  log((driftSections > 0 ? '\n' : '') + `result: ${verdict}${unrecordedNote}`);
+  log((driftSections > 0 ? '\n' : '') + `result: ${resultBody}`);
   // INFORMATIONAL tiers: footer below result. Each tier is either EXPANDED to a full
   // section or FOLDED into the `info:` summary. --verbose expands all of them;
   // --show-all expands ONLY atDefault (inventory mode lists every undeclared value but
@@ -228,7 +252,19 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     if (t === 'atDefault')
       return `atDefault=${items.length} (undeclared values matching a known AWS default — not drift)`;
     if (t === 'generated')
-      return `generated=${items.length} (undeclared AWS/CDK auto-generated names or identifiers — not drift)`;
+      return `generated=${items.length} (auto-generated identifiers not in your template, AWS-assigned at deploy — not drift)`;
+    // readGap is jargon ("not returned by live read"): spell out that these are declared
+    // values cdkrd could not VERIFY because AWS does not return them on read, and split
+    // the cause (write-only props are never readable by design vs simply not returned).
+    if (t === 'readGap') {
+      const writeOnly = items.filter((f) => (f.note ?? '').includes('write-only')).length;
+      const notReturned = items.length - writeOnly;
+      const parts = [
+        ...(notReturned > 0 ? [`${notReturned} not returned by AWS`] : []),
+        ...(writeOnly > 0 ? [`${writeOnly} write-only`] : []),
+      ];
+      return `readGap=${items.length} (declared but unverifiable — AWS doesn't return them on read, not drift: ${parts.join(', ')})`;
+    }
     return `${t}=${items.length} (${groupReasons(items)})`;
   };
   const summaries = INFO_TIERS.filter((t) => !isExpanded(t))

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -43,7 +43,9 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
   it('declared drift still fails, with unrecorded values noted beside the verdict', () => {
     const { code, text } = run([F('declared'), U('Q')]);
     expect(code).toBe(1);
-    expect(text).toContain('result: 1 drift(s) (declared=1) — 1 unrecorded value(s)');
+    // R114: drift + standout unrecorded both visible -> combined findings framing so
+    // the verdict matches the printed blocks (was a lone "1 drift(s)" beside 2 sections).
+    expect(text).toContain('result: 2 findings — 1 drift (declared=1) + 1 undeclared to review');
     expect(text).not.toContain('undeclared=1'); // unrecorded never appears as a drift count
   });
 
@@ -52,7 +54,17 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(code).toBe(1);
     expect(text).toContain('[UNDECLARED DRIFT: 1]');
     expect(text).toContain('[UNRECORDED: 1]');
-    expect(text).toContain('result: 1 drift(s) (undeclared=1) — 1 unrecorded value(s)');
+    expect(text).toContain('result: 2 findings — 1 drift (undeclared=1) + 1 undeclared to review');
+  });
+
+  it('mixed findings line counts only SHOWN unrecorded; folded ones stay a parenthetical (R114)', () => {
+    // 1 declared drift + 1 standout unrecorded (shown) + 2 nested unrecorded (folded)
+    const nested = (p: string): Finding => ({ ...U(p), nested: true });
+    const { code, text } = run([F('declared'), U('Q'), nested('a'), nested('b')]);
+    expect(code).toBe(1);
+    expect(text).toContain(
+      'result: 2 findings — 1 drift (declared=1) + 1 undeclared to review (2 folded; run cdkrd accept)'
+    );
   });
 
   it('deleted still fails alongside unrecorded values (a gone resource is drift, baseline or not)', () => {
@@ -183,7 +195,9 @@ describe('report', () => {
       const lines = text.split('\n');
       const infoIdx = lines.indexOf('info:');
       expect(infoIdx).toBeGreaterThan(-1);
-      expect(lines[infoIdx + 1]).toBe('  - readGap=1 (write-only 1)');
+      expect(lines[infoIdx + 1]).toBe(
+        "  - readGap=1 (declared but unverifiable — AWS doesn't return them on read, not drift: 1 write-only)"
+      );
       expect(lines[infoIdx + 2]).toMatch(
         /^ {2}- skipped=2 \(.*custom resource 1.*override target unresolved 1.*\)$/
       );
@@ -313,7 +327,7 @@ describe('report', () => {
       expect(code).toBe(0);
       expect(text).toMatch(/^result: CLEAN$/m);
       expect(text).toContain(
-        'info: generated=2 (undeclared AWS/CDK auto-generated names or identifiers — not drift)'
+        'info: generated=2 (auto-generated identifiers not in your template, AWS-assigned at deploy — not drift)'
       );
       expect(text).not.toContain('[AWS GENERATED');
       expect(text).not.toContain('TopicName =');


### PR DESCRIPTION
## What

Two first-run report-clarity fixes the reviewer hit while dogfooding.

### 1. Combined findings verdict (mixed drift + unrecorded)

When a drift section AND a standout `[UNRECORDED]` section both print, a lone
`result: 1 drift(s)` read as a mismatch against the 2+ visible blocks. The line
now switches to a combined count in that mixed case only:

```
result: 3 findings — 1 drift (declared=1) + 2 undeclared to review (23 folded; run cdkrd accept)
```

It counts only what is SHOWN (folded values stay a parenthetical), keeps the red
drift verdict + breakdown so exit-1 stays legible, and undeclared stays "to
review" (never counted as drift). Single-category runs (`CLEAN`, only-drift,
only-undeclared) keep their existing verbatim verdict — the mismatch can't arise
there.

### 2. De-jargon two `info:` labels

- **generated**: `AWS/CDK auto-generated names or identifiers` implied CDK wrote
  the value into the template (→ would be *declared*). These are precisely the
  values the template never set — reworded to `auto-generated identifiers not in
  your template, AWS-assigned at deploy`.
- **readGap**: `not returned by live read` → `declared but unverifiable — AWS
  doesn't return them on read, not drift: N not returned, M write-only`.

## Tests

- `tests/report.test.ts`: mixed findings line (declared+undeclared, undeclared
  drift+unrecorded, and the folded-parenthetical case), new generated + readGap
  label assertions. 782 pass.

## Docs

README info-line example, DESIGN + ARCHITECTURE generated-tier descriptions and
the result-line section updated.
