### PR TITLE
fix(read): Budgets override must compare CostFilters (scope) — a thin projection hid out-of-band scope drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,13 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   prints a `warning:` that the deployed template may not match live reality so
   results may be transient. Only stable `*_COMPLETE` states are a fully reliable
   comparison.
+- **SDK-override coverage.** The handful of CC-gap types read via an SDK override
+  (see "CC-gap types" above) compare the properties that override returns. A few
+  readers project a subset of the resource: a declared property the reader doesn't
+  return shows as `readGap` (not silently CLEAN — it's surfaced), and an undeclared
+  one on an unprojected property isn't compared. Coverage is widened as needed
+  (e.g. a budget's `CostFilters` scope is compared); fully CC-readable types (the
+  vast majority) always get the complete live model.
 
 ## FAQ
 

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -213,16 +213,25 @@ const readBudget: OverrideReader = async ({ physicalId, declared, accountId, reg
   // BudgetLimit is in the projection (R67): once R65 made budgets readable, a
   // declared BudgetLimit compared against a projection WITHOUT it reported
   // `desired={...} actual=undefined` false drift. The live Amount is a string
-  // ("5.0") vs the declared number (5) — isStringlyEqualScalar's numeric arm
-  // folds that. The projection otherwise stays deliberately thin: nested
-  // live-only keys are ignored by the declared compare, but computed fields
-  // (CalculatedSpend) must never be offered for comparison at all.
+  // ("5.0") vs the declared number (5) — isStringlyEqualScalar's numeric arm folds that.
+  //
+  // CostFilters is the budget's SCOPE — which services/accounts/tags it watches.
+  // Omitting it made an out-of-band scope change (e.g. narrowing a budget from all
+  // services to one) undetectable: a declared CostFilters became a `readGap` (not
+  // compared) and an undeclared one was wholly invisible. FP-safe to add: DescribeBudget
+  // returns `{}` (or omits it) for an unfiltered budget, which `isTrivialEmpty`
+  // suppresses, so a budget that declares no filters stays CLEAN; a declared filter set
+  // is compared, and one added out of band surfaces. The projection still stays thin
+  // where it must: COMPUTED fields (CalculatedSpend) and AWS-defaulted blobs (TimePeriod's
+  // 2087 end date, the full CostTypes default set) are deliberately NOT offered — they
+  // would be live-only noise.
   return {
     Budget: {
       BudgetName: b.BudgetName,
       BudgetType: b.BudgetType,
       TimeUnit: b.TimeUnit,
       ...(b.BudgetLimit !== undefined && { BudgetLimit: b.BudgetLimit }),
+      ...(b.CostFilters !== undefined && { CostFilters: b.CostFilters }),
     },
   };
 };

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -273,6 +273,21 @@ silent CLEAN. Deploys + destroys a real (tiny) Lambda.
 cd freeform-strip && npm install && bash verify-freeform-strip.sh
 ```
 
+## budget-scope / verify-budget-scope.sh
+
+The false-NEGATIVE guard for narrow SDK-override projections. An
+`AWS::Budgets::Budget` declaring `CostFilters` (its SCOPE — which service it
+watches). The Budgets override reader used to project a thin model WITHOUT
+`CostFilters`, so an out-of-band scope change was undetectable (the declared
+`CostFilters` became a benign `readGap`). The script flips the filter from S3 to
+EC2 out of band and asserts `check` DETECTS the change (`Budget.CostFilters.Service`,
+exit 1) — previously a silent CLEAN. Budgets is global (us-east-1). Deploys +
+destroys a (free) budget.
+
+```bash
+cd budget-scope && npm install && bash verify-budget-scope.sh
+```
+
 ## noise
 
 The false-positive guard. Deploys resources that DECLARE properties whose live

--- a/tests/integration/budget-scope/app.ts
+++ b/tests/integration/budget-scope/app.ts
@@ -1,0 +1,20 @@
+// Minimal CDK app for the AWS::Budgets::Budget CostFilters (scope) false-negative test.
+// The budget declares CostFilters (which service it watches). The SDK-override reader
+// used to project a THIN model (BudgetName/Type/TimeUnit/BudgetLimit) WITHOUT CostFilters,
+// so an out-of-band change to the budget's SCOPE was undetectable (declared CostFilters
+// became a benign readGap). verify-budget-scope.sh changes CostFilters out of band and
+// asserts cdkrd now DETECTS it.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnBudget } from "aws-cdk-lib/aws-budgets";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegBudget");
+new CfnBudget(stack, "Budget", {
+  budget: {
+    budgetType: "COST",
+    timeUnit: "MONTHLY",
+    budgetLimit: { amount: 100, unit: "USD" },
+    costFilters: { Service: ["Amazon Simple Storage Service"] },
+  },
+});
+app.synth();

--- a/tests/integration/budget-scope/cdk.json
+++ b/tests/integration/budget-scope/cdk.json
@@ -1,0 +1,1 @@
+{ "app": "node --experimental-strip-types app.ts" }

--- a/tests/integration/budget-scope/package.json
+++ b/tests/integration/budget-scope/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-budget-scope",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift Budget CostFilters projection-FN test. Run via verify-budget-scope.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/budget-scope/verify-budget-scope.sh
+++ b/tests/integration/budget-scope/verify-budget-scope.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# cdk-real-drift AWS::Budgets::Budget CostFilters (scope) FALSE-NEGATIVE integration test.
+#
+# The SDK-override reader for Budgets projected a THIN model without CostFilters — the
+# budget's SCOPE (which services/accounts it watches). So an out-of-band change to the
+# scope was undetectable: a declared CostFilters became a benign `readGap`, never drift.
+# The fix adds CostFilters to the projection (FP-safe: an unfiltered budget returns `{}`,
+# suppressed by isTrivialEmpty). This deploys a budget filtered to S3, flips the filter to
+# EC2 out of band, and asserts `check` DETECTS it (before the fix: silent CLEAN/readGap).
+#
+# Budgets is a global service (us-east-1 endpoint). A cleanup trap destroys the stack.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegBudget
+REGION=us-east-1
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out /tmp/cdkrd-budget*.json
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy budget (CostFilters = S3) ==="
+AWS_REGION="$REGION" npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ACCT="$(aws sts get-caller-identity --query Account --output text)"
+NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Budgets::Budget'].PhysicalResourceId" --output text)"
+[ -n "$NAME" ] || fail "could not resolve budget name"
+echo "budget=$NAME account=$ACCT"
+
+echo "=== record + check should be CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN right after record"
+
+echo "=== flip CostFilters to EC2 out of band ==="
+aws budgets describe-budget --account-id "$ACCT" --budget-name "$NAME" --query Budget > /tmp/cdkrd-budget.json
+jq '.CostFilters = {"Service":["Amazon Elastic Compute Cloud - Compute"]} | del(.CalculatedSpend)' \
+  /tmp/cdkrd-budget.json > /tmp/cdkrd-budget2.json
+aws budgets update-budget --account-id "$ACCT" --new-budget file:///tmp/cdkrd-budget2.json \
+  || fail "update-budget"
+
+echo "=== check MUST now DETECT the scope change (was a silent readGap) ==="
+OUT=/tmp/cdkrd-budget-check.out
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1 (the CostFilters scope change must be detected), got $rc"
+grep -qi "CostFilters" "$OUT" || fail "CostFilters change not reported — still projected away?"
+
+echo "INTEG PASS"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -230,13 +230,14 @@ describe('SDK overrides', () => {
     ).toBeUndefined();
   });
 
-  it('Budgets: reads the budget by name + account, projecting BudgetLimit (R67)', async () => {
+  it('Budgets: projects BudgetLimit + CostFilters (scope), never the computed CalculatedSpend', async () => {
     budgets.on(DescribeBudgetCommand).resolves({
       Budget: {
         BudgetName: 'b',
         BudgetType: 'COST',
         TimeUnit: 'MONTHLY',
         BudgetLimit: { Amount: '40.0', Unit: 'USD' },
+        CostFilters: { Service: ['Amazon Simple Storage Service'] }, // the budget's SCOPE — must be compared
         CalculatedSpend: { ActualSpend: { Amount: '12.3', Unit: 'USD' } }, // computed — never projected
       },
     });
@@ -247,6 +248,7 @@ describe('SDK overrides', () => {
         BudgetType: 'COST',
         TimeUnit: 'MONTHLY',
         BudgetLimit: { Amount: '40.0', Unit: 'USD' },
+        CostFilters: { Service: ['Amazon Simple Storage Service'] },
       },
     });
   });


### PR DESCRIPTION
## Live-proven FN: a narrow SDK-override projection hides out-of-band drift (Budgets CostFilters)

Continuing the false-negative hunt. The SDK-override readers for CC-gap types hand-build
a live model; **any property a reader doesn't return is invisible to undeclared-drift
detection, and a declared one becomes a benign `readGap`** (surfaced, but not compared).
The Budgets reader projected only `{BudgetName, BudgetType, TimeUnit, BudgetLimit}` — it
dropped **`CostFilters`**, the budget's SCOPE (which services/accounts it watches). So an
out-of-band change to that scope was undetectable.

## Fix

Add `CostFilters` to the Budgets projection. FP-safe: `DescribeBudget` returns `{}` (or
omits it) for an unfiltered budget, which `isTrivialEmpty` suppresses, so a budget that
declares no filters stays CLEAN; a declared filter set is compared, and one added out of
band surfaces. Computed (`CalculatedSpend`) and AWS-defaulted blobs (`TimePeriod`'s 2087
end date, the full `CostTypes` default set) are still deliberately excluded — they would
be live-only noise.

## Verification — FN fixed, no new FP (both checked)

- **Live integ** (`tests/integration/budget-scope/`, new): deploy a budget filtered to
  S3 → record → `check --fail` exit 0 (**CLEAN — no false positive**, even though the
  reader now returns CostFilters) → flip the filter to EC2 via `update-budget` →
  `check` **DETECTS** it (`Budget.CostFilters.Service desired=["…S3"] actual=["…EC2"]`,
  exit 1), previously a silent readGap. Ran end-to-end: **INTEG PASS** (self-destroyed).
- **Unit** (`tests/overrides.test.ts`): the reader now projects CostFilters and still
  never projects the computed `CalculatedSpend`. Full suite green (967).
- README "Limitations" documents the broader SDK-override-projection class honestly;
  integration README + ARCHITECTURE updated.

Found during a pre-release bug-hunt (wave 10 — live-integ false-negative hunt).
