### PR TITLE
fix(classify): reach wrapped inline-policy statements + descend past unresolved siblings

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -96,6 +96,17 @@ const isNestedObject = (x: unknown): x is Record<string, unknown> =>
 const isPolicyStatementArray = (arr: unknown[]): boolean =>
   arr.length > 0 && arr.every((el) => isNestedObject(el) && 'Effect' in el);
 
+// An IAM inline-policy WRAPPER array — `Policies: [{ PolicyName, PolicyDocument }]` on
+// AWS::IAM::Role/User/Group, the dominant CDK inline-policy shape. The wrapper is
+// identity-LESS (PolicyName is not a generic IDENTITY_FIELD) and its elements are NOT
+// statements (no `Effect`), so neither descent above fires — leaving the wrapped
+// PolicyDocument.Statement unreached and a live-only sub-key added to a wrapped statement
+// (e.g. an out-of-band `Condition` narrowing/widening access) invisible, the same FN
+// #151 fixed for TOP-LEVEL documents. Recognized by `PolicyDocument` so the descent can
+// align by PolicyName and reach the statement subset-match for this shape too.
+const isInlinePolicyArray = (arr: unknown[]): boolean =>
+  arr.length > 0 && arr.every((el) => isNestedObject(el) && 'PolicyDocument' in el);
+
 // True when every key of `sub` is present in `sup` with an equal value (objects
 // recurse so a nested declared block must also be a subset; everything else is
 // deep-equal). Used to align a declared policy statement to the live statement it is
@@ -154,6 +165,22 @@ function collectNestedUndeclared(
           }
         }
       });
+      return;
+    }
+    // IAM inline-policy wrappers (Role/User/Group `Policies[]`) are identity-less and
+    // their elements aren't statements, so neither descent above reaches the wrapped
+    // PolicyDocument.Statement. Align by PolicyName and recurse into each matched pair so
+    // the statement subset-descent (above) is reached for this dominant CDK shape too.
+    if (isInlinePolicyArray(declaredVal) && isInlinePolicyArray(liveVal)) {
+      const liveByName = new Map<string, Record<string, unknown>>();
+      for (const el of liveVal)
+        if (isNestedObject(el) && typeof el.PolicyName === 'string')
+          liveByName.set(el.PolicyName, el);
+      for (const dEl of declaredVal) {
+        if (!isNestedObject(dEl) || typeof dEl.PolicyName !== 'string') continue;
+        const match = liveByName.get(dEl.PolicyName);
+        if (match) collectNestedUndeclared(dEl, match, `${path}[${dEl.PolicyName}]`, emit);
+      }
     }
     return;
   }
@@ -464,7 +491,14 @@ export function classifyResource(
   // through the SAME wildcard lookup, equality-gated identically.
   const knownDefPaths = KNOWN_DEFAULT_PATHS[resourceType] ?? {};
   for (const [k, dv] of Object.entries(declared)) {
-    if (dv === UNRESOLVED || hasUnresolved(dv) || !(k in live)) continue;
+    // Only skip a WHOLLY-unresolved property: collectNestedUndeclared descends to emit
+    // LIVE-only keys, and an UNRESOLVED declared leaf is inert there (isNestedObject/
+    // Array both false → no recursion, no emit). So a property that merely CONTAINS an
+    // unresolved sub-value (e.g. Environment.Variables with one GetAtt) can still be
+    // descended to surface a genuinely undeclared sibling sub-key — dropping the old
+    // `hasUnresolved(dv)` guard, which hid that whole class (FP-safe: unresolved subtrees
+    // simply aren't descended).
+    if (dv === UNRESOLVED || !(k in live)) continue;
     collectNestedUndeclared(dv, live[k], k, (path, value) => {
       if (isAllAwsTags(value) || isTrivialEmpty(value)) return;
       const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -382,6 +382,67 @@ describe('sibling-managed inline Policies (IAM Role)', () => {
     const findings = classifyResource(role(['RoleDefaultPolicyABC'], declared), live, noSchema);
     expect(findings).toEqual([]);
   });
+
+  it('a live-only sub-key added to a WRAPPED inline-policy statement surfaces as undeclared (WAVE20 F3)', () => {
+    // The dominant CDK shape: `Policies: [{ PolicyName, PolicyDocument: { Statement } }]`.
+    // The wrapper array is identity-less and its elements aren't statements, so before
+    // the fix the statement subset-descent (#151, top-level docs only) never reached the
+    // wrapped statement — an out-of-band `Condition` on an inline role policy was invisible.
+    const declared = {
+      Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }],
+    };
+    const live = {
+      Policies: [
+        {
+          PolicyName: 'inline-a',
+          PolicyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 's3:GetObject',
+                Resource: '*',
+                Condition: { StringEquals: { 'aws:PrincipalOrgID': 'o-rogue' } },
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const findings = classifyResource(role([], declared), live, noSchema);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      tier: 'undeclared',
+      path: 'Policies[inline-a].PolicyDocument.Statement[0].Condition',
+    });
+    // an identical declared/live inline policy emits nothing (no FP)
+    const clean = classifyResource(
+      role([], { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }] }),
+      { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }] },
+      noSchema
+    );
+    expect(clean).toEqual([]);
+  });
+
+  it('a property containing one UNRESOLVED sub-value still surfaces a genuinely undeclared sibling sub-key (WAVE20 F2)', () => {
+    // Before: a property with ANY unresolved sub-value was skipped WHOLE for nested
+    // descent, hiding live-only undeclared keys under config-bag properties that merely
+    // reference another resource. Now only the unresolved SUBTREE is inert.
+    const declared = { Cfg: { Known: UNRESOLVED, Other: 'x' } };
+    const live = { Cfg: { Known: 'live-val', Other: 'x', LIVE_ONLY: 'rogue' } };
+    const r: DesiredResource = {
+      logicalId: 'R',
+      resourceType: 'AWS::Foo::Bar',
+      physicalId: 'p',
+      declared,
+    };
+    const findings = classifyResource(r, live, noSchema);
+    // the property is still flagged `unresolved` (partial unresolution noted)...
+    expect(tiers(findings).unresolved).toEqual(['Cfg']);
+    // ...AND the live-only undeclared sibling is now surfaced (previously hidden)
+    const u = findings.find((f) => f.tier === 'undeclared');
+    expect(u).toMatchObject({ path: 'Cfg.LIVE_ONLY', actual: 'rogue' });
+  });
 });
 
 describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)', () => {

--- a/tests/integration/iam/verify-inline-statement-subkey.sh
+++ b/tests/integration/iam/verify-inline-statement-subkey.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# cdk-real-drift WRAPPED inline-policy STATEMENT sub-key integration test (real AWS).
+#
+# Proves WAVE20-F3: a live-only sub-key added out of band to a statement INSIDE a
+# declared inline policy (`Properties.Policies[].PolicyDocument.Statement[]`) is
+# detected. Before the fix the statement subset-descent (#151) only reached TOP-LEVEL
+# policy documents (BucketPolicy / KMS key policy); the IAM Role `Policies[]` wrapper is
+# identity-less and its elements aren't statements, so the descent never reached the
+# wrapped statement — an out-of-band `Condition` narrowing/widening access was invisible.
+#
+#   deploy fixture (role with a DECLARED inline policy) -> record -> check CLEAN
+#     (CLEAN here is the FP-safety proof: the new descent runs on the real declared
+#      inline policy and must NOT emit a false undeclared)
+#   -> put-role-policy: re-PUT the SAME declared statement + a live-only Condition
+#   -> check DETECTS an undeclared Policies[...].PolicyDocument.Statement[...].Condition
+#
+# A cleanup trap destroys the stack + removes the baseline even on failure.
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/iam && npm install && bash verify-inline-statement-subkey.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamDeclared
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+DECLARED=DeclaredPolicy
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (role with a DECLARED inline policy) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ROLE_NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::IAM::Role'].PhysicalResourceId" --output text)"
+[ -n "$ROLE_NAME" ] || fail "could not resolve role physical id"
+echo "role=$ROLE_NAME"
+
+echo "=== record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check should be CLEAN (FP-safety: descent on the real declared inline policy) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record — new descent must not FP"
+
+echo "=== inject a live-only Condition INTO the declared statement (out of band) ==="
+# Same Effect/Action/Resource as the declared statement, PLUS a Condition the template
+# never declared. This is NOT a whole-array change (still one inline policy, one
+# statement) — only a sub-key was added, the exact class #151 covered for top-level docs.
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name "$DECLARED" \
+  --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:ListAllMyBuckets","Resource":"*","Condition":{"StringEquals":{"aws:PrincipalOrgID":"o-rogue"}}}]}' \
+  || fail "inject Condition"
+
+echo "=== check should DETECT the undeclared Condition sub-key ==="
+OUT=/tmp/cdk-real-drift-integ-iam-subkey.out
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc — the wrapped statement sub-key was invisible"
+grep -q "Condition" "$OUT" || fail "the undeclared Condition was not reported"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## What

Two drift-classification **false negatives** — real drift made invisible — found by the WAVE 20 classification-core audit.

### F3 (security) — wrapped inline-policy statements were unreachable

`#151` gave the policy-statement *subset-descent* (which surfaces a live-only sub-key added to a declared statement) but only for **top-level** `PolicyDocument`s (BucketPolicy, KMS key policy, readable AssumeRolePolicyDocument). An IAM **Role/User/Group inline policy** lives in `Policies: [{ PolicyName, PolicyDocument: { Statement } }]` — an **identity-less** wrapper array whose elements aren't statements (`PolicyName` isn't a generic identity field; no `Effect`). So neither descent fired and the wrapped statement was never reached: a live-only sub-key added out of band to a wrapped statement — e.g. a **`Condition`** narrowing/widening access on the dominant CDK inline-role-policy shape — was completely invisible.

Now an inline-policy wrapper is recognized by `PolicyDocument`, aligned by `PolicyName`, and recursed into, so the existing statement subset-match reaches it.

### F2 — a property with one unresolved sub-value hid its undeclared siblings

The nested-undeclared descent skipped a property **whole** when it contained *any* unresolved sub-value (`hasUnresolved(dv)`). That hid live-only undeclared keys under any config-bag property that merely references another resource (e.g. an extra key in `Environment.Variables` next to a `GetAtt`). `collectNestedUndeclared` only emits **live-only** keys, and an `UNRESOLVED` declared leaf is inert there (not an object/array → no recursion, no emit), so descending is FP-safe; only the *wholly*-unresolved property is still skipped.

## Safety / proof

- +3 unit tests (F3 detect + FP-clean identical-policy case; F2 partial-unresolved).
- 1074 unit tests + the 286-fixture self-compare corpus green — **no new false positive**.
- **Live-proven (real AWS)** via new `tests/integration/iam/verify-inline-statement-subkey.sh`: deploy a role with a declared inline policy → record → `check` **CLEAN** (the new descent runs on a real declared inline policy and does not FP) → inject a live-only `Condition` into the wrapped statement out of band → `check` **DETECTS** `Policies[DeclaredPolicy].PolicyDocument.Statement[0].Condition`. **INTEG PASS**, stack destroyed (self-cleaning trap).

F1 (a declared sub-value drift hidden when a *sibling* sub-value is unresolved) is the riskier partial-compare and is deferred to its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
