### PR TITLE
fix(noise): RDS DBCluster EngineVersion partial-track prefix match

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -544,6 +544,9 @@ export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
 // path is the dotted path from calculateResourceDrift.
 export const VERSION_PREFIX_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::RDS::DBInstance': new Set(['EngineVersion']),
+  // Aurora clusters resolve a partial track the same way (declared `"8.0"` /
+  // `"5.7.mysql_aurora.2"` reads back the full provisioned patch version).
+  'AWS::RDS::DBCluster': new Set(['EngineVersion']),
 };
 export function isVersionPrefixMatch(declared: unknown, live: unknown): boolean {
   if (typeof declared !== 'string' || typeof live !== 'string') return false;

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -434,9 +434,13 @@ describe('parseSchema', () => {
     expect(isVersionPrefixMatch(8 as unknown, '8.0')).toBe(false); // non-string
   });
 
-  it('R130: VERSION_PREFIX_PATHS gates the rule to RDS DBInstance EngineVersion only', () => {
+  it('R130: VERSION_PREFIX_PATHS gates the rule to RDS EngineVersion only', () => {
     expect(VERSION_PREFIX_PATHS['AWS::RDS::DBInstance']?.has('EngineVersion')).toBe(true);
     expect(VERSION_PREFIX_PATHS['AWS::RDS::DBInstance']?.has('Engine')).toBe(false);
+    // Aurora clusters resolve a partial track the same way as instances.
+    expect(VERSION_PREFIX_PATHS['AWS::RDS::DBCluster']?.has('EngineVersion')).toBe(true);
+    expect(VERSION_PREFIX_PATHS['AWS::RDS::DBCluster']?.has('Engine')).toBe(false);
+    expect(VERSION_PREFIX_PATHS['AWS::S3::Bucket']).toBeUndefined(); // not a blanket rule
   });
 });
 


### PR DESCRIPTION
## What

Aurora clusters (`AWS::RDS::DBCluster`) auto-resolve a partial `EngineVersion`
track to the full provisioned patch version exactly as `AWS::RDS::DBInstance`
does (declared `"8.0"` reads back `"8.0.45"`; `"5.7.mysql_aurora.2"` reads back
the full patch). DBInstance was already covered by `VERSION_PREFIX_PATHS` (R130);
DBCluster was not, so a declared partial Aurora version false-positived as
declared drift.

Add `AWS::RDS::DBCluster` → `EngineVersion` to `VERSION_PREFIX_PATHS`. The
underlying `isVersionPrefixMatch` is unchanged — it stays narrow and
equality-gated (both sides must be dot-separated; the declared segments must each
EQUAL the leading live segments), so a genuine track change still differs.

## Tests

Extends the existing `VERSION_PREFIX_PATHS` gating test to assert DBCluster is
covered, Engine is not, and unrelated types stay undefined. 1180 unit tests +
286-corpus green; typecheck / lint+format / build green.

No live integ: a pure-function registry addition on the declared (intent) side
that only removes a false positive — no AWS write surface. Per-PR change.
