### PR TITLE
feat(read): CC identifier adapters for ApiGateway v1 + Cognito composite types (R129)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,13 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    identifier needs the ScalableDimension parsed out of the resolved
    ScalingTargetId; plus ECS Service (R102), whose `[ServiceArn, Cluster]`
    composite is the SERVICE arn FIRST then the cluster (`${physicalId}|${Cluster}`
-   — the inverse of `compositeWith`'s parent-first order) — `CC_IDENTIFIER_ADAPTERS`
+   — the inverse of `compositeWith`'s parent-first order); plus the ApiGateway v1
+   parent-first `[RestApiId, <child>]` (Model/RequestValidator/Resource/Stage) and
+   Cognito `[UserPoolId, <child>]` (UserPoolDomain/UserPoolResourceServer) composites,
+   and ApiGateway::Deployment which is CHILD-first `[DeploymentId, RestApiId]`
+   (`${physicalId}|${RestApiId}`) — all R129, verified live (skipped 7→0); note
+   ApiGateway::Method needs NO adapter, its CFn physical id is already the full
+   `RestApiId|ResourceId|HttpMethod` — `CC_IDENTIFIER_ADAPTERS`
    in router.ts maps those without leaving the CC read path, which is strictly
    cheaper than an SDK override (no new dependency, no projection). The same adapter
    resolves the revert UpdateResource identifier (stack-actions.ts), not just the

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -35,6 +35,32 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   'AWS::ApiGatewayV2::Integration': compositeWith('ApiId'),
   'AWS::AppConfig::Environment': compositeWith('ApplicationId'),
   'AWS::AppConfig::ConfigurationProfile': compositeWith('ApplicationId'),
+  // ApiGateway v1 (REST) parent-first composites `[RestApiId, <child>]` and Cognito
+  // `[UserPoolId, <child>]` — same parent-first `|` shape as above. The CFn physical
+  // id is only the child (Model→Name, RequestValidator→RequestValidatorId,
+  // Resource→ResourceId, Stage→StageName, UserPoolDomain→Domain,
+  // UserPoolResourceServer→Identifier); the parent comes from the resolved declared
+  // Ref. All verified live (R129): the bare child id reads as a ValidationException /
+  // not-found skip until paired with its parent. (ApiGateway::Method needs NO adapter
+  // — its CFn physical id is ALREADY the full `RestApiId|ResourceId|HttpMethod`.)
+  'AWS::ApiGateway::Model': compositeWith('RestApiId'),
+  'AWS::ApiGateway::RequestValidator': compositeWith('RestApiId'),
+  'AWS::ApiGateway::Resource': compositeWith('RestApiId'),
+  'AWS::ApiGateway::Stage': compositeWith('RestApiId'),
+  'AWS::Cognito::UserPoolDomain': compositeWith('UserPoolId'),
+  'AWS::Cognito::UserPoolResourceServer': compositeWith('UserPoolId'),
+  // ApiGateway::Deployment is the odd one out: its primaryIdentifier is
+  // `[DeploymentId, RestApiId]` — CHILD first (verified live R129: `RestApiId|DeploymentId`
+  // returns not-found; only `DeploymentId|RestApiId` reads). The CFn physical id is the
+  // DeploymentId; RestApiId comes from the resolved declared Ref. Not `compositeWith`
+  // (parent-first); this is child-first like ECS Service.
+  'AWS::ApiGateway::Deployment': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const restApiId = declared.RestApiId;
+    return typeof restApiId === 'string' && restApiId.length > 0
+      ? `${pid}|${restApiId}`
+      : undefined;
+  },
   // ApplicationAutoScaling ScalingPolicy: primaryIdentifier is [Arn,
   // ScalableDimension]. The CFn physical id IS the PolicyARN, but ScalableDimension
   // is not a direct ScalingPolicy property — it rides on the resolved

--- a/tests/integration/ccadapters/app.ts
+++ b/tests/integration/ccadapters/app.ts
@@ -1,0 +1,57 @@
+// cdk-real-drift CC-identifier-adapter integration fixture — R129.
+// These composite-identifier types are CC ValidationException skips when read with
+// the bare CFn physical id; the R129 CC_IDENTIFIER_ADAPTERS pair each with its parent
+// (or, for Deployment, child-first) so Cloud Control reads them. ApiGateway v1
+// Model / RequestValidator / Resource / Stage / Deployment + Cognito UserPoolDomain /
+// UserPoolResourceServer. verify-ccadapters.sh asserts these now READ (no CC
+// ValidationException skip) AND a fresh deploy has ZERO declared drift.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  JsonSchemaType,
+  JsonSchemaVersion,
+  MockIntegration,
+  PassthroughBehavior,
+  RestApi,
+} from "aws-cdk-lib/aws-apigateway";
+import { ResourceServerScope, UserPool } from "aws-cdk-lib/aws-cognito";
+
+const app = new App();
+const stack = new Stack(app, "CdkdriftIntegCcAdapters");
+
+const api = new RestApi(stack, "RestApi", { restApiName: "cdkrd-ccadapters-api" });
+const res = api.root.addResource("items");
+res.addMethod(
+  "GET",
+  new MockIntegration({
+    passthroughBehavior: PassthroughBehavior.NEVER,
+    requestTemplates: { "application/json": '{"statusCode": 200}' },
+    integrationResponses: [{ statusCode: "200" }],
+  }),
+  { methodResponses: [{ statusCode: "200" }] }
+);
+api.addModel("Model", {
+  contentType: "application/json",
+  modelName: "CdkrdProbeModel",
+  schema: {
+    schema: JsonSchemaVersion.DRAFT4,
+    title: "p",
+    type: JsonSchemaType.OBJECT,
+    properties: { id: { type: JsonSchemaType.STRING } },
+  },
+});
+api.addRequestValidator("Validator", {
+  requestValidatorName: "cdkrd-probe-validator",
+  validateRequestBody: true,
+});
+
+const userPool = new UserPool(stack, "UserPool", {
+  userPoolName: "cdkrd-probe-pool",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+userPool.addDomain("Domain", { cognitoDomain: { domainPrefix: "cdkrd-ccadapters-domain" } });
+userPool.addResourceServer("ResourceServer", {
+  identifier: "cdkrd-probe-rs",
+  scopes: [new ResourceServerScope({ scopeName: "read", scopeDescription: "r" })],
+});
+
+app.synth();

--- a/tests/integration/ccadapters/cdk.json
+++ b/tests/integration/ccadapters/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ccadapters/package.json
+++ b/tests/integration/ccadapters/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ccadapters",
+  "private": true,
+  "version": "0.0.0",
+  "description": "CC-identifier-adapter integration fixture (R129) for cdk-real-drift. Run via verify-ccadapters.sh.",
+  "type": "module",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  }
+}

--- a/tests/integration/ccadapters/verify-ccadapters.sh
+++ b/tests/integration/ccadapters/verify-ccadapters.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# cdk-real-drift CC-identifier-adapter integration test — R129.
+#
+# Composite-identifier types that read as a Cloud Control ValidationException skip
+# with the bare CFn physical id, until the R129 CC_IDENTIFIER_ADAPTERS pair each with
+# its parent (parent-first `|`) — or, for ApiGateway::Deployment, child-first:
+#   ApiGateway Model / RequestValidator / Resource / Stage / Deployment,
+#   Cognito UserPoolDomain / UserPoolResourceServer.
+# Asserts:
+#   1. fresh deploy `check` exits 0 with ZERO declared drift (harvest invariant);
+#   2. NO "ValidationException" skip remains (the adapters made these types READABLE);
+#   3. `record --yes` then `check --fail` is CLEAN.
+#
+# CDKRD_CCADAPTERS_KEEP=1 skips the destroy for debug iteration.
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/ccadapters && npm install && bash verify-ccadapters.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkdriftIntegCcAdapters
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+OUT=/tmp/cdkrd-ccadapters.out
+
+cleanup() {
+  if [ -n "${CDKRD_CCADAPTERS_KEEP:-}" ]; then
+    echo "--- keeping stack (CDKRD_CCADAPTERS_KEEP set) — destroy manually when done ---"
+    return
+  fi
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (composite-identifier types) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== 1. baseline-free check: ZERO declared drift AND no ValidationException skip ==="
+$CLI check "$STACK" --region "$REGION" | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
+grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
+# the whole point: the composite-id types must now READ, not skip as ValidationException
+grep -q "ValidationException" "$OUT" && fail "a CC ValidationException skip remains — an adapter is missing/wrong"
+
+echo "=== 2. record + check --fail must be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "INTEG PASS"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -199,6 +199,80 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('api456|route789');
   });
 
+  // R129: ApiGateway v1 (REST) parent-first [RestApiId, <child>] + Cognito
+  // [UserPoolId, <child>] composites — verified live (skipped 7 -> 0 on the ccadapters
+  // fixture). The CFn physical id carries only the child; the parent is the resolved Ref.
+  for (const t of [
+    'AWS::ApiGateway::Model',
+    'AWS::ApiGateway::RequestValidator',
+    'AWS::ApiGateway::Resource',
+    'AWS::ApiGateway::Stage',
+  ]) {
+    it(`${t}: builds the RestApiId|<child> composite identifier`, async () => {
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({ resourceType: t, physicalId: 'child123', declared: { RestApiId: 'api456' } }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('api456|child123');
+    });
+  }
+
+  for (const t of ['AWS::Cognito::UserPoolDomain', 'AWS::Cognito::UserPoolResourceServer']) {
+    it(`${t}: builds the UserPoolId|<child> composite identifier`, async () => {
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({ resourceType: t, physicalId: 'child123', declared: { UserPoolId: 'us-east-1_AbC' } }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('us-east-1_AbC|child123');
+    });
+  }
+
+  it('ApiGateway Model: an unresolved RestApiId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::ApiGateway::Model', physicalId: 'm1', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('m1');
+  });
+
+  // R129: ApiGateway::Deployment is CHILD-first [DeploymentId, RestApiId] — verified
+  // live that `RestApiId|DeploymentId` returns not-found; only `DeploymentId|RestApiId`
+  // reads. The CFn physical id is the DeploymentId.
+  it('ApiGateway Deployment: builds the DeploymentId|RestApiId composite — child FIRST', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGateway::Deployment',
+        physicalId: 'dep123',
+        declared: { RestApiId: 'api456' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('dep123|api456');
+  });
+
+  it('ApiGateway Deployment: an unresolved RestApiId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::ApiGateway::Deployment', physicalId: 'dep123', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('dep123');
+  });
+
   // R77: AppConfig Environment/ConfigurationProfile composite [ApplicationId, <child id>].
   for (const t of ['AWS::AppConfig::Environment', 'AWS::AppConfig::ConfigurationProfile']) {
     it(`${t}: builds the ApplicationId|<child> composite identifier`, async () => {


### PR DESCRIPTION
## What

Seven composite-identifier types read as a **Cloud Control `ValidationException` skip** when `GetResource` is called with the bare CFn physical id. This adds `CC_IDENTIFIER_ADAPTERS` entries that pair each with its parent, keeping them on the cheap generic CC read path (no SDK override / new dependency).

**Empirically verified live** on a probe stack (`aws cloudcontrol get-resource` per candidate shape), then end-to-end: **skipped 7 → 0**.

| Type | primaryIdentifier | adapter |
|---|---|---|
| ApiGateway Model / RequestValidator / Resource / Stage | `[RestApiId, <child>]` (parent-first) | `compositeWith('RestApiId')` |
| Cognito UserPoolDomain / UserPoolResourceServer | `[UserPoolId, <child>]` (parent-first) | `compositeWith('UserPoolId')` |
| ApiGateway Deployment | `[DeploymentId, RestApiId]` (**child-first**) | bespoke `${physicalId}\|${RestApiId}` |

Key live findings:
- **Deployment is child-first** — `RestApiId\|DeploymentId` returns not-found; only `DeploymentId\|RestApiId` reads. Handled like ECS Service, not `compositeWith`.
- **ApiGateway::Method needs no adapter** — its CFn physical id is already the full `RestApiId\|ResourceId\|HttpMethod` composite (the reason it always read).

The same adapter resolves the revert `UpdateResource` identifier, not just the read.

## Tests
- `router.test.ts`: composite-shape unit tests for all 7 (incl. unresolved-parent fallback + Deployment child-first order).
- **868 unit tests** pass; typecheck / lint+format / build green.
- New integ fixture `tests/integration/ccadapters` proving it live (asserts no `ValidationException` skip remains + zero declared drift).
- `docs/ARCHITECTURE.md` updated.

## Live integ — INTEG PASS
Account 531991745243 / us-east-1, self-cleaning:

```
=== 1. baseline-free check: ZERO declared drift AND no ValidationException skip ===
result: CLEAN — 7 unrecorded value(s) await a baseline (6 shown, 1 folded)
  (no `skipped=` line — all composite-id types now read)
=== 2. record + check --fail must be CLEAN ===
result: CLEAN
INTEG PASS
```

Before (main): `skipped=7 (CC ValidationException 7)`. After (this PR): 0 skips.