### PR TITLE
fix(read): project Budgets PlannedBudgetLimits + thin AutoAdjustData (FN)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -237,13 +237,37 @@ const readBudget: OverrideReader = async ({ physicalId, declared, accountId, reg
   // where it must: COMPUTED fields (CalculatedSpend) and AWS-defaulted blobs (TimePeriod's
   // 2087 end date, the full CostTypes default set) are deliberately NOT offered — they
   // would be live-only noise.
+  // PlannedBudgetLimits — a time-phased budget's per-period limits. Omitting it made an
+  // out-of-band change to a future month's limit invisible (a declared one became a
+  // readGap; an undeclared one wholly invisible). FP-safe: DescribeBudget returns it ONLY
+  // for a budget created WITH planned limits (SDK-documented absent-when-unused), so a
+  // plain fixed budget stays CLEAN; the inner Spend.Amount string ("40.0") vs the declared
+  // number is folded by isStringlyEqualScalar, exactly like BudgetLimit.
+  //
+  // AutoAdjustData — switching a budget to auto-adjusting (or changing its look-back) was
+  // undetectable. Projected THIN: only the user-settable AutoAdjustType + HistoricalOptions
+  // .BudgetAdjustmentPeriod. The COMPUTED fields (LastAutoAdjustTime, the auto-calculated
+  // HistoricalOptions.LookBackAvailablePeriods) are deliberately NOT offered — they would
+  // be live-only noise. Absent for a fixed budget, so no first-run noise there.
+  const aad = b.AutoAdjustData;
   return {
     Budget: {
       BudgetName: b.BudgetName,
       BudgetType: b.BudgetType,
       TimeUnit: b.TimeUnit,
       ...(b.BudgetLimit !== undefined && { BudgetLimit: b.BudgetLimit }),
+      ...(b.PlannedBudgetLimits !== undefined && { PlannedBudgetLimits: b.PlannedBudgetLimits }),
       ...(b.CostFilters !== undefined && { CostFilters: b.CostFilters }),
+      ...(aad && {
+        AutoAdjustData: {
+          ...(aad.AutoAdjustType !== undefined && { AutoAdjustType: aad.AutoAdjustType }),
+          ...(aad.HistoricalOptions?.BudgetAdjustmentPeriod !== undefined && {
+            HistoricalOptions: {
+              BudgetAdjustmentPeriod: aad.HistoricalOptions.BudgetAdjustmentPeriod,
+            },
+          }),
+        },
+      }),
     },
   };
 };

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -301,6 +301,37 @@ describe('SDK overrides', () => {
       },
     });
   });
+  it('Budgets: projects PlannedBudgetLimits + THIN AutoAdjustData, dropping the computed auto-adjust fields', async () => {
+    budgets.on(DescribeBudgetCommand).resolves({
+      Budget: {
+        BudgetName: 'b',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        PlannedBudgetLimits: { '1700000000': { Amount: '40.0', Unit: 'USD' } },
+        AutoAdjustData: {
+          AutoAdjustType: 'HISTORICAL',
+          // BudgetAdjustmentPeriod is user-set; LookBackAvailablePeriods is AWS-computed
+          HistoricalOptions: { BudgetAdjustmentPeriod: 6, LookBackAvailablePeriods: 3 },
+          LastAutoAdjustTime: new Date(0), // computed -> must be dropped
+        },
+      },
+    });
+    const out = await SDK_OVERRIDES['AWS::Budgets::Budget'](ctx({ Budget: { BudgetName: 'b' } }));
+    expect(out).toEqual({
+      Budget: {
+        BudgetName: 'b',
+        BudgetType: 'COST',
+        TimeUnit: 'MONTHLY',
+        PlannedBudgetLimits: { '1700000000': { Amount: '40.0', Unit: 'USD' } },
+        // only the user-settable auto-adjust fields; LookBackAvailablePeriods +
+        // LastAutoAdjustTime (computed) are dropped so they are not live-only noise
+        AutoAdjustData: {
+          AutoAdjustType: 'HISTORICAL',
+          HistoricalOptions: { BudgetAdjustmentPeriod: 6 },
+        },
+      },
+    });
+  });
   it('Budgets: undefined without a budget name', async () => {
     expect(await SDK_OVERRIDES['AWS::Budgets::Budget'](ctx({ Budget: {} }))).toBeUndefined();
   });


### PR DESCRIPTION
## What

`readBudget` projected only `BudgetLimit` + `CostFilters`, dropping two CFn-modeled,
user-settable `AWS::Budgets::Budget` properties — so an out-of-band change to either
was invisible:

- **`PlannedBudgetLimits`** — a time-phased budget's per-period limits. A declared one
  became a `readGap`; an undeclared change to a future month's limit was wholly
  invisible. Projected directly. FP-safe: `DescribeBudget` returns it ONLY for a
  budget created WITH planned limits (SDK-documented absent-when-unused), so a plain
  fixed budget stays CLEAN; the inner `Spend.Amount` string ("40.0") vs the declared
  number is folded by `isStringlyEqualScalar`, exactly like `BudgetLimit`.
- **`AutoAdjustData`** — switching a budget to auto-adjusting (or changing its
  look-back) was undetectable. Projected **THIN**: only the user-settable
  `AutoAdjustType` + `HistoricalOptions.BudgetAdjustmentPeriod`. The AWS-**computed**
  fields (`LastAutoAdjustTime`, the auto-calculated
  `HistoricalOptions.LookBackAvailablePeriods`) are deliberately dropped — they would
  be live-only noise. Absent for a fixed budget, so no first-run noise.

Both fields were SDK-verified against `@aws-sdk/client-budgets` before projecting.

## Tests

- `overrides.test.ts` (+1): a planned + auto-adjusting budget projects
  `PlannedBudgetLimits` and the thin `AutoAdjustData` (computed `LastAutoAdjustTime` +
  `LookBackAvailablePeriods` dropped). The existing fixed-budget test still asserts
  neither new field is projected (FP-safe on the common case).

## Verification

- typecheck / lint+format / build / **1044 unit tests (39 files)** + 286-corpus green.
- **LIVE (real AWS)** — the `budget-scope` fixture (a FIXED budget, neither new field
  present): `INTEG PASS`, **`check CLEAN` after record** (my projections add no false
  drift on the common case), the injected `CostFilters` scope drift still detected.
  Stack destroyed; no leftover budget.
