### PR TITLE
feat(check): loud coverage warning on skipped resources + --strict exit on incomplete coverage

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,7 +39,7 @@ un-deployed code edits would show as false "drift".
      - sibling AWS::IAM::Policy entries filtered BY NAME from a role's live
        Policies (an out-of-band inline policy next to them still reports)
 5. classify (tag):  declared | undeclared | atDefault | generated | readGap | unresolved | skipped
-6. report + exit code (report-only by default; --fail → 1 on drift; 2 error)
+6. report + exit code (report-only by default; --fail → 1 on drift; --strict → 1 on incomplete coverage; 2 error)
 ```
 
 cdkrd is **CDK-only**: every run resolves the CDK app (synth, or a pre-synthesized

--- a/README.md
+++ b/README.md
@@ -229,23 +229,23 @@ Errors always exit `2`; `revert` exits `1` when drift remains after it.
 # - run: npx cdkrd check --fail --app cdk.out --region us-east-1
 ```
 
-| option                     | meaning                                                                                                                       |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                |
-| `--profile <p>`            | AWS profile (or `$AWS_PROFILE`)                                                                                               |
-| `-a, --app <cmd\|cdk.out>` | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths |
-| `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                    |
-| `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
-| `--fail`                   | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0                          |
+| option                     | meaning                                                                                                                                                                                                          |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); CDK stacks with explicit `env.region` are auto-detected                                                                                                   |
+| `--profile <p>`            | AWS profile (or `$AWS_PROFILE`)                                                                                                                                                                                  |
+| `-a, --app <cmd\|cdk.out>` | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`) — stack auto-discovery + construct paths                                                                                    |
+| `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                                                                                                       |
+| `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                                                                                                             |
+| `--fail`                   | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0                                                                                                             |
 | `--strict`                 | (check) exit 1 when COVERAGE is incomplete — any resource skipped (unread) or a nested stack not recursed into. A loud coverage `warning:` always prints; `--strict` makes it CI-failing. Orthogonal to `--fail` |
-| `--show-all`               | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
-| `--verbose` / `-v`         | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
-| `--pre-deploy`             | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |
-| `--undeclared-only`        | (check) undeclared drift only — pair cdkrd with `cdk drift` / CFn drift detection for the declared side                       |
-| `--declared-only`          | (check) declared drift vs the DEPLOYED template only (undeclared tier skipped; baseline untouched). Not `--pre-deploy`        |
-| `--dry-run`                | (revert) print the plan; make no changes                                                                                      |
-| `--remove-unrecorded`      | (revert) REMOVE unrecorded values in a NO-PROMPT run (`--yes`/CI); an interactive revert already lists them as opt-in REMOVE  |
-| `--yes` / `-y`             | skip confirmations (revert apply; record records all without the multiselect)                                                 |
+| `--show-all`               | inventory mode: show ALL current undeclared state, ignoring the baseline                                                                                                                                         |
+| `--verbose` / `-v`         | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists                                                                                      |
+| `--pre-deploy`             | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite                                                                                            |
+| `--undeclared-only`        | (check) undeclared drift only — pair cdkrd with `cdk drift` / CFn drift detection for the declared side                                                                                                          |
+| `--declared-only`          | (check) declared drift vs the DEPLOYED template only (undeclared tier skipped; baseline untouched). Not `--pre-deploy`                                                                                           |
+| `--dry-run`                | (revert) print the plan; make no changes                                                                                                                                                                         |
+| `--remove-unrecorded`      | (revert) REMOVE unrecorded values in a NO-PROMPT run (`--yes`/CI); an interactive revert already lists them as opt-in REMOVE                                                                                     |
+| `--yes` / `-y`             | skip confirmations (revert apply; record records all without the multiselect)                                                                                                                                    |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
 the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack name.

--- a/README.md
+++ b/README.md
@@ -216,8 +216,11 @@ tells cdkrd which stacks to look at.
 **Exit codes:** `check` is **report-only by default** — drift prints but exits
 `0` (a note names the flag). Pass **`--fail`** (the `cdk diff --fail` /
 `cdk drift --fail` convention) to exit `1` on drift and suppress all prompts —
-the one flag for scripts and CI. Errors always exit `2`; `revert` exits `1`
-when drift remains after it.
+the one flag for scripts and CI. **`--strict`** is the orthogonal coverage axis:
+it exits `1` when a run was incomplete — any resource skipped (unread) or a
+nested stack not recursed into. A loud coverage `warning:` always prints to
+stderr regardless; `--strict` only decides whether that gap fails the build.
+Errors always exit `2`; `revert` exits `1` when drift remains after it.
 
 ```yaml
 - run: npm ci # cdkrd resolves the CDK app, so its deps must be installed
@@ -234,6 +237,7 @@ when drift remains after it.
 | `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                    |
 | `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                          |
 | `--fail`                   | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0                          |
+| `--strict`                 | (check) exit 1 when COVERAGE is incomplete — any resource skipped (unread) or a nested stack not recursed into. A loud coverage `warning:` always prints; `--strict` makes it CI-failing. Orthogonal to `--fail` |
 | `--show-all`               | inventory mode: show ALL current undeclared state, ignoring the baseline                                                      |
 | `--verbose` / `-v`         | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists   |
 | `--pre-deploy`             | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite         |

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -19,6 +19,7 @@ const BOOLEAN_FLAGS = new Set([
   '--remove-unrecorded',
   '--verbose',
   '-v',
+  '--strict',
 ]);
 
 export interface CommonArgs {
@@ -47,6 +48,13 @@ export interface CommonArgs {
   // convention (R53): drift sets exit 1 and prompts are suppressed. Without it,
   // check REPORTS drift but exits 0 (report-only).
   fail: boolean;
+  // (check) coverage axis, ORTHOGONAL to --fail (which is about drift): make a run
+  // whose coverage was incomplete — any resource SKIPPED (CC-unsupported + no SDK
+  // override, a read error, a missing physical id) or any nested stack not recursed
+  // into — exit non-zero. A loud coverage `warning:` always prints regardless of this
+  // flag; --strict additionally turns that gap into a CI-failing exit. Does not change
+  // the --fail default (a transient throttle should not silently start failing CI).
+  strict: boolean;
   removeUnrecorded: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
   verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
 }
@@ -136,6 +144,7 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     app: values['--app'] ?? process.env.CDKRD_APP,
     json: has('--json'),
     fail: has('--fail'),
+    strict: has('--strict'),
     showAll: has('--show-all'),
     yes: has('--yes') || has('-y'),
     preDeploy: has('--pre-deploy'),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,10 @@ OPTIONS
   --fail                      (check) exit 1 on drift + never prompt — for
                               scripts/CI (same convention as \`cdk diff --fail\`);
                               without it, check REPORTS drift but exits 0
+  --strict                    (check) exit 1 when coverage is INCOMPLETE — any
+                              resource skipped (unread) or a nested stack not
+                              recursed into. A loud coverage warning always prints;
+                              --strict makes it CI-failing. Orthogonal to --fail
   --show-all                  inventory mode: show ALL current undeclared state
                               (not just changes since record)
   --verbose                   (check) expand informational tiers / (revert) the
@@ -58,7 +62,7 @@ OPTIONS
   --dry-run); non-TTY runs never prompt.
 
 EXIT CODES
-  check:  0 = clean (or drift without --fail)   1 = drift (--fail)   2 = error
+  check:  0 = clean (or drift without --fail)   1 = drift (--fail) / incomplete coverage (--strict)   2 = error
   record: 0 = written   2 = error/refused
   ignore: 0 = rule(s) written / nothing to ignore   2 = error/refused
   revert: 0 = converged/aborted   1 = drift remains   2 = error/apply failure

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -68,6 +68,32 @@ export function nestedStackWarning(resources: DesiredResource[], stackName: stri
   return `warning: ${stackName} has ${nested.length} nested CloudFormation stack(s) — cdkrd does not recurse into them, so the resources INSIDE them are NOT checked: ${names.join(', ')}`;
 }
 
+// Resources cdkrd could NOT read this run land in the `skipped` tier — a
+// CC-unsupported type with no SDK override, a read error (throttle / AccessDenied), a
+// missing physical id, a Custom resource. They are genuinely UNCHECKED, yet `skipped`
+// is excluded from the verdict and from `--fail`, and only folded into the `info:`
+// footer — so a materially under-covered run can read `result: CLEAN`, exit 0. Surface
+// the gap LOUDLY (same not-silent principle as the nested-stack / KMS warnings); the
+// `--strict` flag additionally turns it into a non-zero exit. Returns null when nothing
+// was skipped. Pure + exported for unit tests.
+export function coverageWarning(findings: Finding[], stackName: string): string | null {
+  const skipped = findings.filter((f) => f.tier === 'skipped');
+  if (skipped.length === 0) return null;
+  const names = skipped.map((f) => f.constructPath ?? f.logicalId).sort();
+  const shown = names.slice(0, 10);
+  const more = names.length > shown.length ? `, …(+${names.length - shown.length} more)` : '';
+  return `warning: ${stackName}: ${skipped.length} resource(s) were NOT checked (coverage incomplete) — ${shown.join(', ')}${more}; see the skipped breakdown (--verbose)`;
+}
+
+// The coverage gap that `--strict` fails on: any resource skipped (unread) OR any
+// nested stack not recursed into. Pure + exported.
+export function hasCoverageGap(findings: Finding[], resources: DesiredResource[]): boolean {
+  return (
+    findings.some((f) => f.tier === 'skipped') ||
+    resources.some((r) => r.resourceType === 'AWS::CloudFormation::Stack')
+  );
+}
+
 /**
  * Map a stack's drift code to check's final exit (R53, the `cdk diff --fail` /
  * `cdk drift --fail` convention): without --fail, check is REPORT-ONLY — drift
@@ -142,11 +168,14 @@ export async function runCheck(args: string[]): Promise<number> {
       const { desired, schemas, liveByLogical } = gathered;
       let findings = gathered.findings;
 
-      // Loudly flag nested stacks whose resources cdkrd does not recurse into — a
-      // CLEAN verdict must never silently hide an unchecked child stack. To stderr so
-      // it survives `--json` (whose machine output is stdout) without polluting it.
+      // Loudly flag incomplete coverage — a CLEAN verdict must never silently hide an
+      // unchecked nested stack or an unread (skipped) resource. To stderr so it survives
+      // `--json` (whose machine output is stdout) without polluting it. `--strict` turns
+      // any such gap into a non-zero exit (folded into `worst` after the report).
       const nestedWarn = nestedStackWarning(desired.resources, stackName);
       if (nestedWarn) console.error(nestedWarn);
+      const covWarn = coverageWarning(gathered.findings, stackName);
+      if (covWarn) console.error(covWarn);
 
       // Scope flags (R59). --undeclared-only delegates the declared side to
       // `cdk drift` / CFn drift detection (no double reporting when pairing);
@@ -281,6 +310,12 @@ export async function runCheck(args: string[]): Promise<number> {
       }
       if (code === 1) anyDrift = true;
       worst = Math.max(worst, finalCheckExit(code, a.fail));
+      // --strict: incomplete coverage (a skipped resource or an un-recursed nested
+      // stack) is a non-zero exit, independent of --fail's drift axis. The loud
+      // coverage warnings above always print; --strict makes them CI-failing.
+      if (a.strict && hasCoverageGap(gathered.findings, desired.resources)) {
+        worst = Math.max(worst, 1);
+      }
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — skipped`);

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  coverageWarning,
   finalCheckExit,
+  hasCoverageGap,
   nestedStackWarning,
   preDeployFindings,
   undeclaredOnlyFindings,
@@ -215,5 +217,56 @@ describe('nestedStackWarning (loud coverage gap for nested stacks)', () => {
       'S'
     );
     expect(w).toContain('NestedXYZ');
+  });
+});
+
+describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () => {
+  const skipped = (logicalId: string, over: Partial<Finding> = {}): Finding => ({
+    tier: 'skipped',
+    logicalId,
+    resourceType: 'AWS::X::Y',
+    path: '',
+    ...over,
+  });
+  const dr = (resourceType: string): DesiredResource => ({
+    logicalId: 'L',
+    resourceType,
+    declared: {},
+  });
+
+  it('coverageWarning is null when nothing was skipped', () => {
+    expect(coverageWarning([F('undeclared'), F('declared')], 'S')).toBeNull();
+  });
+
+  it('coverageWarning counts + lists skipped resources (construct path preferred, sorted)', () => {
+    const w = coverageWarning(
+      [
+        skipped('B', { constructPath: 'S/Zeta' }),
+        F('declared'),
+        skipped('A', { constructPath: 'S/Alpha' }),
+      ],
+      'MyStack'
+    );
+    expect(w).toContain('MyStack: 2 resource(s) were NOT checked (coverage incomplete)');
+    expect(w).toContain('S/Alpha, S/Zeta');
+  });
+
+  it('coverageWarning caps the list at 10 with a "+N more" suffix', () => {
+    const many = Array.from({ length: 14 }, (_, i) => skipped(`R${String(i).padStart(2, '0')}`));
+    const w = coverageWarning(many, 'S')!;
+    expect(w).toContain('14 resource(s) were NOT checked');
+    expect(w).toContain('…(+4 more)');
+  });
+
+  it('hasCoverageGap is true on a skipped resource', () => {
+    expect(hasCoverageGap([skipped('A')], [dr('AWS::SNS::Topic')])).toBe(true);
+  });
+
+  it('hasCoverageGap is true on a nested stack even with everything else checked', () => {
+    expect(hasCoverageGap([F('undeclared')], [dr('AWS::CloudFormation::Stack')])).toBe(true);
+  });
+
+  it('hasCoverageGap is false when everything was read and there are no nested stacks', () => {
+    expect(hasCoverageGap([F('undeclared'), F('declared')], [dr('AWS::SNS::Topic')])).toBe(false);
   });
 });

--- a/tests/integration/nested/verify-nested.sh
+++ b/tests/integration/nested/verify-nested.sh
@@ -47,4 +47,8 @@ echo "=== parent stack itself should be CLEAN (warning is on stderr, not drift) 
 $CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN exit 0 (the warning must not be counted as drift)"
 
+echo "=== --strict: the nested-stack coverage gap must make exit NON-ZERO ==="
+$CLI check "$STACK" --region "$REGION" --strict
+[ $? -eq 1 ] || fail "expected --strict to exit 1 on the nested-stack coverage gap"
+
 echo "INTEG PASS"


### PR DESCRIPTION
## Make incomplete coverage LOUD + optionally CI-failing (the silent-coverage class from wave 6)

Follow-up to #126. The agent audit found that the whole `skipped` family is the same
silent-gap root: a resource cdkrd couldn't read (CC-unsupported + no SDK override, a
read error like throttle/AccessDenied, a missing physical id, a Custom resource) lands
in the `skipped` tier, which is **excluded from the verdict and from `--fail`** and only
folded into the `info:` footer. So a materially under-covered run can read
`result: CLEAN`, exit 0 — indistinguishable from a fully-checked stack for anyone
relying on the `--fail` exit code or grepping `result:`.

User picked: **loud warning + a `--strict` flag** (and explicitly: do NOT change the
`--fail` default — a transient throttle must not silently start failing CI).

## What this adds

- **Always-on loud coverage warning.** When any resource is `skipped`, `check` prints a
  prominent `warning: <stack>: N resource(s) were NOT checked (coverage incomplete) — …`
  to **stderr** (survives `--json`; same not-silent principle as the nested-stack and
  KMS warnings). Independent of any flag.
- **`--strict` flag (check).** An orthogonal axis to `--fail` (which is about drift):
  `--strict` exits `1` when coverage was incomplete — any `skipped` resource OR any
  nested stack not recursed into. Default behavior is unchanged.

## Verification

- **Unit** (`tests/check.test.ts`): `coverageWarning` (null when nothing skipped;
  counts + lists by construct path, sorted; caps at 10 with `+N more`); `hasCoverageGap`
  (true on a skipped resource, true on a nested stack, false when fully covered).
- **Live integ** (`tests/integration/nested/verify-nested.sh`, extended): on the
  deployed parent+NestedStack, `check` → CLEAN exit 0; `check --fail` → exit 0;
  `check --strict` → **exit 1** (coverage gap). Ran end-to-end: **INTEG PASS**.
- HELP / README "Commands & options" + "Exit codes" / DESIGN updated and consistent.
  Full suite green (956).

Found during a pre-release bug-hunt (wave 7 — closing the silent-coverage class).
