### PR TITLE
fix(check): per-finding keyOf includes attributeKey so a skipped ELB attribute is not reverted

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -73,7 +73,15 @@ export function postRecordNote(remainingUndeclared: number, remainingDeclared: n
 }
 
 // Identity shared by raw and reconciled findings (one property of one resource).
-const keyOf = (f: Finding): string => `${f.logicalId}::${f.path}`;
+// Includes `attributeKey` so the ELB attribute-bag findings — which all share one
+// logicalId+path (`LoadBalancerAttributes`) and differ only by attributeKey — get
+// DISTINCT keys. Without it, choosing `revert` for one bag attribute and `skip` for
+// another in the per-finding picker collapses both to one key, and the
+// `p.findings.filter(keyOf ∈ revertKeys)` re-admit in perFinding then reverts the
+// SKIPPED attribute too — an unintended AWS write. Mirrors revertOpKey in
+// stack-actions.ts (same fix, same reason). Exported for the collision unit test.
+export const keyOf = (f: Finding): string =>
+  `${f.logicalId}::${f.path}${f.attributeKey !== undefined ? `[${f.attributeKey}]` : ''}`;
 
 // The tier tag shown on each picker row. Anchors the vocabulary to its source so
 // "declared" is never misread as the .cdkrd baseline: CFn-declared = in the deployed
@@ -84,8 +92,14 @@ const tierTag = (f: Finding): string =>
     ? 'CFn-declared'
     : `CFn-undeclared · live-only${f.unrecorded ? ' · unrecorded' : ''}`;
 
+// Show `attributeKey` (e.g. `LoadBalancerAttributes[idle_timeout.timeout_seconds]`)
+// so ELB attribute-bag rows are distinguishable in the picker — without it the bag's
+// rows render identically and the user can't tell which attribute they're deciding
+// on (mirrors report.ts's `path[attributeKey]`).
 const pickerLabel = (f: Finding): string =>
-  `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''}  (${tierTag(f)})`;
+  `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''}${
+    f.attributeKey !== undefined ? `[${f.attributeKey}]` : ''
+  }  (${tierTag(f)})`;
 
 /**
  * Re-evaluate check's exit WITHOUT re-reading AWS: reload the (possibly just-written)

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../src/commands/check.js';
 import {
   buildResolveOptions,
+  keyOf,
   postRecordNote,
   resolveMenuMessage,
 } from '../src/commands/interactive-resolve.js';
@@ -147,5 +148,36 @@ describe('finalCheckExit (R53 — report-only by default, --fail opts into exit 
   it('errors (2) ALWAYS propagate, with or without --fail', () => {
     expect(finalCheckExit(2, false)).toBe(2);
     expect(finalCheckExit(2, true)).toBe(2);
+  });
+});
+
+describe('keyOf (per-finding identity — ELB attribute-bag collision guard)', () => {
+  const elb = (attributeKey: string): Finding => ({
+    tier: 'declared',
+    logicalId: 'LB',
+    resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+    path: 'LoadBalancerAttributes',
+    attributeKey,
+    desired: 'x',
+    actual: 'y',
+  });
+
+  it('gives two attributes of one bag DISTINCT keys (same logicalId+path)', () => {
+    const a = elb('idle_timeout.timeout_seconds');
+    const b = elb('deletion_protection.enabled');
+    expect(keyOf(a)).not.toBe(keyOf(b));
+  });
+
+  it('selecting one attribute does NOT re-admit the other (the revert-skip safety bug)', () => {
+    const a = elb('idle_timeout.timeout_seconds');
+    const b = elb('deletion_protection.enabled');
+    const chosen = new Set([keyOf(a)]); // user picked revert for `a`, skip for `b`
+    const readmitted = [a, b].filter((f) => chosen.has(keyOf(f)));
+    expect(readmitted).toEqual([a]); // ONLY a — b (skipped) is not reverted
+  });
+
+  it('a finding without attributeKey keeps the bare logicalId::path key', () => {
+    const f: Finding = { tier: 'undeclared', logicalId: 'R', resourceType: 'T', path: 'P' };
+    expect(keyOf(f)).toBe('R::P');
   });
 });


### PR DESCRIPTION
## Safety bug: per-finding `keyOf` collision reverts a SKIPPED ELB attribute

The interactive post-check resolver keyed findings by `${logicalId}::${path}`, with
no `attributeKey`. Every ELB attribute-bag finding
(`AWS::ElasticLoadBalancingV2::LoadBalancer`/`TargetGroup`) shares ONE
logicalId+path (`LoadBalancerAttributes`) and differs only by `attributeKey`. So in
"Decide per finding":

1. The action picker correctly lets the user pick `revert` for one attribute and
   `skip` for another (selection is index-based).
2. But `perFinding` collects `revertKeys = new Set(groups.revert.map(keyOf))` then
   re-admits findings via `p.findings.filter(f => revertKeys.has(keyOf(f)))`. Because
   `keyOf` collides, the SKIPPED attribute matches the same key → it is re-admitted →
   reverted with `autoSelectAll`.

Net: a user who chose to skip an attribute has it **written to AWS anyway**. This is
the same class as the `revertOpKey` ELB bug (fixed in #118), one layer up and unfixed.
The picker rows were also visually identical (`pickerLabel` omitted `attributeKey`),
so the user couldn't even tell the two attributes apart.

## Fix

`keyOf` now includes `attributeKey` (`logicalId::path[attributeKey]`), mirroring
`revertOpKey`; `pickerLabel` shows `path[attributeKey]`, mirroring `report.ts`.
Non-ELB findings have no `attributeKey`, so their key/label are unchanged.

NOTE: the related `ignore`-verb over-ignore (one attribute ignored silences the whole
bag) is left as-is — it is a genuine design property of path-level ignore rules (the
ignore matcher keys on `<id>.<path>`, which has no attribute axis), not a key bug.

## Tests
`tests/check.test.ts` — two bag attributes get distinct keys; selecting one does not
re-admit the other; a no-attributeKey finding keeps the bare key. Full suite green (945).

Found during a pre-release bug-hunt (wave 4).
