### PR TITLE
fix(read): project MetricFilter ApplyOnTransformedLogs (live-proven)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -514,6 +514,15 @@ const readMetricFilter: OverrideReader = async ({ physicalId, declared, region }
       ...(t.unit !== undefined && { Unit: t.unit }),
       ...(t.dimensions !== undefined && { Dimensions: t.dimensions }),
     })),
+    // ApplyOnTransformedLogs (CFn AWS::Logs::MetricFilter prop) controls whether the
+    // filter evaluates the TRANSFORMED log events instead of the originals — toggling it
+    // out of band silently changes what the metric counts. It was omitted, so that change
+    // was invisible. FP-safe: projected only when present; a live false is a top-level
+    // undeclared value that isTrivialEmpty drops, so a never-set filter stays CLEAN and
+    // only an out-of-band flip to true surfaces.
+    ...(mf.applyOnTransformedLogs !== undefined && {
+      ApplyOnTransformedLogs: mf.applyOnTransformedLogs,
+    }),
   };
 };
 

--- a/tests/integration/logs-metricfilter-proj/app.ts
+++ b/tests/integration/logs-metricfilter-proj/app.ts
@@ -1,0 +1,22 @@
+// CDK app for the AWS::Logs::MetricFilter projection false-negative test. A log group +
+// a metric filter that does NOT declare ApplyOnTransformedLogs.
+//
+// The MetricFilter SDK-override reader projected FilterPattern + MetricTransformations but
+// OMITTED ApplyOnTransformedLogs — so an out-of-band toggle (which changes whether the
+// filter evaluates transformed vs original log events, i.e. what the metric counts) was
+// invisible. verify-metricfilter-proj.sh asserts CLEAN after record (FP guard: a never-set
+// filter's ApplyOnTransformedLogs=false folds via isTrivialEmpty), then flips it to true out
+// of band and asserts cdkrd DETECTS it.
+import { App, Stack } from "aws-cdk-lib";
+import { FilterPattern, LogGroup, MetricFilter } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMetricFilter");
+const lg = new LogGroup(stack, "Lg");
+new MetricFilter(stack, "Mf", {
+  logGroup: lg,
+  metricNamespace: "CdkrdInteg",
+  metricName: "Errors",
+  filterPattern: FilterPattern.literal("ERROR"),
+});
+app.synth();

--- a/tests/integration/logs-metricfilter-proj/cdk.json
+++ b/tests/integration/logs-metricfilter-proj/cdk.json
@@ -1,0 +1,1 @@
+{ "app": "node --experimental-strip-types app.ts" }

--- a/tests/integration/logs-metricfilter-proj/package.json
+++ b/tests/integration/logs-metricfilter-proj/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-metricfilter-proj",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift CodeBuild projection-FN test. Run via verify-metricfilter-proj.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/logs-metricfilter-proj/verify-metricfilter-proj.sh
+++ b/tests/integration/logs-metricfilter-proj/verify-metricfilter-proj.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# cdk-real-drift AWS::Logs::MetricFilter projection FALSE-NEGATIVE integration test.
+#
+# The MetricFilter SDK-override reader projected FilterPattern + MetricTransformations but
+# OMITTED ApplyOnTransformedLogs — so an out-of-band toggle (which changes whether the filter
+# evaluates transformed vs original log events) was undetectable. The fix projects it. This
+# deploys a filter that does NOT declare ApplyOnTransformedLogs, asserts CLEAN after record
+# (FP guard: a never-set filter's false folds via isTrivialEmpty), then flips it true out of
+# band and asserts cdkrd DETECTS it.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMetricFilter
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy LogGroup + MetricFilter (no ApplyOnTransformedLogs) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+LG="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Logs::LogGroup'].PhysicalResourceId" --output text)"
+MF="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Logs::MetricFilter'].PhysicalResourceId" --output text)"
+[ -n "$LG" ] && [ -n "$MF" ] || fail "could not resolve log group / filter name"
+echo "log-group=$LG filter=$MF"
+
+echo "=== record + check should be CLEAN (FP guard: ApplyOnTransformedLogs=false folds) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN right after record — ApplyOnTransformedLogs leaked as drift?"
+
+echo "=== flip ApplyOnTransformedLogs true out of band — must DETECT it ==="
+# Re-put the SAME filter (same pattern + transformations) with applyOnTransformedLogs=true.
+aws logs put-metric-filter --region "$REGION" \
+  --log-group-name "$LG" --filter-name "$MF" --filter-pattern "ERROR" \
+  --apply-on-transformed-logs \
+  --metric-transformations metricName=Errors,metricNamespace=CdkrdInteg,metricValue=1 \
+  || fail "put-metric-filter"
+OUT=/tmp/cdkrd-metricfilter-check.out
+$CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1 for out-of-band ApplyOnTransformedLogs, got $rc"
+grep -qi "ApplyOnTransformedLogs" "$OUT" || fail "out-of-band ApplyOnTransformedLogs not reported — still projected away?"
+
+echo "INTEG PASS"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -615,6 +615,43 @@ describe('SDK overrides', () => {
       });
     });
 
+    it('projects ApplyOnTransformedLogs when set (an out-of-band toggle is no longer invisible)', async () => {
+      logs.on(DescribeMetricFiltersCommand).resolves({
+        metricFilters: [
+          {
+            filterName: 'errs',
+            filterPattern: 'ERROR',
+            metricTransformations: [{ metricName: 'E', metricNamespace: 'App', metricValue: '1' }],
+            applyOnTransformedLogs: true,
+          },
+        ],
+      });
+      const out = (await SDK_OVERRIDES['AWS::Logs::MetricFilter'](
+        ctx({ LogGroupName: '/lg' }, 'errs')
+      )) as Record<string, unknown>;
+      expect(out.ApplyOnTransformedLogs).toBe(true);
+    });
+
+    it('FP-safe: omits ApplyOnTransformedLogs when undefined; a live false folds via isTrivialEmpty', async () => {
+      logs.on(DescribeMetricFiltersCommand).resolves({
+        metricFilters: [
+          {
+            filterName: 'errs',
+            filterPattern: 'ERROR',
+            metricTransformations: [{ metricName: 'E', metricNamespace: 'App', metricValue: '1' }],
+            // a never-set filter: AWS returns false (or omits it) — the reader projects it
+            // faithfully when present; the noise layer's isTrivialEmpty drops a top-level
+            // false so it is not first-run undeclared noise
+            applyOnTransformedLogs: false,
+          },
+        ],
+      });
+      const out = (await SDK_OVERRIDES['AWS::Logs::MetricFilter'](
+        ctx({ LogGroupName: '/lg' }, 'errs')
+      )) as Record<string, unknown>;
+      expect(out.ApplyOnTransformedLogs).toBe(false);
+    });
+
     it('log group described but the named filter absent -> ResourceGoneError (deleted)', async () => {
       // The log group exists and was described; the exact-named filter is gone -> deleted
       // out of band. (Was a false `undefined`/skipped that hid the deletion.)


### PR DESCRIPTION
## What

Closes a silent false-negative in the `AWS::Logs::MetricFilter` SDK-override reader
(WAVE 28's projection audit), **live-verified**.

The reader projected `FilterPattern` + `MetricTransformations` but omitted
`ApplyOnTransformedLogs` — a CFn-declarable property that controls whether the filter
evaluates the **transformed** log events instead of the originals (i.e. what the
metric actually counts). Toggling it out of band was invisible.

## Fix

Project `ApplyOnTransformedLogs`, guarded by `!== undefined`. FP-safe: a never-set
filter's live `false` is a top-level undeclared value that `isTrivialEmpty` drops
(classify.ts), so the filter stays CLEAN and only an out-of-band flip to `true`
surfaces.

## Tests

- **+2 unit tests** (`tests/overrides.test.ts`): projected when set; a live `false`
  is faithfully projected (then folded). 1232 unit tests + 286-corpus green;
  typecheck / lint+format / build green.
- **Live integ (real AWS)** — new `tests/integration/logs-metricfilter-proj`: deploys
  a log group + metric filter that does **not** declare `ApplyOnTransformedLogs` →
  `record` → `check` CLEAN (FP guard), then flips `applyOnTransformedLogs` true out of
  band via `put-metric-filter` and asserts cdkrd **DETECTS** it. `INTEG PASS`, clean
  teardown.

Per-PR change.
