### PR TITLE
chore(hooks): add stale-base-gate + exempt non-src PRs from verify-pr-gate

### DIFF
--- a/.claude/hooks/stale-base-gate.sh
+++ b/.claude/hooks/stale-base-gate.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# stale-base-gate.sh
+#
+# PreToolUse hook. Blocks `git push` of a feature branch when the branch
+# sits ON TOP of the current `origin/main` (origin/main is an ancestor of
+# HEAD) yet its net diff REVERTS one or more files that recent `origin/main`
+# commits changed. This is the exact "stale-base soft-reset clobber"
+# foot-gun that has bitten this repo's worktree flow twice:
+#
+#   A worktree branch is based on main@T0. While it works, a parallel
+#   session merges PR #X, advancing main to T1. The author then runs
+#   `git reset --soft origin/main` (or --hard with a stale working tree) to
+#   "rebase", which moves HEAD onto T1 but keeps the OLD T0 tree — so the
+#   resulting commit, diffed against its T1 parent, DELETES/REVERTS every
+#   file #X just added. Pushing + merging that branch silently rolls #X
+#   back. (See memory rule worktree-stale-base-diff.)
+#
+# Detection (precise, fail-open): only fires when origin/main is already an
+# ancestor of HEAD (the branch CLAIMS to be current). For each path in the
+# branch's net diff vs origin/main, if HEAD's blob for that path matches an
+# EARLIER origin/main state (origin/main~1..~N) while differing from the
+# current origin/main tip — i.e. HEAD carries a PAST version of a file main
+# has since moved on from — that path is being reverted by staleness, not by
+# intent. Any such path blocks the push. A branch that genuinely builds on
+# top of current main (adds/edits files main has NOT touched) is never
+# flagged. Every git failure falls through to `exit 0` (we never block what
+# we cannot prove).
+#
+# cwd resolution mirrors branch-gate.sh (payload .cwd + leading `cd <path>`
+# + last `git -C <path>`), because this repo is worked via `git worktree`.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Only gate `git push` (subcommand position, line-start anchored — same shape
+# as branch-gate.sh so quoted "git push" substrings don't false-positive).
+if ! printf '%s' "$cmd" | grep -qE '^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^[:space:]-][^[:space:]]*)?))*[[:space:]]+push([[:space:]]|$|[|;&`)])'; then
+  exit 0
+fi
+
+# Resolve where the git command actually runs.
+target_dir="${hook_cwd:-$PWD}"
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  [[ "$cd_target" != /* ]] && cd_target="$target_dir/$cd_target"
+  target_dir="$cd_target"
+fi
+if [[ "$cmd" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; then
+  c_target=""; remaining="$cmd"
+  while [[ "$remaining" =~ git[[:space:]]+-C[[:space:]]+([^[:space:]]+) ]]; do
+    c_target="${BASH_REMATCH[1]}"
+    remaining="${remaining#*"${BASH_REMATCH[0]}"}"
+  done
+  c_target="${c_target%\"}"; c_target="${c_target#\"}"
+  c_target="${c_target%\'}"; c_target="${c_target#\'}"
+  [[ "$c_target" != /* ]] && c_target="$target_dir/$c_target"
+  target_dir="$c_target"
+fi
+
+g() { git -C "$target_dir" "$@" 2>/dev/null; }
+
+# Must be a git repo we can read.
+g rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Base ref: prefer the remote-tracking origin/main; fall back to local main.
+base=""
+for ref in origin/main origin/master main master; do
+  if g rev-parse --verify --quiet "$ref" >/dev/null; then base="$ref"; break; fi
+done
+[ -n "$base" ] || exit 0
+
+head_sha=$(g rev-parse HEAD) || exit 0
+base_sha=$(g rev-parse "$base") || exit 0
+[ "$head_sha" = "$base_sha" ] && exit 0  # pushing the base itself — not our concern
+
+# Only the soft-reset clobber shape: base is ALREADY an ancestor of HEAD, so
+# the branch claims to be current. A branch merely BEHIND base is the normal
+# worktree case (three-way merge keeps base's commits) — never flagged here.
+g merge-base --is-ancestor "$base" HEAD || exit 0
+
+# Files in the branch's net diff vs the base tip.
+net=$(g diff --name-only "$base" HEAD) || exit 0
+[ -n "$net" ] || exit 0
+
+# Blob of a path at a ref ("" if absent at that ref).
+blob_at() { g rev-parse "$1:$2" 2>/dev/null || echo ""; }
+
+clobbered=""
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  head_blob=$(blob_at HEAD "$path")
+  base_blob=$(blob_at "$base" "$path")
+  # If HEAD carries a PAST origin/main version of this path (matches base~k
+  # for some recent k) while differing from the current base tip, the branch
+  # is reverting main's history by staleness, not intent.
+  for k in 1 2 3 4 5; do
+    past_blob=$(blob_at "${base}~${k}" "$path")
+    [ -n "$past_blob" ] || continue
+    if [ "$head_blob" = "$past_blob" ] && [ "$past_blob" != "$base_blob" ]; then
+      clobbered="${clobbered}  - ${path} (HEAD == ${base}~${k}, but ${base} has moved on)"$'\n'
+      break
+    fi
+  done
+done <<< "$net"
+
+[ -n "$clobbered" ] || exit 0
+
+{
+  echo "Blocked by stale-base-gate: this push would REVERT recent '${base}' work."
+  echo
+  echo "  resolved target dir: $target_dir"
+  echo "  HEAD sits on top of ${base}, but these paths carry an OLDER ${base}"
+  echo "  version than the current tip — the stale-base soft-reset clobber:"
+  echo
+  printf '%s' "$clobbered"
+  echo
+  echo "Your branch likely did 'git reset --soft/--hard ${base}' with a stale"
+  echo "working tree after ${base} advanced. Pushing + merging it would roll"
+  echo "those commits back. Recover with:"
+  echo "  git -C \"$target_dir\" reset --hard ${base}   # take current ${base}"
+  echo "  # then re-apply ONLY your intended changes and re-commit."
+  echo "If the reversion is truly intended, push from a branch whose history"
+  echo "does not embed ${base} as a parent (so the intent is explicit)."
+} >&2
+exit 2

--- a/.claude/hooks/stale-base-gate.test.sh
+++ b/.claude/hooks/stale-base-gate.test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Smoke test for stale-base-gate.sh.
+#
+# Builds fixture git repos with a real `refs/remotes/origin/main` and asserts
+# the BLOCK (exit 2) vs ALLOW (exit 0) outcomes of the stale-base soft-reset
+# clobber detector. Run from the repo root:
+#   bash .claude/hooks/stale-base-gate.test.sh
+#
+# Why a shell script (not vitest): the hook IS a shell script; its contract is
+# the stdin JSON payload + exit code. A TS wrapper would test the wrapper.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/stale-base-gate.sh"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+git_q() { git -C "$1" -c user.email=t@t -c user.name=t "${@:2}"; }
+
+# Build a repo with:
+#   main:        A (f=v0) -> B (f=v1)   [B is origin/main tip]
+#   feature_rev: forks at B, reverts f back to v0   -> clobber (BLOCK)
+#   feature_new: forks at B, adds a NEW file g       -> clean (ALLOW)
+#   feature_behind: forks at A, edits unrelated h    -> behind main (ALLOW)
+repo="$TMPDIR/repo"
+git init -q -b main "$repo"
+printf 'v0\n' > "$repo/f"; git_q "$repo" add f; git_q "$repo" commit -q -m A
+printf 'v1\n' > "$repo/f"; git_q "$repo" add f; git_q "$repo" commit -q -m B
+B=$(git_q "$repo" rev-parse HEAD)
+A=$(git_q "$repo" rev-parse HEAD~1)
+git_q "$repo" update-ref refs/remotes/origin/main "$B"
+
+# feature_rev: on top of B (origin/main) but tree reverts f to v0 (== A's f).
+git_q "$repo" checkout -q -b feature_rev "$B"
+printf 'v0\n' > "$repo/f"; git_q "$repo" add f; git_q "$repo" commit -q -m "revert f"
+
+# feature_new: on top of B, adds a brand-new file.
+git_q "$repo" checkout -q -b feature_new "$B"
+printf 'x\n' > "$repo/g"; git_q "$repo" add g; git_q "$repo" commit -q -m "add g"
+
+# feature_behind: forks at A (behind origin/main), edits unrelated file.
+git_q "$repo" checkout -q -b feature_behind "$A"
+printf 'h\n' > "$repo/h"; git_q "$repo" add h; git_q "$repo" commit -q -m "add h"
+
+pass=0; fail=0; fail_log=""
+# run_case <name> <expect_exit> <command> <checkout_branch>
+run_case() {
+  local name="$1" want="$2" command="$3" branch="$4" got out
+  git_q "$repo" checkout -q "$branch"
+  local payload; payload=$(printf '{"cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$command")
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1); true
+  printf '%s' "$payload" | "$HOOK" >/dev/null 2>&1; got=$?
+  if [[ "$got" == "$want" ]]; then
+    pass=$((pass + 1)); printf 'OK   %s (exit %s)\n' "$name" "$got"
+  else
+    fail=$((fail + 1))
+    fail_log+="FAIL $name: want $want got $got\n  out: $out\n"
+    printf 'FAIL %s (want %s, got %s)\n' "$name" "$want" "$got"
+  fi
+}
+
+# ALLOW: non-push command passes through untouched (even from a clobber branch).
+run_case "non-push command allowed" 0 "git status" feature_rev
+# ALLOW: a real clobber branch but the command is not a push.
+run_case "git diff on clobber branch allowed" 0 "git diff" feature_rev
+# BLOCK: pushing the stale-base clobber branch.
+run_case "push of stale-base clobber blocked" 2 "git push origin HEAD" feature_rev
+# ALLOW: pushing a branch that adds a new file on top of origin/main.
+run_case "push of clean on-top branch allowed" 0 "git push origin HEAD" feature_new
+# ALLOW: pushing a branch merely BEHIND origin/main (normal worktree case).
+run_case "push of behind-main branch allowed" 0 "git push origin HEAD" feature_behind
+# ALLOW: non-git target dir (cannot judge) passes through.
+bare="$TMPDIR/not-a-repo"; mkdir -p "$bare"
+payload=$(printf '{"cwd":"%s","tool_input":{"command":"git push"}}' "$bare")
+printf '%s' "$payload" | "$HOOK" >/dev/null 2>&1
+if [[ $? == 0 ]]; then pass=$((pass + 1)); echo "OK   non-git target dir allowed (exit 0)"; else
+  fail=$((fail + 1)); echo "FAIL non-git target dir allowed"; fi
+
+echo
+echo "stale-base-gate.test: $pass passed, $fail failed"
+if [[ "$fail" -gt 0 ]]; then printf '%b' "$fail_log"; exit 1; fi

--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -89,6 +89,33 @@ fi
 
 cd "$target_dir" 2>/dev/null || exit 0
 
+# Non-src exemption: /verify-pr's heavy half (live-test changed behavior +
+# real-AWS integration fixtures + retrospective) only earns its cost when the
+# change carries RUNTIME BEHAVIOR — i.e. touches `src/**`. A PR that edits only
+# docs, tooling (.claude/**, .github/**, .mise.toml), or integ teardown scripts
+# has no behavior to live-test; the `check` + `docs` markers (enforced at commit
+# by check-gate) already cover its quality. Demanding a full /verify-pr there
+# (which needs AWS credentials it doesn't exercise) is pure friction. So: if the
+# PR's diff vs the base contains NO `src/**` path, let it through.
+#
+# Fails CLOSED (keeps gating) if the changed-file set can't be computed — we
+# only skip the gate when we can PROVE the diff is src-free.
+base=""
+for ref in origin/main origin/master main master; do
+  if git rev-parse --verify --quiet "$ref" >/dev/null 2>&1; then base="$ref"; break; fi
+done
+if [ -n "$base" ]; then
+  mb=$(git merge-base "$base" HEAD 2>/dev/null || echo "")
+  if [ -n "$mb" ]; then
+    changed=$(git diff --name-only "$mb" HEAD 2>/dev/null || echo "__ERR__")
+    if [ "$changed" != "__ERR__" ] && [ -n "$changed" ] \
+       && ! printf '%s\n' "$changed" | grep -qE '^src/'; then
+      echo "verify-pr-gate: PR diff touches no src/** (docs/tooling-only) — exempt from /verify-pr (check + docs cover it)." >&2
+      exit 0
+    fi
+  fi
+fi
+
 # Prefer the `.mise.toml`-pinned version via `mise exec --` so the repo's
 # canonical markgate wins over an older PATH binary; see check-gate.sh for
 # the schema-bump rationale (0.3.0 markers are silently invisible to 0.3.1).

--- a/.claude/hooks/verify-pr-gate.test.sh
+++ b/.claude/hooks/verify-pr-gate.test.sh
@@ -24,6 +24,23 @@ git -C "$side_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 
 git init -q -b main "$main_repo"
 git -C "$main_repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 
+# Fixture for the NON-SRC EXEMPTION: a repo with a real origin/main and two
+# feature branches off it — one changing only a non-src file (README), one
+# touching src/. The exemption must let the docs-only PR through (exit 0) even
+# when the markgate verdict is stale, but still gate the src/ PR (exit 2).
+exempt_repo="$TMPDIR/exempt-repo"
+gx() { git -C "$exempt_repo" -c user.email=t@t -c user.name=t "$@"; }
+git init -q -b main "$exempt_repo"
+mkdir -p "$exempt_repo/src"
+printf 'keep\n' > "$exempt_repo/src/keep.ts"
+printf 'readme\n' > "$exempt_repo/README.md"
+gx add -A; gx commit -q -m init
+gx update-ref refs/remotes/origin/main HEAD
+gx checkout -q -b feature/docs
+printf 'more\n' >> "$exempt_repo/README.md"; gx add -A; gx commit -q -m "docs only"
+gx checkout -q -b feature/src main
+printf 'change\n' >> "$exempt_repo/src/keep.ts"; gx add -A; gx commit -q -m "src change"
+
 SHIM_DIR="$TMPDIR/bin"
 mkdir -p "$SHIM_DIR"
 CWD_TRACE_FILE="$TMPDIR/cwd-trace"
@@ -161,6 +178,23 @@ run_case "gh issue body quoting 'gh pr create' passes through" 0 stale "" \
 #     the command starts with `echo`. MUST pass through.
 run_case "echo body quoting 'gh pr merge' passes through" 0 stale "" \
   "$(printf '{"cwd":"%s","tool_input":{"command":"echo \"after CI green: gh pr merge --squash\""}}' "$side_repo")"
+
+# --- NON-SRC EXEMPTION cases ---
+#
+# A docs/tooling-only PR (no src/** in the diff) is exempt: it exits 0 BEFORE
+# markgate is consulted, even with a stale verdict. A PR that touches src/** is
+# still gated (exit 2 when stale). expect_cwd="" for the exempt case because the
+# hook returns before invoking markgate (no cwd trace written).
+
+# 14. feature/docs (README-only diff vs origin/main) → exempt, exit 0 even stale.
+gx checkout -q feature/docs
+run_case "non-src (docs-only) PR exempt from verify-pr" 0 stale "" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create --title docs"}}' "$exempt_repo")"
+
+# 15. feature/src (src/ diff vs origin/main) → still gated, exit 2 when stale.
+gx checkout -q feature/src
+run_case "src-touching PR still gated" 2 stale "$exempt_repo" \
+  "$(printf '{"cwd":"%s","tool_input":{"command":"gh pr create --title src"}}' "$exempt_repo")"
 
 echo
 echo "Pass: $pass  Fail: $fail"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh; non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule). NOT wired: pr-review and integ-* — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
+  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule). NOT wired: pr-review and integ-* — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
   "hooks": {
     "PreToolUse": [
       {
@@ -18,6 +18,13 @@
             "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*) or Bash(cd * && git commit*) or Bash(cd * && git push*)",
             "timeout": 10,
             "statusMessage": "Checking target branch is not main..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/stale-base-gate.sh",
+            "if": "Bash(git push*) or Bash(git -C * push*) or Bash(cd * && git push*)",
+            "timeout": 10,
+            "statusMessage": "Checking branch does not stale-base-clobber main..."
           },
           {
             "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,12 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   `gh pr create`. The reviewer re-reviews the PR diff before merge. cdkd's
   branch-protection (`branch-gate`) and verify-pr-merge (`verify-pr-gate`) gates
   ARE now ported and wired (R83), plus the OSS English-only
-  `non-english-text-gate`. pr-review and integ-\* stay UNPORTED on purpose:
+  `non-english-text-gate` and the `stale-base-gate` (blocks a `git push`
+  whose branch sits on `origin/main` yet reverts recent main work — the
+  stale-base soft-reset clobber that bit this worktree flow twice).
+  `verify-pr-gate` is EXEMPT for docs/tooling-only PRs (no `src/**` in the
+  diff): `check` + `docs` already cover them, so a full `/verify-pr` (with
+  its real-AWS live-test) is not demanded. pr-review and integ-\* stay UNPORTED on purpose:
   pr-review is multi-agent (cdkrd is solo); integ-\* depends on cdkd's
   providers/state/destroy paths cdkrd lacks (see `.markgate.yml`).
 


### PR DESCRIPTION
## What

Two hook hardening changes, both born from this session's friction (no `src/`
change — tooling + docs only):

### 1. `stale-base-gate.sh` (new) — pre-push guard against the stale-base clobber

A `git push` is BLOCKED when the branch sits ON TOP of `origin/main`
(origin/main is an ancestor of HEAD) yet its net diff REVERTS one or more files
that recent `origin/main` commits changed. This is the exact "stale-base
soft-reset clobber" that has bitten this worktree flow twice: a branch based on
`main@T0` runs `git reset --soft origin/main` after main advanced to `T1`,
moving HEAD onto `T1` while keeping the OLD `T0` tree — so the commit, diffed
against its `T1` parent, silently deletes/reverts everything the intervening
merge added.

Detection is precise and **fails open**: it only fires when `origin/main` is
already an ancestor of HEAD, and only flags a path whose HEAD blob matches an
EARLIER `origin/main` state (`origin/main~1..~5`) while differing from the
current tip. A branch that genuinely builds on top of current main (adds/edits
files main hasn't touched) is never flagged; a branch merely BEHIND main (the
normal worktree case, handled by three-way merge) is never flagged. Any git
failure → `exit 0`.

Wired in `settings.json` on `git push*` / `git -C * push*` / `cd * && git push*`.

### 2. `verify-pr-gate.sh` — exempt docs/tooling-only PRs

`/verify-pr`'s heavy half (real-AWS live-test + integration fixtures +
retrospective) only earns its cost when the diff carries RUNTIME BEHAVIOR — i.e.
touches `src/**`. A PR that edits only docs, tooling (`.claude/**`,
`.github/**`, `.mise.toml`), or integ teardown scripts has no behavior to
live-test; `check` + `docs` (enforced at commit) already cover it. The gate now
computes the PR's changed-file set vs the base and, if NO `src/**` path is
touched, lets it through. **Fails closed** — only skips when it can prove the
diff is src-free (empty/unknown diff still gates).

## Tests

- `stale-base-gate.test.sh` (new): 6 cases — push of a stale-base clobber branch
  BLOCKS (exit 2); push of a clean on-top branch, a behind-main branch, a
  non-push command, and a non-git dir all ALLOW (exit 0). **6/6 pass.**
- `verify-pr-gate.test.sh`: +2 cases — a docs-only PR is exempt (exit 0 even when
  the marker is stale); a src-touching PR is still gated (exit 2). **15/15 pass**
  (all 13 prior cases still green).

## Gates

typecheck / lint+format / build / **995 unit tests (38 files)** green. No
`src/` change — `.claude/**` + `CLAUDE.md` only.
