### PR TITLE
fix(check): key --pre-deploy synth templates by stack name AND region

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -31,6 +31,12 @@ import { resolveInteractively } from './interactive-resolve.js';
 // synth (not deployed) declared set, so all three are excluded. --declared-only
 // reuses the same filter against the DEPLOYED template (R59) — its "undeclared
 // values are not compared" contract must hold for the `atDefault` footer too, else
+// Key a synth template by stack name + region (a CFn stack name is region-scoped, so
+// the same name can recur across regions in one app). Exported (pure) for unit testing.
+export function synthKey(stackName: string, region: string | undefined): string {
+  return `${stackName}\0${region ?? ''}`;
+}
+
 // `--declared-only` still prints an `At AWS Default (N)` line for values it claims
 // not to compare. Exported (pure) so the contract is unit-tested.
 export function preDeployFindings(findings: Finding[]): Finding[] {
@@ -151,7 +157,14 @@ export async function runCheck(args: string[]): Promise<number> {
       profile: a.profile,
       context: a.context,
     });
-    synthTemplates = new Map(synthed.map((s) => [s.stackName, s.template]));
+    // Key by stackName + region, NOT stackName alone: a stack name is region-scoped in
+    // CloudFormation, so an app can define two same-named stacks in different regions.
+    // Keyed by name alone, the second would overwrite the first and BOTH would then be
+    // compared against the wrong (last-synthesized) template. The region resolution
+    // mirrors resolveStacks (`s.region ?? a.region`) so the loop's lookup key matches.
+    synthTemplates = new Map(
+      synthed.map((s) => [synthKey(s.stackName, s.region ?? a.region), s.template])
+    );
     console.error('(--pre-deploy) comparing live state against the LOCAL synth template');
   }
 
@@ -167,11 +180,12 @@ export async function runCheck(args: string[]): Promise<number> {
       continue;
     }
     try {
-      if (synthTemplates && !synthTemplates.has(stackName)) {
+      const sKey = synthKey(stackName, region);
+      if (synthTemplates && !synthTemplates.has(sKey)) {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
         continue;
       }
-      const gathered = await gatherFindings(stackName, region, synthTemplates?.get(stackName));
+      const gathered = await gatherFindings(stackName, region, synthTemplates?.get(sKey));
       const { desired, schemas, liveByLogical } = gathered;
       let findings = gathered.findings;
 

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -5,6 +5,7 @@ import {
   hasCoverageGap,
   nestedStackWarning,
   preDeployFindings,
+  synthKey,
   undeclaredOnlyFindings,
 } from '../src/commands/check.js';
 import {
@@ -268,5 +269,18 @@ describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () =
 
   it('hasCoverageGap is false when everything was read and there are no nested stacks', () => {
     expect(hasCoverageGap([F('undeclared'), F('declared')], [dr('AWS::SNS::Topic')])).toBe(false);
+  });
+});
+
+describe('synthKey (--pre-deploy template keyed by name + region, WAVE21)', () => {
+  it('distinguishes the same stack name across regions (no template collision)', () => {
+    expect(synthKey('MyStack', 'us-east-1')).not.toBe(synthKey('MyStack', 'eu-west-1'));
+  });
+  it('is stable for the same name + region', () => {
+    expect(synthKey('MyStack', 'us-east-1')).toBe(synthKey('MyStack', 'us-east-1'));
+  });
+  it('treats an undefined (env-agnostic) region as a distinct, stable key', () => {
+    expect(synthKey('MyStack', undefined)).toBe(synthKey('MyStack', undefined));
+    expect(synthKey('MyStack', undefined)).not.toBe(synthKey('MyStack', 'us-east-1'));
   });
 });


### PR DESCRIPTION
## What

Under `--pre-deploy` the synthesized templates were stored in a `Map` keyed by `stackName` **alone**. A CloudFormation stack name is **region-scoped**, so one CDK app can define two same-named stacks in different regions. Keyed by name alone, the second overwrote the first, and **both** were then compared against the wrong (last-synthesized) template — bogus declared drift / missed drift for one of them.

## Fix

Key by `stackName` + `region` via a new exported `synthKey`, with the region resolved the same way `resolveStacks` does (`s.region ?? a.region`) so the per-stack lookup matches.

## Tests

+3 unit tests: same name across regions → distinct keys; stable per name+region; an env-agnostic (`undefined`) region is a distinct, stable key. 1115 tests green. Pure template-selection logic, no AWS surface.

This is the WAVE 21 synth finding (F1). F2 (staged hierarchical-id CLI matching) and F3 (no-args duplicate-name dedup) are lower-severity and noted as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
