### PR TITLE
fix(revert): block a revert whose parent finding would replace a create-only descendant

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -109,10 +109,22 @@ function isUnderCreateOnly(findingPath: string, createOnlyPaths: readonly string
   const f = pathSegments(findingPath);
   for (const co of createOnlyPaths) {
     const c = co.split('.');
-    if (c.length > f.length) continue; // can't be a prefix of the finding path
+    // Block when EITHER path is a prefix of the other (segment-wise; a `*` on either
+    // side is a wildcard):
+    //  - create-only path ⊆ finding path: the finding IS, or is nested under, a
+    //    create-only property — an in-place patch on it is rejected (the nested
+    //    create-only fix);
+    //  - finding path ⊆ create-only path: the finding is a PARENT of a create-only
+    //    property. drift-calculator emits a finding at the PARENT path for a
+    //    length-/shape-changed array or object, so reverting it rewrites the whole
+    //    subtree — INCLUDING the create-only descendant — which AWS also rejects as a
+    //    replacement. Without this the revert proceeded and failed only at apply time
+    //    (e.g. a length change in an object array whose elements carry a create-only
+    //    sub-field, like EFS AccessPoint PosixUser under a replaced parent).
+    const common = Math.min(c.length, f.length);
     let match = true;
-    for (let i = 0; i < c.length; i++) {
-      if (c[i] !== '*' && c[i] !== f[i]) {
+    for (let i = 0; i < common; i++) {
+      if (c[i] !== '*' && f[i] !== '*' && c[i] !== f[i]) {
         match = false;
         break;
       }

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -476,6 +476,32 @@ describe('buildRevertPlan', () => {
     expect(plan('Tags.0.Value').items).toHaveLength(1); // .Value is not under the create-only Key path
   });
 
+  it('a PARENT finding of a create-only sub-path is notRevertable (revert would replace the subtree)', () => {
+    // drift-calculator emits a finding at the PARENT path for a length-/shape-changed
+    // array or object; reverting it rewrites the whole subtree, INCLUDING the create-only
+    // descendant. Block it up front instead of failing at apply time.
+    const efs = schemaWithCreateOnly('AWS::EFS::AccessPoint', 'PosixUser.Uid');
+    const plan = (path: string) =>
+      buildRevertPlan(
+        [
+          F({
+            resourceType: 'AWS::EFS::AccessPoint',
+            tier: 'declared',
+            path,
+            desired: [],
+            actual: [1],
+          }),
+        ],
+        undefined,
+        { schemas: efs }
+      );
+    // the whole PosixUser object reverted -> would rewrite the create-only Uid
+    expect(plan('PosixUser').notRevertable[0]!.reason).toContain('create-only');
+    expect(plan('PosixUser').items).toHaveLength(0);
+    // an unrelated parent that contains NO create-only descendant stays revertable
+    expect(plan('RootDirectory').items).toHaveLength(1);
+  });
+
   it('deleted finding -> notRevertable (recreate via cdk deploy), never a patch op', () => {
     const plan = buildRevertPlan(
       [F({ tier: 'deleted', path: '', desired: undefined, actual: undefined })],


### PR DESCRIPTION
## What

A revert-guard gap found in WAVE 27's schema-strip audit.

`isUnderCreateOnly` only blocked a revert when a create-only path was a **prefix of
the finding path** (the finding is, or is nested under, a create-only property). It
skipped the inverse: a finding at a **parent** path whose subtree **contains** a
create-only descendant.

`drift-calculator` emits a finding at the **parent** path for a length-/shape-changed
array or object. Reverting it rewrites the whole subtree — **including** the
create-only descendant — which AWS rejects as a replacement-requiring change. So a
revert of, e.g., a length change in an object array whose elements carry a
create-only sub-field **proceeded and failed only at apply time**, instead of being
reported `notRevertable` up front (the guard's entire purpose).

## Fix

Match when **either** path is a segment-wise prefix of the other (a `*` on either
side is a wildcard). This keeps the existing "finding at/under create-only" case and
adds the "finding is a parent of create-only" case. A sibling finding that shares no
prefix with any create-only path stays revertable.

## Tests

+1 unit test: a parent finding (`PosixUser`) of a create-only sub-path
(`PosixUser.Uid`) is `notRevertable`; an unrelated parent (`RootDirectory`) stays
revertable. The existing nested + wildcard create-only tests still pass. 1199 unit
tests + 286-corpus green; typecheck / lint+format / build green.

No live integ: a pure-function guard that can only **add** a `notRevertable`
(preventing a doomed apply, never causing a wrong write — same class as the original
create-only guard). Per-PR change.
