### PR TITLE
fix(read): classify a deleted Glue table as deleted, not skipped

### DIFF
--- a/src/aws-errors.ts
+++ b/src/aws-errors.ts
@@ -64,6 +64,7 @@ export function classifyStackStatus(status: string | undefined): {
 //   SNS / Budgets       : NotFoundException
 //   IAM                 : NoSuchEntity / NoSuchEntityException
 //   EC2 EIP             : InvalidAllocationID.NotFound / InvalidAddress.NotFound
+//   Glue                : EntityNotFoundException (GetTable on a deleted table/db)
 // Distinct from "target not resolvable from the template" (override returns
 // undefined → skipped) — this means the resource was read for and is gone.
 const NOT_FOUND_ERROR_NAMES = new Set([
@@ -77,6 +78,7 @@ const NOT_FOUND_ERROR_NAMES = new Set([
   'NoSuchEntityException',
   'InvalidAllocationID.NotFound',
   'InvalidAddress.NotFound',
+  'EntityNotFoundException',
 ]);
 
 export function isResourceNotFoundError(e: unknown): boolean {

--- a/tests/aws-errors.test.ts
+++ b/tests/aws-errors.test.ts
@@ -20,6 +20,7 @@ describe('isResourceNotFoundError', () => {
       'NoSuchEntityException', // IAM
       'InvalidAllocationID.NotFound',
       'InvalidAddress.NotFound', // EC2 EIP
+      'EntityNotFoundException', // Glue GetTable on a deleted table/db
     ]) {
       expect(isResourceNotFoundError(named(n))).toBe(true);
     }


### PR DESCRIPTION
## What

The Glue `GetTable` SDK-override throws `EntityNotFoundException` when the table (or its database) no longer exists, but that error name was missing from `NOT_FOUND_ERROR_NAMES`. So the router classified an **out-of-band-deleted Glue table** as `skipped` — a coverage gap that is **excluded from the drift verdict and `--fail`** — instead of `deleted` (a drift tier). A table deleted out of band let `check` report **CLEAN / exit 0**, hiding a real deletion.

## Fix

Add `EntityNotFoundException` to `NOT_FOUND_ERROR_NAMES`. The router already maps a thrown not-found error to `deleted`. `EntityNotFoundException` is thrown **only** when the table/db does not exist (access denial throws `AccessDeniedException`), so the mapping is unambiguous — **no false-positive surface**, hence no live integ needed (the router's not-found→deleted path is already live-proven for other types).

Exact error name verified against `@aws-sdk/client-glue` `.d.ts` (`name: "EntityNotFoundException"`).

## Tests

+1 unit assertion in the `isResourceNotFoundError` name list. 1076 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
