### PR TITLE
fix(interactive): show the multiselect cursor — focused row was invisible (R118)

### DIFF
--- a/src/commands/bulk-multiselect.ts
+++ b/src/commands/bulk-multiselect.ts
@@ -15,7 +15,6 @@ import {
   S_BAR,
   S_BAR_END,
   S_BAR_START,
-  S_CHECKBOX_ACTIVE,
   S_CHECKBOX_INACTIVE,
   S_CHECKBOX_SELECTED,
 } from '@clack/prompts';
@@ -41,6 +40,22 @@ export function bulkSelectHint(): string {
 type Opt = { value: string; label: string };
 
 /**
+ * One rendered row. The cursor row MUST be visually distinct or up/down navigation
+ * looks dead (R116 regression: `S_CHECKBOX_ACTIVE` and `S_CHECKBOX_INACTIVE` are the
+ * SAME glyph in clack — only colour told them apart — and a selected row always showed
+ * the filled box regardless of focus, so the cursor was invisible). A leading `❯`
+ * pointer marks the focused row even with NO_COLOR; with colour it is also cyan. Pure +
+ * exported so the "focused row differs from the rest" invariant is unit-tested. R118.
+ */
+export function formatRow(label: string, state: { active: boolean; selected: boolean }): string {
+  const pointer = state.active ? '❯' : ' ';
+  const box = state.selected ? S_CHECKBOX_SELECTED : S_CHECKBOX_INACTIVE;
+  const cell = `${pointer} ${box} ${label}`;
+  if (state.active) return style.cursor(cell);
+  return state.selected ? `${pointer} ${style.ok(box)} ${style.ok(label)}` : cell;
+}
+
+/**
  * Show the multi-select and return the picked values, or `undefined` on cancel
  * (Ctrl+C / Esc). `message` is the prompt header; the hint line is appended for you.
  */
@@ -58,15 +73,10 @@ export async function bulkMultiselect(
       }
       const header = `${S_BAR_START}  ${message}\n${S_BAR}  ${style.infoTier(bulkSelectHint())}`;
       const selected = new Set(this.value ?? []);
-      const rows = this.options.map((opt, i) => {
-        const isSelected = selected.has(opt.value);
-        const box = isSelected
-          ? style.ok(S_CHECKBOX_SELECTED)
-          : i === this.cursor
-            ? S_CHECKBOX_ACTIVE
-            : S_CHECKBOX_INACTIVE;
-        return `${S_BAR}  ${box} ${isSelected ? style.ok(opt.label) : opt.label}`;
-      });
+      const rows = this.options.map(
+        (opt, i) =>
+          `${S_BAR}  ${formatRow(opt.label, { active: i === this.cursor, selected: selected.has(opt.value) })}`
+      );
       return `${header}\n${rows.join('\n')}\n${S_BAR_END}`;
     },
   });

--- a/src/report/style.ts
+++ b/src/report/style.ts
@@ -20,6 +20,7 @@ export interface Style {
   actual: (s: string) => string; // actual = value (what it really is)
   ok: (s: string) => string; // reverted: / baseline written:
   fail: (s: string) => string; // FAILED:
+  cursor: (s: string) => string; // the focused row in an interactive multiselect
 }
 
 /** Build the palette on top of a picocolors instance (identity when disabled). */
@@ -35,6 +36,7 @@ export function makeStyle(c: ReturnType<typeof pc.createColors>): Style {
     actual: c.red,
     ok: c.green,
     fail: (s) => c.bold(c.red(s)),
+    cursor: c.cyan,
   };
 }
 

--- a/tests/bulk-multiselect.test.ts
+++ b/tests/bulk-multiselect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { bulkSelectHint, bulkSelectValues } from '../src/commands/bulk-multiselect.js';
+import { bulkSelectHint, bulkSelectValues, formatRow } from '../src/commands/bulk-multiselect.js';
 
 describe('bulkSelectValues (→ = all, ← = none)', () => {
   const opts = [{ value: 'a' }, { value: 'b' }, { value: 'c' }];
@@ -15,6 +15,31 @@ describe('bulkSelectValues (→ = all, ← = none)', () => {
   it('"none" on an empty option list is still empty (no crash)', () => {
     expect(bulkSelectValues([], 'none')).toEqual([]);
     expect(bulkSelectValues([], 'all')).toEqual([]);
+  });
+});
+
+describe('formatRow (R118 — the focused row MUST be visually distinct, color or not)', () => {
+  it('the active row carries the ❯ pointer; inactive rows do not (NO_COLOR-safe cursor)', () => {
+    const active = formatRow('Foo', { active: true, selected: false });
+    const inactive = formatRow('Foo', { active: false, selected: false });
+    expect(active).toContain('❯');
+    expect(inactive).not.toContain('❯');
+    expect(active).not.toBe(inactive); // moving the cursor visibly changes a row
+  });
+
+  it('a selected row differs from an unselected one at the same focus (box state shows)', () => {
+    // assert they DIFFER rather than the exact glyph — clack downgrades the box to an
+    // ASCII fallback when the terminal lacks unicode, so the codepoint is not stable.
+    expect(formatRow('Foo', { active: false, selected: true })).not.toBe(
+      formatRow('Foo', { active: false, selected: false })
+    );
+  });
+
+  it('the focused row differs whether or not it is selected (cursor never hidden)', () => {
+    expect(formatRow('Foo', { active: true, selected: true })).toContain('❯');
+    expect(formatRow('Foo', { active: true, selected: true })).not.toBe(
+      formatRow('Foo', { active: false, selected: true })
+    );
   });
 });
 


### PR DESCRIPTION
R116 regression: the accept/revert multiselect cursor (up/down) looked dead — keys moved `this.cursor` but the render couldn't show where it was (clack's ACTIVE/INACTIVE checkbox glyphs are identical; only colour distinguished them, which the custom render dropped; a selected row always drew the filled box regardless of focus).

**Fix:** a leading `❯` pointer on the focused row (visible even with NO_COLOR) + cyan paint when colour is on (new `style.cursor`). Render goes through a pure, exported `formatRow` with a test asserting the focused row is distinct — the exact invariant that broke. 792 tests pass.

⚠️ Interactive — needs a live check that the cursor is now visible while moving up/down.