### PR TITLE
fix(normalize): treat Name as an array identity field (no false drift on reordered [{Name,Value}])

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -421,7 +421,16 @@ function stripTagsWalk(v: unknown, underTagsKey: boolean): unknown {
 // GlobalSecondaryIndexes (keyed by IndexName), which AWS returns in a different order
 // than the template declares them (a positional diff otherwise reports false drift on
 // every element). Both are set-like identities, not order-significant.
-const IDENTITY_FIELDS = ['Key', 'Id', 'AttributeName', 'IndexName'] as const;
+// WAVE24: `Name` extends it to the very common `[{Name,Value}]` shape — ECS
+// TaskDefinition ContainerDefinitions[].Environment / Secrets / Ulimits and CloudWatch
+// Alarm Dimensions — which Cloud Control returns in a DIFFERENT order than declared
+// (PROVEN live: a 5-var Environment came back fully shuffled), false-flagging every
+// shifted element as `declared` drift. Sorting is comparison-only (both sides, never
+// written back) and `identityField` requires EVERY element to carry a string `Name`, so
+// order-significant arrays without a Name on every element (CloudFront CacheBehaviors —
+// precedence-ordered, no Name; un-named ECS PortMappings) stay UNSORTED. The baseline's
+// `DELTA_IDENTITY_FIELDS` already includes `Name`; this aligns the compare side to it.
+const IDENTITY_FIELDS = ['Key', 'Id', 'AttributeName', 'IndexName', 'Name'] as const;
 // Exported for classify's nested-undeclared array descent (R98): an identity-keyed
 // object array (Tags/Origins/AttributeDefinitions/…) can be aligned element-by-element
 // by its identity value, so a live-only SUB-key inside a declared element is detected.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2043,10 +2043,15 @@ describe('Cognito UserPool Schema identity-keyed subset (WAVE23 — declared att
     const findings = classifyResource(pool(declared), live, bare);
     // no whole-array declared FALSE positive (the prefix mismatch is normalized away)
     expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
-    // the always-present standard attributes surface as foldable nested undeclared inventory
-    expect(findings.filter((f) => f.tier === 'undeclared' && f.nested).length).toBe(
-      liveStandard.length
-    );
+    // the always-present standard attributes each surface as a foldable nested undeclared
+    // inventory element (server-enriched sub-keys of the matched declared attrs may add
+    // more nested undeclared findings — all foldable, none a declared drift)
+    const undeclaredPaths = findings
+      .filter((f) => f.tier === 'undeclared' && f.nested)
+      .map((f) => f.path);
+    for (const n of ['sub', 'phone_number', 'address', 'birthdate', 'name']) {
+      expect(undeclaredPaths).toContain(`Schema[${n}]`);
+    }
   });
 
   it('an out-of-band change to a DECLARED attribute is reported as declared drift', () => {
@@ -2076,5 +2081,69 @@ describe('Cognito UserPool Schema identity-keyed subset (WAVE23 — declared att
       (f) => f.tier === 'undeclared' && f.path === 'Schema[rogue]'
     );
     expect(undeclared).toHaveLength(1);
+  });
+});
+
+describe('Name-keyed object arrays are identity-aligned (WAVE24 — ECS env vars, Alarm dimensions)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const task = (env: { Name: string; Value: string }[]) => ({
+    logicalId: 'Task',
+    resourceType: 'AWS::ECS::TaskDefinition',
+    physicalId: 'p',
+    declared: { ContainerDefinitions: [{ Name: 'app', Environment: env }] },
+  });
+
+  it('a reordered ECS Environment array is NOT false declared drift (Cloud Control shuffles it)', () => {
+    const declared = task([
+      { Name: 'ZEBRA', Value: '1' },
+      { Name: 'ALPHA', Value: '2' },
+      { Name: 'MIKE', Value: '3' },
+    ]);
+    // AWS returns the same set in a different order
+    const live = {
+      ContainerDefinitions: [
+        {
+          Name: 'app',
+          Environment: [
+            { Name: 'MIKE', Value: '3' },
+            { Name: 'ZEBRA', Value: '1' },
+            { Name: 'ALPHA', Value: '2' },
+          ],
+        },
+      ],
+    };
+    expect(classifyResource(declared, live, bare).filter((f) => f.tier === 'declared')).toEqual([]);
+  });
+
+  it('a genuine ECS Environment value change still surfaces as declared drift', () => {
+    const declared = task([
+      { Name: 'ZEBRA', Value: '1' },
+      { Name: 'ALPHA', Value: '2' },
+    ]);
+    const live = {
+      ContainerDefinitions: [
+        {
+          Name: 'app',
+          Environment: [
+            { Name: 'ALPHA', Value: 'CHANGED' },
+            { Name: 'ZEBRA', Value: '1' },
+          ],
+        },
+      ],
+    };
+    const declaredDrift = classifyResource(declared, live, bare).filter(
+      (f) => f.tier === 'declared'
+    );
+    expect(declaredDrift).toHaveLength(1);
+    expect(declaredDrift[0]).toMatchObject({ actual: 'CHANGED' });
   });
 });

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -406,17 +406,6 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "profile"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
           "Name": "address"
         },
         {
@@ -429,119 +418,6 @@
           },
           "Required": false,
           "Name": "birthdate"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "gender"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "preferred_username"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "Number",
-          "Required": false,
-          "NumberAttributeConstraints": {
-            "MinValue": "0"
-          },
-          "Name": "updated_at"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "website"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "picture"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {},
-          "Required": false,
-          "Name": "identities"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": false,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "1",
-            "MaxLength": "2048"
-          },
-          "Required": true,
-          "Name": "sub"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "phone_number"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "Boolean",
-          "Required": false,
-          "Name": "phone_number_verified"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "zoneinfo"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "locale"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -570,7 +446,7 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "given_name"
+          "Name": "family_name"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -581,7 +457,37 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "family_name"
+          "Name": "gender"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "given_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {},
+          "Required": false,
+          "Name": "identities"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "locale"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -615,6 +521,100 @@
           },
           "Required": false,
           "Name": "nickname"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "phone_number"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "phone_number_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "picture"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "preferred_username"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "profile"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": false,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "1",
+            "MaxLength": "2048"
+          },
+          "Required": true,
+          "Name": "sub"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Number",
+          "Required": false,
+          "NumberAttributeConstraints": {
+            "MinValue": "0"
+          },
+          "Name": "updated_at"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "website"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "zoneinfo"
         }
       ],
       "physicalId": "us-east-1_BUaNF3GfH",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -407,17 +407,6 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "profile"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
           "Name": "address"
         },
         {
@@ -430,119 +419,6 @@
           },
           "Required": false,
           "Name": "birthdate"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "gender"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "preferred_username"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "Number",
-          "Required": false,
-          "NumberAttributeConstraints": {
-            "MinValue": "0"
-          },
-          "Name": "updated_at"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "website"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "picture"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {},
-          "Required": false,
-          "Name": "identities"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": false,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "1",
-            "MaxLength": "2048"
-          },
-          "Required": true,
-          "Name": "sub"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "phone_number"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "Boolean",
-          "Required": false,
-          "Name": "phone_number_verified"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "zoneinfo"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "locale"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -571,7 +447,7 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "given_name"
+          "Name": "family_name"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -582,7 +458,37 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "family_name"
+          "Name": "gender"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "given_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {},
+          "Required": false,
+          "Name": "identities"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "locale"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -616,6 +522,100 @@
           },
           "Required": false,
           "Name": "nickname"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "phone_number"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "phone_number_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "picture"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "preferred_username"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "profile"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": false,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "1",
+            "MaxLength": "2048"
+          },
+          "Required": true,
+          "Name": "sub"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Number",
+          "Required": false,
+          "NumberAttributeConstraints": {
+            "MinValue": "0"
+          },
+          "Name": "updated_at"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "website"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "zoneinfo"
         }
       ],
       "physicalId": "us-east-1_4tB3jYmmc",

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -333,6 +333,18 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Policies.SignInPolicy",
+      "actual": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      },
+      "nested": true,
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
@@ -372,34 +384,11 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
-      "tier": "atDefault",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "Policies.SignInPolicy",
-      "actual": {
-        "AllowedFirstAuthFactors": ["PASSWORD"]
-      },
-      "nested": true,
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Schema",
       "actual": [
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "profile"
-        },
         {
           "DeveloperOnlyAttribute": false,
           "Mutable": true,
@@ -431,119 +420,6 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "gender"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "preferred_username"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "Number",
-          "Required": false,
-          "NumberAttributeConstraints": {
-            "MinValue": "0"
-          },
-          "Name": "updated_at"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "website"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "picture"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {},
-          "Required": false,
-          "Name": "identities"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": false,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "1",
-            "MaxLength": "2048"
-          },
-          "Required": true,
-          "Name": "sub"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "phone_number"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "Boolean",
-          "Required": false,
-          "Name": "phone_number_verified"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "zoneinfo"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
-          "Name": "locale"
-        },
-        {
-          "DeveloperOnlyAttribute": false,
-          "Mutable": true,
-          "AttributeDataType": "String",
-          "StringAttributeConstraints": {
-            "MinLength": "0",
-            "MaxLength": "2048"
-          },
-          "Required": false,
           "Name": "email"
         },
         {
@@ -562,7 +438,7 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "given_name"
+          "Name": "family_name"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -573,7 +449,37 @@
             "MaxLength": "2048"
           },
           "Required": false,
-          "Name": "family_name"
+          "Name": "gender"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "given_name"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {},
+          "Required": false,
+          "Name": "identities"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "locale"
         },
         {
           "DeveloperOnlyAttribute": false,
@@ -607,6 +513,100 @@
           },
           "Required": false,
           "Name": "nickname"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "phone_number"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Boolean",
+          "Required": false,
+          "Name": "phone_number_verified"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "picture"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "preferred_username"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "profile"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": false,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "1",
+            "MaxLength": "2048"
+          },
+          "Required": true,
+          "Name": "sub"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "Number",
+          "Required": false,
+          "NumberAttributeConstraints": {
+            "MinValue": "0"
+          },
+          "Name": "updated_at"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "website"
+        },
+        {
+          "DeveloperOnlyAttribute": false,
+          "Mutable": true,
+          "AttributeDataType": "String",
+          "StringAttributeConstraints": {
+            "MinLength": "0",
+            "MaxLength": "2048"
+          },
+          "Required": false,
+          "Name": "zoneinfo"
         }
       ],
       "physicalId": "us-east-1_Ifea0bzss",

--- a/tests/corpus/AWS__ECS__TaskDefinition.Task.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.Task.json
@@ -113,5 +113,16 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Task",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-harvest6:1",
+      "constructPath": "CdkrdIntegHarvest6/Task"
+    }
+  ]
 }

--- a/tests/integration/ecs-writeonly/app.ts
+++ b/tests/integration/ecs-writeonly/app.ts
@@ -39,6 +39,10 @@ const container = taskDefinition.addContainer("App", {
   image: ContainerImage.fromRegistry("public.ecr.aws/amazonlinux/amazonlinux:latest"),
   memoryLimitMiB: 512,
   command: ["echo", "hello"],
+  // WAVE24: multiple env vars declared in a non-sorted order — Cloud Control returns the
+  // ContainerDefinitions[].Environment `[{Name,Value}]` array SHUFFLED, which used to
+  // false-flag every shifted element as declared drift. `check` must stay CLEAN on them.
+  environment: { ZEBRA: "1", ALPHA: "2", MIKE: "3", BRAVO: "4" },
 });
 
 // Managed EBS volume → configuredAtLaunch volume on the task definition, plus

--- a/tests/integration/ecs-writeonly/verify.sh
+++ b/tests/integration/ecs-writeonly/verify.sh
@@ -50,6 +50,11 @@ node -e '
   if (svc.some(f => f.tier === "skipped")) { console.error("ECS Service was SKIPPED — adapter not applied"); process.exit(1); }
   if (svc.some(f => f.tier === "declared")) { console.error("unexpected declared drift pre-mutation:\n"+JSON.stringify(svc,null,2)); process.exit(1); }
   console.log("ECS Service read, no false declared drift ✓");
+  // WAVE24: the TaskDefinition declares 4 env vars; Cloud Control returns them shuffled.
+  // There must be NO declared drift on the TaskDefinition (the Name-keyed-array reorder FP).
+  const task = (j.findings||[]).filter(f => f.resourceType === "AWS::ECS::TaskDefinition" && f.tier === "declared");
+  if (task.length) { console.error("false declared drift on the TaskDefinition (env-var reorder FP):\n"+JSON.stringify(task,null,2)); process.exit(1); }
+  console.log("TaskDefinition env vars read, no reorder false drift ✓");
 ' || fail "ECS Service not readable / false drift"
 
 echo "=== drift: DesiredCount 0 -> 1 out of band ==="


### PR DESCRIPTION
## What (HIGH FP, proven live — on a very common shape)

Cloud Control returns the ubiquitous `[{Name,Value}]` array shape in a **different order** than the template declares: **ECS TaskDefinition** `ContainerDefinitions[].Environment` / `Secrets` / `Ulimits`, **CloudWatch Alarm** `Dimensions`. `IDENTITY_FIELDS` (`Key`/`Id`/`AttributeName`/`IndexName`) omitted `Name`, so `identityField` returned `undefined` for these arrays — `canonicalizeTagListsDeep` never sorted them and `calculateResourceDrift` compared them **positionally**, false-flagging every shifted element as `declared` drift on the first check. (A prior wave **proved this live**: a 5-var Environment came back fully shuffled → 8 false drifts.) The same omission stopped `collectNestedUndeclared` descending the array → a live-only sub-key inside a declared element was missed (FN).

## Fix

Add `Name` to `IDENTITY_FIELDS`. Sorting is **comparison-only** (both sides, never written back), and `identityField` requires **every** element to carry a string `Name`, so order-significant arrays without a `Name` on every element (CloudFront `CacheBehaviors` — precedence-ordered, no `Name`; un-named ECS `PortMappings`) stay **unsorted**. This aligns the compare side with the baseline's `DELTA_IDENTITY_FIELDS`, which already included `Name`.

## Proof

- +unit tests (ECS env reorder no-FP; a value change still surfaces; Cognito `Schema` still no-FP).
- 4 corpus golden files regenerated to the new, **more thorough** output — the ECS Task case now also surfaces a live-only `Cpu:0` as foldable nested undeclared (an FN the descent previously missed). 1158 tests + the 286-fixture corpus green.
- **Live-proven**: the `ecs-writeonly` fixture now declares 4 env vars (`ZEBRA,ALPHA,MIKE,BRAVO`); Cloud Control returns them shuffled, and `check` reports **no** TaskDefinition reorder drift. **INTEG PASS**.

WAVE 24 tricky-type finding (the PROVEN `Name`-keyed-array reorder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
