### PR TITLE
fix(cli): ignore skips un-checkable stacks; reject empty separate-token flag value

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -98,8 +98,11 @@ export function parseCommonArgs(args: string[]): CommonArgs {
         v = inlineValue;
       } else {
         const next = args[i + 1];
-        // a following token that is itself a flag is NOT a value (catches `--region --json`)
-        if (next === undefined || next.startsWith('-')) {
+        // a following token that is itself a flag is NOT a value (catches `--region --json`).
+        // An empty token (`--region ""`) is also "no value": accepting it would let `''`
+        // shadow the env fallback (`?? process.env.AWS_REGION` does not fire on `''`),
+        // and the inline form `--region=` already rejects empty — stay consistent.
+        if (next === undefined || next === '' || next.startsWith('-')) {
           throw new Error(`option "${flag}" requires a value — see cdkrd --help`);
         }
         v = next;

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -4,7 +4,7 @@
 // keeps watching). Writes ONLY the git-committed config file; no AWS writes. The
 // per-stack ignore flow lives in stack-actions.ts (shared with check's interactive
 // prompt in PR-B2).
-import { isStackNotDeployed } from '../aws-errors.js';
+import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
   checkBaselineAccount,
@@ -77,6 +77,13 @@ export async function runIgnore(args: string[]): Promise<number> {
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — nothing to ignore`);
+        continue;
+      }
+      // A stack that exists but has no meaningful deployed state (REVIEW_IN_PROGRESS /
+      // deleting): skip, not error — matching check/record/revert. There is nothing to
+      // ignore, so one un-checkable stack must not drag the whole run to exit 2.
+      if (e instanceof StackNotCheckableError) {
+        console.error(`note: ${stackName}: ${e.message} — nothing to ignore`);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -75,6 +75,13 @@ describe('parseCommonArgs', () => {
       /option "--region" requires a value/
     );
     expect(() => parseCommonArgs(['-c', '--json'])).toThrow(/option "-c" requires a value/);
+    // an empty separate-token value is also "no value" — else `''` would shadow the
+    // env fallback (e.g. $AWS_REGION) and the inline form `--region=` already rejects it
+    expect(() => parseCommonArgs(['--region', ''])).toThrow(/option "--region" requires a value/);
+    expect(() => parseCommonArgs(['--profile', ''])).toThrow(/option "--profile" requires a value/);
+    expect(() => parseCommonArgs(['MyStack', '--app', ''])).toThrow(
+      /option "--app" requires a value/
+    );
   });
 
   it('errors on malformed -c/--context (no key=value)', () => {


### PR DESCRIPTION
## What

Two CLI / verb-consistency fixes surfaced by the per-verb orchestration audit.

### 1. `ignore` errored (exit 2) on un-checkable stacks where the other verbs skip

A stack in `REVIEW_IN_PROGRESS` / `DELETE_IN_PROGRESS` makes `loadDesired` throw
`StackNotCheckableError`. `check`, `record`, and `revert` all catch it and **skip**
the stack (exit 0, with a "nothing to …" note) — but `ignore`'s catch block only
handled `isStackNotDeployed` and fell through to the generic arm, printing
`error: <stack>: …` and setting `worst = 2`. In a multi-stack run, one un-checkable
stack dragged the whole `ignore` invocation to exit 2 even though every other
stack's rules were written fine. Now `ignore` mirrors the sibling verbs.

### 2. Empty separate-token flag value silently shadowed the env fallback

`--region ""` / `--profile ""` / `--app ""` were accepted: `''` doesn't start with
`-`, so it passed as the value. For `--region`/`--profile` that empty string then
**shadowed** the env fallback (`values['--region'] ?? process.env.AWS_REGION` does
not fire on `''`), so `AWS_REGION=us-east-1 cdkrd check --region ""` resolved region
to `''` and failed with "no region". The inline form `--region=` already rejects
empty — the space-separated form now does too.

## Tests

+cli-args unit tests (empty `--region` / `--profile` / `--app` rejected). The
`ignore` arm is a verbatim mirror of the three already-shipped sibling arms (whose
loop-level catch is, like theirs, exercised at integration level rather than a
unit harness that doesn't exist in the repo). 1066 tests green. No live-AWS surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
