### PR TITLE
fix(classify): compare resolved sub-values of a partially-unresolved property

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -305,9 +305,13 @@ export function classifyResource(
   for (const [k, v] of Object.entries(declared)) {
     if (v === UNRESOLVED || hasUnresolved(v)) {
       findings.push({ tier: 'unresolved', logicalId, resourceType, path: k });
-      continue;
-    }
-    if (!(k in live)) {
+      // Wholly unresolved, OR partially unresolved but not in live to compare against:
+      // nothing more to do. Otherwise fall through to compare the RESOLVED sub-values —
+      // a sibling sub-value's drift (e.g. a changed Environment.Variables entry next to a
+      // GetAtt-valued one) must not be hidden just because a SIBLING leaf is unresolved.
+      // The compare below skips any per-leaf record whose declared side is unresolved.
+      if (v === UNRESOLVED || !(k in live)) continue;
+    } else if (!(k in live)) {
       findings.push({
         tier: 'readGap',
         logicalId,
@@ -325,6 +329,9 @@ export function classifyResource(
       const liveBag = live[k] as unknown[];
       for (const dEl of v) {
         if (!isKeyValueEntry(dEl)) continue;
+        // an unresolved declared attribute value can't be compared (already noted at the
+        // property level) — skip it rather than emit a false declared drift vs the symbol
+        if (dEl.Value === UNRESOLVED || hasUnresolved(dEl.Value)) continue;
         const lEl = liveBag.find((e) => isKeyValueEntry(e) && e.Key === dEl.Key);
         const liveValue = lEl ? (lEl as { Value: unknown }).Value : undefined;
         if (deepEqual(dEl.Value, liveValue)) continue;
@@ -358,6 +365,11 @@ export function classifyResource(
     // which subsumes the projection for the one type that needed it; the corpus
     // confirms no other type relied on it.
     for (const d of calculateResourceDrift({ [k]: declaredVal }, { [k]: liveVal })) {
+      // a per-leaf record whose DECLARED side is (or contains) an unresolved value can't
+      // be verified — already noted as `unresolved` at the property level above. Skip it
+      // so the unresolvable leaf never becomes a false `declared` drift vs the symbol,
+      // while its RESOLVED siblings still compare normally (the WAVE20-F1 fix).
+      if (d.stateValue === UNRESOLVED || hasUnresolved(d.stateValue)) continue;
       // a bare name declared for a field AWS returns as the full ARN is not drift
       // (account/region-scoped when opts are provided); likewise an AWS-managed-default
       // KMS alias vs its resolved key ARN

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1607,6 +1607,71 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
   });
 });
 
+describe('partial-unresolved declared compare (WAVE20 F1 — a sibling drift is not hidden)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const run = (declared: Record<string, unknown>, live: Record<string, unknown>) =>
+    classifyResource(
+      { logicalId: 'R', resourceType: 'AWS::Foo::Bar', physicalId: 'p', declared },
+      live,
+      bare
+    );
+
+  it('a RESOLVED sibling sub-value drift surfaces even when another sub-value is unresolved', () => {
+    // Environment.Variables: TABLE_ARN is a GetAtt (UNRESOLVED), LOG_LEVEL is a literal
+    // that drifted out of band. Before the fix the WHOLE property was skipped as
+    // unresolved, hiding the LOG_LEVEL change.
+    const out = run(
+      { Env: { TABLE_ARN: UNRESOLVED, LOG_LEVEL: 'INFO' } },
+      { Env: { TABLE_ARN: 'arn:aws:dynamodb:::table/x', LOG_LEVEL: 'DEBUG' } }
+    );
+    // the property is still flagged unresolved (the GetAtt part is unverifiable)...
+    expect(out.filter((f) => f.tier === 'unresolved').map((f) => f.path)).toEqual(['Env']);
+    // ...AND the resolved sibling's drift is now a declared finding
+    expect(out.filter((f) => f.tier === 'declared')).toEqual([
+      {
+        tier: 'declared',
+        logicalId: 'R',
+        resourceType: 'AWS::Foo::Bar',
+        path: 'Env.LOG_LEVEL',
+        desired: 'INFO',
+        actual: 'DEBUG',
+        physicalId: 'p',
+      },
+    ]);
+  });
+
+  it('FP-safe: when the resolved siblings all match, only the unresolved note is emitted', () => {
+    const out = run(
+      { Env: { TABLE_ARN: UNRESOLVED, LOG_LEVEL: 'INFO' } },
+      { Env: { TABLE_ARN: 'arn:aws:dynamodb:::table/x', LOG_LEVEL: 'INFO' } }
+    );
+    expect(out.filter((f) => f.tier === 'declared')).toEqual([]);
+    expect(out.filter((f) => f.tier === 'unresolved').map((f) => f.path)).toEqual(['Env']);
+  });
+
+  it('the unresolved leaf itself is never reported as declared drift (vs the symbol)', () => {
+    const out = run({ Env: { A: UNRESOLVED } }, { Env: { A: 'anything' } });
+    expect(out.filter((f) => f.tier === 'declared')).toEqual([]);
+    expect(out.filter((f) => f.tier === 'unresolved').map((f) => f.path)).toEqual(['Env']);
+  });
+
+  it('a partially-unresolved property absent from live is a single unresolved note (no compare)', () => {
+    const out = run({ Env: { A: UNRESOLVED, B: 'x' } }, {});
+    expect(out.filter((f) => f.tier === 'unresolved').map((f) => f.path)).toEqual(['Env']);
+    expect(out.filter((f) => f.tier === 'declared')).toEqual([]);
+    expect(out.filter((f) => f.tier === 'readGap')).toEqual([]);
+  });
+});
+
 // An IAM policy Condition value is an UNORDERED SET of strings written as a scalar
 // or an array. AWS may echo a multi-value condition (a CDK enforceSSL /
 // grant-with-SourceArn statement) reordered, or store a scalar-declared value as a


### PR DESCRIPTION
## What

A declared property containing **any** unresolved sub-value was skipped **whole** (`hasUnresolved(v)` → one `unresolved` finding, `continue`), so a **resolved** sibling sub-value's drift was hidden. Example:

```
declared  Environment.Variables = { TABLE_ARN: <GetAtt → UNRESOLVED>, LOG_LEVEL: "INFO" }
live      Environment.Variables = { TABLE_ARN: "arn:…",              LOG_LEVEL: "DEBUG" }
→ before: nothing reported (the LOG_LEVEL change is invisible)
```

Fail-closed was correct only for the unresolved **leaf**, not its knowable, genuinely-drifted siblings.

## Fix

A partially-unresolved property still emits the property-level `unresolved` note **and** runs the normal declared compare. The per-leaf compare skips any record whose declared side is (or contains) an unresolved value, so:
- the unresolvable leaf never becomes a false `declared` drift (vs the `UNRESOLVED` symbol), and
- its **resolved** siblings compare through the **unchanged** noise pipeline.

The ELB attribute-bag branch gets the same guard. A *wholly*-unresolved property, and a partially-unresolved one *absent from live*, stay a single property-level `unresolved` note (unchanged behavior).

## Safety / proof

- **FP-safe by construction**: resolved records flow through the existing, heavily live-proven declared compare untouched — only *when* it is reached changes.
- +4 unit tests (resolved-sibling drift surfaces; clean siblings → no false declared; the unresolved leaf is never declared; partial-unresolved absent-from-live → single note).
- 1084 unit tests + the **286-fixture self-compare corpus green** — no new false positive.
- No new live integ: no new AWS surface — the resolved-leaf compare *is* the existing declared compare, and the corpus self-compare is the FP guard.

This is the WAVE 20 classify **F1** finding (F2+F3 shipped in #170).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
