### PR TITLE
fix(diff): emit a free-form map whole when a key would corrupt the finding path

### DIFF
--- a/src/diff/drift-calculator.ts
+++ b/src/diff/drift-calculator.ts
@@ -38,6 +38,19 @@ function diffAt(
 ): void {
   if (deepEqual(sv, av)) return;
   if (isPlainObject(sv) && isPlainObject(av) && !Array.isArray(sv) && !Array.isArray(av)) {
+    // A free-form map (DockerLabels, Tags, Glue Parameters, …) can hold USER keys that
+    // contain the path grammar's separators — a Docker label `com.example.x`, a tag key
+    // with a `.`, a key with `[`/`]`. Descending would build a child path like
+    // `DockerLabels.com.example.x` that every downstream consumer (toPointer for the
+    // revert JSON-pointer, the baseline `topSegment`, the ignore-rule glob) RE-SPLITS on
+    // `.`/`[`, landing on the WRONG location — a misdirected revert write and a silently
+    // ineffective ignore/baseline rule. When any key would corrupt the path, don't
+    // descend: emit the whole map at the current (safe) path. The revert then rewrites
+    // the map as a unit (correct) and the finding path carries no ambiguous segment.
+    if (hasPathUnsafeKey(sv) || hasPathUnsafeKey(av)) {
+      out.push({ path, stateValue: sv, awsValue: av });
+      return;
+    }
     // Subset semantics: only walk keys present in the desired (state) side, so an
     // AWS-added nested key the template never set is not a DECLARED-side change here.
     // (R96: such live-only nested keys are instead caught by classify's
@@ -89,4 +102,12 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
+}
+
+// A key that contains the path grammar's separators (`.`, `[`, `]`). Descending into
+// such a key would produce a finding path that downstream consumers re-split into the
+// wrong location — so an object holding one is emitted whole at its parent path.
+const PATH_UNSAFE_KEY = /[.[\]]/;
+function hasPathUnsafeKey(o: Record<string, unknown>): boolean {
+  return Object.keys(o).some((k) => PATH_UNSAFE_KEY.test(k));
 }

--- a/tests/drift-calculator.test.ts
+++ b/tests/drift-calculator.test.ts
@@ -38,6 +38,35 @@ describe('calculateResourceDrift', () => {
     expect(d).toEqual([{ path: 'A', stateValue: 1, awsValue: undefined }]);
   });
 
+  it('a free-form map with a DOT in a key is emitted whole at the parent (no corrupt path)', () => {
+    // A Docker label "com.example.x" would otherwise build the path
+    // "DockerLabels.com.example.x", which toPointer / baseline / ignore re-split wrong.
+    const d = calculateResourceDrift(
+      { DockerLabels: { 'com.example.x': 'a', plain: 'p' } },
+      { DockerLabels: { 'com.example.x': 'b', plain: 'p' } }
+    );
+    expect(d).toEqual([
+      {
+        path: 'DockerLabels',
+        stateValue: { 'com.example.x': 'a', plain: 'p' },
+        awsValue: { 'com.example.x': 'b', plain: 'p' },
+      },
+    ]);
+  });
+
+  it('a key containing [ or ] is also treated as path-unsafe', () => {
+    const d = calculateResourceDrift({ Tags: { 'a[0]': 'x' } }, { Tags: { 'a[0]': 'y' } });
+    expect(d).toEqual([{ path: 'Tags', stateValue: { 'a[0]': 'x' }, awsValue: { 'a[0]': 'y' } }]);
+  });
+
+  it('a map with only path-SAFE keys still descends per key (unchanged behavior)', () => {
+    const d = calculateResourceDrift(
+      { Variables: { FOO: '1', BAR: '2' } },
+      { Variables: { FOO: '1', BAR: '9' } }
+    );
+    expect(d).toEqual([{ path: 'Variables.BAR', stateValue: '2', awsValue: '9' }]);
+  });
+
   it('ignorePaths skips a subtree', () => {
     const d = calculateResourceDrift(
       { Code: { S3Key: 'x' } },


### PR DESCRIPTION
## What

A wrong-path defect found in WAVE 27's drift-calculator audit (deferred from that
wave for a careful fix).

A free-form map (`DockerLabels`, `Tags`, Glue `Parameters`, `DefaultArguments`, …)
can carry **user** keys that contain the path grammar's separators — a Docker label
`com.example.x`, a dotted tag key, a key with `[`/`]`. `drift-calculator` descended
into such keys and built a child path like `DockerLabels.com.example.x`. Every
downstream consumer then **re-splits** that path on `.`/`[`:
- `toPointer` (revert) → `/DockerLabels/com/example/x` — a 4-level pointer into a
  flat map → a **misdirected `UpdateResource` write**;
- the baseline `topSegment` and the ignore-rule glob → key on the **wrong location**
  → a silently ineffective `ignore` / baseline entry.

## Fix

When an object has **any** immediate key containing `.`, `[`, or `]`, don't descend
— emit the whole map at the current (safe) parent path. The revert then rewrites the
map **as a unit** (correct), and the finding path carries no ambiguous segment. Maps
with only path-safe keys descend per key exactly as before (Lambda env-var names,
which AWS restricts to `[A-Za-z][A-Za-z0-9_]*`, are unaffected).

## Tests

+3 unit tests (a dotted Docker-label key → whole-map finding; a `[`/`]` key → whole
map; a path-safe map still descends per key). 1202 unit tests + **286-corpus green
with no churn** (no fixture carried a dotted free-form key, confirming no behavior
change for existing cases). typecheck / lint+format / build green.

No live integ: a pure-function diff change that only triggers when a key already
made the old path invalid (the prior behavior was broken). The FP surface is covered
by the green corpus, and the resulting whole-map revert pointer is unit-verified as
correct. Per-PR change.
