### PR TITLE
fix(picker): do not offer record on a modelReadFailed added finding

### DIFF
--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -47,7 +47,12 @@ export type FindingAction = 'record' | 'ignore' | 'revert' | 'skip';
 export function applicableActions(finding: Finding): FindingAction[] {
   if (finding.tier === 'undeclared')
     return isNestedUndeclared(finding) ? ['record', 'ignore'] : ['record', 'ignore', 'revert'];
-  if (finding.tier === 'added') return ['record', 'ignore', 'revert'];
+  if (finding.tier === 'added')
+    // A `modelReadFailed` added finding carries only an identity snippet (its full model
+    // could not be read this run). buildRecorded DROPS it, so offering `record` is a
+    // silent no-op that the closing note still tallies as "1 record" — misleading. Offer
+    // only ignore + revert (a delete needs only the identifier), both of which work.
+    return finding.modelReadFailed ? ['ignore', 'revert'] : ['record', 'ignore', 'revert'];
   if (finding.tier === 'declared') return ['revert', 'ignore'];
   return [];
 }

--- a/tests/action-picker.test.ts
+++ b/tests/action-picker.test.ts
@@ -48,6 +48,12 @@ describe('applicableActions (cycle order mirrors the verbs scope)', () => {
   it('PR4: added → record (snapshot), ignore, revert (DELETE — destructive, last)', () => {
     expect(applicableActions(F('added'))).toEqual(['record', 'ignore', 'revert']);
   });
+  it('a modelReadFailed added drops record (it would be a silent no-op) → ignore, revert only', () => {
+    expect(applicableActions({ ...F('added'), modelReadFailed: true })).toEqual([
+      'ignore',
+      'revert',
+    ]);
+  });
   it('non-actionable tiers → empty (not decidable rows)', () => {
     for (const t of [
       'deleted',


### PR DESCRIPTION
## What

A silent no-op + misleading tally found in WAVE 29's action-picker audit.

A `modelReadFailed` `added` finding (its full live model could not be read this
run — a transient CC `GetResource` failure) carries only an identity snippet.
`buildRecorded` deliberately **drops** such a finding, so picking `record` on it in
the "Decide per finding" flow records **nothing** — yet `summarizeChoices` still
counts it (e.g. "1 record"), telling the user a record happened when it did not,
and the finding re-surfaces unchanged on the next run.

## Fix

`applicableActions` now offers only `ignore` + `revert` for a `modelReadFailed`
added finding (a `revert`/DeleteResource needs only the identifier, and `ignore`
writes a path rule — both work). A clean-read added still offers `record`.

## Tests

+1 unit test (a `modelReadFailed` added → `['ignore','revert']`; the clean-read
added is unchanged). 1212 unit tests + 286-corpus green; typecheck / lint+format /
build green.

No live integ: a pure-function picker-eligibility change with no AWS surface (it
only removes an action that was already a no-op). Per-PR change.
