### PR TITLE
fix(classify): sort unordered-set props in the live model so the recorded value is order-stable

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -122,7 +122,10 @@ async function readAddedModel(
     const raw = JSON.parse(g.ResourceDescription?.Properties ?? '{}') as Record<string, unknown>;
     const schema = schemas.get(c.resourceType) ?? (await getSchemaInfo(cfn, c.resourceType));
     schemas.set(c.resourceType, schema);
-    return { model: normalizeLiveModel(raw, schema, { oaiCanonicalIds }), ok: true };
+    return {
+      model: normalizeLiveModel(raw, schema, { oaiCanonicalIds, resourceType: c.resourceType }),
+      ok: true,
+    };
   } catch {
     return { model: c.live, ok: false };
   }

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -229,10 +229,32 @@ function collectNestedUndeclared(
 // field (a timestamp, a revision id) would read as a false "changed since record" on
 // every check. Mutates a fresh object (the canonicalize step clones), so liveRaw is
 // untouched. Pure: no AWS calls.
+// Sort a resource's per-type UNORDERED-SET properties into a canonical order, in place.
+// canonicalizeForCompare is type-agnostic, so it can't apply these per-type opt-ins; the
+// DECLARED loop sorts them for its compare, but the UNDECLARED loop (and the recorded
+// baseline value + the `added` model) emitted them RAW — so a recorded SG ingress set or
+// Cognito OAuth list, re-read by AWS in a different order, false-flagged as "changed since
+// record" (baselineValueMatches re-canonicalizes without this step). Sorting them here, in
+// the shared live-model normalizer, makes every downstream consumer see one stable order.
+function sortUnorderedSetProps(model: Record<string, unknown>, resourceType: string): void {
+  for (const k of UNORDERED_OBJECT_ARRAY_PROPS[resourceType] ?? [])
+    if (Array.isArray(model[k])) model[k] = sortUnorderedObjectArray(model[k]);
+  for (const k of UNORDERED_ARRAY_PROPS[resourceType] ?? []) {
+    const v = model[k];
+    if (
+      Array.isArray(v) &&
+      v.every((e) => typeof e === 'string' || typeof e === 'number' || typeof e === 'boolean')
+    )
+      model[k] = [...v].sort((a, b) =>
+        `${typeof a}:${String(a)}` < `${typeof b}:${String(b)}` ? -1 : 1
+      );
+  }
+}
+
 export function normalizeLiveModel(
   liveRaw: Record<string, unknown>,
   schema: SchemaInfo,
-  opts: { oaiCanonicalIds?: Record<string, string> } = {}
+  opts: { oaiCanonicalIds?: Record<string, string>; resourceType?: string } = {}
 ): Record<string, unknown> {
   const oaiMap = opts.oaiCanonicalIds ?? {};
   const live = canonicalizeForCompare(
@@ -240,6 +262,7 @@ export function normalizeLiveModel(
   ) as Record<string, unknown>;
   deepStripPaths(live, schema.readOnlyPaths);
   deepStripPaths(live, schema.writeOnlyPaths);
+  if (opts.resourceType) sortUnorderedSetProps(live, opts.resourceType);
   return live;
 }
 
@@ -266,7 +289,7 @@ export function classifyResource(
   // silently diverge; the pipeline is shared with baseline-file.ts so baseline values
   // normalize identically (see pipeline.ts).
   const oaiMap = opts.oaiCanonicalIds ?? {};
-  const live = normalizeLiveModel(liveRaw, schema, { oaiCanonicalIds: oaiMap });
+  const live = normalizeLiveModel(liveRaw, schema, { oaiCanonicalIds: oaiMap, resourceType });
   const declared = canonicalizeForCompare(rewriteOaiPrincipalsDeep(declaredIn, oaiMap)) as Record<
     string,
     unknown

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2147,3 +2147,73 @@ describe('Name-keyed object arrays are identity-aligned (WAVE24 — ECS env vars
     expect(declaredDrift[0]).toMatchObject({ actual: 'CHANGED' });
   });
 });
+
+describe('unordered-set props are order-stable in the live model (WAVE24 — baseline match)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const rule = (port: number) => ({
+    CidrIp: '0.0.0.0/0',
+    IpProtocol: 'tcp',
+    FromPort: port,
+    ToPort: port,
+  });
+  const sg = {
+    logicalId: 'SG',
+    resourceType: 'AWS::EC2::SecurityGroup',
+    physicalId: 'sg-1',
+    declared: {},
+  };
+
+  it('an UNDECLARED SecurityGroupIngress set is emitted in a STABLE order across reordered reads', () => {
+    const a = classifyResource(
+      sg,
+      { SecurityGroupIngress: [rule(22), rule(80), rule(443)] },
+      bare
+    ).find((f) => f.path === 'SecurityGroupIngress');
+    const b = classifyResource(
+      sg,
+      { SecurityGroupIngress: [rule(443), rule(22), rule(80)] },
+      bare
+    ).find((f) => f.path === 'SecurityGroupIngress');
+    // identical recorded value -> baselineValueMatches stays true (no false "changed since record")
+    expect(a?.actual).toEqual(b?.actual);
+  });
+
+  it('an UNDECLARED Cognito OAuth scalar set is order-stable too', () => {
+    const c = {
+      logicalId: 'C',
+      resourceType: 'AWS::Cognito::UserPoolClient',
+      physicalId: 'c',
+      declared: {},
+    };
+    const a = classifyResource(
+      c,
+      { AllowedOAuthScopes: ['openid', 'email', 'profile'] },
+      bare
+    ).find((f) => f.path === 'AllowedOAuthScopes');
+    const b = classifyResource(
+      c,
+      { AllowedOAuthScopes: ['profile', 'openid', 'email'] },
+      bare
+    ).find((f) => f.path === 'AllowedOAuthScopes');
+    expect(a?.actual).toEqual(b?.actual);
+  });
+
+  it('a genuine SecurityGroupIngress change still differs (not masked by the sort)', () => {
+    const a = classifyResource(sg, { SecurityGroupIngress: [rule(22), rule(80)] }, bare).find(
+      (f) => f.path === 'SecurityGroupIngress'
+    );
+    const b = classifyResource(sg, { SecurityGroupIngress: [rule(22), rule(8080)] }, bare).find(
+      (f) => f.path === 'SecurityGroupIngress'
+    );
+    expect(a?.actual).not.toEqual(b?.actual);
+  });
+});


### PR DESCRIPTION
## What (HIGH FP — false "changed since record")

A per-type **unordered-set** property — EC2 SecurityGroup `SecurityGroupIngress`/`Egress`; Cognito UserPoolClient `AllowedOAuthFlows`/`Scopes`/`ExplicitAuthFlows`; WAFv2 IPSet `Addresses` — was sorted **only** in the declared-compare loop. When such a property is **undeclared** (the common SG case: rules added via separate `AWS::EC2::SecurityGroupIngress` resources reflect into the SG's live model) and **recorded**, a later live read that returns the **same set in a different order** false-flagged it as *"changed since record"* — `baselineValueMatches` re-canonicalizes the recorded value through `canonicalizeForCompare`, which (being type-agnostic) has no unordered-set step. The `added` model inherited the same gap.

## Fix

Sort these per-type props into a canonical order inside the shared `normalizeLiveModel` (now passed the `resourceType`), so **every** downstream consumer — the declared compare, the undeclared/atDefault emit, the recorded baseline value, and the `added` model — sees one stable order. A genuine element change still differs after the sort.

## Tests

+3 unit tests (SG ingress + Cognito scalar set order-stable across a reorder; a real change still differs). 1167 tests + the 286-fixture corpus green — no regression. Pure normalization sort, corpus-guarded.

WAVE 24 baseline-equality finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
