### PR TITLE
fix(read): identify API Gateway root by live path so an unresolved RootResourceId can't false-flag the root

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -86,9 +86,17 @@ export function diffApiGatewayChildren(input: ApiGatewayChildInput): AddedChild[
     liveResources,
     liveMethodsByResource,
   } = input;
-  // Declared = template resources + the implicit root.
+  // Declared = template resources + the implicit root. The root `/` resource is ALWAYS
+  // created with the RestApi and is never an "added" out-of-band resource. Identify it
+  // by its LIVE path '/' (authoritative) IN ADDITION to rootResourceId — the latter
+  // comes from the RestApi's CC read (liveAttrs), which may be skipped / throttled /
+  // missing the attr, leaving rootResourceId undefined. Without the path fallback the
+  // live root would then be flagged `added`, and a `revert` would issue DeleteResource
+  // against the API's ROOT resource — a destructive false positive.
+  const liveRootId = liveResources.find((r) => r.path === '/')?.id;
   const declaredResources = new Set(declaredResourceIds);
   if (rootResourceId) declaredResources.add(rootResourceId);
+  if (liveRootId) declaredResources.add(liveRootId);
   const declaredMethods = new Set(declaredMethodKeys);
 
   const pathOf = new Map<string, string>();
@@ -113,6 +121,11 @@ export function diffApiGatewayChildren(input: ApiGatewayChildInput): AddedChild[
   // undeclared method is its own added finding.
   for (const [resourceId, methods] of Object.entries(liveMethodsByResource)) {
     if (addedResourceIds.has(resourceId)) continue;
+    // When rootResourceId is unresolved (RestApi read incomplete), the template's
+    // root-method ResourceId (Fn::GetAtt RootResourceId) couldn't resolve, so
+    // declaredMethodKeys is missing the root's DECLARED methods — skip method-diffing
+    // the live root to avoid falsely flagging a declared root method as added.
+    if (!rootResourceId && resourceId === liveRootId) continue;
     for (const m of methods) {
       if (declaredMethods.has(`${resourceId}|${m.httpMethod}`)) continue;
       added.push({

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -109,6 +109,34 @@ describe('diffApiGatewayChildren', () => {
     });
     expect(added).toEqual([]);
   });
+
+  it('identifies the root by its live path even when rootResourceId is UNRESOLVED (no destructive false-added)', () => {
+    // The RestApi read was skipped/missing RootResourceId -> rootResourceId undefined.
+    // The live root (path '/') must STILL not be flagged added (else a revert would
+    // DeleteResource the API root), and its declared methods must not falsely surface.
+    const added = diffApiGatewayChildren({
+      apiId: API,
+      rootResourceId: undefined,
+      declaredResourceIds: [],
+      declaredMethodKeys: [], // unresolvable because RootResourceId didn't resolve
+      liveResources: [{ id: ROOT, path: '/' }],
+      liveMethodsByResource: { [ROOT]: [{ httpMethod: 'GET' }] },
+    });
+    expect(added).toEqual([]);
+    // a genuine non-root added resource is still flagged in the same (degraded) read
+    const added2 = diffApiGatewayChildren({
+      apiId: API,
+      rootResourceId: undefined,
+      declaredResourceIds: [],
+      declaredMethodKeys: [],
+      liveResources: [
+        { id: ROOT, path: '/' },
+        { id: 'res9', path: '/added' },
+      ],
+      liveMethodsByResource: {},
+    });
+    expect(added2.map((a) => a.identifier)).toEqual([`${API}|res9`]);
+  });
 });
 
 describe('diffApiGatewayV2Children (HTTP / WebSocket API)', () => {


### PR DESCRIPTION
## What

`diffApiGatewayChildren` marked the API Gateway REST root `/` resource as implicitly
declared **only** via `rootResourceId`, which comes from the RestApi's Cloud Control
read (`liveAttrs`). If that read was skipped / throttled / missing the attr,
`rootResourceId` was `undefined` → the live root resource matched no declared id →
it was flagged as an out-of-band **`added` Resource**. A `revert` on that finding
would then issue `DeleteResource` against the API's **ROOT** resource — a destructive
false positive.

Fix: identify the root by its **live path `/`** (authoritative — there is exactly one
root per API, created with the RestApi) in addition to `rootResourceId`, so the live
root is always treated as the implicit declared root even when `rootResourceId` can't
be resolved. Additionally, when `rootResourceId` is unresolved the root's declared
method keys (`Fn::GetAtt RootResourceId`) also can't resolve, so the root's methods
are not method-diffed — avoiding a secondary "added Method" false positive on the
root.

## Safety

The change only **adds** the live root to the declared set — it can only **suppress**
the false root-added, never create a new `added` finding. On the normal path
(`rootResourceId` present) `liveRootId === rootResourceId`, so behavior is identical.

## Tests

- `child-enumerators.test.ts` (+1): with `rootResourceId: undefined`, the live root
  (path `/`) is NOT flagged added and its methods don't surface; a genuine non-root
  added resource (`/added`) is still flagged in the same degraded read.

## Verification

- typecheck / lint+format / build / **1050 unit tests (39 files)** + 286-corpus green.
- **LIVE (real AWS)** — the `apigw-added` fixture (REST API with a root + out-of-band
  added children): `INTEG PASS` — normal root + added-children detection is unchanged;
  stack destroyed clean.
