### PR TITLE
docs(redesign-notes): keep sibling-managed role policies undeclared (R124)

### DIFF
--- a/docs/redesign-notes.md
+++ b/docs/redesign-notes.md
@@ -141,3 +141,21 @@ core thesis is unchanged.
   would re-flood with exactly the `false`/empty noise the subtractive model exists
   to remove, drowning the real signal. The recorded-then-changed-to-empty case is
   still caught by baseline removal-detection, which is the case that matters.
+
+- **Reclassifying sibling-managed role policies as DECLARED to match `cdk drift`.**
+  When a role's grants come from a sibling `AWS::IAM::Policy` (the CDK DefaultPolicy
+  from `addToPolicy`, or an explicit `iam.Policy({ roles: [...] })`), the role's own
+  template has no `Policies` key, so cdkrd classifies an out-of-band inline policy on
+  the role as **undeclared**. `cdk drift` instead resolves the sibling into the role's
+  _effective_ `Policies` and reports such an addition as **declared** `/Policies/N`
+  drift. Tempting to match it. Rejected: it is a label-only difference with **no
+  coverage gap**, proven from both sides by live integ —
+  `iam/verify-inline-policy.sh` (a rogue inline policy added next to the sibling IS
+  detected as undeclared, and is revertable per-name) and
+  `iam/verify-sibling-policy-doc.sh` (an out-of-band edit to the sibling's OWN
+  document IS detected as CFn-declared drift on the `AWS::IAM::Policy` resource
+  itself). So nothing is missed either way. Reclassifying would require IAM-specific
+  logic to merge sibling policy documents into the role's effective `Policies` —
+  per-type special-casing against the generic subtractive model — and "undeclared" is
+  the more faithful label anyway: the role template genuinely does not declare those
+  policies, and seeing what the template never declared is cdkrd's differentiator.


### PR DESCRIPTION
Settle the long-standing design question by recording it under **Considered and rejected** in redesign-notes.md: an out-of-band inline policy on a role whose grants come from a sibling `AWS::IAM::Policy` stays classified **undeclared** (cdkrd's reality-vs-template model), rather than reclassified to **declared** to mirror `cdk drift`.

It is a label-only difference with **no coverage gap**, proven from both sides by live integ — `iam/verify-inline-policy.sh` (rogue add → undeclared, revertable) and `iam/verify-sibling-policy-doc.sh` (sibling's own doc edit → CFn-declared drift on the Policy resource, R122/#96). Reclassifying would need IAM-specific sibling-merge logic against the generic subtractive model, and "undeclared" is the more faithful label.

Docs-only. `vp check` 0 errors.