### PR TITLE
fix(normalize,baseline,revert): Fn::Sub non-scalar leak FP + nested baseline double-report FP + added-delete NotFound tolerance

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -458,11 +458,31 @@ export function applyBaseline(
   const deletedLogical = new Set(
     findings.filter((f) => f.tier === 'deleted').map((f) => f.logicalId)
   );
+  // A recorded nested undeclared value whose DECLARED parent property is itself
+  // drifting this run is subsumed by that `declared` finding: the parent array/object
+  // changed (e.g. CloudFront `DistributionConfig.Origins` -> []), so the nested value's
+  // disappearance is the SAME real change, not a separate "baseline value removed".
+  // Emitting both double-counts the drift and yields an un-actionable revert op against
+  // a nested path that no longer exists — the exact class already suppressed for
+  // `deleted`/`skipped`. Suppress when a current `declared` finding's path is a prefix
+  // of the recorded path (so a sibling NOT under the drifting parent still surfaces).
+  const declaredDriftByLogical = new Map<string, string[]>();
+  for (const f of findings) {
+    if (f.tier !== 'declared') continue;
+    const arr = declaredDriftByLogical.get(f.logicalId) ?? [];
+    arr.push(f.path);
+    declaredDriftByLogical.set(f.logicalId, arr);
+  }
+  const underDeclaredDrift = (logicalId: string, path: string): boolean =>
+    (declaredDriftByLogical.get(logicalId) ?? []).some(
+      (p) => path === p || path.startsWith(`${p}.`) || path.startsWith(`${p}[`)
+    );
   const promotedStale: string[] = [];
   for (const a of recorded) {
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;
     if (skippedLogical.has(a.logicalId)) continue; // unread this run -> not "removed"
     if (deletedLogical.has(a.logicalId)) continue; // subsumed by the `deleted` finding
+    if (underDeclaredDrift(a.logicalId, a.path)) continue; // subsumed by parent declared drift
     // promoted into the template since record → not a removal, just stale baseline
     if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
       promotedStale.push(`${a.logicalId}.${a.path}`);

--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -247,14 +247,20 @@ export function resolveSub(v: unknown, ctx: ResolverContext): unknown {
       // ${LogicalId.Attr} GetAtt form — resolve against live attributes.
       const dot = ref.indexOf('.');
       const r = resolveGetAtt([ref.slice(0, dot), ref.slice(dot + 1)], ctx);
-      if (r === UNRESOLVED || r === NOVALUE) {
+      // A non-scalar resolution can't be interpolated: an object GetAtt attribute
+      // (`${DB.Endpoint}` = {Address,Port}) would leak `[object Object]`, an array
+      // (a `CommaDelimitedList` Ref / `Fn::Split` value) the JS comma-join — either a
+      // bogus declared value the diff then reports as drift on a clean stack. Fail
+      // closed, mirroring the `vars` branch above (isScalarInterpolant is also false
+      // for the UNRESOLVED / NOVALUE symbols, so it subsumes that earlier check).
+      if (!isScalarInterpolant(r)) {
         unresolved = true;
         return '';
       }
       return String(r);
     }
     const r = resolveRef(ref, ctx);
-    if (r === UNRESOLVED || r === NOVALUE) {
+    if (!isScalarInterpolant(r)) {
       unresolved = true;
       return '';
     }

--- a/src/revert/apply.ts
+++ b/src/revert/apply.ts
@@ -18,6 +18,22 @@ export interface ApplyResult {
 const POLL_INTERVAL_MS = 2000;
 const TIMEOUT_MS = 5 * 60 * 1000;
 
+// A DELETE whose target is ALREADY absent is the goal state, not a failure. Two ways
+// this happens for an `added`-resource revert: (1) deleting an API Gateway Resource
+// CASCADE-deletes its child Resources/Methods — and each added child is an independent
+// finding applied in unspecified order, so a later DeleteResource on a child can race
+// the cascade; (2) the user removed it between `check` and `revert`. Cloud Control
+// surfaces an absent target as ResourceNotFoundException (thrown) or a FAILED event
+// whose message says not-found. Treat both as success so a revert that REACHES the
+// goal state isn't reported as FAILED (which would also wrongly bump the exit code).
+export function isAlreadyGone(e: unknown): boolean {
+  const o = (e ?? {}) as { name?: unknown; message?: unknown };
+  const name = typeof o.name === 'string' ? o.name : '';
+  if (name === 'ResourceNotFoundException' || name === 'NotFoundException') return true;
+  const m = (typeof o.message === 'string' ? o.message : '').toLowerCase();
+  return m.includes('not found') || m.includes('does not exist') || m.includes('notfound');
+}
+
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // Poll a Cloud Control ProgressEvent (Update or Delete) to a terminal state.
@@ -77,8 +93,13 @@ export async function applyRevertDelete(
     const res = await cc.send(
       new DeleteResourceCommand({ TypeName: item.resourceType, Identifier: identifier })
     );
-    return await pollToCompletion(cc, res.ProgressEvent);
+    const result = await pollToCompletion(cc, res.ProgressEvent);
+    // already-gone surfaced as a FAILED event (vs a thrown error, handled below)
+    if (!result.ok && isAlreadyGone({ message: result.error })) return { ok: true };
+    return result;
   } catch (e) {
-    return { ok: false, error: (e as Error).message };
+    const err = e as { name?: string; message?: string };
+    if (isAlreadyGone(err)) return { ok: true };
+    return { ok: false, error: err.message ?? String(e) };
   }
 }

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -1,0 +1,54 @@
+import { CloudControlClient, DeleteResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { applyRevertDelete, isAlreadyGone } from '../src/revert/apply.js';
+import type { RevertItem } from '../src/revert/plan.js';
+
+const cc = mockClient(CloudControlClient);
+beforeEach(() => cc.reset());
+
+const deleteItem = (): RevertItem => ({
+  logicalId: 'Child',
+  displayId: 'Api ▸ ANY /a',
+  resourceType: 'AWS::ApiGateway::Method',
+  physicalId: 'api123|res456|ANY',
+  kind: 'delete',
+  ops: [],
+});
+
+describe('isAlreadyGone', () => {
+  it('true for not-found error names', () => {
+    expect(isAlreadyGone({ name: 'ResourceNotFoundException' })).toBe(true);
+    expect(isAlreadyGone({ name: 'NotFoundException' })).toBe(true);
+  });
+  it('true for not-found messages (case-insensitive, various phrasings)', () => {
+    expect(isAlreadyGone({ message: 'Resource was not found' })).toBe(true);
+    expect(isAlreadyGone({ message: 'The resource does not exist' })).toBe(true);
+    expect(isAlreadyGone({ message: 'NotFound' })).toBe(true);
+  });
+  it('false for unrelated errors', () => {
+    expect(isAlreadyGone({ name: 'AccessDeniedException', message: 'not authorized' })).toBe(false);
+    expect(isAlreadyGone({})).toBe(false);
+    expect(isAlreadyGone({ message: 'throttled' })).toBe(false);
+  });
+});
+
+describe('applyRevertDelete — already-gone tolerance', () => {
+  it('treats a thrown ResourceNotFoundException as SUCCESS (cascade/manual delete race)', async () => {
+    const e = new Error('Resource of type AWS::ApiGateway::Method with id ... was not found');
+    e.name = 'ResourceNotFoundException';
+    cc.on(DeleteResourceCommand).rejects(e);
+    expect(await applyRevertDelete(cc as unknown as CloudControlClient, deleteItem())).toEqual({
+      ok: true,
+    });
+  });
+
+  it('still FAILS on a genuine error', async () => {
+    const e = new Error('not authorized to perform cloudcontrolapi:DeleteResource');
+    e.name = 'AccessDeniedException';
+    cc.on(DeleteResourceCommand).rejects(e);
+    const r = await applyRevertDelete(cc as unknown as CloudControlClient, deleteItem());
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('not authorized');
+  });
+});

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -535,6 +535,52 @@ describe('baseline', () => {
     expect(out).toEqual([deleted]);
   });
 
+  it('does NOT double-report a recorded nested value whose DECLARED parent is drifting', () => {
+    // The declared array `Origins` drifted out of band (e.g. -> []). The recorded
+    // nested undeclared value `Origins[o1].ConnectionAttempts` is gone BECAUSE the
+    // parent changed — subsumed by the single `declared` Origins finding. It must NOT
+    // also surface as a separate "baseline value removed" undeclared finding (double-
+    // count + an un-actionable revert op against a now-gone nested path). A recorded
+    // SIBLING not under the drifting parent still surfaces (precision guard).
+    const b = baseline([
+      {
+        logicalId: 'D',
+        resourceType: 'AWS::CloudFront::Distribution',
+        path: 'Origins[o1].ConnectionAttempts',
+        value: 5,
+      },
+      {
+        logicalId: 'D',
+        resourceType: 'AWS::CloudFront::Distribution',
+        path: 'Comment',
+        value: 'x',
+      },
+    ]);
+    const declaredOrigins: Finding = {
+      tier: 'declared',
+      logicalId: 'D',
+      resourceType: 'AWS::CloudFront::Distribution',
+      path: 'Origins',
+      desired: [{ id: 'o1' }],
+      actual: [],
+    };
+    const out = applyBaseline([declaredOrigins], b);
+    // the nested value UNDER the drifting Origins is suppressed
+    expect(
+      out.some(
+        (f) =>
+          f.path === 'Origins[o1].ConnectionAttempts' &&
+          f.note === 'baseline value removed since record'
+      )
+    ).toBe(false);
+    // the unrelated sibling (not under any declared drift) still surfaces as removed
+    expect(
+      out.some((f) => f.path === 'Comment' && f.note === 'baseline value removed since record')
+    ).toBe(true);
+    // the declared Origins finding passes through untouched
+    expect(out.some((f) => f.tier === 'declared' && f.path === 'Origins')).toBe(true);
+  });
+
   it('does NOT report a removal when the recorded path was promoted into the template', () => {
     const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
     const warnings: string[] = [];

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -86,6 +86,25 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::Sub': ['x-${V}', { V: 'ok' }] }, ctx())).toBe('x-ok');
   });
 
+  // The DOTTED-GetAtt and plain-Ref branches of Fn::Sub must fail closed on a
+  // non-scalar exactly like the variable-map branch above — previously they only
+  // guarded UNRESOLVED/NOVALUE and leaked `[object Object]` for an object GetAtt
+  // attribute or the JS comma-join for an array Ref, producing a bogus declared
+  // value that the diff then reported as drift on a clean stack.
+  it('Fn::Sub GetAtt/Ref branches fail closed on a non-scalar resolution', () => {
+    const c = ctx({
+      params: { Env: 'prod', SubnetList: ['subnet-a', 'subnet-b'] }, // CommaDelimitedList
+      liveAttrs: { DB: { Endpoint: { Address: 'db.host', Port: 5432 }, Address: 'db.host' } },
+    });
+    // object GetAtt attribute -> UNRESOLVED (was "[object Object]")
+    expect(resolve({ 'Fn::Sub': 'e=${DB.Endpoint}' }, c)).toBe(UNRESOLVED);
+    // array Ref (a CommaDelimitedList parameter) -> UNRESOLVED (was "subnet-a,subnet-b")
+    expect(resolve({ 'Fn::Sub': 'sn-${SubnetList}' }, c)).toBe(UNRESOLVED);
+    // scalar interpolants still resolve (regression guard)
+    expect(resolve({ 'Fn::Sub': 'env-${Env}' }, c)).toBe('env-prod');
+    expect(resolve({ 'Fn::Sub': 'h=${DB.Address}' }, c)).toBe('h=db.host');
+  });
+
   it('Fn::GetAtt resolves against live attributes (incl. dotted path), else UNRESOLVED', () => {
     const c = ctx({
       liveAttrs: { Role: { Arn: 'arn:aws:iam::123:role/r' }, Db: { Endpoint: { Address: 'h' } } },


### PR DESCRIPTION
## What

Three drift-accuracy bugs surfaced by a fresh multi-agent bug-hunt round — two
false POSITIVES and one revert robustness gap. All are corpus-guarded / unit-tested
pure-function or mock-tested changes (no gather-time reader projection change).

### 1. FP — `Fn::Sub` leaks a non-scalar interpolant (`normalize/intrinsic-resolver.ts`)

`resolveSub`'s variable-map branch already fails closed via `isScalarInterpolant`,
but the **dotted-GetAtt** and **plain-Ref** branches only guarded `UNRESOLVED`/`NOVALUE`
and then `String(r)`-ed. So an OBJECT GetAtt attribute (`${DB.Endpoint}` = `{Address,Port}`)
leaked `"[object Object]"`, and an ARRAY Ref (a `CommaDelimitedList` parameter) leaked
the JS comma-join — a bogus DECLARED value the diff then reported as drift on a clean
stack (and, in the array case, a latent FN where the comma-join coincidentally equals a
live value). Both branches now use the same `!isScalarInterpolant(r)` guard (it subsumes
the `UNRESOLVED`/`NOVALUE` check).

### 2. FP — recorded nested value double-reports when its declared parent drifts (`baseline/baseline-file.ts`)

`applyBaseline` already subsumes recorded values under a `deleted`/`skipped` resource.
But a recorded nested undeclared value (e.g. `DistributionConfig.Origins[o1].ConnectionAttempts`)
whose **declared** parent array (`Origins`) drifts out of band (e.g. → `[]`) fell through
to a separate "baseline value removed since record" finding — double-counting the one
real change and producing an un-actionable revert op against a now-gone nested path. Now
suppressed when a current `declared` finding's path is a prefix of the recorded path; a
recorded sibling NOT under the drifting parent still surfaces (precision guard).

### 3. Robustness — `applyRevertDelete` reports an already-gone target as FAILED (`revert/apply.ts`)

Reverting an out-of-band `added` API Gateway subtree deletes each child as an independent
finding in unspecified order; deleting a parent Resource CASCADE-deletes its children, so
a later `DeleteResource` on a child races the cascade and threw `ResourceNotFoundException`
→ printed `FAILED` and bumped the exit code, even though the goal state (resource absent)
was reached. Now an already-gone target (thrown not-found OR a not-found FAILED event) is
treated as SUCCESS — also covering the user removing it between `check` and `revert`.

## Tests (+7)

- `intrinsic-resolver.test.ts`: Fn::Sub GetAtt/Ref branches → `UNRESOLVED` on object
  GetAtt + array Ref; scalar interpolants still resolve.
- `baseline.test.ts`: nested value under a drifting declared parent is suppressed; an
  unrelated sibling still surfaces as removed; the declared finding passes through.
- `apply.test.ts` (new): `isAlreadyGone` name/message matrix; `applyRevertDelete` returns
  `ok` on a thrown `ResourceNotFoundException`, still fails on a genuine error.

## Verification

- typecheck / lint+format / build / **1006 unit tests (39 files)** green — incl. the
  286-case corpus replay (no existing classification changed → the Fn::Sub + baseline
  changes are FP/FN-safe across the recorded corpus).
- No gather-time reader projection change → no new live-AWS FP surface; classification is
  corpus-covered and the revert change is mock-covered, so no live integ is warranted for
  this PR (per-PR change; `/verify-pr` is the pre-RELEASE gate).
