### PR TITLE
fix(read): report a deleted Route53 record / MetricFilter as deleted, not skipped

### DIFF
--- a/src/aws-errors.ts
+++ b/src/aws-errors.ts
@@ -65,6 +65,11 @@ export function classifyStackStatus(status: string | undefined): {
 //   IAM                 : NoSuchEntity / NoSuchEntityException
 //   EC2 EIP             : InvalidAllocationID.NotFound / InvalidAddress.NotFound
 //   Glue                : EntityNotFoundException (GetTable on a deleted table/db)
+//   cdkrd ResourceGoneError : a list/describe-based override whose PARENT container
+//                             exists but whose specific keyed resource is absent (a
+//                             Route53 record / MetricFilter deleted while its zone /
+//                             log group survives) — the SDK returns success+empty, not
+//                             a throw, so the reader raises this to mean "deleted".
 // Distinct from "target not resolvable from the template" (override returns
 // undefined → skipped) — this means the resource was read for and is gone.
 const NOT_FOUND_ERROR_NAMES = new Set([
@@ -79,7 +84,21 @@ const NOT_FOUND_ERROR_NAMES = new Set([
   'InvalidAllocationID.NotFound',
   'InvalidAddress.NotFound',
   'EntityNotFoundException',
+  'ResourceGoneError',
 ]);
+
+// Raised by a list/describe-based SDK-override reader when the parent container was
+// queried successfully but the specific keyed resource is ABSENT — i.e. it was deleted
+// out of band (the AWS API returns success with the item missing, not a not-found
+// throw). The router maps this (via isResourceNotFoundError) to the `deleted` tier, the
+// same as a native not-found error. NOT used for "couldn't resolve the target from the
+// template" — that case returns undefined → `skipped`.
+export class ResourceGoneError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ResourceGoneError';
+  }
+}
 
 export function isResourceNotFoundError(e: unknown): boolean {
   const name = (e as { name?: string })?.name ?? '';

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -33,6 +33,7 @@ import { GetBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
 import { GetScheduleCommand, SchedulerClient } from '@aws-sdk/client-scheduler';
 import { GetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { ResourceGoneError } from '../aws-errors.js';
 import { READ_RETRY } from './client-config.js';
 
 export interface OverrideCtx {
@@ -349,7 +350,13 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
       canon(x.Name) === canon(name) &&
       (x.SetIdentifier ?? undefined) === declSetId
   );
-  if (!rec) return undefined;
+  // The zone was listed successfully but the declared name+type(+SetIdentifier) record
+  // is absent — it was deleted out of band. Distinct from the "couldn't resolve the
+  // target" guard above (which returns undefined → skipped): here we KNOW it is gone.
+  if (!rec)
+    throw new ResourceGoneError(
+      `Route53 RecordSet ${name} ${type} absent from zone ${hostedZoneId}`
+    );
   const model: Record<string, unknown> = {
     Name: alignTrailingDot(rec.Name, declared.Name),
     Type: rec.Type,
@@ -459,7 +466,12 @@ const readMetricFilter: OverrideReader = async ({ physicalId, declared, region }
     mf = r.metricFilters?.find((m) => m.filterName === filterName);
     nextToken = r.nextToken;
   } while (!mf && nextToken);
-  if (!mf) return undefined;
+  // The log group was described successfully (every page) but the exact-named filter is
+  // absent — it was deleted out of band. (A deleted LOG GROUP instead throws
+  // ResourceNotFoundException above → also `deleted`; an unresolvable target returned
+  // undefined → skipped before the describe.)
+  if (!mf)
+    throw new ResourceGoneError(`MetricFilter ${filterName} absent from log group ${logGroup}`);
   return {
     LogGroupName: logGroup,
     FilterName: filterName,

--- a/tests/aws-errors.test.ts
+++ b/tests/aws-errors.test.ts
@@ -3,6 +3,7 @@ import {
   classifyStackStatus,
   isResourceNotFoundError,
   isStackNotDeployed,
+  ResourceGoneError,
 } from '../src/aws-errors.js';
 
 const named = (name: string): Error => Object.assign(new Error(name), { name });
@@ -28,6 +29,10 @@ describe('isResourceNotFoundError', () => {
 
   it('also matches the legacy .Code field shape', () => {
     expect(isResourceNotFoundError({ Code: 'NoSuchBucket' })).toBe(true);
+  });
+
+  it('recognizes ResourceGoneError so a list/describe-absent reader maps to deleted', () => {
+    expect(isResourceNotFoundError(new ResourceGoneError('record absent from zone'))).toBe(true);
   });
 
   it('does NOT match unrelated errors (throttling / access denied)', () => {

--- a/tests/integration/route53-weighted/verify-r53-record-deleted.sh
+++ b/tests/integration/route53-weighted/verify-r53-record-deleted.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# cdk-real-drift Route53 record DELETED-out-of-band detection integration test.
+#
+# Proves WAVE20 gather-F1 (Route53 slice): a declared record deleted out of band while
+# its hosted zone SURVIVES is now reported `deleted`, not silently `skipped`. Before the
+# fix the SDK-override reader listed the (existing) zone, found no matching record, and
+# returned undefined -> the router classified it `skipped` (a coverage gap excluded from
+# the drift verdict / --fail), so `check` reported CLEAN / exit 0 and the deletion was
+# invisible.
+#
+# Reuses the weighted-record app (zone + blue + green). Asserts:
+#   (1) record + check is CLEAN — BOTH records present are read, NEITHER false-`deleted`
+#       (the FP-safety proof: a present record must never be misread as gone).
+#   (2) after deleting GREEN out of band (zone + blue untouched), check reports GREEN
+#       `deleted` (exit 1) and does NOT report blue as deleted.
+# A hosted zone deleted within 12 hours of creation incurs no Route53 charge.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegR53
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+RECORD_NAME="app.cdkrd-r53-integ.internal."
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy hosted zone + two weighted A records (blue=10, green=90) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ZID="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Route53::HostedZone'].PhysicalResourceId" --output text)"
+[ -n "$ZID" ] || fail "could not resolve hosted zone id"
+echo "hostedZone=$ZID"
+
+echo "=== record + check should be CLEAN (both records present -> NEITHER false-deleted) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN — a present record was misread as deleted (FP)"
+
+echo "=== delete GREEN out of band (zone + blue untouched) ==="
+aws route53 change-resource-record-sets --hosted-zone-id "$ZID" --region "$REGION" \
+  --change-batch "{\"Changes\":[{\"Action\":\"DELETE\",\"ResourceRecordSet\":{\"Name\":\"$RECORD_NAME\",\"Type\":\"A\",\"SetIdentifier\":\"green\",\"Weight\":90,\"TTL\":60,\"ResourceRecords\":[{\"Value\":\"2.2.2.2\"}]}}]}" \
+  >/dev/null || fail "change-resource-record-sets DELETE"
+
+echo "=== check MUST report GREEN deleted (and NOT blue) ==="
+OUT=/tmp/cdkrd-r53-deleted.out
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1 for the deleted GREEN record, got $rc (was it skipped?)"
+grep -qi "deleted" "$OUT" || fail "no deleted finding reported for the out-of-band-removed record"
+grep -qi "Green" "$OUT" || fail "the deletion was not attributed to the Green record"
+grep -qi "Blue.*deleted\|deleted.*Blue" "$OUT" && fail "blue (still present) was falsely reported deleted"
+
+echo "INTEG PASS"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -20,6 +20,7 @@ import { GetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import { SDK_OVERRIDES } from '../src/read/overrides.js';
+import { ResourceGoneError } from '../src/aws-errors.js';
 import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
 
 const s3 = mockClient(S3Client);
@@ -401,15 +402,23 @@ describe('SDK overrides', () => {
       expect(out).toMatchObject({ Type: 'TXT', TTL: '300', ResourceRecords: ['"hi"'] });
     });
 
-    it('undefined when no record matches (-> stays skipped, no false drift)', async () => {
+    it('zone queried but the declared record absent -> ResourceGoneError (deleted, not skipped)', async () => {
+      // The zone exists and was listed; the declared name+type record is gone -> deleted
+      // out of band. (Was a false `undefined`/skipped that hid the deletion.)
       route53.on(ListResourceRecordSetsCommand).resolves({
         ResourceRecordSets: [{ Name: 'other.example.com.', Type: 'A' }],
       });
-      expect(
-        await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+      await expect(
+        SDK_OVERRIDES['AWS::Route53::RecordSet'](
           ctx({ HostedZoneId: 'Z1', Name: 'app.example.com.', Type: 'A' })
         )
-      ).toBeUndefined();
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('undefined (skipped) when the target cannot be resolved from the template', async () => {
+      // No HostedZoneId/Name/Type in declared and a non-composite physical id -> the
+      // query can't be formed: stay skipped (NOT deleted), the list is never even called.
+      expect(await SDK_OVERRIDES['AWS::Route53::RecordSet'](ctx({}, 'opaque-id'))).toBeUndefined();
     });
 
     it('disambiguates same-name+type variants by SetIdentifier (no wrong-record read) and projects routing fields', async () => {
@@ -550,11 +559,17 @@ describe('SDK overrides', () => {
       });
     });
 
-    it('undefined when the named filter is absent (-> stays skipped)', async () => {
+    it('log group described but the named filter absent -> ResourceGoneError (deleted)', async () => {
+      // The log group exists and was described; the exact-named filter is gone -> deleted
+      // out of band. (Was a false `undefined`/skipped that hid the deletion.)
       logs.on(DescribeMetricFiltersCommand).resolves({ metricFilters: [] });
-      expect(
-        await SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'missing'))
-      ).toBeUndefined();
+      await expect(
+        SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'missing'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('undefined (skipped) when the target cannot be resolved (no log group / filter name)', async () => {
+      expect(await SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({}, ''))).toBeUndefined();
     });
 
     it('follows nextToken to find an exact filter paginated past the first page', async () => {
@@ -582,14 +597,15 @@ describe('SDK overrides', () => {
       });
     });
 
-    it('stops at the last page (no nextToken) and returns undefined if never found', async () => {
+    it('stops at the last page (no nextToken) and reports deleted if never found', async () => {
       logs
         .on(DescribeMetricFiltersCommand)
         .resolvesOnce({ metricFilters: [{ filterName: 'errs-extra' }], nextToken: 'page2' })
         .resolvesOnce({ metricFilters: [{ filterName: 'errs-more' }] });
-      expect(
-        await SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'errs'))
-      ).toBeUndefined();
+      // every page described, exact name never present -> deleted out of band (not skipped)
+      await expect(
+        SDK_OVERRIDES['AWS::Logs::MetricFilter'](ctx({ LogGroupName: '/lg' }, 'errs'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
     });
   });
 


### PR DESCRIPTION
## What

A declared **Route53 RecordSet** or **Logs MetricFilter** deleted out of band — while its **parent** container (hosted zone / log group) survives — was reported `skipped`, not `deleted`. Both readers list/describe the parent, `.find()` the keyed resource, and returned `undefined` when absent → the router maps that to `skipped` (a coverage gap **excluded from the drift verdict and `--fail`**). So a record/filter deleted out of band let `check` report **CLEAN / exit 0**, hiding the deletion.

## Fix

The reader returned `undefined` for **two distinct** cases:
1. *couldn't resolve the target from the template* — correctly `skipped`;
2. *parent queried successfully, keyed resource absent* — should be `deleted`.

Split them: a new `ResourceGoneError` (recognized by `isResourceNotFoundError` → router maps it to `deleted`, like a native not-found) is thrown **only** for case 2; case 1 still returns `undefined` → `skipped`.

Lambda Permission's single-statement removal stays `skipped` (deliberate, documented — asserting one statement's deletion would need its `StatementId`; that reader is unchanged).

## Safety / proof

The FP risk is a *present* record/filter the `.find()` misses → a false `deleted`. The find logic is already hardened (Route53 SetIdentifier match #137, MetricFilter pagination #147), and the live proof confirms a present record is **never** false-deleted.

- +5 unit tests (gone→`ResourceGoneError`/deleted + can't-resolve→undefined/skipped for both readers; `ResourceGoneError` recognized as not-found). 1090 tests green.
- **Live-proven (real AWS)** via new `tests/integration/route53-weighted/verify-r53-record-deleted.sh`: deploy zone + two records → record → `check` **CLEAN** (both present records read, **neither** false-deleted = FP-safety) → delete GREEN out of band (zone + blue untouched) → `check` reports **GREEN `deleted`** (exit 1), blue not false-deleted. **INTEG PASS**, hosted zone destroyed (no billing orphan).

This is the second WAVE 20 deferred item (gather-F1); MetricFilter shares the same `ResourceGoneError`→router→`deleted` path and its present-find was already live-proven (#147).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
