### PR TITLE
feat(check): interactive UX polish from live dogfood (R125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ explainable — the same change shows up:
 ```console
 $ npx cdkrd check ApiStack
 === cdkrd check: ApiStack (us-east-1) ===
-[UNDECLARED DRIFT: 1] (live-only — not in your CloudFormation template; the differentiator)
+[CFn-UNDECLARED DRIFT: 1] (live-only — not in your CloudFormation template; the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
 
 result: 1 drift(s) (undeclared=1)
@@ -68,10 +68,10 @@ info:
   ...
 
 ApiStack: unrecorded values found — what do you want to do?
+  ❯ Nothing (decide later)
     Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
     Ignore all — stop reporting it (writes .cdkrd/config.json)
     Decide per finding — pick an action for each
-  ❯ Nothing (decide later)
 ```
 
 The report always prints **first**, so you see the standout values before deciding
@@ -90,11 +90,11 @@ reports it and asks right there:
 
 ```console
 ApiStack: drift found — what do you want to do?
+  ❯ Nothing (decide later)
     Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
     Revert all — write the desired values to AWS
     Ignore all — stop reporting it (writes .cdkrd/config.json)
     Decide per finding — pick an action for each
-  ❯ Nothing (decide later)
 ```
 
 - **Record all** records the undeclared values in the baseline, so `check` stays
@@ -134,15 +134,15 @@ cdkrd compares the **live AWS resource** against your **CloudFormation template*
 vocabulary names exactly which of the three sources a finding relates to, so
 "declared" is never ambiguous:
 
-| term                       | source                                        | meaning                                                 |
-| -------------------------- | --------------------------------------------- | ------------------------------------------------------- |
-| **CFn-declared**           | your CloudFormation template                  | the property IS in the template; the live value drifted |
-| **undeclared** (live-only) | the live resource                             | the property is on the resource but NOT in the template |
-| **recorded / unrecorded**  | your `.cdkrd` baseline file (a separate axis) | whether you have snapshotted that live-only value yet   |
+| term                           | source                                        | meaning                                                 |
+| ------------------------------ | --------------------------------------------- | ------------------------------------------------------- |
+| **CFn-declared**               | your CloudFormation template                  | the property IS in the template; the live value drifted |
+| **CFn-undeclared** (live-only) | the live resource                             | the property is on the resource but NOT in the template |
+| **recorded / unrecorded**      | your `.cdkrd` baseline file (a separate axis) | whether you have snapshotted that live-only value yet   |
 
 So `CFn-declared` ≠ "declared in my CDK code" and ≠ "in my `.cdkrd` baseline" — it
-means the deployed **CloudFormation** template. `undeclared` and `unrecorded` are
-different axes (template vs baseline file), not synonyms.
+means the deployed **CloudFormation** template. `CFn-undeclared` and `unrecorded`
+are different axes (template vs baseline file), not synonyms.
 
 After `check` finds drift, you decide what each finding means — and the verbs mirror
 the choice:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -138,10 +138,11 @@ lives per stack/account/region; the `ignore` rules live once, app-wide, in
 `.cdkrd/config.json` (`config/config-file.ts` — `addIgnoreRules` writes,
 `applyIgnores` reads).
 
-In a TTY, `check` offers to resolve the drift **inline** (R28, extended R121):
-after reporting it prompts `Record all / Revert all / Ignore all / Decide per
-finding / Nothing` (each bulk option shown only when ≥1 finding can take it;
-"Decide per finding" only when >1 finding is decidable). The bulk options apply one
+In a TTY, `check` offers to resolve the drift **inline** (R28, extended R121/R125):
+after reporting it prompts `Nothing / Record all / Revert all / Ignore all / Decide
+per finding` (Nothing is FIRST so the safe no-op is the default cursor; each bulk
+option shown only when ≥1 finding can take it; "Decide per finding" only when >1
+finding is decidable). A cancelled sub-prompt (Esc) returns to this menu (R125). The bulk options apply one
 action to every applicable finding (each leads to that verb's own multiselect);
 "Decide per finding" opens the per-finding **action picker**
 ([action-picker.ts](../src/commands/action-picker.ts) — `↑↓` move, `space` cycle
@@ -234,9 +235,10 @@ checked.
   - **stack-actions.ts** — the per-stack record/ignore/revert actions shared by the
     standalone verbs and check's interactive prompt (`recordStack` / `ignoreStack` /
     `revertStack`), so they can never diverge.
-  - **interactive-resolve.ts** — check's after-report resolution (R28/R121): the
-    top-level select (Record all / Revert all / Ignore all / Decide per finding /
-    Nothing) and the per-finding dispatch into the stack actions; returns the
+  - **interactive-resolve.ts** — check's after-report resolution (R28/R121/R125): the
+    top-level select (Nothing first as the safe default, then Record all / Revert all /
+    Ignore all / Decide per finding) looped so a cancelled sub-prompt returns to the
+    menu (Esc = back), and the per-finding dispatch into the stack actions; returns the
     re-evaluated exit code.
   - **action-picker.ts** — the per-finding action picker (R121), built on `@clack/core`'s
     base `Prompt` to bind `↑↓` / `space` (cycle) / `→` (all to focused) / `enter`.
@@ -711,8 +713,8 @@ never-snapshot-complete resource has nothing to violate (§8). `applyBaseline`
 tags such findings `unrecorded` — on a no-baseline first run that is every
 undeclared value, and after a cherry-pick record it is still every value the
 user did not pick. They render as their own `[UNRECORDED: N]` section (note:
-`not drift — undeclared and not in the baseline yet; record to record`) alongside
-any real `[UNDECLARED DRIFT]` section, are excluded from the verdict and the
+`not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to
+track it`) alongside any real `[CFn-UNDECLARED DRIFT]` section, are excluded from the verdict and the
 `--fail` exit, and the `result:` line carries the count + the way out
 (`— N unrecorded value(s) await a baseline (X shown, Y folded; run cdkrd record)`
 when some fold; R112). When BOTH a drift section and a standout `[UNRECORDED]`

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -15,6 +15,7 @@
 // and unit-tested; the prompt is a thin rendering/key shell.
 import { isCancel, Prompt } from '@clack/core';
 import { S_BAR, S_BAR_END, S_BAR_START } from '@clack/prompts';
+import { isNestedUndeclared } from '../revert/plan.js';
 import type { Finding } from '../types.js';
 import { style } from '../report/style.js';
 
@@ -25,14 +26,18 @@ export type FindingAction = 'record' | 'ignore' | 'revert' | 'skip';
  * The actions that apply to a finding, in cycle order (EXCLUDING the always-present
  * `skip`). Mirrors the verbs' scope:
  *  - undeclared → record (snapshot the norm; gentlest, keeps watching), then ignore
- *    (stop watching), then revert (REMOVE the live value — destructive, so last);
+ *    (stop watching), then revert (REMOVE the live value — destructive, so last) —
+ *    BUT revert is dropped for a NESTED undeclared value, which is detect/record-only
+ *    (R99): offering it would let the user pick an action revert can't run;
  *  - declared → revert (restore the template intent — the natural fix), then ignore;
  *  - everything else (deleted / readGap / unresolved / atDefault / generated / skipped)
  *    has no in-tool action → an empty list, so it is not a decidable row.
- * Pure + exported.
+ * Pure + exported. `isNestedUndeclared` is the SAME predicate buildRevertPlan uses, so
+ * the picker's revert offer and revert's actual capability never diverge.
  */
 export function applicableActions(finding: Finding): FindingAction[] {
-  if (finding.tier === 'undeclared') return ['record', 'ignore', 'revert'];
+  if (finding.tier === 'undeclared')
+    return isNestedUndeclared(finding) ? ['record', 'ignore'] : ['record', 'ignore', 'revert'];
   if (finding.tier === 'declared') return ['revert', 'ignore'];
   return [];
 }

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -32,7 +32,6 @@ import {
   ignoreStack,
   includeUnrecordedRemovals,
   recordStack,
-  resolveInteractiveRevertExit,
   revertStack,
 } from './stack-actions.js';
 
@@ -81,7 +80,7 @@ const keyOf = (f: Finding): string => `${f.logicalId}::${f.path}`;
 const tierTag = (f: Finding): string =>
   f.tier === 'declared'
     ? 'CFn-declared'
-    : `undeclared · live-only${f.unrecorded ? ' · unrecorded' : ''}`;
+    : `CFn-undeclared · live-only${f.unrecorded ? ' · unrecorded' : ''}`;
 
 const pickerLabel = (f: Finding): string =>
   `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''}  (${tierTag(f)})`;
@@ -115,7 +114,12 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
   const actions = availableActions(p.reconciled, p.baseline, p.schemas, includeRemovals);
   if (!actions.record && !actions.ignore && !actions.revert) return p.code;
 
-  const options: { value: string; label: string }[] = [];
+  const decidable = p.reconciled.filter((f) => applicableActions(f).length > 0);
+  // Nothing FIRST so the safe no-op is the top row AND the default cursor — Enter is a
+  // harmless exit, never an accidental write. The action options follow.
+  const options: { value: string; label: string }[] = [
+    { value: 'nothing', label: 'Nothing (decide later)' },
+  ];
   if (actions.record)
     options.push({
       value: 'record-all',
@@ -129,31 +133,39 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
       value: 'ignore-all',
       label: 'Ignore all — stop reporting it (writes .cdkrd/config.json)',
     });
-  const decidable = p.reconciled.filter((f) => applicableActions(f).length > 0);
   if (decidable.length > 1)
     options.push({ value: 'per-finding', label: 'Decide per finding — pick an action for each' });
-  options.push({ value: 'nothing', label: 'Nothing (decide later)' });
 
-  const choice = await select({
-    message:
-      p.code === 1
-        ? `${p.stackName}: drift found — what do you want to do?`
-        : `${p.stackName}: unrecorded values found — what do you want to do?`,
-    options,
-    initialValue: 'nothing',
-  });
-  if (isCancel(choice) || choice === 'nothing') return p.code;
+  // Loop so a CANCELLED sub-prompt (Esc) returns to this menu instead of exiting — a
+  // "back" affordance. A sub-action returns null when its prompt was cancelled (no AWS /
+  // baseline / config write happened, so re-showing the menu is side-effect-free);
+  // Esc / Nothing at THIS top menu exits with the pre-prompt code.
+  while (true) {
+    const choice = await select({
+      message:
+        p.code === 1
+          ? `${p.stackName}: drift found — what do you want to do?`
+          : `${p.stackName}: unrecorded values found — what do you want to do?`,
+      options,
+      initialValue: 'nothing',
+    });
+    if (isCancel(choice) || choice === 'nothing') return p.code;
 
-  if (choice === 'record-all') return recordAll(p);
-  if (choice === 'ignore-all') return ignoreAll(p);
-  if (choice === 'revert-all') return revertAll(p);
-  if (choice === 'per-finding') return perFinding(p, decidable);
-  return p.code;
+    let result: number | null;
+    if (choice === 'record-all') result = await recordAll(p);
+    else if (choice === 'ignore-all') result = await ignoreAll(p);
+    else if (choice === 'revert-all') result = await revertAll(p);
+    else if (choice === 'per-finding') result = await perFinding(p, decidable);
+    else result = p.code;
+
+    if (result === null) continue; // sub-prompt cancelled → back to the menu
+    return result;
+  }
 }
 
 // record records UNDECLARED only; recordStack emits the "declared/deleted NOT approved"
 // scope note after the write (R117), so this path warns consistently with `cdkrd record`.
-async function recordAll(p: ResolveParams): Promise<number> {
+async function recordAll(p: ResolveParams): Promise<number | null> {
   const result = await recordStack({
     stackName: p.stackName,
     region: p.region,
@@ -162,7 +174,9 @@ async function recordAll(p: ResolveParams): Promise<number> {
     yes: p.yes,
     interactive: true,
   });
-  if (!result.wrote) return p.code;
+  // !wrote in this interactive path means the multiselect was cancelled (nothing
+  // written) — signal "back to the menu" rather than exit.
+  if (!result.wrote) return null;
   // R52: a successful interactive record is a SUCCESS for THIS run — unselected
   // undeclared values surface from the next check on, not as a failure now. Declared/
   // deleted drift is outside record's reach and keeps exit 1. Say what remains plainly.
@@ -182,7 +196,7 @@ async function recordAll(p: ResolveParams): Promise<number> {
   return remainingDeclared > 0 ? 1 : 0;
 }
 
-async function ignoreAll(p: ResolveParams): Promise<number> {
+async function ignoreAll(p: ResolveParams): Promise<number | null> {
   // reconciled = the report's declared + undeclared findings; ignoreStack shows its own
   // multiselect (default all) when !yes, mirroring `cdkrd ignore`.
   const result = await ignoreStack({
@@ -191,10 +205,12 @@ async function ignoreAll(p: ResolveParams): Promise<number> {
     yes: p.yes,
     interactive: true,
   });
-  return result.wrote ? recomputeExit(p, new Set()) : p.code;
+  // reconciled findings are all not-yet-ignored, so a completed run always writes a new
+  // rule; !wrote means the multiselect was cancelled → back to the menu.
+  return result.wrote ? recomputeExit(p, new Set()) : null;
 }
 
-async function revertAll(p: ResolveParams): Promise<number> {
+async function revertAll(p: ResolveParams): Promise<number | null> {
   const outcome = await revertStack({
     stackName: p.stackName,
     region: p.region,
@@ -207,14 +223,15 @@ async function revertAll(p: ResolveParams): Promise<number> {
     verbose: p.verbose,
     interactive: true,
   });
-  // R30: an aborted confirm wrote nothing, so the drift still stands — keep exit 1.
-  return resolveInteractiveRevertExit(p.code, outcome);
+  // R30: an aborted confirm wrote nothing — signal "back to the menu" (the drift still
+  // stands; the caller keeps the pre-prompt code if the user then exits).
+  return outcome.aborted ? null : outcome.exit;
 }
 
-async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<number> {
+async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<number | null> {
   const rows = decidable.map((f) => ({ label: pickerLabel(f), applicable: applicableActions(f) }));
   const chosen = await actionPicker(`${p.stackName}: assign an action to each finding`, rows);
-  if (chosen === undefined) return p.code; // cancelled — nothing applied
+  if (chosen === undefined) return null; // picker cancelled (Esc) → back to the menu
   const groups = groupByAction(decidable, chosen);
   if (groups.record.length + groups.ignore.length + groups.revert.length === 0) return p.code;
 

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -23,7 +23,7 @@ import { style } from './style.js';
 const TIER_NAMES: Record<Tier, string> = {
   deleted: 'DELETED',
   declared: 'CFn-DECLARED DRIFT',
-  undeclared: 'UNDECLARED DRIFT',
+  undeclared: 'CFn-UNDECLARED DRIFT',
   atDefault: 'AT AWS DEFAULT',
   generated: 'AWS GENERATED',
   ignored: 'IGNORED',
@@ -99,8 +99,12 @@ export function formatFinding(f: Finding): string {
 // section-title color by tier: deleted/declared = red (drift), undeclared =
 // yellow (the differentiator), informational tiers = dim.
 function tierStyle(t: Tier): (s: string) => string {
-  if (t === 'undeclared') return style.undeclaredTier;
-  if (t === 'deleted' || t === 'declared') return style.driftTier;
+  // All three DRIFT tiers are RED — they are drift (exit-affecting). undeclared was
+  // previously yellow (undeclaredTier), which collided with the [UNRECORDED] section
+  // (also yellow) and made a real undeclared DRIFT look identical to a not-drift
+  // unrecorded value. Yellow (undeclaredTier) is now reserved for UNRECORDED / "to
+  // review" — so colour alone separates drift (red) from to-review (yellow). R125.
+  if (t === 'deleted' || t === 'declared' || t === 'undeclared') return style.driftTier;
   return style.infoTier;
 }
 
@@ -218,7 +222,7 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
         : 'run cdkrd record';
     resultBody =
       `${drifted + unrecordedShown.length} findings — ${style.drift(`${drifted} drift`)} (${driftCounts})` +
-      ` + ${unrecordedShown.length} undeclared to review` +
+      ` + ${style.undeclaredTier(`${unrecordedShown.length} undeclared to review`)}` +
       style.infoTier(` (${foldedHint})`);
   } else {
     // the verdict is the one line that must stand out: green CLEAN / red drift count

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -15,6 +15,20 @@ import { SDK_OVERRIDES } from '../read/overrides.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { SDK_PROP_WRITERS, SDK_WRITERS } from './writers.js';
 
+/**
+ * A nested undeclared value (a live sub-key inside a declared object, R96/R98) is
+ * detect/record-only — never revertable (toPointer can't build a safe RFC6902 patch for
+ * a dotted/bracketed path; R99). Detected by PATH SHAPE, not just `Finding.nested`: a
+ * baseline value removed since record is reconstructed without the flag but keeps its
+ * nested path. A top-level undeclared path is a single key (no '.'/'['). Pure + exported
+ * so the interactive action picker offers `revert` ONLY where revert can actually run.
+ */
+export function isNestedUndeclared(f: Finding): boolean {
+  return (
+    f.tier === 'undeclared' && (Boolean(f.nested) || f.path.includes('.') || f.path.includes('['))
+  );
+}
+
 export interface PatchOp {
   op: 'add' | 'remove';
   path: string; // RFC6902 JSON pointer into the resource Properties model
@@ -115,7 +129,7 @@ export function buildRevertPlan(
     // reconstructed (baseline-file.ts) WITHOUT the flag, but keeps its nested path. A
     // top-level undeclared path is a single key (never contains '.'/'['), and declared
     // drift is a different tier — so this never blocks a top-level revert.
-    if (f.tier === 'undeclared' && (f.nested || f.path.includes('.') || f.path.includes('['))) {
+    if (isNestedUndeclared(f)) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,

--- a/tests/action-picker.test.ts
+++ b/tests/action-picker.test.ts
@@ -22,8 +22,24 @@ const F = (tier: Finding['tier']): Finding => ({
 });
 
 describe('applicableActions (cycle order mirrors the verbs scope)', () => {
-  it('undeclared → record, ignore, revert (destructive revert last)', () => {
+  it('undeclared (top-level) → record, ignore, revert (destructive revert last)', () => {
     expect(applicableActions(F('undeclared'))).toEqual(['record', 'ignore', 'revert']);
+  });
+  it('NESTED undeclared drops revert — it is detect/record-only (R99)', () => {
+    // dotted, bracketed, or flagged-nested undeclared → no revert offered (revert can't
+    // build a safe RFC6902 patch for a nested path), matching buildRevertPlan.
+    expect(applicableActions({ ...F('undeclared'), path: 'Origins.0.Timeout' })).toEqual([
+      'record',
+      'ignore',
+    ]);
+    expect(applicableActions({ ...F('undeclared'), path: 'Origins[o1].Timeout' })).toEqual([
+      'record',
+      'ignore',
+    ]);
+    expect(applicableActions({ ...F('undeclared'), path: 'P', nested: true })).toEqual([
+      'record',
+      'ignore',
+    ]);
   });
   it('declared → revert (the natural fix), ignore — never record', () => {
     expect(applicableActions(F('declared'))).toEqual(['revert', 'ignore']);

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -52,7 +52,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
   it('undeclared DRIFT and UNRECORDED coexist as separate sections (partial baseline)', () => {
     const { code, text } = run([F('undeclared'), U('Q')]);
     expect(code).toBe(1);
-    expect(text).toContain('[UNDECLARED DRIFT: 1]');
+    expect(text).toContain('[CFn-UNDECLARED DRIFT: 1]');
     expect(text).toContain('[UNRECORDED: 1]');
     expect(text).toContain('result: 2 findings — 1 drift (undeclared=1) + 1 undeclared to review');
   });
@@ -83,7 +83,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
   it('untagged undeclared (recorded value changed / appeared since record) is drift as before', () => {
     const { code, text } = run([F('undeclared')]);
     expect(code).toBe(1);
-    expect(text).toContain('[UNDECLARED DRIFT: 1]');
+    expect(text).toContain('[CFn-UNDECLARED DRIFT: 1]');
   });
 });
 
@@ -123,7 +123,7 @@ describe('report', () => {
   it('section header carries the count INSIDE the brackets, note outside (R48)', () => {
     const { text } = run([F('undeclared'), F('declared', 'Q')]);
     expect(text).toContain(
-      '[UNDECLARED DRIFT: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
+      '[CFn-UNDECLARED DRIFT: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
     );
     // declared is now anchored to the deployed CloudFormation template (CFn-) so it
     // can't be misread as "in my CDK code" or "in the .cdkrd baseline"
@@ -375,7 +375,7 @@ describe('report', () => {
       const lines = run([F('declared'), F('undeclared', 'Q')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
       expect(lines[1]).toMatch(/^\[CFn-DECLARED DRIFT: 1\]/);
-      const undeclaredIdx = lines.findIndex((l) => l.startsWith('[UNDECLARED'));
+      const undeclaredIdx = lines.findIndex((l) => l.startsWith('[CFn-UNDECLARED'));
       expect(lines[undeclaredIdx - 1]).toBe(''); // grouping blank between sections
     });
 


### PR DESCRIPTION
Six fixes from dogfooding the latest build on a real stack:

1. **Nothing-first** in the after-report select — safe no-op is the top row + default cursor (Enter never an accidental write).
2. **esc = back** — top-level select is looped; cancelling a sub-prompt returns to the menu instead of exiting. Nothing/Esc at the top still exits.
3. **picker drops `revert` for NESTED undeclared** (detect/record-only, R99) — uses the SAME predicate as buildRevertPlan (`isNestedUndeclared`, now exported) so the offer matches capability.
4. **`[UNDECLARED DRIFT]` → `[CFn-UNDECLARED DRIFT]`** for symmetry with CFn-DECLARED (both anchored to the CloudFormation-template axis); picker tag + 3-source legend updated.
5. **emphasis**: result-line "N undeclared to review" is now coloured (was plain).
6. **colour fix**: all three DRIFT tiers are RED; undeclared was yellow and collided with the `[UNRECORDED]` section (also yellow), so a real undeclared DRIFT looked identical to a not-drift unrecorded value. Yellow is now reserved for UNRECORDED / to-review — colour alone separates drift (red) from to-review (yellow).

Docs (README + ARCHITECTURE) + tests updated. **830 unit tests pass**, `vp check` 0 errors, fresh typecheck + build OK. Interactive flow is TTY-only → loop/back verified by live dogfood; pure logic unit-tested.

Follow-ups queued (pre-launch): R126 element-level granularity for identity-keyed undeclared arrays; R127 config region scope; R128 chain-actions after a partial resolve.