### PR TITLE
fix(normalize): treat free-form user-map values as opaque in the policy/json-text canonicalizers

### DIFF
--- a/src/normalize/cc-api-strip.ts
+++ b/src/normalize/cc-api-strip.ts
@@ -35,7 +35,7 @@ const ALWAYS_STRIPPED = new Set<string>([
 // `CreationDate` — are not under one of these keys, so they are still stripped; the few
 // nested AWS-managed fields in STRUCTURED objects, e.g. StepFunctions
 // `LoggingConfiguration.CreatedAt`, are also not under these keys, so they still strip.)
-const FREE_FORM_MAP_PARENTS = new Set([
+export const FREE_FORM_MAP_PARENTS = new Set([
   'Variables', // AWS::Lambda::Function Environment.Variables
   'Parameters', // AWS::Glue::Table/Database TableInput/DatabaseInput.Parameters
   'DefaultArguments', // AWS::Glue::Job

--- a/src/normalize/policy-canonical.ts
+++ b/src/normalize/policy-canonical.ts
@@ -5,6 +5,8 @@
 // Normalizations: URL-decode + JSON.parse strings; fill default Version;
 // scalar/array unify + sort for Action/Resource/Principal; sort statements.
 
+import { FREE_FORM_MAP_PARENTS } from './cc-api-strip.js';
+
 function isObj(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
 }
@@ -237,16 +239,29 @@ function sortDeep(v: unknown): unknown {
  * embedded JSON-text strings with a canonical (sorted, minified) form.
  */
 export function normalizePoliciesDeep(v: unknown): unknown {
+  return normWalk(v, false);
+}
+
+// `freeForm` = this subtree lives under a free-form USER map (Lambda env Variables,
+// Glue Parameters/DefaultArguments, DockerLabels, Labels, map-Tags). Those values are
+// opaque user data AWS stores VERBATIM (Map<String,String>), so re-serializing /
+// policy-canonicalizing a JSON-shaped value there would SUPPRESS a real out-of-band
+// key-order / statement edit by the user (a false negative) — the same R69 protection
+// cc-api-strip applies, extended to the policy/json-text canonicalizers that run after
+// it. Sticky down the subtree (everything under a user map is user data).
+function normWalk(v: unknown, freeForm: boolean): unknown {
   if (typeof v === 'string') {
+    if (freeForm) return v; // opaque user data — never canonicalize
     const p = parsePolicyString(v);
     if (p) return canonicalizePolicy(p);
     return canonicalizeJsonText(v);
   }
-  if (Array.isArray(v)) return v.map(normalizePoliciesDeep);
-  if (isPolicyDoc(v)) return canonicalizePolicy(v);
+  if (Array.isArray(v)) return v.map((el) => normWalk(el, freeForm));
+  if (!freeForm && isPolicyDoc(v)) return canonicalizePolicy(v);
   if (isObj(v)) {
     const out: Record<string, unknown> = {};
-    for (const [k, val] of Object.entries(v)) out[k] = normalizePoliciesDeep(val);
+    for (const [k, val] of Object.entries(v))
+      out[k] = normWalk(val, freeForm || FREE_FORM_MAP_PARENTS.has(k));
     return out;
   }
   return v;

--- a/tests/integration/freeform-strip/app.ts
+++ b/tests/integration/freeform-strip/app.ts
@@ -1,8 +1,13 @@
 // Minimal CDK app for the cc-api-strip free-form-map false-negative test. A Lambda with
-// ONE declared env var. verify-freeform-strip.sh adds an out-of-band env var whose KEY
+// declared env vars. verify-freeform-strip.sh adds an out-of-band env var whose KEY
 // collides with an AWS-managed field name (`LastModified`); cc-api-strip used to strip
 // it by name at any depth, so the out-of-band change was SILENTLY undetectable. The fix
 // stops stripping inside free-form user maps (Environment.Variables), so it now surfaces.
+//
+// CONFIG is a JSON-shaped env var VALUE. verify-freeform-json.sh proves the WAVE21
+// fix: the json-text/policy canonicalizers used to re-serialize such a value, folding
+// away a real out-of-band key-order edit (a false negative); they now treat free-form
+// map values as opaque user data, so the edit surfaces.
 import { App, Stack } from "aws-cdk-lib";
 import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
 
@@ -12,6 +17,9 @@ new Function(stack, "TestFn", {
   runtime: Runtime.NODEJS_20_X,
   handler: "index.handler",
   code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 });"),
-  environment: { APP_VERSION: "x" },
+  environment: {
+    APP_VERSION: "x",
+    CONFIG: JSON.stringify({ region: "us-east-1", mode: "a" }),
+  },
 });
 app.synth();

--- a/tests/integration/freeform-strip/verify-freeform-json.sh
+++ b/tests/integration/freeform-strip/verify-freeform-json.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# cdk-real-drift free-form-map JSON-VALUE canonicalization false-negative test (real AWS).
+#
+# Proves WAVE21: the policy/json-text canonicalizers re-serialized (sorted) a JSON-shaped
+# value inside a free-form USER map (Lambda Environment.Variables), so a real out-of-band
+# key-ORDER edit of the user's JSON config string was folded away — silently CLEAN (a
+# false negative). AWS stores Lambda env var values VERBATIM (Map<String,String>), so the
+# canonicalization was never compensating for an AWS reshape; it only HID user edits.
+#
+#   deploy (CONFIG='{"region":"us-east-1","mode":"a"}') -> check CLEAN (FP-safety: the
+#     present value is read back verbatim, declared == live)
+#   -> reorder CONFIG's keys out of band (same data, different order)
+#   -> check DETECTS the Environment.Variables.CONFIG drift (before the fix: CLEAN)
+#
+# A cleanup trap destroys the stack + removes the baseline even on failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegFreeform
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy (Lambda with a JSON-shaped CONFIG env var) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN_NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN_NAME" ] || fail "could not resolve function name"
+echo "function=$FN_NAME"
+
+echo "=== check should be CLEAN (the JSON value is read back verbatim -> no FP) ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN — a verbatim JSON env value was misread as drift (FP)"
+
+echo "=== reorder CONFIG's keys out of band (same data, different key order) ==="
+# Pass the env as a JSON file — the shorthand parser chokes on a JSON-string value.
+ENV_JSON="$(mktemp)"
+printf '{"Variables":{"APP_VERSION":"x","CONFIG":"{\\"mode\\":\\"a\\",\\"region\\":\\"us-east-1\\"}"}}' > "$ENV_JSON"
+aws lambda update-function-configuration --function-name "$FN_NAME" --region "$REGION" \
+  --environment "file://$ENV_JSON" >/dev/null || fail "update-function-configuration"
+rm -f "$ENV_JSON"
+# wait for the config update to settle
+aws lambda wait function-updated --function-name "$FN_NAME" --region "$REGION" || true
+
+echo "=== check MUST detect the CONFIG key-order edit (declared drift) ==="
+OUT=/tmp/cdkrd-freeform-json.out
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1 for the CONFIG key-order edit, got $rc (folded away?)"
+grep -qi "CONFIG" "$OUT" || fail "the CONFIG env-var edit was not reported"
+
+echo "INTEG PASS"

--- a/tests/integration/freeform-strip/verify-freeform-strip.sh
+++ b/tests/integration/freeform-strip/verify-freeform-strip.sh
@@ -46,9 +46,13 @@ $CLI check "$STACK" --region "$REGION" --fail
 [ $? -eq 0 ] || fail "expected CLEAN right after record"
 
 echo "=== inject out-of-band env var keyed LastModified (a managed-field NAME) ==="
+# Keep the declared vars (APP_VERSION + the JSON-shaped CONFIG) so only LastModified is
+# the drift; a JSON-string value needs file:// (the shorthand parser chokes on it).
+ENV_JSON="$(mktemp)"
+printf '{"Variables":{"APP_VERSION":"x","CONFIG":"{\\"region\\":\\"us-east-1\\",\\"mode\\":\\"a\\"}","LastModified":"sneaky-out-of-band"}}' > "$ENV_JSON"
 aws lambda update-function-configuration --function-name "$FN_NAME" --region "$REGION" \
-  --environment "Variables={APP_VERSION=x,LastModified=sneaky-out-of-band}" >/dev/null \
-  || fail "inject env var"
+  --environment "file://$ENV_JSON" >/dev/null || fail "inject env var"
+rm -f "$ENV_JSON"
 # wait for the update to settle
 aws lambda wait function-updated --function-name "$FN_NAME" --region "$REGION" || true
 

--- a/tests/policy-canonical.test.ts
+++ b/tests/policy-canonical.test.ts
@@ -121,6 +121,65 @@ describe('policy canonicalization', () => {
     expect(normalizePoliciesDeep(pretty)).toBe(normalizePoliciesDeep(mini));
   });
 
+  describe('free-form user-map values are opaque (WAVE21 — R69 extended past cc-strip)', () => {
+    const reordered = (parent: string) => ({
+      a: normalizePoliciesDeep({ [parent]: { CONFIG: '{"region":"us-east-1","mode":"a"}' } }),
+      b: normalizePoliciesDeep({ [parent]: { CONFIG: '{"mode":"a","region":"us-east-1"}' } }),
+    });
+
+    it('a JSON-string value under Variables is NOT re-serialized (a real key-order edit stays visible)', () => {
+      const { a, b } = reordered('Variables');
+      expect(deepEqual(a, b)).toBe(false);
+    });
+
+    for (const parent of ['Parameters', 'DefaultArguments', 'DockerLabels', 'Labels', 'Tags']) {
+      it(`a JSON-string value under ${parent} is opaque too`, () => {
+        const { a, b } = reordered(parent);
+        expect(deepEqual(a, b)).toBe(false);
+      });
+    }
+
+    it('a policy-SHAPED user value under a free-form map is NOT policy-canonicalized', () => {
+      const s1 = '{"Statement":[{"Effect":"Allow","Action":"a"},{"Effect":"Allow","Action":"b"}]}';
+      const s2 = '{"Statement":[{"Effect":"Allow","Action":"b"},{"Effect":"Allow","Action":"a"}]}';
+      expect(
+        deepEqual(
+          normalizePoliciesDeep({ Variables: { P: s1 } }),
+          normalizePoliciesDeep({ Variables: { P: s2 } })
+        )
+      ).toBe(false);
+    });
+
+    it('a REAL policy NOT under a free-form map still canonicalizes (no regression)', () => {
+      const r1 = {
+        PolicyDocument: {
+          Statement: [
+            { Effect: 'Allow', Action: 'a' },
+            { Effect: 'Allow', Action: 'b' },
+          ],
+        },
+      };
+      const r2 = {
+        PolicyDocument: {
+          Statement: [
+            { Effect: 'Allow', Action: 'b' },
+            { Effect: 'Allow', Action: 'a' },
+          ],
+        },
+      };
+      expect(deepEqual(normalizePoliciesDeep(r1), normalizePoliciesDeep(r2))).toBe(true);
+    });
+
+    it('a genuine value change under a free-form map still differs', () => {
+      expect(
+        deepEqual(
+          normalizePoliciesDeep({ Variables: { X: '{"a":1}' } }),
+          normalizePoliciesDeep({ Variables: { X: '{"a":2}' } })
+        )
+      ).toBe(false);
+    });
+  });
+
   // Condition canonicalization: an IAM condition key's value is an unordered SET
   // of strings written as a scalar or an array; IAM treats both forms identically
   // and AWS may store/return either, in any order. Without canonicalization a


### PR DESCRIPTION
## What (HIGH — false negative on user data)

`cc-api-strip` exempts free-form **user** maps — Lambda `Environment.Variables`, Glue `Parameters` / `DefaultArguments`, `DockerLabels`, `Labels`, map-shaped `Tags` — from name-based stripping (R69), because their keys/values are user data. But the **next** normalizer in the pipeline, `normalizePoliciesDeep`, walked the whole tree with **no** such awareness: a JSON-shaped string value there was re-serialized by `canonicalizeJsonText` (or fully policy-canonicalized if policy-shaped). So a real out-of-band **key-order / statement edit** of the user's config string was folded away — silently **CLEAN** (a false negative re-opening the exact R69 class one normalizer downstream).

## Fix

Make `normalizePoliciesDeep` free-form-map-aware: a value under a `FREE_FORM_MAP_PARENTS` key is **opaque** user data. AWS stores these `Map<String,String>` values **verbatim**, so the canonicalization was never compensating for an AWS reshape — it only **hid** edits. The flag is sticky down the subtree. Real policies / JSON-text **not** under a free-form map still canonicalize (no regression). `FREE_FORM_MAP_PARENTS` is now exported as the single source of truth.

## Proof

- + unit tests: opaque under all 6 parents; a policy-shaped user value is not canonicalized; a real top-level policy still folds (no regression); a genuine value change still differs. 1105 tests + the 286-fixture self-compare corpus green.
- **Live-proven (real AWS)** via new `verify-freeform-json.sh`: deploy a Lambda with a JSON-shaped `CONFIG` env var → `check` **CLEAN** (read back verbatim, no FP) → reorder `CONFIG`'s keys out of band → `check` **DETECTS** `Environment.Variables.CONFIG` drift. **INTEG PASS**. (`verify-freeform-strip.sh` updated to preserve `CONFIG` via `file://`; re-run also INTEG PASS — no regression to the sibling fixture.)

This is the WAVE 21 canonicalization-pipeline finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
