### PR TITLE
fix(baseline): fail safe on a malformed or newer-schema baseline file

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -68,13 +68,31 @@ export async function loadBaseline(
     if ((e as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
     throw e;
   }
-  const parsed = JSON.parse(raw) as BaselineFile & { accepted?: RecordedEntry[] };
+  const path = baselinePath(stackName, accountId, region);
+  let parsed: BaselineFile & { accepted?: RecordedEntry[] };
+  try {
+    parsed = JSON.parse(raw) as BaselineFile & { accepted?: RecordedEntry[] };
+  } catch {
+    throw new Error(`baseline file ${path} is not valid JSON (corrupt or partially written)`);
+  }
+  if (parsed === null || typeof parsed !== 'object')
+    throw new Error(`baseline file ${path} is malformed: root is not an object`);
   // Back-compat: baselines written before `accept` was renamed to `record` stored the
   // entries under `accepted`; the field is now `recorded`. Read the old key so a
   // committed baseline keeps loading — the next `record` rewrites it under `recorded`.
   if (parsed.recorded === undefined && parsed.accepted !== undefined)
     parsed.recorded = parsed.accepted;
   delete parsed.accepted;
+  // Fail-safe validation (a baseline is a git-committed, hand-editable, cross-version
+  // artifact): a newer schemaVersion must error CLEARLY rather than be silently
+  // mis-applied as v2, and a missing/non-array `recorded` must error here rather than
+  // crash later with an opaque TypeError inside applyBaseline (`recorded.find`).
+  if (typeof parsed.schemaVersion === 'number' && parsed.schemaVersion > 2)
+    throw new Error(
+      `baseline file ${path} was written by a newer cdkrd (schemaVersion ${parsed.schemaVersion}); upgrade cdkrd`
+    );
+  if (!Array.isArray(parsed.recorded))
+    throw new Error(`baseline file ${path} is malformed: \`recorded\` is missing or not an array`);
   return parsed;
 }
 

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -955,6 +955,52 @@ describe('baseline', () => {
     });
   });
 
+  describe('loadBaseline fail-safe validation (WAVE23 — a malformed/newer baseline errors clearly)', () => {
+    const withBaselineFile = async (contents: string, fn: () => Promise<void>) => {
+      const dir = await mkdtemp(join(tmpdir(), 'cdkrd-baseline-'));
+      const cwd = process.cwd();
+      process.chdir(dir);
+      try {
+        const p = baselinePath('s', '111122223333', 'r');
+        await mkdir(dirname(p), { recursive: true });
+        await writeFile(p, contents, 'utf8');
+        await fn();
+      } finally {
+        process.chdir(cwd);
+        await rm(dir, { recursive: true, force: true });
+      }
+    };
+
+    it('throws a CLEAR error on corrupt JSON (not an opaque SyntaxError)', async () => {
+      await withBaselineFile('{ "recorded": [', async () => {
+        await expect(loadBaseline('s', '111122223333', 'r')).rejects.toThrow(/not valid JSON/);
+      });
+    });
+
+    it('throws when `recorded` is missing/not an array (not a later opaque TypeError)', async () => {
+      await withBaselineFile(JSON.stringify({ schemaVersion: 2, stackName: 's' }), async () => {
+        await expect(loadBaseline('s', '111122223333', 'r')).rejects.toThrow(
+          /`recorded` is missing or not an array/
+        );
+      });
+    });
+
+    it('throws on a newer schemaVersion (a future cdkrd wrote it) instead of mis-applying as v2', async () => {
+      await withBaselineFile(JSON.stringify({ schemaVersion: 3, recorded: [] }), async () => {
+        await expect(loadBaseline('s', '111122223333', 'r')).rejects.toThrow(/newer cdkrd/);
+      });
+    });
+
+    it('still loads a valid v1/v2 baseline (no false rejection)', async () => {
+      await withBaselineFile(
+        JSON.stringify({ schemaVersion: 2, recorded: [], stackName: 's' }),
+        async () => {
+          expect((await loadBaseline('s', '111122223333', 'r'))?.recorded).toEqual([]);
+        }
+      );
+    });
+  });
+
   describe('warnTemplateHashDrift', () => {
     it('warns when the stored hash differs from the current template', () => {
       const b = { ...baseline([]), templateHash: hashTemplate('{"old":1}') };


### PR DESCRIPTION
## What (MEDIUM — confusing crash + forward-compat silent mis-apply)

`loadBaseline` did **zero** shape validation:
- A git-committed baseline hand-edited / truncated so `recorded` is missing or not an array loaded fine, then crashed deep inside `applyBaseline` with an opaque `TypeError: Cannot read properties of undefined (reading 'find')`.
- A baseline written by a **future** cdkrd (`schemaVersion >= 3`) was silently interpreted as v2 — a cross-version, git-committed artifact mis-applied rather than flagged.

## Fix

Validate in `loadBaseline`: clear errors for corrupt JSON, a non-object root, a missing/non-array `recorded`, and a `schemaVersion` newer than the code understands. The exit code was always safe (per-stack catch → exit 2); this makes the **message** actionable (`baseline file <path> is malformed: …` / `… written by a newer cdkrd; upgrade`) instead of a baffling `TypeError`.

## Tests

+4 unit tests (corrupt JSON; missing `recorded`; newer schemaVersion; a valid v2 still loads). 1137 tests green. No AWS surface.

WAVE 23 robustness finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
