### PR TITLE
fix(gather): retry composite-id CC-adapter resources whose GetAtt parent resolves in pass 1.5

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -14,7 +14,7 @@ import {
 } from '../read/kms-aliases.js';
 import { type AddedChild, CHILD_ENUMERATORS } from '../read/child-enumerators.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
-import { readLive, type ReadResult } from '../read/router.js';
+import { CC_IDENTIFIER_ADAPTERS, readLive, type ReadResult } from '../read/router.js';
 import { getSchemaInfo } from '../schema/schema-strip.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
 
@@ -236,19 +236,29 @@ export async function gatherFindings(
     if (r.declaredRaw) r.declared = resolveProperties(r.declaredRaw, desired.ctx);
   }
 
-  // Pass 1.5: declared-dependent SDK overrides key off props that are frequently
-  // Fn::GetAtt (AWS::Lambda::Permission.FunctionName = GetAtt[fn, Arn]). Those were
-  // UNRESOLVED during pass 1 (liveAttrs was still being filled), so their pass-1
-  // override read wrongly skipped as "target not resolvable" — the resource is
-  // structurally readable, we just asked too early. Re-read ONCE, concurrently, the
-  // override-routed resources that pass 1 skipped and whose target is now resolvable.
-  const retryTargets = desired.resources.filter(
-    (r) =>
+  // Pass 1.5: declared-dependent reads key off props that are frequently Fn::GetAtt
+  // and so were UNRESOLVED during pass 1 (liveAttrs was still being filled) — the
+  // resource is structurally readable, we just asked too early. Two shapes hit this:
+  //   - SDK overrides whose target prop is a GetAtt (Lambda Permission.FunctionName =
+  //     GetAtt[fn,Arn]) → pass 1 returned `skippedReason` ("target not resolvable").
+  //   - CC composite-id types whose PARENT key is a GetAtt (ApiGatewayV2 Route.ApiId =
+  //     GetAtt[Api,ApiId], ECS Service.Cluster = GetAtt[Cluster,Arn]): the composite
+  //     identifier couldn't be built, so CC was queried with the BARE child id — which
+  //     fails as `skippedReason` (ValidationException) OR, worse, `deleted`
+  //     (ResourceNotFound) → a FALSE "deleted out of band". (Ref-sourced parents
+  //     resolve in pass 1 via physIds, so only the GetAtt form is affected.)
+  // Re-read ONCE, concurrently, both shapes when the earlier result was a skip OR a
+  // deleted — now that liveAttrs is populated the parent resolves. A genuinely deleted
+  // resource just reads not-found again, so re-reading the `deleted` set is safe.
+  const retryTargets = desired.resources.filter((r) => {
+    const prev = reads.get(r.logicalId);
+    return (
       r.physicalId &&
       r.declaredRaw &&
-      SDK_OVERRIDES[r.resourceType] &&
-      reads.get(r.logicalId)?.skippedReason
-  );
+      (SDK_OVERRIDES[r.resourceType] || CC_IDENTIFIER_ADAPTERS[r.resourceType]) &&
+      (prev?.skippedReason || prev?.deleted)
+    );
+  });
   await readAll(cc, retryTargets, region, desired, reads);
 
   // OAI canonical-id map (CloudFront legacy OAI principal reconciliation) — harvested

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -298,3 +298,90 @@ describe('gatherFindings pass-1.5 override retry (R27)', () => {
     expect(lambda.commandCalls(LambdaGetPolicyCommand)).toHaveLength(0);
   });
 });
+
+// A CC composite-identifier resource (ApiGatewayV2 Route) whose PARENT key (ApiId) is
+// an Fn::GetAtt is read in pass 1 with the BARE child id (the parent isn't resolved
+// yet) → CC returns not-found → a FALSE `deleted`. Pass 1.5 must retry it (it is a
+// CC_IDENTIFIER_ADAPTERS type, and the prior outcome was `deleted`) now that liveAttrs
+// carries the parent's ApiId, building the composite `apiId|routeId`.
+describe('gatherFindings pass-1.5 composite-id retry (GetAtt parent)', () => {
+  const template = JSON.stringify({
+    Resources: {
+      Api: { Type: 'AWS::ApiGatewayV2::Api', Properties: { Name: 'api' } },
+      Route: {
+        Type: 'AWS::ApiGatewayV2::Route',
+        Properties: { ApiId: { 'Fn::GetAtt': ['Api', 'ApiId'] }, RouteKey: 'GET /x' },
+      },
+    },
+  });
+  const cfnFixture = () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({ TemplateBody: template });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Api',
+          PhysicalResourceId: 'api456',
+          ResourceType: 'AWS::ApiGatewayV2::Api',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE' as const,
+        },
+        {
+          LogicalResourceId: 'Route',
+          PhysicalResourceId: 'route789',
+          ResourceType: 'AWS::ApiGatewayV2::Route',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE' as const,
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+    cfn.on(DescribeTypeCommand).resolves({ Schema: '{}' });
+    return cfn;
+  };
+
+  it('re-reads the Route with the composite id, so it is NOT falsely deleted', async () => {
+    cfnFixture();
+    const notFound = Object.assign(new Error('not found'), {
+      name: 'ResourceNotFoundException',
+    });
+    const cc = mockClient(CloudControlClient);
+    // Api reads by its bare physical id and exposes ApiId -> liveAttrs[Api].ApiId
+    cc.on(GetResourceCommand, { Identifier: 'api456' }).resolves({
+      ResourceDescription: {
+        Identifier: 'api456',
+        Properties: JSON.stringify({ ApiId: 'api456', Name: 'api' }),
+      },
+    });
+    // pass 1: bare child id -> not-found (the false-deleted trigger)
+    cc.on(GetResourceCommand, { Identifier: 'route789' }).rejects(notFound);
+    // pass 1.5: composite id -> the real route (declared == live -> CLEAN)
+    cc.on(GetResourceCommand, { Identifier: 'api456|route789' }).resolves({
+      ResourceDescription: {
+        Identifier: 'api456|route789',
+        Properties: JSON.stringify({ ApiId: 'api456', RouteId: 'route789', RouteKey: 'GET /x' }),
+      },
+    });
+
+    const { findings } = await gatherFindings('S', 'us-east-1');
+
+    // the Route is NEITHER falsely deleted NOR skipped — pass 1.5 read it composite
+    expect(findings.find((f) => f.logicalId === 'Route' && f.tier === 'deleted')).toBeUndefined();
+    expect(findings.find((f) => f.logicalId === 'Route' && f.tier === 'skipped')).toBeUndefined();
+    // CC was actually queried with the composite identifier
+    const ids = cc.commandCalls(GetResourceCommand).map((c) => c.args[0].input.Identifier);
+    expect(ids).toContain('api456|route789');
+    // declared == live -> the Route is CLEAN
+    expect(findings.find((f) => f.logicalId === 'Route')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

A CC composite-identifier resource whose **parent key is an `Fn::GetAtt`** was read
in pass 1 with the **bare child id** (the parent isn't resolved yet — `liveAttrs` is
still being filled) and so failed: CC returns `ValidationException` → a silent
`skipped` (coverage-gap FN), or `ResourceNotFound` → a **false `deleted` out of
band** (FP). Pass 1.5 exists to re-read exactly these "asked too early" resources,
but its retry filter only covered **SDK overrides** with a `skippedReason` — CC
composite-id types (routed through `CC_IDENTIFIER_ADAPTERS`, not `SDK_OVERRIDES`)
were never retried, and the `deleted` outcome wasn't retried at all.

Affected types (any whose declared parent ref can be a GetAtt): `ApiGatewayV2::{Route,
Integration,Stage}`, `ApiGateway::{Resource,Stage,Model,RequestValidator,Deployment}`,
`Cognito::UserPool*`, `AppConfig::*`, `ECS::Service`, `ApplicationAutoScaling::ScalingPolicy`.
(`Ref`-sourced parents resolve in pass 1, so only the `GetAtt` form is affected — which
is why it slipped past prior waves.)

Fix: widen the pass-1.5 retry filter to also include `CC_IDENTIFIER_ADAPTERS` types
and to retry when the prior outcome was `deleted` (not just `skippedReason`). Once
`liveAttrs` carries the parent, the composite identifier (`apiId|routeId`, …) builds
and the resource reads correctly.

## Safety

The retry fires **only** when the prior read was `skippedReason || deleted`, so a
**working read (`.live`) is never re-touched** — provably non-regressive for working
reads. The change has **no false-positive surface**: it can only correct a
false-deleted/skipped resource, never create new drift. A genuinely deleted resource
just reads not-found again on retry and stays `deleted`.

## Tests

- `gather.test.ts` (+1): an `ApiGatewayV2::Route` whose `ApiId` is `Fn::GetAtt[Api,
  ApiId]` — pass 1 reads the bare `route789` → not-found; pass 1.5 retries with the
  composite `api456|route789` → the route reads CLEAN. Asserts NOT deleted, NOT
  skipped, and that CC was queried with the composite identifier. (The existing
  pass-1.5 Lambda-Permission override-retry tests still pass.)

## Verification

- typecheck / lint+format / build / **1036 unit tests (39 files)** green.
- No live integ: unlike a projection-add (which can create false drift and needs a
  live FP check), a **retry** change has no FP surface — it only re-attempts reads
  that already failed, and working reads are provably untouched. The mocked-CC unit
  test exercises the exact composite-retry path.
