### PR TITLE
fix(read): stop projecting EIP NetworkInterfaceId (false drift); project PublicIpv4Pool

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -298,7 +298,12 @@ const readEc2Eip: OverrideReader = async ({ physicalId, region }) => {
   if (str(addr.NetworkBorderGroup)) model.NetworkBorderGroup = addr.NetworkBorderGroup;
   if (str(addr.PublicIp)) model.PublicIp = addr.PublicIp;
   if (str(addr.InstanceId)) model.InstanceId = addr.InstanceId;
-  if (str(addr.NetworkInterfaceId)) model.NetworkInterfaceId = addr.NetworkInterfaceId;
+  // NOTE: NetworkInterfaceId is NOT projected — it is not a declarable CFn property of
+  // AWS::EC2::EIP (verified against the registry schema: the property set has no
+  // NetworkInterfaceId), so it is neither readOnly-stripped nor a known default. AWS
+  // populates it for any EIP associated with an ENI, so projecting it false-flagged an
+  // `undeclared` drift on EVERY associated EIP on the first check.
+  if (str(addr.PublicIpv4Pool)) model.PublicIpv4Pool = addr.PublicIpv4Pool; // declarable; absent for AWS-pool EIPs (FP-safe)
   if (tags && tags.length > 0) model.Tags = tags;
   return model;
 };

--- a/tests/eip-reader.test.ts
+++ b/tests/eip-reader.test.ts
@@ -43,6 +43,25 @@ describe('AWS::EC2::EIP SDK override', () => {
     expect(call.args[0].input).toEqual({ AllocationIds: ['eipalloc-123'] });
   });
 
+  it('does NOT project NetworkInterfaceId (not a declarable EIP property) and DOES project PublicIpv4Pool (WAVE22)', async () => {
+    ec2.on(DescribeAddressesCommand).resolves({
+      Addresses: [
+        {
+          AllocationId: 'eipalloc-assoc',
+          Domain: 'vpc',
+          PublicIp: '52.0.0.9',
+          InstanceId: 'i-xyz',
+          NetworkInterfaceId: 'eni-deadbeef', // AWS returns this for an associated EIP — must NOT surface
+          PublicIpv4Pool: 'ipv4pool-ec2-abc', // a declarable property — must surface
+        },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::EC2::EIP'](ctx('eipalloc-assoc'));
+    // NetworkInterfaceId would have false-flagged an undeclared drift on every associated EIP
+    expect(out).not.toHaveProperty('NetworkInterfaceId');
+    expect(out).toMatchObject({ InstanceId: 'i-xyz', PublicIpv4Pool: 'ipv4pool-ec2-abc' });
+  });
+
   it('reads a classic EIP by public IP when physical id is not an alloc id', async () => {
     ec2.on(DescribeAddressesCommand).resolves({
       Addresses: [{ Domain: 'standard', PublicIp: '52.0.0.2' }],


### PR DESCRIPTION
## What (HIGH FP + minor FN)

### FP — `NetworkInterfaceId` false-drifts every associated EIP
The `AWS::EC2::EIP` SDK-override reader projected `addr.NetworkInterfaceId`, but that is **not** a declarable CloudFormation property of `AWS::EC2::EIP` — verified against the live registry schema (its property set is `PublicIp, AllocationId, Domain, NetworkBorderGroup, TransferAddress, InstanceId, PublicIpv4Pool, IpamPoolId, Address, Tags` — no `NetworkInterfaceId`). So it was neither `readOnly`-stripped nor a known default, and AWS populates it for any EIP associated with an ENI — so it false-flagged an `undeclared` drift on **every associated EIP** on the first `check`.

### FN — `PublicIpv4Pool` was dropped
`PublicIpv4Pool` **is** a declarable EIP property (in the registry schema, not read/write/create-only) that the reader dropped, so a declared value was never compared (degraded to `readGap`) and an out-of-band value was invisible.

## Fix

Stop projecting `NetworkInterfaceId` (pure FP removal — not declarable, not revertable, so dropping it cannot hide any declared drift). Project `PublicIpv4Pool` when present (absent for standard AWS-pool EIPs → FP-safe).

Both SDK fields verified against `@aws-sdk/client-ec2` `.d.ts`.

## Tests

+1 unit test (NetworkInterfaceId not surfaced; PublicIpv4Pool surfaced). 1124 tests green. No live integ: a pure FP-reducing projection change, verified against the live CFn registry schema.

This is a WAVE 22 override-reader finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
