### PR TITLE
fix(diff,read): suppress stringly-typed scalar-array FP (R23) + paginate MetricFilter read (FN)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -23,6 +23,7 @@ import {
   isJsonStringStructEqual,
   isPemEqual,
   isStringlyEqualScalar,
+  isStringlyEqualScalarArray,
   isGeneratedName,
   isTrivialEmpty,
   isVersionPrefixMatch,
@@ -247,6 +248,11 @@ export function classifyResource(
       // CFn stringly-typed scalar (Glue Parameters Map<String,String>, "5432" ports):
       // declared `true`/`5432` vs AWS `"true"`/`"5432"` is not drift.
       if (isStringlyEqualScalar(d.stateValue, d.awsValue)) continue;
+      // CFn stringly-typed scalar ARRAY (R23): the drift-calculator emits the whole
+      // array as one record, so the per-leaf check above can't see the elements of a
+      // declared `[80, 443]` vs live `["80", "443"]`. Same typed<->string collapse,
+      // element-wise; a genuine element change still differs.
+      if (isStringlyEqualScalarArray(d.stateValue, d.awsValue)) continue;
       // A declared object whose live form is the same value as a JSON STRING
       // (R75: SSM Document.Content) — equal after parse, key-order-insensitive.
       if (isJsonStringStructEqual(d.stateValue, d.awsValue)) continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -676,12 +676,12 @@ export function sortUnorderedObjectArray(v: unknown): unknown {
 // (never collapses objects/arrays); a genuine value change (`true` vs `"false"`,
 // `5` vs `"6"`) still differs, so real drift is preserved.
 //
-// KNOWN LIMITATION (R23): this runs in classify's declared loop on LEAF drift records
-// only. The drift-calculator reports a scalar-array mismatch as ONE parent-path record
-// (value = the whole array), so element-wise stringly comparison never happens — a
-// typed `[80, 443]` vs live `["80", "443"]` still reports drift. The direction is a
-// false POSITIVE (noise), never hidden drift, so it is fail-safe; collapsing it would
-// need a drift-calculator change. Revisit only if a real fixture hits it.
+// SCOPE: this scalar check runs in classify's declared loop on LEAF drift records.
+// The drift-calculator reports a scalar-ARRAY mismatch as ONE parent-path record
+// (value = the whole array), so this per-leaf check never sees the ELEMENTS of a
+// typed `[80, 443]` vs live `["80", "443"]`. That array shape is handled by
+// `isStringlyEqualScalarArray` (R23) below, which applies this same typed<->string
+// collapse element-wise — so both the scalar and scalar-array forms are suppressed.
 const DECIMAL_RE = /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/;
 
 export function isStringlyEqualScalar(a: unknown, b: unknown): boolean {
@@ -698,6 +698,24 @@ export function isStringlyEqualScalar(a: unknown, b: unknown): boolean {
   if (prim(a) && typeof b === 'string') return eq(a, b);
   if (prim(b) && typeof a === 'string') return eq(b, a);
   return false;
+}
+
+// R23: a scalar ARRAY whose elements are pairwise stringly-equal is not drift.
+// CFn stringly-typed list fields (declared `[80, 443]` while AWS returns
+// `["80", "443"]`, declared `[true]` vs live `["true"]`) surface from the
+// drift-calculator as ONE parent-path record carrying the WHOLE array, so the
+// per-leaf `isStringlyEqualScalar` above never compares the elements. This applies
+// the same typed<->string collapse element-wise: positional (order-sensitive —
+// unordered sets are handled by UNORDERED_ARRAY_PROPS), equal length + all scalars
+// required, each pair equal either strictly or via `isStringlyEqualScalar`. A
+// genuine element change (`[80, 443]` vs `["80", "8443"]`) still differs, so real
+// drift is preserved.
+export function isStringlyEqualScalarArray(a: unknown, b: unknown): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  const scalar = (v: unknown): boolean =>
+    typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
+  if (!a.every(scalar) || !b.every(scalar)) return false;
+  return a.every((v, i) => v === b[i] || isStringlyEqualScalar(v, b[i]));
 }
 
 // A1: trivially-empty/off values AWS returns for unset features. Objects recurse:

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -11,6 +11,7 @@ import { BatchGetProjectsCommand, CodeBuildClient } from '@aws-sdk/client-codebu
 import {
   CloudWatchLogsClient,
   DescribeMetricFiltersCommand,
+  type MetricFilter,
 } from '@aws-sdk/client-cloudwatch-logs';
 import { DescribeAddressesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { GetTableCommand, GlueClient } from '@aws-sdk/client-glue';
@@ -416,10 +417,24 @@ const readMetricFilter: OverrideReader = async ({ physicalId, declared, region }
   const filterName = str(physicalId) ?? str(declared.FilterName);
   if (!logGroup || !filterName) return undefined;
   const c = new CloudWatchLogsClient({ region, ...READ_RETRY });
-  const r = await c.send(
-    new DescribeMetricFiltersCommand({ logGroupName: logGroup, filterNamePrefix: filterName })
-  );
-  const mf = r.metricFilters?.find((m) => m.filterName === filterName);
+  // `filterNamePrefix: filterName` narrows each page to filters that START WITH this
+  // name — but when many filters share the prefix (a name that is also a prefix of
+  // others), the EXACT-named one can be paginated past the first page. Follow
+  // nextToken until it is found, so a present filter is never misread as deleted (a
+  // false negative). Stops as soon as the exact match appears.
+  let mf: MetricFilter | undefined;
+  let nextToken: string | undefined;
+  do {
+    const r = await c.send(
+      new DescribeMetricFiltersCommand({
+        logGroupName: logGroup,
+        filterNamePrefix: filterName,
+        ...(nextToken && { nextToken }),
+      })
+    );
+    mf = r.metricFilters?.find((m) => m.filterName === filterName);
+    nextToken = r.nextToken;
+  } while (!mf && nextToken);
   if (!mf) return undefined;
   return {
     LogGroupName: logGroup,

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -91,6 +91,38 @@ describe('classifyResource (the heart)', () => {
       )
     ).toBe(false);
   });
+
+  // R23: a CFn stringly-typed scalar ARRAY (declared [80, 443] vs live ["80","443"])
+  // surfaces from the drift-calculator as one parent-path record carrying the whole
+  // array; the per-leaf stringly check could not see the elements. Now suppressed.
+  it('stringly-typed scalar array is not declared drift, real element change still is (R23)', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const res: DesiredResource = {
+      logicalId: 'LB',
+      resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+      physicalId: 'lb-phys',
+      declared: { Ports: [80, 443], Flags: [true, false] },
+    };
+    // AWS echoes the typed list as strings, same order — no declared drift.
+    const clean = tiers(
+      classifyResource(res, { Ports: ['80', '443'], Flags: ['true', 'false'] }, emptySchema)
+    );
+    expect(clean.declared).toEqual([]);
+    // A genuine element change still surfaces as declared drift.
+    const drifted = tiers(
+      classifyResource(res, { Ports: ['80', '8443'], Flags: ['true', 'false'] }, emptySchema)
+    );
+    expect(drifted.declared).toEqual(['Ports']);
+  });
 });
 
 // R10: classifyResource threads optional { accountId, region } into isArnNameMatch.

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -181,6 +181,29 @@ describe('noise suppressors', () => {
     expect(isStringlyEqualScalar(true, '1')).toBe(false);
   });
 
+  it('isStringlyEqualScalarArray: typed<->string element arrays fold, real drift kept (R23)', async () => {
+    const { isStringlyEqualScalarArray } = await import('../src/normalize/noise.js');
+    // declared typed ports vs AWS stringly form, same order
+    expect(isStringlyEqualScalarArray([80, 443], ['80', '443'])).toBe(true);
+    expect(isStringlyEqualScalarArray(['80', '443'], [80, 443])).toBe(true);
+    expect(isStringlyEqualScalarArray([true, false], ['true', 'false'])).toBe(true);
+    // R67 numeric formatting carries through element-wise
+    expect(isStringlyEqualScalarArray([5, 40], ['5.0', '40.00'])).toBe(true);
+    // identical arrays (strict) still fold
+    expect(isStringlyEqualScalarArray(['a', 'b'], ['a', 'b'])).toBe(true);
+    // a genuine element change still differs
+    expect(isStringlyEqualScalarArray([80, 443], ['80', '8443'])).toBe(false);
+    // length change is real drift
+    expect(isStringlyEqualScalarArray([80], [80, 443])).toBe(false);
+    // ORDER matters (unordered sets are handled separately by UNORDERED_ARRAY_PROPS)
+    expect(isStringlyEqualScalarArray([80, 443], ['443', '80'])).toBe(false);
+    // never collapses object/nested arrays (those have their own canonicalizers)
+    expect(isStringlyEqualScalarArray([{ a: 1 }], ['[object Object]'])).toBe(false);
+    expect(isStringlyEqualScalarArray([[1]], [['1']])).toBe(false);
+    // non-arrays
+    expect(isStringlyEqualScalarArray(80, '80')).toBe(false);
+  });
+
   it('isAllAwsTags: every element an aws:* {Key,Value}', () => {
     expect(isAllAwsTags([{ Key: 'aws:cloudformation:stack-id', Value: 'x' }])).toBe(true);
     expect(

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -524,6 +524,41 @@ describe('SDK overrides', () => {
         await SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'missing'))
       ).toBeUndefined();
     });
+
+    it('follows nextToken to find an exact filter paginated past the first page', async () => {
+      // The exact-named "errs" filter is a prefix of "errs-extra"/"errs-more", so it
+      // can land on a later page. Page 1 has only prefix-siblings + a nextToken.
+      logs
+        .on(DescribeMetricFiltersCommand)
+        .resolvesOnce({
+          metricFilters: [{ filterName: 'errs-extra' }, { filterName: 'errs-more' }],
+          nextToken: 'page2',
+        })
+        .resolvesOnce({
+          metricFilters: [
+            { filterName: 'errs', filterPattern: 'ERROR', metricTransformations: [] },
+          ],
+        });
+      const out = await SDK_OVERRIDES['AWS::Logs::MetricFilter'](
+        ctx({ LogGroupName: '/aws/lambda/fn' }, 'errs')
+      );
+      expect(out).toEqual({
+        LogGroupName: '/aws/lambda/fn',
+        FilterName: 'errs',
+        FilterPattern: 'ERROR',
+        MetricTransformations: [],
+      });
+    });
+
+    it('stops at the last page (no nextToken) and returns undefined if never found', async () => {
+      logs
+        .on(DescribeMetricFiltersCommand)
+        .resolvesOnce({ metricFilters: [{ filterName: 'errs-extra' }], nextToken: 'page2' })
+        .resolvesOnce({ metricFilters: [{ filterName: 'errs-more' }] });
+      expect(
+        await SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'errs'))
+      ).toBeUndefined();
+    });
   });
 
   describe('Scheduler Schedule (R74)', () => {


### PR DESCRIPTION
## What

Two real bugs from the pre-release bug-hunt tail — one false POSITIVE, one false
NEGATIVE. The other two tail candidates were investigated and RULED OUT (bottom).

### 1. FP — stringly-typed scalar ARRAY reports false drift (R23)

CFn has stringly-typed list fields: CDK emits `[80, 443]` / `[true, false]` while
AWS echoes `["80", "443"]` / `["true", "false"]`. The per-leaf
`isStringlyEqualScalar` already collapses a single typed<->string scalar, but the
drift-calculator reports a scalar-ARRAY mismatch as ONE parent-path record carrying
the WHOLE array — so the elements were never compared and the array reported as
declared drift. This was a documented KNOWN LIMITATION ("revisit only if a real
fixture hits it").

Fix: `isStringlyEqualScalarArray` (in `normalize/noise.ts`) applies the same
typed<->string collapse element-wise; classify consults it right after the per-leaf
scalar check. Positional (order-sensitive — unordered sets stay handled by
`UNORDERED_ARRAY_PROPS`), equal-length + all-scalars required. A genuine element
change (`[80, 443]` vs `["80", "8443"]`) or length change still reports. Fail-safe:
it can only SUPPRESS noise where values are semantically equal, never hide a real
change.

### 2. FN — MetricFilter read misses a filter paginated past page 1

`readMetricFilter` called `DescribeMetricFilters` with `filterNamePrefix: <name>`
and `.find`-ed the exact match on the FIRST page only. When the name is also a
prefix of other filters (`errs`, `errs-extra`, `errs-more`), the exact-named one
can land on a later page — and the reader then returns `undefined`, misreading a
PRESENT filter as deleted.

Fix: follow `nextToken` until the exact filter is found (or pages exhausted). Purely
additive — the projected shape is unchanged, so there is no FP risk; it only stops a
present filter from being missed.

## Tests

- `noise-and-strip.test.ts`: `isStringlyEqualScalarArray` — typed<->string folds
  (incl. R67 numeric formatting element-wise), order matters, length/element changes
  and object/nested arrays do not fold.
- `classify.test.ts`: end-to-end — declared `[80,443]` vs live `["80","443"]` yields
  NO declared drift; `["80","8443"]` still does.
- `overrides.test.ts`: MetricFilter follows `nextToken` to find a paginated exact
  filter; stops at the last page and returns undefined when never found.

## Verification

- typecheck / lint+format / build / **999 unit tests (38 files)** green — incl. the
  286-case corpus replay (no existing classification changed → the R23 suppression is
  FP/FN-safe across the recorded corpus).
- **Live (real AWS):** the `harvest` integ fixture (deploys an `AWS::Logs::MetricFilter`
  among other types) printed `INTEG PASS` / `result: CLEAN` on the changed reader; the
  stack was destroyed and an orphan sweep came back `SWEEP CLEAN`.
- The full 50-fixture release sweep was NOT run (this is a per-PR change; `/verify-pr`
  is the pre-RELEASE gate). The targeted fixture covering the changed reader + the
  corpus covering the R23 classify change are the relevant coverage.

## Ruled out (not bugs)

- **Scheduler Tags**: `AWS::Scheduler::Schedule` has NO `Tags` property in its CFn
  schema (tags live on `AWS::Scheduler::ScheduleGroup`) — nothing for the reader to
  project.
- **Secrets Manager partial-ARN FP**: requires a user to hard-code a suffix-less secret
  ARN; CDK references resolve to the full ARN (with the 6-char suffix) that matches
  live. No concrete repro — left as-is.
