### PR TITLE
docs: frame `cdkrd check` as the entry point (record/ignore/revert inline or for scripts)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,13 @@ node dist/cli.js ignore [<stack>...] [--all]   # stop reporting chosen drift via
 node dist/cli.js revert [<stack>...] [--all]   # write the desired value back to AWS (confirms)
 ```
 
+- **`check` is the primary entry point.** Day to day the user runs only
+  `cdkrd check` and acts from its interactive prompt — it establishes the first
+  baseline (R141) and offers record / revert / ignore inline on what it finds
+  (R121/R133). The standalone `record` / `ignore` / `revert` verbs are the SAME
+  actions for scripting / non-TTY / CI (with `--yes`); a human rarely invokes
+  them directly. Baselines stay a reviewed git artifact — CI only runs
+  `check --fail` (it never writes a baseline); a human records locally + commits.
 - `check`, `record`, and `ignore` never write to AWS (`record` writes only the
   baseline file; `ignore` writes only `.cdkrd/config.json`). `revert` is the one
   AWS-mutating verb and always confirms first (`--dry-run` to preview, `--yes`/`-y`

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ tells cdkrd which stacks to look at.
 | `cdkrd ignore [<stack>...]` | stop reporting chosen drift via `.cdkrd/config.json` (CI: `--yes`)     |
 | `cdkrd revert [<stack>...]` | write the desired value back to AWS (confirms; `--dry-run` to preview) |
 
+**`cdkrd check` is the entry point.** Run it and act from its interactive
+prompt — it establishes the first baseline (on a fresh deploy) and offers
+**record / revert / ignore** inline on whatever it finds, so day to day you only
+run `cdkrd check`. The standalone `record` / `ignore` / `revert` verbs are the
+**same actions** for scripting / non-TTY / CI (with `--yes`); a human rarely
+needs to invoke them directly. (Baselines stay a reviewed, git-committed artifact
+either way — CI never writes one; you record locally and commit it.)
+
 **Exit codes:** `check` is **report-only by default** — drift prints but exits
 `0` (a note names the flag). Pass **`--fail`** (the `cdk diff --fail` /
 `cdk drift --fail` convention) to exit `1` on drift and suppress all prompts —

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,12 @@ USAGE
                               — STOPS watching (declared, undeclared, or added)
   cdkrd revert [<stack>...]   write the desired value back to AWS (confirms)
 
+  \`cdkrd check\` is the entry point: run it and act from its prompt — it
+  establishes the first baseline and offers record / revert / ignore inline on
+  whatever it finds, so day to day you only run check. The standalone verbs above
+  are the SAME actions for scripts / non-TTY / CI (with --yes); a human rarely
+  needs them directly.
+
   cdkrd is CDK-only: it synthesizes the CDK app (--app / cdk.json, or a
   pre-synthesized cdk.out) to discover stacks. With no stack argument, every
   stack the app defines is targeted; a <stack> arg (exact or a *?-glob) selects


### PR DESCRIPTION
Positioning-only docs change (no behavior change).

## Why
The 4-verb listing read as four co-equal commands a user must learn. In practice the UX is **check-centric**: day to day you run only `cdkrd check` and act from its interactive prompt — it **establishes the first baseline** (R141) and offers **record / revert / ignore inline** on what it finds (R121/R133). The standalone verbs are the *same actions* for scripting / non-TTY / CI; a human rarely invokes them directly, and baselines stay a reviewed git artifact (CI never writes one — it only runs `check --fail`).

## What
Add the "`cdkrd check` is the entry point" framing in:
- the `--help` / HELP text (`src/cli.ts`),
- README "Commands & options",
- CLAUDE.md's 4-verb model section.

So users don't think they must run `cdkrd record` separately.

Docs + the HELP string only — no logic change. typecheck / oxc / build / 1159 tests green. HELP renders correctly.

> CI billing still paused → `--admin` merge per prior agreement; verified by the full local gate suite.
