### PR TITLE
fix(ignore): match a constructPath rule against removed-since-record findings

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -407,6 +407,10 @@ export interface ApplyBaselineOptions {
   // path is now DECLARED in the template is the recommended "promote undeclared
   // drift into code" workflow, NOT a removal — suppress the false removal finding.
   declaredByLogical?: Map<string, Set<string>>;
+  // logicalId -> CDK construct path. Used to restore constructPath onto the synthetic
+  // "baseline value removed since record" finding so a constructPath-form ignore rule
+  // matches it (a RecordedEntry carries no constructPath of its own).
+  constructPathByLogical?: Map<string, string>;
   warn?: (s: string) => void; // stderr note channel for the promotion case
 }
 
@@ -602,6 +606,14 @@ export function applyBaseline(
       tier: 'undeclared',
       logicalId: a.logicalId,
       resourceType: a.resourceType,
+      // Restore the construct path that every LIVE finding for this resource carries
+      // (a RecordedEntry doesn't store it). Without it, a constructPath-form ignore
+      // rule — the form `cdkrd ignore` writes by preference — would NOT match this
+      // synthetic "removed since record" finding (applyIgnores keys on constructPath
+      // when present), so the removal would re-surface despite the ignore.
+      ...(opts.constructPathByLogical?.get(a.logicalId) !== undefined && {
+        constructPath: opts.constructPathByLogical.get(a.logicalId),
+      }),
       path: a.path,
       desired: a.value,
       actual: undefined,
@@ -629,6 +641,17 @@ export function declaredKeysByLogical(
   resources: { logicalId: string; declared: Record<string, unknown> }[]
 ): Map<string, Set<string>> {
   return new Map(resources.map((r) => [r.logicalId, new Set(Object.keys(r.declared))]));
+}
+
+// logicalId -> construct path, for resources that carry one. Feeds
+// ApplyBaselineOptions.constructPathByLogical so the synthetic removed-since-record
+// finding can be matched by a constructPath-form ignore rule.
+export function constructPathsByLogical(
+  resources: { logicalId: string; constructPath?: string | undefined }[]
+): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const r of resources) if (r.constructPath !== undefined) m.set(r.logicalId, r.constructPath);
+  return m;
 }
 
 /**

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -10,6 +10,7 @@ import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
   checkBaselineAccount,
+  constructPathsByLogical,
   declaredKeysByLogical,
   loadBaseline,
   warnBaselineSchemaV1,
@@ -313,6 +314,7 @@ export async function runCheck(args: string[]): Promise<number> {
           ? findings
           : applyBaseline(findings, baseline, {
               declaredByLogical: declaredKeysByLogical(desired.resources),
+              constructPathByLogical: constructPathsByLogical(desired.resources),
               warn: (s: string) => {
                 if (!a.json) console.error(s);
               },

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -10,6 +10,7 @@ import {
   baselinePath,
   buildRecorded,
   carryForwardUnreadable,
+  constructPathsByLogical,
   formatPromotedStaleNote,
   identityArrayDelta,
   checkBaselineAccount,
@@ -701,6 +702,34 @@ describe('baseline', () => {
       path: 'P',
       note: 'baseline value removed since record',
     });
+  });
+
+  it('restores constructPath onto the removed-since-record finding (so a constructPath ignore rule matches)', () => {
+    const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+    const out = applyBaseline([], b, {
+      constructPathByLogical: new Map([['A', 'MyStack/A']]),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      path: 'P',
+      constructPath: 'MyStack/A',
+      note: 'baseline value removed since record',
+    });
+  });
+
+  it('omits constructPath when the resource has none (no map entry)', () => {
+    const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+    const out = applyBaseline([], b, { constructPathByLogical: new Map() });
+    expect(out[0]!.constructPath).toBeUndefined();
+  });
+
+  it('constructPathsByLogical maps only resources that carry a construct path', () => {
+    const m = constructPathsByLogical([
+      { logicalId: 'A', constructPath: 'MyStack/A' },
+      { logicalId: 'B' }, // no construct path
+    ]);
+    expect(m.get('A')).toBe('MyStack/A');
+    expect(m.has('B')).toBe(false);
   });
 
   it('does NOT report a removal for a resource SKIPPED this run (transient, not actually removed)', () => {


### PR DESCRIPTION
## What

An ignore-defeating false report found in WAVE 26's verdict/reconciliation audit.

When a recorded undeclared value is **removed out of band**, `applyBaseline`
synthesizes an `undeclared` finding noted `baseline value removed since record`.
That finding is built from a `RecordedEntry`, which stores no `constructPath`. But
`applyIgnores` matches a finding against an ignore rule by **constructPath when the
finding has one**, and the `ignore` verb writes the **constructPath form** of the
rule by preference (the common case on CDK stacks).

Result: a user who `ignore`d an undeclared property that was **also** recorded in
the baseline would see the removal **re-surface as drift** (and exit 1 under
`--fail`) — the ignore silently failed for that one finding, because the synthetic
finding lacked the constructPath the rule keys on.

## Fix

Thread a `logicalId -> constructPath` map into `applyBaseline` (new
`constructPathsByLogical` helper + `ApplyBaselineOptions.constructPathByLogical`,
populated from `desired.resources` in `check`) and restore `constructPath` onto
the synthetic removed finding — so it carries the same identity every live finding
for that resource does, and the constructPath ignore rule matches.

## Tests

+3 unit tests: constructPath is restored onto the removed finding; omitted when
the resource has none; `constructPathsByLogical` maps only resources that carry a
path. 1193 unit tests + 286-corpus green; typecheck / lint+format / build green.

No live integ: a pure-function reconciliation fix verified by unit tests; it only
restores a display/identity field so an existing ignore rule matches, with no AWS
surface. Per-PR change.
