### PR TITLE
fix(normalize): match the ARN's exact final component, not a path suffix

### DIFF
--- a/src/normalize/arn-identity.ts
+++ b/src/normalize/arn-identity.ts
@@ -6,10 +6,11 @@
 //
 // Conservative + value-shape-based (NOT field-name-based, so it needs no per-type
 // table): treat the two as equal when EXACTLY ONE side is a well-formed ARN, the
-// other is a bare (non-ARN) name, and the ARN's final component is EXACTLY that name
-// (after the last ':' or '/'). A bare name in such a field resolves to that one
-// resource in the stack's own account+region, whose ARN ends with `:<name>` — so this
-// never hides a real drift to a DIFFERENT name (the suffix must match exactly).
+// other is a bare (non-ARN) name, and the name EQUALS the ARN's final component — its
+// whole final colon-segment, OR the part after that segment's last '/' (the resource
+// id of a `type/id` ARN). The match is on a COMPLETE component, never a partial path
+// suffix, so a declared `a/b/c` never equals a live `arn:…:bucket/x/a/b/c` (a different
+// object) — a real identity change is not hidden.
 //
 // BIDIRECTIONAL: the bare name may be on EITHER side. `desired=name, actual=ARN`
 // occurs when AWS stores the full ARN for a name-recording input (Lambda
@@ -43,7 +44,19 @@ function arnMatchesName(
   opts?: { accountId?: string; region?: string }
 ): boolean {
   if (name.length === 0) return false;
-  if (!(arn.endsWith(`:${name}`) || arn.endsWith(`/${name}`))) return false;
+  // Match the ARN's EXACT final component, NOT a raw suffix. The final colon-segment is
+  // the resource portion (`myFn`, `role/myRole`, `bucket/a/b/c`); the name must equal
+  // that whole portion OR the part after its last `/` (the resource id of a `type/id`
+  // ARN). A bare `endsWith('/'+name)` matched a MULTI-segment path suffix — declared
+  // `a/b/c` falsely equalled live `arn:…:bucket/x/a/b/c` (a DIFFERENT object), hiding a
+  // real identity change. Equality on the final component never spans a `/` boundary, so
+  // that FN is closed while every real name<->ARN echo (`myRole` vs `…:role/myRole`,
+  // `myFn` vs `…:function:myFn`, `my-bucket` vs `arn:aws:s3:::my-bucket`) still matches.
+  const afterColon = arn.slice(arn.lastIndexOf(':') + 1);
+  const afterSlash = afterColon.includes('/')
+    ? afterColon.slice(afterColon.lastIndexOf('/') + 1)
+    : afterColon;
+  if (name !== afterColon && name !== afterSlash) return false;
   // arn:partition:service:region:account:resource — segments 3 (region) + 4 (account)
   const seg = arn.split(':');
   const arnRegion = seg[3] ?? '';

--- a/tests/arn-identity.test.ts
+++ b/tests/arn-identity.test.ts
@@ -30,6 +30,23 @@ describe('isArnNameMatch (name <-> ARN identity)', () => {
     expect(isArnNameMatch('MyFn', `${fnArn}:PROD`)).toBe(false);
   });
 
+  it('does NOT match a MULTI-segment path suffix (a different object is not hidden)', () => {
+    // A bare name that is only a partial path-suffix of a longer key is a DIFFERENT
+    // resource — must surface as drift, not be equated. (The old endsWith matched it.)
+    expect(isArnNameMatch('a/b/c', 'arn:aws:s3:::my-bucket/x/a/b/c')).toBe(false);
+    expect(isArnNameMatch('b/c', 'arn:aws:s3:::my-bucket/a/b/c')).toBe(false);
+  });
+
+  it('matches the WHOLE final colon-segment (the full resource portion)', () => {
+    // a name declared as the full `type/id` (or full S3 bucket/key) still matches
+    expect(isArnNameMatch('role/MyRole', 'arn:aws:iam::111122223333:role/MyRole')).toBe(true);
+    expect(isArnNameMatch('my-bucket/key.txt', 'arn:aws:s3:::my-bucket/key.txt')).toBe(true);
+  });
+
+  it('matches the resource id after the last / (the common bare-name echo)', () => {
+    expect(isArnNameMatch('MyRole', 'arn:aws:iam::111122223333:role/MyRole')).toBe(true);
+  });
+
   // Bidirectional: the bare name may be on the DESIRED side and the ARN on the
   // ACTUAL side (AWS::Lambda::Url.TargetFunctionArn: template resolves GetAtt to the
   // function ARN, live read returns the bare function name).


### PR DESCRIPTION
## What

A false negative in the differentiator, found in WAVE 30's arn-identity audit.

`isArnNameMatch` suppresses a declared bare **name** vs a live full **ARN** as a
name↔ARN echo (e.g. Lambda `FunctionName: "MyFn"` vs the live function ARN). It did
so with `arn.endsWith('/' + name)` — which matches a **multi-segment path suffix**,
not the exact final component its own doc comment promised. So:
- declared `"a/b/c"` falsely equalled live `arn:aws:s3:::my-bucket/x/a/b/c` (a
  **different** object);
- declared `"x"` equalled a live log group `/my/x`;

— **hiding a real identity repoint** (the live field now points at a different
resource), the worst class for a drift tool.

## Fix

Require the name to **equal** the ARN's final component: its whole final
colon-segment (the full resource portion, e.g. `role/MyRole`, `bucket/key`) **or**
the part after that segment's last `/` (the resource id of a `type/id` ARN, e.g.
`MyRole`). The match is on a complete component and never spans a `/`, so the
partial-suffix FN is closed — while every real echo still matches (`MyRole` vs
`…:role/MyRole`, `MyFn` vs `…:function:MyFn`, `my-bucket` vs
`arn:aws:s3:::my-bucket`). The account/region scoping is unchanged.

## Tests

+3 unit tests (a multi-segment path suffix no longer matches; the full resource
portion and the after-last-`/` id both still match). 1218 unit tests + **286-corpus
green** — no existing name↔ARN echo regressed (the FP-safety guard). typecheck /
lint+format / build green.

No live integ: a pure-function tightening that only closes a false negative; the
corpus is the FP guard and is green. Per-PR change.

Note: branched onto current `origin/main` (includes #224).
