### PR TITLE
fix(config): reject an empty ignore-rule path (a silent no-op rule)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -106,6 +106,11 @@ function validateIgnoreEntry(entry: unknown, index: number): void {
     );
   if (typeof obj.path !== 'string')
     throw new Error(`${at}: "path" is required and must be a string`);
+  if (obj.path === '')
+    // an empty path matches NOTHING (the glob `^$` never matches a `<id>.<path>` target
+    // and the ancestor walk never reaches empty) — a silent no-op rule the user believes
+    // is suppressing a property. Reject it loudly so the no-op can't masquerade as active.
+    throw new Error(`${at}: "path" must not be empty`);
   for (const k of ['stack', 'region'] as const)
     if (obj[k] !== undefined && typeof obj[k] !== 'string')
       throw new Error(`${at}: "${k}" must be a string`);

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -349,6 +349,11 @@ describe('loadConfig', () => {
     await expect(loadConfig()).rejects.toThrow(/"path" is required and must be a string/);
   });
 
+  it('an empty "path" → throws (a silent no-op rule must not masquerade as active, WAVE23)', async () => {
+    await write('{ "ignore": [{ "path": "" }] }');
+    await expect(loadConfig()).rejects.toThrow(/"path" must not be empty/);
+  });
+
   it('an object entry with a non-string scope → throws', async () => {
     await write('{ "ignore": [{ "path": "x", "region": 1 }] }');
     await expect(loadConfig()).rejects.toThrow(/"region" must be a string/);


### PR DESCRIPTION
An empty `path` in an ignore rule passed validation but matches nothing (glob `^$` + ancestor walk never reach empty) — a silent no-op the user believes is active. Reject it loudly, matching loadConfig's other fail-fast guards. +1 unit test. 1138 green. No AWS surface. WAVE 23 robustness finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)