### PR TITLE
fix(baseline): a deleted resource no longer double-reports per-property baseline removals

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -442,15 +442,27 @@ export function applyBaseline(
   // physical id — gather emits a `skipped` finding) was NOT observed, so its baseline
   // values are unknown, NOT removed. Excluding it prevents a transient skip from
   // flooding the report with false "baseline value removed since record" drift (its
-  // values still exist; we just couldn't read them this run). `deleted` is left as a
-  // genuine removal — those values really are gone.
+  // values still exist; we just couldn't read them this run).
+  //
+  // A resource DELETED out of band already surfaces as a single resource-level
+  // `deleted` finding (gather.ts), which SUBSUMES every recorded baseline value it
+  // had — the whole resource is gone, so of course each of its values is too. Emitting
+  // an extra per-property "baseline value removed" undeclared finding for each is
+  // redundant noise that also inflates the drift COUNT (one deletion would read as
+  // 1 + N drifts) and, for `revert`, yields un-actionable ops against a resource that
+  // no longer exists. Suppress them too; the `deleted` finding carries the drift. (Gated
+  // on an actual `deleted` finding, so a removal NOT already reported still surfaces.)
   const skippedLogical = new Set(
     findings.filter((f) => f.tier === 'skipped').map((f) => f.logicalId)
+  );
+  const deletedLogical = new Set(
+    findings.filter((f) => f.tier === 'deleted').map((f) => f.logicalId)
   );
   const promotedStale: string[] = [];
   for (const a of recorded) {
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;
     if (skippedLogical.has(a.logicalId)) continue; // unread this run -> not "removed"
+    if (deletedLogical.has(a.logicalId)) continue; // subsumed by the `deleted` finding
     // promoted into the template since record → not a removal, just stale baseline
     if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
       promotedStale.push(`${a.logicalId}.${a.path}`);

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -512,6 +512,29 @@ describe('baseline', () => {
     expect(out).toEqual([skipped]);
   });
 
+  it('does NOT double-report per-property removals for a resource DELETED out of band', () => {
+    // 'A' was deleted out of band -> gather emits ONE resource-level `deleted` finding,
+    // which already conveys that the whole resource (and every recorded value) is gone.
+    // Its recorded baseline values must NOT each re-surface as a "baseline value removed"
+    // undeclared finding: that is redundant noise and inflates the drift count (1 deletion
+    // would read as 1 + N drifts).
+    const b = baseline([
+      { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P1', value: ['x'] },
+      { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P2', value: ['y'] },
+    ]);
+    const deleted: Finding = {
+      tier: 'deleted',
+      logicalId: 'A',
+      resourceType: 'AWS::X::Y',
+      path: '',
+      note: 'resource deleted out of band',
+    };
+    const out = applyBaseline([deleted], b);
+    expect(out.some((f) => f.note === 'baseline value removed since record')).toBe(false);
+    // ONLY the single deleted finding remains — the deletion is the drift
+    expect(out).toEqual([deleted]);
+  });
+
   it('does NOT report a removal when the recorded path was promoted into the template', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     const warnings: string[] = [];


### PR DESCRIPTION
## What

When a resource is **deleted out of band**, `gather` emits a single resource-level
`deleted` finding. But `applyBaseline` ALSO walked the baseline and emitted a
`baseline value removed since record` **undeclared** finding for **each** recorded
value of that now-gone resource. Result: one deletion was reported as **1 + N
drifts**.

Found via live dogfood — a deleted Glue crawler with 2 baselined undeclared values:

```
BEFORE:
  [Deleted: 1]      Crawler — resource deleted out of band
  [Undeclared: 2]   Crawler.RecrawlPolicy     — baseline value removed = undefined
                    Crawler.SchemaChangePolicy — baseline value removed = undefined
  result: 3 drift(s) (deleted=1 undeclared=2)
```

Problems:
- **Redundant noise** — the `deleted` finding already says the whole resource is gone.
- **Inflated drift count** — one deletion reads as 3 drifts.
- **Un-actionable revert ops** — the per-property removals would target a resource
  that no longer exists.

## Fix

Suppress per-property `baseline value removed` findings for any `logicalId` that
already has a `deleted` finding — the exact exclusion the `skipped` tier already
gets. Gated on an actual `deleted` finding, so a removal that is NOT already reported
still surfaces.

```
AFTER:
  [Deleted: 1]   Crawler — resource deleted out of band
  result: 1 drift(s) (deleted=1)
```

(Live-verified on the deployed stack.)

## Tests

- `tests/baseline.test.ts`: a deleted resource with 2 baselined values yields ONLY
  the single `deleted` finding, no per-property removals.

Gates: typecheck / lint+format / build / 981 unit tests green; live-verified.
