### PR TITLE
fix(config): clear the unrecorded flag when re-tagging a finding to ignored

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -290,6 +290,14 @@ export function applyIgnores(
         targets.some((t) => pathMatches(r.pathPattern, t))
     );
     if (!hit) return f;
-    return { ...f, tier: 'ignored', note: `ignored by config rule "${hit.raw}"` };
+    // Clear the `unrecorded` flag (set by applyBaseline for a not-yet-recorded
+    // undeclared/added value): an `ignored` finding is a DECIDED value — the user told
+    // cdkrd to STOP reporting it — so it must not still surface under `[Not Recorded]`
+    // nor nag "run cdkrd record" (report/stack-actions filter that section by the FLAG,
+    // not the tier). This upholds the `record` vs `ignore` invariant (ignore stops
+    // watching). The exit code was always safe (ignored is not a drift tier); this fixes
+    // the spurious reporting that defeated the purpose of `ignore`.
+    const { unrecorded: _unrecorded, ...rest } = f;
+    return { ...rest, tier: 'ignored', note: `ignored by config rule "${hit.raw}"` };
   });
 }

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -132,6 +132,15 @@ describe('applyIgnores', () => {
     expect(f?.tier).toBe('ignored');
   });
 
+  it('clears the unrecorded flag when re-tagging to ignored (ignore STOPS watching, WAVE22)', () => {
+    // applyBaseline marks a not-yet-recorded undeclared value `unrecorded`; once ignored
+    // it is a DECIDED value and must not still surface under [Not Recorded] / "run record".
+    const f = { ...undeclared('MyTable', 'ProvisionedThroughput'), unrecorded: true };
+    const [out] = ign([f], 'S', cfg([p('*.ProvisionedThroughput')]));
+    expect(out?.tier).toBe('ignored');
+    expect(out?.unrecorded).toBeUndefined();
+  });
+
   it('parent-segment rule covers child paths', () => {
     const [f] = ign([undeclared('Role', 'Policies.0.PolicyName')], 'S', cfg([p('Role.Policies')]));
     expect(f?.tier).toBe('ignored');


### PR DESCRIPTION
## What (MEDIUM — violates the `ignore` STOPS-watching invariant)

`applyBaseline` sets `unrecorded: true` on a not-yet-recorded undeclared/added value. `applyIgnores` re-tagged a matching finding to `ignored` with `{ ...f, tier: 'ignored' }` — which **carried that flag over**.

`report.ts` and `stack-actions.ts` filter the `[Not Recorded]` section and the *"N unrecorded value(s) await a baseline — run cdkrd record"* nag by the **flag**, not the tier. So a value the user explicitly told cdkrd to **ignore** still appeared under `[Not Recorded]` and was nagged to be recorded — self-contradictory output (`ignored by config rule "…"` filed under Not-Recorded) that directly violates the documented `record` vs `ignore` invariant (*ignore STOPS watching — never reported again*).

Exit codes were always safe (`ignored` is not a drift tier); the damage was confined to spurious reporting that defeated the purpose of `ignore`.

## Fix

Drop the stale `unrecorded` flag in the `ignored` re-tag.

## Tests

+1 unit test (an ignored finding carries no `unrecorded` flag). 1125 tests green. Pure config logic, no AWS surface.

This is a WAVE 22 verb-cycle-invariant finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
