### PR TITLE
fix(revert,schema): block nested create-only paths up front + collapse interior /properties/ pointers

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -91,10 +91,35 @@ export interface RevertOptions {
   schemas?: Map<string, SchemaInfo>;
 }
 
-// the first dotted segment of a finding path ("A.B.0" -> "A"), used to test the
-// top-level create-only set.
-function topSegment(path: string): string {
-  return path.split('.')[0] ?? path;
+// True when a finding path is AT or UNDER any create-only schema path. The schema's
+// `createOnlyPaths` are full dotted paths with `*` wildcards (e.g. `EncryptionConfiguration
+// .KmsKey`, `PosixUser.*`, `Foo.*.Bar`); a finding's array-index segments (`[id]` or a
+// numeric `.0`) align with those `*`. Segment-wise PREFIX membership, so a NESTED
+// create-only property (parent mutable) is caught — the previous top-level-only check
+// (`createOnly.has(firstSegment)`) missed those, and a `revert` then built an in-place
+// patch that AWS rejects only at apply time (e.g. ECR `EncryptionConfiguration.KmsKey`,
+// EFS AccessPoint `PosixUser.*`).
+function pathSegments(path: string): string[] {
+  return path
+    .replace(/\[[^\]]*\]/g, '.*')
+    .split('.')
+    .filter((s) => s.length > 0);
+}
+function isUnderCreateOnly(findingPath: string, createOnlyPaths: readonly string[]): boolean {
+  const f = pathSegments(findingPath);
+  for (const co of createOnlyPaths) {
+    const c = co.split('.');
+    if (c.length > f.length) continue; // can't be a prefix of the finding path
+    let match = true;
+    for (let i = 0; i < c.length; i++) {
+      if (c[i] !== '*' && c[i] !== f[i]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) return true;
+  }
+  return false;
 }
 
 export function buildRevertPlan(
@@ -228,7 +253,8 @@ export function buildRevertPlan(
     }
     // create-only property: an in-place UpdateResource patch would be rejected (the
     // change needs a replacement) — report it now instead of failing at apply time.
-    if (opts.schemas?.get(f.resourceType)?.createOnly.has(topSegment(f.path))) {
+    const schema = opts.schemas?.get(f.resourceType);
+    if (schema && isUnderCreateOnly(f.path, schema.createOnlyPaths)) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -40,7 +40,19 @@ async function fetch(client: CloudFormationClient, resourceType: string): Promis
 
 // JSON pointer "/properties/A/B/*/C" -> dotted "A.B.*.C"
 function pointerToDotted(p: string): string {
-  return p.replace(/^\/properties\//, '').replace(/\//g, '.');
+  // A JSON-pointer property path is `/properties/Foo/Bar`. Some CFn registry schemas
+  // (e.g. OpenSearch `conditionalCreateOnlyProperties`) emit an INTERIOR or TRAILING
+  // `/properties/` segment — `/properties/EncryptionAtRestOptions/properties` (the
+  // block itself) or `/properties/AdvancedSecurityOptions/properties/Enabled`. Strip
+  // the leading one, collapse any interior `/properties/` to the real nesting boundary,
+  // and drop a trailing `/properties`, so the dotted path matches the actual model key
+  // (`EncryptionAtRestOptions`, `AdvancedSecurityOptions.Enabled`) instead of keeping a
+  // literal `properties` segment that matches nothing.
+  return p
+    .replace(/^\/properties\//, '')
+    .replace(/\/properties\//g, '/')
+    .replace(/\/properties$/, '')
+    .replace(/\//g, '.');
 }
 
 // Unlike readOnly/writeOnly/createOnly (CFn pre-flattens those into pointer

--- a/tests/path-strip.test.ts
+++ b/tests/path-strip.test.ts
@@ -42,4 +42,20 @@ describe('parseSchema nested paths', () => {
     expect(info.writeOnlyPaths).toContain('LifecycleConfiguration.Rules.*.Transition');
     expect(info.readOnlyPaths).toEqual(['Arn']);
   });
+
+  it('collapses interior + trailing /properties/ segments (OpenSearch conditionalCreateOnly)', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        conditionalCreateOnlyProperties: [
+          '/properties/EncryptionAtRestOptions/properties', // the block itself
+          '/properties/AdvancedSecurityOptions/properties/Enabled', // interior /properties/
+        ],
+      })
+    );
+    // the literal `properties` segment is stripped so the dotted path matches the model
+    expect(info.createOnlyPaths).toEqual([
+      'EncryptionAtRestOptions',
+      'AdvancedSecurityOptions.Enabled',
+    ]);
+  });
 });

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -391,6 +391,55 @@ describe('buildRevertPlan', () => {
     expect(plan.items).toHaveLength(1);
   });
 
+  it('a NESTED create-only path (parent mutable) is notRevertable, not a doomed in-place patch', () => {
+    // ECR EncryptionConfiguration is mutable but EncryptionConfiguration.KmsKey is
+    // create-only; the top-level-only check missed it and built a patch AWS rejects at
+    // apply time. createOnlyPaths carries the nested path; isUnderCreateOnly catches it.
+    const ecr = (...paths: string[]) => schemaWithCreateOnly('AWS::ECR::Repository', ...paths);
+    const drift = (path: string) =>
+      buildRevertPlan(
+        [
+          F({
+            resourceType: 'AWS::ECR::Repository',
+            tier: 'declared',
+            path,
+            desired: 'a',
+            actual: 'b',
+          }),
+        ],
+        undefined,
+        { schemas: ecr('EncryptionConfiguration.KmsKey') }
+      );
+    expect(drift('EncryptionConfiguration.KmsKey').notRevertable[0]!.reason).toContain(
+      'create-only'
+    );
+    expect(drift('EncryptionConfiguration.KmsKey').items).toHaveLength(0);
+    // a SIBLING nested path that is NOT create-only still plans a revert op
+    expect(drift('EncryptionConfiguration.RegistryId').items).toHaveLength(1);
+  });
+
+  it('a wildcard nested create-only path matches an array-index finding path', () => {
+    // EFS AccessPoint PosixUser.* (and a `Foo.*.Bar` array form) are create-only
+    const efs = schemaWithCreateOnly('AWS::EFS::AccessPoint', 'PosixUser.*', 'Tags.*.Key');
+    const plan = (path: string) =>
+      buildRevertPlan(
+        [
+          F({
+            resourceType: 'AWS::EFS::AccessPoint',
+            tier: 'declared',
+            path,
+            desired: 'a',
+            actual: 'b',
+          }),
+        ],
+        undefined,
+        { schemas: efs }
+      );
+    expect(plan('PosixUser.Uid').notRevertable[0]!.reason).toContain('create-only');
+    expect(plan('Tags.0.Key').notRevertable[0]!.reason).toContain('create-only'); // numeric index aligns with *
+    expect(plan('Tags.0.Value').items).toHaveLength(1); // .Value is not under the create-only Key path
+  });
+
   it('deleted finding -> notRevertable (recreate via cdk deploy), never a patch op', () => {
     const plan = buildRevertPlan(
       [F({ tier: 'deleted', path: '', desired: undefined, actual: undefined })],


### PR DESCRIPTION
## What

Two pure-function revert/schema fixes (no live-AWS surface).

### 1. Nested create-only paths weren't blocked up front (`revert/plan.ts`)

The create-only guard tested only the **top-level** set
(`createOnly.has(firstSegment)`). A NESTED create-only property whose parent is
mutable — ECR `EncryptionConfiguration.KmsKey`, EFS AccessPoint `PosixUser.*`,
VPCEndpoint `DnsOptions.*`, … (47 such paths across real types in the corpus) — was
NOT reported `notRevertable`, so `revert` built an in-place `UpdateResource` patch
that AWS **rejects only at apply time** instead of the intended up-front
"create-only property — change requires resource replacement". Fix: `isUnderCreateOnly`
does segment-wise PREFIX membership against the full `createOnlyPaths` (its `*`
wildcards align with a finding's array-index segments). A non-create-only sibling
still plans a revert op (no over-block).

### 2. `pointerToDotted` mis-parsed interior/trailing `/properties/` (`schema/schema-strip.ts`)

It only stripped the LEADING `/properties/`. Some CFn registry schemas (OpenSearch
`conditionalCreateOnlyProperties`) emit an interior or trailing `/properties/`
segment — `/properties/EncryptionAtRestOptions/properties`,
`/properties/AdvancedSecurityOptions/properties/Enabled` — which then kept a literal
`properties` segment in the dotted path and matched no model key. Fix: collapse
interior + trailing `/properties/` (→ `EncryptionAtRestOptions`,
`AdvancedSecurityOptions.Enabled`). This also makes those create-only paths actually
match in fix (1).

## Tests

- `revert-plan.test.ts`: a nested create-only path (`EncryptionConfiguration.KmsKey`)
  is `notRevertable` while a non-create-only sibling stays revertable; a wildcard
  create-only path (`PosixUser.*`, `Tags.*.Key`) matches an array-index finding path
  (`Tags.0.Key`) while `Tags.0.Value` stays revertable.
- `path-strip.test.ts`: interior + trailing `/properties/` collapse to the real keys.

## Verification

- typecheck / lint+format / build / **1055 unit tests (39 files)** + 286-corpus green.
- No live integ: the create-only guard reports `notRevertable` BEFORE any AWS mutation
  — it can only ADD a `notRevertable` (preventing a doomed apply), never cause a wrong
  write; both changes are deterministic pure functions.
