### PR TITLE
fix(check): never auto-confirm an AWS write through the read-only check menu

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -325,7 +325,13 @@ async function revertAll(p: ResolveParams): Promise<SubResult | null> {
     baseline: p.baseline,
     config: p.config,
     dryRun: false,
-    yes: p.yes,
+    // NEVER inherit --yes here. `check` is the read-only verb; reaching a revert
+    // through its interactive menu must still show the "this WRITES to AWS" confirm.
+    // `yes:true` would skip BOTH the op-multiselect AND that confirm (the whole block
+    // in revertStack is `if (!yes)`), so `check --yes` + "Revert all" would mutate AWS
+    // with no prompt. The standalone `cdkrd revert --yes` bypass is intended and goes
+    // through revert.ts directly, not this path.
+    yes: false,
     removeUnrecorded: p.removeUnrecorded,
     verbose: p.verbose,
     interactive: true,
@@ -385,7 +391,11 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
       baseline: p.baseline,
       config: p.config,
       dryRun: false,
-      yes: p.yes,
+      // NEVER inherit --yes (see revertAll): the read-only `check` verb must still
+      // confirm an AWS write. autoSelectAll skips the op-multiselect (the picker already
+      // chose), but the "this WRITES to AWS" confirm must fire — which only happens when
+      // yes is false (the confirm lives inside `if (!yes)` in revertStack).
+      yes: false,
       removeUnrecorded: p.removeUnrecorded,
       verbose: p.verbose,
       interactive: true,

--- a/tests/interactive-resolve.test.ts
+++ b/tests/interactive-resolve.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// Mock the prompt: the top menu `select` returns 'revert-all' once, isCancel is false.
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, select: vi.fn(), isCancel: () => false };
+});
+
+// Mock stack-actions: keep the real availableActions / buildRevertPlan etc., but replace
+// the AWS-mutating revertStack with a spy so we can assert HOW the interactive menu calls
+// it (specifically: yes must be false so the AWS-write confirm fires under read-only check).
+vi.mock('../src/commands/stack-actions.js', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    revertStack: vi.fn().mockResolvedValue({ exit: 0, aborted: false }),
+  };
+});
+
+import { select } from '@clack/prompts';
+import { resolveInteractively } from '../src/commands/interactive-resolve.js';
+import { revertStack } from '../src/commands/stack-actions.js';
+import type { Finding } from '../src/types.js';
+
+const declaredDrift: Finding = {
+  tier: 'declared',
+  logicalId: 'B',
+  physicalId: 'b-phys',
+  resourceType: 'AWS::S3::Bucket',
+  path: 'VersioningConfiguration.Status',
+  desired: 'Enabled',
+  actual: 'Suspended',
+};
+
+const params = (yes: boolean) =>
+  ({
+    stackName: 'S',
+    region: 'us-east-1',
+    // only `.resources` is read on the revert path (declaredKeysByLogical + gathered.desired)
+    desired: { resources: [{ logicalId: 'B', resourceType: 'AWS::S3::Bucket', declared: {} }] },
+    findings: [declaredDrift],
+    reconciled: [declaredDrift],
+    baseline: undefined,
+    schemas: new Map(),
+    liveByLogical: new Map(),
+    config: { version: 1, ignore: [] },
+    code: 1,
+    yes,
+    removeUnrecorded: false,
+    verbose: false,
+  }) as unknown as Parameters<typeof resolveInteractively>[0];
+
+describe('resolveInteractively — read-only check never auto-confirms an AWS write', () => {
+  beforeEach(() => {
+    vi.mocked(revertStack).mockClear();
+    vi.mocked(select).mockReset();
+  });
+
+  it('"Revert all" forces yes:false to revertStack EVEN WHEN check was run with --yes', async () => {
+    vi.mocked(select).mockResolvedValueOnce('revert-all');
+    await resolveInteractively(params(true)); // check --yes
+    expect(revertStack).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(revertStack).mock.calls[0]![0]).toMatchObject({ yes: false });
+  });
+
+  it('"Revert all" also passes yes:false without --yes (unchanged behavior)', async () => {
+    vi.mocked(select).mockResolvedValueOnce('revert-all');
+    await resolveInteractively(params(false));
+    expect(vi.mocked(revertStack).mock.calls[0]![0]).toMatchObject({ yes: false });
+  });
+});


### PR DESCRIPTION
## What

A confirm-bypass on the verb documented as **read-only**, found in WAVE 28's
command-flow audit.

`check` opens its interactive resolution menu (Record all / Revert all / Ignore all
/ Decide per finding) in a TTY and threaded its `--yes` flag straight into the revert
sub-actions. In `revertStack` the op-multiselect **and** the "this WRITES to AWS"
confirm both live inside one `if (!yes)` block — so `yes:true` skips **both**.

Result: `cdkrd check --yes` + "Revert all" (or "Decide per finding" → revert)
**mutated AWS with no prompt at all**. A user who passes `--yes` habitually, or
expects it to only affect record/ignore semantics, got an unconfirmed write from the
read-only verb. (The standalone `cdkrd revert --yes` bypass is intended and goes
through `revert.ts` directly, not this path.)

## Fix

Force `yes: false` for the in-menu revert so the AWS-write confirm **always** fires.
`perFinding` keeps `autoSelectAll: true`, which skips the now-redundant op-multiselect
(the picker already chose the findings) while the confirm still runs. `record` /
`ignore` keep honoring `--yes` since they never touch AWS.

## Tests

+2 unit tests (new `tests/interactive-resolve.test.ts`, mocking the prompt +
`revertStack`): the revert sub-action receives `yes: false` even when `check` ran with
`--yes`, and also without it. 1210 unit tests + 286-corpus green; typecheck /
lint+format / build green.

No live integ: the change only **adds** a confirmation (it removes an unconfirmed
write path; it can't cause a wrong write). The wiring is unit-tested and
`revertStack`'s confirm-on-`yes:false` is already covered. Per-PR change.

Note: branched onto current `origin/main` (includes #219).
