### PR TITLE
fix(yaml): degrade a dot-less !GetAtt instead of crashing the whole parse

### DIFF
--- a/src/desired/yaml-cfn.ts
+++ b/src/desired/yaml-cfn.ts
@@ -58,7 +58,14 @@ function buildCustomTags(): Array<ScalarTag | CollectionTag> {
     tag: '!GetAtt',
     resolve(value: string): unknown {
       const dot = value.indexOf('.');
-      if (dot < 0) throw new Error(`!GetAtt requires '<LogicalId>.<Attribute>'; got '${value}'`);
+      // A dot-less `!GetAtt X` is malformed (CFn wants `<LogicalId>.<Attribute>`),
+      // but a custom-tag `resolve` that THROWS aborts the whole `yaml` parse — one
+      // bad scalar would crash the entire stack check (GetTemplate returns the
+      // deployed body verbatim, and a --pre-deploy synth / hand-written template can
+      // carry it). Degrade to a 1-element Fn::GetAtt instead: resolveGetAtt requires
+      // length >= 2, so it resolves to UNRESOLVED and that one property is skipped,
+      // never mis-compared — the rest of the template still parses.
+      if (dot < 0) return { 'Fn::GetAtt': [value] };
       return { 'Fn::GetAtt': [value.slice(0, dot), value.slice(dot + 1)] };
     },
     identify: () => false,

--- a/tests/yaml-cfn.test.ts
+++ b/tests/yaml-cfn.test.ts
@@ -32,4 +32,19 @@ describe('yaml-cfn parse', () => {
   it('rejects a non-object root', () => {
     expect(() => parseCfnTemplate('[1,2]')).toThrow();
   });
+
+  it('degrades a dot-less !GetAtt to a 1-element array instead of crashing the whole parse', () => {
+    // A custom-tag resolve() that throws aborts the ENTIRE yaml parse — one malformed
+    // !GetAtt would crash the whole stack check. It must degrade to UNRESOLVED-able
+    // form (length 1 -> resolveGetAtt returns UNRESOLVED) and keep parsing the rest.
+    const t = parseCfnTemplate(`Resources:
+  B:
+    Type: AWS::S3::Bucket
+    Properties:
+      Bad: !GetAtt JustALogicalId
+      Good: !GetAtt Foo.Arn`);
+    const p = (t as any).Resources.B.Properties;
+    expect(p.Bad).toEqual({ 'Fn::GetAtt': ['JustALogicalId'] }); // 1-element -> UNRESOLVED downstream
+    expect(p.Good).toEqual({ 'Fn::GetAtt': ['Foo', 'Arn'] }); // the rest still parses
+  });
 });


### PR DESCRIPTION
## What

A crash found in WAVE 27's YAML/template-parsing audit.

The `!GetAtt` scalar custom-tag resolver **threw** when its value had no `.`. A
`yaml` custom-tag `resolve()` that throws aborts the **entire** parse — so a single
malformed `!GetAtt <LogicalId>` (no `.<Attribute>`) crashed the whole stack check,
not just that one property. `GetTemplate` returns the deployed body verbatim, and
a `--pre-deploy` synth / hand-written template can carry such a value.

## Fix

Degrade a dot-less `!GetAtt` to a 1-element `Fn::GetAtt` array. `resolveGetAtt`
requires length ≥ 2, so it resolves to `UNRESOLVED` — that one property is skipped
(never mis-compared), and the rest of the template still parses. Fail-closed,
matching the resolver's philosophy. The valid `!GetAtt A.B` / `!GetAtt [A, B.C]`
forms are unchanged.

## Tests

+1 unit test: a template mixing a dot-less and a valid `!GetAtt` parses without
throwing, the bad one becomes `{Fn::GetAtt:['JustALogicalId']}`, the good one
`{Fn::GetAtt:['Foo','Arn']}`. 1198 unit tests + 286-corpus green; typecheck /
lint+format / build green.

No live integ: a deterministic parse-degradation on the declared (intent) side; it
only converts a crash into a skipped property, no AWS surface. Per-PR change.
