### PR TITLE
fix(revert): align policy-document writer ops to the canonical statement order

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -39,6 +39,7 @@ import {
 import { DeleteBucketPolicyCommand, PutBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
 import { SetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { SetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { canonicalizeForCompare } from '../normalize/pipeline.js';
 import { type OverrideCtx, SDK_OVERRIDES } from '../read/overrides.js';
 import { applyOps } from './apply-ops.js';
 import type { PatchOp } from './plan.js';
@@ -57,7 +58,19 @@ async function desiredModel(
 ): Promise<Record<string, unknown>> {
   const reader = SDK_OVERRIDES[type];
   const current = (reader && (await reader(ctx))) ?? {};
-  return applyOps(current, ops);
+  // A revert op path indexes the model classify COMPARED — which is canonicalized
+  // (canonicalizePolicy SORTS the Statement array, reshapes Action/Resource, …). But the
+  // override reader returns the RAW live document, whose statement order can differ. An
+  // op like `…/Statement/1/Resource` would then land on a DIFFERENT statement than the
+  // one classify found drifted — corrupting an unrelated statement and leaving the real
+  // drift unreverted (a security-relevant wrong write). Canonicalize the current
+  // PolicyDocument the same way so an indexed op hits the SAME statement; the written
+  // doc is the canonical (statement-sorted, AWS-equivalent) form of the declared intent.
+  const aligned =
+    current.PolicyDocument === undefined
+      ? current
+      : { ...current, PolicyDocument: canonicalizeForCompare(current.PolicyDocument) };
+  return applyOps(aligned, ops);
 }
 const policyJson = (m: Record<string, unknown>): string | undefined =>
   m.PolicyDocument === undefined ? undefined : JSON.stringify(m.PolicyDocument);

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -119,6 +119,45 @@ describe('IAM ManagedPolicy writer', () => {
       ])
     ).rejects.toThrow(/managed policy arn/);
   });
+
+  it('a statement-indexed op lands on the canonical statement, not the raw one (WAVE21)', async () => {
+    // The live doc's RAW statement order differs from the canonical (sorted) order
+    // classify compared. A finding at canonical Statement[1] (zzz:Write) must revert
+    // THAT statement — not raw Statement[1] (aaa:Read). Before the fix the op corrupted
+    // aaa:Read and left zzz:Write's HACKED resource unreverted.
+    stubReader({
+      Version: '2012-10-17',
+      Statement: [
+        { Effect: 'Allow', Action: 'zzz:Write', Resource: 'HACKED' }, // raw[0], canonical[1]
+        { Effect: 'Allow', Action: 'aaa:Read', Resource: 'r2' }, // raw[1], canonical[0]
+      ],
+    });
+    iam
+      .on(ListPolicyVersionsCommand)
+      .resolves({ Versions: [{ VersionId: 'v1', IsDefaultVersion: true }] });
+    iam.on(CreatePolicyVersionCommand).resolves({});
+
+    // revert the drifted zzz:Write Resource (canonical index 1) back to the declared value
+    await SDK_WRITERS['AWS::IAM::ManagedPolicy'](ctx(), [
+      {
+        op: 'add',
+        path: '/PolicyDocument/Statement/1/Resource',
+        value: ['r1'],
+        human: 'PolicyDocument.Statement.1.Resource -> deployed-template value',
+      },
+    ]);
+
+    const created = iam.commandCalls(CreatePolicyVersionCommand);
+    expect(created).toHaveLength(1);
+    const written = JSON.parse(created[0]!.args[0].input.PolicyDocument as string) as {
+      Statement: { Action: string[]; Resource: unknown }[];
+    };
+    const byAction = (a: string) => written.Statement.find((s) => s.Action.includes(a));
+    // the RIGHT statement was reverted...
+    expect(byAction('zzz:Write')!.Resource).toEqual(['r1']);
+    // ...and the unrelated statement was NOT corrupted (stayed r2)
+    expect(byAction('aaa:Read')!.Resource).toEqual(['r2']);
+  });
 });
 
 describe('IAM Role inline Policies prop-scoped writer', () => {


### PR DESCRIPTION
## What (HIGH — wrong AWS write / data loss / security)

A declared drift on a **multi-statement** policy document was reverted onto the **wrong statement** — corrupting an unrelated statement and leaving the real drift in place.

`classify` compares the **canonicalized** model, and `canonicalizePolicy` **sorts** the `Statement` array — so a finding path indexes the *sorted* array (e.g. `PolicyDocument.Statement.1.Resource`). But the SDK writer's `desiredModel` read the **raw** live document via the override reader and applied the indexed op to it. When the raw statement order differs from canonical, index `N` lands on a different statement.

**Proven:** a drift on a `zzz:Write` statement (canonical index 1, raw index 0) reverted raw index 1 (`aaa:Read`) instead — overwriting `aaa:Read`'s `Resource` **and** leaving `zzz:Write`'s drift unreverted.

Reachable for all five policy-document writers: `AWS::S3::BucketPolicy`, `AWS::SNS::TopicPolicy`, `AWS::SQS::QueuePolicy`, `AWS::IAM::Policy`, `AWS::IAM::ManagedPolicy`.

## Fix

Canonicalize the current `PolicyDocument` with the same `canonicalizeForCompare` **before** applying the ops, so an indexed op hits the **same** statement classify found drifted. The written document is the canonical (statement-sorted, AWS-equivalent) form of the declared intent.

## Proof

- +1 regression unit test: a canonical-index op reverts the **right** statement and leaves the unrelated one intact — **verified it FAILS without the fix** (corrupts `aaa:Read`, leaves `zzz:Write` HACKED). 1093 tests green.
- **Live-proven (real AWS)**: the `policies` integration fixture exercises **all five** `SDK_WRITERS` reverting end-to-end; AWS reads confirm the injected statement is gone and the declared statement survived — **INTEG PASS**, stack destroyed.

This is the WAVE 21 revert-writers finding. (Finding 2 — the written value being canonical-shaped rather than the template literal — is folded in here and is AWS-equivalent for IAM.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
