### PR TITLE
docs(readme): note CC-unreadable/unsupported resource types are reported as skipped

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,11 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   one on an unprojected property isn't compared. Coverage is widened as needed
   (e.g. a budget's `CostFilters` scope is compared); fully CC-readable types (the
   vast majority) always get the complete live model.
+- **Unsupported / unreadable resource types.** A resource type Cloud Control can't
+  read — one with no Cloud Control support, or one whose CC handler errors (e.g. a
+  server-side CC bug) and that has no SDK override — is reported as `skipped`
+  (coverage incomplete), surfaced in the `skipped=N — NOT checked` line and
+  **never** silently treated as CLEAN; `--strict` makes such a gap CI-failing.
 
 ## FAQ
 


### PR DESCRIPTION
Closes a small doc gap surfaced in review. The README already documents the `skipped` tier, the `skipped=N — NOT checked (coverage incomplete)` line, and `--strict` — but had no explicit statement covering an **arbitrary** resource type Cloud Control can't read (no CC support, or a server-side CC handler error like the known `AWS::SES::ConfigurationSetEventDestination` NPE, with no SDK override). Adds one bullet to Known limitations: such a type is reported as `skipped` (coverage incomplete), surfaced and never silently CLEAN; `--strict` makes it CI-failing. Docs-only.