### PR TITLE
feat(report): rename added tier to "Added Resource" and sort it after the property tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ vocabulary names exactly which of the three sources a finding relates to, so
 | ------------------------------ | --------------------------------------------- | ------------------------------------------------------- |
 | **CFn-declared**               | your CloudFormation template                  | the property IS in the template; the live value drifted |
 | **CFn-undeclared** (live-only) | the live resource                             | the property is on the resource but NOT in the template |
-| **Added** (out-of-band)        | the live resource                             | a whole resource exists live but is NOT in the template |
+| **Added Resource**             | the live resource                             | a whole resource exists live but is NOT in the template |
 | **recorded / unrecorded**      | your `.cdkrd` baseline file (a separate axis) | whether you have snapshotted that live-only value yet   |
 
 So `CFn-declared` ≠ "declared in my CDK code" and ≠ "in my `.cdkrd` baseline" — it

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -28,7 +28,7 @@ import { style } from './style.js';
 // which ties directly to the `cdkrd record` verb.
 const TIER_NAMES: Record<Tier, string> = {
   deleted: 'Deleted',
-  added: 'Added (Out-of-Band)',
+  added: 'Added Resource',
   declared: 'CFn-Declared Drift',
   undeclared: 'CFn-Undeclared Drift',
   atDefault: 'At AWS Default',
@@ -46,7 +46,7 @@ const TIER_NAMES: Record<Tier, string> = {
 const TIER_NOTES: Partial<Record<Tier, string>> = {
   deleted: 'resource deleted out of band — always drift',
   added:
-    'a live resource not in your CloudFormation template — created out of band under a declared parent; always drift',
+    'a WHOLE live resource not in your CloudFormation template (the resource-level counterpart of CFn-Undeclared) — created out of band under a declared parent; always drift',
   declared: 'declared in your CloudFormation template — the live value differs',
   undeclared:
     'live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator',
@@ -58,7 +58,11 @@ const TIER_NOTES: Partial<Record<Tier, string>> = {
   skipped:
     'NOT checked (coverage incomplete) — CC API unsupported / no physical id / custom resource',
 };
-const DRIFT_TIERS: Tier[] = ['deleted', 'added', 'declared', 'undeclared'];
+// Section + result-line order (both iterate this). `added` (whole out-of-band
+// resources) sorts AFTER the property tiers — declared/undeclared are the per-property
+// differentiator the report leads with, and the resource-level `added` follows them.
+// `deleted` stays first (the most blatant drift).
+const DRIFT_TIERS: Tier[] = ['deleted', 'declared', 'undeclared', 'added'];
 // atDefault leads the informational footer: it is the bulk of a first run (undeclared
 // values sitting at their AWS default) and folding it is the whole point of R86 — the
 // report states the complete undeclared count but lists only the values that actually

--- a/tests/integration/apigw-added/app.ts
+++ b/tests/integration/apigw-added/app.ts
@@ -2,7 +2,7 @@
 // A REST API with a declared method on a child resource (POST /scoring) AND a declared
 // method on the ROOT `/` resource (GET /). verify.sh then adds an ANY method on root
 // out of band (via the AWS CLI) — a whole resource not in the template — and asserts
-// cdkrd reports EXACTLY that one under [Added (Out-of-Band)] (added=1). The declared
+// cdkrd reports EXACTLY that one under [Added Resource] (added=1). The declared
 // GET / is the false-positive guard: its ResourceId is `GetAtt RootResourceId`, which
 // must re-resolve to the live root id so the declared root method is NOT flagged added.
 import { App, Stack } from "aws-cdk-lib";

--- a/tests/integration/apigw-added/verify.sh
+++ b/tests/integration/apigw-added/verify.sh
@@ -2,7 +2,7 @@
 # cdk-real-drift `added` (out-of-band resource) integration test (real AWS).
 #   deploy fixture (REST API, POST /scoring) -> record -> check CLEAN
 #   -> inject an out-of-band ANY method on the ROOT `/` resource (aws apigateway
-#      put-method) -> check DETECTS it under [Added (Out-of-Band)] -> destroy.
+#      put-method) -> check DETECTS it under [Added Resource] -> destroy.
 # This is the case CFn drift / cdk drift / driftctl all miss: a WHOLE resource
 # (an API Gateway Method) created out of band, not just an undeclared property.
 # A cleanup trap destroys the stack even on failure, so no orphan resources remain.
@@ -53,7 +53,7 @@ echo "=== check should DETECT the added method ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdk-real-drift-integ-added.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
-grep -q "Added (Out-of-Band)" /tmp/cdk-real-drift-integ-added.out || fail "added section not reported"
+grep -q "Added Resource" /tmp/cdk-real-drift-integ-added.out || fail "added section not reported"
 grep -q "ANY /" /tmp/cdk-real-drift-integ-added.out || fail "ANY / method not reported"
 # Exactly ONE added finding: the declared GET / (ResourceId = GetAtt RootResourceId)
 # must re-resolve to the live root id and NOT false-positive as added (added=1, not 2).

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -118,8 +118,27 @@ describe('report', () => {
     };
     const { code, text } = run([f]);
     expect(code).toBe(1);
-    expect(text).toContain('Added (Out-of-Band)');
+    expect(text).toContain('Added Resource');
     expect(text).toContain('Stack/Api ▸ ANY /');
+  });
+
+  it('the Added section sorts AFTER declared/undeclared (sections + result line)', () => {
+    const added: Finding = {
+      tier: 'added',
+      logicalId: 'Api/x',
+      constructPath: 'Stack/Api ▸ /x',
+      resourceType: 'AWS::ApiGateway::Resource',
+      path: '',
+    };
+    const { text } = run([added, F('declared', 'P'), F('undeclared', 'Q')]);
+    // section order: CFn-Declared Drift -> CFn-Undeclared Drift -> Added Resource
+    const iDeclared = text.indexOf('CFn-Declared Drift');
+    const iUndeclared = text.indexOf('CFn-Undeclared Drift');
+    const iAdded = text.indexOf('Added Resource');
+    expect(iDeclared).toBeLessThan(iUndeclared);
+    expect(iUndeclared).toBeLessThan(iAdded);
+    // result-line counts in the same order, added last
+    expect(text).toMatch(/declared=1 undeclared=1 added=1/);
   });
 
   it('json mode emits parseable JSON with findings + drifted count', () => {


### PR DESCRIPTION
## What

Two report-display refinements to the `added` tier (review feedback), no behavior change:

1. **Order** — the `Added Resource` section (and its `result:` count) now sorts **after** `CFn-Declared` / `CFn-Undeclared`. The per-property differentiator leads; the resource-level finding follows. `result:` reads `declared=1 undeclared=1 added=1`.
2. **Label** — `Added (Out-of-Band)` → **`Added Resource`**. The distinction from `CFn-Undeclared Drift` is **property-vs-resource**: undeclared is a live PROPERTY on a declared resource; added is a WHOLE live resource not in the template. Naming the unit makes that explicit, and the count keeps the singular reading fine (`[Added Resource: 3]`). The tier note now states it is "a WHOLE live resource … the resource-level counterpart of CFn-Undeclared".

### Before
```
[Added (Out-of-Band): 1] (...)
  .../ScoringApi ▸ /aaa (AWS::ApiGateway::Resource) — created out of band ...
[CFn-Declared Drift: 1] (...)
[CFn-Undeclared Drift: 1] (...)
result: 3 drift(s) (added=1 declared=1 undeclared=1)
```
### After
```
[CFn-Declared Drift: 1] (...)
[CFn-Undeclared Drift: 1] (...)
[Added Resource: 1] (a WHOLE live resource not in your CloudFormation template (the resource-level counterpart of CFn-Undeclared) ...)
  .../ScoringApi ▸ /aaa (AWS::ApiGateway::Resource) — created out of band ...
result: 3 drift(s) (declared=1 undeclared=1 added=1)
```

## How

Pure rendering change: reorder `DRIFT_TIERS` (drives both the section order and the `result:` counts) + rename in `TIER_NAMES` + sharpen `TIER_NOTES`. No AWS path touched.

## Verification

A new unit test locks the section order, the `result:`-line order, and the `Added Resource` label (995 tests pass, 0 lint errors). The integ grep + fixture comments are updated to the new header. No live deploy — the change is report-rendering only and fully unit-locked.
