### PR TITLE
docs(report): anchor declared/undeclared to their source (CFn-declared) (R123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ explainable — the same change shows up:
 ```console
 $ npx cdkrd check ApiStack
 === cdkrd check: ApiStack (us-east-1) ===
-[UNDECLARED DRIFT: 1] (not declared in your template — the differentiator)
+[UNDECLARED DRIFT: 1] (live-only — not in your CloudFormation template; the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
 
 result: 1 drift(s) (undeclared=1)
@@ -58,7 +58,7 @@ there is nothing to compare them to yet), then offers to record a baseline:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[UNRECORDED: 2] (not drift — undeclared and not in the baseline yet; record to record)
+[UNRECORDED: 2] (not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it)
   ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
 
@@ -68,7 +68,7 @@ info:
   ...
 
 ApiStack: unrecorded values found — what do you want to do?
-    Record all undeclared — snapshot into the baseline (keeps watching)
+    Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
     Ignore all — stop reporting it (writes .cdkrd/config.json)
     Decide per finding — pick an action for each
   ❯ Nothing (decide later)
@@ -90,7 +90,7 @@ reports it and asks right there:
 
 ```console
 ApiStack: drift found — what do you want to do?
-    Record all undeclared — snapshot into the baseline (keeps watching)
+    Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
     Revert all — write the desired values to AWS
     Ignore all — stop reporting it (writes .cdkrd/config.json)
     Decide per finding — pick an action for each
@@ -129,6 +129,21 @@ Requirements: Node.js >= 20, AWS credentials via the standard SDK chain
 
 ## How it works
 
+cdkrd compares the **live AWS resource** against your **CloudFormation template**
+(the one you DEPLOYED by default; the local synth with `--pre-deploy`). The
+vocabulary names exactly which of the three sources a finding relates to, so
+"declared" is never ambiguous:
+
+| term                       | source                                        | meaning                                                 |
+| -------------------------- | --------------------------------------------- | ------------------------------------------------------- |
+| **CFn-declared**           | your CloudFormation template                  | the property IS in the template; the live value drifted |
+| **undeclared** (live-only) | the live resource                             | the property is on the resource but NOT in the template |
+| **recorded / unrecorded**  | your `.cdkrd` baseline file (a separate axis) | whether you have snapshotted that live-only value yet   |
+
+So `CFn-declared` ≠ "declared in my CDK code" and ≠ "in my `.cdkrd` baseline" — it
+means the deployed **CloudFormation** template. `undeclared` and `unrecorded` are
+different axes (template vs baseline file), not synonyms.
+
 After `check` finds drift, you decide what each finding means — and the verbs mirror
 the choice:
 
@@ -146,10 +161,10 @@ undeclared — and the property is never reported again). `record` is
 undeclared-only; `ignore` is the only in-tool way to accept a **declared** drift
 without editing code or reverting.
 
-- **Declared** properties are compared against the **deployed template** — no
-  baseline involved, drift is detected from the first run.
-- **Undeclared** properties are compared against a **baseline** you record with
-  `record`: a JSON file at `.cdkrd/<stack>.<accountId>.<region>.json`, committed
+- **CFn-declared** properties are compared against the **deployed CloudFormation
+  template** — no baseline involved, drift is detected from the first run.
+- **Undeclared** (live-only) properties are compared against a **baseline** you
+  record with `record`: a JSON file at `.cdkrd/<stack>.<accountId>.<region>.json`, committed
   to git. A PR that changes it is a visible, reviewable change to "what real
   state we record". Account id and region are part of the filename, so the same
   stack deployed to several accounts never collides (gitignore personal-account
@@ -284,7 +299,7 @@ incident shows up before `cdk deploy` silently reverts it:
 $ npx cdkrd check --pre-deploy
 (--pre-deploy) comparing live state against the LOCAL synth template
 === cdkrd check: ApiStack (us-east-1) ===
-[DECLARED DRIFT: 1]
+[CFn-DECLARED DRIFT: 1]
   ApiStack/Api/Handler.MemorySize (AWS::Lambda::Function)
       desired=1024
       actual =2048
@@ -375,7 +390,7 @@ text.
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[DECLARED DRIFT: 1]
+[CFn-DECLARED DRIFT: 1]
   ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"
       actual ="Suspended"

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -74,10 +74,17 @@ export function postRecordNote(remainingUndeclared: number, remainingDeclared: n
 // Identity shared by raw and reconciled findings (one property of one resource).
 const keyOf = (f: Finding): string => `${f.logicalId}::${f.path}`;
 
+// The tier tag shown on each picker row. Anchors the vocabulary to its source so
+// "declared" is never misread as the .cdkrd baseline: CFn-declared = in the deployed
+// CloudFormation template; undeclared = live-only (not in the template); `unrecorded`
+// is the separate baseline-file axis.
+const tierTag = (f: Finding): string =>
+  f.tier === 'declared'
+    ? 'CFn-declared'
+    : `undeclared · live-only${f.unrecorded ? ' · unrecorded' : ''}`;
+
 const pickerLabel = (f: Finding): string =>
-  `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''}  (${f.tier}${
-    f.unrecorded ? ', unrecorded' : ''
-  })`;
+  `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''}  (${tierTag(f)})`;
 
 /**
  * Re-evaluate check's exit WITHOUT re-reading AWS: reload the (possibly just-written)
@@ -112,7 +119,8 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
   if (actions.record)
     options.push({
       value: 'record-all',
-      label: 'Record all undeclared — snapshot into the baseline (keeps watching)',
+      label:
+        'Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)',
     });
   if (actions.revert)
     options.push({ value: 'revert-all', label: 'Revert all — write the desired values to AWS' });

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -22,7 +22,7 @@ import { style } from './style.js';
 
 const TIER_NAMES: Record<Tier, string> = {
   deleted: 'DELETED',
-  declared: 'DECLARED DRIFT',
+  declared: 'CFn-DECLARED DRIFT',
   undeclared: 'UNDECLARED DRIFT',
   atDefault: 'AT AWS DEFAULT',
   generated: 'AWS GENERATED',
@@ -32,9 +32,15 @@ const TIER_NAMES: Record<Tier, string> = {
   skipped: 'SKIPPED',
 };
 // Explanation printed after the bracketed name+count, outside the brackets.
+// The notes anchor the THREE sources cdkrd touches, so "declared" is never misread as
+// "in my CDK code" or "in the .cdkrd baseline": (1) the DEPLOYED CloudFormation template
+// (declared/undeclared), (2) the live resource (undeclared = live-only), (3) the .cdkrd
+// baseline file (recorded/unrecorded — a separate axis).
 const TIER_NOTES: Partial<Record<Tier, string>> = {
   deleted: 'resource deleted out of band — always drift',
-  undeclared: 'not declared in your template — the differentiator',
+  declared: 'declared in your CloudFormation template — the live value differs',
+  undeclared:
+    'live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator',
   atDefault: 'undeclared, but the live value matches a known AWS default — not drift',
   generated: 'auto-generated identifier not in your template (AWS-assigned at deploy) — not drift',
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
@@ -181,7 +187,7 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     section(
       unrecordedShown,
       'UNRECORDED',
-      'not drift — undeclared and not in the baseline yet; record to record',
+      'not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it',
       style.undeclaredTier,
       driftSections > 0
     )

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -123,9 +123,13 @@ describe('report', () => {
   it('section header carries the count INSIDE the brackets, note outside (R48)', () => {
     const { text } = run([F('undeclared'), F('declared', 'Q')]);
     expect(text).toContain(
-      '[UNDECLARED DRIFT: 1] (not declared in your template — the differentiator)'
+      '[UNDECLARED DRIFT: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
     );
-    expect(text).toContain('[DECLARED DRIFT: 1]'); // no note for declared
+    // declared is now anchored to the deployed CloudFormation template (CFn-) so it
+    // can't be misread as "in my CDK code" or "in the .cdkrd baseline"
+    expect(text).toContain(
+      '[CFn-DECLARED DRIFT: 1] (declared in your CloudFormation template — the live value differs)'
+    );
     // the old bare-digit-right-of-bracket form is gone
     expect(text).not.toMatch(/\] \d/);
   });
@@ -362,7 +366,7 @@ describe('report', () => {
     it('drift: first section directly under the header; blank line BEFORE result: (R48)', () => {
       const lines = run([F('declared')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toBe('[DECLARED DRIFT: 1]'); // no stray blank after the header
+      expect(lines[1]).toMatch(/^\[CFn-DECLARED DRIFT: 1\]/); // no stray blank after the header
       const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
       expect(lines[resultIdx - 1]).toBe(''); // the verdict is separated from the section above
     });
@@ -370,7 +374,7 @@ describe('report', () => {
     it('two drift sections: blank BETWEEN them, none after the header (R48)', () => {
       const lines = run([F('declared'), F('undeclared', 'Q')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toBe('[DECLARED DRIFT: 1]');
+      expect(lines[1]).toMatch(/^\[CFn-DECLARED DRIFT: 1\]/);
       const undeclaredIdx = lines.findIndex((l) => l.startsWith('[UNDECLARED'));
       expect(lines[undeclaredIdx - 1]).toBe(''); // grouping blank between sections
     });


### PR DESCRIPTION
## Summary

`declared` / `undeclared` were ambiguous about **where**. Users (including the
designer) read them as "declared in my CDK code / synth output" or — the worse
confusion — "recorded in the `.cdkrd` file that `check` generates", conflating the
**CloudFormation-template axis** with the **baseline-file axis** (`undeclared` vs
`unrecorded` are different things).

This anchors the **user-facing** vocabulary to the three sources cdkrd touches.
Internal tier IDs and the `--declared-only` / `--undeclared-only` flags are
unchanged (grep-ability + test stability).

## The three sources

| term                       | source                       | meaning                                          |
| -------------------------- | ---------------------------- | ------------------------------------------------ |
| **CFn-declared**           | your CloudFormation template | in the template; live value drifted              |
| **undeclared** (live-only) | the live resource            | on the resource, NOT in the template             |
| **recorded / unrecorded**  | your `.cdkrd` baseline file  | whether you've snapshotted that live-only value  |

## Changes (display only)

- **report headers/notes**: `[DECLARED DRIFT]` → `[CFn-DECLARED DRIFT]`;
  declared/undeclared/unrecorded notes now name the CFn template vs the `.cdkrd`
  baseline explicitly. `[DELETED]` and `[UNRECORDED]` headers unchanged
  (`UNRECORDED` stays deliberately **not drift**, per R60/R62).
- **per-finding picker** row tag: `(declared)` → `(CFn-declared)`; `(undeclared)` →
  `(undeclared · live-only[ · unrecorded])`.
- **interactive "Record all"** label names the `.cdkrd` baseline + live-only.
- **README**: a 3-source legend + updated examples / How-it-works prose.

The declared note intentionally omits "deployed" so it's accurate under
`--pre-deploy` (compares against the local synth template, which prints its own
banner).

## Why DELETED/UNRECORDED keep their headers

All three drift tiers are labelled drift (`CFn-DECLARED DRIFT` / `UNDECLARED DRIFT`;
`DELETED`'s note says "always drift"). `UNRECORDED` deliberately does **not** say
drift — a live-only value with no baseline yet has no expectation to violate
(exit 0), the R60/R62 design that avoids a first-run false-positive flood.

## Verification

`vp check` 0 errors, fresh `tsgo` clean, build ok, **829 unit tests pass**.
Integ scripts grep `"DECLARED DRIFT"` as a substring → still match `CFn-DECLARED DRIFT`.
