### PR TITLE
fix(config): bracket-aware ignore parent match + glob star-collapse (ReDoS)

### DIFF
--- a/src/commands/glob-match.ts
+++ b/src/commands/glob-match.ts
@@ -12,7 +12,12 @@ export function isGlob(s: string): boolean {
 /** Convert a glob pattern to an anchored RegExp (other metachars escaped to literals). */
 export function globToRegExp(pattern: string): RegExp {
   let out = '^';
-  for (const ch of pattern) {
+  // Collapse runs of consecutive `*` to a single `*` FIRST: `***` is semantically
+  // identical to `*` (any run of characters), but compiling each star to `.*` yields
+  // `.*.*.*…` which backtracks CATASTROPHICALLY (O(len^N)) on a long non-matching
+  // subject — a self-inflicted multi-second hang (ReDoS) on a user-authored glob like
+  // `*****` (a natural gitignore-style attempt). One `.*` per run can't backtrack.
+  for (const ch of pattern.replace(/\*+/g, '*')) {
     if (ch === '*') out += '.*';
     else if (ch === '?') out += '.';
     else out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -219,15 +219,25 @@ export function parseIgnoreRule(entry: IgnoreRuleObject): IgnoreRule {
 
 /**
  * True when `pattern` matches `target` (= "<logicalId>.<path>"), either exactly or
- * as a PARENT segment: a rule "X.Policies" also ignores child paths like
- * "X.Policies.0.PolicyName" (so ignoring a structured property covers its leaves).
- * Parent matching is at dot-segment boundaries only, combined with the glob.
+ * as a PARENT path: a rule "X.Policies" also ignores child paths like
+ * "X.Policies.0.PolicyName" AND "X.Policies[MyPol].PolicyName" (so ignoring a
+ * structured property covers its leaves, including array / identity-keyed elements).
+ * Parent matching walks ancestors at each `.` OR `[` boundary, combined with the glob.
  */
 function pathMatches(pattern: string, target: string): boolean {
   if (matchesGlob(pattern, target)) return true;
-  const segs = target.split('.');
-  for (let i = 1; i < segs.length; i++) {
-    if (matchesGlob(pattern, segs.slice(0, i).join('.'))) return true;
+  // A rule on a PARENT property ignores its whole subtree — including array / identity-
+  // keyed children whose path glues the index to its key inside ONE dot-segment
+  // (`Policies[MyPol].PolicyName`, `Statement[0].Condition`, `Tags[env]`). Walk ancestor
+  // paths by trimming at each `.` OR `[` boundary (not just `.`), so a rule `X.Policies`
+  // covers `X.Policies[MyPol].PolicyName` and `X.Statement` covers
+  // `X.Statement[0].Condition` — the dot-only split silently failed for bracket children.
+  let t = target;
+  while (true) {
+    const cut = Math.max(t.lastIndexOf('.'), t.lastIndexOf('['));
+    if (cut <= 0) break;
+    t = t.slice(0, cut);
+    if (matchesGlob(pattern, t)) return true;
   }
   return false;
 }

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -114,6 +114,27 @@ describe('applyIgnores', () => {
     expect(f?.tier).toBe('ignored');
   });
 
+  it('parent rule covers BRACKET-indexed child paths (array / identity-keyed elements)', () => {
+    // classify emits bracket paths (`Policies[MyPol].PolicyName`, `Statement[0].Condition`,
+    // `Tags[env]`); the dot-only split silently failed to cover them under a parent rule.
+    expect(
+      ign([undeclared('Role', 'Policies[MyPol].PolicyName')], 'S', cfg([p('Role.Policies')]))[0]
+        ?.tier
+    ).toBe('ignored');
+    expect(
+      ign(
+        [undeclared('P', 'PolicyDocument.Statement[0].Condition')],
+        'S',
+        cfg([p('P.PolicyDocument.Statement')])
+      )[0]?.tier
+    ).toBe('ignored');
+    expect(ign([undeclared('R', 'Tags[env]')], 'S', cfg([p('R.Tags')]))[0]?.tier).toBe('ignored');
+    // a SIBLING not under the rule's subtree is NOT ignored (no over-suppression)
+    expect(
+      ign([undeclared('Role', 'Other[MyPol].X')], 'S', cfg([p('Role.Policies')]))[0]?.tier
+    ).toBe('undeclared');
+  });
+
   it('re-tags an `added` (whole out-of-band resource, empty path) finding to ignored', () => {
     const addedFinding: Finding = {
       tier: 'added',

--- a/tests/glob-match.test.ts
+++ b/tests/glob-match.test.ts
@@ -75,4 +75,17 @@ describe('globToRegExp', () => {
   it('escapes dot to a literal', () => {
     expect(globToRegExp('a.b').source).toBe('^a\\.b$');
   });
+
+  it('collapses a run of consecutive `*` to a single `.*` (ReDoS-safe, same semantics)', () => {
+    // `*****` is semantically identical to `*`; without the collapse it compiles to
+    // `.*.*.*.*.*` which backtracks catastrophically on a long non-matching subject.
+    // The `^.*X$` source (one `.*`, not five) IS the fix — it cannot backtrack-partition.
+    expect(globToRegExp('*****X').source).toBe('^.*X$');
+    expect(globToRegExp('a***b').source).toBe('^a.*b$');
+    // semantics preserved
+    expect(matchesGlob('*****X', 'aaaaaX')).toBe(true);
+    expect(matchesGlob('*****X', 'aaaaaY')).toBe(false);
+    // a long non-match returns promptly (no catastrophic backtracking)
+    expect(matchesGlob('**********X', 'a'.repeat(60))).toBe(false);
+  });
 });


### PR DESCRIPTION
## What

Two pure-function config/glob fixes (no live-AWS surface).

### 1. Ignore parent rule misses bracket-indexed children (`config/config-file.ts`)

`pathMatches` generated ancestor paths by splitting on `.` only, so a rule
`X.Policies` produced parents `X` and `X.Policies[MyPol]` — **never** `X.Policies`.
The `[id]` is glued to its key inside one dot-segment, so a parent rule could not
cover array / identity-keyed children — yet `classify` emits exactly those bracket
paths (`Policies[MyPol].PolicyName`, `Statement[0].Condition`, `Tags[env]`). The
documented parent-rule guarantee ("a rule `X.Policies` also ignores child paths")
silently failed for the most common nested drift = **under-suppression** (a user's
ignore keeps getting re-surfaced). Fix: walk ancestors at each `.` **OR** `[`
boundary; a sibling not under the subtree is still not ignored (over-suppression
guarded + tested).

### 2. Catastrophic backtracking in `globToRegExp` (`commands/glob-match.ts`)

Each `*` became `.*`, so a run of N consecutive stars compiled to `.*.*.*…` which
backtracks **O(len^N)** on a long non-matching subject — a self-inflicted
multi-second hang (ReDoS) on a user-authored glob like `*****` (a natural
gitignore-style attempt) in a stack-name arg or an ignore `path`/`stack`/`region`.
Fix: collapse a run of consecutive `*` to a single `*` before compiling (`*****` is
semantically identical to `*`); `^.*X$` can't backtrack-partition. Semantics
unchanged.

## Tests

- `config-file.test.ts`: a parent rule covers `Policies[MyPol].PolicyName`,
  `PolicyDocument.Statement[0].Condition`, `Tags[env]`; a sibling `Other[MyPol].X` is
  NOT ignored by `Role.Policies` (over-suppression guard).
- `glob-match.test.ts`: `*****X` compiles to `^.*X$` (one `.*`), semantics preserved,
  a long non-match returns promptly.

## Verification

- typecheck / lint+format / build / **1043 unit tests (39 files)** green. No live
  integ: both are deterministic pure functions with no AWS surface (ignore-rule
  matching + glob compilation; no classification corpus involvement).
