### PR TITLE
fix(read): warn when kms:ListAliases is denied instead of silently degrading (R115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,8 +389,9 @@ covers them. If you scope tighter, the calls are:
   `route53:ListResourceRecordSets`, `glue:GetTable`, `logs:DescribeMetricFilters`,
   `scheduler:GetSchedule`
 - Optional: `kms:ListAliases` — enables strict verification that a declared
-  `alias/aws/*` key was not swapped for a customer-managed key (without it, that
-  case is conservatively suppressed)
+  `alias/aws/*` key was not swapped for a customer-managed key. Without it that
+  case is conservatively suppressed AND cdkrd prints a one-line warning per region
+  (the swap would otherwise go undetected), so the reduced coverage is never silent
 
 </details>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -357,7 +357,9 @@ _real change still detected_ ([tests/classify.test.ts](../tests/classify.test.ts
    **strict**: the live key must be the alias's managed key, so a customer-managed key
    swapped in out of band (a security-relevant change) IS reported as drift. Without
    `kms:ListAliases` it falls back to the shape-based collapse (noise, never a false
-   positive).
+   positive) — but `gather` then prints a one-line per-region warning
+   (`kmsListAliasesDeniedWarning`, deduped via a process-lifetime region set), so the
+   degraded coverage (blind to a key swap) is surfaced rather than silent (R115).
 
 > Classes 1 & 3 are a latent risk in any AWS-snapshot diff; they were also
 > back-ported to **cdkd** (PR #802, merged) since cdkd's `drift-calculator` shared

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -7,7 +7,11 @@ import { type Desired, loadDesired } from '../desired/template-adapter.js';
 import { classifyResource } from '../diff/classify.js';
 import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import { READ_RETRY } from '../read/client-config.js';
-import { fetchManagedAliasTargets, usesManagedKmsAlias } from '../read/kms-aliases.js';
+import {
+  fetchManagedAliasTargets,
+  kmsListAliasesDeniedWarning,
+  usesManagedKmsAlias,
+} from '../read/kms-aliases.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
 import { readLive, type ReadResult } from '../read/router.js';
 import { getSchemaInfo } from '../schema/schema-strip.js';
@@ -18,6 +22,11 @@ export interface GatherResult {
   findings: Finding[];
   schemas: Map<string, SchemaInfo>; // resourceType -> schema (so revert can honor createOnly)
 }
+
+// Regions already warned about a denied kms:ListAliases — the warning is one-per-region
+// (a multi-stack run in the same region should not repeat it). Process-lifetime (matches
+// the per-region alias cache in kms-aliases.ts).
+const kmsDeniedWarned = new Set<string>();
 
 // Bounded-concurrency live-read pool (pull-next-when-free): serial reads cost
 // ~300ms each, so 200+ resources took >1min; the SDK's adaptive retry handles
@@ -168,11 +177,18 @@ export async function gatherFindings(
 
   // KMS managed-alias resolution (R9): only if the stack declares any `alias/aws/*`,
   // fetch alias -> target key id once so classify can tell a managed-default key from
-  // a customer-managed key swapped in out of band. Missing kms:ListAliases -> {} (the
-  // classifier falls back to the conservative shape-based match).
-  const kmsAliasTargets = desired.resources.some((r) => usesManagedKmsAlias(r.declared))
-    ? await fetchManagedAliasTargets(region)
-    : {};
+  // a customer-managed key swapped in out of band. Missing kms:ListAliases -> empty +
+  // denied (the classifier falls back to the conservative shape-based match) — and we
+  // WARN once per region, because that fallback is BLIND to a customer-key swap (R115).
+  let kmsAliasTargets: Record<string, string> = {};
+  if (desired.resources.some((r) => usesManagedKmsAlias(r.declared))) {
+    const resolved = await fetchManagedAliasTargets(region);
+    kmsAliasTargets = resolved.targets;
+    if (resolved.denied && !kmsDeniedWarned.has(region)) {
+      kmsDeniedWarned.add(region);
+      console.error(kmsListAliasesDeniedWarning(region));
+    }
+  }
   const oaiCanonicalIds = buildOaiCanonicalIds(desired);
   const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets, oaiCanonicalIds };
 
@@ -243,8 +259,10 @@ export async function regatherTouched(
   for (const r of targets) {
     if (r.declaredRaw) r.declared = resolveProperties(r.declaredRaw, desired.ctx);
   }
+  // Re-check path (revert convergence): reuse the cached targets; the denial warning,
+  // if any, already fired in the primary gather, so just take the resolved map.
   const kmsAliasTargets = targets.some((r) => usesManagedKmsAlias(r.declared))
-    ? await fetchManagedAliasTargets(region)
+    ? (await fetchManagedAliasTargets(region)).targets
     : {};
   // Built from desired.ctx.liveAttrs (populated by the original gather), so the OAI
   // map is complete even though regather only re-reads the touched resources.

--- a/src/read/kms-aliases.ts
+++ b/src/read/kms-aliases.ts
@@ -3,17 +3,26 @@
 // stored by AWS as the key ARN) apart from a customer-managed key swapped in out of
 // band — the latter is a real, security-relevant drift the shape-only check missed.
 // Listing aliases is account-wide, so one paginated ListAliases per region is enough;
-// cached per region. On any error (e.g. missing kms:ListAliases) returns {} so the
-// classifier falls back to the conservative shape-based match (noise, not false drift).
+// cached per region. On any error (e.g. missing kms:ListAliases) returns `denied: true`
+// with empty targets so the classifier falls back to the conservative shape-based match
+// (noise, not false drift) — but the caller WARNS, because that fallback is blind to a
+// customer-key swap (it suppresses every `alias/aws/*` vs key-ARN pair). The result
+// (success OR denial) is cached so a denied region is not re-queried per stack.
 import { KMSClient, ListAliasesCommand } from '@aws-sdk/client-kms';
 import { READ_RETRY } from './client-config.js';
 
-const cache = new Map<string, Record<string, string>>();
+export interface ManagedAliasTargets {
+  targets: Record<string, string>; // alias/aws/<svc> -> target key id
+  denied: boolean; // true when ListAliases failed (e.g. missing kms:ListAliases)
+}
 
-export async function fetchManagedAliasTargets(region: string): Promise<Record<string, string>> {
+const cache = new Map<string, ManagedAliasTargets>();
+
+export async function fetchManagedAliasTargets(region: string): Promise<ManagedAliasTargets> {
   const cached = cache.get(region);
   if (cached) return cached;
-  const out: Record<string, string> = {};
+  const targets: Record<string, string> = {};
+  let result: ManagedAliasTargets;
   try {
     const c = new KMSClient({ region, ...READ_RETRY });
     let marker: string | undefined;
@@ -21,16 +30,29 @@ export async function fetchManagedAliasTargets(region: string): Promise<Record<s
       const r = await c.send(new ListAliasesCommand({ Marker: marker, Limit: 100 }));
       for (const a of r.Aliases ?? []) {
         if (a.AliasName?.startsWith('alias/aws/') && a.TargetKeyId)
-          out[a.AliasName] = a.TargetKeyId;
+          targets[a.AliasName] = a.TargetKeyId;
       }
       marker = r.Truncated ? r.NextMarker : undefined;
     } while (marker);
+    result = { targets, denied: false };
   } catch {
     // no kms:ListAliases (or any error) → fall back to shape-based suppression
-    return {};
+    result = { targets: {}, denied: true };
   }
-  cache.set(region, out);
-  return out;
+  cache.set(region, result);
+  return result;
+}
+
+/** The one-line warning emitted when ListAliases is denied but the stack declares an
+ *  AWS-managed alias: the managed-vs-customer key check degrades to shape-only, which
+ *  is BLIND to a customer-managed key swapped in for an `alias/aws/*` default. Pure +
+ *  exported so the wording is unit-tested. */
+export function kmsListAliasesDeniedWarning(region: string): string {
+  return (
+    `warning: ${region}: kms:ListAliases denied — managed-KMS-alias drift detection is degraded. ` +
+    `A customer-managed key swapped in for an AWS-managed default (alias/aws/*) will NOT be detected ` +
+    `(every alias/aws/* is treated as matching any live key). Grant kms:ListAliases for full coverage.`
+  );
 }
 
 /** True when any resolved declared value in the stack references an AWS-managed KMS

--- a/tests/kms-aliases.test.ts
+++ b/tests/kms-aliases.test.ts
@@ -1,7 +1,11 @@
 import { KMSClient, ListAliasesCommand } from '@aws-sdk/client-kms';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
-import { fetchManagedAliasTargets, usesManagedKmsAlias } from '../src/read/kms-aliases.js';
+import {
+  fetchManagedAliasTargets,
+  kmsListAliasesDeniedWarning,
+  usesManagedKmsAlias,
+} from '../src/read/kms-aliases.js';
 
 const kms = mockClient(KMSClient);
 beforeEach(() => kms.reset());
@@ -31,13 +35,27 @@ describe('fetchManagedAliasTargets', () => {
       })
       .resolves({ Aliases: [{ AliasName: 'alias/aws/s3', TargetKeyId: 'key-s3' }] });
     const out = await fetchManagedAliasTargets('us-west-2');
-    expect(out).toEqual({ 'alias/aws/rds': 'key-rds', 'alias/aws/s3': 'key-s3' });
+    expect(out).toEqual({
+      targets: { 'alias/aws/rds': 'key-rds', 'alias/aws/s3': 'key-s3' },
+      denied: false,
+    });
   });
 
-  it('returns {} (fall back) when ListAliases throws (e.g. missing kms:ListAliases)', async () => {
+  it('returns denied (empty targets) when ListAliases throws (e.g. missing kms:ListAliases)', async () => {
     kms
       .on(ListAliasesCommand)
       .rejects(Object.assign(new Error('denied'), { name: 'AccessDenied' }));
-    expect(await fetchManagedAliasTargets('eu-central-1')).toEqual({});
+    // distinct region so the per-region cache from the success test above is not reused
+    expect(await fetchManagedAliasTargets('eu-central-1')).toEqual({ targets: {}, denied: true });
+  });
+});
+
+describe('kmsListAliasesDeniedWarning', () => {
+  it('names the region, the denied permission, and that a key-swap is NOT detected', () => {
+    const w = kmsListAliasesDeniedWarning('ap-northeast-1');
+    expect(w).toContain('ap-northeast-1');
+    expect(w).toContain('kms:ListAliases');
+    expect(w).toContain('will NOT be detected');
+    expect(w).toContain('Grant kms:ListAliases');
   });
 });


### PR DESCRIPTION
## What (Finding 5 — audit follow-up)

Managed-KMS-alias drift detection prefetches `ListAliases` and STRICTLY checks the
live key is the alias's managed key — so a customer-managed key swapped in for an
`alias/aws/*` default is caught. The blind spot is **only** when `kms:ListAliases`
is **denied**: resolution returns empty and the match degrades to shape-only
(every `alias/aws/*` matches any live key ARN), silently hiding exactly that swap.

You framed this as "fail-open (noisy) vs wait-and-see". This takes a **third
option that dominates both**: keep the conservative suppression (zero new false
positives) but **warn once per region** when `ListAliases` is denied and the stack
uses `alias/aws/*`. No per-resource noise; the security blindness is now
visible + actionable.

## How

- `fetchManagedAliasTargets` → `{ targets, denied }`, caches the denial (a denied
  region is not re-queried per stack).
- `gather` prints `kmsListAliasesDeniedWarning(region)` once per region (deduped
  via a process-lifetime set) when denied AND the stack declares `alias/aws/*`.
- Classifier input unchanged (still the targets map) — no false-positive risk.

## Tests

`tests/kms-aliases.test.ts`: new return shape, `denied` flag, warning wording.
783 pass.

## Docs

README required-permissions note + ARCHITECTURE managed-KMS-alias section.
