### PR TITLE
fix(read): project CodeBuild Project.Cache (FN) + fold NO_CACHE default

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -148,6 +148,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     TimeoutInMinutes: 60,
     QueuedTimeoutInMinutes: 480,
     Visibility: 'PRIVATE', // the default; folds to atDefault so a never-declared project is not first-run noise — flipping to PUBLIC_READ no longer matches and surfaces
+    Cache: { Type: 'NO_CACHE' }, // BatchGetProjects always returns cache; the unconfigured default folds to atDefault so a never-declared cache is not first-run noise — switching to S3/LOCAL no longer matches and surfaces
   },
   'AWS::DynamoDB::Table': {
     BillingMode: 'PROVISIONED',

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -598,6 +598,20 @@ const readCodeBuildProject: OverrideReader = async ({ physicalId, declared, regi
       ...(vpc.subnets !== undefined && { Subnets: vpc.subnets }),
       ...(vpc.securityGroupIds !== undefined && { SecurityGroupIds: vpc.securityGroupIds }),
     };
+  // Cache — was omitted, so an out-of-band switch to/from S3 caching (a cost + a
+  // cross-project cache-sharing surface) was undetectable. BatchGetProjects ALWAYS
+  // returns cache (default `{type:'NO_CACHE'}`), so the never-configured case is
+  // folded to atDefault via KNOWN_DEFAULTS (`Cache: {Type:'NO_CACHE'}`); a declared
+  // S3/LOCAL cache projects its real shape and matches the template. Modes/Location
+  // are projected only when present so the NO_CACHE default is exactly `{Type:'NO_CACHE'}`
+  // (else it would not fold). A declared cache change still surfaces.
+  const cache = p.cache;
+  if (cache)
+    model.Cache = {
+      ...(cache.type !== undefined && { Type: cache.type }),
+      ...(cache.location !== undefined && { Location: cache.location }),
+      ...(cache.modes?.length && { Modes: cache.modes }),
+    };
   return model;
 };
 

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -20,6 +20,7 @@ import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
 
 const s3 = mockClient(S3Client);
 const sns = mockClient(SNSClient);
@@ -731,6 +732,49 @@ describe('SDK overrides', () => {
       // the reader faithfully projects false; the noise layer's isTrivialEmpty drops a
       // never-enabled badge so it is not first-run undeclared noise
       expect(out.BadgeEnabled).toBe(false);
+    });
+
+    it('projects Cache — an out-of-band cache change is no longer invisible; NO_CACHE default folds via KNOWN_DEFAULTS', async () => {
+      // a declared S3 cache projects its real shape (matches the template)
+      codebuild.on(BatchGetProjectsCommand).resolves({
+        projects: [
+          {
+            name: 'p',
+            source: { type: 'NO_SOURCE' },
+            artifacts: { type: 'NO_ARTIFACTS' },
+            cache: { type: 'S3', location: 'bkt/cache', modes: ['LOCAL_SOURCE_CACHE'] },
+          },
+        ],
+      });
+      const s3 = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+        string,
+        unknown
+      >;
+      expect(s3.Cache).toEqual({
+        Type: 'S3',
+        Location: 'bkt/cache',
+        Modes: ['LOCAL_SOURCE_CACHE'],
+      });
+
+      // the always-present NO_CACHE default projects exactly {Type:'NO_CACHE'} so it
+      // folds to atDefault via KNOWN_DEFAULTS (no Location/Modes leak)
+      codebuild.reset();
+      codebuild.on(BatchGetProjectsCommand).resolves({
+        projects: [
+          {
+            name: 'p',
+            source: { type: 'NO_SOURCE' },
+            artifacts: { type: 'NO_ARTIFACTS' },
+            cache: { type: 'NO_CACHE' },
+          },
+        ],
+      });
+      const none = (await SDK_OVERRIDES['AWS::CodeBuild::Project'](ctx({}, 'p'))) as Record<
+        string,
+        unknown
+      >;
+      expect(none.Cache).toEqual({ Type: 'NO_CACHE' });
+      expect(KNOWN_DEFAULTS['AWS::CodeBuild::Project'].Cache).toEqual({ Type: 'NO_CACHE' });
     });
 
     it('undefined when the project is absent (-> stays skipped)', async () => {


### PR DESCRIPTION
## What

`readCodeBuildProject` omitted the `Cache` property from its projection, so an
out-of-band CodeBuild cache change — switching to/from S3 caching (a cost surface)
or sharing a cache across projects — was undetectable: a declared cache became a
benign `readGap`, an undeclared one was invisible.

Fix: project `Cache` (`{Type, Location?, Modes?}`) from `BatchGetProjects`.
`BatchGetProjects` ALWAYS returns `cache` (default `{type:'NO_CACHE'}`), so the
never-configured case is folded to `atDefault` via a new `KNOWN_DEFAULTS` entry
`Cache: {Type:'NO_CACHE'}`. `Location`/`Modes` are projected only when present so
the NO_CACHE default is exactly `{Type:'NO_CACHE'}` (else it would not fold). A
declared S3/LOCAL cache projects its real shape and matches the template; a genuine
cache change still surfaces.

## Tests

- `overrides.test.ts`: a declared S3 cache projects `{Type,Location,Modes}`; the
  `NO_CACHE` default projects exactly `{Type:'NO_CACHE'}` and the `KNOWN_DEFAULTS`
  entry matches it (folds to atDefault).

## Verification

- typecheck / lint+format / build / **1027 unit tests (39 files)** + 286-corpus green.
- **LIVE (real AWS)** — `harvest` fixture (deploys a CodeBuild Project that declares
  `Cache`): `INTEG PASS`, `result: CLEAN`, and the **`Build.Cache` readGap RESOLVED**
  (readGap count 3 → 2; the declared cache is now verifiable, not an unverifiable gap)
  with **no new false drift** across the fixture's ~26 types. Stack destroyed; orphan
  sweep `SWEEP CLEAN`.

## Scope note

A multi-agent bug-hunt also flagged MetricFilter (`ApplyOnTransformedLogs` /
`FieldSelectionCriteria` / `EmitSystemFieldDimensions`) and Route53
(`CidrRoutingConfig` / `GeoProximityLocation`) projection FNs — both **dropped after
verifying those fields do not exist in the installed SDK response types** (so they're
not readable; not an FN). Budgets `PlannedBudgetLimits`/`AutoAdjustData` deferred
pending its own live FP check. This PR ships only the one SDK-verified, live-proven
projection.
