### PR TITLE
feat(report): legible drift report — multi-line array delta, distinct tier names, esc hints (R130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ explainable — the same change shows up:
 ```console
 $ npx cdkrd check ApiStack
 === cdkrd check: ApiStack (us-east-1) ===
-[CFn-UNDECLARED DRIFT: 1] (live-only — not in your CloudFormation template; the differentiator)
+[CFn-Undeclared DRIFT: 1] (live-only — not in your CloudFormation template; the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
 
 result: 1 drift(s) (undeclared=1)
@@ -299,7 +299,7 @@ incident shows up before `cdk deploy` silently reverts it:
 $ npx cdkrd check --pre-deploy
 (--pre-deploy) comparing live state against the LOCAL synth template
 === cdkrd check: ApiStack (us-east-1) ===
-[CFn-DECLARED DRIFT: 1]
+[CFn-Declared DRIFT: 1]
   ApiStack/Api/Handler.MemorySize (AWS::Lambda::Function)
       desired=1024
       actual =2048
@@ -390,7 +390,7 @@ text.
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[CFn-DECLARED DRIFT: 1]
+[CFn-Declared DRIFT: 1]
   ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"
       actual ="Suspended"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ explainable — the same change shows up:
 ```console
 $ npx cdkrd check ApiStack
 === cdkrd check: ApiStack (us-east-1) ===
-[CFn-Undeclared DRIFT: 1] (live-only — not in your CloudFormation template; the differentiator)
+[CFn-Undeclared Drift: 1] (live-only — not in your CloudFormation template; the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) = [{"PolicyName":"manual-debug-access", ...}]
 
 result: 1 drift(s) (undeclared=1)
@@ -58,7 +58,7 @@ there is nothing to compare them to yet), then offers to record a baseline:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[UNRECORDED: 2] (not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it)
+[Not Recorded: 2] (not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it)
   ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
 
@@ -256,7 +256,7 @@ per finding / Nothing` inline (shown above). Each option appears only when it
   confirmation writes nothing — the drift still stands and stays reported.
 - **`revert`** shows the plan, then a multiselect of the op(s) to write:
   RESTORE ops (template / baseline values) are pre-selected, while REMOVE ops
-  (deleting a live value not in your template — a standout `[UNRECORDED]` value, or
+  (deleting a live value not in your template — a standout `[Not Recorded]` value, or
   one not in the baseline) start **unselected** and are labeled `(REMOVE)` —
   removal is an explicit per-item choice (R113: no `--remove-unrecorded` needed in a
   prompt, since the unselected row IS the consent). In the multiselect, **space**
@@ -299,7 +299,7 @@ incident shows up before `cdk deploy` silently reverts it:
 $ npx cdkrd check --pre-deploy
 (--pre-deploy) comparing live state against the LOCAL synth template
 === cdkrd check: ApiStack (us-east-1) ===
-[CFn-Declared DRIFT: 1]
+[CFn-Declared Drift: 1]
   ApiStack/Api/Handler.MemorySize (AWS::Lambda::Function)
       desired=1024
       actual =2048
@@ -351,7 +351,7 @@ that folds everything informational.
 
 - **Drift tiers** — `deleted` / `declared` / `undeclared` — are always listed in
   full and drive the `--fail` exit. They are the point.
-- **`[UNRECORDED: N]`** — undeclared values you have not recorded yet. Listed in
+- **`[Not Recorded: N]`** — undeclared values you have not recorded yet. Listed in
   full, but not drift (there is nothing to compare them to): they never fail the
   build, and `result:` points you at `cdkrd record`. Once a resource is fully
   snapshotted, a value that _appears_ later is real drift (`appeared since record`).
@@ -390,7 +390,7 @@ text.
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[CFn-Declared DRIFT: 1]
+[CFn-Declared Drift: 1]
   ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"
       actual ="Suspended"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -502,7 +502,7 @@ only when non-zero — unrecorded values are named as such, never folded into
   prompt (TTY, no `--yes`) the standout undeclared values ARE surfaced as opt-in
   REMOVE rows (`includeUnrecordedRemovals`, R113): the multiselect's unselected-by-
   default rows are the per-item consent the flag provides, so listing them — like
-  declared drift — is consistent with showing them as `[UNRECORDED]`, and no flag is
+  declared drift — is consistent with showing them as `[Not Recorded]`, and no flag is
   needed. Declared drift is always revertable (the template is its source). For
   unrecorded values this guard outranks the create-only guard (R35): the fundamental
   blocker is "no revert target exists" — a "requires replacement" reason would
@@ -701,7 +701,7 @@ folded into an `info:` footer (per-tier counts + a reason breakdown, e.g.
 line when one tier is present, one bullet line per tier (with a single
 `--verbose` hint) when 2+; `--verbose` expands them to full lists; 0-count
 tiers are never printed. Section headers carry the count INSIDE the brackets
-(`[CFn-Declared DRIFT: 3]`, the explanatory note outside) — a bare digit right of
+(`[CFn-Declared Drift: 3]`, the explanatory note outside) — a bare digit right of
 `]` read as noise (R48). No blank line precedes the header; the FIRST drift
 section follows the header directly, later sections get a grouping blank, and
 `result:` gets a blank line before it ONLY when a drift section was printed —
@@ -719,12 +719,12 @@ ENTRY is the contract that defines undeclared drift; a value with no entry on a
 never-snapshot-complete resource has nothing to violate (§8). `applyBaseline`
 tags such findings `unrecorded` — on a no-baseline first run that is every
 undeclared value, and after a cherry-pick record it is still every value the
-user did not pick. They render as their own `[UNRECORDED: N]` section (note:
+user did not pick. They render as their own `[Not Recorded: N]` section (note:
 `not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to
-track it`) alongside any real `[CFn-Undeclared DRIFT]` section, are excluded from the verdict and the
+track it`) alongside any real `[CFn-Undeclared Drift]` section, are excluded from the verdict and the
 `--fail` exit, and the `result:` line carries the count + the way out
 (`— N unrecorded value(s) await a baseline (X shown, Y folded; run cdkrd record)`
-when some fold; R112). When BOTH a drift section and a standout `[UNRECORDED]`
+when some fold; R112). When BOTH a drift section and a standout `[Not Recorded]`
 section print, a lone `N drift(s)` verdict reads as a mismatch against the 2+
 visible blocks, so the line switches to a combined findings count counting only
 what is SHOWN — `result: 3 findings — 1 drift (declared=1) + 2 undeclared to

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -701,7 +701,7 @@ folded into an `info:` footer (per-tier counts + a reason breakdown, e.g.
 line when one tier is present, one bullet line per tier (with a single
 `--verbose` hint) when 2+; `--verbose` expands them to full lists; 0-count
 tiers are never printed. Section headers carry the count INSIDE the brackets
-(`[DECLARED DRIFT: 3]`, the explanatory note outside) — a bare digit right of
+(`[CFn-Declared DRIFT: 3]`, the explanatory note outside) — a bare digit right of
 `]` read as noise (R48). No blank line precedes the header; the FIRST drift
 section follows the header directly, later sections get a grouping blank, and
 `result:` gets a blank line before it ONLY when a drift section was printed —
@@ -721,7 +721,7 @@ tags such findings `unrecorded` — on a no-baseline first run that is every
 undeclared value, and after a cherry-pick record it is still every value the
 user did not pick. They render as their own `[UNRECORDED: N]` section (note:
 `not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to
-track it`) alongside any real `[CFn-UNDECLARED DRIFT]` section, are excluded from the verdict and the
+track it`) alongside any real `[CFn-Undeclared DRIFT]` section, are excluded from the verdict and the
 `--fail` exit, and the `result:` line carries the count + the way out
 (`— N unrecorded value(s) await a baseline (X shown, Y folded; run cdkrd record)`
 when some fold; R112). When BOTH a drift section and a standout `[UNRECORDED]`

--- a/docs/why-a-baseline-file.md
+++ b/docs/why-a-baseline-file.md
@@ -34,7 +34,7 @@ Two properties of that state follow immediately:
 - **It is the definition of undeclared drift.** Undeclared "drift" is only
   meaningful relative to an recorded reference. With no reference there is
   nothing to violate — which is exactly why a value you never recorded renders
-  as `[UNRECORDED]`, not drift (R60; per VALUE since R62 — a partial record
+  as `[Not Recorded]`, not drift (R60; per VALUE since R62 — a partial record
   leaves the unpicked values unrecorded rather than flipping them to drift).
 
 ## 2. Why schema defaults cannot substitute
@@ -159,7 +159,7 @@ The file does not cost the first-run experience:
 
 - The **first `check` needs no file** and is fully functional: the declared and
   deleted tiers are stateless (template vs live) and fail the run from run #1;
-  the undeclared tier shows as `[UNRECORDED: N]` with the record path spelled
+  the undeclared tier shows as `[Not Recorded: N]` with the record path spelled
   out (R49/R60).
 - The baseline is **never hand-authored** — it is the machine-recorded byproduct
   of one human decision (the interactive record after the first check, or

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -75,9 +75,11 @@ export function actionChip(action: FindingAction): string {
   return `[ ${center(action, CHIP_WIDTH)} ]`;
 }
 
-/** The dim key-hint line shown under the message. Pure + exported for unit tests. */
+/** The dim key-hint line shown under the message. Pure + exported for unit tests.
+ *  The action picker only runs inside check's interactive flow, where Esc returns to
+ *  the action menu — so `esc = back` (R130). */
 export function actionPickerHint(): string {
-  return '↑↓ = move · space = cycle · → = all to focused · enter = apply';
+  return '↑↓ = move · space = cycle · → = all to focused · enter = apply · esc = back';
 }
 
 /**

--- a/src/commands/bulk-multiselect.ts
+++ b/src/commands/bulk-multiselect.ts
@@ -32,9 +32,12 @@ export function bulkSelectValues(options: { value: string }[], action: 'all' | '
   return action === 'all' ? options.map((o) => o.value) : [];
 }
 
-/** The dim key-hint line shown under the message. Pure + exported for unit tests. */
+/** The dim key-hint line shown under the message. Pure + exported for unit tests.
+ *  `esc = cancel` is listed last (R130): Esc aborts the prompt — in check's interactive
+ *  flow that returns to the action menu, in a standalone `record`/`ignore` it cancels
+ *  the command; either way the selection is discarded, so `cancel` is accurate in both. */
 export function bulkSelectHint(): string {
-  return 'space = toggle · → = all · ← = none · enter = confirm';
+  return 'space = toggle · → = all · ← = none · enter = confirm · esc = cancel';
 }
 
 type Opt = { value: string; label: string };

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -20,19 +20,22 @@
 import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
 
+// Section headers are Title Case (not all-caps) — uniform and readable, and crucially
+// so `CFn-Declared Drift` vs `CFn-Undeclared Drift`, which share the `CFn-` prefix, the
+// ` Drift` suffix, and the same red colour, read as distinct WORDS at a glance instead
+// of two near-identical all-caps tokens (R130 dogfood). `CFn` / `AWS` stay as the
+// acronyms they are. The not-in-baseline section is `[Not Recorded]` (literal below),
+// which ties directly to the `cdkrd record` verb.
 const TIER_NAMES: Record<Tier, string> = {
-  deleted: 'DELETED',
-  // Mixed case (not all-caps) so DECLARED vs UNDECLARED — which share the `CFn-` prefix
-  // and ` DRIFT` suffix and the same red colour — read as distinct words at a glance
-  // instead of two near-identical all-caps tokens (R130 dogfood).
-  declared: 'CFn-Declared DRIFT',
-  undeclared: 'CFn-Undeclared DRIFT',
-  atDefault: 'AT AWS DEFAULT',
-  generated: 'AWS GENERATED',
-  ignored: 'IGNORED',
-  readGap: 'READ GAP',
-  unresolved: 'UNRESOLVED',
-  skipped: 'SKIPPED',
+  deleted: 'Deleted',
+  declared: 'CFn-Declared Drift',
+  undeclared: 'CFn-Undeclared Drift',
+  atDefault: 'At AWS Default',
+  generated: 'AWS Generated',
+  ignored: 'Ignored',
+  readGap: 'Read Gap',
+  unresolved: 'Unresolved',
+  skipped: 'Skipped',
 };
 // Explanation printed after the bracketed name+count, outside the brackets.
 // The notes anchor the THREE sources cdkrd touches, so "declared" is never misread as
@@ -215,7 +218,7 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   if (
     section(
       unrecordedShown,
-      'UNRECORDED',
+      'Not Recorded',
       'not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it',
       style.undeclaredTier,
       driftSections > 0

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -22,8 +22,11 @@ import { style } from './style.js';
 
 const TIER_NAMES: Record<Tier, string> = {
   deleted: 'DELETED',
-  declared: 'CFn-DECLARED DRIFT',
-  undeclared: 'CFn-UNDECLARED DRIFT',
+  // Mixed case (not all-caps) so DECLARED vs UNDECLARED — which share the `CFn-` prefix
+  // and ` DRIFT` suffix and the same red colour — read as distinct words at a glance
+  // instead of two near-identical all-caps tokens (R130 dogfood).
+  declared: 'CFn-Declared DRIFT',
+  undeclared: 'CFn-Undeclared DRIFT',
   atDefault: 'AT AWS DEFAULT',
   generated: 'AWS GENERATED',
   ignored: 'IGNORED',
@@ -100,15 +103,21 @@ export function formatFinding(f: Finding): string {
   return s;
 }
 
-// R128: render an identity-keyed array delta as one indented line per changed element
+// R128/R130: render an identity-keyed array delta as one block per changed element
 // (added / changed / removed), keyed by its identity value — far more legible than a
-// 200-char whole-array dump when only one element of many differs from the baseline.
+// whole-array dump when only one element of many differs. The element id sits on its
+// own marker line (+ added / ~ changed / - removed); the baseline / actual value(s)
+// follow on their own indented lines (mirrors the declared tier's desired/actual
+// layout — `baseline`/`actual` are padded so the `=` aligns), so two long policy
+// documents are read top-to-bottom instead of wrapping on one line (R130).
 function formatArrayDelta(d: ArrayDelta): string {
+  // 8 = len('baseline'); pad 'actual' to match so the '=' column lines up.
+  const baseline = (v: unknown): string => `\n          baseline=${style.desired(j(v))}`;
+  const actual = (v: unknown): string => `\n          actual  =${style.actual(j(v))}`;
   let s = ` — ${d.identityField}-keyed element(s) changed vs .cdkrd baseline:`;
-  for (const a of d.added) s += `\n      + [${a.id}] = ${style.actual(j(a.value))}`;
-  for (const c of d.changed)
-    s += `\n      ~ [${c.id}] baseline=${style.desired(j(c.recorded))} actual=${style.actual(j(c.actual))}`;
-  for (const r of d.removed) s += `\n      - [${r.id}] = ${style.desired(j(r.value))}`;
+  for (const a of d.added) s += `\n      + [${a.id}]${actual(a.value)}`;
+  for (const c of d.changed) s += `\n      ~ [${c.id}]${baseline(c.recorded)}${actual(c.actual)}`;
+  for (const r of d.removed) s += `\n      - [${r.id}]${baseline(r.value)}`;
   return s;
 }
 

--- a/tests/action-picker.test.ts
+++ b/tests/action-picker.test.ts
@@ -117,6 +117,7 @@ describe('actionPickerHint', () => {
     expect(h).toContain('space');
     expect(h).toContain('→');
     expect(h).toContain('enter');
+    expect(h).toContain('esc'); // R130: Esc returns to the action menu
   });
 });
 

--- a/tests/bulk-multiselect.test.ts
+++ b/tests/bulk-multiselect.test.ts
@@ -50,6 +50,7 @@ describe('bulkSelectHint', () => {
     expect(h).toContain('→');
     expect(h).toContain('←');
     expect(h).toContain('enter');
+    expect(h).toContain('esc'); // R130: Esc cancels (returns to the menu in check's interactive flow)
     expect(h).not.toContain('toggle all'); // the discoverable-but-cryptic `a`/`i` are gone
   });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -24,7 +24,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(code).toBe(0);
     expect(text).toContain('[UNRECORDED: 2]');
     expect(text).toContain('not drift —'); // R112: the section says so up front
-    expect(text).not.toContain('UNDECLARED DRIFT');
+    expect(text).not.toContain('Undeclared DRIFT');
     expect(text).toContain(
       'result: CLEAN — 2 unrecorded value(s) await a baseline (run cdkrd record)'
     );
@@ -52,7 +52,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
   it('undeclared DRIFT and UNRECORDED coexist as separate sections (partial baseline)', () => {
     const { code, text } = run([F('undeclared'), U('Q')]);
     expect(code).toBe(1);
-    expect(text).toContain('[CFn-UNDECLARED DRIFT: 1]');
+    expect(text).toContain('[CFn-Undeclared DRIFT: 1]');
     expect(text).toContain('[UNRECORDED: 1]');
     expect(text).toContain('result: 2 findings — 1 drift (undeclared=1) + 1 undeclared to review');
   });
@@ -83,7 +83,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
   it('untagged undeclared (recorded value changed / appeared since record) is drift as before', () => {
     const { code, text } = run([F('undeclared')]);
     expect(code).toBe(1);
-    expect(text).toContain('[CFn-UNDECLARED DRIFT: 1]');
+    expect(text).toContain('[CFn-Undeclared DRIFT: 1]');
   });
 });
 
@@ -116,19 +116,19 @@ describe('report', () => {
 
   it('text mode groups by tier with counts', () => {
     const { text } = run([F('undeclared')]);
-    expect(text).toContain('UNDECLARED DRIFT');
+    expect(text).toContain('Undeclared DRIFT');
     expect(text).toContain('result:');
   });
 
   it('section header carries the count INSIDE the brackets, note outside (R48)', () => {
     const { text } = run([F('undeclared'), F('declared', 'Q')]);
     expect(text).toContain(
-      '[CFn-UNDECLARED DRIFT: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
+      '[CFn-Undeclared DRIFT: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
     );
     // declared is now anchored to the deployed CloudFormation template (CFn-) so it
     // can't be misread as "in my CDK code" or "in the .cdkrd baseline"
     expect(text).toContain(
-      '[CFn-DECLARED DRIFT: 1] (declared in your CloudFormation template — the live value differs)'
+      '[CFn-Declared DRIFT: 1] (declared in your CloudFormation template — the live value differs)'
     );
     // the old bare-digit-right-of-bracket form is gone
     expect(text).not.toMatch(/\] \d/);
@@ -153,6 +153,36 @@ describe('report', () => {
     expect(text).toContain('+ [aaa]');
     // the whole-array dump (the other element) is NOT shown — only the delta
     expect(text).not.toContain('"PolicyName":"keep"');
+  });
+
+  it('R130 puts a changed element id, baseline and actual on their own aligned lines', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      actual: [{ PolicyName: 'p', v: 2 }],
+      arrayDelta: {
+        identityField: 'PolicyName',
+        added: [{ id: 'add', value: { PolicyName: 'add' } }],
+        changed: [
+          { id: 'p', recorded: { PolicyName: 'p', v: 1 }, actual: { PolicyName: 'p', v: 2 } },
+        ],
+        removed: [{ id: 'gone', value: { PolicyName: 'gone' } }],
+      },
+    };
+    const lines = run([f]).text.split('\n');
+    // the marker line carries only the id; value(s) follow on their own indented lines
+    expect(lines).toContain('      ~ [p]');
+    const bIdx = lines.findIndex((l) => l.includes('baseline=') && l.includes('"v":1'));
+    const aIdx = lines.findIndex((l) => l.includes('actual  =') && l.includes('"v":2'));
+    expect(bIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBe(bIdx + 1); // actual directly under baseline
+    // padded so the '=' aligns (len('baseline') === 'actual  '.length)
+    expect(lines[bIdx]?.indexOf('=')).toBe(lines[aIdx]?.indexOf('='));
+    // added shows actual only; removed shows baseline only
+    expect(lines).toContain('      + [add]');
+    expect(lines).toContain('      - [gone]');
   });
 
   it('shows the CDK construct path instead of the logical id when present', () => {
@@ -180,7 +210,7 @@ describe('report', () => {
 
     it('does NOT print a 0-count tier header (CLEAN stack is compact)', () => {
       const { text } = run([reason('readGap', 'write-only — cannot be read back')]);
-      expect(text).not.toContain('DECLARED DRIFT');
+      expect(text).not.toContain('Declared DRIFT');
       expect(text).not.toContain('UNDECLARED');
       expect(text).not.toContain('DELETED');
     });
@@ -254,8 +284,8 @@ describe('report', () => {
     });
 
     it('drift tiers stay fully detailed regardless of verbose', () => {
-      expect(run([F('declared')]).text).toContain('DECLARED DRIFT');
-      expect(run([F('declared')], { verbose: true }).text).toContain('DECLARED DRIFT');
+      expect(run([F('declared')]).text).toContain('Declared DRIFT');
+      expect(run([F('declared')], { verbose: true }).text).toContain('Declared DRIFT');
     });
 
     it('no info: line when there are no informational findings', () => {
@@ -387,7 +417,7 @@ describe('report', () => {
     it('drift: first section directly under the header; blank line BEFORE result: (R48)', () => {
       const lines = run([F('declared')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toMatch(/^\[CFn-DECLARED DRIFT: 1\]/); // no stray blank after the header
+      expect(lines[1]).toMatch(/^\[CFn-Declared DRIFT: 1\]/); // no stray blank after the header
       const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
       expect(lines[resultIdx - 1]).toBe(''); // the verdict is separated from the section above
     });
@@ -395,8 +425,8 @@ describe('report', () => {
     it('two drift sections: blank BETWEEN them, none after the header (R48)', () => {
       const lines = run([F('declared'), F('undeclared', 'Q')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toMatch(/^\[CFn-DECLARED DRIFT: 1\]/);
-      const undeclaredIdx = lines.findIndex((l) => l.startsWith('[CFn-UNDECLARED'));
+      expect(lines[1]).toMatch(/^\[CFn-Declared DRIFT: 1\]/);
+      const undeclaredIdx = lines.findIndex((l) => l.startsWith('[CFn-Undeclared'));
       expect(lines[undeclaredIdx - 1]).toBe(''); // grouping blank between sections
     });
 

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -19,22 +19,22 @@ function run(findings: Finding[], opts: Parameters<typeof report>[2] = {}) {
 const U = (path = 'P'): Finding => ({ ...F('undeclared', path), unrecorded: true });
 
 describe('report unrecorded findings (R60/R62 — per finding: never decided is inventory, not drift)', () => {
-  it('unrecorded findings render as [UNRECORDED: N], labelled "not drift", and do NOT count as drift', () => {
+  it('unrecorded findings render as [Not Recorded: N], labelled "not drift", and do NOT count as drift', () => {
     const { code, text } = run([U(), U('Q')]);
     expect(code).toBe(0);
-    expect(text).toContain('[UNRECORDED: 2]');
+    expect(text).toContain('[Not Recorded: 2]');
     expect(text).toContain('not drift —'); // R112: the section says so up front
-    expect(text).not.toContain('Undeclared DRIFT');
+    expect(text).not.toContain('Undeclared Drift');
     expect(text).toContain(
       'result: CLEAN — 2 unrecorded value(s) await a baseline (run cdkrd record)'
     );
   });
 
   it('result note names the shown/folded split so the section count and total reconcile (R112)', () => {
-    // 2 standout (shown in [UNRECORDED: 2]) + 3 nested (folded) = 5 total
+    // 2 standout (shown in [Not Recorded: 2]) + 3 nested (folded) = 5 total
     const nested = (p: string): Finding => ({ ...U(p), nested: true });
     const { text } = run([U(), U('Q'), nested('a'), nested('b'), nested('c')]);
-    expect(text).toContain('[UNRECORDED: 2]'); // only the standout are listed
+    expect(text).toContain('[Not Recorded: 2]'); // only the standout are listed
     expect(text).toContain(
       'result: CLEAN — 5 unrecorded value(s) await a baseline (2 shown, 3 folded; run cdkrd record)'
     );
@@ -49,11 +49,11 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(text).not.toContain('undeclared=1'); // unrecorded never appears as a drift count
   });
 
-  it('undeclared DRIFT and UNRECORDED coexist as separate sections (partial baseline)', () => {
+  it('undeclared DRIFT and Not Recorded coexist as separate sections (partial baseline)', () => {
     const { code, text } = run([F('undeclared'), U('Q')]);
     expect(code).toBe(1);
-    expect(text).toContain('[CFn-Undeclared DRIFT: 1]');
-    expect(text).toContain('[UNRECORDED: 1]');
+    expect(text).toContain('[CFn-Undeclared Drift: 1]');
+    expect(text).toContain('[Not Recorded: 1]');
     expect(text).toContain('result: 2 findings — 1 drift (undeclared=1) + 1 undeclared to review');
   });
 
@@ -83,7 +83,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
   it('untagged undeclared (recorded value changed / appeared since record) is drift as before', () => {
     const { code, text } = run([F('undeclared')]);
     expect(code).toBe(1);
-    expect(text).toContain('[CFn-Undeclared DRIFT: 1]');
+    expect(text).toContain('[CFn-Undeclared Drift: 1]');
   });
 });
 
@@ -103,7 +103,7 @@ describe('report', () => {
 
   it('deleted appears as its own tier section in text output', () => {
     const { text } = run([F('deleted', '')]);
-    expect(text).toContain('DELETED');
+    expect(text).toContain('Deleted');
   });
 
   it('json mode emits parseable JSON with findings + drifted count', () => {
@@ -116,19 +116,19 @@ describe('report', () => {
 
   it('text mode groups by tier with counts', () => {
     const { text } = run([F('undeclared')]);
-    expect(text).toContain('Undeclared DRIFT');
+    expect(text).toContain('Undeclared Drift');
     expect(text).toContain('result:');
   });
 
   it('section header carries the count INSIDE the brackets, note outside (R48)', () => {
     const { text } = run([F('undeclared'), F('declared', 'Q')]);
     expect(text).toContain(
-      '[CFn-Undeclared DRIFT: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
+      '[CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)'
     );
     // declared is now anchored to the deployed CloudFormation template (CFn-) so it
     // can't be misread as "in my CDK code" or "in the .cdkrd baseline"
     expect(text).toContain(
-      '[CFn-Declared DRIFT: 1] (declared in your CloudFormation template — the live value differs)'
+      '[CFn-Declared Drift: 1] (declared in your CloudFormation template — the live value differs)'
     );
     // the old bare-digit-right-of-bracket form is gone
     expect(text).not.toMatch(/\] \d/);
@@ -210,9 +210,9 @@ describe('report', () => {
 
     it('does NOT print a 0-count tier header (CLEAN stack is compact)', () => {
       const { text } = run([reason('readGap', 'write-only — cannot be read back')]);
-      expect(text).not.toContain('Declared DRIFT');
+      expect(text).not.toContain('Declared Drift');
       expect(text).not.toContain('UNDECLARED');
-      expect(text).not.toContain('DELETED');
+      expect(text).not.toContain('Deleted');
     });
 
     it('result: line lists only non-zero DRIFT counts; CLEAN prints just CLEAN', () => {
@@ -228,7 +228,7 @@ describe('report', () => {
       const { text } = run([
         reason('skipped', 'custom resource — no cloud-side model to read', 'Custom::Foo'),
       ]);
-      expect(text).not.toContain('[SKIPPED');
+      expect(text).not.toContain('[Skipped');
       expect(text).toContain(
         'info: skipped=1 (custom resource 1) — run with --verbose for the list'
       );
@@ -245,8 +245,8 @@ describe('report', () => {
         ),
       ];
       const { text } = run(findings);
-      expect(text).not.toContain('[SKIPPED');
-      expect(text).not.toContain('[READ GAP');
+      expect(text).not.toContain('[Skipped');
+      expect(text).not.toContain('[Read Gap');
       const lines = text.split('\n');
       const infoIdx = lines.indexOf('info:');
       expect(infoIdx).toBeGreaterThan(-1);
@@ -275,17 +275,17 @@ describe('report', () => {
           verbose: true,
         }
       );
-      expect(text).toContain('[SKIPPED');
+      expect(text).toContain('[Skipped');
       expect(text).not.toContain('info:');
       const lines = text.split('\n');
-      expect(lines.findIndex((l) => l.includes('[SKIPPED'))).toBeGreaterThan(
+      expect(lines.findIndex((l) => l.includes('[Skipped'))).toBeGreaterThan(
         lines.findIndex((l) => l.startsWith('result:'))
       );
     });
 
     it('drift tiers stay fully detailed regardless of verbose', () => {
-      expect(run([F('declared')]).text).toContain('Declared DRIFT');
-      expect(run([F('declared')], { verbose: true }).text).toContain('Declared DRIFT');
+      expect(run([F('declared')]).text).toContain('Declared Drift');
+      expect(run([F('declared')], { verbose: true }).text).toContain('Declared Drift');
     });
 
     it('no info: line when there are no informational findings', () => {
@@ -307,12 +307,12 @@ describe('report', () => {
       expect(code).toBe(0);
       expect(text).toMatch(/^result: CLEAN$/m);
       expect(text).toMatch(/info: ignored=1 \("\*\.DesiredCount" 1\)/);
-      expect(text).not.toContain('[IGNORED');
+      expect(text).not.toContain('[Ignored');
     });
 
     it('--verbose expands ignored to a full section', () => {
       const { text } = run([ignored('*.DesiredCount')], { verbose: true });
-      expect(text).toContain('[IGNORED');
+      expect(text).toContain('[Ignored');
       expect(text).not.toContain('info:');
     });
   });
@@ -334,7 +334,7 @@ describe('report', () => {
         'info: atDefault=2 (undeclared values matching a known AWS default — not drift)'
       );
       // never listed in the body by default, and never a drift section
-      expect(text).not.toContain('[AT AWS DEFAULT');
+      expect(text).not.toContain('[At AWS Default');
       expect(text).not.toContain('TracingConfig =');
     });
 
@@ -342,15 +342,15 @@ describe('report', () => {
       const { code, text } = run([U('RealEdit'), AD('TracingConfig'), AD('PackageType')]);
       // U() is unrecorded (not drift) → CLEAN, but the real value is shown; defaults fold
       expect(code).toBe(0);
-      expect(text).toContain('[UNRECORDED: 1]');
+      expect(text).toContain('[Not Recorded: 1]');
       expect(text).toContain('L.RealEdit');
       expect(text).toContain('atDefault=2');
-      expect(text).not.toContain('[AT AWS DEFAULT');
+      expect(text).not.toContain('[At AWS Default');
     });
 
     it('--verbose expands atDefault to a full section with each value shown', () => {
       const { text } = run([AD('TracingConfig')], { verbose: true });
-      expect(text).toContain('[AT AWS DEFAULT: 1]');
+      expect(text).toContain('[At AWS Default: 1]');
       expect(text).toContain('L.TracingConfig (AWS::Lambda::Function) = {"Mode":"PassThrough"}');
       expect(text).not.toContain('info:');
     });
@@ -363,7 +363,7 @@ describe('report', () => {
         ],
         { expandAtDefault: true }
       );
-      expect(text).toContain('[AT AWS DEFAULT: 1]'); // expanded
+      expect(text).toContain('[At AWS Default: 1]'); // expanded
       expect(text).toContain('info: skipped=1'); // still folded
     });
   });
@@ -384,13 +384,13 @@ describe('report', () => {
       expect(text).toContain(
         'info: generated=2 (auto-generated identifiers not in your template, AWS-assigned at deploy — not drift)'
       );
-      expect(text).not.toContain('[AWS GENERATED');
+      expect(text).not.toContain('[AWS Generated');
       expect(text).not.toContain('TopicName =');
     });
 
     it('--verbose expands generated to a full section showing each value', () => {
       const { text } = run([G('TopicName')], { verbose: true });
-      expect(text).toContain('[AWS GENERATED: 1]');
+      expect(text).toContain('[AWS Generated: 1]');
       expect(text).toContain('L.TopicName (AWS::SNS::Topic) = "Stack-TopicABC123-9F16VRgpExOs"');
       expect(text).not.toContain('info:');
     });
@@ -417,7 +417,7 @@ describe('report', () => {
     it('drift: first section directly under the header; blank line BEFORE result: (R48)', () => {
       const lines = run([F('declared')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toMatch(/^\[CFn-Declared DRIFT: 1\]/); // no stray blank after the header
+      expect(lines[1]).toMatch(/^\[CFn-Declared Drift: 1\]/); // no stray blank after the header
       const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
       expect(lines[resultIdx - 1]).toBe(''); // the verdict is separated from the section above
     });
@@ -425,7 +425,7 @@ describe('report', () => {
     it('two drift sections: blank BETWEEN them, none after the header (R48)', () => {
       const lines = run([F('declared'), F('undeclared', 'Q')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
-      expect(lines[1]).toMatch(/^\[CFn-Declared DRIFT: 1\]/);
+      expect(lines[1]).toMatch(/^\[CFn-Declared Drift: 1\]/);
       const undeclaredIdx = lines.findIndex((l) => l.startsWith('[CFn-Undeclared'));
       expect(lines[undeclaredIdx - 1]).toBe(''); // grouping blank between sections
     });
@@ -476,9 +476,9 @@ describe('R96 nested unrecorded folding', () => {
     unrecorded: true,
     ...(nested ? { nested: true } : {}),
   });
-  it('nested unrecorded folds into info:, top-level lists in [UNRECORDED]', () => {
+  it('nested unrecorded folds into info:, top-level lists in [Not Recorded]', () => {
     const { text } = run([NU('TopLevel'), NU('Conf.A', true), NU('Conf.B', true)]);
-    expect(text).toContain('[UNRECORDED: 1]');
+    expect(text).toContain('[Not Recorded: 1]');
     expect(text).toContain('L.TopLevel');
     expect(text).toContain('nested=2');
     expect(text).not.toContain('Conf.A');


### PR DESCRIPTION
## What (all from live dogfood feedback) — report/interactive readability, output only

### 1. Array delta (R128) is now multi-line
A changed element's `baseline` and `actual` were dumped on **one line** — two long policy documents wrapped illegibly. Now the element id sits on its own marker line and the value(s) follow on their own indented lines (padded so `=` aligns), mirroring the declared tier:
```
  ApiStack/ServiceRole.Policies (AWS::IAM::Role) — PolicyName-keyed element(s) changed vs .cdkrd baseline:
      + [addedPolicy]
          actual  ={"PolicyName":"addedPolicy",...}
      ~ [changedPolicy]
          baseline={...,"Action":["s3:*","s3:ListBucket"]...}
          actual  ={...,"Action":["s3:ListBucket"]...}
```

### 2. Section headers — Title Case, distinct, renamed
`[CFn-DECLARED DRIFT]` vs `[CFn-UNDECLARED DRIFT]` shared the `CFn-` prefix, the ` DRIFT` suffix, and the **same red colour** — hard to tell apart. Now **all** section headers are Title Case (uniform + readable), so the words read as distinct:
```
[Deleted: 1]
[CFn-Declared Drift: 1]
[CFn-Undeclared Drift: 2]
[Not Recorded: 2]
```
- `[UNRECORDED]` → **`[Not Recorded]`** (ties directly to the `cdkrd record` verb).
- Colours unchanged (drift = red, not-recorded = yellow). JSON output is keyed on the lowercase tier keys, so it is unaffected.

### 3. Esc key hints
Esc returns to the menu since R125 but neither hint said so. Added `esc = cancel` (bulk multiselect) and `esc = back` (action picker).

## Tests / docs
- New multi-line array-delta layout test; all tier-name / section-header assertions updated.
- `bulkSelectHint` / `actionPickerHint` assert the esc hint.
- 879 unit tests pass; tsgo (direct) / lint+format / build green. Verified end-to-end against the real ai-api report shape.
- README + `docs/ARCHITECTURE.md` + `docs/why-a-baseline-file.md` example output updated.
