### PR TITLE
feat(report): fold coverage warning into info: footer so the drift result is line 1 (R127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,11 @@ tells cdkrd which stacks to look at.
 `cdk drift --fail` convention) to exit `1` on drift and suppress all prompts —
 the one flag for scripts and CI. **`--strict`** is the orthogonal coverage axis:
 it exits `1` when a run was incomplete — any resource skipped (unread) or a
-nested stack not recursed into. A loud coverage `warning:` always prints to
-stderr regardless; `--strict` only decides whether that gap fails the build.
+nested stack not recursed into. The gap is always surfaced regardless: skipped
+resources as the `skipped=N — NOT checked (coverage incomplete)` line in the
+report's `info:` footer (a stderr `warning:` under `--json`, which has no footer),
+a nested stack as a loud stderr `warning:`. `--strict` only decides whether that
+gap fails the build.
 Errors always exit `2`; `revert` exits `1` when drift remains after it.
 
 ```yaml
@@ -237,7 +240,7 @@ Errors always exit `2`; `revert` exits `1` when drift remains after it.
 | `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                                                                                                       |
 | `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                                                                                                             |
 | `--fail`                   | (check) exit 1 on drift + never prompt — for scripts/CI; without it, check reports drift but exits 0                                                                                                             |
-| `--strict`                 | (check) exit 1 when COVERAGE is incomplete — any resource skipped (unread) or a nested stack not recursed into. A loud coverage `warning:` always prints; `--strict` makes it CI-failing. Orthogonal to `--fail` |
+| `--strict`                 | (check) exit 1 when COVERAGE is incomplete — any resource skipped (unread) or a nested stack not recursed into. A coverage gap is always surfaced loudly; `--strict` makes it CI-failing. Orthogonal to `--fail` |
 | `--show-all`               | inventory mode: show ALL current undeclared state, ignoring the baseline                                                                                                                                         |
 | `--verbose` / `-v`         | (check) expand informational tiers from the `info:` footer / (revert) the per-reason NOT-revertable summary — to full lists                                                                                      |
 | `--pre-deploy`             | (check) compare live vs the LOCAL synth template — the declared drift your next `cdk deploy` would silently overwrite                                                                                            |

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -174,8 +174,16 @@ export async function runCheck(args: string[]): Promise<number> {
       // any such gap into a non-zero exit (folded into `worst` after the report).
       const nestedWarn = nestedStackWarning(desired.resources, stackName);
       if (nestedWarn) console.error(nestedWarn);
-      const covWarn = coverageWarning(gathered.findings, stackName);
-      if (covWarn) console.error(covWarn);
+      // Coverage gap (skipped / unread resources): R127 folds this into the report's
+      // info: footer for TEXT mode — the `skipped=` line there now carries the "NOT
+      // checked (coverage incomplete)" framing, so emitting a separate stderr warning
+      // BEFORE the report would (a) bury the drift result below the fold (the very UX
+      // complaint that prompted R127) and (b) duplicate the footer. --json has no info:
+      // footer, so keep the loud stderr warning there to preserve the invariant.
+      if (a.json) {
+        const covWarn = coverageWarning(gathered.findings, stackName);
+        if (covWarn) console.error(covWarn);
+      }
       // a mid-operation / failed stack state still gets compared, but the result may be
       // transient/unreliable — say so loudly (REVIEW_IN_PROGRESS / deleting states never
       // reach here; loadDesired throws StackNotCheckableError, handled in the catch).

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -52,7 +52,8 @@ const TIER_NOTES: Partial<Record<Tier, string>> = {
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
   readGap: "declared, but AWS doesn't return it on read so cdkrd can't verify it — not drift",
   unresolved: 'declared paths needing GetAtt — skipped, not drift',
-  skipped: 'CC API unsupported / no physical id',
+  skipped:
+    'NOT checked (coverage incomplete) — CC API unsupported / no physical id / custom resource',
 };
 const DRIFT_TIERS: Tier[] = ['deleted', 'declared', 'undeclared'];
 // atDefault leads the informational footer: it is the bulk of a first run (undeclared
@@ -308,6 +309,13 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
       ];
       return `readGap=${items.length} (declared but unverifiable — AWS doesn't return them on read, not drift: ${parts.join(', ')})`;
     }
+    // skipped = resources cdkrd genuinely could NOT read this run (CC-unsupported with
+    // no SDK override, read error, missing physical id, custom resource). It is the one
+    // info: tier that is a COVERAGE GAP, not a not-drift classification — so it carries
+    // the "NOT checked / coverage incomplete" framing here (R28-era loud coverage warning,
+    // folded into the footer in R127 so the drift result stays the first thing on screen).
+    if (t === 'skipped')
+      return `skipped=${items.length} — NOT checked (coverage incomplete: ${groupReasons(items)})`;
     return `${t}=${items.length} (${groupReasons(items)})`;
   };
   const summaries = INFO_TIERS.filter((t) => !isExpanded(t))

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -229,8 +229,10 @@ describe('report', () => {
         reason('skipped', 'custom resource — no cloud-side model to read', 'Custom::Foo'),
       ]);
       expect(text).not.toContain('[Skipped');
+      // R127: the skipped footer line carries the loud "NOT checked (coverage
+      // incomplete)" framing (folded from the old pre-report stderr warning).
       expect(text).toContain(
-        'info: skipped=1 (custom resource 1) — run with --verbose for the list'
+        'info: skipped=1 — NOT checked (coverage incomplete: custom resource 1) — run with --verbose for the list'
       );
     });
 
@@ -254,7 +256,7 @@ describe('report', () => {
         "  - readGap=1 (declared but unverifiable — AWS doesn't return them on read, not drift: 1 write-only)"
       );
       expect(lines[infoIdx + 2]).toMatch(
-        /^ {2}- skipped=2 \(.*custom resource 1.*override target unresolved 1.*\)$/
+        /^ {2}- skipped=2 — NOT checked \(coverage incomplete: .*custom resource 1.*override target unresolved 1.*\)$/
       );
       expect(lines[infoIdx + 3]).toBe('  run with --verbose for the list');
       expect(text.match(/--verbose/g)).toHaveLength(1);
@@ -410,7 +412,7 @@ describe('report', () => {
       expect(text.split('\n')).toEqual([
         '=== cdkrd check: stack (us-east-1) ===',
         'result: CLEAN',
-        'info: skipped=1 (custom resource 1) — run with --verbose for the list',
+        'info: skipped=1 — NOT checked (coverage incomplete: custom resource 1) — run with --verbose for the list',
       ]);
     });
 


### PR DESCRIPTION
## Problem (dogfood feedback)

Running `check` on a real stack, the very first line was:

```
warning: dev-...-AiApi: 11 resource(s) were NOT checked (coverage incomplete) — A, B, C, …(+1 more); see the skipped breakdown (--verbose)
=== cdkrd check: dev-...-AiApi (ap-northeast-1) ===
[CFn-Declared Drift: 1] ...
```

Two problems:
1. **The key result is below the fold.** The loud coverage `warning:` is printed to stderr *before* `report()`, so it lands on line 1 and pushes the `=== cdkrd check ===` header and the actual drift findings down.
2. **It duplicates the `info:` footer**, which already states `skipped=11 (custom resource 11)`.

## Fix

Fold the coverage gap into the report's `info:` footer (where `skipped=N` already lives), so the drift result stays the first thing on screen:

- The footer's `skipped=` line now carries the loud framing: `skipped=11 — NOT checked (coverage incomplete: custom resource 11)`.
- The `--verbose`-expanded `Skipped` section's note matches the same framing.
- `--json` has no `info:` footer, so it **keeps** the loud stderr `warning:` — the never-silently-under-cover invariant is preserved for machine output.
- The nested-stack warning is unchanged (its resource names appear nowhere else in the report, so listing them is the only surface).

Before:
```
warning: ...: 11 resource(s) were NOT checked ...   <- line 1
=== cdkrd check: ... ===
[CFn-Declared Drift: 1] ...
```
After:
```
=== cdkrd check: ... ===                            <- line 1
[CFn-Declared Drift: 1] ...
result: ...
info:
  - skipped=11 — NOT checked (coverage incomplete: custom resource 11)
  ...
```

## Tests

- Updated `report.test.ts` skipped-footer assertions (single-tier, multi-tier, exact 3-line CLEAN).
- `result: appears ABOVE the info: footer` already guarantees the result-first ordering.
- Full suite: 969 passed.

Gates: typecheck / lint+format / build / unit tests all green (check + docs markers set).
