### PR TITLE
fix(check): fold per-entry 'baseline now declared' notes into one summary line (R134)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -418,13 +418,18 @@ export function applyBaseline(
       .filter((f) => f.tier === 'undeclared' || f.tier === 'atDefault')
       .map((f) => `${f.logicalId}.${f.path}`)
   );
+  // R134: baseline entries promoted into the template since record are a "clean up your
+  // baseline" nudge, NOT drift — but emitting one note PER entry floods the output (a
+  // config-dense stack can have dozens, e.g. every Lambda's LoggingConfig.* once CDK
+  // starts declaring them). Collect them and emit ONE folded summary line (the `info:`
+  // footer pattern), so a `revert` touching a single op no longer prints 20+ unrelated
+  // lines. The fix is the same for every caller: re-run `record` to re-snapshot.
+  const promotedStale: string[] = [];
   for (const a of recorded) {
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;
     // promoted into the template since record → not a removal, just stale baseline
     if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
-      opts.warn?.(
-        `note: ${a.logicalId}.${a.path}: baseline entry is now declared in the template — re-run \`cdkrd record\` to clean it up.`
-      );
+      promotedStale.push(`${a.logicalId}.${a.path}`);
       continue;
     }
     kept.push({
@@ -437,7 +442,20 @@ export function applyBaseline(
       note: 'baseline value removed since record',
     });
   }
+  if (promotedStale.length > 0) opts.warn?.(formatPromotedStaleNote(promotedStale));
   return kept;
+}
+
+/**
+ * The folded one-line note for baseline entries now declared in the template (R134). One
+ * line with a count instead of one line per entry; `record` re-snapshots to clear them.
+ * Pure + exported for unit tests.
+ */
+export function formatPromotedStaleNote(paths: string[]): string {
+  const n = paths.length;
+  const subject = n === 1 ? `baseline entry (${paths[0]}) is` : `${n} baseline entries are`;
+  const them = n === 1 ? 'it' : 'them';
+  return `note: ${subject} now declared in the template — re-run \`cdkrd record\` to clean ${them} up.`;
 }
 
 /** logicalId -> set of declared top-level keys, for applyBaseline's promotion check. */

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -9,6 +9,7 @@ import {
   type BaselineFile,
   baselinePath,
   buildRecorded,
+  formatPromotedStaleNote,
   identityArrayDelta,
   checkBaselineAccount,
   computeCompleteResources,
@@ -447,6 +448,42 @@ describe('baseline', () => {
     });
     expect(out).toHaveLength(0); // no false "removed" finding
     expect(warnings[0]).toContain('now declared in the template');
+  });
+
+  it('R134: folds MANY promoted-stale entries into ONE warn line (not one per entry)', () => {
+    // three recorded paths, all since declared in the template → previously 3 notes
+    const b = baseline([
+      { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P1', value: ['x'] },
+      { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P2', value: ['y'] },
+      { logicalId: 'B', resourceType: 'AWS::X::Y', path: 'Q', value: ['z'] },
+    ]);
+    const warnings: string[] = [];
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([
+        ['A', new Set(['P1', 'P2'])],
+        ['B', new Set(['Q'])],
+      ]),
+      warn: (m) => warnings.push(m),
+    });
+    expect(out).toHaveLength(0);
+    expect(warnings).toHaveLength(1); // ONE folded line, not three
+    expect(warnings[0]).toContain('3 baseline entries are now declared in the template');
+    expect(warnings[0]).toContain('re-run `cdkrd record`');
+  });
+
+  describe('formatPromotedStaleNote (R134 — folded one-liner)', () => {
+    it('singular names the one entry', () => {
+      const note = formatPromotedStaleNote(['A.P']);
+      expect(note).toBe(
+        'note: baseline entry (A.P) is now declared in the template — re-run `cdkrd record` to clean it up.'
+      );
+    });
+    it('plural folds to a count (no per-entry list)', () => {
+      const note = formatPromotedStaleNote(['A.P1', 'A.P2', 'B.Q']);
+      expect(note).toContain('3 baseline entries are now declared');
+      expect(note).toContain('clean them up');
+      expect(note).not.toContain('A.P1'); // folded — individual paths not listed
+    });
   });
 
   it('still reports a removal when the recorded path is genuinely gone (not declared)', () => {


### PR DESCRIPTION
## Bug (found dogfooding)

Reverting a **single** op printed a flood of ~20 unrelated notes:

```
note: SttLambdaWordFn233D60D6.LoggingConfig.SystemLogLevel: baseline entry is now declared in the template — re-run `cdkrd record` to clean it up.
note: TtsLambdaTextToSpeech4A6376DF.LoggingConfig.ApplicationLogLevel: baseline entry is now declared ...
... (20+ more)
```

### Root cause

When a recorded undeclared value is later **promoted into the template** (CDK starts declaring a setting it previously didn't — e.g. every Lambda's `LoggingConfig.*`), [`applyBaseline`](src/baseline/baseline-file.ts) emitted **one note per entry**. `revert` reconciles the baseline before building its plan (`warn: console.error`), so a single-op revert dumped a note for every stale entry across the whole stack — completely unrelated to what was being reverted. (`check` passes no `warn`, which is why only `revert` / interactive per-finding flooded.)

## Fix

Collect the promoted-stale entries and emit **ONE folded summary line** with a count — the same fold pattern as check's `info:` footer — instead of one line per entry:

```
note: 23 baseline entries are now declared in the template — re-run `cdkrd record` to clean them up.
```

The remedy is unchanged (re-run `record` to re-snapshot). Singular keeps the entry name; plural folds to a count.

## Tests

- `formatPromotedStaleNote` (pure): singular names the one entry; plural folds to a count with no per-entry list.
- `applyBaseline`: 3 promoted-stale entries → `warn` called **once**, message carries the count.
- Existing promotion test still green; full suite 901 unit tests pass.

No README/flag surface touched.