### PR TITLE
feat(check,report): element-level granularity for recorded identity-keyed undeclared arrays (R128)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -22,7 +22,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { deepEqual } from '../diff/drift-calculator.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
-import type { Finding } from '../types.js';
+import type { ArrayDelta, Finding } from '../types.js';
 
 export interface RecordedEntry {
   logicalId: string;
@@ -235,6 +235,73 @@ export function baselineValueMatches(
   return deepEqual(canonicalizeForCompare(baselineValue), currentCanonicalValue);
 }
 
+// Identity fields for the ELEMENT-LEVEL DELTA display only (R128) — deliberately
+// broader than classify's `IDENTITY_FIELDS` (which gate canonicalization + the R98
+// nested descent and so must stay corpus-validated). This set is consulted ONLY to
+// align a recorded-but-CHANGED undeclared array's elements for the report; the
+// finding is already drift either way, so a wider identity set here can only sharpen
+// what is shown and can NEVER create a false positive. `PolicyName` is the IAM Role
+// inline-Policies case the user hit; `Name` covers the common named-element array.
+const DELTA_IDENTITY_FIELDS = ['Key', 'Id', 'AttributeName', 'IndexName', 'PolicyName', 'Name'];
+
+const isPlainObjectArray = (arr: unknown[]): boolean =>
+  arr.length > 0 && arr.every((x) => x !== null && typeof x === 'object' && !Array.isArray(x));
+
+// Pick the first identity field that EVERY element on BOTH sides carries as a string
+// AND that is UNIQUE within each side. Uniqueness matters: a non-unique key would
+// collapse two distinct elements into one map entry and mis-describe the delta — so
+// fall back to the whole-array display (undefined) rather than show a wrong delta.
+function deltaIdentityField(a: unknown[], b: unknown[]): string | undefined {
+  if (!isPlainObjectArray(a) || !isPlainObjectArray(b)) return undefined;
+  return DELTA_IDENTITY_FIELDS.find((f) => {
+    const idsOf = (arr: unknown[]): string[] =>
+      arr
+        .map((x) => (x as Record<string, unknown>)[f])
+        .filter((v): v is string => typeof v === 'string');
+    const ia = idsOf(a);
+    const ib = idsOf(b);
+    return (
+      ia.length === a.length &&
+      ib.length === b.length &&
+      new Set(ia).size === ia.length &&
+      new Set(ib).size === ib.length
+    );
+  });
+}
+
+/**
+ * Element-level delta of a recorded-but-CHANGED undeclared identity-keyed object
+ * array (R128) — e.g. an IAM Role's inline Policies keyed by `PolicyName`. Computed
+ * for the REPORT only: the finding stays at the whole-array path, so `record` still
+ * snapshots the whole array (the property never un-records) and revert is unaffected;
+ * this just says WHICH element(s) differ so the report shows the delta instead of
+ * dumping the full array. Aligns by a unique identity field present on both sides,
+ * then deep-compares matched pairs (so a same-name-but-changed-document element IS
+ * still surfaced as `changed`, never missed). Returns undefined when the two sides
+ * are not both unique-identity-keyed object arrays, or when nothing actually differs
+ * after alignment (e.g. a pure reorder) — the caller then falls back to whole-array
+ * display.
+ */
+export function identityArrayDelta(recordedVal: unknown, liveVal: unknown): ArrayDelta | undefined {
+  if (!Array.isArray(recordedVal) || !Array.isArray(liveVal)) return undefined;
+  const idf = deltaIdentityField(recordedVal, liveVal);
+  if (!idf) return undefined;
+  const byId = (arr: unknown[]): Map<string, unknown> =>
+    new Map(arr.map((x) => [String((x as Record<string, unknown>)[idf]), x]));
+  const rec = byId(recordedVal);
+  const live = byId(liveVal);
+  const added: ArrayDelta['added'] = [];
+  const changed: ArrayDelta['changed'] = [];
+  const removed: ArrayDelta['removed'] = [];
+  for (const [id, v] of live) {
+    if (!rec.has(id)) added.push({ id, value: v });
+    else if (!deepEqual(rec.get(id), v)) changed.push({ id, recorded: rec.get(id), actual: v });
+  }
+  for (const [id, v] of rec) if (!live.has(id)) removed.push({ id, value: v });
+  if (added.length === 0 && changed.length === 0 && removed.length === 0) return undefined;
+  return { identityField: idf, added, removed, changed };
+}
+
 /**
  * Split a freshly-built recorded set against the existing baseline into the values
  * a human must decide on (`changed` = new path OR value differs) and the values
@@ -327,7 +394,12 @@ export function applyBaseline(
       continue;
     }
     if (entry) {
-      kept.push(f); // recorded value changed -> drift
+      // recorded value changed -> drift. For an identity-keyed object array (IAM
+      // inline Policies, …) attach the element-level delta so the report shows WHICH
+      // element changed rather than the whole array (R128). Display-only: the finding
+      // still names the whole-array path, so record/revert are unaffected.
+      const delta = identityArrayDelta(canonicalizeForCompare(entry.value), f.actual);
+      kept.push(delta ? { ...f, arrayDelta: delta } : f);
     } else if (complete.has(f.logicalId)) {
       // the record snapshot covered this whole resource, so this value is new
       kept.push({

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -17,7 +17,7 @@
 // one-line-per-tier bullet list when 2+ (R37); `--verbose` expands them to full
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
-import type { Finding, Tier } from '../types.js';
+import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
 
 const TIER_NAMES: Record<Tier, string> = {
@@ -91,8 +91,24 @@ export function formatFinding(f: Finding): string {
   if (f.note) s += ` — ${f.note}`;
   if (f.tier === 'declared')
     s += `\n      desired=${style.desired(j(f.desired))}\n      actual =${style.actual(j(f.actual))}`;
+  else if (f.tier === 'undeclared' && f.arrayDelta)
+    // R128: a recorded identity-keyed array changed — show the element delta, not the
+    // whole array dump (the property stays recorded; this is the WHICH-element view).
+    s += formatArrayDelta(f.arrayDelta);
   else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
     s += ` = ${style.actual(j(f.actual))}`;
+  return s;
+}
+
+// R128: render an identity-keyed array delta as one indented line per changed element
+// (added / changed / removed), keyed by its identity value — far more legible than a
+// 200-char whole-array dump when only one element of many differs from the baseline.
+function formatArrayDelta(d: ArrayDelta): string {
+  let s = ` — ${d.identityField}-keyed element(s) changed vs .cdkrd baseline:`;
+  for (const a of d.added) s += `\n      + [${a.id}] = ${style.actual(j(a.value))}`;
+  for (const c of d.changed)
+    s += `\n      ~ [${c.id}] baseline=${style.desired(j(c.recorded))} actual=${style.actual(j(c.actual))}`;
+  for (const r of d.removed) s += `\n      - [${r.id}] = ${style.desired(j(r.value))}`;
   return s;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,22 @@ export interface Finding {
   // expanded by --show-all; recorded by record like any undeclared value, so a later
   // out-of-band change to it surfaces.
   nested?: boolean;
+  // undeclared tier only (R128): a recorded undeclared identity-keyed object array
+  // (e.g. an IAM Role's inline Policies keyed by PolicyName) whose value CHANGED vs
+  // the baseline — set by applyBaseline for the REPORT only. The finding still names
+  // the whole-array path (so record keeps snapshotting the whole array and the
+  // property never un-records); this just describes WHICH element(s) differ so the
+  // report shows the delta, not the full array dump. See `identityArrayDelta`.
+  arrayDelta?: ArrayDelta;
+}
+
+// Element-level delta of a recorded-but-changed undeclared identity-keyed object
+// array (R128). DISPLAY metadata only: the finding stays at the whole-array path.
+export interface ArrayDelta {
+  identityField: string; // the field the elements were aligned by (e.g. 'PolicyName')
+  added: { id: string; value: unknown }[]; // live elements with no baseline match
+  removed: { id: string; value: unknown }[]; // baseline elements gone from live
+  changed: { id: string; recorded: unknown; actual: unknown }[]; // matched id, content differs
 }
 
 export interface SchemaInfo {

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -9,6 +9,7 @@ import {
   type BaselineFile,
   baselinePath,
   buildRecorded,
+  identityArrayDelta,
   checkBaselineAccount,
   computeCompleteResources,
   hashTemplate,
@@ -239,6 +240,75 @@ describe('baseline', () => {
   it('applyBaseline keeps a CHANGED undeclared value (= drift)', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     expect(applyBaseline([undeclared('A', 'P', ['y'])], b)).toHaveLength(1);
+  });
+
+  describe('identityArrayDelta (R128 — element-level granularity for recorded arrays)', () => {
+    const p = (name: string, doc: unknown) => ({ PolicyName: name, PolicyDocument: doc });
+
+    it('returns undefined when not both arrays', () => {
+      expect(identityArrayDelta('x', ['y'])).toBeUndefined();
+      expect(identityArrayDelta([{ PolicyName: 'a' }], { PolicyName: 'a' })).toBeUndefined();
+    });
+
+    it('returns undefined when no shared unique identity field (whole-array fallback)', () => {
+      // objects with no Key/Id/PolicyName/Name -> cannot align
+      expect(identityArrayDelta([{ Effect: 'Allow' }], [{ Effect: 'Deny' }])).toBeUndefined();
+    });
+
+    it('returns undefined when a candidate identity is non-unique (avoid mis-aligned delta)', () => {
+      const rec = [p('dup', 1), p('dup', 2)];
+      const live = [p('dup', 1), p('dup', 3)];
+      expect(identityArrayDelta(rec, live)).toBeUndefined();
+    });
+
+    it('returns undefined for a pure reorder (nothing actually changed)', () => {
+      const rec = [p('a', 1), p('b', 2)];
+      const live = [p('b', 2), p('a', 1)];
+      expect(identityArrayDelta(rec, live)).toBeUndefined();
+    });
+
+    it('detects an ADDED element keyed by PolicyName (the user-hit case)', () => {
+      const rec = [p('a', 1)];
+      const live = [p('a', 1), p('aaa', 2)];
+      const d = identityArrayDelta(rec, live);
+      expect(d).toMatchObject({ identityField: 'PolicyName' });
+      expect(d?.added).toEqual([{ id: 'aaa', value: p('aaa', 2) }]);
+      expect(d?.changed).toEqual([]);
+      expect(d?.removed).toEqual([]);
+    });
+
+    it('detects a CHANGED element (same name, different document) — not missed', () => {
+      const rec = [p('a', { act: 's3:Get' })];
+      const live = [p('a', { act: 's3:*' })];
+      const d = identityArrayDelta(rec, live);
+      expect(d?.added).toEqual([]);
+      expect(d?.changed).toEqual([
+        { id: 'a', recorded: p('a', { act: 's3:Get' }), actual: p('a', { act: 's3:*' }) },
+      ]);
+    });
+
+    it('detects a REMOVED element', () => {
+      const rec = [p('a', 1), p('b', 2)];
+      const live = [p('a', 1)];
+      const d = identityArrayDelta(rec, live);
+      expect(d?.removed).toEqual([{ id: 'b', value: p('b', 2) }]);
+    });
+
+    it('applyBaseline attaches arrayDelta to a changed recorded array (display-only, path stays whole)', () => {
+      const b = baseline([
+        { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'Policies', value: [p('a', 1)] },
+      ]);
+      const out = applyBaseline([undeclared('A', 'Policies', [p('a', 1), p('aaa', 2)])], b);
+      expect(out).toHaveLength(1);
+      expect(out[0].path).toBe('Policies'); // whole-array path preserved (record unaffected)
+      expect(out[0].arrayDelta?.added).toEqual([{ id: 'aaa', value: p('aaa', 2) }]);
+    });
+
+    it('applyBaseline leaves a changed scalar array without arrayDelta (whole-array fallback)', () => {
+      const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+      const out = applyBaseline([undeclared('A', 'P', ['y'])], b);
+      expect(out[0].arrayDelta).toBeUndefined();
+    });
   });
 
   it('applyBaseline keeps a NEW undeclared path (unrecorded on a never-complete resource), passes non-undeclared through', () => {

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -134,6 +134,27 @@ describe('report', () => {
     expect(text).not.toMatch(/\] \d/);
   });
 
+  it('R128 renders an identity-keyed arrayDelta element-by-element, not the whole array', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      actual: [{ PolicyName: 'keep' }, { PolicyName: 'aaa' }],
+      arrayDelta: {
+        identityField: 'PolicyName',
+        added: [{ id: 'aaa', value: { PolicyName: 'aaa' } }],
+        changed: [],
+        removed: [],
+      },
+    };
+    const { text } = run([f]);
+    expect(text).toContain('PolicyName-keyed element(s) changed vs .cdkrd baseline');
+    expect(text).toContain('+ [aaa]');
+    // the whole-array dump (the other element) is NOT shown — only the delta
+    expect(text).not.toContain('"PolicyName":"keep"');
+  });
+
   it('shows the CDK construct path instead of the logical id when present', () => {
     const f: Finding = {
       tier: 'undeclared',


### PR DESCRIPTION
## What

A recorded undeclared **identity-keyed object array** (the user-hit case: an IAM Role's inline `Policies` keyed by `PolicyName`) that changes vs the `.cdkrd` baseline used to report the **whole array** as one undeclared drift. Adding a single inline policy via the console made the *entire* `Policies` property re-surface as drift — obscuring which element actually changed.

Now `check` reports it **element-by-element**:

```
[CFn-UNDECLARED DRIFT: 1] (live-only ..., changed from your .cdkrd baseline — the differentiator)
  ApiStack/ServiceRole.Policies (AWS::IAM::Role) — PolicyName-keyed element(s) changed vs .cdkrd baseline:
      + [aaa] = {"PolicyName":"aaa","PolicyDocument":{...}}
```

## How

- `identityArrayDelta(recorded, live)` (baseline-file.ts): aligns elements by a **unique** identity field present on both sides, then deep-compares matched pairs → `{added, removed, changed}`. Returns `undefined` (whole-array fallback) when the sides aren't both unique-identity-keyed object arrays, or when nothing differs after alignment (pure reorder).
- `applyBaseline` attaches the delta to the changed undeclared finding; the report renders the per-element delta.
- A same-name-but-changed-document element is still surfaced as `changed` — **never missed** (the concern raised in design).

## Why it's safe / bounded

- **Display-only.** The finding keeps the whole-array path (`Policies`), so:
  - `record` still snapshots the whole array → the property **never un-records**.
  - `revert`/`ignore`/`config` see the same path as before — unchanged.
- The delta uses a **broader identity set** (adds `PolicyName`/`Name`) than classify's corpus-gated `IDENTITY_FIELDS` — deliberately kept out of the classification path so it needs no corpus re-validation. It only sharpens an **already-drift** finding's display, so it can **never create a false positive**.

## Tests

- `identityArrayDelta`: added/changed/removed, non-unique-key guard, pure-reorder guard, non-array guard.
- `applyBaseline`: attaches delta for identity-keyed array, whole-array fallback for scalar arrays, path preserved.
- `report`: renders element delta, not the whole-array dump.
- 859 unit tests pass; typecheck / lint+format / build green. Verified end-to-end with real policy-doc canonicalization (matched element correctly drops out).
