### PR TITLE
fix(check): skip REVIEW_IN_PROGRESS/deleting stacks with a clear note; warn on mid-operation/failed states

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,13 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 - **Lambda Permission:** if only the specific statement was removed out of band
   (while the function's policy still exists), it is reported as `skipped`, not
   `deleted` — identifying the exact statement would need its `StatementId`.
+- **Stack state.** A stack with no meaningful deployed reality is **skipped with a
+  clear note**, not compared to a meaningless CLEAN: `REVIEW_IN_PROGRESS` (a change
+  set created but never deployed) and a delete in progress. A stack mid-operation
+  (any other `*_IN_PROGRESS`) or in a `*_FAILED` state is still checked, but `check`
+  prints a `warning:` that the deployed template may not match live reality so
+  results may be transient. Only stable `*_COMPLETE` states are a fully reliable
+  comparison.
 
 ## FAQ
 

--- a/src/aws-errors.ts
+++ b/src/aws-errors.ts
@@ -7,6 +7,55 @@ export function isStackNotDeployed(e: unknown): boolean {
   return /does not exist/i.test(msg) || (/ValidationError/i.test(msg) && /stack/i.test(msg));
 }
 
+// A stack that EXISTS but is in a state with no meaningful deployed reality to compare
+// against — REVIEW_IN_PROGRESS (a change set was created but never executed; nothing is
+// deployed) or a delete in progress. loadDesired throws this so `check` SKIPS it with a
+// clear note instead of silently comparing live state against a template that was never
+// deployed (which would read as a meaningless CLEAN).
+export class StackNotCheckableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StackNotCheckableError';
+  }
+}
+
+// Classify a CloudFormation StackStatus for checkability:
+//   skip — REVIEW_IN_PROGRESS (change set never deployed) or DELETE_IN_PROGRESS: no
+//          meaningful deployed reality, so comparing is nonsense (loadDesired throws).
+//   warn — any OTHER `*_IN_PROGRESS` (mid-operation: live state in flux) or `*_FAILED`
+//          (the deployed template may not match live reality): the comparison runs but
+//          results may be transient/unreliable, so `check` prints a warning.
+//   ok   — a stable `*_COMPLETE` state (incl. ROLLBACK_COMPLETE / IMPORT_COMPLETE): a
+//          valid comparison. Pure + exported for tests.
+export function classifyStackStatus(status: string | undefined): {
+  kind: 'ok' | 'skip' | 'warn';
+  message: string;
+} {
+  const s = status ?? '';
+  if (s === 'REVIEW_IN_PROGRESS')
+    return {
+      kind: 'skip',
+      message:
+        'in REVIEW_IN_PROGRESS — a change set was created but never deployed, so there is no deployed state to check',
+    };
+  if (s === 'DELETE_IN_PROGRESS')
+    return {
+      kind: 'skip',
+      message: 'is being deleted (DELETE_IN_PROGRESS) — nothing stable to check',
+    };
+  if (s.endsWith('_IN_PROGRESS'))
+    return {
+      kind: 'warn',
+      message: `stack is mid-operation (${s}) — live state is in flux, so drift results may be transient`,
+    };
+  if (s.endsWith('_FAILED'))
+    return {
+      kind: 'warn',
+      message: `stack is in a failed state (${s}) — the deployed template may not match live reality, so drift results may be unreliable`,
+    };
+  return { kind: 'ok', message: '' };
+}
+
 // "the resource itself no longer exists in AWS" — i.e. it was deleted out of band.
 // Covers Cloud Control GetResource + every SDK-override reader's not-found error:
 //   CC API / Lambda     : ResourceNotFoundException

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -6,7 +6,7 @@
 // exits 0 (a hint names --fail); with --fail drift exits 1 and prompts are
 // suppressed. Errors always exit 2. The exit is the worst across all checked
 // stacks.
-import { isStackNotDeployed } from '../aws-errors.js';
+import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
   checkBaselineAccount,
@@ -176,6 +176,11 @@ export async function runCheck(args: string[]): Promise<number> {
       if (nestedWarn) console.error(nestedWarn);
       const covWarn = coverageWarning(gathered.findings, stackName);
       if (covWarn) console.error(covWarn);
+      // a mid-operation / failed stack state still gets compared, but the result may be
+      // transient/unreliable — say so loudly (REVIEW_IN_PROGRESS / deleting states never
+      // reach here; loadDesired throws StackNotCheckableError, handled in the catch).
+      if (desired.stackStatusWarning)
+        console.error(`warning: ${stackName}: ${desired.stackStatusWarning}`);
 
       // Scope flags (R59). --undeclared-only delegates the declared side to
       // `cdk drift` / CFn drift detection (no double reporting when pairing);
@@ -319,6 +324,12 @@ export async function runCheck(args: string[]): Promise<number> {
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — skipped`);
+        continue;
+      }
+      // a stack that exists but has no meaningful deployed state (REVIEW_IN_PROGRESS /
+      // deleting): skip with a clear reason, not a meaningless CLEAN and not an error.
+      if (e instanceof StackNotCheckableError) {
+        console.error(`note: ${stackName}: ${e.message} — skipped`);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -2,7 +2,7 @@
 // Write the current undeclared state into the baseline FILE(s). Writes ONLY
 // git-committed baselines; no AWS writes. The per-stack record flow lives in
 // stack-actions.ts (shared with check's interactive prompt, R28).
-import { isStackNotDeployed } from '../aws-errors.js';
+import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
@@ -59,6 +59,10 @@ export async function runRecord(args: string[]): Promise<number> {
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — nothing to record`);
+        continue;
+      }
+      if (e instanceof StackNotCheckableError) {
+        console.error(`note: ${stackName}: ${e.message} — nothing to record`);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -5,7 +5,7 @@
 //   undeclared -> baseline value (restore) or removal (if never recorded)
 // The per-stack plan / apply / converge flow lives in stack-actions.ts (shared with
 // check's interactive prompt, R28).
-import { isStackNotDeployed } from '../aws-errors.js';
+import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   type BaselineFile,
   checkBaselineAccount,
@@ -77,6 +77,10 @@ export async function runRevert(args: string[]): Promise<number> {
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed — skipped`);
+        continue;
+      }
+      if (e instanceof StackNotCheckableError) {
+        console.error(`note: ${stackName}: ${e.message} — skipped`);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -9,6 +9,7 @@ import {
   ListExportsCommand,
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
+import { classifyStackStatus, StackNotCheckableError } from '../aws-errors.js';
 import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import type { DesiredResource, ResolverContext } from '../types.js';
 import { parseCfnTemplate } from './yaml-cfn.js';
@@ -20,6 +21,10 @@ export interface Desired {
   resources: DesiredResource[];
   rawTemplate: string; // verbatim deployed template body (for baseline templateHash)
   ctx: ResolverContext; // exposed so gather can re-resolve GetAtt once live attrs are read
+  // set when the stack's StackStatus is mid-operation / failed (a comparison still runs
+  // but results may be unreliable — check prints this). REVIEW_IN_PROGRESS / deleting
+  // states never reach here: loadDesired throws StackNotCheckableError for those.
+  stackStatusWarning?: string | undefined;
 }
 
 /** Parse a deployed template body (JSON or CFn-flavored YAML). */
@@ -134,6 +139,19 @@ export async function loadDesired(
     client.send(new DescribeStacksCommand({ StackName: stackName })),
     listStackResources(client, stackName),
   ]);
+  const stack = stkRes.Stacks?.[0];
+  // Stack-state gate — runs BEFORE the template is parsed: a REVIEW_IN_PROGRESS stack
+  // (a change set created but never deployed) returns an EMPTY GetTemplate body, which
+  // would otherwise blow up parseTemplateBody with "Unexpected end of JSON input". Skip
+  // a stack with no meaningful deployed reality (REVIEW_IN_PROGRESS / deleting) rather
+  // than silently compare live state against a never-deployed template; carry a warning
+  // for mid-operation / failed states. Skipped under --pre-deploy (the declared source
+  // is the LOCAL synth, not the deployed stack).
+  const stateClass = templateOverride
+    ? ({ kind: 'ok', message: '' } as const)
+    : classifyStackStatus(stack?.StackStatus);
+  if (stateClass.kind === 'skip') throw new StackNotCheckableError(stateClass.message);
+  const stackStatusWarning = stateClass.kind === 'warn' ? stateClass.message : undefined;
   const template = (templateOverride ?? parseTemplateBody(tmplRes.TemplateBody ?? '{}')) as Record<
     string,
     any
@@ -141,7 +159,6 @@ export async function loadDesired(
   const rawTemplate = templateOverride
     ? JSON.stringify(templateOverride)
     : (tmplRes.TemplateBody ?? '{}');
-  const stack = stkRes.Stacks?.[0];
   const stackId = stack?.StackId ?? '';
   const accountId = stackId.split(':')[4] ?? '';
 
@@ -192,7 +209,7 @@ export async function loadDesired(
         res.Type === 'AWS::IAM::Role' ? rolesWithSiblingPolicy.get(logicalId) : undefined,
     });
   }
-  return { stackName, region, accountId, resources, rawTemplate, ctx };
+  return { stackName, region, accountId, resources, rawTemplate, ctx, stackStatusWarning };
 }
 
 // CDK construct paths end in "/Resource" for the L1 node; drop it for readability

--- a/tests/aws-errors.test.ts
+++ b/tests/aws-errors.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { isResourceNotFoundError, isStackNotDeployed } from '../src/aws-errors.js';
+import {
+  classifyStackStatus,
+  isResourceNotFoundError,
+  isStackNotDeployed,
+} from '../src/aws-errors.js';
 
 const named = (name: string): Error => Object.assign(new Error(name), { name });
 
@@ -36,5 +40,44 @@ describe('isStackNotDeployed', () => {
   it('matches CFn does-not-exist / ValidationError stack errors', () => {
     expect(isStackNotDeployed(new Error('Stack with id X does not exist'))).toBe(true);
     expect(isStackNotDeployed(named('ValidationError'))).toBe(false); // needs "stack" in message
+  });
+});
+
+describe('classifyStackStatus (stack-state checkability)', () => {
+  it('REVIEW_IN_PROGRESS → skip (change set never deployed)', () => {
+    const c = classifyStackStatus('REVIEW_IN_PROGRESS');
+    expect(c.kind).toBe('skip');
+    expect(c.message).toMatch(/never deployed/);
+  });
+
+  it('DELETE_IN_PROGRESS → skip (being deleted)', () => {
+    expect(classifyStackStatus('DELETE_IN_PROGRESS').kind).toBe('skip');
+  });
+
+  it('other *_IN_PROGRESS → warn (mid-operation)', () => {
+    for (const s of ['UPDATE_IN_PROGRESS', 'CREATE_IN_PROGRESS', 'UPDATE_ROLLBACK_IN_PROGRESS']) {
+      const c = classifyStackStatus(s);
+      expect(c.kind).toBe('warn');
+      expect(c.message).toContain(s);
+    }
+  });
+
+  it('*_FAILED → warn (may not match reality)', () => {
+    for (const s of ['CREATE_FAILED', 'UPDATE_FAILED', 'UPDATE_ROLLBACK_FAILED']) {
+      expect(classifyStackStatus(s).kind).toBe('warn');
+    }
+  });
+
+  it('stable *_COMPLETE states (incl. rollback/import complete) → ok', () => {
+    for (const s of [
+      'CREATE_COMPLETE',
+      'UPDATE_COMPLETE',
+      'ROLLBACK_COMPLETE',
+      'UPDATE_ROLLBACK_COMPLETE',
+      'IMPORT_COMPLETE',
+      undefined,
+    ]) {
+      expect(classifyStackStatus(s).kind).toBe('ok');
+    }
   });
 });


### PR DESCRIPTION
## Silent meaningless result: a never-deployed / transitional stack reads as CLEAN

Continuing the silent-gap theme. `loadDesired` read the stack's `StackId` + `Parameters`
but **never looked at `StackStatus`**. So:

- A **`REVIEW_IN_PROGRESS`** stack (a change set was created but never executed — nothing
  is actually deployed) was treated as a normal stack. Worse, its `GetTemplate` returns an
  EMPTY body, so `check` either blew up with `Unexpected end of JSON input` or — once that
  was past — compared live state against a never-deployed template and read a meaningless
  CLEAN.
- A stack mid-operation (`*_IN_PROGRESS`) or in a `*_FAILED` state was compared with no
  hint that the deployed template may not match live reality (transient/unreliable result).

## Fix

A stack-state gate in `loadDesired` (runs BEFORE the template is parsed):
- **skip** with a clear note — `REVIEW_IN_PROGRESS` ("a change set was created but never
  deployed — there is no deployed state to check") and `DELETE_IN_PROGRESS` — via a new
  `StackNotCheckableError`, handled in `check` / `record` / `revert` like the existing
  "not deployed" skip (a note + continue, NOT a meaningless CLEAN and NOT an error 2).
- **warn** — any other `*_IN_PROGRESS` (mid-operation) or `*_FAILED` (may not match
  reality): the comparison still runs, but `check` prints a `warning:`.
- **ok** — stable `*_COMPLETE` states (incl. `ROLLBACK_COMPLETE` / `IMPORT_COMPLETE`).

`classifyStackStatus` is pure + unit-tested. Skipped under `--pre-deploy` (its declared
source is the local synth, not the deployed stack).

## Verification

- **Unit** (`tests/aws-errors.test.ts`): REVIEW/DELETE→skip, other in-progress→warn,
  failed→warn, complete/undefined→ok.
- **Live**: created a real `REVIEW_IN_PROGRESS` stack via `create-change-set
  --change-set-type CREATE` (status confirmed `REVIEW_IN_PROGRESS`), ran `cdkrd check
  --fail` → printed `note: …: in REVIEW_IN_PROGRESS — a change set was created but never
  deployed … — skipped`, exit 0 (not the prior JSON-parse crash, not a meaningless CLEAN);
  cleaned up. Full suite green (961).

Found during a pre-release bug-hunt (wave 8 — stack-state silent gap).
