### PR TITLE
fix(baseline): reconcile the 'generated' tier like atDefault (recorded value reset to a generated form is drift)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -214,11 +214,11 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
                          (undeclared also carries a nested:true flag for a live
                          sub-key inside a declared object the template never set; R96)
 6. baseline filter       applyBaseline(): undeclared findings already recorded → drop;
-                         atDefault reconciled too (an UNCHANGED recorded value now
-                         at-default is suppressed, not a false "removed since record")
-                         — but a recorded value CHANGED to the default (e.g. reset
-                         out of band) is real drift; a SKIPPED resource's recorded
-                         values are unread, not "removed"
+                         atDefault AND generated reconciled too (an UNCHANGED recorded
+                         value now at-default/generated is suppressed, not a false
+                         "removed since record") — but a recorded value CHANGED to a
+                         default/generated form (e.g. reset out of band) is real drift;
+                         a SKIPPED resource's recorded values are unread, not "removed"
 7. report + exit code    report.ts: drift tiers in full + info: footer (1 line;
                          1 bullet/tier when 2+; --verbose expands, --show-all expands
                          atDefault + nested undeclared); --json carries all findings;

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -372,10 +372,13 @@ export function applyBaseline(
   const complete = new Set(baseline.completeResources ?? []); // v1 file: nothing complete
   const kept: Finding[] = [];
   for (const f of findings) {
-    // atDefault is reconciled alongside undeclared (R86): a value the user already
-    // recorded is suppressed whichever tier it lands in today, so a baseline entry
-    // whose live value is now classified at-default does NOT read as "removed".
-    if (f.tier !== 'undeclared' && f.tier !== 'atDefault') {
+    // atDefault AND generated are reconciled alongside undeclared (R86): a value the
+    // user already recorded is suppressed whichever undeclared-side tier it lands in
+    // today, so a baseline entry whose live value is now classified at-default OR
+    // generated does NOT read as "removed" — and a recorded value CHANGED to one of
+    // those forms still surfaces as drift (handled below), not folded away. (The three
+    // tiers here mirror the `currentPaths` filter at the bottom of this function.)
+    if (f.tier !== 'undeclared' && f.tier !== 'atDefault' && f.tier !== 'generated') {
       kept.push(f);
       continue;
     }
@@ -399,11 +402,12 @@ export function applyBaseline(
       kept.push({ ...f, tier: 'undeclared', ...(delta && { arrayDelta: delta }) });
       continue;
     }
-    if (f.tier === 'atDefault') {
-      // No recorded entry and the value equals a known AWS default (the equality gate
-      // proved it): folded inventory — never drift, never unrecorded. A genuine change
-      // away from the default would not match a default and arrives as tier
-      // 'undeclared', handled below.
+    if (f.tier === 'atDefault' || f.tier === 'generated') {
+      // No recorded entry and the value equals a known AWS default / an AWS-generated
+      // form (the equality gate proved it): folded inventory — never drift, never
+      // unrecorded. A genuine change AWAY from it would not match and arrives as tier
+      // 'undeclared', handled below; a recorded value changed TO it is the entry branch
+      // above (drift).
       kept.push(f);
       continue;
     }
@@ -417,12 +421,15 @@ export function applyBaseline(
       kept.push({ ...f, unrecorded: true }); // never decided -> not drift
     }
   }
-  // removed: recorded entries whose path is no longer present in any current undeclared
-  // OR at-default finding (R86: an recorded value reclassified at-default is still
-  // present, not removed).
+  // removed: recorded entries whose path is no longer present in any current
+  // undeclared / at-default / generated finding (R86: a recorded value reclassified to
+  // any of those undeclared-side tiers is still PRESENT — reconciled above as either
+  // suppressed-unchanged or drift — not "removed"). Must match the reconciliation tier
+  // set at the top of the loop, else a recorded value changed to a generated/at-default
+  // form would be both surfaced as drift AND double-reported here as removed.
   const currentPaths = new Set(
     findings
-      .filter((f) => f.tier === 'undeclared' || f.tier === 'atDefault')
+      .filter((f) => f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
       .map((f) => `${f.logicalId}.${f.path}`)
   );
   // R134: baseline entries promoted into the template since record are a "clean up your

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -232,6 +232,45 @@ describe('baseline', () => {
         actual: 3600,
       });
     });
+
+    it('a recorded value changed to an AWS-GENERATED form IS drift (generalizes the atDefault case)', () => {
+      // same class as the atDefault reset, for the `generated` tier: a recorded
+      // undeclared LogFormat reset out of band to the AWS-generated default. classify
+      // tags today's value `generated`; because it CHANGED from the baseline it must
+      // surface as drift, not be folded as generated nor mislabeled "removed".
+      const generated = (logicalId: string, path: string, value: unknown): Finding => ({
+        tier: 'generated',
+        logicalId,
+        resourceType: 'AWS::Lambda::Function',
+        path,
+        actual: value,
+      });
+      const b = baseline([
+        {
+          logicalId: 'Fn',
+          resourceType: 'AWS::Lambda::Function',
+          path: 'LogFormat',
+          value: 'JSON',
+        },
+      ]);
+      const out = applyBaseline([generated('Fn', 'LogFormat', 'Text')], b);
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ tier: 'undeclared', path: 'LogFormat', actual: 'Text' });
+      // and NOT a duplicate "removed since record" entry
+      expect(out.some((f) => f.note === 'baseline value removed since record')).toBe(false);
+    });
+
+    it('a generated value with NO baseline entry passes through folded (not removed, not drift)', () => {
+      const generated: Finding = {
+        tier: 'generated',
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'LoggingConfig',
+        actual: { LogGroup: '/aws/lambda/x' },
+      };
+      const out = applyBaseline([generated], baseline([]));
+      expect(out).toEqual([generated]);
+    });
   });
 
   it('re-canonicalizes the baseline value before compare (old unsorted form still matches)', () => {


### PR DESCRIPTION
## Generalizing the #122 atDefault-reset fix to the `generated` tier

Per the observation that "Finding 1 (a recorded value reset to the AWS default is
hidden) probably has sibling cases" — it does: the `generated` tier had the exact
same shape.

`applyBaseline` only reconciled `undeclared` and `atDefault` findings against the
baseline. A `generated` finding (a live value equal to the resource's AWS-minted
form — e.g. a Lambda's default `LogFormat`/`LoggingConfig`) was passed straight
through as folded inventory. So a recorded undeclared value reset out of band to the
generated form was:
- folded as `generated` (not drift), AND
- because `generated` was absent from the `currentPaths` set, **also** emitted by the
  removal pass as a misleading "baseline value removed since record" (`actual=undefined`).

i.e. a real change was both mislabeled and never counted as the drift it is.

## Fix

Reconcile `generated` exactly like `atDefault` (the three undeclared-side tiers now
move together):
1. let `generated` into the per-finding reconciliation loop,
2. fold a no-entry `generated` value as inventory,
3. add `generated` to `currentPaths` so the removal pass doesn't double-report.

A recorded value changed to a generated form now surfaces as ONE drift (forced tier
`undeclared`); an unchanged/never-recorded generated value stays folded.

## Audit of the sibling classes (the user's two hints)
- **"reset hides drift" class:** `atDefault` (#122) was the only FULLY-hidden tier
  (it was the lone non-`undeclared` tier inside `currentPaths`). `generated` is fixed
  here. The trivially-empty / `aws:*`-tag / physical-id-echo DROPS in classify emit no
  finding at all, so a recorded value changing to one of those still SURFACES (via the
  removal pass) — labeled "removed" rather than "changed"; left as-is (genuinely
  ambiguous: classify dropped the value, so "gone" vs "now empty" is indistinguishable).
- **"skip-selected acted-on" class (ELB):** audited every finding-emit site in
  classify — the ONLY source of two findings sharing `(logicalId, path)` is the ELB
  attribute bag (`attributeKey`). Every other path is unique per finding, so the
  collision is structurally ELB-only. All ACTION keys now include `attributeKey`
  (`revertOpKey` #118, `keyOf` #123); `recordedKey` never sees ELB (declared tier, not
  recorded); the ignore multiselect collapses harmlessly (ignore rules are path-level).
  No non-ELB instance exists. (No code change needed there.)

## Tests
`tests/baseline.test.ts` — recorded value changed to a generated form → drift (no
duplicate "removed"); a no-entry generated value passes through folded. Suite green (947).
