### PR TITLE
test(integ): harvest11 FP-rich uncovered types — zero declared FP (R126)

### DIFF
--- a/tests/corpus/AWS__Athena__DataCatalog.DataCatalog.json
+++ b/tests/corpus/AWS__Athena__DataCatalog.DataCatalog.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DataCatalog",
+    "resourceType": "AWS::Athena::DataCatalog",
+    "physicalId": "cdkrd_catalog",
+    "constructPath": "CdkdriftIntegHarvest11/DataCatalog",
+    "declared": {
+      "Description": "cdkrd harvest data catalog",
+      "Name": "cdkrd_catalog",
+      "Parameters": {
+        "catalog-id": "111111111111"
+      },
+      "Type": "GLUE"
+    }
+  },
+  "liveRaw": {
+    "Status": "CREATE_COMPLETE",
+    "Type": "GLUE",
+    "Description": "cdkrd harvest data catalog",
+    "Parameters": {
+      "catalog-id": "111111111111"
+    },
+    "Tags": [],
+    "Name": "cdkrd_catalog"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "DataCatalog",
+      "resourceType": "AWS::Athena::DataCatalog",
+      "path": "Status",
+      "actual": "CREATE_COMPLETE",
+      "physicalId": "cdkrd_catalog",
+      "constructPath": "CdkdriftIntegHarvest11/DataCatalog"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeDeploy__DeploymentConfig.DeploymentConfig.json
+++ b/tests/corpus/AWS__CodeDeploy__DeploymentConfig.DeploymentConfig.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DeploymentConfig",
+    "resourceType": "AWS::CodeDeploy::DeploymentConfig",
+    "physicalId": "cdkrd-deploy-config",
+    "constructPath": "CdkdriftIntegHarvest11/DeploymentConfig",
+    "declared": {
+      "ComputePlatform": "Server",
+      "DeploymentConfigName": "cdkrd-deploy-config",
+      "MinimumHealthyHosts": {
+        "Type": "HOST_COUNT",
+        "Value": 1
+      }
+    }
+  },
+  "liveRaw": {
+    "ComputePlatform": "Server",
+    "DeploymentConfigName": "cdkrd-deploy-config",
+    "MinimumHealthyHosts": {
+      "Type": "HOST_COUNT",
+      "Value": 1
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": [
+      "ComputePlatform",
+      "DeploymentConfigName",
+      "MinimumHealthyHosts",
+      "TrafficRoutingConfig",
+      "ZonalConfig"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ComputePlatform",
+      "DeploymentConfigName",
+      "MinimumHealthyHosts",
+      "TrafficRoutingConfig",
+      "ZonalConfig"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__FlowLog.FlowLog3CB084E9.json
+++ b/tests/corpus/AWS__EC2__FlowLog.FlowLog3CB084E9.json
@@ -1,0 +1,114 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FlowLog3CB084E9",
+    "resourceType": "AWS::EC2::FlowLog",
+    "physicalId": "fl-036ddfda22c64b9f1",
+    "constructPath": "CdkdriftIntegHarvest11/FlowLog/FlowLog",
+    "declared": {
+      "DeliverLogsPermissionArn": "arn:aws:iam::111111111111:role/CdkdriftIntegHarvest11-FlowLogIAMRoleDCBD2EB4-A1N3UUwf9Sl7",
+      "LogDestinationType": "cloud-watch-logs",
+      "LogGroupName": "CdkdriftIntegHarvest11-FlowLogGroup3E25AA51-k0tgRIrKmYgT",
+      "ResourceId": "vpc-08640d82f0e608130",
+      "ResourceType": "VPC",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkdriftIntegHarvest11/FlowLog"
+        }
+      ],
+      "TrafficType": "ALL"
+    }
+  },
+  "liveRaw": {
+    "LogFormat": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+    "ResourceId": "vpc-08640d82f0e608130",
+    "MaxAggregationInterval": 600,
+    "ResourceType": "VPC",
+    "Id": "fl-036ddfda22c64b9f1",
+    "LogGroupName": "CdkdriftIntegHarvest11-FlowLogGroup3E25AA51-k0tgRIrKmYgT",
+    "DeliverLogsPermissionArn": "arn:aws:iam::111111111111:role/CdkdriftIntegHarvest11-FlowLogIAMRoleDCBD2EB4-A1N3UUwf9Sl7",
+    "LogDestinationType": "cloud-watch-logs",
+    "Tags": [
+      {
+        "Value": "CdkdriftIntegHarvest11",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "FlowLog3CB084E9",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest11/d7772f20-68ce-11f1-8db7-0ebb1f9d7ed7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest11/FlowLog",
+        "Key": "Name"
+      }
+    ],
+    "TrafficType": "ALL"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "DeliverCrossAccountRole",
+      "DeliverLogsPermissionArn",
+      "DestinationOptions",
+      "LogDestination",
+      "LogDestinationType",
+      "LogFormat",
+      "LogGroupName",
+      "MaxAggregationInterval",
+      "ResourceId",
+      "ResourceType",
+      "TagFieldSpecifications",
+      "TrafficType"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DeliverCrossAccountRole",
+      "DeliverLogsPermissionArn",
+      "DestinationOptions",
+      "LogDestination",
+      "LogDestinationType",
+      "LogFormat",
+      "LogGroupName",
+      "MaxAggregationInterval",
+      "ResourceId",
+      "ResourceType",
+      "TagFieldSpecifications",
+      "TrafficType"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "FlowLog3CB084E9",
+      "resourceType": "AWS::EC2::FlowLog",
+      "path": "LogFormat",
+      "actual": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
+      "physicalId": "fl-036ddfda22c64b9f1",
+      "constructPath": "CdkdriftIntegHarvest11/FlowLog/FlowLog"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "FlowLog3CB084E9",
+      "resourceType": "AWS::EC2::FlowLog",
+      "path": "MaxAggregationInterval",
+      "actual": 600,
+      "physicalId": "fl-036ddfda22c64b9f1",
+      "constructPath": "CdkdriftIntegHarvest11/FlowLog/FlowLog"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Glue__Crawler.Crawler.json
+++ b/tests/corpus/AWS__Glue__Crawler.Crawler.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Crawler",
+    "resourceType": "AWS::Glue::Crawler",
+    "physicalId": "cdkrd-crawler",
+    "constructPath": "CdkdriftIntegHarvest11/Crawler",
+    "declared": {
+      "Configuration": "{\"Version\":1,\"CrawlerOutput\":{\"Partitions\":{\"AddOrUpdateBehavior\":\"InheritFromTable\"}}}",
+      "DatabaseName": "cdkrd_db",
+      "Name": "cdkrd-crawler",
+      "RecrawlPolicy": {
+        "RecrawlBehavior": "CRAWL_EVERYTHING"
+      },
+      "Role": "arn:aws:iam::111111111111:role/CdkdriftIntegHarvest11-CrawlerRoleA9495AEE-8Ubamf7UE4OD",
+      "SchemaChangePolicy": {
+        "DeleteBehavior": "LOG",
+        "UpdateBehavior": "LOG"
+      },
+      "Targets": {
+        "S3Targets": [
+          {
+            "Path": "s3://cdkdriftintegharvest11-crawlerbucketc8cf2ecb-ytu9fjtcuzrc/data/"
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Role": "CdkdriftIntegHarvest11-CrawlerRoleA9495AEE-8Ubamf7UE4OD",
+    "Classifiers": [],
+    "SchemaChangePolicy": {
+      "UpdateBehavior": "LOG",
+      "DeleteBehavior": "LOG"
+    },
+    "Configuration": "{\"Version\":1.0,\"CrawlerOutput\":{\"Partitions\":{\"AddOrUpdateBehavior\":\"InheritFromTable\"}}}",
+    "LakeFormationConfiguration": {
+      "AccountId": "",
+      "UseLakeFormationCredentials": false
+    },
+    "RecrawlPolicy": {
+      "RecrawlBehavior": "CRAWL_EVERYTHING"
+    },
+    "DatabaseName": "cdkrd_db",
+    "Targets": {
+      "HudiTargets": [],
+      "S3Targets": [
+        {
+          "Path": "s3://cdkdriftintegharvest11-crawlerbucketc8cf2ecb-ytu9fjtcuzrc/data/",
+          "Exclusions": []
+        }
+      ],
+      "CatalogTargets": [],
+      "DeltaTargets": [],
+      "MongoDBTargets": [],
+      "JdbcTargets": [],
+      "DynamoDBTargets": [],
+      "IcebergTargets": []
+    },
+    "Tags": {},
+    "Name": "cdkrd-crawler"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Logs__ResourcePolicy.LogsResourcePolicy7D9294F8.json
+++ b/tests/corpus/AWS__Logs__ResourcePolicy.LogsResourcePolicy7D9294F8.json
@@ -1,0 +1,34 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LogsResourcePolicy7D9294F8",
+    "resourceType": "AWS::Logs::ResourcePolicy",
+    "physicalId": "cdkrd-logs-policy",
+    "constructPath": "CdkdriftIntegHarvest11/LogsResourcePolicy/ResourcePolicy",
+    "declared": {
+      "PolicyDocument": "{\"Statement\":[{\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Resource\":\"*\"}],\"Version\":\"2012-10-17\"}",
+      "PolicyName": "cdkrd-logs-policy"
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "cdkrd-logs-policy",
+    "PolicyDocument": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"route53.amazonaws.com\"},\"Action\":[\"logs:PutLogEvents\",\"logs:CreateLogStream\"],\"Resource\":\"*\"}]}"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["PolicyName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PolicyName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SES__EmailIdentity.EmailIdentity7187767D.json
+++ b/tests/corpus/AWS__SES__EmailIdentity.EmailIdentity7187767D.json
@@ -1,0 +1,129 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EmailIdentity7187767D",
+    "resourceType": "AWS::SES::EmailIdentity",
+    "physicalId": "cdkrd-harvest11.example.com",
+    "constructPath": "CdkdriftIntegHarvest11/EmailIdentity",
+    "declared": {
+      "EmailIdentity": "cdkrd-harvest11.example.com",
+      "MailFromAttributes": {
+        "MailFromDomain": "mail.cdkrd-harvest11.example.com"
+      }
+    }
+  },
+  "liveRaw": {
+    "DkimDNSTokenValue1": "cfh36sspac56rg5yfcduo6meouxhtzaq.dkim.amazonses.com",
+    "DkimDNSTokenName2": "qsyjvv635lzyxgzdq3owrdf2pdy67mwb._domainkey.cdkrd-harvest11.example.com",
+    "DkimDNSTokenName3": "4uypizlexhgrzihzijqlcelbwo23tqrc._domainkey.cdkrd-harvest11.example.com",
+    "DkimDNSTokenName1": "cfh36sspac56rg5yfcduo6meouxhtzaq._domainkey.cdkrd-harvest11.example.com",
+    "EmailIdentity": "cdkrd-harvest11.example.com",
+    "DkimDNSTokenValue2": "qsyjvv635lzyxgzdq3owrdf2pdy67mwb.dkim.amazonses.com",
+    "DkimSigningAttributes": {
+      "NextSigningKeyLength": "RSA_2048_BIT"
+    },
+    "DkimDNSTokenValue3": "4uypizlexhgrzihzijqlcelbwo23tqrc.dkim.amazonses.com",
+    "DkimAttributes": {
+      "SigningEnabled": true
+    },
+    "FeedbackAttributes": {
+      "EmailForwardingEnabled": true
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkdriftIntegHarvest11/d7772f20-68ce-11f1-8db7-0ebb1f9d7ed7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkdriftIntegHarvest11",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "EmailIdentity7187767D",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "MailFromAttributes": {
+      "MailFromDomain": "mail.cdkrd-harvest11.example.com",
+      "BehaviorOnMxFailure": "USE_DEFAULT_VALUE"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "DkimDNSTokenName1",
+      "DkimDNSTokenName2",
+      "DkimDNSTokenName3",
+      "DkimDNSTokenValue1",
+      "DkimDNSTokenValue2",
+      "DkimDNSTokenValue3"
+    ],
+    "writeOnly": [],
+    "createOnly": ["EmailIdentity"],
+    "readOnlyPaths": [
+      "DkimDNSTokenName1",
+      "DkimDNSTokenName2",
+      "DkimDNSTokenName3",
+      "DkimDNSTokenValue1",
+      "DkimDNSTokenValue2",
+      "DkimDNSTokenValue3"
+    ],
+    "writeOnlyPaths": [
+      "DkimSigningAttributes.DomainSigningPrivateKey",
+      "DkimSigningAttributes.DomainSigningSelector"
+    ],
+    "createOnlyPaths": ["EmailIdentity"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EmailIdentity7187767D",
+      "resourceType": "AWS::SES::EmailIdentity",
+      "path": "DkimSigningAttributes",
+      "actual": {
+        "NextSigningKeyLength": "RSA_2048_BIT"
+      },
+      "physicalId": "cdkrd-harvest11.example.com",
+      "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EmailIdentity7187767D",
+      "resourceType": "AWS::SES::EmailIdentity",
+      "path": "DkimAttributes",
+      "actual": {
+        "SigningEnabled": true
+      },
+      "physicalId": "cdkrd-harvest11.example.com",
+      "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EmailIdentity7187767D",
+      "resourceType": "AWS::SES::EmailIdentity",
+      "path": "FeedbackAttributes",
+      "actual": {
+        "EmailForwardingEnabled": true
+      },
+      "physicalId": "cdkrd-harvest11.example.com",
+      "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EmailIdentity7187767D",
+      "resourceType": "AWS::SES::EmailIdentity",
+      "path": "MailFromAttributes.BehaviorOnMxFailure",
+      "actual": "USE_DEFAULT_VALUE",
+      "nested": true,
+      "physicalId": "cdkrd-harvest11.example.com",
+      "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SecretsManager__ResourcePolicy.SecretPolicy06C9821C.json
+++ b/tests/corpus/AWS__SecretsManager__ResourcePolicy.SecretPolicy06C9821C.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SecretPolicy06C9821C",
+    "resourceType": "AWS::SecretsManager::ResourcePolicy",
+    "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-iC3xJ0",
+    "constructPath": "CdkdriftIntegHarvest11/Secret/Policy",
+    "declared": {
+      "ResourcePolicy": {
+        "Statement": [
+          {
+            "Action": "secretsmanager:GetSecretValue",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Resource": "*",
+            "Sid": "AllowRoot"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "SecretId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-iC3xJ0"
+    }
+  },
+  "liveRaw": {
+    "SecretId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-iC3xJ0",
+    "ResourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "secretsmanager:GetSecretValue",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "AllowRoot"
+        }
+      ]
+    },
+    "Id": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-iC3xJ0"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["BlockPublicPolicy"],
+    "createOnly": ["SecretId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["BlockPublicPolicy"],
+    "createOnlyPaths": ["SecretId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/harvest11/app.ts
+++ b/tests/integration/harvest11/app.ts
@@ -1,0 +1,187 @@
+// cdk-real-drift corpus-harvest wave 11 (real AWS) — R126.
+// Uncovered types weighted toward the FP-rich normalization classes — JSON policy
+// docs (policy-canonical), JSON-STRING config (isJsonStringStructEqual), Map params
+// (stringly), and nested declared config:
+//   SecretsManager ResourcePolicy, Logs ResourcePolicy, CodeDeploy DeploymentConfig,
+//   Athena DataCatalog, CodeBuild ReportGroup, SES EmailIdentity, Cognito
+//   UserPoolDomain + UserPoolResourceServer, ApiGateway Model + RequestValidator,
+//   Glue Crawler (JSON Configuration string), EC2 FlowLog. Each carries a few
+//   NON-default declared properties so a declared-side normalization FP surfaces.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnDataCatalog } from "aws-cdk-lib/aws-athena";
+import { ReportGroup, ReportGroupType } from "aws-cdk-lib/aws-codebuild";
+import { CfnDeploymentConfig } from "aws-cdk-lib/aws-codedeploy";
+import { ResourceServerScope, UserPool } from "aws-cdk-lib/aws-cognito";
+import {
+  FlowLog,
+  FlowLogDestination,
+  FlowLogResourceType,
+  FlowLogTrafficType,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import {
+  JsonSchemaType,
+  JsonSchemaVersion,
+  MockIntegration,
+  PassthroughBehavior,
+  RestApi,
+} from "aws-cdk-lib/aws-apigateway";
+import { CfnCrawler, CfnDatabase } from "aws-cdk-lib/aws-glue";
+import {
+  AccountRootPrincipal,
+  Effect,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { LogGroup, ResourcePolicy, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+import { EmailIdentity, Identity } from "aws-cdk-lib/aws-ses";
+
+const app = new App();
+const stack = new Stack(app, "CdkdriftIntegHarvest11");
+const account = Stack.of(stack).account;
+
+// --- SecretsManager Secret + ResourcePolicy (JSON policy doc → policy-canonical) ---
+const secret = new Secret(stack, "Secret", {
+  secretName: "cdkrd-secret",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+secret.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "AllowRoot",
+    effect: Effect.ALLOW,
+    actions: ["secretsmanager:GetSecretValue"],
+    principals: [new AccountRootPrincipal()],
+    resources: ["*"],
+  })
+);
+
+// --- Logs ResourcePolicy (JSON policy doc) ---
+new ResourcePolicy(stack, "LogsResourcePolicy", {
+  resourcePolicyName: "cdkrd-logs-policy",
+  policyStatements: [
+    new PolicyStatement({
+      effect: Effect.ALLOW,
+      actions: ["logs:PutLogEvents", "logs:CreateLogStream"],
+      principals: [new ServicePrincipal("route53.amazonaws.com")],
+      resources: ["*"],
+    }),
+  ],
+});
+
+// --- CodeDeploy custom DeploymentConfig ---
+new CfnDeploymentConfig(stack, "DeploymentConfig", {
+  deploymentConfigName: "cdkrd-deploy-config",
+  computePlatform: "Server",
+  minimumHealthyHosts: { type: "HOST_COUNT", value: 1 },
+});
+
+// --- Athena DataCatalog (GLUE type, Parameters Map<String,String>) ---
+new CfnDataCatalog(stack, "DataCatalog", {
+  name: "cdkrd_catalog",
+  type: "GLUE",
+  description: "cdkrd harvest data catalog",
+  parameters: { "catalog-id": account },
+});
+
+// --- CodeBuild ReportGroup ---
+new ReportGroup(stack, "ReportGroup", {
+  reportGroupName: "cdkrd-reports",
+  type: ReportGroupType.TEST,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+// --- SES EmailIdentity (domain identity, unverified; nested DKIM/MailFrom config) ---
+new EmailIdentity(stack, "EmailIdentity", {
+  identity: Identity.domain("cdkrd-harvest11.example.com"),
+  mailFromDomain: "mail.cdkrd-harvest11.example.com",
+});
+
+// --- Cognito UserPool + UserPoolDomain + UserPoolResourceServer ---
+const userPool = new UserPool(stack, "UserPool", {
+  userPoolName: "cdkrd-pool",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+userPool.addDomain("Domain", {
+  cognitoDomain: { domainPrefix: "cdkrd-harvest11-drift-pool" },
+});
+userPool.addResourceServer("ResourceServer", {
+  identifier: "cdkrd-api",
+  userPoolResourceServerName: "cdkrd-rs",
+  scopes: [new ResourceServerScope({ scopeName: "read", scopeDescription: "read scope" })],
+});
+
+// --- ApiGateway RestApi + Model + RequestValidator (JSON schema; method needed to deploy) ---
+const api = new RestApi(stack, "RestApi", { restApiName: "cdkrd-rest-api" });
+api.root.addMethod(
+  "GET",
+  new MockIntegration({
+    passthroughBehavior: PassthroughBehavior.NEVER,
+    requestTemplates: { "application/json": '{"statusCode": 200}' },
+    integrationResponses: [{ statusCode: "200" }],
+  }),
+  { methodResponses: [{ statusCode: "200" }] }
+);
+api.addModel("Model", {
+  contentType: "application/json",
+  modelName: "CdkrdModel",
+  description: "cdkrd harvest model",
+  schema: {
+    schema: JsonSchemaVersion.DRAFT4,
+    title: "cdkrd",
+    type: JsonSchemaType.OBJECT,
+    properties: { id: { type: JsonSchemaType.STRING } },
+  },
+});
+api.addRequestValidator("RequestValidator", {
+  requestValidatorName: "cdkrd-validator",
+  validateRequestBody: true,
+  validateRequestParameters: true,
+});
+
+// --- Glue Database + Crawler (Configuration is a JSON STRING → isJsonStringStructEqual) ---
+const crawlerTarget = new Bucket(stack, "CrawlerBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+new CfnDatabase(stack, "GlueDatabase", {
+  catalogId: account,
+  databaseInput: { name: "cdkrd_db" },
+});
+const crawlerRole = new Role(stack, "CrawlerRole", {
+  assumedBy: new ServicePrincipal("glue.amazonaws.com"),
+});
+crawlerTarget.grantRead(crawlerRole);
+new CfnCrawler(stack, "Crawler", {
+  name: "cdkrd-crawler",
+  role: crawlerRole.roleArn,
+  databaseName: "cdkrd_db",
+  targets: { s3Targets: [{ path: `s3://${crawlerTarget.bucketName}/data/` }] },
+  schemaChangePolicy: { updateBehavior: "LOG", deleteBehavior: "LOG" },
+  recrawlPolicy: { recrawlBehavior: "CRAWL_EVERYTHING" },
+  configuration: JSON.stringify({
+    Version: 1.0,
+    CrawlerOutput: { Partitions: { AddOrUpdateBehavior: "InheritFromTable" } },
+  }),
+});
+
+// --- EC2 FlowLog (VPC -> CloudWatch Logs; nested config) ---
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+const flowLogGroup = new LogGroup(stack, "FlowLogGroup", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+new FlowLog(stack, "FlowLog", {
+  resourceType: FlowLogResourceType.fromVpc(vpc),
+  destination: FlowLogDestination.toCloudWatchLogs(flowLogGroup),
+  trafficType: FlowLogTrafficType.ALL,
+});
+
+app.synth();

--- a/tests/integration/harvest11/cdk.json
+++ b/tests/integration/harvest11/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/harvest11/package.json
+++ b/tests/integration/harvest11/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-harvest11",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Corpus-harvest CDK app wave 11 (uncovered FP-rich CFn types) for cdk-real-drift. Run via verify-harvest11.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/harvest11/verify-harvest11.sh
+++ b/tests/integration/harvest11/verify-harvest11.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# cdk-real-drift corpus-harvest integration test wave 11 (real AWS) — R126.
+#
+# Uncovered types weighted toward the FP-rich normalization classes: SecretsManager
+# ResourcePolicy + Logs ResourcePolicy (JSON policy docs), CodeDeploy DeploymentConfig,
+# Athena DataCatalog (Map params), CodeBuild ReportGroup, SES EmailIdentity, Cognito
+# UserPoolDomain + UserPoolResourceServer, ApiGateway Model + RequestValidator, Glue
+# Crawler (JSON Configuration string), EC2 FlowLog. Asserts the two harvest invariants:
+#   1. baseline-free `check` — fresh deploy = ZERO declared drift, exit 0;
+#   2. `record --yes` then `check --fail` — CLEAN across every type.
+#
+# CDKRD_HARVEST11_KEEP=1 skips the destroy for debug iteration.
+# Run with CDKRD_CORPUS_DIR=<dir> to record golden-corpus cases.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/harvest11 && npm install && bash verify-harvest11.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkdriftIntegHarvest11
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-harvest11.out
+
+cleanup() {
+  if [ -n "${CDKRD_HARVEST11_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_HARVEST11_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (wave 11: uncovered FP-rich types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+
+echo "=== 2. record + check --fail must be CLEAN across every type ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## What

Pre-release FP/noise verification **wave 11**, deliberately weighted toward the historically FP-prone normalization classes:
- **JSON policy docs** (policy-canonical) — SecretsManager ResourcePolicy, Logs ResourcePolicy
- **JSON-STRING config** (`isJsonStringStructEqual`) — Glue Crawler `Configuration`
- **Map params** (stringly) — Athena DataCatalog `Parameters`
- **nested declared config** — SES EmailIdentity, Cognito

## Types covered (12 uncovered)
SecretsManager ResourcePolicy · Logs ResourcePolicy · CodeDeploy DeploymentConfig · Athena DataCatalog · CodeBuild ReportGroup · SES EmailIdentity · Cognito UserPoolDomain + UserPoolResourceServer · ApiGateway Model + RequestValidator · Glue Crawler · EC2 FlowLog.

## Result — ZERO declared FP

Fresh deploy `check` = **CLEAN**, zero declared drift. **No normalization false positive in any FP-rich class:** policy-canonical handled both ResourcePolicy JSON docs, `isJsonStringStructEqual` handled the Glue Crawler `Configuration` JSON string, and the Athena Map params + Cognito/SES nested config all classified correctly as not-drift. **No source change needed.**

This is a strong release signal — the prior wave (R125) found the PEM-trailing-newline FP, but the JSON-policy / JSON-string / Map / nested classes are clean.

## Tests
- Locks **7 new-type golden corpus cases** (the readable ones: Athena DataCatalog, CodeDeploy DeploymentConfig, EC2 FlowLog, Glue Crawler, Logs ResourcePolicy, SecretsManager ResourcePolicy, SES EmailIdentity).
- **848 unit tests** pass; typecheck / lint+format / build green.

## CC-skips (not FPs)
`ValidationException` (composite identifiers, honest fail-closed): ApiGateway Model/RequestValidator, Cognito UserPoolDomain/UserPoolResourceServer, CodeBuild ReportGroup — a future `CC_IDENTIFIER_ADAPTERS` lead, **not** false positives.

## Live integ — INTEG PASS
Account 531991745243 / us-east-1, self-cleaning:

```
=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
result: CLEAN — 16 unrecorded value(s) await a baseline (14 shown, 2 folded; run cdkrd record)
=== 2. record + check --fail must be CLEAN across every type ===
result: CLEAN
INTEG PASS
```

Verified post-run: stack deleted, secret force-deleted (no recovery-window orphan).