### PR TITLE
fix(normalize,report): Fn::Equals string-coercion (wrong Fn::If branch) + boundary-safe value truncation

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -161,7 +161,21 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
 
 function scalarEqual(a: unknown, b: unknown): boolean {
   if (Array.isArray(a) || Array.isArray(b)) return JSON.stringify(a) === JSON.stringify(b);
-  return a === b;
+  if (a === b) return true;
+  // CloudFormation evaluates `Fn::Equals` as a STRING comparison. A Number/Boolean
+  // template Parameter is carried as a string by buildResolverContext (params are
+  // stringified), so `Fn::Equals[{Ref: MaxAZs="2"}, 2]` (literal NUMBER) must be TRUE,
+  // and `[{Ref: Enabled="true"}, true]` TRUE — else the WRONG `Fn::If` branch bakes a
+  // corrupted declared value into the diff (a phantom FP, or a hidden FN), and this
+  // operator is fail-OPEN unlike the rest of the resolver. Coerce string<->number/
+  // boolean via exact String() match (CFn does NOT fold "2.0"==2 in Equals, so no
+  // numeric-format folding here); genuine inequality still differs.
+  const prim = (x: unknown): x is number | boolean =>
+    typeof x === 'number' || typeof x === 'boolean';
+  if ((typeof a === 'string' && prim(b)) || (typeof b === 'string' && prim(a))) {
+    return String(a) === String(b);
+  }
+  return false;
 }
 
 // Evaluate a condition operand to true | false | UNRESOLVED (fail-closed).

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -367,9 +367,33 @@ export function stackSeparator(log: (s: string) => void = console.log): () => vo
   };
 }
 const VALUE_CAP = 200;
+
+// Slice on SAFE boundaries so truncating a JSON-stringified value never splits a
+// surrogate pair (a lone surrogate renders as the replacement char `�`) or a JSON
+// escape (a dangling odd run of backslashes would escape the following `…`). Trims a
+// leading low-surrogate / trailing high-surrogate left by a mid-pair cut and a
+// trailing odd backslash run left by a mid-escape cut. Cosmetic-only (TEXT mode; the
+// `--json` path emits the raw untruncated value), but keeps long policy-doc values
+// from rendering as corrupted `\uD83C…` / `…\\n\\…`.
+export function safeSlice(s: string, start: number, end: number): string {
+  let out = s.slice(start, end);
+  if (out.length > 0) {
+    const first = out.charCodeAt(0);
+    if (first >= 0xdc00 && first <= 0xdfff) out = out.slice(1); // leading low surrogate
+  }
+  if (out.length > 0) {
+    const last = out.charCodeAt(out.length - 1);
+    if (last >= 0xd800 && last <= 0xdbff) out = out.slice(0, -1); // trailing high surrogate
+  }
+  let bs = 0;
+  for (let k = out.length - 1; k >= 0 && out[k] === '\\'; k--) bs++;
+  if (bs % 2 === 1) out = out.slice(0, -1); // trailing half-escape (odd backslash run)
+  return out;
+}
+
 function j(v: unknown): string {
   const s = JSON.stringify(v);
-  return s && s.length > VALUE_CAP ? s.slice(0, VALUE_CAP) + '…' : (s ?? String(v));
+  return s && s.length > VALUE_CAP ? safeSlice(s, 0, VALUE_CAP) + '…' : (s ?? String(v));
 }
 
 // Truncate a desired/actual (or baseline/actual) PAIR so the FIRST point at which the
@@ -388,7 +412,7 @@ export function jPair(a: unknown, b: unknown): { a: string; b: string } {
   const CONTEXT = 40; // chars of shared lead-in kept before the divergence, for orientation
   const start = Math.max(0, i - CONTEXT);
   const window = (s: string): string => {
-    let out = s.slice(start, start + VALUE_CAP);
+    let out = safeSlice(s, start, start + VALUE_CAP);
     if (start > 0) out = `…${out}`;
     if (start + VALUE_CAP < s.length) out = `${out}…`;
     return out;

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -53,6 +53,29 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::If': ['IsProd', 'yes', 'no'] }, c)).toBe('yes');
   });
 
+  // CFn evaluates Fn::Equals as a STRING comparison; a Number/Boolean parameter is
+  // carried as a string, so it must equal a numeric/boolean template LITERAL — else the
+  // wrong Fn::If branch bakes a corrupted declared value into the diff.
+  it('Fn::Equals coerces a stringified Number/Boolean param to a numeric/boolean literal', () => {
+    const cNum = ctx({
+      params: { Env: 'prod', MaxAZs: '2' }, // a Number param, stringified
+      conditions: { HasTwo: { 'Fn::Equals': [{ Ref: 'MaxAZs' }, 2] } }, // literal NUMBER
+    });
+    expect(resolve({ 'Fn::If': ['HasTwo', 2, 1] }, cNum)).toBe(2); // was 1 (wrong branch)
+    expect(resolve({ 'Fn::Equals': [{ Ref: 'MaxAZs' }, 2] }, cNum)).toBe(true);
+
+    const cBool = ctx({
+      params: { Env: 'prod', Enabled: 'true' }, // a Boolean param, stringified
+      conditions: { On: { 'Fn::Equals': [{ Ref: 'Enabled' }, true] } }, // literal BOOLEAN
+    });
+    expect(resolve({ 'Fn::If': ['On', 'on', 'off'] }, cBool)).toBe('on');
+
+    // genuine inequality still differs (no over-coercion): "2" != 3, "2" != "2.0"
+    const cNo = ctx({ params: { N: '2' }, conditions: { C: { 'Fn::Equals': [{ Ref: 'N' }, 3] } } });
+    expect(resolve({ 'Fn::If': ['C', 'yes', 'no'] }, cNo)).toBe('no');
+    expect(resolve({ 'Fn::Equals': ['2.0', 2] }, ctx())).toBe(false); // CFn Equals is exact-string
+  });
+
   it('Fn::GetAtt is UNRESOLVED without live attrs; Fn::Join drops NoValue', () => {
     expect(resolve({ 'Fn::GetAtt': ['X', 'Arn'] }, ctx())).toBe(UNRESOLVED);
     expect(resolve({ 'Fn::Join': ['-', ['a', { Ref: 'AWS::NoValue' }, 'b']] }, ctx())).toBe('a-b');

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { jPair, report, stackSeparator } from '../src/report/report.js';
+import { jPair, report, safeSlice, stackSeparator } from '../src/report/report.js';
 import type { Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
@@ -596,5 +596,47 @@ describe('jPair (pair-aware truncation keeps the divergence visible)', () => {
   it('a long value vs a short one still shows where they diverge', () => {
     const { a, b } = jPair('z'.repeat(250), 'z'.repeat(10));
     expect(a).not.toBe(b);
+  });
+});
+
+describe('safeSlice (boundary-safe truncation — no split surrogate / escape)', () => {
+  const hasLoneSurrogate = (s: string): boolean => {
+    for (let i = 0; i < s.length; i++) {
+      const c = s.charCodeAt(i);
+      if (c >= 0xd800 && c <= 0xdbff) {
+        const n = s.charCodeAt(i + 1);
+        if (!(n >= 0xdc00 && n <= 0xdfff)) return true; // high not followed by low
+        i++;
+      } else if (c >= 0xdc00 && c <= 0xdfff) {
+        return true; // lone low surrogate
+      }
+    }
+    return false;
+  };
+
+  it('never ends on a half surrogate pair (tail cut through an emoji)', () => {
+    const s = `${'a'.repeat(9)}🎉${'b'.repeat(5)}`; // emoji straddles index 9-10
+    expect(hasLoneSurrogate(safeSlice(s, 0, 10))).toBe(false); // would cut the pair
+    expect(hasLoneSurrogate(s.slice(0, 10))).toBe(true); // the unsafe slice DOES split it
+  });
+
+  it('never starts on a half surrogate pair (head cut through an emoji)', () => {
+    const s = `${'a'.repeat(9)}🎉${'b'.repeat(5)}`;
+    expect(hasLoneSurrogate(safeSlice(s, 10, 16))).toBe(false); // start mid-pair -> low dropped
+  });
+
+  it('never ends on an odd run of backslashes (tail cut through a \\n escape)', () => {
+    const s = JSON.stringify(`${'a'.repeat(8)}\n\n\n${'b'.repeat(5)}`); // has \\n escapes
+    // find a cut landing right after a backslash
+    const idx = s.indexOf('\\') + 1; // between the \ and the n
+    const out = safeSlice(s, 0, idx);
+    // count trailing backslashes — must be EVEN (no dangling half-escape)
+    let bs = 0;
+    for (let k = out.length - 1; k >= 0 && out[k] === '\\'; k--) bs++;
+    expect(bs % 2).toBe(0);
+  });
+
+  it('leaves a clean boundary untouched', () => {
+    expect(safeSlice('hello world', 0, 5)).toBe('hello');
   });
 });


### PR DESCRIPTION
## What

Two pure-function correctness fixes (no live-AWS surface).

### 1. `Fn::Equals` strict `===` → wrong `Fn::If` branch (`normalize/intrinsic-resolver.ts`)

`scalarEqual` compared with `===`, but a Number/Boolean template **Parameter** is
carried as a **string** (params are stringified by `buildResolverContext`).
CloudFormation evaluates `Fn::Equals` as a **string** comparison, so
`Fn::Equals[{Ref: MaxAZs="2"}, 2]` (numeric literal) is TRUE in CFn — cdkrd returned
FALSE and picked the **wrong `Fn::If` branch**, baking a corrupted declared value
into the diff. Unlike the rest of the resolver this path is **fail-OPEN** (it doesn't
return `UNRESOLVED`), so the corrupted value becomes either a phantom FP or a hidden
FN. Fix: coerce string↔number/boolean via exact `String()` match (CFn does NOT fold
`"2.0"==2` in `Equals`, so no numeric-format folding); genuine inequality still
differs.

### 2. Value truncation splits a surrogate pair / JSON escape (`report/report.ts`)

`j()` and `jPair().window()` truncated a `JSON.stringify`'d value with a fixed
code-unit `slice`, so a cut through an astral char (emoji, CJK-ext) left a **lone
surrogate** (renders as `�`) and a cut through a `\n`/`\"`/`\uXXXX` escape left a
**dangling odd backslash** (escapes the following `…`). New `safeSlice` trims a
leading low-surrogate / trailing high-surrogate and a trailing odd backslash run.
TEXT mode only — `--json` emits the raw untruncated value (verified unaffected).

## Tests

- `intrinsic-resolver.test.ts`: `Fn::Equals` coerces a stringified Number/Boolean
  param to a numeric/boolean literal (right `Fn::If` branch); genuine inequality and
  `"2.0" != 2` still differ.
- `report.test.ts`: `safeSlice` never ends on a half surrogate pair (emoji tail/head
  cut) nor an odd backslash run (escape cut); the unsafe `slice` is shown to corrupt.

## Verification

- typecheck / lint+format / build / **1041 unit tests (39 files)** + 286-corpus green.
  The `Fn::Equals` change does NOT alter any recorded corpus classification —
  corpus-guarded FP-safe. No live integ: both are deterministic pure functions with no
  AWS surface (intrinsic resolution is corpus-covered; report is text-rendering).
