### PR TITLE
fix(check): loudly warn that nested-stack resources are NOT checked (no silent under-coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,13 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   textually.
 - **Custom resources** (`Custom::*`) have no cloud-side model and are always
   `skipped` (without an API call).
+- **Nested stacks** (the CDK `NestedStack` construct / any
+  `AWS::CloudFormation::Stack` resource) are deployed as separate child stacks;
+  `cdkrd` checks the parent's `AWS::CloudFormation::Stack` resource but does **not**
+  recurse into the child, so the resources **inside** a nested stack are not checked.
+  This is never silent — `check` prints a prominent `warning:` line naming each
+  nested stack so an incomplete-coverage run is never mistaken for a fully-checked
+  CLEAN one. (Check a nested stack directly by passing its deployed child stack name.)
 - **Lambda Permission:** if only the specific statement was removed out of band
   (while the function's policy still exists), it is reported as `skipped`, not
   `deleted` — identifying the exact statement would need its `StatementId`.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -20,7 +20,7 @@ import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { report, stackSeparator } from '../report/report.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
-import type { Finding } from '../types.js';
+import type { DesiredResource, Finding } from '../types.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { resolveInteractively } from './interactive-resolve.js';
@@ -49,6 +49,23 @@ export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
   return findings.filter(
     (f) => f.tier !== 'declared' && f.tier !== 'readGap' && f.tier !== 'unresolved'
   );
+}
+
+// A nested CloudFormation stack (the CDK `NestedStack` construct, or any plain
+// `AWS::CloudFormation::Stack` resource) is deployed as a SEPARATE child stack whose
+// own resources are the real infrastructure. cdkrd checks the PARENT's
+// `AWS::CloudFormation::Stack` resource (its TemplateURL / Parameters) via Cloud
+// Control, but does NOT recurse into the child stack — so the child's resources
+// (buckets, roles, …) are never checked. A drift tool silently under-covering is the
+// danger: a CLEAN verdict that never looked inside the nested stack reads as
+// fully-checked. Surface the gap LOUDLY so coverage is never silently incomplete.
+// Returns the warning line, or null when the stack has no nested stacks. Pure +
+// exported for unit tests.
+export function nestedStackWarning(resources: DesiredResource[], stackName: string): string | null {
+  const nested = resources.filter((r) => r.resourceType === 'AWS::CloudFormation::Stack');
+  if (nested.length === 0) return null;
+  const names = nested.map((r) => r.constructPath ?? r.logicalId).sort();
+  return `warning: ${stackName} has ${nested.length} nested CloudFormation stack(s) — cdkrd does not recurse into them, so the resources INSIDE them are NOT checked: ${names.join(', ')}`;
 }
 
 /**
@@ -124,6 +141,12 @@ export async function runCheck(args: string[]): Promise<number> {
       const gathered = await gatherFindings(stackName, region, synthTemplates?.get(stackName));
       const { desired, schemas, liveByLogical } = gathered;
       let findings = gathered.findings;
+
+      // Loudly flag nested stacks whose resources cdkrd does not recurse into — a
+      // CLEAN verdict must never silently hide an unchecked child stack. To stderr so
+      // it survives `--json` (whose machine output is stdout) without polluting it.
+      const nestedWarn = nestedStackWarning(desired.resources, stackName);
+      if (nestedWarn) console.error(nestedWarn);
 
       // Scope flags (R59). --undeclared-only delegates the declared side to
       // `cdk drift` / CFn drift detection (no double reporting when pairing);

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
   finalCheckExit,
+  nestedStackWarning,
   preDeployFindings,
   undeclaredOnlyFindings,
 } from '../src/commands/check.js';
@@ -11,7 +12,7 @@ import {
   resolveMenuMessage,
 } from '../src/commands/interactive-resolve.js';
 import type { Actions } from '../src/commands/stack-actions.js';
-import type { Finding } from '../src/types.js';
+import type { DesiredResource, Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
   tier,
@@ -179,5 +180,40 @@ describe('keyOf (per-finding identity — ELB attribute-bag collision guard)', (
   it('a finding without attributeKey keeps the bare logicalId::path key', () => {
     const f: Finding = { tier: 'undeclared', logicalId: 'R', resourceType: 'T', path: 'P' };
     expect(keyOf(f)).toBe('R::P');
+  });
+});
+
+describe('nestedStackWarning (loud coverage gap for nested stacks)', () => {
+  const r = (resourceType: string, over: Partial<DesiredResource> = {}): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    declared: {},
+    ...over,
+  });
+
+  it('returns null when there are no nested stacks', () => {
+    expect(nestedStackWarning([r('AWS::SNS::Topic'), r('AWS::S3::Bucket')], 'S')).toBeNull();
+  });
+
+  it('warns, counts, and lists nested stacks by construct path (sorted)', () => {
+    const w = nestedStackWarning(
+      [
+        r('AWS::CloudFormation::Stack', { logicalId: 'B', constructPath: 'S/Zeta' }),
+        r('AWS::SNS::Topic'),
+        r('AWS::CloudFormation::Stack', { logicalId: 'A', constructPath: 'S/Alpha' }),
+      ],
+      'MyStack'
+    );
+    expect(w).toContain('MyStack has 2 nested CloudFormation stack(s)');
+    expect(w).toContain('NOT checked');
+    expect(w).toContain('S/Alpha, S/Zeta'); // sorted, construct paths preferred
+  });
+
+  it('falls back to logicalId when no construct path', () => {
+    const w = nestedStackWarning(
+      [r('AWS::CloudFormation::Stack', { logicalId: 'NestedXYZ' })],
+      'S'
+    );
+    expect(w).toContain('NestedXYZ');
   });
 });

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -224,6 +224,20 @@ deploys/destroys nothing.
 cd stages && npm install && bash verify-stages.sh
 ```
 
+## nested / verify-nested.sh
+
+A parent stack with a CDK `NestedStack` (the child has its own SNS topic). A nested
+stack deploys as a separate child CloudFormation stack; `cdkrd` checks the parent's
+`AWS::CloudFormation::Stack` resource but does NOT recurse into the child, so the
+child's resources are unchecked. Asserts `check` prints a prominent `warning:` line
+naming the nested stack (coverage is never silently incomplete) while the parent
+itself reads CLEAN (the warning is on stderr, not counted as drift). Deploys +
+destroys a real (tiny) stack.
+
+```bash
+cd nested && npm install && bash verify-nested.sh
+```
+
 ## atdefault
 
 Validates the R86 `atDefault` fold end-to-end (a default-config Lambda + a bare

--- a/tests/integration/nested/app.ts
+++ b/tests/integration/nested/app.ts
@@ -1,0 +1,14 @@
+// Minimal CDK app with a `NestedStack`: the parent holds an SNS topic plus a
+// NestedStack whose own SNS topic is the CHILD resource. cdkrd checks the parent's
+// `AWS::CloudFormation::Stack` resource but does NOT recurse into the child stack, so
+// the child topic is unchecked — verify-nested.sh asserts `check` LOUDLY warns about
+// that coverage gap (it must never silently read CLEAN over an unchecked child stack).
+import { App, Stack, NestedStack } from "aws-cdk-lib";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const parent = new Stack(app, "CdkRealDriftIntegNested");
+new Topic(parent, "ParentTopic");
+const child = new NestedStack(parent, "ChildNested");
+new Topic(child, "ChildTopic");
+app.synth();

--- a/tests/integration/nested/cdk.json
+++ b/tests/integration/nested/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/nested/package.json
+++ b/tests/integration/nested/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-nested",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift nested-stack coverage-warning integration test. Run via verify-nested.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/nested/verify-nested.sh
+++ b/tests/integration/nested/verify-nested.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# cdk-real-drift nested-stack coverage-WARNING integration test (real AWS).
+#
+# A CDK `NestedStack` deploys as a separate child CloudFormation stack. cdkrd checks
+# the parent's `AWS::CloudFormation::Stack` resource but does NOT recurse into the
+# child, so the child's resources are unchecked. A drift tool silently under-covering
+# is the danger; this asserts `check` LOUDLY warns about the nested stack (so a CLEAN
+# verdict is never silently incomplete), and that the parent itself reads CLEAN.
+#
+#   deploy parent (+ nested child) -> record -> check
+#     -> assert the nested-stack coverage WARNING is printed
+#     -> assert the parent stack is otherwise CLEAN
+# A cleanup trap destroys the stack + removes the baseline even on failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNested
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy parent + nested child ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check: must LOUDLY warn about the nested stack (coverage gap) ==="
+OUT=/tmp/cdk-real-drift-integ-nested.out
+$CLI check "$STACK" --region "$REGION" 2>&1 | tee "$OUT"
+grep -qi "nested CloudFormation stack" "$OUT" || fail "no nested-stack coverage warning printed"
+grep -qi "NOT checked" "$OUT" || fail "warning did not say the child resources are NOT checked"
+
+echo "=== parent stack itself should be CLEAN (warning is on stderr, not drift) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN exit 0 (the warning must not be counted as drift)"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Scary SILENT gap: CDK `NestedStack` resources are never checked, verdict reads CLEAN

The user flagged that wave 5 still surfaced a scary bug (Stages), so this wave hunted
the scariest class: **silent gaps** where cdkrd doesn't actually check something yet
reports CLEAN. The biggest is CDK `NestedStack`.

A `NestedStack` (mainstream CDK pattern) deploys as a SEPARATE child CloudFormation
stack. `stacksRecursively` (the #125 fix) covers nested *assemblies* (Stages) but NOT
nested *stacks* — a nested stack is one `AWS::CloudFormation::Stack` resource in the
parent, with its real resources in the child stack. cdkrd checks the parent's
`AWS::CloudFormation::Stack` resource (TemplateURL/Parameters) but never recurses into
the child, so **every resource inside a NestedStack is unchecked** — and the run reads
`result: CLEAN`, exit 0, with no mention of it. Verified locally (a parent + a nested
child topic: only the parent is discovered; `*.nested.template.json` exists in cdk.out
but is not a deployable stack artifact).

## Fix

Full recursion into child stacks is a sizeable feature (resolve each child stack name,
fetch its template, check it) and deserves its own deliberate design. The *bug* here is
the **silence** — a drift tool must never silently under-cover. So `check` now detects
`AWS::CloudFormation::Stack` resources and prints a prominent `warning:` line (to
stderr, so it survives `--json`) naming each nested stack and stating its resources are
NOT checked. An incomplete-coverage run can no longer be mistaken for a fully-checked
CLEAN one. (Follow-up: actually recurse into child stacks.)

## Verification

- **Unit** (`tests/check.test.ts`): `nestedStackWarning` returns null with no nested
  stacks; counts + lists them by construct path (sorted); falls back to logicalId.
- **Live integ** (`tests/integration/nested/verify-nested.sh`, new fixture): deploy a
  parent + `NestedStack` child → `record` → `check` asserts the warning is printed AND
  the parent reads CLEAN (`--fail` exit 0 — the warning is not counted as drift). Ran
  end-to-end on a real account: **INTEG PASS** (self-destroyed).
- README "Limitations" + integration README updated. Full unit suite green (950).

## Other silent-gap findings (this wave's audit, for follow-up)
The skipped/readGap/unresolved family is architecturally excluded from the verdict and
`--fail`, and is only folded into the `info:` footer — so a read error (throttle /
AccessDenied), a CC-unsupported type, or a `REVIEW_IN_PROGRESS` stack can leave a run
materially under-covered while `--fail` still exits 0. Worth a follow-up: a run-level
"coverage: N checked, K not checked" surfacing (the same not-silent principle).

Found during a pre-release bug-hunt (wave 6, silent-gap audit).
