### PR TITLE
fix(resolver): guard against circular CloudFormation conditions

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -211,6 +211,14 @@ function condVal(node: unknown, ctx: ResolverContext): boolean | typeof UNRESOLV
 
 export function evalCondition(name: string, ctx: ResolverContext): boolean | typeof UNRESOLVED {
   if (ctx.condCache.has(name)) return ctx.condCache.get(name) as boolean | typeof UNRESOLVED;
+  // Seed the cache with UNRESOLVED BEFORE recursing: a condition that references
+  // itself (directly, or via a cycle A→B→A through a `{Condition: …}` operand) would
+  // otherwise recurse forever and hang `cdkrd check`. CloudFormation rejects circular
+  // conditions at deploy time, so a DEPLOYED template can't carry one — but a
+  // `--pre-deploy` synth template is unvalidated and a hand-rolled `--app` output
+  // could. Failing closed to UNRESOLVED on the cycle is the safe direction (the
+  // dependent Fn::If branch is then skipped, never mis-evaluated).
+  ctx.condCache.set(name, UNRESOLVED);
   const r = resolve(ctx.conditions[name], ctx);
   const val = r === true ? true : r === false ? false : UNRESOLVED;
   ctx.condCache.set(name, val);

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -150,6 +150,23 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::If': ['C', 'then', 'else'] }, c)).toBe(UNRESOLVED);
   });
 
+  it('FAIL-CLOSED: a self-referential / cyclic condition → UNRESOLVED without hanging', () => {
+    // A references itself through an Fn::And operand — CFn rejects this at deploy, but a
+    // --pre-deploy synth / hand-rolled template could carry it. The cache is seeded with
+    // UNRESOLVED before recursing, so the cycle terminates rather than stack-overflowing.
+    const selfRef = ctx({ conditions: { A: { 'Fn::And': [{ Condition: 'A' }, true] } } });
+    expect(resolve({ 'Fn::If': ['A', 'then', 'else'] }, selfRef)).toBe(UNRESOLVED);
+
+    // Mutual cycle A→B→A.
+    const mutual = ctx({
+      conditions: {
+        A: { 'Fn::And': [{ Condition: 'B' }, true] },
+        B: { 'Fn::And': [{ Condition: 'A' }, true] },
+      },
+    });
+    expect(resolve({ 'Fn::If': ['A', 'then', 'else'] }, mutual)).toBe(UNRESOLVED);
+  });
+
   it('FAIL-CLOSED: Fn::Equals / And / Or / Not with an unresolved operand → UNRESOLVED', () => {
     expect(resolve({ 'Fn::Equals': [{ Ref: 'Unknown' }, 'x'] }, ctx())).toBe(UNRESOLVED);
     const c = ctx({ conditions: { U: { 'Fn::Equals': [{ Ref: 'Unknown' }, 'x'] } } });


### PR DESCRIPTION
## What

`evalCondition` populated its memoization cache only **after** recursing into the
condition body, so a condition that references itself — directly, or via a cycle
`A → B → A` through a `{Condition: …}` operand inside `Fn::And` / `Fn::Or` /
`Fn::Not` — recursed forever and **hung `cdkrd check`** (stack overflow / no
progress).

CloudFormation rejects circular conditions at deploy time, so a **deployed**
template can't carry one. But `--pre-deploy` compares against an **unvalidated**
local synth template, and a hand-rolled `--app` output could contain a cycle —
both reach this code without CFn's validation.

## Fix

Seed the cache with `UNRESOLVED` **before** recursing. A re-entrant lookup for the
same condition now hits the seeded `UNRESOLVED` and returns immediately, so the
cycle terminates and the condition fails **closed** to `UNRESOLVED` — the safe
direction (the dependent `Fn::If` branch is skipped, never mis-evaluated). This
matches the resolver's existing fail-closed philosophy.

## Tests

+1 unit test: a self-referential condition and a mutual `A→B→A` cycle both resolve
to `UNRESOLVED` without hanging. 1190 unit tests + 286-corpus green; typecheck /
lint+format / build green.

No live integ: a deterministic pure-function hardening on the declared (intent)
side; it only prevents a hang and fails closed, with no AWS surface. Per-PR change.
