### PR TITLE
fix(baseline): recorded value reset to AWS default is drift; skipped resource is not 'removed'

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,8 +214,11 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
                          (undeclared also carries a nested:true flag for a live
                          sub-key inside a declared object the template never set; R96)
 6. baseline filter       applyBaseline(): undeclared findings already recorded → drop;
-                         atDefault reconciled too (an recorded value now at-default is
-                         suppressed, not a false "removed since record")
+                         atDefault reconciled too (an UNCHANGED recorded value now
+                         at-default is suppressed, not a false "removed since record")
+                         — but a recorded value CHANGED to the default (e.g. reset
+                         out of band) is real drift; a SKIPPED resource's recorded
+                         values are unread, not "removed"
 7. report + exit code    report.ts: drift tiers in full + info: footer (1 line;
                          1 bullet/tier when 2+; --verbose expands, --show-all expands
                          atDefault + nested undeclared); --json carries all findings;

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -385,22 +385,29 @@ export function applyBaseline(
     // normalization rules still matches today's live, so a cdkrd version bump alone
     // never resurfaces a suppressed value as false drift.
     if (entry && baselineValueMatches(entry.value, f.actual)) continue; // recorded, unchanged
+    if (entry) {
+      // recorded value CHANGED -> drift. This takes PRIORITY over the at-default fold
+      // below: a recorded NON-default value reset out of band to the AWS default is a
+      // real out-of-band change (e.g. an undeclared MaxSessionDuration recorded at 7200,
+      // reset to the 3600 default), so it must surface as drift, not be folded away as
+      // inventory. classify tagged today's at-default value `atDefault`, which is NOT a
+      // drift tier — force `undeclared` so the changed-from-baseline value is counted as
+      // drift. For an identity-keyed object array (IAM inline Policies, …) attach the
+      // element-level delta so the report shows WHICH element changed (R128, display-only;
+      // the finding still names the whole-array path, so record/revert are unaffected).
+      const delta = identityArrayDelta(canonicalizeForCompare(entry.value), f.actual);
+      kept.push({ ...f, tier: 'undeclared', ...(delta && { arrayDelta: delta }) });
+      continue;
+    }
     if (f.tier === 'atDefault') {
-      // No (or a non-matching) recorded entry: the value still equals a known AWS
-      // default (the equality gate proved it), so it stays folded inventory — never
-      // drift, never unrecorded. A genuine change away from the default would not
-      // match a default and would arrive as tier 'undeclared', handled below.
+      // No recorded entry and the value equals a known AWS default (the equality gate
+      // proved it): folded inventory — never drift, never unrecorded. A genuine change
+      // away from the default would not match a default and arrives as tier
+      // 'undeclared', handled below.
       kept.push(f);
       continue;
     }
-    if (entry) {
-      // recorded value changed -> drift. For an identity-keyed object array (IAM
-      // inline Policies, …) attach the element-level delta so the report shows WHICH
-      // element changed rather than the whole array (R128). Display-only: the finding
-      // still names the whole-array path, so record/revert are unaffected.
-      const delta = identityArrayDelta(canonicalizeForCompare(entry.value), f.actual);
-      kept.push(delta ? { ...f, arrayDelta: delta } : f);
-    } else if (complete.has(f.logicalId)) {
+    if (complete.has(f.logicalId)) {
       // the record snapshot covered this whole resource, so this value is new
       kept.push({
         ...f,
@@ -424,9 +431,19 @@ export function applyBaseline(
   // starts declaring them). Collect them and emit ONE folded summary line (the `info:`
   // footer pattern), so a `revert` touching a single op no longer prints 20+ unrelated
   // lines. The fix is the same for every caller: re-run `record` to re-snapshot.
+  // A resource that was SKIPPED this run (CC-API gap / transient read error / no
+  // physical id — gather emits a `skipped` finding) was NOT observed, so its baseline
+  // values are unknown, NOT removed. Excluding it prevents a transient skip from
+  // flooding the report with false "baseline value removed since record" drift (its
+  // values still exist; we just couldn't read them this run). `deleted` is left as a
+  // genuine removal — those values really are gone.
+  const skippedLogical = new Set(
+    findings.filter((f) => f.tier === 'skipped').map((f) => f.logicalId)
+  );
   const promotedStale: string[] = [];
   for (const a of recorded) {
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;
+    if (skippedLogical.has(a.logicalId)) continue; // unread this run -> not "removed"
     // promoted into the template since record → not a removal, just stale baseline
     if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
       promotedStale.push(`${a.logicalId}.${a.path}`);

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -215,6 +215,23 @@ describe('baseline', () => {
       const out = applyBaseline([atDefault('Bkt', 'Encryption', { alg: 'AES256' })], b);
       expect(out).toEqual([]);
     });
+
+    it('a recorded NON-default value reset to the AWS default IS drift (not folded away)', () => {
+      // baseline recorded MaxSessionDuration=7200 (a tweak); someone resets it out of
+      // band to the 3600 default, which classify tags `atDefault`. Because the value
+      // CHANGED from the baseline, it must surface as drift — forced to tier
+      // `undeclared` so it is counted (atDefault is informational, not a drift tier).
+      const b = baseline([
+        { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
+      ]);
+      const out = applyBaseline([atDefault('A', 'MaxSessionDuration', 3600)], b);
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({
+        tier: 'undeclared',
+        path: 'MaxSessionDuration',
+        actual: 3600,
+      });
+    });
   });
 
   it('re-canonicalizes the baseline value before compare (old unsorted form still matches)', () => {
@@ -437,6 +454,23 @@ describe('baseline', () => {
       path: 'P',
       note: 'baseline value removed since record',
     });
+  });
+
+  it('does NOT report a removal for a resource SKIPPED this run (transient, not actually removed)', () => {
+    // 'A' has a recorded baseline value but its read was skipped this run (CC-API gap /
+    // transient error) -> gather emits a `skipped` finding. Its baseline values are
+    // unread, NOT removed, so they must not flood the report as false "removed" drift.
+    const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+    const skipped: Finding = {
+      tier: 'skipped',
+      logicalId: 'A',
+      resourceType: 'AWS::X::Y',
+      path: '',
+    };
+    const out = applyBaseline([skipped], b);
+    expect(out.some((f) => f.note === 'baseline value removed since record')).toBe(false);
+    // the skipped finding itself passes through untouched
+    expect(out).toEqual([skipped]);
   });
 
   it('does NOT report a removal when the recorded path was promoted into the template', () => {


### PR DESCRIPTION
## Two `applyBaseline` reconciliation bugs

### 1. FALSE NEGATIVE — a recorded value reset to the AWS default is silently hidden
In `applyBaseline`, the `atDefault` fold short-circuited BEFORE the "recorded entry
changed → drift" branch. So:
- `record` snapshots an undeclared `MaxSessionDuration: 7200` (a tweak).
- Someone resets it out of band to `3600` (the AWS default) → classify tags it
  `atDefault`.
- The entry exists and the value changed (`baselineValueMatches(7200, 3600)` =
  false), but control hit `if (f.tier === 'atDefault') kept.push(f)` and folded it
  as inventory — **the reset-to-default change never surfaced as drift.**

This hit every `KNOWN_DEFAULTS` / `schema.defaults` value (IAM `Path`/`Description`,
S3 BPA/encryption, Lambda `MemorySize`/`Timeout`, SQS `VisibilityTimeout`, …) —
"someone reset my tweaked setting back to the service default" is textbook drift.

**Fix:** handle the changed-entry case first and force tier `undeclared` (atDefault
is informational, not a drift tier) so the change is counted.

### 2. FALSE POSITIVE — a transiently SKIPPED resource floods "baseline value removed since record"
The removal pass built `currentPaths` only from `undeclared`/`atDefault` findings. A
resource `skipped` this run (CC-API gap / transient read error) produces neither, so
**every** recorded entry for it was emitted as `actual=undefined` "baseline value
removed since record" drift — an alarming, wrong burst on `--fail`. (`computeCompleteResources`
already excludes `skipped`; the removal pass didn't.)

**Fix:** skip the removal-emit for resources with a `skipped` finding this run
(their values are unread, not gone). `deleted` is left as a genuine removal.

## Tests
`tests/baseline.test.ts` — recorded non-default value reset to the default → drift
(tier undeclared); a skipped resource's recorded values are not reported removed.
Full suite green (942).

Found during a pre-release bug-hunt (wave 4).
