### PR TITLE
fix(report): word the added-resource UX as "not-recorded", not "undeclared"

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -65,7 +65,10 @@ export function postRecordNote(remainingUndeclared: number, remainingDeclared: n
       remainingUndeclared > 0
         ? ` ${remainingUndeclared} unrecorded value(s) also stay reported.`
         : '';
-    return `record succeeded, but ${remainingDeclared} declared/deleted/added drift(s) remain un-addressed (fix the code or choose Revert).${alsoUndeclared}`;
+    // resolutions span the tiers: declared → fix the code / revert / ignore; deleted →
+    // cdk deploy; a changed-since-record added resource → re-record (accept) / revert /
+    // ignore. "fix the code, or revert / ignore them" covers all without listing each.
+    return `record succeeded, but ${remainingDeclared} declared/deleted/added drift(s) remain un-addressed (fix the code, or revert / ignore them).${alsoUndeclared}`;
   }
   if (remainingUndeclared > 0)
     return `record succeeded — ${remainingUndeclared} unrecorded value(s) stay reported from the next check on.`;

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -257,7 +257,7 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // R114: when DRIFT and standout UNRECORDED values are BOTH visible, a lone
   // "1 drift(s)" verdict reads as a mismatch against the 2+ printed blocks (the user
   // sees [DECLARED DRIFT: 1] + [UNRECORDED: 2] but a single "1 drift"). Combine them
-  // under one findings count — `N findings — X drift (...) + Y undeclared to review` —
+  // under one findings count — `N findings — X drift (...) + Y not-recorded to review` —
   // keeping the red drift verdict and its breakdown so exit-1 stays legible, and
   // counting only what is SHOWN (folded values are not findings, just a parenthetical).
   // The combined framing fires ONLY in this mixed case; single-category runs keep their
@@ -271,7 +271,9 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
         : 'run cdkrd record';
     resultBody =
       `${drifted + unrecordedShown.length} findings — ${style.drift(`${drifted} drift`)} (${driftCounts})` +
-      ` + ${style.undeclaredTier(`${unrecordedShown.length} undeclared to review`)}` +
+      // "not-recorded" (not "undeclared"): the [Not Recorded] set is undeclared
+      // PROPERTIES plus out-of-band `added` RESOURCES (PR4) — both await a record.
+      ` + ${style.undeclaredTier(`${unrecordedShown.length} not-recorded to review`)}` +
       style.infoTier(` (${foldedHint})`);
   } else {
     // the verdict is the one line that must stand out: green CLEAN / red drift count

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -45,7 +45,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(code).toBe(1);
     // R114: drift + standout unrecorded both visible -> combined findings framing so
     // the verdict matches the printed blocks (was a lone "1 drift(s)" beside 2 sections).
-    expect(text).toContain('result: 2 findings — 1 drift (declared=1) + 1 undeclared to review');
+    expect(text).toContain('result: 2 findings — 1 drift (declared=1) + 1 not-recorded to review');
     expect(text).not.toContain('undeclared=1'); // unrecorded never appears as a drift count
   });
 
@@ -54,7 +54,9 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(code).toBe(1);
     expect(text).toContain('[CFn-Undeclared Drift: 1]');
     expect(text).toContain('[Not Recorded: 1]');
-    expect(text).toContain('result: 2 findings — 1 drift (undeclared=1) + 1 undeclared to review');
+    expect(text).toContain(
+      'result: 2 findings — 1 drift (undeclared=1) + 1 not-recorded to review'
+    );
   });
 
   it('mixed findings line counts only SHOWN unrecorded; folded ones stay a parenthetical (R114)', () => {
@@ -63,7 +65,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     const { code, text } = run([F('declared'), U('Q'), nested('a'), nested('b')]);
     expect(code).toBe(1);
     expect(text).toContain(
-      'result: 2 findings — 1 drift (declared=1) + 1 undeclared to review (2 folded; run cdkrd record)'
+      'result: 2 findings — 1 drift (declared=1) + 1 not-recorded to review (2 folded; run cdkrd record)'
     );
   });
 


### PR DESCRIPTION
Two small PR4 (#148) follow-ups now that out-of-band `added` resources flow through the Not-Recorded / record machinery:

- **Mixed result line**: `N findings — X drift (...) + Y undeclared to review` counted an unrecorded `added` **resource** under "undeclared" — but an added resource is not an undeclared property. Reworded to **`Y not-recorded to review`** (the umbrella covering both undeclared properties and added resources, matching the `[Not Recorded]` section name).
- **`postRecordNote`**: the resolution hint `(fix the code or choose Revert)` omitted the paths that apply to a remaining `added` drift (revert / ignore / re-record) — now `(fix the code, or revert / ignore them)`.

Pure wording; no behavior change. 1035 unit tests pass (report + check assertions updated); typecheck / lint / build green. No live integ needed (report-string only).