### PR TITLE
fix(normalize): keep order-significant Lambda Layers ARN list unsorted (false-negative)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -382,7 +382,9 @@ _real change still detected_ ([tests/classify.test.ts](../tests/classify.test.ts
    HTTP-method enum sets (CloudFront `AllowedMethods` / `CachedMethods`) are unordered;
    positional diff flagged them. Fix: `canonicalizeIdArraysDeep` (sort arrays whose
    every element is an AWS id `subnet-…`/`sg-…`, an ARN, or an HTTP verb; plain scalar
-   lists untouched).
+   lists untouched). EXCEPTION: a list containing a Lambda layer-version ARN
+   (`…:lambda:…:layer:…`) is order-SIGNIFICANT (later layers overlay earlier), so it is
+   left unsorted — a genuine `Layers` reorder surfaces as drift, not a false negative.
 3. **name ↔ ARN (bidirectional)** — CDK declares a bare name (Lambda
    EventSourceMapping/Permission `FunctionName`, ECS `Service.Cluster`) and AWS returns
    the full ARN; OR the reverse — the template resolves a `Fn::GetAtt` to an ARN

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -557,10 +557,27 @@ const isIdLike = (s: unknown): boolean =>
 const HTTP_METHODS = new Set(['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']);
 const isHttpMethod = (s: unknown): boolean => typeof s === 'string' && HTTP_METHODS.has(s);
 
+// THE one known order-SIGNIFICANT id/ARN array: AWS::Lambda::Function.Layers is a
+// list of layer-version ARNs where order is meaningful — later layers overlay files
+// from earlier ones, so swapping two layers changes the function's merged content.
+// Every other id/ARN array (SubnetIds, SecurityGroupIds, …) is a set, so the generic
+// sort above is safe; a layer ARN is uniquely shaped
+// (`arn:aws…:lambda:<region>:<acct>:layer:<name>:<version>`), so detect it by shape
+// and leave any array containing one UNSORTED — an out-of-band layer reorder then
+// surfaces as drift instead of being silently suppressed (the false negative the
+// blanket sort otherwise produced). Same content-based, no-per-type-table philosophy.
+const LAMBDA_LAYER_ARN_RE = /^arn:aws[a-z-]*:lambda:[^:]*:\d*:layer:/;
+const hasOrderSignificantId = (arr: unknown[]): boolean =>
+  arr.some((s) => typeof s === 'string' && LAMBDA_LAYER_ARN_RE.test(s));
+
 export function canonicalizeIdArraysDeep(v: unknown): unknown {
   if (Array.isArray(v)) {
     const mapped = v.map(canonicalizeIdArraysDeep);
-    if (mapped.length > 1 && (mapped.every(isIdLike) || mapped.every(isHttpMethod)))
+    if (
+      mapped.length > 1 &&
+      !hasOrderSignificantId(mapped) &&
+      (mapped.every(isIdLike) || mapped.every(isHttpMethod))
+    )
       return [...(mapped as string[])].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     return mapped;
   }

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -129,6 +129,31 @@ describe('noise suppressors', () => {
     expect(canonicalizeIdArraysDeep(['GET', 'CUSTOM'])).toEqual(['GET', 'CUSTOM']);
   });
 
+  it('canonicalizeIdArraysDeep: does NOT sort the order-significant Lambda Layers ARN list', () => {
+    // Lambda Function.Layers is order-significant (later layers overlay earlier).
+    // The generic ARN sort would suppress a genuine reorder — a false negative.
+    const layersA = [
+      'arn:aws:lambda:us-east-1:123456789012:layer:libA:3',
+      'arn:aws:lambda:us-east-1:123456789012:layer:libB:1',
+    ];
+    const layersB = [
+      'arn:aws:lambda:us-east-1:123456789012:layer:libB:1',
+      'arn:aws:lambda:us-east-1:123456789012:layer:libA:3',
+    ];
+    // each side is preserved verbatim (NOT sorted) ...
+    expect(canonicalizeIdArraysDeep({ Layers: layersA })).toEqual({ Layers: layersA });
+    expect(canonicalizeIdArraysDeep({ Layers: layersB })).toEqual({ Layers: layersB });
+    // ... so a reorder stays distinguishable (would surface as drift)
+    expect(canonicalizeIdArraysDeep({ Layers: layersA })).not.toEqual(
+      canonicalizeIdArraysDeep({ Layers: layersB })
+    );
+    // a NON-layer ARN list (e.g. SecurityGroupIds) still sorts as before
+    expect(canonicalizeIdArraysDeep(['arn:aws:s3:::b', 'arn:aws:s3:::a']) as string[]).toEqual([
+      'arn:aws:s3:::a',
+      'arn:aws:s3:::b',
+    ]);
+  });
+
   it('isStringlyEqualScalar: a primitive equals its String() form, real drift kept', async () => {
     const { isStringlyEqualScalar } = await import('../src/normalize/noise.js');
     expect(isStringlyEqualScalar(true, 'true')).toBe(true);


### PR DESCRIPTION
## Bug: out-of-band Lambda `Layers` reorder is silently suppressed (false negative)

`canonicalizeIdArraysDeep` sorts **any** array whose every element is an AWS id or
ARN, on the documented bet that "no such array is order-significant". But
`AWS::Lambda::Function.Layers` is a counterexample: it is a list of layer-version
ARNs and **is order-significant** — later layers overlay files from earlier ones,
so swapping two layers changes the function's merged content. Sorting both sides
makes a genuine out-of-band reorder compare equal, so the drift is **never
reported** (a false negative on a real, behavior-changing change).

## Fix

A Lambda layer-version ARN is uniquely shaped
(`arn:aws…:lambda:<region>:<acct>:layer:<name>:<version>`). Detect it by shape and
leave any array containing one **unsorted**, so a `Layers` reorder surfaces as
drift. Every other id/ARN array (SubnetIds, SecurityGroupIds, …) is genuinely a
set and keeps sorting. Same content-based, no-per-type-table philosophy as the
existing `isIdLike` / `isHttpMethod` checks; applied on both sides via the shared
pipeline, so baselines stay consistent.

## Tests

`tests/noise-and-strip.test.ts` — a reordered Layers list stays distinguishable
(NOT sorted), while a non-layer ARN list still sorts. Full suite green (936).

Found during a pre-release bug hunt.
