### PR TITLE
fix(normalize): suppress CloudWatch Logs log-group ARN trailing :* wildcard (false declared drift on fresh deploy)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -7,7 +7,11 @@
 //
 // Pure: no AWS calls. liveRaw is the CC API GetResource model (un-stripped).
 
-import { isArnNameMatch, isManagedKmsAliasMatch } from '../normalize/arn-identity.js';
+import {
+  isArnNameMatch,
+  isLogGroupArnWildcardMatch,
+  isManagedKmsAliasMatch,
+} from '../normalize/arn-identity.js';
 import { stripCcApiAwsManagedFields } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
@@ -237,6 +241,9 @@ export function classifyResource(
       // KMS alias vs its resolved key ARN
       if (isArnNameMatch(d.stateValue, d.awsValue, opts)) continue;
       if (isManagedKmsAliasMatch(d.stateValue, d.awsValue, opts.kmsAliasTargets)) continue;
+      // a CloudWatch Logs log-group ARN whose only difference is the trailing `:*`
+      // wildcard (CDK emits it; API Gateway AccessLogSetting strips it) is not drift
+      if (isLogGroupArnWildcardMatch(d.stateValue, d.awsValue)) continue;
       // CFn stringly-typed scalar (Glue Parameters Map<String,String>, "5432" ports):
       // declared `true`/`5432` vs AWS `"true"`/`"5432"` is not drift.
       if (isStringlyEqualScalar(d.stateValue, d.awsValue)) continue;

--- a/src/normalize/arn-identity.ts
+++ b/src/normalize/arn-identity.ts
@@ -87,3 +87,30 @@ export function isManagedKmsAliasMatch(
   // unresolved alias → conservative shape-based suppression (today's behavior)
   return true;
 }
+
+// A CloudWatch Logs log-group ARN carries a trailing `:*` wildcard segment
+// (`...:log-group:/my/group:*`) that scopes it to the group's log STREAMS. CDK's
+// `logGroup.logGroupArn` emits the ARN WITH that `:*`, so a template references it
+// that way — but several services store + return the SAME ARN with the `:*`
+// stripped (observed: API Gateway `AWS::ApiGateway::Stage`
+// AccessLogSetting.DestinationArn). A positional string diff then reports false
+// drift on a fresh deploy with nothing changed:
+//   desired = "arn:aws:logs:...:log-group:/aws/api-gateway/x:*"
+//   actual  = "arn:aws:logs:...:log-group:/aws/api-gateway/x"
+//
+// Shape-based + value-only (NOT field-name-based, so no per-type table): suppress
+// ONLY when BOTH sides are well-formed log-group ARNs that are byte-identical after
+// dropping a single trailing `:*` from each. A different log group still differs
+// after the strip, so this never hides a real repoint.
+const LOG_GROUP_ARN_RE = /^arn:aws[a-z-]*:logs:[^:]*:\d*:log-group:/;
+const stripLogGroupWildcard = (s: string): string => (s.endsWith(':*') ? s.slice(0, -2) : s);
+export function isLogGroupArnWildcardMatch(desired: unknown, actual: unknown): boolean {
+  if (
+    typeof desired !== 'string' ||
+    typeof actual !== 'string' ||
+    !LOG_GROUP_ARN_RE.test(desired) ||
+    !LOG_GROUP_ARN_RE.test(actual)
+  )
+    return false;
+  return stripLogGroupWildcard(desired) === stripLogGroupWildcard(actual);
+}

--- a/tests/arn-identity.test.ts
+++ b/tests/arn-identity.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { isArnNameMatch, isManagedKmsAliasMatch } from '../src/normalize/arn-identity.js';
+import {
+  isArnNameMatch,
+  isLogGroupArnWildcardMatch,
+  isManagedKmsAliasMatch,
+} from '../src/normalize/arn-identity.js';
 
 describe('isArnNameMatch (name <-> ARN identity)', () => {
   const fnArn = 'arn:aws:lambda:us-east-1:111122223333:function:MyFn';
@@ -93,5 +97,34 @@ describe('isManagedKmsAliasMatch (managed-default KMS alias <-> key ARN)', () =>
     it('falls back to shape-based suppression when the alias is unresolved (no perms)', () => {
       expect(isManagedKmsAliasMatch('alias/aws/rds', keyArn, {})).toBe(true);
     });
+  });
+});
+
+describe('isLogGroupArnWildcardMatch (CloudWatch Logs log-group ARN :* wildcard)', () => {
+  const base = 'arn:aws:logs:ap-northeast-1:111122223333:log-group:/aws/api-gateway/scoring/x';
+  it('suppresses desired-with-:* vs actual-without (API Gateway AccessLogSetting case)', () => {
+    expect(isLogGroupArnWildcardMatch(`${base}:*`, base)).toBe(true);
+  });
+  it('suppresses in the reverse direction (actual carries the :*)', () => {
+    expect(isLogGroupArnWildcardMatch(base, `${base}:*`)).toBe(true);
+  });
+  it('suppresses when both carry the :* (defensive — diff already equal)', () => {
+    expect(isLogGroupArnWildcardMatch(`${base}:*`, `${base}:*`)).toBe(true);
+  });
+  it('reports drift on a DIFFERENT log group (real repoint preserved)', () => {
+    const other = 'arn:aws:logs:ap-northeast-1:111122223333:log-group:/aws/api-gateway/other';
+    expect(isLogGroupArnWildcardMatch(`${base}:*`, other)).toBe(false);
+  });
+  it('does NOT match non-log-group ARNs', () => {
+    expect(
+      isLogGroupArnWildcardMatch(
+        'arn:aws:lambda:us-east-1:1:function:Fn:*',
+        'arn:aws:lambda:us-east-1:1:function:Fn'
+      )
+    ).toBe(false);
+  });
+  it('ignores non-strings', () => {
+    expect(isLogGroupArnWildcardMatch(5, `${base}:*`)).toBe(false);
+    expect(isLogGroupArnWildcardMatch(`${base}:*`, null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

On a fresh `cdk deploy` with **nothing changed**, the first `cdkrd check` reported a false declared drift on an API Gateway access-log destination:

```
[CFn-Declared Drift: 1]
  .../DeploymentStage.goto.AccessLogSetting.DestinationArn (AWS::ApiGateway::Stage)
      desired="arn:aws:logs:...:log-group:/aws/api-gateway/scoring/dev-goto-aim-scoring-api:*"
      actual ="arn:aws:logs:...:log-group:/aws/api-gateway/scoring/dev-goto-aim-scoring-api"
```

The only difference is the trailing `:*`. CDK's `logGroup.logGroupArn` emits a CloudWatch Logs log-group ARN **with** the `:*` stream wildcard, but API Gateway (`AWS::ApiGateway::Stage` `AccessLogSetting.DestinationArn`) stores + returns the **same** ARN with `:*` stripped. A positional string diff flags it as drift.

## Fix

Add `isLogGroupArnWildcardMatch` in `src/normalize/arn-identity.ts` — shape-based and value-only (no per-type table, consistent with `isArnNameMatch` / `isManagedKmsAliasMatch`):

- Suppress **only** when BOTH sides are well-formed log-group ARNs (`/^arn:aws[a-z-]*:logs:[^:]*:\d*:log-group:/`) that are byte-identical after dropping a single trailing `:*` from each.
- A different log group still differs after the strip → a real repoint is never hidden. Bidirectional (the `:*` may be on either side).

Wired into `classify.ts` alongside the other declared-side suppressions.

## Tests

- New `isLogGroupArnWildcardMatch` suite in `tests/arn-identity.test.ts` (both directions, different-group still drifts, non-log-group ARNs not matched, non-strings ignored).
- Full suite green: **977 passed**, including the 286-entry corpus FP check.
