### PR TITLE
fix(desired): prefetch ImportValue exports for YAML short-form !ImportValue

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -177,10 +177,13 @@ export async function loadDesired(
   );
 
   // Fn::ImportValue is synchronous in the resolver, so prefetch exports here — but
-  // ONLY when the template actually references it (a substring check on the body),
-  // so normal stacks pay nothing for the extra ListExports call(s).
-  const templateBody = templateOverride ? JSON.stringify(templateOverride) : rawTemplate;
-  if (templateBody.includes('Fn::ImportValue')) {
+  // ONLY when the template actually references it, so normal stacks pay nothing for the
+  // extra ListExports call(s). Gate on the PARSED template, NOT the raw body: a YAML
+  // deployed template carries the short-form `!ImportValue` tag, so a substring check on
+  // the raw body would miss it and leave exports unfetched — the import then resolves
+  // UNRESOLVED and its declared property is silently skipped (missed drift).
+  // parseTemplateBody has already normalized short-form tags to long-form `Fn::ImportValue`.
+  if (JSON.stringify(template).includes('Fn::ImportValue')) {
     ctx.exports = await listExports(client, region);
   }
 

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -262,6 +262,29 @@ describe('loadDesired Fn::ImportValue exports prefetch', () => {
     expect(desired.resources[0]!.declared).toEqual({ Tag: 'arn:aws:x:::shared' });
   });
 
+  it('prefetches + resolves a YAML short-form !ImportValue (WAVE20)', async () => {
+    // A YAML deployed template carries the short-form tag `!ImportValue`, never the
+    // long-form string `Fn::ImportValue`. Gating the prefetch on the raw body missed it,
+    // leaving the import UNRESOLVED (missed drift). The gate now reads the PARSED template.
+    const cfn = mockClient(CloudFormationClient);
+    stackMocks(
+      cfn,
+      [
+        'Resources:',
+        '  Q:',
+        '    Type: AWS::SQS::Queue',
+        '    Properties:',
+        '      Tag: !ImportValue SharedArn',
+      ].join('\n')
+    );
+    cfn
+      .on(ListExportsCommand)
+      .resolves({ Exports: [{ Name: 'SharedArn', Value: 'arn:aws:x:::shared' }] });
+
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'IV', 'us-west-2');
+    expect(desired.resources[0]!.declared).toEqual({ Tag: 'arn:aws:x:::shared' });
+  });
+
   it('does NOT call ListExports when the template has no Fn::ImportValue', async () => {
     const cfn = mockClient(CloudFormationClient);
     stackMocks(


### PR DESCRIPTION
## What

The `Fn::ImportValue` exports prefetch was gated on a substring check of the **raw** deployed-template body (`templateBody.includes('Fn::ImportValue')`). A **YAML** deployed template carries the short-form tag `!ImportValue` — never the long-form string — so the check was `false`, `ctx.exports` stayed `{}`, and the resolver returned `UNRESOLVED` for the import. The declared property referencing it was then silently skipped: a **missed drift**.

Affects console- / SAM- / hand-authored YAML stacks (CDK output is JSON, so the long-form check happened to work there). The `--pre-deploy` override path was already safe (it `JSON.stringify`s).

## Fix

Gate on the **parsed** template instead of the raw body. `parseTemplateBody` has already normalized short-form tags to long-form `Fn::ImportValue`, so `JSON.stringify(template).includes('Fn::ImportValue')` fires for both JSON and YAML bodies (and the `templateOverride` object).

## Tests

+1 regression test: a YAML `!ImportValue` resolves to its export value (verified it **fails without the fix**). 1077 tests green. Pure logic change, no FP surface (only *adds* the prefetch when an import is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
