### PR TITLE
fix(added): exclude VGW-propagated routes from EC2 Route enumeration

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -1304,9 +1304,10 @@ async function enumerateVpcChildren(ctx: EnumeratorContext): Promise<AddedChild[
 // invisible to cdk drift / CFn drift detection (they only compare template-declared
 // resources). The RouteTable's own live model does NOT reflect its routes inline (it
 // carries only RouteTableId / VpcId / Tags), so there is no double-report to suppress.
-// The VPC-CIDR LOCAL route is auto-created with the route table (it is not a declared
-// AWS::EC2::Route), so it is skipped (`Origin === 'CreateRouteTable'` / `GatewayId ===
-// 'local'`). Only IPv4 routes (those with a DestinationCidrBlock) are handled, since the
+// Non-declarable routes are skipped by `isEnumerableRoute`: the auto-created VPC-CIDR
+// LOCAL route (`Origin CreateRouteTable` / `GatewayId local`) and VGW-PROPAGATED routes
+// (`Origin EnableVgwRoutePropagation` — BGP/propagated, not declarable `AWS::EC2::Route`
+// resources). Only IPv4 routes (those with a DestinationCidrBlock) are handled, since the
 // CC identifier keys on CidrBlock. The CC primaryIdentifier for AWS::EC2::Route is the
 // composite `["/properties/RouteTableId","/properties/CidrBlock"]`, so the `identifier`
 // is the composite `RouteTableId|CidrBlock` (RouteTableId first) — that is what CC
@@ -1340,6 +1341,25 @@ async function describeRouteTable(client: EC2Client, routeTableId: string): Prom
   return res.RouteTables?.[0]?.Routes ?? [];
 }
 
+// A live route is an enumerable out-of-band `AWS::EC2::Route` only if it is one a user
+// could have declared. EXCLUDED:
+//   - the auto-created VPC-CIDR LOCAL route (Origin CreateRouteTable / GatewayId local);
+//   - an IPv6-only route (no DestinationCidrBlock — the CC identifier keys on CidrBlock);
+//   - a route inserted by VGW route PROPAGATION (Origin EnableVgwRoutePropagation): these
+//     are BGP/propagated, not declarable `AWS::EC2::Route` resources, and AWS re-creates
+//     them — flagging one as `added` is a false positive, and a `revert` DeleteResource
+//     would either churn (AWS re-propagates) or fail. Pure + exported for unit tests.
+export function isEnumerableRoute(
+  route: Ec2Route
+): route is Ec2Route & { DestinationCidrBlock: string } {
+  return (
+    typeof route.DestinationCidrBlock === 'string' &&
+    route.Origin !== 'CreateRouteTable' &&
+    route.Origin !== 'EnableVgwRoutePropagation' &&
+    route.GatewayId !== 'local'
+  );
+}
+
 async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const routeTableId = parent.physicalId; // a RouteTable's physical id IS its RouteTableId
@@ -1362,14 +1382,7 @@ async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<Adde
   const client = new EC2Client({ region, ...READ_RETRY });
   const routes = await describeRouteTable(client, routeTableId);
   const liveRoutes = routes
-    // Skip the auto-created VPC-local route (not a declared AWS::EC2::Route) and any
-    // IPv6-only route (no DestinationCidrBlock — the CC identifier keys on CidrBlock).
-    .filter(
-      (route): route is Ec2Route & { DestinationCidrBlock: string } =>
-        typeof route.DestinationCidrBlock === 'string' &&
-        route.Origin !== 'CreateRouteTable' &&
-        route.GatewayId !== 'local'
-    )
+    .filter(isEnumerableRoute)
     .map((route) => ({ cidr: route.DestinationCidrBlock }));
 
   return diffRouteTableChildren({ routeTableId, declaredCidrs, liveRoutes });

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -17,6 +17,7 @@ import {
   diffUserPoolGroups,
   diffUserPoolResourceServers,
   diffVpcChildren,
+  isEnumerableRoute,
 } from '../src/read/child-enumerators.js';
 
 const API = 'abc123';
@@ -804,6 +805,51 @@ describe('diffRouteTableChildren (EC2 routes)', () => {
         liveRoutes: [{ cidr: '0.0.0.0/0' }, { cidr: '192.168.0.0/16' }],
       })
     ).toEqual([]);
+  });
+
+  describe('isEnumerableRoute', () => {
+    it('keeps a user-declarable route (manual CreateRoute with a real CIDR)', () => {
+      expect(
+        isEnumerableRoute({
+          DestinationCidrBlock: '10.99.0.0/16',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-123',
+        })
+      ).toBe(true);
+    });
+
+    it('excludes the auto-created VPC-local route', () => {
+      expect(
+        isEnumerableRoute({
+          DestinationCidrBlock: '10.0.0.0/16',
+          Origin: 'CreateRouteTable',
+          GatewayId: 'local',
+        })
+      ).toBe(false);
+    });
+
+    it('excludes a VGW-propagated route (Origin EnableVgwRoutePropagation) — not a declarable resource', () => {
+      // The reported false-`added`: a route table with EnableVgwRoutePropagation:true
+      // gets BGP/propagated routes with a real CIDR and a VGW GatewayId (not 'local'),
+      // so the old filter let them through and flagged each as an out-of-band Route.
+      expect(
+        isEnumerableRoute({
+          DestinationCidrBlock: '172.16.0.0/16',
+          Origin: 'EnableVgwRoutePropagation',
+          GatewayId: 'vgw-0abc123',
+        })
+      ).toBe(false);
+    });
+
+    it('excludes an IPv6-only route (no DestinationCidrBlock)', () => {
+      expect(
+        isEnumerableRoute({
+          DestinationIpv6CidrBlock: '::/0',
+          Origin: 'CreateRoute',
+          GatewayId: 'igw-123',
+        })
+      ).toBe(false);
+    });
   });
 });
 


### PR DESCRIPTION
## What

A false-`added` found in WAVE 26's gather/enumerator audit.

The `AWS::EC2::RouteTable` child enumerator flags live routes not in the template
as out-of-band `AWS::EC2::Route` resources. Its filter only excluded the
auto-created VPC-local route (`Origin CreateRouteTable` / `GatewayId local`). But
a route table with **VGW route propagation** enabled
(`EnableVgwRoutePropagation: true`, common in hybrid/VPN VPCs) gets BGP/propagated
routes, each with a real `DestinationCidrBlock`, a VGW `GatewayId` (not `local`),
and `Origin: 'EnableVgwRoutePropagation'`. Those slipped through the filter and
were reported as out-of-band added routes — a false positive. Worse, a `revert`
would issue a Cloud Control `DeleteResource` on a propagated route, which AWS
just re-propagates (churn) or which fails.

## Fix

Extract the route-eligibility test into a pure, exported `isEnumerableRoute()`
predicate that additionally excludes `Origin === 'EnableVgwRoutePropagation'`. A
declared or manual out-of-band route always has `Origin: 'CreateRoute'` (route
propagation is a route-table toggle, never a `Route` resource), so this hides no
real declared or manual route — no false negative.

`EnableVgwRoutePropagation` is a real `RouteOrigin` enum value and `Route.Origin`
exists in the installed `@aws-sdk/client-ec2` (verified against
`dist-types/models`).

## Tests

+4 unit tests for `isEnumerableRoute` (keeps a manual `CreateRoute`; excludes the
local route, the VGW-propagated route, and an IPv6-only route). 1189 unit tests +
286-corpus green; typecheck / lint+format / build green.

No live integ: provisioning a VGW + VPN to produce a propagated route is
impractical, and the change only **narrows** an existing enumerator (it can only
remove a detection, never add a wrong one) via an SDK-verified, unit-tested
predicate. Per-PR change.
