### PR TITLE
fix(gather): re-resolve consumers after pass 1.5 fills composite-id liveAttrs

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -264,6 +264,20 @@ export async function gatherFindings(
   });
   await readAll(cc, retryTargets, region, desired, reads);
 
+  // Re-resolve once MORE when pass 1.5 actually read something: it populated liveAttrs
+  // for the composite-id / SDK-override types it just read, so a CONSUMER whose declared
+  // Fn::GetAtt targets one of those (e.g. a prop = GetAtt[<an ECS Service / Permission>,
+  // attr]) was still UNRESOLVED after the first re-resolution above (which ran BEFORE
+  // pass 1.5) — its property would be classified `unresolved` and skipped = a missed
+  // drift. Monotonic and FP-safe: liveAttrs only grew, so this can only turn an
+  // UNRESOLVED into a concrete value, never change an already-resolved one. Cheap:
+  // retryTargets is empty for the common stack, so this loop is skipped entirely.
+  if (retryTargets.length > 0) {
+    for (const r of desired.resources) {
+      if (r.declaredRaw) r.declared = resolveProperties(r.declaredRaw, desired.ctx);
+    }
+  }
+
   // OAI canonical-id map (CloudFront legacy OAI principal reconciliation) — harvested
   // from already-read liveAttrs, so it is ready before pass 1.6 normalizes added child
   // models AND reused for pass 2's classifyOpts below. Empty unless the stack declares

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -301,6 +301,100 @@ describe('gatherFindings pass-1.5 override retry (R27)', () => {
     // GetPolicy was never called (the reader bails on the unresolved FunctionName)
     expect(lambda.commandCalls(LambdaGetPolicyCommand)).toHaveLength(0);
   });
+
+  it('re-resolves a CONSUMER whose GetAtt targets a type read only in pass 1.5 (missed-drift FN)', async () => {
+    // Q's KmsMasterKeyId is Fn::GetAtt[Perm, Action]. Perm (an SDK_OVERRIDE) is read only
+    // in pass 1.5 (its FunctionName GetAtt resolves after pass 1), so liveAttrs[Perm] is
+    // populated AFTER the first re-resolution. Without a second re-resolution Q's prop
+    // stays UNRESOLVED and its drift is silently skipped. The live Action differs from
+    // the live KmsMasterKeyId, so once Q's GetAtt resolves a DECLARED drift must surface.
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: {
+          Fn: { Type: 'AWS::Lambda::Function', Properties: { FunctionName: 'Fn-phys' } },
+          Perm: {
+            Type: 'AWS::Lambda::Permission',
+            Properties: {
+              FunctionName: { 'Fn::GetAtt': ['Fn', 'Arn'] },
+              Action: 'lambda:InvokeFunction',
+              Principal: 's3.amazonaws.com',
+            },
+          },
+          Q: {
+            Type: 'AWS::SQS::Queue',
+            Properties: { KmsMasterKeyId: { 'Fn::GetAtt': ['Perm', 'Action'] } },
+          },
+        },
+      }),
+    });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Fn',
+          PhysicalResourceId: 'Fn-phys',
+          ResourceType: 'AWS::Lambda::Function',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+        {
+          LogicalResourceId: 'Perm',
+          PhysicalResourceId: 'Perm-phys',
+          ResourceType: 'AWS::Lambda::Permission',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+        {
+          LogicalResourceId: 'Q',
+          PhysicalResourceId: 'Q-phys',
+          ResourceType: 'AWS::SQS::Queue',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+    cfn.on(DescribeTypeCommand).resolves({ Schema: '{}' });
+
+    const cc = mockClient(CloudControlClient);
+    cc.on(GetResourceCommand, { Identifier: 'Fn-phys' }).resolves({
+      ResourceDescription: { Identifier: 'Fn-phys', Properties: JSON.stringify({ Arn: FN_ARN }) },
+    });
+    cc.on(GetResourceCommand, { Identifier: 'Q-phys' }).resolves({
+      ResourceDescription: {
+        Identifier: 'Q-phys',
+        Properties: JSON.stringify({ KmsMasterKeyId: 'lambda:DIFFERENT' }),
+      },
+    });
+    const lambda = mockClient(LambdaClient);
+    lambda.on(LambdaGetPolicyCommand).resolves({
+      Policy: JSON.stringify({
+        Statement: [
+          { Action: 'lambda:InvokeFunction', Principal: { Service: 's3.amazonaws.com' } },
+        ],
+      }),
+    });
+    lambda.on(ListEventSourceMappingsCommand).resolves({ EventSourceMappings: [] });
+
+    const { findings } = await gatherFindings('S', 'us-east-1');
+    // Q's GetAtt resolved to Perm's live Action ('lambda:InvokeFunction'); live
+    // KmsMasterKeyId is 'lambda:DIFFERENT' → a DECLARED drift that would be missed
+    // (skipped as unresolved) without the second re-resolution pass.
+    const qDrift = findings.find((f) => f.logicalId === 'Q' && f.path === 'KmsMasterKeyId');
+    expect(qDrift?.tier).toBe('declared');
+    expect(qDrift?.desired).toBe('lambda:InvokeFunction');
+    expect(qDrift?.actual).toBe('lambda:DIFFERENT');
+  });
 });
 
 // A CC composite-identifier resource (ApiGatewayV2 Route) whose PARENT key (ApiId) is


### PR DESCRIPTION
## What

A missed-drift FN found in WAVE 30's gather multi-pass audit.

`gatherFindings` re-resolves every resource's declared properties once `liveAttrs`
is populated, so `Fn::GetAtt` resolves — but that re-resolution runs **once, before
pass 1.5**. Pass 1.5 then reads the composite-id / SDK-override types that were
`UNRESOLVED`-skipped in pass 1 (their own identity is a `GetAtt` that only resolves
after pass 1) and populates **their** `liveAttrs`. A **consumer** whose declared
`Fn::GetAtt` targets one of those types (e.g. a property = `GetAtt[<an ECS Service /
Lambda Permission>, attr]`) was never re-resolved afterward → its property stayed
`UNRESOLVED`, was classified `unresolved`, and its drift was **silently skipped**.

## Fix

Re-run the per-resource `resolveProperties` once more after pass 1.5 **when it
actually read something** (`retryTargets` non-empty). Monotonic and FP-safe:
`liveAttrs` only grew, so the second pass can only turn an `UNRESOLVED` into a
concrete value, never change an already-resolved one — and the loop is skipped
entirely for the common stack (empty `retryTargets`). This mirrors the
re-resolve-after-refreshed-reads already done in `regatherTouched`.

## Tests

+1 unit test: a consumer (`AWS::SQS::Queue`) whose `KmsMasterKeyId` is
`GetAtt[Perm, Action]`, where `Perm` (a Lambda Permission, an SDK override) is read
only in pass 1.5 — the live `Action` differs from the live `KmsMasterKeyId`, so a
**declared drift** must surface. Verified it FAILS without the fix (the property is
skipped as unresolved) and passes with it. 1222 unit tests + 286-corpus green;
typecheck / lint+format / build green.

No live integ: the second re-resolution is a pure, monotonic function over the
already-read `liveAttrs` (no new AWS reads); the new unit test exercises the exact
multi-pass path. Per-PR change.

Note: branched onto current `origin/main`.
