### PR TITLE
fix(revert): carry live value as prior on declared ops so IAM Role inline-policy revert removes rogue entries

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -223,6 +223,16 @@ function revertOp(f: Finding, recorded: BaselineFile['recorded']): PatchOp {
       op: 'add',
       path: pointer,
       value: f.desired,
+      // Carry the current live value as `prior`, exactly like the undeclared branches
+      // below. A property-scoped SDK writer that reverts PER ENTRY needs it:
+      // `writeIamRoleInlinePolicies` deletes every inline policy present in `prior`
+      // that the declared `value` no longer keeps. Without `prior` a declared
+      // `/Policies` drift (a rogue inline policy added out of band → whole-array drift)
+      // would re-PUT the declared policies but NEVER delete the rogue one — a silent,
+      // security-relevant incomplete revert. Cloud Control serialization ignores
+      // `prior`, and the ELB attribute-bag writers key off `attributeKey`, so this is
+      // inert for them.
+      prior: f.actual,
       ...(f.attributeKey !== undefined && { attributeKey: f.attributeKey }),
       human: `${f.path}${f.attributeKey ? `[${f.attributeKey}]` : ''} -> deployed-template value`,
     };

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -173,6 +173,21 @@ sibling `AWS::IAM::Policy`):
 cd iam && bash verify-inline-policy.sh
 ```
 
+### iam / verify-declared-inline-revert.sh
+
+A third `iam` script (its own stack `CdkRealDriftIntegIamDeclared`, a role that
+DECLARES an inline policy) covering the DECLARED-side revert: a rogue inline
+policy added out-of-band makes the live `Policies` a length-2 array vs the
+declared length-1, a DECLARED whole-array drift. `revert --yes` must DELETE only
+the rogue and keep the declared policy — which needs the declared revert op to
+carry the live value as `prior` (without it the rogue survived: a silent,
+security-relevant incomplete revert). PASS confirms rogue gone + declared policy
+intact + `check` CLEAN.
+
+```bash
+cd iam && bash verify-declared-inline-revert.sh
+```
+
 ### iam / verify-sibling-policy-doc.sh
 
 A third `iam` script proving there is **no false-negative** when the sibling

--- a/tests/integration/iam/app.ts
+++ b/tests/integration/iam/app.ts
@@ -1,11 +1,26 @@
 // Minimal CDK app for the cdk-real-drift IAM integration tests.
-// One IAM Role assumed by ec2.amazonaws.com, no permissions boundary declared.
-// addToPolicy() creates the sibling AWS::IAM::Policy (the CDK "DefaultPolicy"
-// pattern) that verify-inline-policy.sh exercises: the sibling's entry in the
-// role's live Policies must be filtered, while an out-of-band inline policy
-// added next to it must still be detected and reverted.
+//
+// Stack CdkRealDriftIntegIam: one IAM Role assumed by ec2.amazonaws.com, no
+// permissions boundary declared. addToPolicy() creates the sibling AWS::IAM::Policy
+// (the CDK "DefaultPolicy" pattern) that verify-inline-policy.sh exercises: the
+// sibling's entry in the role's live Policies must be filtered, while an out-of-band
+// inline policy added next to it must still be detected and reverted (UNDECLARED case).
+//
+// Stack CdkRealDriftIntegIamDeclared: a role that DECLARES an inline policy via
+// `inlinePolicies` (so the template's Properties.Policies is non-empty). A rogue
+// inline policy added out of band makes the role's live Policies a length-2 array vs
+// the declared length-1 — a DECLARED whole-array drift. verify-declared-inline-revert.sh
+// exercises that revert deletes ONLY the rogue and keeps the declared policy (the
+// declared-revert `prior` fix). A separate stack so the two roles never collide in the
+// single-role queries the existing scripts run.
 import { App, Stack } from "aws-cdk-lib";
-import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import {
+  Effect,
+  PolicyDocument,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
 
 const app = new App();
 const stack = new Stack(app, "CdkRealDriftIntegIam");
@@ -20,4 +35,22 @@ role.addToPolicy(
     resources: ["*"],
   }),
 );
+
+const declaredStack = new Stack(app, "CdkRealDriftIntegIamDeclared");
+new Role(declaredStack, "DeclaredRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  description: "cdk-real-drift IAM integration test role with a DECLARED inline policy",
+  inlinePolicies: {
+    DeclaredPolicy: new PolicyDocument({
+      statements: [
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ["s3:ListAllMyBuckets"],
+          resources: ["*"],
+        }),
+      ],
+    }),
+  },
+});
+
 app.synth();

--- a/tests/integration/iam/verify-declared-inline-revert.sh
+++ b/tests/integration/iam/verify-declared-inline-revert.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# cdk-real-drift DECLARED inline-policy revert integration test (real AWS).
+#
+# Reproduces B1 end-to-end: a role that DECLARES an inline policy (template
+# Properties.Policies non-empty) gets a rogue inline policy added out of band, which
+# makes the live Policies a length-2 array vs the declared length-1 — a DECLARED
+# whole-array drift. The fix gives the declared revert op a `prior` (the live value)
+# so writeIamRoleInlinePolicies can DELETE the rogue entry; before the fix the
+# declared op carried no `prior`, so revert re-PUT the declared policy but NEVER
+# deleted the rogue one (a silent, security-relevant incomplete revert).
+#
+#   deploy fixture -> record -> check CLEAN
+#   -> put-role-policy (rogue) -> check DETECTS declared Policies drift
+#   -> revert --yes -> rogue GONE, DeclaredPolicy INTACT -> check CLEAN
+#
+# A cleanup trap destroys the stack + removes the baseline even on failure.
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/iam && npm install && bash verify-declared-inline-revert.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamDeclared
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+ROGUE=CdkrdRogueInlinePolicy
+DECLARED=DeclaredPolicy
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (role with a DECLARED inline policy) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ROLE_NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::IAM::Role'].PhysicalResourceId" --output text)"
+[ -n "$ROLE_NAME" ] || fail "could not resolve role physical id"
+echo "role=$ROLE_NAME"
+
+# sanity: the declared inline policy is live, and it is the ONLY inline policy
+INITIAL="$(aws iam list-role-policies --role-name "$ROLE_NAME" --query 'PolicyNames' --output text)"
+echo "initial inline policies: $INITIAL"
+echo "$INITIAL" | grep -q "$DECLARED" || fail "fixture is missing its declared inline policy"
+
+echo "=== record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check should be CLEAN (declared policy matches, no drift) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record"
+
+echo "=== inject DECLARED-side drift (rogue inline policy next to the declared one) ==="
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name "$ROGUE" \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"sqs:ListQueues","Resource":"*"}]}' \
+  || fail "inject drift"
+
+echo "=== check should DETECT a Policies drift naming the rogue ==="
+OUT=/tmp/cdk-real-drift-integ-iam-declared.out
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "Policies" "$OUT" || fail "Policies drift not reported"
+grep -q "$ROGUE" "$OUT" || fail "rogue policy name not in the reported value"
+
+echo "=== revert should DELETE the rogue and KEEP the declared policy (the B1 fix) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+POLICIES="$(aws iam list-role-policies --role-name "$ROLE_NAME" --query 'PolicyNames' --output text)"
+echo "post-revert inline policies: $POLICIES"
+echo "$POLICIES" | grep -q "$ROGUE" && fail "rogue policy still attached after revert (B1: declared op had no prior)"
+echo "$POLICIES" | grep -q "$DECLARED" || fail "revert wiped the DECLARED inline policy"
+aws iam get-role-policy --role-name "$ROLE_NAME" --policy-name "$DECLARED" \
+  --query 'PolicyDocument.Statement[0].Action' --output text | grep -q "s3:ListAllMyBuckets" \
+  || fail "declared inline policy document changed"
+
+echo "=== check should be CLEAN again ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "INTEG PASS"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -71,6 +71,34 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('declared drift carries the live value as `prior` (per-entry SDK writers need it)', () => {
+    // A declared /Policies drift on an IAM Role (a rogue inline policy added out of
+    // band → whole-array drift) must carry the live array as `prior` so
+    // writeIamRoleInlinePolicies can DELETE the rogue entry, not just re-PUT the
+    // declared ones. Before the fix the declared op had no `prior` → silent incomplete
+    // revert (the rogue policy survived).
+    const declaredPolicies = [{ PolicyName: 'P', PolicyDocument: { Statement: [] } }];
+    const livePolicies = [
+      { PolicyName: 'P', PolicyDocument: { Statement: [] } },
+      { PolicyName: 'rogue', PolicyDocument: { Statement: [] } },
+    ];
+    const f = F({
+      tier: 'declared',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      desired: declaredPolicies,
+      actual: livePolicies,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Policies',
+      value: declaredPolicies,
+      prior: livePolicies,
+    });
+  });
+
   it('undeclared drift with an recorded prior value -> add op restoring the baseline value', () => {
     const f = F({
       tier: 'undeclared',


### PR DESCRIPTION
## Bug (security-relevant): declared IAM Role inline-policy revert leaves rogue policies behind

A role that DECLARES inline policies (template `Properties.Policies` non-empty)
plus a rogue inline policy added out of band produces a DECLARED whole-array
`Policies` drift (declared length-1 vs live length-2). That drift reverts through
the property-scoped `writeIamRoleInlinePolicies`, which deletes every inline policy
in `op.prior` that the declared `value` no longer keeps. But `revertOp`'s **declared**
branch never set `prior` (only the undeclared branches did), so the writer saw
`prior === undefined` → computed **no deletions** → re-PUT the declared policy and
**left the rogue policy attached**. Revert reported success; the rogue survived — a
silent, security-relevant incomplete revert.

## Fix

Set `prior: f.actual` (the live value) on the declared revert op, exactly like the
undeclared branches. Cloud Control serialization ignores `prior`, and the ELB
attribute-bag writers key off `attributeKey`, so this is inert for every other
writer — only the per-entry IAM-Role inline-policy writer (which needs it) changes
behavior.

## Verification

- **Unit** (`tests/revert-plan.test.ts`): a declared `/Policies` drift now produces
  an `sdk` op carrying `prior` = the live array. The writer-level deletion logic was
  already covered in `writers.test.ts` ("deletes prior entries not in desired").
  Full suite green (940).
- **Live integ** (`tests/integration/iam/verify-declared-inline-revert.sh`, new
  fixture stack `CdkRealDriftIntegIamDeclared`): deploy → record → check CLEAN →
  inject rogue inline policy → check DETECTS declared `Policies` drift → `revert
  --yes` → **rogue gone, declared policy intact, check CLEAN**. Ran on a real account
  end-to-end: `INTEG PASS` (stack self-destroyed by the cleanup trap).

Found during a pre-release bug hunt.
