### PR TITLE
feat(report): never print "0 shown" + drop the first-run [To Record] header

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ there is nothing to compare them to yet), then offers to record a baseline:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-[To Record: 3] (live-only values, no baseline yet — run cdkrd record to start tracking)
+[Not Recorded: 3] (not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it)
   ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
   ApiStack/Api.EndpointConfiguration.IpAddressType (AWS::ApiGateway::RestApi) = "ipv4"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -754,18 +754,22 @@ tags such findings `unrecorded` — on a no-baseline first run that is every
 undeclared value, and after a cherry-pick record it is still every value the
 user did not pick. They render as their own section, are excluded from the
 verdict and the `--fail` exit, and the `result:` line carries the count + the
-way out. **First run vs steady state (R138):** with NO baseline file the run is
-framed as a setup step, not a clean check — the section is `[To Record: N]`
-(note: `live-only values, no baseline yet — run cdkrd record to start tracking`),
-nested unrecorded values are EXPANDED (so the report lists the SAME set the
-record prompt offers — no contradictory `0 shown, N folded`), and the verdict is
-`NO DRIFT — N value(s) to record (run cdkrd record)`, NOT a green `CLEAN` (which
-read as "nothing to do" right before the record prompt). Once a baseline exists,
-steady-state rendering returns: the section is `[Not Recorded: N]` (note:
-`not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to
-track it`), nested values fold (R96), and the line reads
+way out. The section is always `[Not Recorded: N]` (note: `not drift — a live-only
+value not yet in your .cdkrd baseline; run cdkrd record to track it`). **First run
+vs steady state (R138):** with NO baseline file the run is framed as a setup step,
+not a clean check — nested unrecorded values are EXPANDED (so the report lists the
+SAME set the record prompt offers — no contradictory `0 shown, N folded`), and the
+verdict is `NO DRIFT — N value(s) to record (run cdkrd record)`, NOT a green `CLEAN`
+(which read as "nothing to do" right before the record prompt). Once a baseline
+exists, nested values fold (R96) and the line reads
 `CLEAN — N unrecorded value(s) await a baseline (X shown, Y folded; run cdkrd record)`
-when some fold (R112). When BOTH a drift section and a standout `[Not Recorded]`
+when some fold (R112). **Never `0 shown` (R139):** the fold is suppressed whenever it
+would hide EVERY unrecorded value (they are all nested) — folding to `0 shown, N
+folded` while the record prompt still asks about those N is the same contradiction in
+steady state, so the values are expanded; folding still applies once at least one
+value stands out. (R139 also dropped R138's first-run-only `[To Record]` header — one
+concept, two labels; the verdict already carries the "to record" framing.) When BOTH a
+drift section and a standout `[Not Recorded]`
 section print, a lone `N drift(s)` verdict reads as a mismatch against the 2+
 visible blocks, so the line switches to a combined findings count counting only
 what is SHOWN — `result: 3 findings — 1 drift (declared=1) + 2 undeclared to

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -208,8 +208,15 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // record prompt asks about — folding them to "0 shown, N folded" contradicts the very
   // next prompt. Expand on firstRun; the steady-state fold (R96) is otherwise unchanged.
   const expandNested = !!opts.verbose || !!opts.expandAtDefault || !!opts.firstRun;
-  const unrecordedShown = expandNested ? unrecordedItems : unrecordedItems.filter((f) => !f.nested);
-  const nestedFolded = expandNested ? [] : unrecordedItems.filter((f) => f.nested === true);
+  let unrecordedShown = expandNested ? unrecordedItems : unrecordedItems.filter((f) => !f.nested);
+  // R139: never print "0 shown". If folding hid EVERY unrecorded value (they are all
+  // nested), the report would say "0 shown, N folded" and the record prompt would then
+  // immediately ask about those N — the same contradiction R138 fixed for the first run,
+  // but it can also arise in steady state when a newly-appeared value is nested. Expand
+  // them so the report and the prompt always agree; folding still applies whenever at
+  // least one value stands out.
+  if (unrecordedShown.length === 0) unrecordedShown = unrecordedItems;
+  const nestedFolded = unrecordedItems.filter((f) => !unrecordedShown.includes(f));
   // Count inside the brackets (`[NAME: N]`), explanation outside (dim) — see the
   // layout comment at the top (R48). `leadingBlank` separates a section from
   // whatever precedes it; the FIRST drift section sits directly under the header.
@@ -240,18 +247,14 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   }
   // UNRECORDED: full detail like a drift section (these values await a decision —
   // hiding them would defeat the differentiator), but kept OUT of the verdict.
-  // R138: on a first run (no baseline) name the section for the action the user is about
-  // to take ("To Record"); in steady state it is values that appeared since record
-  // ("Not Recorded").
-  const recordSectionName = opts.firstRun ? 'To Record' : 'Not Recorded';
-  const recordSectionNote = opts.firstRun
-    ? 'live-only values, no baseline yet — run cdkrd record to start tracking'
-    : 'not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it';
+  // R139: one section name in both first-run and steady state — the verdict already
+  // carries the first-run "to record" framing, so a separate "[To Record]" header (R138)
+  // only split one concept into two labels. "Not Recorded" reads correctly either way.
   if (
     section(
       unrecordedShown,
-      recordSectionName,
-      recordSectionNote,
+      'Not Recorded',
+      'not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it',
       style.undeclaredTier,
       driftSections > 0
     )

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -40,18 +40,31 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     );
   });
 
-  it('R138: first run (no baseline) expands nested + names a "to record" state, not CLEAN', () => {
+  it('R138/R139: first run (no baseline) expands nested + NO DRIFT verdict, one section name', () => {
     // All three nested — in steady state they would fold to "0 shown, 3 folded"; on a
     // first run they expand so the report lists the same set the record prompt offers.
     const nested = (p: string): Finding => ({ ...U(p), nested: true });
     const { code, text } = run([nested('a'), nested('b'), nested('c')], { firstRun: true });
     expect(code).toBe(0); // unrecorded never counts as drift
-    expect(text).toContain('[To Record: 3]'); // first-run section name
-    expect(text).toContain('no baseline yet'); // first-run section note
-    expect(text).not.toContain('Not Recorded'); // steady-state name is not used
+    expect(text).toContain('[Not Recorded: 3]'); // R139: one section name in both states
     expect(text).toContain('result: NO DRIFT — 3 value(s) to record (run cdkrd record)');
     expect(text).not.toContain('CLEAN'); // the contradiction we are fixing
     expect(text).not.toContain('shown'); // no "X shown, Y folded" split on a first run
+    expect(text).not.toContain('folded');
+  });
+
+  it('R139: steady state, ALL unrecorded nested -> 0-shown guard expands them (never "0 shown")', () => {
+    // No firstRun: nested would normally fold, but folding every value would print
+    // "0 shown, 3 folded" and the record prompt would still ask about all 3. The guard
+    // expands them so the report and the prompt agree. Verdict stays the steady CLEAN line.
+    const nested = (p: string): Finding => ({ ...U(p), nested: true });
+    const { code, text } = run([nested('a'), nested('b'), nested('c')]);
+    expect(code).toBe(0);
+    expect(text).toContain('[Not Recorded: 3]'); // all 3 listed, not folded away
+    expect(text).toContain(
+      'result: CLEAN — 3 unrecorded value(s) await a baseline (run cdkrd record)'
+    );
+    expect(text).not.toContain('0 shown'); // the residual this guard closes
     expect(text).not.toContain('folded');
   });
 


### PR DESCRIPTION
Two small follow-ups to R138 (#163), both touching the same first-run report logic.

## 1. Never print `0 shown` (the residual R138 left)

R138 fixed the first-run contradiction (`CLEAN — 0 shown, N folded` → record prompt asks about N). But the same shape can still arise in **steady state**: a baseline exists and a newly-appeared unrecorded value happens to be nested → it folds → `0 shown, N folded`, yet the interactive prompt still asks about it.

Fix: **if folding would hide EVERY unrecorded value, expand them** so the report and the prompt always agree. Folding still applies whenever at least one value stands out (day-to-day noise stays quiet). Also covers the drift + all-nested case (mixed verdict).

## 2. One section name (revert R138's `[To Record]`)

R138 renamed the section to `[To Record: N]` on a first run only — splitting one concept into two labels (`[To Record]` vs steady `[Not Recorded]`). The verdict already carries the "to record" framing (`NO DRIFT — N value(s) to record`), so the header is now **always `[Not Recorded: N]`**. The first-run difference is just the verdict + nested expansion.

### First-run output after R139

```
=== cdkrd check: dev-goto-ScoringApiStack (ap-northeast-1) ===
[Not Recorded: 3] (not drift — a live-only value not yet in your .cdkrd baseline; run cdkrd record to track it)
  .../CustomDomainName.EndpointConfiguration.IpAddressType = "ipv4"
  .../OPTIONS.Integration.CacheNamespace = "7n6zf3"
  .../POST.Integration.CacheNamespace = "7n6zf3"

result: NO DRIFT — 3 value(s) to record (run cdkrd record)
```

## Tests
- `report.test.ts`: R138 first-run test updated to the unified `[Not Recorded]` header; new test pins the steady-state 0-shown guard (all-nested → expanded, never `0 shown`).
- All 1073 unit tests pass; typecheck / oxc lint+format / build green.
