### PR TITLE
fix(report): pair-aware value truncation so a long desired/actual diff is never hidden as identical blobs

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -95,9 +95,10 @@ export function formatFinding(f: Finding): string {
   const pathDisplay = f.attributeKey ? `${f.path}[${f.attributeKey}]` : f.path;
   let s = `${pathDisplay ? `${id}.${pathDisplay}` : id} (${f.resourceType})`;
   if (f.note) s += ` — ${f.note}`;
-  if (f.tier === 'declared')
-    s += `\n      desired=${style.desired(j(f.desired))}\n      actual =${style.actual(j(f.actual))}`;
-  else if (f.tier === 'undeclared' && f.arrayDelta)
+  if (f.tier === 'declared') {
+    const { a: d, b: act } = jPair(f.desired, f.actual);
+    s += `\n      desired=${style.desired(d)}\n      actual =${style.actual(act)}`;
+  } else if (f.tier === 'undeclared' && f.arrayDelta)
     // R128: a recorded identity-keyed array changed — show the element delta, not the
     // whole array dump (the property stays recorded; this is the WHICH-element view).
     s += formatArrayDelta(f.arrayDelta);
@@ -119,7 +120,11 @@ function formatArrayDelta(d: ArrayDelta): string {
   const actual = (v: unknown): string => `\n          actual  =${style.actual(j(v))}`;
   let s = ` — ${d.identityField}-keyed element(s) changed vs .cdkrd baseline:`;
   for (const a of d.added) s += `\n      + [${a.id}]${actual(a.value)}`;
-  for (const c of d.changed) s += `\n      ~ [${c.id}]${baseline(c.recorded)}${actual(c.actual)}`;
+  for (const c of d.changed) {
+    // pair-aware truncation so a long recorded-vs-live element shows WHERE it diverges
+    const { a: base, b: act } = jPair(c.recorded, c.actual);
+    s += `\n      ~ [${c.id}]\n          baseline=${style.desired(base)}\n          actual  =${style.actual(act)}`;
+  }
   for (const r of d.removed) s += `\n      - [${r.id}]${baseline(r.value)}`;
   return s;
 }
@@ -336,7 +341,32 @@ export function stackSeparator(log: (s: string) => void = console.log): () => vo
     else log('');
   };
 }
+const VALUE_CAP = 200;
 function j(v: unknown): string {
   const s = JSON.stringify(v);
-  return s && s.length > 200 ? s.slice(0, 200) + '…' : s;
+  return s && s.length > VALUE_CAP ? s.slice(0, VALUE_CAP) + '…' : (s ?? String(v));
+}
+
+// Truncate a desired/actual (or baseline/actual) PAIR so the FIRST point at which the
+// two diverge is visible even when both exceed the cap — one shared window centered on
+// the divergence, applied to both. Independently slicing each at a fixed 200-char prefix
+// (the old behavior) made two long values that differ only PAST the cap render as
+// identical blobs, hiding the very change the report exists to show (common for long
+// inline-policy / bucket-policy documents). Pure + exported for tests.
+export function jPair(a: unknown, b: unknown): { a: string; b: string } {
+  const as = JSON.stringify(a) ?? String(a);
+  const bs = JSON.stringify(b) ?? String(b);
+  if (as.length <= VALUE_CAP && bs.length <= VALUE_CAP) return { a: as, b: bs };
+  let i = 0;
+  const min = Math.min(as.length, bs.length);
+  while (i < min && as[i] === bs[i]) i++; // first index at which they differ
+  const CONTEXT = 40; // chars of shared lead-in kept before the divergence, for orientation
+  const start = Math.max(0, i - CONTEXT);
+  const window = (s: string): string => {
+    let out = s.slice(start, start + VALUE_CAP);
+    if (start > 0) out = `…${out}`;
+    if (start + VALUE_CAP < s.length) out = `${out}…`;
+    return out;
+  };
+  return { a: window(as), b: window(bs) };
 }

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { report, stackSeparator } from '../src/report/report.js';
+import { jPair, report, stackSeparator } from '../src/report/report.js';
 import type { Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
@@ -491,5 +491,33 @@ describe('R96 nested unrecorded folding', () => {
   it('--verbose also expands nested', () => {
     const { text } = run([NU('Conf.A', true)], { verbose: true });
     expect(text).toContain('L.Conf.A');
+  });
+});
+
+describe('jPair (pair-aware truncation keeps the divergence visible)', () => {
+  it('short values pass through whole, both sides', () => {
+    expect(jPair('abc', 'abd')).toEqual({ a: '"abc"', b: '"abd"' });
+  });
+
+  it('two long values that differ only PAST the 200-char cap do NOT render identical', () => {
+    const prefix = 'x'.repeat(230);
+    const { a, b } = jPair(`${prefix}AAA`, `${prefix}BBB`);
+    expect(a).not.toBe(b); // the old fixed-prefix slice made these identical
+    expect(a).toContain('AAA'); // the diverging tail is visible
+    expect(b).toContain('BBB');
+    expect(a.startsWith('…')).toBe(true); // windowed, with a leading ellipsis
+  });
+
+  it('the window is the SAME for both sides (aligned), centered on the first difference', () => {
+    const prefix = 'y'.repeat(300);
+    const { a, b } = jPair(`${prefix}_LEFT_only`, `${prefix}_RIGHT_x`);
+    // both windows start at the same offset, so the shared lead-in lines up
+    const lead = (s: string) => s.replace(/…/g, '').slice(0, 20);
+    expect(lead(a)).toBe(lead(b));
+  });
+
+  it('a long value vs a short one still shows where they diverge', () => {
+    const { a, b } = jPair('z'.repeat(250), 'z'.repeat(10));
+    expect(a).not.toBe(b);
   });
 });


### PR DESCRIPTION
## Report bug: two long values that differ past 200 chars rendered as IDENTICAL blobs

`j()` truncated every value at a fixed 200-char prefix (`s.slice(0,200)+'…'`), applied
**independently** to `desired` and `actual`. So a declared drift whose two values share
a >200-char common prefix and differ only after it printed two identical truncated
blobs — `desired=<200 chars>…` / `actual =<same 200 chars>…` — hiding the very change the
report exists to show. Common for long inline-policy / bucket-policy documents (the
differentiator domain). Same problem for a long recorded-vs-live `arrayDelta` element.

## Fix

`jPair(a, b)` truncates a value PAIR with a single shared window centered on the FIRST
index at which the two diverge (keeping ~40 chars of shared lead-in for orientation), so
the diverging region is always visible and the two sides stay aligned. Wired into the
declared `desired`/`actual` and the `arrayDelta` changed-element `baseline`/`actual`.
Short values still pass through whole.

## Tests
`tests/report.test.ts` — two long values differing only past the cap no longer render
identical (the diverging tails are shown); the window is the same offset on both sides;
a long-vs-short pair still shows the divergence. Full suite green (967); the existing
R128/R130 arrayDelta layout tests still pass (short values unchanged).

Found during a pre-release bug-hunt (wave 9 — report/ deferred items).
