### PR TITLE
fix(normalize): canonicalize IAM policy Condition value-sets to kill false declared drift

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -80,7 +80,7 @@ COPY (low coupling, verified):
 NEW (cdkd does NOT have these):
 
 - **schema-strip** — `describe-type` readOnly/writeOnly → strip set (cdkd hand-codes per-provider instead; this is our differentiator: less per-type code)
-- **policy canonicalizer** — scalar/array unify + statement sort + account-id↔root-ARN (no Version fabrication); cdkd only URL-decodes + JSON.parse, raw-compares → tolerates false positives
+- **policy canonicalizer** — scalar/array unify + statement sort + account-id↔root-ARN + Condition value-set canonicalize (scalar/array unify + sort) (no Version fabrication); cdkd only URL-decodes + JSON.parse, raw-compares → tolerates false positives
 - **desired-adapter** — GetTemplate + DescribeStackResources → resolved declared
 - **baseline file I/O** — git-committed JSON (the `record` verb; KEEPS watching)
 - **config ignore rules** — git-committed `.cdkrd/config.json`; the `ignore` verb

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -326,7 +326,7 @@ all live changes
   − declared (vs template)            → tagged "declared drift"
   − schema readOnly/writeOnly         → stripped (describe-type, nested + '*')
   − cc-api managed fields             → stripped (timestamps, revision ids)
-  − policy-doc representational noise  → canonicalized (scalar/array, stmt order, acct-id↔root-ARN)
+  − policy-doc representational noise  → canonicalized (scalar/array, stmt order, acct-id↔root-ARN, Condition value-set)
   − aws:* tags ({Key,Value}[] anywhere; maps only under a `Tags` key — never
     IAM condition keys like aws:SecureTransport, R69) → stripped
   − schema defaults + known defaults  → tagged "atDefault" (R86): NOT dropped — folded

--- a/src/normalize/policy-canonical.ts
+++ b/src/normalize/policy-canonical.ts
@@ -51,6 +51,33 @@ function sortKeys(o: Record<string, unknown>): Record<string, unknown> {
 
 const ARRAYISH_KEYS = new Set(['Action', 'NotAction', 'Resource', 'NotResource']);
 
+// An IAM `Condition` block is `{ <operator>: { <conditionKey>: <scalar|array> } }`.
+// A condition key's value is an UNORDERED SET of strings the operator matches
+// against, written either as a scalar (single value) or an array — IAM treats the
+// two forms identically and may store/return either, in any element order. Without
+// canonicalization a multi-value condition (`aws:SourceArn: [arnA, arnB]`) that AWS
+// echoes reordered, or a single-value condition the template declares as a scalar
+// while AWS stores it as a one-element array, both fire a false declared drift.
+// Mirror the Action/Resource treatment: unify scalar↔array and sort each value set,
+// on both sides, so a reordered-or-reshaped-but-equal condition compares equal while
+// a genuine value change still differs after the sort. Operator/condition-key ORDER
+// needs no sorting — deepEqual is key-order-insensitive.
+function canonicalizeCondition(v: unknown): unknown {
+  if (!isObj(v)) return v;
+  const out: Record<string, unknown> = {};
+  for (const op of Object.keys(v)) {
+    const body = v[op];
+    if (!isObj(body)) {
+      out[op] = body;
+      continue;
+    }
+    const inner: Record<string, unknown> = {};
+    for (const key of Object.keys(body)) inner[key] = toSortedArray(body[key]);
+    out[op] = inner;
+  }
+  return out;
+}
+
 function canonicalizeStatement(s: unknown): unknown {
   if (!isObj(s)) return s;
   const out: Record<string, unknown> = {};
@@ -58,6 +85,7 @@ function canonicalizeStatement(s: unknown): unknown {
     const v = s[k];
     if (ARRAYISH_KEYS.has(k)) out[k] = toSortedArray(v);
     else if (k === 'Principal' || k === 'NotPrincipal') out[k] = canonicalizePrincipal(v);
+    else if (k === 'Condition') out[k] = canonicalizeCondition(v);
     else out[k] = v;
   }
   return out;

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1513,3 +1513,61 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
     ]);
   });
 });
+
+// An IAM policy Condition value is an UNORDERED SET of strings written as a scalar
+// or an array. AWS may echo a multi-value condition (a CDK enforceSSL /
+// grant-with-SourceArn statement) reordered, or store a scalar-declared value as a
+// one-element array — both were false `declared` drift before canonicalizeCondition.
+describe('classifyResource IAM policy Condition canonicalization', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const declaredPaths = (declared: Record<string, unknown>, live: Record<string, unknown>) =>
+    classifyResource(
+      { logicalId: 'R', resourceType: 'AWS::SNS::TopicPolicy', physicalId: 'p', declared },
+      live,
+      bare
+    )
+      .filter((f) => f.tier === 'declared')
+      .map((f) => f.path);
+  const stmt = (cond: unknown) => ({
+    PolicyDocument: {
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 'sns:Publish', Resource: '*', Condition: cond }],
+    },
+  });
+
+  it('a reordered multi-value Condition is NOT declared drift', () => {
+    expect(
+      declaredPaths(
+        stmt({ StringEquals: { 'aws:SourceArn': ['arnA', 'arnB'] } }),
+        stmt({ StringEquals: { 'aws:SourceArn': ['arnB', 'arnA'] } })
+      )
+    ).toEqual([]);
+  });
+
+  it('a scalar-declared Condition value AWS stores as a one-element array is NOT drift', () => {
+    expect(
+      declaredPaths(
+        stmt({ StringEquals: { 'aws:SourceAccount': '123456789012' } }),
+        stmt({ StringEquals: { 'aws:SourceAccount': ['123456789012'] } })
+      )
+    ).toEqual([]);
+  });
+
+  it('a GENUINE Condition value change IS still declared drift', () => {
+    expect(
+      declaredPaths(
+        stmt({ StringEquals: { 'aws:SourceArn': ['arnA', 'arnB'] } }),
+        stmt({ StringEquals: { 'aws:SourceArn': ['arnA', 'arnC'] } })
+      )
+    ).not.toEqual([]);
+  });
+});

--- a/tests/policy-canonical.test.ts
+++ b/tests/policy-canonical.test.ts
@@ -90,6 +90,120 @@ describe('policy canonicalization', () => {
     const mini = '{"rules":[{"b":2,"a":1}]}';
     expect(normalizePoliciesDeep(pretty)).toBe(normalizePoliciesDeep(mini));
   });
+
+  // Condition canonicalization: an IAM condition key's value is an unordered SET
+  // of strings written as a scalar or an array; IAM treats both forms identically
+  // and AWS may store/return either, in any order. Without canonicalization a
+  // reordered multi-value condition, or a scalar-declared single value AWS stores
+  // as a one-element array, fires a false declared drift.
+  it('treats a reordered multi-value Condition as equal', () => {
+    const a = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: { StringEquals: { 'aws:SourceArn': ['arnA', 'arnB'] } },
+        },
+      ],
+    });
+    const b = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: { StringEquals: { 'aws:SourceArn': ['arnB', 'arnA'] } },
+        },
+      ],
+    });
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it('treats a scalar Condition value and its one-element-array form as equal', () => {
+    const a = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: { StringEquals: { 'aws:SourceAccount': '123456789012' } },
+        },
+      ],
+    });
+    const b = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: { StringEquals: { 'aws:SourceAccount': ['123456789012'] } },
+        },
+      ],
+    });
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it('is order-independent across Condition operator keys', () => {
+    const a = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: {
+            StringEquals: { 'aws:x': '1' },
+            Bool: { 'aws:SecureTransport': 'true' },
+          },
+        },
+      ],
+    });
+    const b = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: {
+            Bool: { 'aws:SecureTransport': 'true' },
+            StringEquals: { 'aws:x': '1' },
+          },
+        },
+      ],
+    });
+    expect(deepEqual(a, b)).toBe(true);
+  });
+
+  it('still reports a GENUINE Condition value change (no over-suppression)', () => {
+    const a = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: { StringEquals: { 'aws:SourceArn': ['arnA', 'arnB'] } },
+        },
+      ],
+    });
+    const b = canonicalizePolicy({
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: 's3:GetObject',
+          Resource: '*',
+          Condition: { StringEquals: { 'aws:SourceArn': ['arnA', 'arnC'] } },
+        },
+      ],
+    });
+    expect(deepEqual(a, b)).toBe(false);
+  });
+
+  it('leaves a non-object Condition value untouched (defensive)', () => {
+    const out = canonicalizePolicy({
+      Statement: [{ Effect: 'Allow', Action: 's3:*', Resource: '*', Condition: 'weird' }],
+    });
+    expect((out.Statement as any[])[0].Condition).toBe('weird');
+  });
 });
 
 describe('CloudFront OAI principal reconciliation (rewriteOaiPrincipalsDeep)', () => {


### PR DESCRIPTION
## Bug: false `declared` drift on IAM policy `Condition` value-sets

An IAM policy `Condition` value is an **unordered set of strings** written either
as a scalar or an array — IAM treats both forms identically and AWS may store /
return either, in any element order. The policy canonicalizer normalized
`Action` / `Resource` / `Principal` (scalar↔array unify + sort) but **not the
`Condition` block**, so:

- a reordered multi-value condition (`aws:SourceArn: [arnA, arnB]` the service
  echoes as `[arnB, arnA]`), and
- a scalar-declared single value AWS stores as a one-element array
  (`aws:SourceAccount: "123"` ↔ `["123"]`)

both fired a **false `declared` drift**. These shapes are extremely common in
real CDK apps (every cross-service `grant*` with a `SourceArn`/`SourceAccount`
condition, `enforceSSL`, org-id conditions, …), so this was a frequent false
positive (誤検知).

## Fix

Add `canonicalizeCondition` to `policy-canonical.ts` and wire it into
`canonicalizeStatement` — for each condition key, unify scalar↔array and sort the
value set, on both sides (mirrors the existing `Action`/`Resource` treatment).
Operator/condition-key **order** needs no sorting (`deepEqual` is
key-order-insensitive). Equality-gated and fail-closed: a genuine value change
still differs after the sort.

## Tests

- `tests/policy-canonical.test.ts` — reorder, scalar↔array, operator-key order,
  genuine-change-still-detected, non-object defensive case.
- `tests/classify.test.ts` — end-to-end through `classifyResource` (reorder &
  scalar↔array suppressed; genuine change still surfaces).
- Full suite green (933 tests); golden-corpus replay unchanged.

Found during a pre-release false-positive bug hunt.
