### PR TITLE
chore: tear down stacks with delstack (rule + .mise.toml pin + 53 integ traps)

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,8 @@
 [tools]
 "ubi:go-to-k/markgate" = "0.3.3"
+# Force-delete CloudFormation stacks (incl. DELETE_FAILED / retained / protected
+# resources) so test & integ teardown never leaves orphans — see CLAUDE.md.
+"ubi:go-to-k/delstack" = "2.11.1"
 
 [tools."http:vp"]
 version = "0.1.20"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,22 @@ detail:
 - **Run `vp run build`** after modifying source, before telling the user to test.
 - **Conventional commits**: use `feat:` / `fix:` / `chore:` / `docs:` / `test:`
   prefixes. A `pr-title-check` workflow enforces PR titles.
+- **Delete CloudFormation stacks with `delstack`, NOT `aws cloudformation
+delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
+  `DELETE_FAILED` — orphaning its resources — whenever a member can't be deleted
+  (e.g. an out-of-band-modified Route53 record once blocked its hosted zone's
+  deletion in a live integ, silently leaving the zone billing). `delstack`
+  force-deletes the stack and its retained/protected/blocking resources, so it
+  never orphans. Two forms: plain **`delstack -s <stack> -r <region> -y -f`** is
+  CloudFormation-based (delete a stack by name); the **`delstack cdk`** subcommand
+  is a drop-in for `cdk destroy` (CDK-aware) — `delstack cdk -a cdk.out -r
+<region> -f -y` reads an existing `cdk.out` (no re-synth; omit `-a` to
+  synthesize, or `-s` to target specific stacks). Integ/dogfood teardown traps
+  use `delstack cdk -a cdk.out` (it was `cdk destroy`). Pinned in `.mise.toml`
+  (`ubi:go-to-k/delstack`). `delstack` only sees stack members — after deleting,
+  still SWEEP for stack-EXTERNAL orphans it can't reach: auto-created
+  `/aws/lambda/*` and access-log groups, RETAIN-policy stateful resources,
+  Secrets in their recovery window, KMS keys pending deletion.
 - **markgate gates** (see `.markgate.yml`) — each has a companion skill that sets
   its marker:
   - `/check` → `check` marker (typecheck / lint+format / build / unit tests).

--- a/tests/integration/apigw-added/verify-revert.sh
+++ b/tests/integration/apigw-added/verify-revert.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/apigw-added/verify.sh
+++ b/tests/integration/apigw-added/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/atdefault/verify.sh
+++ b/tests/integration/atdefault/verify.sh
@@ -30,7 +30,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/basic/verify-deleted-guards.sh
+++ b/tests/integration/basic/verify-deleted-guards.sh
@@ -21,7 +21,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/basic/verify-mutation-matrix.sh
+++ b/tests/integration/basic/verify-mutation-matrix.sh
@@ -39,7 +39,7 @@ OUT=/tmp/cdkrd-mutation-matrix.out
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/basic/verify-vs-cdk-drift.sh
+++ b/tests/integration/basic/verify-vs-cdk-drift.sh
@@ -21,7 +21,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/basic/verify.sh
+++ b/tests/integration/basic/verify.sh
@@ -16,7 +16,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/budget-scope/verify-budget-scope.sh
+++ b/tests/integration/budget-scope/verify-budget-scope.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out /tmp/cdkrd-budget*.json
 }
 trap cleanup EXIT

--- a/tests/integration/ccadapters/verify-ccadapters.sh
+++ b/tests/integration/ccadapters/verify-ccadapters.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/cloudfront-atdefault/verify.sh
+++ b/tests/integration/cloudfront-atdefault/verify.sh
@@ -16,7 +16,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup (CloudFront destroy is slow) ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/cloudfront-oai/verify.sh
+++ b/tests/integration/cloudfront-oai/verify.sh
@@ -23,7 +23,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/cloudfront/verify-cloudfront.sh
+++ b/tests/integration/cloudfront/verify-cloudfront.sh
@@ -31,7 +31,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/cloudwatch-alarm/verify.sh
+++ b/tests/integration/cloudwatch-alarm/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/codebuild-proj/verify-codebuild-proj.sh
+++ b/tests/integration/codebuild-proj/verify-codebuild-proj.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/dynamodb/verify-nested.sh
+++ b/tests/integration/dynamodb/verify-nested.sh
@@ -35,7 +35,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/dynamodb/verify.sh
+++ b/tests/integration/dynamodb/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/ecs-writeonly/verify.sh
+++ b/tests/integration/ecs-writeonly/verify.sh
@@ -26,7 +26,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/freeform-strip/verify-freeform-strip.sh
+++ b/tests/integration/freeform-strip/verify-freeform-strip.sh
@@ -22,7 +22,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest/verify-harvest.sh
+++ b/tests/integration/harvest/verify-harvest.sh
@@ -25,7 +25,7 @@ OUT=/tmp/cdkrd-harvest.out
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest10/verify-harvest10.sh
+++ b/tests/integration/harvest10/verify-harvest10.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest11/verify-harvest11.sh
+++ b/tests/integration/harvest11/verify-harvest11.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest12/verify-harvest12.sh
+++ b/tests/integration/harvest12/verify-harvest12.sh
@@ -30,7 +30,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest13/verify-harvest13.sh
+++ b/tests/integration/harvest13/verify-harvest13.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest2/verify-harvest2.sh
+++ b/tests/integration/harvest2/verify-harvest2.sh
@@ -25,7 +25,7 @@ OUT=/tmp/cdkrd-harvest2.out
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest3/verify-harvest3.sh
+++ b/tests/integration/harvest3/verify-harvest3.sh
@@ -34,13 +34,13 @@ OUT=/tmp/cdkrd-harvest3.out
 cleanup() {
   # CDKRD_HARVEST3_KEEP=1 skips the destroy so a corpus/debug session can keep
   # iterating against the deployed stack. Destroy manually when done:
-  #   npx cdk destroy -f CdkrdIntegHarvest3 && rm -rf .cdkrd cdk.out
+  #   delstack cdk -a cdk.out -r us-east-1 -f -y && rm -rf .cdkrd cdk.out
   if [ -n "${CDKRD_HARVEST3_KEEP:-}" ]; then
     echo "--- keeping stack (CDKRD_HARVEST3_KEEP set) — destroy manually when done ---"
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest4/verify-harvest4.sh
+++ b/tests/integration/harvest4/verify-harvest4.sh
@@ -35,7 +35,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest5/verify-harvest5.sh
+++ b/tests/integration/harvest5/verify-harvest5.sh
@@ -28,7 +28,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest6/verify-harvest6.sh
+++ b/tests/integration/harvest6/verify-harvest6.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest7/verify-harvest7.sh
+++ b/tests/integration/harvest7/verify-harvest7.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest8/verify-harvest8.sh
+++ b/tests/integration/harvest8/verify-harvest8.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/harvest9/verify-harvest9.sh
+++ b/tests/integration/harvest9/verify-harvest9.sh
@@ -29,7 +29,7 @@ cleanup() {
     return
   fi
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/iam/verify-declared-inline-revert.sh
+++ b/tests/integration/iam/verify-declared-inline-revert.sh
@@ -28,7 +28,7 @@ DECLARED=DeclaredPolicy
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/iam/verify-inline-policy.sh
+++ b/tests/integration/iam/verify-inline-policy.sh
@@ -26,7 +26,7 @@ ROGUE=CdkrdRogueInlinePolicy
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/iam/verify-sibling-policy-doc.sh
+++ b/tests/integration/iam/verify-sibling-policy-doc.sh
@@ -31,7 +31,7 @@ OUT=/tmp/cdk-real-drift-integ-iam-sibling-doc.out
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/iam/verify.sh
+++ b/tests/integration/iam/verify.sh
@@ -17,7 +17,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/lambda/verify.sh
+++ b/tests/integration/lambda/verify.sh
@@ -24,7 +24,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/mutation-arrays/verify.sh
+++ b/tests/integration/mutation-arrays/verify.sh
@@ -21,7 +21,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/mutation-multi/verify.sh
+++ b/tests/integration/mutation-multi/verify.sh
@@ -18,7 +18,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/mutation-tags/verify.sh
+++ b/tests/integration/mutation-tags/verify.sh
@@ -6,7 +6,7 @@
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
 STACK=CdkRealDriftIntegMutationTags; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
-cleanup() { echo "--- cleanup ---"; npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+cleanup() { echo "--- cleanup ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
 trap cleanup EXIT
 fail() { echo "INTEG FAIL: $*"; exit 1; }
 echo "=== build + deploy + record ==="

--- a/tests/integration/nested/verify-nested.sh
+++ b/tests/integration/nested/verify-nested.sh
@@ -21,7 +21,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/noise/verify.sh
+++ b/tests/integration/noise/verify.sh
@@ -27,7 +27,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/policies/verify.sh
+++ b/tests/integration/policies/verify.sh
@@ -18,7 +18,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/readgap/verify.sh
+++ b/tests/integration/readgap/verify.sh
@@ -22,7 +22,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   # purge the secret immediately (cdk destroy only SCHEDULES deletion)
   aws secretsmanager delete-secret --secret-id "$SECRET" \
     --force-delete-without-recovery --region "$REGION" >/dev/null 2>&1 || true

--- a/tests/integration/revert-multi/verify.sh
+++ b/tests/integration/revert-multi/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/revert/verify.sh
+++ b/tests/integration/revert/verify.sh
@@ -14,7 +14,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/route53-weighted/verify-route53-weighted.sh
+++ b/tests/integration/route53-weighted/verify-route53-weighted.sh
@@ -26,7 +26,7 @@ ZONE_NAME="app.cdkrd-r53-integ.internal."
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/securitygroup/verify.sh
+++ b/tests/integration/securitygroup/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/sns-topic-tags-revert/verify.sh
+++ b/tests/integration/sns-topic-tags-revert/verify.sh
@@ -18,7 +18,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/sqs/verify.sh
+++ b/tests/integration/sqs/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/ssm/verify.sh
+++ b/tests/integration/ssm/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT

--- a/tests/integration/stepfunctions/verify.sh
+++ b/tests/integration/stepfunctions/verify.sh
@@ -19,7 +19,7 @@ CLI="node $ROOT/dist/cli.js"
 
 cleanup() {
   echo "--- cleanup ---"
-  npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
   rm -rf .cdkrd cdk.out
 }
 trap cleanup EXIT


### PR DESCRIPTION
## What

Delete CloudFormation stacks with `delstack`, not `aws cloudformation delete-stack`
/ `cdk destroy`.

**Why:** plain deletion leaves a stack `DELETE_FAILED` and orphans its resources
whenever a member can't be deleted. A live integ (`route53-weighted`) once left a
billing Route53 hosted zone after its out-of-band-modified record blocked the stack
delete — exactly the "no leftover resources" failure this fixes.

## Changes

- **`CLAUDE.md`** Workflow Rules: mandate `delstack` for stack deletion. Two forms
  documented — plain `delstack -s <stack> -r <region> -y -f` (CloudFormation-based)
  and the `cdk destroy`-compatible `delstack cdk -a cdk.out -r <region> -f -y`
  subcommand (reads existing `cdk.out`, no re-synth). Plus a reminder to sweep
  stack-EXTERNAL orphans `delstack` can't see (auto-created log groups, RETAIN
  resources, secrets in recovery window, KMS pending-deletion keys).
- **`.mise.toml`**: pin `ubi:go-to-k/delstack = 2.11.1`.
- **53 integ teardown traps**: `npx cdk destroy -f "$STACK"` →
  `delstack cdk -a cdk.out -r "$REGION" -f -y` (falls back to `cdk destroy` then
  `|| true`, so the trap never fails).

## Verification

- typecheck / lint+format / build / **994 unit tests** green.
- **Live-verified** the new teardown: `basic` and `revert` fixtures both `INTEG PASS`
  and tear down cleanly via `delstack cdk`; a standalone `delstack cdk -a cdk.out`
  force-deletes a real stack + its resources (stack + SQS queue confirmed gone).
- Diff touches **only** docs + tooling + integ-teardown traps — **no `src/`**, no
  unit-test changes. The full 53-fixture release suite was **not** re-run (it verifies
  drift-detection behavior, which this PR does not change); the teardown change itself
  is the thing verified, on representative fixtures.

No `src/` change → no behavior change to `cdkrd` itself.
