### PR TITLE
fix(read): paginate Route53 ListResourceRecordSets (a page-2 record was a false deleted)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -17,6 +17,8 @@ import { DescribeAddressesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { GetTableCommand, GlueClient } from '@aws-sdk/client-glue';
 import {
   ListResourceRecordSetsCommand,
+  type ListResourceRecordSetsCommandOutput,
+  type ResourceRecordSet,
   type RRType,
   Route53Client,
 } from '@aws-sdk/client-route-53';
@@ -336,28 +338,51 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
   // StartRecord cursor, which holds all variants of one name+type consecutively) and
   // disambiguate by SetIdentifier below.
   const c = new Route53Client({ region, ...READ_RETRY });
-  const r = await c.send(
-    new ListResourceRecordSetsCommand({
-      HostedZoneId: hostedZoneId,
-      StartRecordName: name,
-      StartRecordType: type as RRType,
-    })
-  );
   const canon = (s: string): string => s.replace(/\.$/, '').toLowerCase();
   // Match the declared SetIdentifier too: a simple record declares none and AWS
   // returns none (undefined === undefined), while a weighted/latency variant matches
   // its specific identifier instead of whichever sibling happened to come first.
   const declSetId = str(declared.SetIdentifier);
-  const rec = r.ResourceRecordSets?.find(
-    (x) =>
-      x.Type === type &&
-      x.Name &&
-      canon(x.Name) === canon(name) &&
-      (x.SetIdentifier ?? undefined) === declSetId
-  );
-  // The zone was listed successfully but the declared name+type(+SetIdentifier) record
-  // is absent — it was deleted out of band. Distinct from the "couldn't resolve the
-  // target" guard above (which returns undefined → skipped): here we KNOW it is gone.
+  const isOurNameType = (x: ResourceRecordSet): boolean =>
+    x.Type === type && !!x.Name && canon(x.Name) === canon(name);
+  const isExact = (x: ResourceRecordSet): boolean =>
+    isOurNameType(x) && (x.SetIdentifier ?? undefined) === declSetId;
+  // PAGINATE: a name+type with many SetIdentifier variants (weighted/latency/geo/failover/
+  // multivalue), or a name that sorts past the default ~300-record page, can land the
+  // declared record on a LATER page. Reading only page 1 would misread a PRESENT record as
+  // absent and throw ResourceGoneError → a FALSE `deleted` (and revert would then recreate
+  // an existing record). Page from the name+type cursor until the exact record is found.
+  // Early-stop once our name+type's records are exhausted: Route53 returns records sorted,
+  // so all variants of one name+type are contiguous — once we've seen them and a page has
+  // none, the declared SetIdentifier is genuinely absent.
+  let rec: ResourceRecordSet | undefined;
+  let sawOurNameType = false;
+  let startName: string | undefined = name;
+  let startType: RRType | undefined = type as RRType;
+  let startId: string | undefined;
+  for (;;) {
+    const r: ListResourceRecordSetsCommandOutput = await c.send(
+      new ListResourceRecordSetsCommand({
+        HostedZoneId: hostedZoneId,
+        StartRecordName: startName,
+        StartRecordType: startType,
+        ...(startId !== undefined && { StartRecordIdentifier: startId }),
+      })
+    );
+    const page = r.ResourceRecordSets ?? [];
+    rec = page.find(isExact);
+    if (rec) break;
+    const pageHasOurNameType = page.some(isOurNameType);
+    if (pageHasOurNameType) sawOurNameType = true;
+    // exhausted our name+type's contiguous run, or the whole listing -> genuinely absent
+    if ((sawOurNameType && !pageHasOurNameType) || !r.IsTruncated) break;
+    startName = r.NextRecordName;
+    startType = r.NextRecordType as RRType | undefined;
+    startId = r.NextRecordIdentifier;
+  }
+  // The zone was listed successfully (every page) but the declared name+type(+SetIdentifier)
+  // record is absent — it was deleted out of band. Distinct from the "couldn't resolve the
+  // target" guard above (returns undefined → skipped): here we KNOW it is gone.
   if (!rec)
     throw new ResourceGoneError(
       `Route53 RecordSet ${name} ${type} absent from zone ${hostedZoneId}`

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -421,6 +421,62 @@ describe('SDK overrides', () => {
       expect(await SDK_OVERRIDES['AWS::Route53::RecordSet'](ctx({}, 'opaque-id'))).toBeUndefined();
     });
 
+    it('follows IsTruncated to find a record paginated past the first page (no false deleted, WAVE23)', async () => {
+      // A name+type with many SetIdentifier variants can land the declared one on page 2.
+      // Reading only page 1 would throw ResourceGoneError -> a FALSE `deleted`.
+      route53
+        .on(ListResourceRecordSetsCommand)
+        .resolvesOnce({
+          ResourceRecordSets: [
+            { Name: 'app.example.com.', Type: 'A', SetIdentifier: 'blue', Weight: 10 },
+          ],
+          IsTruncated: true,
+          NextRecordName: 'app.example.com.',
+          NextRecordType: 'A',
+          NextRecordIdentifier: 'green',
+        })
+        .resolvesOnce({
+          ResourceRecordSets: [
+            {
+              Name: 'app.example.com.',
+              Type: 'A',
+              SetIdentifier: 'green',
+              Weight: 90,
+              TTL: 60,
+              ResourceRecords: [{ Value: '2.2.2.2' }],
+            },
+          ],
+          IsTruncated: false,
+        });
+      const out = await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+        ctx({ HostedZoneId: 'Z1', Name: 'app.example.com.', Type: 'A', SetIdentifier: 'green' })
+      );
+      // the page-2 record was found (NOT a false ResourceGoneError) with its routing fields
+      expect(out).toMatchObject({ SetIdentifier: 'green', Weight: 90, TTL: '60' });
+    });
+
+    it('throws deleted only after exhausting all pages (a genuinely absent record)', async () => {
+      route53
+        .on(ListResourceRecordSetsCommand)
+        .resolvesOnce({
+          ResourceRecordSets: [{ Name: 'app.example.com.', Type: 'A', SetIdentifier: 'blue' }],
+          IsTruncated: true,
+          NextRecordName: 'app.example.com.',
+          NextRecordType: 'A',
+          NextRecordIdentifier: 'blue',
+        })
+        // page 2 moved past our name+type entirely -> exhausted, genuinely gone
+        .resolvesOnce({
+          ResourceRecordSets: [{ Name: 'zzz.example.com.', Type: 'A' }],
+          IsTruncated: false,
+        });
+      await expect(
+        SDK_OVERRIDES['AWS::Route53::RecordSet'](
+          ctx({ HostedZoneId: 'Z1', Name: 'app.example.com.', Type: 'A', SetIdentifier: 'green' })
+        )
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
     it('disambiguates same-name+type variants by SetIdentifier (no wrong-record read) and projects routing fields', async () => {
       // Two weighted records share Name+Type; only SetIdentifier tells them apart. The
       // old reader (MaxItems:1 + Type/Name-only match) would read whichever came first


### PR DESCRIPTION
## What (HIGH FP — false `deleted`, a regression risk from #178)

`readRoute53RecordSet` read only the **first** page of `ListResourceRecordSets` (default ~300 records). A name+type with many `SetIdentifier` variants (weighted / latency / geo / failover / multivalue), or a name sorting past the page boundary, can land the declared record on a **later** page — and since #178 the reader **throws `ResourceGoneError`** when the record is absent (→ the `deleted` tier). So a **present** record paginated past page 1 was misread as a **false `deleted`** (and `revert` would then try to recreate an already-existing record). This is the dangerous direction `MetricFilter` (#147) already guards against.

## Fix

Page from the name+type cursor (`StartRecordName`/`StartRecordType`/`StartRecordIdentifier`) until the exact record is found, early-stopping once our name+type's contiguous run is exhausted (Route53 returns records sorted, so all variants of one name+type are consecutive). Only then is the record genuinely absent → `ResourceGoneError` → `deleted`.

SDK fields (`IsTruncated` / `NextRecordName` / `NextRecordType` / `NextRecordIdentifier`) verified against `@aws-sdk/client-route-53` `.d.ts`.

## Proof

- +2 unit tests: a page-2 record is found (not a false deleted); `deleted` only after exhausting pages.
- 1127 tests green.
- **Live-proven**: `verify-r53-record-deleted.sh` still **INTEG PASS** (present record CLEAN, deleted record detected) with the rewritten reader.

WAVE 23 pagination finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
