### PR TITLE
fix(check): --declared-only/--pre-deploy also drop the atDefault tier (undeclared-side)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -26,12 +26,17 @@ import { gatherFindings } from './gather.js';
 import { resolveInteractively } from './interactive-resolve.js';
 
 // --pre-deploy reports declared-side drift the next deploy would clobber; the
-// undeclared tier (and its `generated` sibling — an undeclared-side classification)
-// is meaningless against a synth (not deployed) declared set, so it is excluded.
-// --declared-only reuses the same filter against the DEPLOYED template (R59).
-// Exported (pure) so the contract is unit-tested.
+// undeclared tier AND its undeclared-side siblings (`generated` and `atDefault` —
+// both classified only in classify's undeclared loops) are meaningless against a
+// synth (not deployed) declared set, so all three are excluded. --declared-only
+// reuses the same filter against the DEPLOYED template (R59) — its "undeclared
+// values are not compared" contract must hold for the `atDefault` footer too, else
+// `--declared-only` still prints an `At AWS Default (N)` line for values it claims
+// not to compare. Exported (pure) so the contract is unit-tested.
 export function preDeployFindings(findings: Finding[]): Finding[] {
-  return findings.filter((f) => f.tier !== 'undeclared' && f.tier !== 'generated');
+  return findings.filter(
+    (f) => f.tier !== 'undeclared' && f.tier !== 'generated' && f.tier !== 'atDefault'
+  );
 }
 
 // --undeclared-only (R59): the declared-side comparison is delegated to

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -20,8 +20,14 @@ const F = (tier: Finding['tier'], path = 'P'): Finding => ({
 });
 
 describe('preDeployFindings (--pre-deploy scope)', () => {
-  it('drops undeclared findings (meaningless against a synth declared set)', () => {
-    const out = preDeployFindings([F('declared'), F('undeclared'), F('undeclared', 'Q')]);
+  it('drops all undeclared-side tiers (undeclared / generated / atDefault)', () => {
+    const out = preDeployFindings([
+      F('declared'),
+      F('undeclared'),
+      F('generated'),
+      F('atDefault'),
+      F('undeclared', 'Q'),
+    ]);
     expect(out.map((f) => f.tier)).toEqual(['declared']);
   });
 


### PR DESCRIPTION
## Bug: `--declared-only` / `--pre-deploy` leak the `atDefault` tier

`preDeployFindings` (shared by `--pre-deploy` and `--declared-only`) dropped the
`undeclared` and `generated` tiers but NOT `atDefault`. All three are
undeclared-side classifications (emitted only in classify's undeclared loops), so
keeping `atDefault` contradicts the `--declared-only` contract — the note printed
under it promises "undeclared values are not compared (baseline untouched)", yet
the report still prints an `At AWS Default (N)` footer for exactly those values.
`generated` (the sibling fold) was already dropped; `atDefault` was an oversight.

## Fix

Drop `atDefault` too, alongside `undeclared` / `generated`. Pure filter change; no
effect on the declared/deleted/readGap/unresolved tiers or exit codes.

## Tests
`tests/check.test.ts` — `preDeployFindings` now drops all three undeclared-side
tiers (undeclared / generated / atDefault) and still keeps
declared/deleted/readGap/unresolved/skipped. Full suite green (940).

Found during a pre-release bug-hunt (wave 2). README's `--declared-only` row
("undeclared tier skipped") already matches the corrected behavior.
