### PR TITLE
fix(check): apply --strict coverage gate under --pre-deploy

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -107,6 +107,21 @@ export function hasCoverageGap(findings: Finding[], resources: DesiredResource[]
   );
 }
 
+// The exit contribution of `--strict`: a coverage gap is a non-zero exit
+// independent of --fail's drift axis. Returns 1 when --strict is set AND coverage
+// is incomplete, else 0. Pure + exported so BOTH the normal and the --pre-deploy
+// path fold the identical value into `worst` — the --pre-deploy branch returns
+// early (its own report + continue), so without sharing this it silently never
+// applied --strict (a skipped resource / un-recursed nested stack under
+// --strict --pre-deploy exited 0).
+export function strictCoverageExit(
+  strict: boolean,
+  findings: Finding[],
+  resources: DesiredResource[]
+): number {
+  return strict && hasCoverageGap(findings, resources) ? 1 : 0;
+}
+
 /**
  * Map a stack's drift code to check's final exit (R53, the `cdk diff --fail` /
  * `cdk drift --fail` convention): without --fail, check is REPORT-ONLY — drift
@@ -255,6 +270,11 @@ export async function runCheck(args: string[]): Promise<number> {
         );
         if (preDeployCode === 1) anyDrift = true;
         worst = Math.max(worst, finalCheckExit(preDeployCode, a.fail));
+        // --strict still applies under --pre-deploy: live reads (and so the skipped
+        // tier / un-recursed nested stacks) happen here too, only the DECLARED side
+        // comes from the synth template. Fold the coverage-gap exit BEFORE the early
+        // continue, or --strict --pre-deploy would silently never fail.
+        worst = Math.max(worst, strictCoverageExit(a.strict, gathered.findings, desired.resources));
         continue;
       }
 
@@ -356,9 +376,7 @@ export async function runCheck(args: string[]): Promise<number> {
       // --strict: incomplete coverage (a skipped resource or an un-recursed nested
       // stack) is a non-zero exit, independent of --fail's drift axis. The loud
       // coverage warnings above always print; --strict makes them CI-failing.
-      if (a.strict && hasCoverageGap(gathered.findings, desired.resources)) {
-        worst = Math.max(worst, 1);
-      }
+      worst = Math.max(worst, strictCoverageExit(a.strict, gathered.findings, desired.resources));
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — skipped`);

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -5,6 +5,7 @@ import {
   hasCoverageGap,
   nestedStackWarning,
   preDeployFindings,
+  strictCoverageExit,
   synthKey,
   undeclaredOnlyFindings,
 } from '../src/commands/check.js';
@@ -281,6 +282,17 @@ describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () =
 
   it('hasCoverageGap is false when everything was read and there are no nested stacks', () => {
     expect(hasCoverageGap([F('undeclared'), F('declared')], [dr('AWS::SNS::Topic')])).toBe(false);
+  });
+
+  it('strictCoverageExit is 1 only when --strict AND a coverage gap (else 0)', () => {
+    const gap = [skipped('A')];
+    const clean = [F('declared')];
+    const res = [dr('AWS::SNS::Topic')];
+    expect(strictCoverageExit(true, gap, res)).toBe(1); // strict + gap → fail
+    expect(strictCoverageExit(false, gap, res)).toBe(0); // gap but no --strict → 0
+    expect(strictCoverageExit(true, clean, res)).toBe(0); // strict but no gap → 0
+    // a nested stack is a coverage gap too (the value shared with the --pre-deploy path)
+    expect(strictCoverageExit(true, clean, [dr('AWS::CloudFormation::Stack')])).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What

`check --strict` makes incomplete coverage (a skipped/unread resource or an
un-recursed nested stack) a non-zero exit. But the `--pre-deploy` branch returns
early — it prints its own declared-only report and `continue`s the stack loop
**before** the `--strict` coverage check at the bottom of the loop body. So
`check --strict --pre-deploy` silently exited 0 even with a real coverage gap.

This is wrong: `--pre-deploy` only changes the **declared** side (synth template
instead of the deployed template) — the live reads still happen, so the
`skipped` tier and nested stacks still exist and are still genuinely unchecked.

Fix: extract the gate into a pure `strictCoverageExit(strict, findings,
resources)` helper (returns 1 only when `--strict` AND a coverage gap, else 0)
and fold its value into `worst` on **both** the normal path and the `--pre-deploy`
branch (before its early `continue`).

## Tests

+1 unit test for `strictCoverageExit` (strict+gap → 1; gap-without-strict and
strict-without-gap → 0; nested-stack gap → 1). 1181 unit tests green; typecheck /
lint+format / build green.

No live integ: a pure-function exit-code wiring change; `strictCoverageExit` is
deterministic and unit-tested, and the change can only ADD a coverage-gap exit
that was already intended (never causes a wrong AWS action — check is read-only).
Per-PR change.

## Follow-up flagged (not in this PR)

A separate, debatable exit-code question — should `check --show-all --fail` exit
1 purely because undeclared *inventory* exists (the baseline is bypassed under
`--show-all`, so those values aren't tagged `unrecorded` and currently count as
drift)? That hinges on a UX decision about inventory-mode semantics, so I left it
for review rather than baking it in.
