### PR TITLE
fix(normalize): preserve policy doc-level Id/sibling keys + tighten isPolicyDoc to real statements

### DIFF
--- a/src/normalize/policy-canonical.ts
+++ b/src/normalize/policy-canonical.ts
@@ -10,7 +10,17 @@ function isObj(v: unknown): v is Record<string, unknown> {
 }
 
 function isPolicyDoc(v: unknown): v is Record<string, unknown> {
-  return isObj(v) && 'Statement' in v;
+  if (!isObj(v) || !('Statement' in v)) return false;
+  // Require `Statement` to actually look like IAM statements — an array of (or a
+  // single) object carrying an `Effect` (Allow/Deny) — NOT just any value under a key
+  // literally named "Statement". Otherwise a user free-form field named `Statement`
+  // (a string, number, or arbitrary object) would be force-canonicalized into policy
+  // shape: a scalar wrapped into a one-element array, sibling keys reordered, two
+  // different values equated (the cc-api-strip free-form-map mangling class). Mirrors
+  // isPolicyStatementArray in classify.ts.
+  const looksLikeStatement = (el: unknown): boolean => isObj(el) && 'Effect' in el;
+  const s = v.Statement;
+  return Array.isArray(s) ? s.every(looksLikeStatement) : looksLikeStatement(s);
 }
 
 /** Parse a (possibly URL-encoded) JSON string into a policy doc, or null. */
@@ -113,14 +123,20 @@ function normalizeAccountPrincipal(v: unknown): unknown {
 
 export function canonicalizePolicy(doc: Record<string, unknown>): Record<string, unknown> {
   const statements = Array.isArray(doc.Statement) ? doc.Statement : [doc.Statement];
+  // Preserve ALL top-level keys (only `Statement` is rewritten). A policy document
+  // may carry a doc-level `Id` (IAM/S3 policy grammar) or other top-level fields; a
+  // prior whitelist of just `Statement`/`Version` DROPPED them, so two policies that
+  // differ ONLY in `Id` (or any sibling key) canon-equalled — hiding an out-of-band
+  // `Id`/sibling change (a false negative).
   const out: Record<string, unknown> = {
+    ...doc,
     Statement: statements.map(canonicalizeStatement).sort(byJson),
   };
   // Keep Version only if present. Filling a default would create a false
   // declared-drift when the template omits Version but AWS stored a literal
   // (e.g. legacy "2008-10-17"); under subset comparison an absent declared
   // Version simply isn't compared, which is the correct outcome.
-  if (doc.Version !== undefined) out.Version = doc.Version;
+  if (doc.Version === undefined) delete out.Version;
   return out;
 }
 

--- a/tests/policy-canonical.test.ts
+++ b/tests/policy-canonical.test.ts
@@ -20,6 +20,36 @@ describe('policy canonicalization', () => {
     expect(canonicalizePolicy({ Statement: [] })).not.toHaveProperty('Version');
   });
 
+  it('preserves a top-level Id (and other top-level keys); policies differing only in Id are NOT equal', () => {
+    const stmt = [{ Effect: 'Allow', Action: 's3:Get', Resource: '*' }];
+    const a = canonicalizePolicy({ Version: '2012-10-17', Id: 'A', Statement: stmt });
+    const b = canonicalizePolicy({ Version: '2012-10-17', Id: 'B', Statement: stmt });
+    expect(a.Id).toBe('A');
+    expect(deepEqual(a, b)).toBe(false); // an out-of-band doc-level Id change is no longer hidden
+    // same Id with a reordered statement still canon-equal (canonicalization still applies)
+    const c = canonicalizePolicy({
+      Version: '2012-10-17',
+      Id: 'A',
+      Statement: [{ Effect: 'Allow', Resource: '*', Action: 's3:Get' }],
+    });
+    expect(deepEqual(a, c)).toBe(true);
+  });
+
+  it('does NOT mangle a non-policy value under a key literally named Statement', () => {
+    // a free-form field whose Statement is a STRING is not an IAM policy — pass through
+    expect(normalizePoliciesDeep({ Statement: 'hello', Other: [3, 1, 2] })).toEqual({
+      Statement: 'hello',
+      Other: [3, 1, 2],
+    });
+    // a Statement array whose elements lack `Effect` is not a policy — untouched
+    expect(normalizePoliciesDeep({ Statement: [{ Foo: 1 }] })).toEqual({ Statement: [{ Foo: 1 }] });
+    // a REAL policy (statements carry Effect) IS still canonicalized (Action sorted)
+    const real = normalizePoliciesDeep({
+      Statement: [{ Effect: 'Allow', Action: ['b', 'a'], Resource: '*' }],
+    }) as { Statement: { Action: unknown }[] };
+    expect(real.Statement[0].Action).toEqual(['a', 'b']);
+  });
+
   it('is order-independent across statements and within Action arrays', () => {
     const a = canonicalizePolicy({
       Statement: [


### PR DESCRIPTION
## What

Two pure-function policy-canonicalization fixes (no live-AWS surface).

### 1. `canonicalizePolicy` dropped a policy doc-level `Id` / sibling keys (FN)

`canonicalizePolicy` built its output from scratch with only `Statement` (+ `Version`
if present), so a doc-level `Id` (legal in the IAM/S3 policy grammar) and any other
top-level key were **dropped**. Two policies differing ONLY in `Id` then canon-equalled
→ an out-of-band `Id` (or sibling-key) change was hidden. Fix: spread all top-level keys
and rewrite only `Statement` (the "don't fabricate Version" behavior is preserved by
deleting `Version` when the source omits it).

### 2. `isPolicyDoc` over-fired on any object with a `Statement` key

`isPolicyDoc` returned true for ANY object containing a key literally named
`Statement` — so a user free-form field named `Statement` (a string, number, or
arbitrary object) was force-canonicalized into policy shape: a scalar wrapped into a
one-element array, sibling keys reordered/dropped, two different values equated (the
same mangling class as the cc-api-strip free-form-map bug). Fix: require `Statement`
to be an array of (or a single) object carrying an `Effect` — mirroring
`isPolicyStatementArray` in classify. Currently latent (no corpus hit) — a hardening
fix that closes the landmine for any future type with a `Statement`-named field.

## Tests

- `policy-canonical.test.ts`: a top-level `Id` is preserved and two policies differing
  only in `Id` are NOT equal (same `Id` + reordered statement still canon-equal); a
  non-policy value under a `Statement` key (string / no-`Effect` array) passes through
  untouched while a real `Effect`-bearing policy is still canonicalized.

## Verification

- typecheck / lint+format / build / **1052 unit tests (39 files)** + 286-corpus green
  (no existing policy classification changed → FP/FN-safe) + the baseline round-trip
  tests pass (canonicalization stays idempotent + consistent across classify / baseline
  / added consumers). No live integ: pure deterministic canonicalization, corpus-covered.
