### PR TITLE
fix(config): bound ignore-rule path globs to a single segment (no cross-dot over-match)

### DIFF
--- a/src/commands/glob-match.ts
+++ b/src/commands/glob-match.ts
@@ -30,3 +30,24 @@ export function globToRegExp(pattern: string): RegExp {
 export function matchesGlob(pattern: string, name: string): boolean {
   return globToRegExp(pattern).test(name);
 }
+
+/**
+ * Path-axis glob (for ignore-rule `path` patterns against a `<id>.<sub.path>` target):
+ * a SEGMENT-aware variant where `*` / `?` do NOT cross a `.` or `[` boundary. So
+ * `*.DesiredCount` matches `<anyId>.DesiredCount` (the documented intent — `*` = one id
+ * segment) but NOT a same-named leaf nested deeper (`Tbl.Config.DesiredCount`, or a
+ * free-form-map key literally named `DesiredCount`). Subtree coverage of a PARENT rule
+ * (`X.Policies` covering `X.Policies[Mp].Name`) is handled separately by the ancestor
+ * walk in `pathMatches`, so bounding `*` here does not under-match. The stack/region
+ * axes keep `matchesGlob` (their names contain no `.`/`[`, so it is equivalent there).
+ */
+export function matchesPathGlob(pattern: string, target: string): boolean {
+  let out = '^';
+  for (const ch of pattern.replace(/\*+/g, '*')) {
+    if (ch === '*') out += '[^.[]*';
+    else if (ch === '?') out += '[^.[]';
+    else out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+  out += '$';
+  return new RegExp(out).test(target);
+}

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -32,7 +32,7 @@
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { matchesGlob } from '../commands/glob-match.js';
+import { matchesGlob, matchesPathGlob } from '../commands/glob-match.js';
 import type { Finding } from '../types.js';
 
 // An ignore rule. `path` is the glob against "<logicalId>.<path>" /
@@ -225,7 +225,7 @@ export function parseIgnoreRule(entry: IgnoreRuleObject): IgnoreRule {
  * Parent matching walks ancestors at each `.` OR `[` boundary, combined with the glob.
  */
 function pathMatches(pattern: string, target: string): boolean {
-  if (matchesGlob(pattern, target)) return true;
+  if (matchesPathGlob(pattern, target)) return true;
   // A rule on a PARENT property ignores its whole subtree — including array / identity-
   // keyed children whose path glues the index to its key inside ONE dot-segment
   // (`Policies[MyPol].PolicyName`, `Statement[0].Condition`, `Tags[env]`). Walk ancestor
@@ -237,7 +237,7 @@ function pathMatches(pattern: string, target: string): boolean {
     const cut = Math.max(t.lastIndexOf('.'), t.lastIndexOf('['));
     if (cut <= 0) break;
     t = t.slice(0, cut);
-    if (matchesGlob(pattern, t)) return true;
+    if (matchesPathGlob(pattern, t)) return true;
   }
   return false;
 }

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -100,6 +100,29 @@ describe('applyIgnores', () => {
     expect(out.map((f) => f.tier)).toEqual(['ignored', 'declared']);
   });
 
+  it('wildcard *.X does NOT cross dot segments — a deeper same-named leaf is not over-ignored (WAVE21)', () => {
+    // `*.DesiredCount` means "<anyId>.DesiredCount" (the documented intent), NOT "any
+    // `.DesiredCount` at any depth". A genuinely-drifted DesiredCount nested deeper (or a
+    // free-form-map key literally named DesiredCount) must NOT be silently hidden.
+    const out = ign(
+      [
+        declared('Svc', 'DesiredCount'), // the intended target -> ignored
+        declared('Tbl', 'Config.DesiredCount'), // nested deeper -> must stay drift
+        undeclared('Tbl', 'SomeMap.DesiredCount'), // free-form leaf -> must stay drift
+      ],
+      'S',
+      cfg([p('*.DesiredCount')])
+    );
+    expect(out.map((f) => f.tier)).toEqual(['ignored', 'declared', 'undeclared']);
+  });
+
+  it('a parent rule still covers a deep same-named leaf via the ancestor walk (no under-match)', () => {
+    // segment-bounding `*` must not break subtree coverage: an explicit parent rule
+    // (`Tbl.Config`) still ignores everything under it, including `Tbl.Config.DesiredCount`.
+    const [f] = ign([declared('Tbl', 'Config.DesiredCount')], 'S', cfg([p('Tbl.Config')]));
+    expect(f?.tier).toBe('ignored');
+  });
+
   it('re-tags undeclared too', () => {
     const [f] = ign(
       [undeclared('MyTable', 'ProvisionedThroughput')],

--- a/tests/glob-match.test.ts
+++ b/tests/glob-match.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { globToRegExp, isGlob, matchesGlob } from '../src/commands/glob-match.js';
+import { globToRegExp, isGlob, matchesGlob, matchesPathGlob } from '../src/commands/glob-match.js';
 
 describe('isGlob', () => {
   it('detects * and ?', () => {
@@ -87,5 +87,23 @@ describe('globToRegExp', () => {
     expect(matchesGlob('*****X', 'aaaaaY')).toBe(false);
     // a long non-match returns promptly (no catastrophic backtracking)
     expect(matchesGlob('**********X', 'a'.repeat(60))).toBe(false);
+  });
+});
+
+describe('matchesPathGlob (segment-aware — does not cross . or [ boundaries)', () => {
+  it('* / ? stay within one dot/bracket segment', () => {
+    expect(matchesPathGlob('*.DesiredCount', 'Svc123.DesiredCount')).toBe(true); // id wildcard
+    expect(matchesPathGlob('*.DesiredCount', 'Tbl.Config.DesiredCount')).toBe(false); // no cross-dot
+    expect(matchesPathGlob('Fn*.Mem', 'FnABC.Mem')).toBe(true);
+    expect(matchesPathGlob('Fn*.Mem', 'FnA.Sub.Mem')).toBe(false);
+    expect(matchesPathGlob('*', 'BareId')).toBe(true);
+    expect(matchesPathGlob('*', 'A.B')).toBe(false); // bare star is one segment (subtree via ancestor walk)
+    expect(matchesPathGlob('Tags[*]', 'Tags[env]')).toBe(true); // within a bracket key
+    expect(matchesPathGlob('Tags[*]', 'Tags[env].Sub')).toBe(false);
+  });
+
+  it('still collapses *+ runs (no catastrophic backtracking)', () => {
+    expect(matchesPathGlob('****X', 'aaaaaX')).toBe(true);
+    expect(matchesPathGlob('**********X', 'a'.repeat(60))).toBe(false);
   });
 });


### PR DESCRIPTION
## What (FN — an over-broad ignore rule hid real drift)

An ignore rule's `path` glob compiled `*` to `.*`, which **crosses** `.` / `[` segment boundaries. So the documented headline rule `path: "*.DesiredCount"` (meant as `<anyId>.DesiredCount`) **also** matched a same-named leaf nested anywhere deeper — `Tbl.Config.DesiredCount`, or a free-form-map key literally named `DesiredCount` — silently re-tagging a genuinely-drifted value as `ignored`. Since `ignored` is excluded from the drift verdict and `--fail`, an over-broad rule **hid real drift**.

## Fix

Add a segment-aware `matchesPathGlob` (`*` → `[^.[]*`, `?` → `[^.[]`) used **only** for the ignore-rule **path** axis, so `*` stays within one dot/bracket segment. Subtree coverage of a **parent** rule (`X.Policies` covering `X.Policies[Mp].Name`) is preserved by the existing ancestor walk in `pathMatches`, so bounding `*` does **not** under-match. The stack/region axes keep `matchesGlob` (their names contain no `.`/`[`). The `*+`-run collapse (ReDoS guard) is kept.

This aligns the implementation with the documented intent (`*` = one id segment).

## Tests

+ unit tests: segment-aware `matchesPathGlob`; `*.X` no longer over-ignores a deep leaf; an explicit parent rule still covers the subtree (no under-match). 1109 tests green. Pure path-matching logic, no AWS surface.

This is the WAVE 21 config-ignore finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
