### PR TITLE
fix(normalize): intrinsic resolver fails closed on non-scalar Join/Sub interpolants

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -20,6 +20,18 @@ export function isDynamicReference(v: string): boolean {
   return DYNAMIC_REFERENCE_RE.test(v);
 }
 
+// A value safe to interpolate into a joined / substituted STRING: a primitive
+// (string / number / boolean). A symbol (UNRESOLVED / NOVALUE) or an object / array
+// means resolution was incomplete (a deep GetAtt) or the template is malformed —
+// fail closed to UNRESOLVED rather than leak `[object Object]` / `Symbol(unresolved)`
+// into the declared value, which would then mis-compare as false drift. (`Fn::Join`
+// filters NOVALUE out of the list FIRST, so its remaining non-scalar parts are the
+// genuinely-unresolved ones.)
+function isScalarInterpolant(v: unknown): boolean {
+  const t = typeof v;
+  return t === 'string' || t === 'number' || t === 'boolean';
+}
+
 export function resolve(node: unknown, ctx: ResolverContext): unknown {
   if (Array.isArray(node)) return node.map((n) => resolve(n, ctx));
   // A CloudFormation DYNAMIC REFERENCE (`{{resolve:ssm:…}}`,
@@ -58,7 +70,10 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
         const resolved = resolve(list, ctx);
         if (!Array.isArray(resolved)) return UNRESOLVED;
         const parts = resolved.filter((p) => p !== NOVALUE);
-        if (parts.some((p) => p === UNRESOLVED)) return UNRESOLVED;
+        // Any non-scalar remaining part (the UNRESOLVED symbol, OR a nested
+        // object/array that leaked from a deep unresolved GetAtt / malformed list)
+        // means we cannot faithfully join — fail closed rather than String()-leak.
+        if (parts.some((p) => !isScalarInterpolant(p))) return UNRESOLVED;
         const joined = parts.join(delim);
         // CDK frequently ASSEMBLES a dynamic reference with Fn::Join (e.g. an RDS
         // MasterUsername = Join("", ["{{resolve:secretsmanager:", Ref(secret),
@@ -219,7 +234,10 @@ export function resolveSub(v: unknown, ctx: ResolverContext): unknown {
     if (ref.startsWith('!')) return `\${${ref.slice(1)}}`;
     if (ref in vars) {
       const r = resolve(vars[ref], ctx);
-      if (r === UNRESOLVED) {
+      // Mirror the Ref / GetAtt branches below: a non-scalar resolution (UNRESOLVED,
+      // NOVALUE, or a leaked object/array) cannot be interpolated — fail closed
+      // instead of injecting `Symbol(novalue)` / `[object Object]` into the string.
+      if (!isScalarInterpolant(r)) {
         unresolved = true;
         return '';
       }

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -58,6 +58,34 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::Join': ['-', ['a', { Ref: 'AWS::NoValue' }, 'b']] }, ctx())).toBe('a-b');
   });
 
+  // A non-scalar resolved part (a nested object/array carrying a deep unresolved
+  // GetAtt, or a malformed non-string list element) must fail closed to UNRESOLVED
+  // — never String()-leak `[object Object]` / `Symbol(unresolved)` into the joined
+  // value, which would mis-compare as false drift.
+  it('Fn::Join fails closed when a list element is a non-scalar carrying deep UNRESOLVED', () => {
+    expect(
+      resolve({ 'Fn::Join': ['', ['p-', { wrap: { 'Fn::GetAtt': ['X', 'Y'] } }, '-s']] }, ctx())
+    ).toBe(UNRESOLVED);
+    expect(resolve({ 'Fn::Join': ['', ['a', [{ 'Fn::GetAtt': ['X', 'Y'] }], 'b']] }, ctx())).toBe(
+      UNRESOLVED
+    );
+    // a fully-scalar join still resolves (regression guard)
+    expect(resolve({ 'Fn::Join': ['-', ['a', 'b', 'c']] }, ctx())).toBe('a-b-c');
+  });
+
+  // The Fn::Sub variable-map branch must match the Ref/GetAtt branches: a NOVALUE or
+  // object/array resolution is unresolvable, not `Symbol(novalue)` / `[object Object]`.
+  it('Fn::Sub fails closed when a variable resolves to a non-scalar', () => {
+    expect(resolve({ 'Fn::Sub': ['x-${V}', { V: { Ref: 'AWS::NoValue' } }] }, ctx())).toBe(
+      UNRESOLVED
+    );
+    expect(
+      resolve({ 'Fn::Sub': ['x-${V}', { V: { wrap: { 'Fn::GetAtt': ['X', 'Y'] } } }] }, ctx())
+    ).toBe(UNRESOLVED);
+    // a scalar var (incl. a numeric Ref) still substitutes (regression guard)
+    expect(resolve({ 'Fn::Sub': ['x-${V}', { V: 'ok' }] }, ctx())).toBe('x-ok');
+  });
+
   it('Fn::GetAtt resolves against live attributes (incl. dotted path), else UNRESOLVED', () => {
     const c = ctx({
       liveAttrs: { Role: { Arn: 'arn:aws:iam::123:role/r' }, Db: { Endpoint: { Address: 'h' } } },


### PR DESCRIPTION
## Bug: intrinsic resolver leaks `[object Object]` / `Symbol(...)` into declared values

`Fn::Join` and the `Fn::Sub` variable-map branch only guarded against the
**top-level** `UNRESOLVED` symbol before stringifying. When a list element / Sub
variable resolves to a **non-scalar** — a nested object or array carrying a deep
unresolved `Fn::GetAtt`, or `AWS::NoValue` — the guard misses it and `String()` /
`Array.join` leak garbage into the resolved declared value:

- `Fn::Join` element `{ wrap: { "Fn::GetAtt": [...] } }` → `"...[object Object]..."`
- `Fn::Join` element that is an array → comma-joined string
- `Fn::Sub` var resolving to `AWS::NoValue` → `"Symbol(novalue)"`; to an object → `"[object Object]"`

The leaked string then mis-compares against live state as a **false `declared`
drift** (誤検知). The `Fn::Sub` Ref/GetAtt branches already handle `NOVALUE`; the
variable-map branch did not — an inconsistency.

## Fix

Add `isScalarInterpolant` (a resolved value safe to interpolate into a string is a
primitive: string/number/boolean) and use it in both spots to **fail closed to
`UNRESOLVED`** when a part/variable is a symbol or object/array. This matches the
resolver's established fail-closed philosophy (`Fn::GetAtt`, `Fn::If`,
`Fn::FindInMap`, …) and is strictly safe: a leaked garbage string could only ever
*manufacture* a false positive, never match live — so failing closed removes
false drift without hiding any real change. (`Fn::Join` still prunes `NoValue`
from the list first, so legitimate `NoValue` drops are unaffected.)

## Tests

`tests/intrinsic-resolver.test.ts` — Join with object/array element carrying a
deep GetAtt → UNRESOLVED; Sub var resolving to NoValue/object → UNRESOLVED; plus
regression guards that fully-scalar Join/Sub still resolve.
Full suite green (935 tests).

Found during a pre-release false-positive bug hunt.
