### PR TITLE
fix(revert): refuse IAM Role Policies revert when sibling policy names unresolved

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -639,9 +639,22 @@ export function classifyResource(
   // attach physicalId (for revert) + construct path (display) onto every finding
   const cp = resource.constructPath;
   const pid = resource.physicalId;
+  // R111 fail-open carries a revert hazard: when the role's sibling AWS::IAM::Policy
+  // names were UNRESOLVED we did NOT filter the sibling-managed (DefaultPolicy)
+  // entries out of the live Policies array (above), so a declared `Policies` diff
+  // here lists own + sibling-managed entries together. The per-entry revert writer
+  // (writeIamRoleInlinePolicies) deletes every prior entry the declared set drops —
+  // which would DELETE the sibling-managed inline policy, removing real IAM grants.
+  // We cannot separate them, so mark the Policies finding(s) so the revert plan
+  // refuses to act (a wrong-write to live IAM is worse than an un-reverted FP).
+  const unresolvedSibling =
+    resourceType === 'AWS::IAM::Role' && resource.siblingPolicyNames === 'unresolved';
   return findings.map((f) => ({
     ...f,
     ...(pid !== undefined && { physicalId: pid }),
     ...(cp !== undefined && { constructPath: cp }),
+    ...(unresolvedSibling && (f.path.split(/[.[]/)[0] ?? f.path) === 'Policies'
+      ? { siblingPolicyNames: 'unresolved' as const }
+      : {}),
   }));
 }

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -263,6 +263,22 @@ export function buildRevertPlan(
       });
       continue;
     }
+    // R111: an IAM Role whose sibling AWS::IAM::Policy names could NOT be resolved
+    // statically keeps the sibling-managed (DefaultPolicy) entries in its live
+    // Policies array — classify could not separate them, and marked this finding
+    // accordingly. The per-entry writer (writeIamRoleInlinePolicies) deletes every
+    // prior entry the declared set drops, so reverting here would DELETE a managed
+    // inline policy, removing real IAM grants. Refuse rather than wrong-write.
+    if (f.siblingPolicyNames === 'unresolved') {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason:
+          'inline policies are managed by a sibling AWS::IAM::Policy whose name could not be resolved — reverting could delete a managed policy',
+      });
+      continue;
+    }
     // property-scoped SDK writers match the EXACT top-level finding path only
     // (deeper paths keep going through Cloud Control); a resource can therefore
     // split into one cc item and one sdk item per scoped path — key the grouping

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,13 @@ export interface Finding {
   // "changed since record" off the degraded snippet (it suppresses a recorded one until
   // a clean read, like a transiently-skipped resource). Self-heals on the next check.
   modelReadFailed?: boolean;
+  // declared tier only (R111): set to 'unresolved' on an IAM Role `Policies` finding
+  // when the role's sibling AWS::IAM::Policy names could NOT be resolved, so classify
+  // left the sibling-managed (DefaultPolicy) entries in the live array. The revert plan
+  // reads this and refuses to act — a per-entry revert would DELETE a managed inline
+  // policy (real IAM grants). Mirrors DesiredResource.siblingPolicyNames; only the
+  // 'unresolved' sentinel is propagated (the resolved case is already filtered out).
+  siblingPolicyNames?: 'unresolved' | undefined;
 }
 
 // Element-level delta of a recorded-but-changed undeclared identity-keyed object

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -383,6 +383,26 @@ describe('sibling-managed inline Policies (IAM Role)', () => {
     expect(findings).toEqual([]);
   });
 
+  it("declared role Policies + UNRESOLVED sibling: the Policies finding carries the 'unresolved' marker (revert hazard)", () => {
+    // With an unresolved sibling the live Policies array is NOT filtered, so the
+    // declared compare (own vs own+sibling) emits a declared Policies finding. It must
+    // carry siblingPolicyNames:'unresolved' so the revert plan refuses — a per-entry
+    // revert would otherwise DELETE the sibling-managed DefaultPolicy entry.
+    const declared = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }] };
+    const live = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }, sibling] };
+    const findings = classifyResource(role('unresolved', declared), live, noSchema);
+    const f = findings.find((x) => x.path === 'Policies');
+    expect(f).toBeDefined();
+    expect(f!.siblingPolicyNames).toBe('unresolved');
+  });
+
+  it('a resolved sibling never stamps the marker (revert stays enabled for the rogue case)', () => {
+    const declared = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }] };
+    const live = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }, rogue] };
+    const findings = classifyResource(role(['RoleDefaultPolicyABC'], declared), live, noSchema);
+    for (const f of findings) expect(f.siblingPolicyNames).toBeUndefined();
+  });
+
   it('a live-only sub-key added to a WRAPPED inline-policy statement surfaces as undeclared (WAVE20 F3)', () => {
     // The dominant CDK shape: `Policies: [{ PolicyName, PolicyDocument: { Statement } }]`.
     // The wrapper array is identity-less and its elements aren't statements, so before

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -250,6 +250,42 @@ describe('buildRevertPlan', () => {
     ]);
   });
 
+  it("an IAM Role Policies finding marked siblingPolicyNames:'unresolved' is NOT revertable (would delete a managed policy)", () => {
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'declared',
+          resourceType: 'AWS::IAM::Role',
+          path: 'Policies',
+          desired: [{ PolicyName: 'inline-a' }],
+          actual: [{ PolicyName: 'inline-a' }, { PolicyName: 'RoleDefaultPolicyABC' }],
+          siblingPolicyNames: 'unresolved',
+        }),
+      ],
+      undefined
+    );
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('sibling AWS::IAM::Policy whose name');
+  });
+
+  it('an IAM Role Policies finding with a RESOLVED sibling (no marker) stays revertable', () => {
+    const plan = buildRevertPlan(
+      [
+        F({
+          tier: 'declared',
+          resourceType: 'AWS::IAM::Role',
+          path: 'Policies',
+          desired: [{ PolicyName: 'inline-a' }],
+          actual: [{ PolicyName: 'inline-a' }, { PolicyName: 'rogue' }],
+        }),
+      ],
+      undefined
+    );
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+  });
+
   it('a CC-gap type WITH an SDK writer (BucketPolicy) is revertable via kind=sdk', () => {
     const plan = buildRevertPlan(
       [


### PR DESCRIPTION
## What

A wrong-write to live IAM, found in WAVE 26's revert-path audit.

**Setup:** R111 made the IAM Role sibling-policy filter fail OPEN — when a sibling
`AWS::IAM::Policy`'s `PolicyName` can't be resolved statically (an `Fn::Sub` /
`Fn::Join` name, or a hand-written template with no resolver ctx),
`classifyResource` does NOT filter the sibling-managed (`DefaultPolicy`) entries
out of the role's live `Policies` array (so a rogue inline policy is never hidden).

**The bug:** if that same role ALSO declares its own inline `Policies`, the
declared compare emits a `Policies` finding whose `actual` lists **own +
sibling-managed** entries together. The per-entry revert writer
(`writeIamRoleInlinePolicies`) issues a `DeleteRolePolicy` for every prior entry
the declared set no longer keeps — so a `revert` would **delete the
sibling-managed `DefaultPolicy` inline policy, removing real IAM grants**.

## Fix

`classifyResource` now stamps `siblingPolicyNames: 'unresolved'` on the `Policies`
finding for an unresolved-sibling role, and `buildRevertPlan` refuses to act on
it (`notRevertable`, with a clear reason). The finding is still **reported**
(R111's visibility is preserved) — only the unsafe revert is blocked. The
resolved-sibling path is untouched: classify already filters sibling entries
there, so a genuine **rogue** inline policy stays revertable.

## Tests

+4 unit tests: classify stamps the marker on the declared+unresolved case and
never on the resolved case; the plan blocks a marked finding and keeps an
unmarked one revertable. 1185 unit tests + 286-corpus green; typecheck /
lint+format / build green.

No live integ: the change can only **add** a `notRevertable` (it prevents a
wrong-write, never causes one — the same class as the create-only guard PR), and
the detection side is a pure-function classify change verified by unit tests and
the FP-guarding corpus. Per-PR change.
