### PR TITLE
fix(classify): align Cognito UserPool Schema by attribute identity (no whole-array false drift)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -52,6 +52,31 @@ const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': 'LoadBalancerAttributes',
   'AWS::ElasticLoadBalancingV2::TargetGroup': 'TargetGroupAttributes',
 };
+
+// Identity-keyed object arrays where the template declares only a SUBSET of the elements
+// AWS always returns — keyed by the property -> the element's identity field. Cognito
+// UserPool `Schema` is the case: AWS returns all ~21 standard attributes (sub, email,
+// phone_number, …) plus any custom ones, every time, regardless of what the template
+// declares. Comparing the declared subset positionally against the full live array is a
+// length-mismatch whole-array FALSE positive on the first check of any pool that sets
+// `standardAttributes`/`customAttributes` (extremely common). The declared loop aligns
+// the declared elements to live BY this identity, compares them element-wise, and emits
+// the live-only elements as nested undeclared inventory (foldable, recordable) — so a
+// genuine out-of-band CUSTOM attribute addition still surfaces, but the standard-attribute
+// baseline no longer false-drifts. (Distinct from ELB bags, which are {Key,Value} and
+// revert by Key; these are rich objects compared by subset.)
+interface SubsetArraySpec {
+  idField: string;
+  // normalize the identity before matching: Cognito stores a custom attribute the
+  // template declares as `tier` under the live Name `custom:tier` (and a developer-only
+  // one as `dev:tier`), so an exact-Name match would treat the declared attribute as
+  // removed (a false declared drift). Strip those AWS-added prefixes on both sides.
+  normalizeId?: (id: string) => string;
+}
+const stripCognitoAttrPrefix = (id: string): string => id.replace(/^(custom|dev):/, '');
+const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpec>> = {
+  'AWS::Cognito::UserPool': { Schema: { idField: 'Name', normalizeId: stripCognitoAttrPrefix } },
+};
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
   !!t &&
   typeof t === 'object' &&
@@ -349,13 +374,68 @@ export function classifyResource(
       }
       continue;
     }
+    // Per-type identity-keyed SUBSET arrays (Cognito UserPool.Schema): the template
+    // declares a SUBSET of the elements AWS always returns. Align the declared elements
+    // to live BY identity so they compare element-wise (no whole-array length-mismatch
+    // FALSE positive), and emit the live-only elements as nested undeclared inventory.
+    const subsetSpec = IDENTITY_KEYED_SUBSET_ARRAYS[resourceType]?.[k];
     // Per-type unordered OBJECT-array sets (R88: EC2 SecurityGroup ingress/egress) —
     // rule objects with no single identity field that AWS returns reordered. Sort BOTH
     // sides by canonical JSON before the positional diff so a reorder is not false
     // drift; a genuine rule change still differs after the sort.
     const unorderedObjArray = UNORDERED_OBJECT_ARRAY_PROPS[resourceType]?.has(k);
-    const declaredVal = unorderedObjArray ? sortUnorderedObjectArray(v) : v;
-    const liveVal = unorderedObjArray ? sortUnorderedObjectArray(live[k]) : live[k];
+    let declaredVal: unknown = v;
+    let liveVal: unknown = live[k];
+    if (subsetSpec && Array.isArray(v) && Array.isArray(live[k])) {
+      const { idField, normalizeId } = subsetSpec;
+      const idOf = (e: unknown): string | undefined => {
+        if (!isNestedObject(e) || typeof e[idField] !== 'string') return undefined;
+        const raw = e[idField] as string;
+        return normalizeId ? normalizeId(raw) : raw;
+      };
+      const liveById = new Map<string, unknown>();
+      for (const el of live[k] as unknown[]) {
+        const id = idOf(el);
+        if (id !== undefined) liveById.set(id, el);
+      }
+      const declaredIds = new Set<string>();
+      const declaredSorted: unknown[] = [];
+      const liveAligned: unknown[] = [];
+      // align each declared element to its live match by identity (undefined if the
+      // declared attribute was removed from the pool -> a genuine declared drift). Set
+      // the idField to the NORMALIZED id on both sides so the per-element compare below
+      // doesn't false-flag the prefix difference itself (declared `tier` vs live
+      // `custom:tier`) — the identity is already matched, the rest compares by value.
+      for (const dEl of [...(v as unknown[])].sort((a, b) =>
+        (idOf(a) ?? '') < (idOf(b) ?? '') ? -1 : 1
+      )) {
+        const id = idOf(dEl);
+        if (id === undefined) continue;
+        declaredIds.add(id);
+        const match = liveById.get(id);
+        declaredSorted.push(isNestedObject(dEl) ? { ...dEl, [idField]: id } : dEl);
+        liveAligned.push(isNestedObject(match) ? { ...match, [idField]: id } : match);
+      }
+      // live-only elements (the always-present standard attributes, OR an out-of-band
+      // custom attribute the template never declared) -> nested undeclared inventory
+      for (const lEl of live[k] as unknown[]) {
+        const id = idOf(lEl);
+        if (id !== undefined && !declaredIds.has(id))
+          findings.push({
+            tier: 'undeclared',
+            logicalId,
+            resourceType,
+            path: `${k}[${id}]`,
+            actual: lEl,
+            nested: true,
+          });
+      }
+      declaredVal = declaredSorted;
+      liveVal = liveAligned;
+    } else if (unorderedObjArray) {
+      declaredVal = sortUnorderedObjectArray(v);
+      liveVal = sortUnorderedObjectArray(live[k]);
+    }
     // R95: the live side is compared in FULL — no subset projection. An R75
     // generic `projectLiveToDeclaredSubset` used to drop live elements whose
     // identity key was not declared, to mute the extra default attributes ELB

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1984,3 +1984,86 @@ describe('R140: nested AWS-populated values fold (so a clean deploy is clean)', 
     }
   });
 });
+
+describe('Cognito UserPool Schema identity-keyed subset (WAVE23 — declared attrs vs the full live set)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const pool = (declared: Record<string, unknown>) => ({
+    logicalId: 'Pool',
+    resourceType: 'AWS::Cognito::UserPool',
+    physicalId: 'p',
+    declared,
+  });
+  const liveAttr = (Name: string, over: Record<string, unknown> = {}) => ({
+    Name,
+    AttributeDataType: 'String',
+    DeveloperOnlyAttribute: false,
+    Mutable: true,
+    Required: false,
+    StringAttributeConstraints: { MinLength: '0', MaxLength: '2048' },
+    ...over,
+  });
+  // AWS always returns the full standard-attribute set plus declared customs
+  const liveStandard = ['sub', 'phone_number', 'address', 'birthdate', 'name'].map((n) =>
+    liveAttr(n)
+  );
+
+  it('a declared attribute subset does NOT false-drift against the full live Schema', () => {
+    // CDK emits a custom attribute as the BARE name `tier`; Cognito returns it prefixed
+    // as `custom:tier`. The identity match normalizes the prefix so the declared subset
+    // aligns to live and does not false-drift.
+    const declared = {
+      Schema: [
+        { Name: 'email', Mutable: true, Required: true },
+        { Name: 'tier', AttributeDataType: 'String', Mutable: true },
+      ],
+    };
+    const live = {
+      Schema: [...liveStandard, liveAttr('email', { Required: true }), liveAttr('custom:tier')],
+    };
+    const findings = classifyResource(pool(declared), live, bare);
+    // no whole-array declared FALSE positive (the prefix mismatch is normalized away)
+    expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+    // the always-present standard attributes surface as foldable nested undeclared inventory
+    expect(findings.filter((f) => f.tier === 'undeclared' && f.nested).length).toBe(
+      liveStandard.length
+    );
+  });
+
+  it('an out-of-band change to a DECLARED attribute is reported as declared drift', () => {
+    const declared = { Schema: [{ Name: 'email', Mutable: true, Required: true }] };
+    const live = { Schema: [...liveStandard, liveAttr('email', { Required: false })] };
+    const declaredDrift = classifyResource(pool(declared), live, bare).filter(
+      (f) => f.tier === 'declared'
+    );
+    expect(declaredDrift).toHaveLength(1);
+    expect(declaredDrift[0]).toMatchObject({ desired: true, actual: false });
+  });
+
+  it('a declared attribute absent from live (removed from the pool) is declared drift', () => {
+    const declared = { Schema: [{ Name: 'custom:gone', AttributeDataType: 'String' }] };
+    const live = { Schema: [...liveStandard] }; // custom:gone not present
+    const declaredDrift = classifyResource(pool(declared), live, bare).filter(
+      (f) => f.tier === 'declared'
+    );
+    expect(declaredDrift).toHaveLength(1);
+  });
+
+  it('an out-of-band CUSTOM attribute added (never declared) surfaces as undeclared', () => {
+    const declared = { Schema: [{ Name: 'email', Mutable: true }] };
+    const live = { Schema: [...liveStandard, liveAttr('email'), liveAttr('custom:rogue')] };
+    // the path carries the normalized identity (the `custom:` prefix is stripped)
+    const undeclared = classifyResource(pool(declared), live, bare).filter(
+      (f) => f.tier === 'undeclared' && f.path === 'Schema[rogue]'
+    );
+    expect(undeclared).toHaveLength(1);
+  });
+});

--- a/tests/integration/cognito/app.ts
+++ b/tests/integration/cognito/app.ts
@@ -3,8 +3,19 @@
 // AllowedOAuthFlows / AllowedOAuthScopes and CallbackURLs are UNORDERED enum/string
 // arrays AWS may return reordered (R74 unordered-set handling); a UserPoolGroup uses
 // a COMPOSITE Cloud Control identifier (UserPoolId|GroupName, R84).
+//
+// The Pool also declares standardAttributes + customAttributes (WAVE23): CDK emits a
+// `Schema` array, but AWS always returns the FULL ~21-attribute set. The declared subset
+// must compare element-wise (no whole-array false drift) — `check` (no baseline) must
+// find ZERO declared drift, the standard attrs surfacing as foldable undeclared inventory.
 import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
-import { CfnUserPoolGroup, OAuthScope, UserPool, UserPoolClient } from "aws-cdk-lib/aws-cognito";
+import {
+  CfnUserPoolGroup,
+  OAuthScope,
+  StringAttribute,
+  UserPool,
+  UserPoolClient,
+} from "aws-cdk-lib/aws-cognito";
 
 const app = new App();
 const stack = new Stack(app, "CdkRealDriftIntegCognito");
@@ -12,6 +23,8 @@ const stack = new Stack(app, "CdkRealDriftIntegCognito");
 const pool = new UserPool(stack, "Pool", {
   selfSignUpEnabled: true,
   removalPolicy: RemovalPolicy.DESTROY,
+  standardAttributes: { email: { required: true, mutable: true } },
+  customAttributes: { tier: new StringAttribute({ mutable: true }) },
 });
 
 new UserPoolClient(stack, "Client", {


### PR DESCRIPTION
## What (HIGH FP on a popular type)

`AWS::Cognito::UserPool` reads its full live `Schema` via Cloud Control: AWS **always** returns the ~21 standard attributes (`sub`, `email`, `phone_number`, …) plus any custom ones, regardless of what the template declares. So any pool that sets `standardAttributes` / `customAttributes` (extremely common) declared a **subset**, and the positional declared compare hit a length-mismatch → a **whole-array `declared` false positive on the very first check** — a trust-destroying FP on a popular type. (Corpus-invisible only because the existing fixture declared no attributes.)

## Fix

Add an `IDENTITY_KEYED_SUBSET_ARRAYS` registry (`AWS::Cognito::UserPool.Schema` → identity `Name`):
- Align the declared attributes to live **by identity**, compare element-wise — a genuine out-of-band change to a declared attribute still surfaces; a declared attribute removed from the pool is `declared` drift.
- Emit the live-only elements as **nested undeclared inventory** (foldable, recordable) — so an out-of-band **custom** attribute addition still surfaces, but the standard-attribute baseline no longer false-drifts.
- The identity is normalized for the `custom:`/`dev:` prefix Cognito adds (CDK declares a custom attr as `tier`; AWS returns `custom:tier`), so the prefix difference itself isn't a false drift.

## Proof

- +4 unit tests (subset no-FP; declared attribute change → declared drift; declared attribute removed → declared drift; out-of-band custom attribute → undeclared). 1142 tests + the 286-fixture self-compare corpus green.
- **Live-proven**: the `cognito` integ fixture now declares `standardAttributes` + `customAttributes`, and `check` (no baseline) finds **ZERO declared drift**, record-then-check stays **CLEAN**. **INTEG PASS**.

WAVE 23 tricky-type finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
