### PR TITLE
fix(revert): preserve aws:* managed tags for map-shaped Tags too (no AWS reject)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -424,7 +424,39 @@ export function tagPreservingOps(
   ops: PatchOp[],
   liveRaw: Record<string, unknown> | undefined
 ): PatchOp[] {
-  const managed = awsManagedTags(liveRaw?.['Tags']);
+  const liveTags = liveRaw?.['Tags'];
+  // MAP-shaped Tags (key->value, e.g. AWS::SSM::Parameter): the managed tags are aws:*
+  // KEYS. awsManagedTags only understood the {Key,Value}[] list shape, so a map-shaped
+  // /Tags revert dropped the aws:* keys -> AWS rejects ("aws: prefixed tag key names are
+  // not allowed for external use"). Mirror stripTagsWalk/isAllAwsTags and preserve them.
+  if (liveTags !== null && typeof liveTags === 'object' && !Array.isArray(liveTags)) {
+    const managedMap = Object.fromEntries(
+      Object.entries(liveTags).filter(([k]) => k.startsWith('aws:'))
+    );
+    if (Object.keys(managedMap).length === 0) return ops;
+    return ops.map((op) => {
+      if (op.path !== TAGS_POINTER) return op;
+      const userMap =
+        op.op === 'add' &&
+        op.value !== null &&
+        typeof op.value === 'object' &&
+        !Array.isArray(op.value)
+          ? Object.fromEntries(
+              Object.entries(op.value as Record<string, unknown>).filter(
+                ([k]) => !k.startsWith('aws:')
+              )
+            )
+          : {};
+      return {
+        op: 'add',
+        path: TAGS_POINTER,
+        value: { ...userMap, ...managedMap },
+        ...(op.prior !== undefined && { prior: op.prior }),
+        human: `${op.human} (preserving aws:* managed tags)`,
+      };
+    });
+  }
+  const managed = awsManagedTags(liveTags);
   if (managed.length === 0) return ops; // nothing managed to protect — leave ops as-is
   return ops.map((op) => {
     if (op.path !== TAGS_POINTER) return op;

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -845,4 +845,45 @@ describe('tagPreservingOps (revert must not strip aws:* managed tags — the SNS
     expect(out[0]!.op).toBe('add');
     expect(out[1]).toBe(other); // the non-Tags op is returned by reference, unchanged
   });
+
+  describe('MAP-shaped Tags (AWS::SSM::Parameter — key->value, WAVE24)', () => {
+    // CC returns SSM Parameter Tags as a map; the managed tags are aws:* KEYS
+    const liveMapManaged = {
+      Tags: {
+        'aws:cloudformation:stack-name': 'S',
+        'aws:cloudformation:logical-id': 'Param',
+        Team: 'platform',
+      },
+    };
+
+    it('a `remove /Tags` keeps ONLY the live aws:* map keys (not a dropped-managed reject)', () => {
+      const [out] = tagPreservingOps([op({ op: 'remove' })], liveMapManaged);
+      expect(out).toMatchObject({
+        op: 'add',
+        path: '/Tags',
+        value: {
+          'aws:cloudformation:stack-name': 'S',
+          'aws:cloudformation:logical-id': 'Param',
+        },
+      });
+      expect(out!.value).not.toHaveProperty('Team'); // user key dropped by the remove
+    });
+
+    it('an `add /Tags` merges the user map with the live aws:* keys (and drops any aws:* from the value)', () => {
+      const [out] = tagPreservingOps(
+        [op({ op: 'add', value: { Team: 'data', 'aws:should-not-be-here': 'x' } })],
+        liveMapManaged
+      );
+      expect(out!.value).toEqual({
+        Team: 'data',
+        'aws:cloudformation:stack-name': 'S',
+        'aws:cloudformation:logical-id': 'Param',
+      });
+    });
+
+    it('leaves the op unchanged when a map-shaped Tags has no aws:* keys', () => {
+      const ops = [op({ op: 'remove' })];
+      expect(tagPreservingOps(ops, { Tags: { Team: 'x' } })).toBe(ops);
+    });
+  });
 });


### PR DESCRIPTION
## What (MEDIUM — revert rejected / managed tags dropped for map-shaped Tags)

`tagPreservingOps` re-attaches the live `aws:*` managed tags onto a `/Tags` revert op so Cloud Control's read-modify-write doesn't tell the provider to untag them (which AWS rejects: *"aws: prefixed tag key names are not allowed for external use"*). But it routed everything through `awsManagedTags`, which understands **only** the `{Key,Value}[]` **list** shape — so a **map**-shaped Tags type (key→value, e.g. `AWS::SSM::Parameter`) fell through (`managed.length === 0` → op returned as-is), and the map-shaped `/Tags` revert dropped the `aws:*` keys → the same SNS-tags reject the list path was written to prevent, unprotected for map types.

The compare side already strips `aws:*` from **both** shapes (`stripTagsWalk` / `isAllAwsTags`), so the finding never carries them and the write side must re-attach.

## Fix

Handle the map shape: collect the live `aws:*` **keys** and merge them onto the op's value (an `add` keeps the user map minus any `aws:*` key; a `remove` keeps only the managed keys), mirroring the list path.

## Tests

+3 unit tests (map `remove` keeps managed; map `add` merges; no-`aws:*`-keys no-op). 1174 tests green. The list-shape mechanism is live-proven by `sns-topic-tags-revert`; this is the analogous key-merge for map types.

WAVE 24 revert-mechanics finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
