### PR TITLE
fix(read): Glue Table override projects TargetTable (resource-link repoint was undetectable)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -356,6 +356,11 @@ const readGlueTable: OverrideReader = async ({ physicalId, declared, region }) =
   copy('StorageDescriptor', 'StorageDescriptor');
   copy('ViewOriginalText', 'ViewOriginalText');
   copy('ViewExpandedText', 'ViewExpandedText');
+  // TargetTable — a Glue resource-link table points at another catalog/db/table; it
+  // was the one CFn-modeled TableInput field the projection omitted, so an out-of-band
+  // repoint was undetectable. Absent for a normal (non-link) table, so adding it is
+  // inert there (no FP) and only the resource-link case gains coverage.
+  copy('TargetTable', 'TargetTable');
   const model: Record<string, unknown> = { DatabaseName: dbName, TableInput: ti };
   if (catalogId) model.CatalogId = catalogId;
   return model;

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -363,6 +363,23 @@ describe('SDK overrides', () => {
       });
     });
 
+    it('projects TargetTable (resource link) when present, drops it when absent', async () => {
+      glue.on(GetTableCommand).resolves({
+        Table: {
+          Name: 't',
+          TargetTable: { CatalogId: '111', DatabaseName: 'shared-db', Name: 'shared-t' },
+        },
+      });
+      const out = (await SDK_OVERRIDES['AWS::Glue::Table'](
+        ctx({ DatabaseName: 'db', TableInput: { Name: 't' } }, 'db|t')
+      )) as { TableInput: Record<string, unknown> };
+      expect(out.TableInput.TargetTable).toEqual({
+        CatalogId: '111',
+        DatabaseName: 'shared-db',
+        Name: 'shared-t',
+      });
+    });
+
     it('undefined when database/table cannot be resolved', async () => {
       expect(await SDK_OVERRIDES['AWS::Glue::Table'](ctx({}))).toBeUndefined();
     });


### PR DESCRIPTION
## Finishing the override-projection FN class: Glue Table `TargetTable`

The last narrow projection from the wave-10 audit. `readGlueTable` copied every CFn
`TableInput` field EXCEPT `TargetTable` — the pointer a Glue **resource-link** table
uses to reference another catalog/database/table. So an out-of-band repoint of a
resource link was undetectable (declared → readGap, undeclared → invisible).

## Fix

Project `TargetTable`. It is absent for a normal (non-link) table, so the addition is
**inert there (no FP, corpus unchanged)** — only the resource-link case gains coverage.

## Tests
`tests/overrides.test.ts` — `TargetTable` is projected when present. Full suite green
(969). No live integ: the field is provably absent for normal tables (so no FP is
possible), and a Glue resource-link setup is too niche to warrant a deploy — the FN is
structural and the fix trivially FP-safe.

With this, the SDK-override projection FN class found in wave 10 is closed: Budgets
`CostFilters` (#131), CodeBuild Visibility/VpcConfig/ConcurrentBuildLimit/SourceVersion
(#132), and Glue Table `TargetTable` (here).

Found during a pre-release bug-hunt (wave 11).
