### PR TITLE
fix(normalize): resolve Fn::Select index + honor Fn::FindInMap DefaultValue

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -83,9 +83,14 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
       }
       case 'Fn::Select': {
         if (!Array.isArray(v)) return UNRESOLVED;
-        const [idx, list] = v as [number, unknown];
+        const [idxRaw, list] = v as [unknown, unknown];
         const arr = resolve(list, ctx);
         if (!Array.isArray(arr)) return UNRESOLVED;
+        // The index may itself be an intrinsic (CFn allows e.g. { Ref: SomeParam } /
+        // Fn::FindInMap as the index) — resolve it before coercing. (Number() on the
+        // raw UNRESOLVED symbol would throw, so guard it first.)
+        const idx = resolve(idxRaw, ctx);
+        if (idx === UNRESOLVED) return UNRESOLVED;
         const i = Number(idx);
         // Fail-closed: out-of-range index (or a NaN index) would otherwise yield
         // `undefined` and report false `desired: undefined` drift. The selected
@@ -96,7 +101,7 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
       }
       case 'Fn::FindInMap': {
         if (!Array.isArray(v) || v.length < 3) return UNRESOLVED;
-        const [mapName, topKey, secondKey] = v.map((x) => resolve(x, ctx));
+        const [mapName, topKey, secondKey] = v.slice(0, 3).map((x) => resolve(x, ctx));
         // All 3 keys must resolve to strings and the path must exist; else fail-closed.
         if (
           typeof mapName !== 'string' ||
@@ -105,7 +110,21 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
         )
           return UNRESOLVED;
         const val = ctx.mappings?.[mapName]?.[topKey]?.[secondKey];
-        return val === undefined ? UNRESOLVED : val;
+        if (val !== undefined) return val;
+        // CFn supports an optional 4th argument — { DefaultValue: ... } — returned when
+        // the map path is absent. Honor it so a declared default is still compared (else
+        // a knowable declared value is silently dropped to UNRESOLVED = missed drift).
+        const fourth = v[3];
+        if (
+          fourth !== null &&
+          typeof fourth === 'object' &&
+          !Array.isArray(fourth) &&
+          'DefaultValue' in fourth
+        ) {
+          const def = resolve((fourth as Record<string, unknown>).DefaultValue, ctx);
+          return def === UNRESOLVED ? UNRESOLVED : def;
+        }
+        return UNRESOLVED;
       }
       case 'Fn::Split': {
         if (!Array.isArray(v) || v.length < 2) return UNRESOLVED;

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -190,6 +190,26 @@ describe('intrinsic resolver', () => {
     );
   });
 
+  it('Fn::FindInMap honors the optional 4th DefaultValue when the path is absent', () => {
+    const c = ctx({ mappings: { RegionMap: { 'us-east-1': { ami: 'ami-123' } } } });
+    // missing path + DefaultValue -> the declared default (not UNRESOLVED)
+    expect(
+      resolve({ 'Fn::FindInMap': ['RegionMap', 'us-east-1', 'nope', { DefaultValue: 'fb' }] }, c)
+    ).toBe('fb');
+    // present path still wins over the default
+    expect(
+      resolve({ 'Fn::FindInMap': ['RegionMap', 'us-east-1', 'ami', { DefaultValue: 'fb' }] }, c)
+    ).toBe('ami-123');
+    // the default may itself be an intrinsic
+    expect(
+      resolve({ 'Fn::FindInMap': ['Ghost', 'x', 'y', { DefaultValue: { Ref: 'Env' } }] }, c)
+    ).toBe('prod');
+    // an unresolvable default stays fail-closed
+    expect(
+      resolve({ 'Fn::FindInMap': ['Ghost', 'x', 'y', { DefaultValue: { Ref: 'Nope' } }] }, c)
+    ).toBe(UNRESOLVED);
+  });
+
   it('Fn::Split splits a resolved string, propagates UNRESOLVED', () => {
     expect(resolve({ 'Fn::Split': [',', 'a,b,c'] }, ctx())).toEqual(['a', 'b', 'c']);
     expect(resolve({ 'Fn::Split': [',', { Ref: 'Env' }] }, ctx())).toEqual(['prod']);
@@ -214,6 +234,16 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::Select': [1, ['a', 'b']] }, ctx())).toBe('b'); // in-range ok
     expect(resolve({ 'Fn::Select': [5, ['a', 'b']] }, ctx())).toBe(UNRESOLVED); // OOB
     expect(resolve({ 'Fn::Select': [0, [{ Ref: 'Ghost' }, 'b']] }, ctx())).toBe(UNRESOLVED); // unresolved element
+  });
+
+  it('Fn::Select resolves an intrinsic index (CFn allows Ref/FindInMap as the index)', () => {
+    const c = ctx({ params: { Env: 'prod', Idx: '1' } });
+    // index is a Ref to a (numeric-string) param -> resolved, then selected
+    expect(resolve({ 'Fn::Select': [{ Ref: 'Idx' }, ['a', 'b', 'c']] }, c)).toBe('b');
+    // a string-literal index still works
+    expect(resolve({ 'Fn::Select': ['2', ['a', 'b', 'c']] }, c)).toBe('c');
+    // an unresolvable index stays fail-closed (no throw on the UNRESOLVED symbol)
+    expect(resolve({ 'Fn::Select': [{ Ref: 'Ghost' }, ['a', 'b']] }, c)).toBe(UNRESOLVED);
   });
 
   it('hasUnresolved detects sentinel at depth', () => {


### PR DESCRIPTION
## What

Two declared-side intrinsic-resolution **false negatives** — a *knowable* declared
value was silently dropped to `UNRESOLVED`, suppressing drift detection on that
property:

### `Fn::Select` — index not resolved
The index was coerced raw (`Number(idx)`) without resolving it first. CloudFormation
allows the `Fn::Select` index to be an intrinsic (`{ Ref: SomeParam }`,
`Fn::FindInMap`, …), so such an index became `NaN` → fail-closed → missed drift.
Now the index is resolved first, guarding the `UNRESOLVED` symbol (on which
`Number()` would otherwise throw).

### `Fn::FindInMap` — 4th `DefaultValue` ignored
CFn supports an optional 4th argument `{ DefaultValue: ... }` returned when the map
path is absent. The resolver only destructured the first three elements and returned
`UNRESOLVED` on a missing path — dropping a declared default it could have compared.
Now it honors the 4th arg (itself resolvable); a present map path still wins, and an
unresolvable default stays fail-closed.

## Safety

Both stay **fail-closed** on anything unknowable, so there is no false-positive
surface — a value either resolves accurately (correct drift detection) or stays
`UNRESOLVED` (skipped). Verified against the full unit suite + the 286-fixture
self-compare corpus (all green). Pure-function change, no live-AWS surface.

## Tests

+2 test blocks (`Fn::Select` intrinsic/string/unresolvable index; `Fn::FindInMap`
default honored / path-wins / intrinsic-default / unresolvable-default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
