### PR TITLE
fix(diff): detect a live-only sub-key added to a declared IAM policy statement (FN)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -71,6 +71,33 @@ const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
 // Pure: the caller decides suppression and finding shape.
 const isNestedObject = (x: unknown): x is Record<string, unknown> =>
   x !== null && typeof x === 'object' && !Array.isArray(x);
+
+// An IAM policy STATEMENT array (PolicyDocument.Statement, AssumeRolePolicyDocument
+// .Statement, inline Policies[].PolicyDocument.Statement, …). Recognized by the
+// `Effect` (Allow/Deny) key every statement carries — NOT by path, so it catches
+// statements at any depth. Statements are identity-LESS (no Key/Id/AttributeName/
+// IndexName), so the identity-keyed descent below skips them; this marker re-enables
+// a SAFE (subset-match) descent for exactly this shape, leaving other identity-less
+// arrays (SecurityGroup rules etc.) untouched.
+const isPolicyStatementArray = (arr: unknown[]): boolean =>
+  arr.length > 0 && arr.every((el) => isNestedObject(el) && 'Effect' in el);
+
+// True when every key of `sub` is present in `sup` with an equal value (objects
+// recurse so a nested declared block must also be a subset; everything else is
+// deep-equal). Used to align a declared policy statement to the live statement it is
+// a subset of — robust to the statement re-sort canonicalization applies once a
+// sub-key is added (so positional alignment would break) and to extra live-only keys.
+function isPolicySubsetOf(sub: Record<string, unknown>, sup: Record<string, unknown>): boolean {
+  for (const [k, v] of Object.entries(sub)) {
+    if (!(k in sup)) return false;
+    const sv = sup[k];
+    if (isNestedObject(v) && isNestedObject(sv)) {
+      if (!isPolicySubsetOf(v, sv)) return false;
+    } else if (!deepEqual(v, sv)) return false;
+  }
+  return true;
+}
+
 function collectNestedUndeclared(
   declaredVal: unknown,
   liveVal: unknown,
@@ -80,13 +107,39 @@ function collectNestedUndeclared(
   if (Array.isArray(declaredVal) && Array.isArray(liveVal)) {
     if (declaredVal.length === 0 || liveVal.length === 0) return;
     const idf = identityField(declaredVal);
-    if (!idf || identityField(liveVal) !== idf) return;
-    const liveById = new Map<string, Record<string, unknown>>();
-    for (const el of liveVal) if (isNestedObject(el)) liveById.set(String(el[idf]), el);
-    for (const dEl of declaredVal) {
-      if (!isNestedObject(dEl)) continue;
-      const match = liveById.get(String(dEl[idf]));
-      if (match) collectNestedUndeclared(dEl, match, `${path}[${String(dEl[idf])}]`, emit);
+    if (idf && identityField(liveVal) === idf) {
+      const liveById = new Map<string, Record<string, unknown>>();
+      for (const el of liveVal) if (isNestedObject(el)) liveById.set(String(el[idf]), el);
+      for (const dEl of declaredVal) {
+        if (!isNestedObject(dEl)) continue;
+        const match = liveById.get(String(dEl[idf]));
+        if (match) collectNestedUndeclared(dEl, match, `${path}[${String(dEl[idf])}]`, emit);
+      }
+      return;
+    }
+    // IAM policy STATEMENT arrays are identity-less, so the descent above is skipped —
+    // which hid a live-only sub-key ADDED to a declared statement out of band (e.g. a
+    // `Condition` narrowing/widening access, or an extra `Principal`): the product's
+    // core "a setting you never declared changed" promise failing on a security-
+    // relevant resource. Re-enable the descent for THIS shape only, aligning each
+    // declared statement to the live statement it is a SUBSET of (content match,
+    // greedy 1:1) so the live-only sub-keys surface. A declared statement with no
+    // superset match genuinely changed → left to the declared compare. Other identity-
+    // less arrays stay undescended (no `Effect` marker), preserving their FP safety.
+    if (isPolicyStatementArray(declaredVal) && isPolicyStatementArray(liveVal)) {
+      const used = new Set<number>();
+      declaredVal.forEach((dEl, di) => {
+        if (!isNestedObject(dEl)) return;
+        for (let i = 0; i < liveVal.length; i++) {
+          if (used.has(i)) continue;
+          const lEl = liveVal[i];
+          if (isNestedObject(lEl) && isPolicySubsetOf(dEl, lEl)) {
+            used.add(i);
+            collectNestedUndeclared(dEl, lEl, `${path}[${di}]`, emit);
+            break;
+          }
+        }
+      });
     }
     return;
   }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1650,3 +1650,113 @@ describe('normalizeLiveModel (PR4 — the shared live-model normalizer used for 
     expect(input).toEqual({ AuthorizationType: 'NONE', MethodId: 'x' });
   });
 });
+
+// A live-only sub-key ADDED to a declared IAM policy STATEMENT out of band (e.g. a
+// Condition) was invisible: statements are identity-less, so the nested-undeclared
+// descent skipped them. Now an Effect-marked statement array is descended via a
+// subset match — catching the sub-key while leaving other identity-less arrays
+// (SecurityGroup rules) untouched.
+describe('nested undeclared on IAM policy statements (identity-less subset descent)', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const policyRes = (statements: unknown[]): DesiredResource => ({
+    logicalId: 'P',
+    resourceType: 'AWS::IAM::ManagedPolicy',
+    physicalId: 'p',
+    declared: { PolicyDocument: { Version: '2012-10-17', Statement: statements } },
+  });
+
+  it('detects a Condition added out of band to a declared statement (the FN this fixes)', () => {
+    const res = policyRes([{ Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:b' }]);
+    const live = {
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: 's3:GetObject',
+            Resource: 'arn:b',
+            Condition: { Bool: { 'aws:SecureTransport': 'false' } }, // added out of band
+          },
+        ],
+      },
+    };
+    const t = tiers(classifyResource(res, live, emptySchema));
+    expect(t.undeclared).toContain('PolicyDocument.Statement[0].Condition');
+  });
+
+  it('CLEAN when the live policy equals the declared policy (no false nested undeclared)', () => {
+    const stmt = { Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:b' };
+    const t = tiers(
+      classifyResource(
+        policyRes([stmt]),
+        { PolicyDocument: { Version: '2012-10-17', Statement: [{ ...stmt }] } },
+        emptySchema
+      )
+    );
+    expect(t.undeclared).toEqual([]);
+    expect(t.declared).toEqual([]);
+  });
+
+  it('subset-match survives the statement re-sort: detects the added key on the right statement', () => {
+    const res = policyRes([
+      { Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:a' },
+      { Effect: 'Allow', Action: 's3:PutObject', Resource: 'arn:b' },
+    ]);
+    // the put-object statement gains a Condition live; canonicalization re-sorts
+    // statements by content, so positional alignment would misfire — subset match must
+    // still pin the Condition to the put-object statement and leave the other clean.
+    const live = {
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Action: 's3:PutObject',
+            Resource: 'arn:b',
+            Condition: { StringEquals: { 'aws:username': 'x' } },
+          },
+          { Effect: 'Allow', Action: 's3:GetObject', Resource: 'arn:a' },
+        ],
+      },
+    };
+    const t = tiers(classifyResource(res, live, emptySchema));
+    expect(t.undeclared.filter((p) => p.endsWith('.Condition'))).toHaveLength(1);
+    expect(t.undeclared.some((p) => p.endsWith('.Condition'))).toBe(true);
+    expect(t.declared).toEqual([]); // no false declared drift on the reordered clean statement
+  });
+
+  it('FP-safe: an identity-less array WITHOUT an Effect marker (SecurityGroup-rule shape) is NOT descended', () => {
+    const res: DesiredResource = {
+      logicalId: 'SG',
+      resourceType: 'AWS::EC2::SecurityGroup',
+      physicalId: 'sg',
+      declared: {
+        SecurityGroupIngress: [
+          { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+        ],
+      },
+    };
+    const live = {
+      SecurityGroupIngress: [
+        {
+          IpProtocol: 'tcp',
+          FromPort: 443,
+          ToPort: 443,
+          CidrIp: '0.0.0.0/0',
+          Description: 'added',
+        },
+      ],
+    };
+    const t = tiers(classifyResource(res, live, emptySchema));
+    expect(t.undeclared.some((p) => p.includes('Description'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

An out-of-band sub-key ADDED to a **declared IAM policy statement** — e.g. a
`Condition` that narrows or widens access, or an extra `Principal` — was
**invisible**. This is exactly the "a setting you never declared changed" promise
that is cdkrd's differentiator, failing on a security-relevant resource.

Root cause: `collectNestedUndeclared` aligns object-array elements **by identity**
(`Key`/`Id`/`AttributeName`/`IndexName`) to find live-only sub-keys, and skips
**identity-less** arrays entirely (they can't be matched reliably — a deliberate
FP-avoidance for SecurityGroup rules). IAM policy `Statement` arrays are
identity-less, so the descent skipped them and a live-only sub-key inside a declared
statement was never emitted. (The declared compare also misses it — it walks only
declared keys, subset semantics.)

Fix: re-enable the descent for the policy-statement shape ONLY. A statement array is
recognized by the `Effect` (Allow/Deny) key every statement carries (NOT by path, so
it works at any depth — `PolicyDocument`, `AssumeRolePolicyDocument`, inline
`Policies[].PolicyDocument`). Each declared statement is aligned to the live
statement it is a **subset of** (content match, greedy 1:1) — robust to the
statement re-sort canonicalization applies once a sub-key changes the sort key — and
the live-only sub-keys surface as `undeclared` (`PolicyDocument.Statement[i].…`).
Other identity-less arrays (SecurityGroup rules) have no `Effect` marker and stay
**undescended**, preserving their FP safety.

## Tests (+4)

- detects a `Condition` added out of band to a declared statement (the FN);
- CLEAN when live == declared (no false nested undeclared);
- subset-match survives the statement re-sort in a multi-statement policy (pins the
  added key to the right statement, no false declared drift on the reordered one);
- FP-safe: an identity-less SecurityGroup-rule-shaped array is NOT descended.

## Verification

- typecheck / lint+format / build / **1031 unit tests (39 files)** + 286-corpus green
  (no existing classification changed → FP/FN-safe across the recorded corpus, which
  includes IAM/bucket/topic/queue/KMS policies and SG rules).
- **LIVE (real AWS)** — the `policies` fixture (deploys 5 real policy types:
  S3/SNS/SQS bucket/topic/queue + IAM inline + IAM managed): `INTEG PASS`, **`check
  CLEAN` after record** — my sub-key descent introduces **no false drift** on any of
  the 5 types — and the existing whole-statement detection + revert still work. Stack
  destroyed; orphan sweep `SWEEP CLEAN`.
