### PR TITLE
fix(synth): discover stacks via stacksRecursively so CDK Stage-nested stacks are not silently skipped

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -767,7 +767,10 @@ report meaningfully per path).
 ## 10. Synth integration
 
 [src/synth/](../src/synth/) wraps `@aws-cdk/toolkit-lib` (same dep as cdk-local):
-`synthApp()` returns per-stack `{stackName, region, template}`; `discoverStacks()`
+`synthApp()` returns per-stack `{stackName, region, template}` from
+`cloudAssembly.stacksRecursively` (NOT `.stacks`, which is the top-level assembly
+only — `stacksRecursively` descends into nested assemblies so stacks inside a CDK
+`Stage` / CDK Pipelines are discovered, not silently skipped); `discoverStacks()`
 feeds stack resolution. Used for: (a) stack resolution — cdkrd is CDK-only, so EVERY
 invocation discovers the app's stacks (all / exact-name / glob all select among them;
 R33), (b) construct-path display, (c) `--pre-deploy` (the synth template becomes the

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -59,7 +59,14 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 
   const cached = await toolkit.synth(source);
   try {
-    return cached.cloudAssembly.stacks.map((s) => ({
+    // `stacksRecursively` (NOT `stacks`): `stacks` returns only the TOP-LEVEL
+    // assembly's stacks, so every stack nested inside a CDK `Stage` (the CDK
+    // Pipelines / multi-env pattern) is silently invisible — never discovered, never
+    // checked, with no error. `stacksRecursively` descends into nested assemblies and
+    // is a SUPERSET of `stacks`, so a non-staged app is unaffected. `s.stackName` is
+    // the deployed CloudFormation stack name (CDK stage-qualifies it), which is the
+    // correct live-read target.
+    return cached.cloudAssembly.stacksRecursively.map((s) => ({
       stackName: s.stackName,
       region: CONCRETE_REGION.test(s.environment.region) ? s.environment.region : undefined,
       template: s.template as Record<string, unknown>,

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -209,6 +209,21 @@ goes unnoticed. It does not:
 cd iam && bash verify-sibling-policy-doc.sh
 ```
 
+## stages / verify-stages.sh
+
+DISCOVERY-only (no deploy): a CDK app with a top-level stack AND a stack nested
+inside a `Stage` (the CDK Pipelines / multi-env pattern). Asserts `cdkrd check`
+enumerates BOTH `TopStack` and the staged `ProdStage-ApiStack`. A staged stack is
+absent from `cloudAssembly.stacks` (top-level assembly only), so `synthApp` must use
+`stacksRecursively` — without it the staged stack is silently never discovered.
+Synthesizes locally and runs `check` (stacks not deployed → each "skipped"); only the
+discovered stack NAMES are asserted. Needs AWS creds for the DescribeStacks probe but
+deploys/destroys nothing.
+
+```bash
+cd stages && npm install && bash verify-stages.sh
+```
+
 ## atdefault
 
 Validates the R86 `atDefault` fold end-to-end (a default-config Lambda + a bare

--- a/tests/integration/stages/app.ts
+++ b/tests/integration/stages/app.ts
@@ -1,0 +1,17 @@
+// Minimal CDK app exercising the CDK `Stage` construct (the CDK Pipelines /
+// multi-env pattern): one TOP-LEVEL stack and one stack nested inside a Stage.
+// verify-stages.sh asserts cdkrd discovers BOTH — the staged stack is invisible
+// to `cloudAssembly.stacks` (top-level only) and requires `stacksRecursively`.
+import { App, Stack, Stage } from "aws-cdk-lib";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+
+const top = new Stack(app, "TopStack");
+new Topic(top, "TopTopic");
+
+const stage = new Stage(app, "ProdStage");
+const staged = new Stack(stage, "ApiStack");
+new Topic(staged, "ApiTopic");
+
+app.synth();

--- a/tests/integration/stages/cdk.json
+++ b/tests/integration/stages/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/stages/package.json
+++ b/tests/integration/stages/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-stages",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift Stages stack-discovery integration test. Run via verify-stages.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/stages/verify-stages.sh
+++ b/tests/integration/stages/verify-stages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# cdk-real-drift CDK-Stages stack-DISCOVERY integration test.
+#
+# A stack nested inside a CDK `Stage` (the CDK Pipelines / multi-env pattern) is
+# absent from `cloudAssembly.stacks` (top-level assembly only) — `synthApp` must use
+# `stacksRecursively` to descend into nested assemblies, else the staged stack is
+# silently never discovered, never checked. This asserts BOTH the top-level stack and
+# the staged stack are enumerated.
+#
+# DISCOVERY-ONLY: it synthesizes locally and runs `check` (the stacks are NOT
+# deployed, so each reports "not deployed yet — skipped"); we only assert that both
+# stack NAMES appear in the output. Needs AWS creds for the DescribeStacks probe, but
+# deploys/destroys NOTHING.
+# Usage:  cd tests/integration/stages && npm install && bash verify-stages.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() { rm -rf cdk.out .cdkrd; }
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== check (synthesize + discover; nothing deployed) ==="
+OUT=/tmp/cdk-real-drift-integ-stages.out
+AWS_REGION="$REGION" $CLI check --app "node --experimental-strip-types app.ts" 2>&1 | tee "$OUT"
+
+grep -q "TopStack" "$OUT" || fail "top-level TopStack not discovered"
+grep -q "ProdStage-ApiStack" "$OUT" || fail "staged ProdStage-ApiStack not discovered (stacksRecursively regression?)"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Detection gap: stacks inside a CDK `Stage` are silently never checked

`synthApp` discovered stacks via `cloudAssembly.stacks`, which returns only the
**top-level** assembly's stacks. Every stack nested inside a CDK `Stage` construct
(the CDK Pipelines / multi-env pattern — `new Stage(app, 'Prod'); new MyStack(prodStage, 'Api')`)
synthesizes into a **nested assembly** and is therefore invisible: never discovered,
never checked, with no error or warning.

Reproduced locally (a top-level `TopStack` + a staged `ProdStage/ApiStack`):
```
# before:  cdkrd check --app "..."
note: TopStack: not deployed yet — skipped        ← ApiStack absent entirely
# after:
note: TopStack: not deployed yet — skipped
note: ProdStage-ApiStack: not deployed yet — skipped
```

## Fix

Use `cloudAssembly.stacksRecursively`, which descends into nested assemblies. It is a
**superset** of `.stacks`, so a non-staged app is unaffected (verified: `TopStack`
still discovered). `s.stackName` is already the deployed CloudFormation stack name
(CDK stage-qualifies it, e.g. `ProdStage-ApiStack`), which is the correct live-read
target.

## Tests

New discovery-only integ fixture `tests/integration/stages/` (a top-level stack + a
Stage-nested stack) with `verify-stages.sh`: synthesizes locally and asserts `check`
enumerates BOTH stack names. No deploy. Ran end-to-end: **INTEG PASS**. Unit suite
unaffected (947); `synthApp` spawns a CDK app subprocess so it isn't unit-testable
without `aws-cdk-lib` — the integ fixture is the right level (mirrors the existing
`iam`/`basic`/… fixtures).

Found during a pre-release bug-hunt (wave 5, synth/ audit).
