### PR TITLE
fix(revert): write policy reverts to ALL attachment targets, not just the first

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -48,7 +48,13 @@ export type SdkWriter = (ctx: OverrideCtx, ops: PatchOp[]) => Promise<void>;
 
 const str = (v: unknown): string | undefined =>
   typeof v === 'string' && v.length > 0 ? v : undefined;
-const firstStr = (v: unknown): string | undefined => (Array.isArray(v) ? str(v[0]) : str(v));
+// Every non-empty string in v (an array of targets, or a single scalar). A policy
+// resource can attach to MORE THAN ONE target (an AWS::IAM::Policy on several Roles,
+// an SNS TopicPolicy spanning several Topics) — revert must write to ALL of them, or
+// the drift silently persists on every target after the first while the run reports
+// "reverted".
+const strList = (v: unknown): string[] =>
+  (Array.isArray(v) ? v : [v]).map(str).filter((s): s is string => s !== undefined);
 
 // reconstruct the desired full model = current (read back) with revert ops applied
 async function desiredModel(
@@ -85,25 +91,33 @@ const writeS3BucketPolicy: SdkWriter = async (ctx, ops) => {
 };
 
 const writeSnsTopicPolicy: SdkWriter = async (ctx, ops) => {
-  const topic = firstStr(ctx.declared['Topics']);
-  if (!topic) throw new Error('cannot resolve topic for revert');
+  const topics = strList(ctx.declared['Topics']);
+  if (topics.length === 0) throw new Error('cannot resolve topic for revert');
   const desired = policyJson(await desiredModel('AWS::SNS::TopicPolicy', ctx, ops)) ?? '';
-  await new SNSClient({ region: ctx.region }).send(
-    new SetTopicAttributesCommand({
-      TopicArn: topic,
-      AttributeName: 'Policy',
-      AttributeValue: desired,
-    })
-  );
+  const c = new SNSClient({ region: ctx.region });
+  // A TopicPolicy can attach to several Topics — set the policy on every one.
+  for (const topic of topics) {
+    await c.send(
+      new SetTopicAttributesCommand({
+        TopicArn: topic,
+        AttributeName: 'Policy',
+        AttributeValue: desired,
+      })
+    );
+  }
 };
 
 const writeSqsQueuePolicy: SdkWriter = async (ctx, ops) => {
-  const queue = firstStr(ctx.declared['Queues']);
-  if (!queue) throw new Error('cannot resolve queue for revert');
+  const queues = strList(ctx.declared['Queues']);
+  if (queues.length === 0) throw new Error('cannot resolve queue for revert');
   const desired = policyJson(await desiredModel('AWS::SQS::QueuePolicy', ctx, ops)) ?? '';
-  await new SQSClient({ region: ctx.region }).send(
-    new SetQueueAttributesCommand({ QueueUrl: queue, Attributes: { Policy: desired } })
-  );
+  const c = new SQSClient({ region: ctx.region });
+  // A QueuePolicy can attach to several Queues — set the policy on every one.
+  for (const queue of queues) {
+    await c.send(
+      new SetQueueAttributesCommand({ QueueUrl: queue, Attributes: { Policy: desired } })
+    );
+  }
 };
 
 const writeIamPolicy: SdkWriter = async (ctx, ops) => {
@@ -112,22 +126,27 @@ const writeIamPolicy: SdkWriter = async (ctx, ops) => {
   const desired = policyJson(await desiredModel('AWS::IAM::Policy', ctx, ops));
   if (desired === undefined) throw new Error('cannot revert an IAM inline policy to absent');
   const c = new IAMClient({ region: ctx.region });
-  const role = firstStr(ctx.declared['Roles']);
-  const user = firstStr(ctx.declared['Users']);
-  const group = firstStr(ctx.declared['Groups']);
-  if (role)
+  // An AWS::IAM::Policy can attach to ANY combination of Roles, Users and Groups, and
+  // to several of each — the same inline policy is put on every one. Reverting only the
+  // first target (the old behavior) left the drift in place on every other attachment
+  // while reporting success.
+  const roles = strList(ctx.declared['Roles']);
+  const users = strList(ctx.declared['Users']);
+  const groups = strList(ctx.declared['Groups']);
+  if (roles.length + users.length + groups.length === 0)
+    throw new Error('IAM policy has no role/user/group target');
+  for (const role of roles)
     await c.send(
       new PutRolePolicyCommand({ RoleName: role, PolicyName: name, PolicyDocument: desired })
     );
-  else if (user)
+  for (const user of users)
     await c.send(
       new PutUserPolicyCommand({ UserName: user, PolicyName: name, PolicyDocument: desired })
     );
-  else if (group)
+  for (const group of groups)
     await c.send(
       new PutGroupPolicyCommand({ GroupName: group, PolicyName: name, PolicyDocument: desired })
     );
-  else throw new Error('IAM policy has no role/user/group target');
 };
 
 // IAM managed policies are versioned: a "settable" PolicyDocument lives in the

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -9,10 +9,23 @@ import {
   DeleteRolePolicyCommand,
   GetPolicyCommand,
   GetPolicyVersionCommand,
+  GetRolePolicyCommand,
   IAMClient,
   ListPolicyVersionsCommand,
+  PutGroupPolicyCommand,
   PutRolePolicyCommand,
+  PutUserPolicyCommand,
 } from '@aws-sdk/client-iam';
+import {
+  GetTopicAttributesCommand,
+  SetTopicAttributesCommand,
+  SNSClient,
+} from '@aws-sdk/client-sns';
+import {
+  GetQueueAttributesCommand,
+  SetQueueAttributesCommand,
+  SQSClient,
+} from '@aws-sdk/client-sqs';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
@@ -21,6 +34,8 @@ import { resolveSdkWriter, SDK_WRITERS } from '../src/revert/writers.js';
 
 const iam = mockClient(IAMClient);
 const elb = mockClient(ElasticLoadBalancingV2Client);
+const sns = mockClient(SNSClient);
+const sqs = mockClient(SQSClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -52,6 +67,8 @@ const stubReader = (currentDoc: unknown): void => {
 beforeEach(() => {
   iam.reset();
   elb.reset();
+  sns.reset();
+  sqs.reset();
 });
 
 describe('IAM ManagedPolicy writer', () => {
@@ -314,5 +331,65 @@ describe('ELB attribute-bag prop-scoped writers (R78)', () => {
       { op: 'add', path: '/LoadBalancerAttributes', value: '1', human: '' },
     ]);
     expect(elb.commandCalls(ModifyLoadBalancerAttributesCommand)).toHaveLength(0);
+  });
+});
+
+describe('policy writers revert ALL attachment targets (not just the first)', () => {
+  it('IAM Policy: the inline policy is put on EVERY role, user and group', async () => {
+    iam.on(GetRolePolicyCommand).resolves({ PolicyDocument: '{}' }); // reader reads the first role
+    iam.on(PutRolePolicyCommand).resolves({});
+    iam.on(PutUserPolicyCommand).resolves({});
+    iam.on(PutGroupPolicyCommand).resolves({});
+    await SDK_WRITERS['AWS::IAM::Policy'](
+      ctx({
+        declared: {
+          PolicyName: 'p',
+          Roles: ['role-a', 'role-b'],
+          Users: ['user-a'],
+          Groups: ['group-a'],
+        },
+      }),
+      [addOp(DESIRED)]
+    );
+    expect(iam.commandCalls(PutRolePolicyCommand).map((c) => c.args[0].input.RoleName)).toEqual([
+      'role-a',
+      'role-b',
+    ]);
+    expect(iam.commandCalls(PutUserPolicyCommand).map((c) => c.args[0].input.UserName)).toEqual([
+      'user-a',
+    ]);
+    expect(iam.commandCalls(PutGroupPolicyCommand).map((c) => c.args[0].input.GroupName)).toEqual([
+      'group-a',
+    ]);
+  });
+
+  it('IAM Policy: no target throws', async () => {
+    await expect(
+      SDK_WRITERS['AWS::IAM::Policy'](ctx({ declared: { PolicyName: 'p' } }), [addOp(DESIRED)])
+    ).rejects.toThrow('no role/user/group target');
+  });
+
+  it('SNS TopicPolicy: the policy is set on EVERY topic', async () => {
+    sns.on(GetTopicAttributesCommand).resolves({ Attributes: { Policy: '{}' } });
+    sns.on(SetTopicAttributesCommand).resolves({});
+    await SDK_WRITERS['AWS::SNS::TopicPolicy'](
+      ctx({ declared: { Topics: ['arn:aws:sns:us-east-1:1:t1', 'arn:aws:sns:us-east-1:1:t2'] } }),
+      [addOp(DESIRED)]
+    );
+    expect(
+      sns.commandCalls(SetTopicAttributesCommand).map((c) => c.args[0].input.TopicArn)
+    ).toEqual(['arn:aws:sns:us-east-1:1:t1', 'arn:aws:sns:us-east-1:1:t2']);
+  });
+
+  it('SQS QueuePolicy: the policy is set on EVERY queue', async () => {
+    sqs.on(GetQueueAttributesCommand).resolves({ Attributes: { Policy: '{}' } });
+    sqs.on(SetQueueAttributesCommand).resolves({});
+    await SDK_WRITERS['AWS::SQS::QueuePolicy'](
+      ctx({ declared: { Queues: ['https://sqs/q1', 'https://sqs/q2'] } }),
+      [addOp(DESIRED)]
+    );
+    expect(
+      sqs.commandCalls(SetQueueAttributesCommand).map((c) => c.args[0].input.QueueUrl)
+    ).toEqual(['https://sqs/q1', 'https://sqs/q2']);
   });
 });


### PR DESCRIPTION
## What

A silent incomplete-revert found in WAVE 26's revert-path audit.

Three policy writers reverted only the **first** attachment target:
- `writeIamPolicy` used `firstStr(Roles)` in an `else if` chain — it reverted only
  the first Role, and ignored Users/Groups entirely whenever any Role was present.
- `writeSnsTopicPolicy` reverted only the first `Topics` entry.
- `writeSqsQueuePolicy` reverted only the first `Queues` entry.

An `AWS::IAM::Policy` attached to several roles (or to roles **and** users/groups),
or a `TopicPolicy` / `QueuePolicy` spanning several topics/queues, left the drift
in place on every target after the first — while the run reported the revert
**succeeded**.

## Fix

Add a `strList()` helper (every non-empty string in an array-or-scalar value) and
loop **every** target: `PutRolePolicy` / `PutUserPolicy` / `PutGroupPolicy` for all
roles + users + groups; `SetTopicAttributes` for every topic; `SetQueueAttributes`
for every queue. The "no role/user/group target" error is preserved (now keyed on
the combined count). No change to the set of revertable types.

## Tests

+4 unit tests (mocked SDK clients): the inline policy is put on every
role+user+group; the topic policy on every topic; the queue policy on every queue;
no-target still throws. 1197 unit tests + 286-corpus green; typecheck /
lint+format / build green.

No live integ: the multi-target loop is verified by SDK-mock unit tests asserting
one write call per target; provisioning a multi-attachment policy live adds no
coverage the mocks don't already give. The single-target path (the dominant case)
is unchanged. Per-PR change.
