### PR TITLE
fix(revert): do not report CLEAN when post-revert convergence is unverifiable

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -751,10 +751,24 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   }
   const remainingDrift = post.filter(isDrift);
   const remaining = remainingDrift.length;
+  // A touched resource whose verification RE-READ failed (skipped tier — a throttle /
+  // transient CC or SDK-override read error) is NOT proof the write landed: a write CC
+  // accepted (200) but silently rejected, followed by an unreadable re-read, would
+  // otherwise count as zero drift and print "CLEAN". Likewise a FAILED delete of an
+  // UNRECORDED `added` resource is re-added to `post` but is excluded from `isDrift`
+  // (unrecorded), so it too would read as CLEAN though the resource still lives. Treat
+  // both as UNCONFIRMED — never claim convergence we could not verify.
+  const unverified = post.filter((f) => touched.has(f.logicalId) && f.tier === 'skipped').length;
+  const unconfirmed = unverified + failedDeleteIds.size;
+  const converged = remaining === 0 && unconfirmed === 0;
   console.log(
-    remaining === 0
+    converged
       ? style.clean(`${stackName}: CLEAN after revert.`)
-      : style.drift(`${stackName}: ${remaining} drift(s) remain.`)
+      : remaining > 0
+        ? style.drift(`${stackName}: ${remaining} drift(s) remain.`)
+        : style.drift(
+            `${stackName}: revert applied, but ${unconfirmed} resource(s) could not be confirmed converged (see above).`
+          )
   );
   // unrecorded values are not drift, but silently dropping them here would read
   // as "all good" when a decision is still pending — one dim pointer line (R62).
@@ -765,11 +779,22 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
         `  (${unrecordedLeft} unrecorded value(s) still await a baseline — run cdkrd record)`
       )
     );
+  // A touched resource we could not re-read leaves the revert UNVERIFIED — point the
+  // user at a re-run rather than implying success. (A failed delete already printed its
+  // own `FAILED:` line above and bumped the exit to 2 in the apply loop.)
+  if (unverified > 0)
+    console.log(
+      style.infoTier(
+        `  (${unverified} resource(s) could not be re-read to verify — re-run cdkrd check to confirm)`
+      )
+    );
   // Say WHICH drift survived — without this the user must re-run `check` just to
   // learn what didn't converge (R46). A terse id-per-line pointer, not a report;
   // capped so a no-baseline partial revert doesn't re-list 100+ lines (R52).
   for (const line of formatSurvivingDrift(remainingDrift)) console.log(line);
-  if (remaining > 0) worst = Math.max(worst, 1);
+  // remaining drift OR an unverifiable re-read both mean "not confirmed clean" → exit 1
+  // (a failed delete already set 2). Never return 0 ("converged") when we could not check.
+  if (remaining > 0 || unverified > 0) worst = Math.max(worst, 1);
   return { exit: worst, aborted: false };
 }
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -521,6 +521,22 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     expect(logs).toContain('  - B.VersioningConfiguration.Status (declared)');
     expect(cc.commandCalls(GetResourceCommand)).toHaveLength(2); // first read + one retry, no more
   });
+
+  it('verification re-read FAILS → NOT "CLEAN", exit 1 (a skipped re-read is not proof the write landed)', async () => {
+    // The write was accepted (200), but the convergence re-read throttles, so the
+    // touched resource comes back `skipped`. Before the fix this counted as zero drift
+    // and printed "CLEAN after revert." with exit 0 — a false success on a possibly-
+    // failed write. Now it is reported as unconfirmed and exits 1.
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc);
+    cc.on(GetResourceCommand).rejects(new Error('ThrottlingException'));
+
+    const { outcome, logs } = await run();
+    expect(outcome.exit).toBe(1);
+    expect(logs).not.toContain('CLEAN after revert');
+    expect(logs).toContain('could not be confirmed converged');
+    expect(logs).toContain('could not be re-read to verify');
+  });
 });
 
 describe('recordStack non-interactive refusal (R38)', () => {


### PR DESCRIPTION
## What

A false-success on the revert verification step, found in WAVE 29's
apply/convergence audit.

After a revert applies, `revertStack` re-reads the touched resources to verify
convergence and counts `isDrift` findings. Two cases slipped through as **"CLEAN
after revert." with the wrong exit**:

1. **Unverifiable re-read (exit-0 false success).** If a touched resource's
   verification re-read comes back `skipped` — a throttle or transient CC /
   SDK-override read error — it contributes zero drift, no eventual-consistency
   retry fires (the retry is gated on `driftCount > 0`), and the run prints
   `CLEAN` with **exit 0**. But a `skipped` re-read is not proof the write landed:
   a write CloudControl accepted (`200`) yet silently rejected, followed by an
   unreadable re-read, reads as converged.

2. **Failed delete of an unrecorded `added` resource (message lie).** Its re-added
   finding carries `unrecorded: true`, which `isDrift` excludes, so it also printed
   `CLEAN` (the exit was already `2` from the apply loop, but the message
   contradicted it).

## Fix

Only print `CLEAN after revert.` when nothing drifted **and** everything was
verifiable. A `skipped` re-read of a touched resource, or any failed delete, is
treated as **unconfirmed**: the run no longer claims convergence, an unverifiable
re-read now exits **1** (not 0) and points the user at a re-run, and a failed
delete keeps its exit 2 without the misleading "CLEAN" line.

## Tests

+1 unit test: the convergence re-read throttles → the run does **not** print
`CLEAN`, says "could not be confirmed converged" + "could not be re-read to
verify", and exits 1. The existing converged / retry / still-drifted tests are
unchanged. 1211 unit tests + 286-corpus green; typecheck / lint+format / build
green.

No live integ: a reporting/exit-correctness change on the convergence step — it
makes the exit strictly more conservative (1 instead of a false 0) and never
changes what is written to AWS. Per-PR change.
