### PR TITLE
fix(report): clarify the unresolved info-line + add /hunt-bugs round

### DIFF
--- a/.claude/hooks/bughunt-clean-gate.sh
+++ b/.claude/hooks/bughunt-clean-gate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# bughunt-clean-gate.sh
+#
+# PreToolUse hook. Blocks `git commit`, `gh pr create`, and `gh pr merge` while a
+# /hunt-bugs session still has un-deleted AWS resources tracked in the sentinel
+# `.markgate-bughunt-pending` (at the shared main-tree root).
+#
+# WHY: /hunt-bugs deploys real AWS stacks to find latent cdkrd bugs. The one
+# unacceptable outcome is forgetting to delete them. Rather than trust the operator
+# to remember, the skill records every deployed stack in the sentinel via
+# `bughunt-track.sh add`, and this gate makes it physically impossible to land any
+# commit / PR until `bughunt-track.sh clear` empties the sentinel — which the skill
+# runs ONLY after delete + orphan-zero verification. The rule says "always delete
+# bug-hunt resources"; this hook enforces it.
+#
+# The sentinel is resolved at the SHARED main-tree root (via --git-common-dir) so a
+# fix committed from a feature worktree still sees a sentinel armed from the main
+# tree.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+
+# Gate only `git commit`, `gh pr create`, and `gh pr merge`. Line-start anchored
+# (tolerating an optional `cd <path> &&` prefix and `gh -C <path>`) so the command
+# words inside a quoted argument body do NOT false-positive.
+git_commit_re='^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?git([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+commit([[:space:]]|$)'
+gh_pr_re='^[[:space:]]*(cd[[:space:]]+[^[:space:]]+[[:space:]]*&&[[:space:]]*)?gh([[:space:]]+-C[[:space:]]+[^[:space:]]+)?[[:space:]]+pr[[:space:]]+(create|merge)([[:space:]]|$|[|;&`)])'
+
+if ! printf '%s' "$cmd" | grep -qE "$git_commit_re" \
+  && ! printf '%s' "$cmd" | grep -qE "$gh_pr_re"; then
+  exit 0
+fi
+
+# Resolve where the command runs (cwd-aware; mirrors the other gates).
+target_dir="${hook_cwd:-$PWD}"
+if [[ "$cmd" =~ ^[[:space:]]*cd[[:space:]]+([^[:space:]\&\;\|]+) ]]; then
+  cd_target="${BASH_REMATCH[1]}"
+  cd_target="${cd_target%\"}"; cd_target="${cd_target#\"}"
+  cd_target="${cd_target%\'}"; cd_target="${cd_target#\'}"
+  [[ "$cd_target" != /* ]] && cd_target="$target_dir/$cd_target"
+  target_dir="$cd_target"
+fi
+
+# Not a git repo (or git unavailable) → nothing to gate.
+git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# Resolve the shared main-tree root (parent of the common .git dir) so the sentinel
+# is the same path regardless of which worktree this runs in.
+git_common="$(git -C "$target_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$git_common" ]; then
+  main_root="$(dirname "$git_common")"
+else
+  main_root="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "$target_dir")"
+fi
+sentinel="${main_root}/.markgate-bughunt-pending"
+
+# Sentinel absent or empty → no pending bug-hunt resources → pass.
+[ -s "$sentinel" ] || exit 0
+
+pending=$(grep -cvE '^[[:space:]]*$' "$sentinel" 2>/dev/null || echo 0)
+[ "$pending" -gt 0 ] || exit 0
+
+{
+  echo "Blocked by bughunt-clean-gate: a /hunt-bugs session still has"
+  echo "${pending} un-deleted stack(s) tracked in:"
+  echo "  ${sentinel}"
+  echo
+  echo "Pending stacks:"
+  sed 's/^/  - /' "$sentinel"
+  echo
+  echo "Required action — delete every tracked stack, verify zero orphans,"
+  echo "then release the gate:"
+  echo "  delstack cdk -a cdk.out -r <region> -f -y          # from each fixture dir"
+  echo "  .claude/skills/hunt-bugs/bughunt-track.sh verify --region <region>"
+  echo "  .claude/skills/hunt-bugs/bughunt-track.sh clear"
+  echo
+  echo "Do NOT delete the sentinel by hand to bypass this — the whole point is"
+  echo "that bug-hunt resources cannot be forgotten. Clear it only after the"
+  echo "delete + orphan-zero verification actually passed."
+} >&2
+exit 2

--- a/.claude/hooks/bughunt-clean-gate.test.sh
+++ b/.claude/hooks/bughunt-clean-gate.test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Smoke tests for bughunt-clean-gate.sh
+#
+# Sets up a throwaway git repo, optionally arms the bug-hunt sentinel at the repo
+# root, runs the hook against simulated tool input, and asserts the expected
+# pass (0) / block (2) behavior. Run: bash .claude/hooks/bughunt-clean-gate.test.sh
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/bughunt-clean-gate.sh"
+PASS=0
+FAIL=0
+
+# run <name> <armed:0|1> <cmd> <expect_exit>
+run() {
+  local name="$1" armed="$2" cmd="$3" expect="$4"
+
+  local tmp
+  tmp=$(mktemp -d)
+  pushd "$tmp" >/dev/null
+
+  git init -q -b main
+  git config user.email t@t
+  git config user.name t
+  : > seed
+  git add -A
+  git commit -q -m init
+
+  if [ "$armed" = "1" ]; then
+    printf 'CdkRealDriftIntegFoo\nCdkRealDriftIntegBar\n' > "$tmp/.markgate-bughunt-pending"
+  fi
+
+  local payload exit_code
+  payload="{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)},\"cwd\":\"$tmp\"}"
+  set +e
+  printf '%s' "$payload" | bash "$HOOK" >/dev/null 2>&1
+  exit_code=$?
+  set -e
+
+  popd >/dev/null
+  rm -rf "$tmp"
+
+  if [ "$exit_code" -eq "$expect" ]; then
+    PASS=$((PASS + 1))
+    echo "ok   - $name (exit $exit_code)"
+  else
+    FAIL=$((FAIL + 1))
+    echo "FAIL - $name (got $exit_code, expected $expect)"
+  fi
+}
+
+# Disarmed: every command passes through.
+run "disarmed + git commit passes"        0 "git commit -m x"        0
+run "disarmed + gh pr merge passes"       0 "gh pr merge 5 --squash" 0
+
+# Armed: gated commands block.
+run "armed + git commit blocks"           1 "git commit -m x"        2
+run "armed + git -C commit blocks"        1 "git -C . commit -m x"   2
+run "armed + gh pr create blocks"         1 "gh pr create --fill"    2
+run "armed + gh pr merge blocks"          1 "gh pr merge 5 --squash" 2
+
+# Armed: non-gated commands still pass.
+run "armed + git status passes"           1 "git status"            0
+run "armed + git push passes"             1 "git push origin main"  0
+
+# Armed: quoted-body false positives must NOT block (line-start anchoring).
+run "armed + echo mentioning git commit"  1 "echo 'run git commit later'"           0
+run "armed + echo mentioning gh pr merge" 1 "echo 'remember to gh pr merge soon'"   0
+
+echo
+echo "bughunt-clean-gate: ${PASS} passed, ${FAIL} failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule). NOT wired: pr-review and integ-* — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
+  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; bughunt-clean-gate blocks `git commit`/`gh pr create`/`gh pr merge` while the .markgate-bughunt-pending sentinel is non-empty (armed by /hunt-bugs via bughunt-track.sh add before any integ deploy; released by bughunt-track.sh clear only after every tracked stack is deleted + SWEEP CLEAN); stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule). NOT wired: pr-review and the read-only integ gate — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
   "hooks": {
     "PreToolUse": [
       {
@@ -18,6 +18,13 @@
             "if": "Bash(git commit*) or Bash(git push*) or Bash(git -C * commit*) or Bash(git -C * push*) or Bash(cd * && git commit*) or Bash(cd * && git push*)",
             "timeout": 10,
             "statusMessage": "Checking target branch is not main..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/bughunt-clean-gate.sh",
+            "if": "Bash(git commit*) or Bash(git -C * commit*) or Bash(cd * && git commit*) or Bash(gh pr create*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr merge*) or Bash(cd * && gh pr create*) or Bash(cd * && gh pr merge*)",
+            "timeout": 10,
+            "statusMessage": "Checking for un-deleted bug-hunt resources..."
           },
           {
             "type": "command",

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: hunt-bugs
+description: Proactively hunt for cdkrd bugs by deploying real CDK stacks that exercise common-but-untested AWS resources, configs, and CloudFormation notations against real AWS, then catch false positives + missed detection and fix what breaks. Use for a periodic "find latent bugs" sweep, not for verifying a specific change.
+argument-hint: "[area hint, e.g. 'rich S3' | 'CFn intrinsics' | 'console-edit detection']"
+---
+
+# cdkrd Bug Hunt
+
+Find latent cdkrd bugs the way real users hit them: deploy a CDK stack that uses a
+resource / config / CloudFormation notation **cdkrd has not exercised yet**, then
+`check` it against real AWS and watch for misbehavior. cdkrd's logic is heavily
+unit-tested, so the remaining bugs live in the gap between its model of AWS and the
+**actual** live AWS response — only a real deploy surfaces those. Reading the source
+finds *suspected* bugs; deploying finds *real* ones.
+
+This is a deliberately exploratory, possibly-expensive workflow. Cost is acceptable
+**only because every deployed stack is deleted and verified gone** — see "Cleanup is
+non-negotiable", which is enforced by a gate, not by trust.
+
+## Core principles
+
+1. **Many-people-hit beats niche.** Prioritize the resources/configs a large
+   fraction of CDK users deploy every day — S3 (encryption/lifecycle/CORS/
+   intelligent-tiering), Lambda (arm64/env/tracing/reserved-concurrency/
+   FunctionUrl/logGroup), VPC (subnets/NAT/routes/endpoints), DynamoDB, IAM, API
+   Gateway, ECS/Fargate, RDS, SQS/SNS, CloudFront — over exotic edge cases. A bug
+   in a daily pattern is worth ten niche ones.
+2. **The two signals.** A freshly deployed stack with NO out-of-band change is the
+   cleanest oracle:
+   - **False positive (FP)** — the most user-damaging class. After `record`, a
+     `check` MUST be CLEAN. Any `declared`-tier drift on a clean recorded stack
+     means cdkrd's declared template value normalizes differently from the live
+     value (a normalization / default-folding bug). `record` snapshots only the
+     UNDECLARED dimension, so a surviving post-record drift is necessarily a
+     declared-dimension FP — exactly the class worth catching.
+   - **False negative (FN) / missed detection** — `record`→`check`→CLEAN does NOT
+     exercise detection. So ALSO mutate a **declared, MUTABLE** property out of band
+     (the "someone changed it in the console" scenario — Lambda `MemorySize`/
+     `Timeout`, SQS `VisibilityTimeout`) and assert `check` DETECTS it (exit 1),
+     then `revert` restores it, then `check` is CLEAN. Pick a MUTABLE property:
+     create-only/immutable ones (Subnet AZ, NAT AllocationId) can't drift.
+3. **Check coverage first.** Before building anything, `grep` the existing fixtures
+   so you hunt in genuinely-uncovered territory:
+   ```bash
+   grep -rln "Kinesis\|Dashboard\|Secret\|intelligentTiering\|FunctionUrl" tests/integration/*/app.ts
+   ```
+   Empty hits = untested = good hunting ground.
+4. **Parallelize, but cap at 3–4 stacks.** Independent stacks (unique names) can
+   deploy concurrently as background tasks, but more is not better — it makes logs
+   and teardown hard to follow. VPC/NAT (~3 min) pace a wave; most others ~1–2 min.
+
+## Workflow
+
+### 1. Worktree + build
+
+Per CLAUDE.md, never work in the main checkout:
+`git worktree add .worktrees/<name> -b wt-<name> main` →
+`mise trust .worktrees/<name>/.mise.toml` → `pnpm install` → `vp run build` (the CLI
+runs from `dist/`).
+
+### 2. Scaffold fixtures + ARM the cleanup gate
+
+Add fixtures under `tests/integration/<name>/` — mirror an existing one (`app.ts` +
+`cdk.json` + `package.json` + `verify.sh`). A clean-FP `verify.sh` is: deploy →
+`record --yes` → `check --fail` MUST exit 0. Run `npm install` then `cdk synth` for
+all fixtures in parallel FIRST (cheap, catches TS errors before any paid deploy).
+
+**Before deploying, record every stack you are about to deploy into the sentinel —
+this arms the cleanup gate:**
+```bash
+.claude/skills/hunt-bugs/bughunt-track.sh add CdkRealDriftIntegS3Rich CdkRealDriftIntegVpcCommon ...
+```
+
+### 3. Deploy (parallel, capped) + check
+
+Run the `verify.sh` set in parallel (≤3–4). Each `verify.sh` MUST have a cleanup
+`trap` that runs `delstack cdk -a cdk.out -r "$REGION" -f -y` (NOT `cdk destroy` —
+see CLAUDE.md) on EXIT, so even a failed run deletes its stack. Triage every
+`result:` that is not CLEAN, and scan the `info:` footer: a `skipped=` on a COMMON
+type is a read-gap many users hit (an SDK-override candidate); an `unresolved=`
+points at declared values whose intrinsics cdkrd couldn't resolve.
+
+### 4. Test detection (the FN half)
+
+For at least one common type, mutate a declared MUTABLE property out of band and
+assert `check` detects → `revert` → `check` CLEAN → live value restored
+(`lambda-rich/verify-detect.sh` is the reference).
+
+### 5. On a confirmed bug: fix it — with a unit test (mandatory)
+
+When a finding is a real bug:
+
+1. **Root-cause it** in `src/` (normalize / diff-classify / read-router / overrides
+   / intrinsic-resolver / report — wherever the divergence-from-reality lives).
+2. **Fix it in the worktree.**
+3. **Add a unit test that fails without the fix and passes with it.** This is
+   mandatory, not optional — a bug found by integ MUST leave behind a unit test that
+   pins the corrected behavior, so the regression can never come back silently
+   (integ alone is too slow/expensive to be the only guard). Re-run `vp run build` +
+   `vp run test`.
+4. **Re-run the live repro with the fixed binary** to confirm the real-AWS behavior
+   is now correct.
+5. **Keep the fixture** as a committed regression integ under
+   `tests/integration/<name>/`, in the SAME PR as the fix — never defer the integ.
+
+### 6. Cleanup — non-negotiable (see below), then ship
+
+Delete every tracked stack, run `bughunt-track.sh verify`, then `clear`. Then
+`/check` + `/check-docs` markers → commit → push → `/verify-pr` → `gh pr create`.
+
+### 7. Merge + remove the worktree
+
+Take it all the way to merged — do not leave a green PR hanging:
+
+1. `gh pr merge <#> --squash --delete-branch` (the remote branch). If CI is down
+   for billing, `--admin` after confirming the local gates passed.
+2. **Remove the worktree** — a hunt always creates one (`.worktrees/<name>`), and a
+   left-behind worktree is the silent residue of this flow. From the MAIN checkout:
+   `git worktree remove .worktrees/<name>` (add `--force` if it refuses on
+   leftover build artifacts), then `git branch -D wt-<name>` if the branch lingers,
+   and `git worktree prune`. Confirm with `git worktree list` — only the main
+   checkout should remain. (Mirror of CLAUDE.md's integrate-then-remove rule.)
+
+### 8. Record what you learned
+
+Save a memory for any recurring surprise (a whole *class* of latent bug, a
+verification gotcha) so the next sweep starts smarter.
+
+## Cleanup is non-negotiable (gate-enforced)
+
+Forgetting to delete bug-hunt stacks is the one unacceptable outcome, so it is
+enforced structurally rather than by discipline:
+
+- `bughunt-track.sh add <stacks...>` writes the deployed stack names to the
+  gitignored sentinel `.markgate-bughunt-pending`.
+- The `bughunt-clean-gate` PreToolUse hook (`.claude/hooks/bughunt-clean-gate.sh`)
+  **blocks `git commit`, `gh pr create`, and `gh pr merge` while that sentinel is
+  non-empty** — so you physically cannot land the fix PR (or any commit) until the
+  bug-hunt stacks are deleted and verified gone.
+- `bughunt-track.sh verify` asserts each tracked stack is GONE from CloudFormation
+  AND `sweep-orphans.sh` reports SWEEP CLEAN; `bughunt-track.sh clear` empties the
+  sentinel (releasing the gate) and is meant to be run ONLY after that passes.
+
+`delstack` only deletes stack MEMBERS. `sweep-orphans.sh` catches the
+stack-EXTERNAL orphans teardown leaves behind — auto-created `/aws/lambda/*` log
+groups (notably from S3 `autoDeleteObjects` custom-resource Lambdas), RETAIN
+stateful resources, Secrets in recovery, KMS keys pending deletion. Do NOT delete
+the sentinel by hand to bypass the gate.
+
+## Gotchas (learned the hard way — keep current)
+
+- **`record` hides undeclared FPs.** A `record→check→CLEAN` fixture only proves the
+  DECLARED dimension is FP-free; undeclared mis-classification is snapshotted away.
+  To probe it, `check` BEFORE record and read the `atDefault`/`unresolved`/`[Not
+  Recorded]` breakdown with `--verbose`.
+- **Immutable props can't drift.** Don't treat an `unresolved`/unverifiable
+  create-only property (Subnet `AvailabilityZone` via `Fn::Select(Fn::GetAZs)`, NAT
+  `AllocationId` via `Fn::GetAtt` EIP) as a bug — it's correctly classified. And
+  don't "fix" it by resolving `Fn::GetAZs`: AZ ordering differs from
+  `DescribeAvailabilityZones`, risking an FP, for zero detection benefit.
+- **`set -e` aborts inline multi-step bash.** An interactive shell with `set -e`
+  stops a one-off inline script right after a `check --fail` that exits 1. Put the
+  detect→revert→re-check sequence in a standalone `verify.sh` (with explicit
+  `|| fail`), or guard with `set +e`.
+- **Always `npm install` + `cdk synth` before deploy** — a synth-time TS error is
+  free to catch; a half-failed deploy is not.
+- **A clean result IS a result.** "6 common+rich stacks, zero FPs, detection+revert
+  verified" is a legitimate, valuable outcome. Do NOT manufacture a fix to have
+  something to show.

--- a/.claude/skills/hunt-bugs/bughunt-track.sh
+++ b/.claude/skills/hunt-bugs/bughunt-track.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# bughunt-track.sh — arm / verify / release the bug-hunt cleanup gate.
+#
+# The /hunt-bugs skill deploys real AWS resources (CloudFormation stacks via the
+# integ fixtures). To make "always delete them" a structural guarantee — not a
+# matter of remembering — every deployed stack is tracked in a gitignored sentinel
+# file. The bughunt-clean-gate hook (.claude/hooks/bughunt-clean-gate.sh) blocks
+# `git commit` / `gh pr create` / `gh pr merge` while that sentinel is non-empty,
+# so a bug-hunt session cannot land any commit until its stacks are deleted and
+# verified gone.
+#
+# Subcommands:
+#   add <Stack> [<Stack> ...]   Record stacks about to be deployed (arms gate).
+#   verify [--region R]         Assert each tracked stack is GONE from
+#                               CloudFormation AND sweep-orphans.sh is CLEAN.
+#                               Non-zero exit if anything remains. Does NOT clear.
+#   clear                       Empty the sentinel (releases the gate). Run ONLY
+#                               after verify passes (delete + orphan-zero).
+#   list                        Print the currently-tracked stacks.
+#
+# The sentinel lives at the SHARED main-tree root (via --git-common-dir) so the
+# deploy-time tracker and the gate hook — which may run from different worktrees —
+# agree on one path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_COMMON_DIR="$(git -C "${SCRIPT_DIR}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "${GIT_COMMON_DIR}" ]; then
+  REPO_ROOT="$(dirname "${GIT_COMMON_DIR}")"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+SENTINEL="${REPO_ROOT}/.markgate-bughunt-pending"
+SWEEP="${REPO_ROOT}/tests/integration/sweep-orphans.sh"
+
+cmd="${1:-}"
+shift || true
+
+case "${cmd}" in
+  add)
+    if [ "$#" -eq 0 ]; then
+      echo "usage: bughunt-track.sh add <Stack> [<Stack> ...]" >&2
+      exit 2
+    fi
+    touch "${SENTINEL}"
+    for stack in "$@"; do
+      if ! grep -qxF "${stack}" "${SENTINEL}" 2>/dev/null; then
+        echo "${stack}" >>"${SENTINEL}"
+      fi
+    done
+    echo "tracked $# stack(s); bughunt-clean gate is now ARMED"
+    ;;
+
+  list)
+    if [ -s "${SENTINEL}" ]; then
+      cat "${SENTINEL}"
+    else
+      echo "(no tracked stacks)"
+    fi
+    ;;
+
+  verify)
+    region="${AWS_REGION:-us-east-1}"
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --region) region="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+      esac
+    done
+    if [ ! -s "${SENTINEL}" ]; then
+      echo "no tracked stacks — nothing to verify"
+      exit 0
+    fi
+    fail=0
+    # 1) every tracked stack must be GONE from CloudFormation (delete succeeded).
+    while IFS= read -r stack; do
+      [ -z "${stack}" ] && continue
+      status="$(aws cloudformation describe-stacks --stack-name "${stack}" --region "${region}" \
+        --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "GONE")"
+      if [ "${status}" = "GONE" ] || [ "${status}" = "DELETE_COMPLETE" ] || [ -z "${status}" ]; then
+        echo "ok: ${stack} is gone (${status})"
+      else
+        echo "STILL PRESENT: stack ${stack} is ${status} — delete it (delstack cdk -a cdk.out -r ${region} -f -y)" >&2
+        fail=1
+      fi
+    done <"${SENTINEL}"
+    # 2) no stack-EXTERNAL orphans may remain (log groups, RETAIN resources, etc.).
+    if [ -x "${SWEEP}" ]; then
+      sweep_out="$(AWS_REGION="${region}" bash "${SWEEP}" 2>&1 || true)"
+      if printf '%s\n' "${sweep_out}" | grep -q "SWEEP CLEAN"; then
+        echo "ok: sweep-orphans.sh reports SWEEP CLEAN"
+      else
+        echo "ORPHANS REMAIN — sweep-orphans.sh did not report SWEEP CLEAN:" >&2
+        printf '%s\n' "${sweep_out}" | tail -8 >&2
+        echo "run: AWS_REGION=${region} bash ${SWEEP} --delete" >&2
+        fail=1
+      fi
+    else
+      echo "WARN: ${SWEEP} not found/executable — skipping orphan sweep" >&2
+    fi
+    if [ "${fail}" -ne 0 ]; then
+      echo "verify FAILED — delete the remaining stacks/orphans before clearing the gate" >&2
+      exit 1
+    fi
+    echo "verify OK — every tracked stack is gone and no orphans remain"
+    ;;
+
+  clear)
+    rm -f "${SENTINEL}"
+    echo "sentinel cleared; bughunt-clean gate is now RELEASED"
+    ;;
+
+  *)
+    echo "usage: bughunt-track.sh {add|verify|clear|list} ..." >&2
+    exit 2
+    ;;
+esac

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,13 @@ cdk.context.json
 # markgate pr-review sentinel
 .markgate-pr-review-sha
 
+# /hunt-bugs cleanup sentinel: lists integ stacks deployed to real AWS; the
+# bughunt-clean-gate.sh PreToolUse hook blocks git commit / gh pr create / gh pr
+# merge while it is non-empty, so bug-hunt resources cannot be forgotten. Written
+# by bughunt-track.sh add, cleared by bughunt-track.sh clear after delete +
+# orphan-zero verification.
+.markgate-bughunt-pending
+
 # cdkd-parity tracking-issue sentinel (per-worktree; written by /check-cdkd-parity)
 .cdkd-parity-issue
 

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -29,6 +29,13 @@
 #               remains, and it has no companion /run-integ skill yet. 14d TTL
 #               (AWS-side wire-format + Cloud Control behavior drift over time).
 #
+# Bug-hunt cleanup is NOT a markgate gate — it is a sentinel-file gate
+# (.markgate-bughunt-pending + .claude/hooks/bughunt-clean-gate.sh), armed by
+# /hunt-bugs's bughunt-track.sh BEFORE any deploy and released only after every
+# deployed stack is deleted + SWEEP CLEAN. A sentinel (not a content hash) is used
+# deliberately: it tracks outstanding live resources regardless of which fixture
+# files a later commit happens to touch, so a deployed stack can never be forgotten.
+#
 # NOTE: the commit/PR-blocking ENFORCEMENT (the .claude hooks that call markgate)
 # is now installed (R83): check-gate (commit), verify-pr-gate (gh pr create/merge),
 # plus the marker-free branch-gate and non-english-text-gate. Hooks are wired ONLY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,16 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     live-test + retrospective; named `verify-pr` for layout parity with cdkd).
   - A `check-gate` PreToolUse hook blocks `git commit` unless both the `check` and
     `docs` markers are fresh. Run the relevant skill before committing.
+  - `/hunt-bugs` is the (non-marker) skill that drives a periodic real-AWS bug-hunt:
+    deploy UNCOVERED, high-frequency resource types / configs / CFn notations, then
+    catch false positives (clean `record`→`check` must be CLEAN) and missed
+    detection (mutate a declared MUTABLE prop → `check` must detect → `revert`).
+    Cleanup is enforced by a SENTINEL gate, not a markgate marker:
+    `bughunt-track.sh add <stacks>` arms `.markgate-bughunt-pending` BEFORE any
+    deploy, and the `bughunt-clean-gate` hook blocks `git commit` / `gh pr create` /
+    `gh pr merge` while it is non-empty — released by `bughunt-track.sh clear` only
+    after every tracked stack is deleted (via `delstack`) and `sweep-orphans.sh`
+    reports SWEEP CLEAN. A deployed stack can never be forgotten.
 - **ALWAYS develop in a git worktree — never edit or branch in the main
   checkout, even for a single "sequential" session.** Sessions that believed
   they were alone have collided twice: a README clobber, and a branch created in

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -54,7 +54,8 @@ const TIER_NOTES: Partial<Record<Tier, string>> = {
   generated: 'auto-generated identifier not in your template (AWS-assigned at deploy) — not drift',
   ignored: 'matched a .cdkrd/config.json ignore rule — not drift',
   readGap: "declared, but AWS doesn't return it on read so cdkrd can't verify it — not drift",
-  unresolved: 'declared paths needing GetAtt — skipped, not drift',
+  unresolved:
+    "declared, but its value references a CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value, so it can't be compared — skipped, not drift",
   skipped:
     'NOT checked (coverage incomplete) — CC API unsupported / no physical id / custom resource',
 };
@@ -162,7 +163,7 @@ function tierStyle(t: Tier): (s: string) => string {
 function reasonKey(f: Finding): string {
   const n = f.note ?? '';
   if (f.tier === 'ignored') return n.replace(/^ignored by config rule /, '') || 'ignored';
-  if (f.tier === 'unresolved') return 'GetAtt unresolved';
+  if (f.tier === 'unresolved') return 'intrinsic unresolved';
   if (n.includes('write-only')) return 'write-only';
   if (n.startsWith('custom resource')) return 'custom resource';
   if (n.includes('target not resolvable')) return 'override target unresolved';
@@ -326,6 +327,12 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
       ];
       return `readGap=${items.length} (declared but unverifiable — AWS doesn't return them on read, not drift: ${parts.join(', ')})`;
     }
+    // unresolved is jargon too: these are declared values whose CloudFormation intrinsic
+    // (Fn::GetAtt, Fn::GetAZs, …) cdkrd could not resolve to a concrete value, so there is
+    // nothing concrete to compare against live — unverifiable, not drift. The generic
+    // groupReasons breakdown would just echo "intrinsic unresolved N", so spell it out.
+    if (t === 'unresolved')
+      return `unresolved=${items.length} (declared values whose CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value — unverifiable, not drift)`;
     // skipped = resources cdkrd genuinely could NOT read this run (CC-unsupported with
     // no SDK override, read error, missing physical id, custom resource). It is the one
     // info: tier that is a COVERAGE GAP, not a not-drift classification — so it carries

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -382,6 +382,36 @@ normalization classes most likely to regress:
 cd dynamodb && bash verify.sh   # …and likewise for each fixture above
 ```
 
+## rich / common false-positive fixtures (integ bug-hunt round)
+
+Added by the `/hunt-bugs` skill — a periodic real-AWS round that deploys
+UNCOVERED, richly-configured resources (prioritizing the high-frequency patterns
+many users actually deploy) and asserts a freshly recorded stack reports CLEAN.
+Each `verify.sh` is the FP shape (deploy → `record --yes` → `check --fail` MUST
+exit 0); `lambda-rich/verify-detect.sh` adds the false-NEGATIVE half.
+
+| fixture       | resource(s)                                          | what it stresses                                              |
+| ------------- | ---------------------------------------------------- | ------------------------------------------------------------- |
+| `s3-rich`     | S3 Bucket (KMS, lifecycle, CORS, intelligent-tiering, enforceSSL, autoDeleteObjects) | the single most-deployed resource, richly configured          |
+| `lambda-rich` | Lambda (arm64, env, tracing, ephemeral, reserved-concurrency, FunctionUrl, logGroup) | common Lambda "production" knobs; `verify-detect.sh` = console-edit detect+revert |
+| `vpc-common`  | ec2.Vpc (subnets / NAT / routes / IGW / S3 endpoint) | dense default-folding + `unresolved` intrinsics across networking |
+| `rich-fp`     | Kinesis, SQS FIFO, SNS FIFO, CloudWatch Dashboard, Secrets Manager | JSON-string bodies, FIFO flags, generated secrets             |
+| `notation-fp` | SNS/SQS via L1 + `Fn::FindInMap` / `Fn::Sub` map / `Fn::If` / `Fn::Select`+`Fn::Split` | CloudFormation intrinsic resolution against live values       |
+| `niche-fp`    | ECR, Step Functions, WAFv2 WebACL (regional), EventBridge Rule | nested rule/visibility configs, JSON LifecyclePolicy/Definition |
+
+```bash
+cd s3-rich && npm install && bash verify.sh   # …and likewise for each fixture above
+cd lambda-rich && npm install && bash verify-detect.sh   # the detect+revert half
+```
+
+Cleanup after any of these is mandatory and gate-enforced. `/hunt-bugs` arms a
+sentinel before deploying (`bughunt-track.sh add <stacks>`); the
+`bughunt-clean-gate` hook then blocks `git commit` / `gh pr create` / `gh pr merge`
+until `bughunt-track.sh verify` (every tracked stack gone + `sweep-orphans.sh`
+SWEEP CLEAN — it catches the `/aws/lambda/*` log group an S3 `autoDeleteObjects`
+custom-resource Lambda leaves behind) passes and `bughunt-track.sh clear` releases
+the gate.
+
 ## harvest
 
 A corpus-harvest fixture (R71): ~18 cheap, fast-create/delete types in one

--- a/tests/integration/lambda-rich/app.ts
+++ b/tests/integration/lambda-rich/app.ts
@@ -1,0 +1,55 @@
+// CDK app for the cdk-real-drift richly-configured Lambda false-positive test.
+// Lambda is among the most commonly deployed CDK resources. This exercises the
+// common "production" knobs at once: arm64 architecture, environment variables,
+// X-Ray active tracing, ephemeral storage, reserved concurrency, an explicit log
+// group with retention, and a Function URL with CORS. A freshly deployed +
+// recorded function with NO out-of-band change MUST report CLEAN.
+import { App, Duration, RemovalPolicy, Size, Stack } from "aws-cdk-lib";
+import {
+  Architecture,
+  Code,
+  Function as LambdaFunction,
+  FunctionUrlAuthType,
+  HttpMethod,
+  Runtime,
+  Tracing,
+} from "aws-cdk-lib/aws-lambda";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaRich");
+
+const logGroup = new LogGroup(stack, "Logs", {
+  retention: RetentionDays.TWO_WEEKS,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const fn = new LambdaFunction(stack, "Handler", {
+  runtime: Runtime.NODEJS_20_X,
+  architecture: Architecture.ARM_64,
+  handler: "index.handler",
+  code: Code.fromInline("export const handler = async () => ({ ok: true });"),
+  memorySize: 256,
+  timeout: Duration.seconds(15),
+  ephemeralStorageSize: Size.mebibytes(1024),
+  tracing: Tracing.ACTIVE,
+  reservedConcurrentExecutions: 2,
+  description: "cdkrd lambda-rich test handler",
+  environment: {
+    STAGE: "test",
+    FEATURE_FLAG: "on",
+  },
+  logGroup,
+});
+
+fn.addFunctionUrl({
+  authType: FunctionUrlAuthType.NONE,
+  cors: {
+    allowedOrigins: ["https://example.com"],
+    allowedMethods: [HttpMethod.GET, HttpMethod.POST],
+    allowedHeaders: ["content-type"],
+    maxAge: Duration.minutes(5),
+  },
+});
+
+app.synth();

--- a/tests/integration/lambda-rich/cdk.json
+++ b/tests/integration/lambda-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-rich/package.json
+++ b/tests/integration/lambda-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-rich/verify-detect.sh
+++ b/tests/integration/lambda-rich/verify-detect.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Lambda detect + revert integration test (real AWS): the "someone changed it in
+# the console" scenario, the single most common real-world drift. Deploy -> record
+# -> change DECLARED MUTABLE props (MemorySize, Timeout) out of band -> check MUST
+# DETECT the declared drift (exit 1) -> revert -> check MUST be CLEAN and the live
+# config MUST be restored. This is the false-negative / detection half that a
+# plain record->check->CLEAN fixture (verify.sh) does not exercise.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN" ] || fail "could not resolve function physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: MemorySize 256->512, Timeout 15->30 (console-edit) ==="
+aws lambda update-function-configuration --function-name "$FN" --region "$REGION" \
+  --memory-size 512 --timeout 30 >/dev/null || fail "inject drift"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-lambda-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "MemorySize" /tmp/cdkrd-lambda-detect.out || fail "MemorySize not reported"
+grep -q "Timeout" /tmp/cdkrd-lambda-detect.out || fail "Timeout not reported"
+
+echo "=== revert (write declared values back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live config MUST be restored to 256 / 15 ==="
+GOT="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" \
+  --query "[MemorySize,Timeout]" --output text)"
+[ "$GOT" = "256	15" ] || fail "live config not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/lambda-rich/verify.sh
+++ b/tests/integration/lambda-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded stack with NO out-of-band change
+# must report no drift; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/niche-fp/app.ts
+++ b/tests/integration/niche-fp/app.ts
@@ -1,0 +1,74 @@
+// CDK app for the cdk-real-drift "niche but requested" false-positive test.
+// Bundles property-rich types that lacked a dedicated clean-check fixture, each a
+// distinct normalization stress:
+//   - ECR Repository:        JSON-string LifecyclePolicy + scan/encryption config
+//   - Step Functions:        DefinitionString JSON + tracing config
+//   - WAFv2 WebACL (regional): deeply nested Rules / VisibilityConfig / DefaultAction
+//   - EventBridge Rule:      rich EventPattern (nested detail)
+// A freshly deployed + recorded stack with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Repository, TagMutability } from "aws-cdk-lib/aws-ecr";
+import { Rule } from "aws-cdk-lib/aws-events";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+import { DefinitionBody, Pass, StateMachine, Wait, WaitTime } from "aws-cdk-lib/aws-stepfunctions";
+import { Duration } from "aws-cdk-lib";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegNicheFp");
+
+new Repository(stack, "Images", {
+  imageScanOnPush: true,
+  imageTagMutability: TagMutability.IMMUTABLE,
+  emptyOnDelete: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+  lifecycleRules: [
+    { description: "expire untagged", tagStatus: undefined, maxImageAge: Duration.days(14) },
+    { description: "keep last 10 tagged", tagPrefixList: ["v"], maxImageCount: 10 },
+  ],
+});
+
+new StateMachine(stack, "Flow", {
+  tracingEnabled: true,
+  definitionBody: DefinitionBody.fromChainable(
+    new Pass(stack, "Start").next(new Wait(stack, "Pause", { time: WaitTime.duration(Duration.seconds(1)) })),
+  ),
+});
+
+new CfnWebACL(stack, "Acl", {
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdNicheAcl",
+    sampledRequestsEnabled: true,
+  },
+  rules: [
+    {
+      name: "AWSCommon",
+      priority: 0,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: "AWS",
+          name: "AWSManagedRulesCommonRuleSet",
+        },
+      },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: "cdkrdCommon",
+        sampledRequestsEnabled: true,
+      },
+    },
+  ],
+});
+
+new Rule(stack, "OrderRule", {
+  description: "cdkrd niche-fp order events",
+  eventPattern: {
+    source: ["cdkrd.shop"],
+    detailType: ["order.placed"],
+    detail: { status: ["NEW", "PENDING"], amount: [{ numeric: [">", 100] }] },
+  },
+});
+
+app.synth();

--- a/tests/integration/niche-fp/cdk.json
+++ b/tests/integration/niche-fp/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/niche-fp/package.json
+++ b/tests/integration/niche-fp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-niche-fp",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift niche-fp false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/niche-fp/verify.sh
+++ b/tests/integration/niche-fp/verify.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNicheFp
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/notation-fp/app.ts
+++ b/tests/integration/notation-fp/app.ts
@@ -1,0 +1,47 @@
+// CDK app for the cdk-real-drift CloudFormation-notation false-positive test.
+// Real-world templates wire resource properties through intrinsics; cdkrd reads the
+// ORIGINAL deployed template (intrinsics intact) and must resolve them to the same
+// value AWS actually applied. This fixture drives several common intrinsics through
+// L1 resources via escape hatches:
+//   - Fn::FindInMap (CfnMapping)         -> SNS DisplayName + a queue tag prefix
+//   - Fn::Sub (map form, nested var)     -> queue tag value
+//   - Fn::If (CfnCondition)              -> queue DelaySeconds
+//   - Fn::Select + Fn::Split             -> queue MessageRetentionPeriod source
+// A freshly deployed + recorded stack with NO out-of-band change MUST report CLEAN;
+// a mis-resolved intrinsic would surface as a false declared drift.
+import { App, CfnCondition, CfnMapping, Fn, Stack, Token } from "aws-cdk-lib";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegNotationFp");
+
+const cfg = new CfnMapping(stack, "Cfg", {
+  mapping: {
+    settings: { display: "cdkrd-notation", retention: "60.120.240" },
+  },
+});
+
+const isUsEast = new CfnCondition(stack, "IsUsEast", {
+  expression: Fn.conditionEquals(stack.region, "us-east-1"),
+});
+
+new CfnTopic(stack, "Topic", {
+  displayName: cfg.findInMap("settings", "display"),
+});
+
+new CfnQueue(stack, "Queue", {
+  // Fn::If on a region condition -> 45 in us-east-1, else 15.
+  delaySeconds: Fn.conditionIf(isUsEast.logicalId, 45, 15) as unknown as number,
+  // Fn::Select(1, Fn::Split(".", "60.120.240")) -> "120" -> Number.
+  messageRetentionPeriod: Token.asNumber(Fn.select(1, Fn.split(".", cfg.findInMap("settings", "retention")))),
+  tags: [
+    {
+      key: "name",
+      // Fn::Sub map form with a nested Fn::FindInMap variable.
+      value: Fn.sub("${prefix}-queue", { prefix: cfg.findInMap("settings", "display") }),
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/notation-fp/cdk.json
+++ b/tests/integration/notation-fp/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/notation-fp/package.json
+++ b/tests/integration/notation-fp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-notation-fp",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift notation-fp false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/notation-fp/verify.sh
+++ b/tests/integration/notation-fp/verify.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNotationFp
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/rich-fp/app.ts
+++ b/tests/integration/rich-fp/app.ts
@@ -1,0 +1,61 @@
+// CDK app for the cdk-real-drift "rich false-positive" integration test.
+// Mixes several property-rich resource types that were NOT previously covered by a
+// dedicated clean-check fixture, to surface normalization / default-folding false
+// positives: a freshly deployed + recorded stack with NO out-of-band change MUST
+// report CLEAN. Each type stresses a different normalization edge:
+//   - Kinesis Stream:   StreamModeDetails + RetentionPeriodHours + StreamEncryption
+//   - SQS FIFO queue:    JSON-string RedrivePolicy (with a GetAtt ARN), dedup scope
+//   - SNS FIFO topic:    ContentBasedDeduplication + Fifo flags
+//   - CloudWatch Dash:   DashboardBody is a JSON string built via Fn::Join intrinsics
+//   - Secrets Manager:   GenerateSecretString + a resource policy
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Dashboard, TextWidget } from "aws-cdk-lib/aws-cloudwatch";
+import { Stream, StreamMode } from "aws-cdk-lib/aws-kinesis";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Queue, DeduplicationScope, FifoThroughputLimit } from "aws-cdk-lib/aws-sqs";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRichFp");
+
+new Stream(stack, "Events", {
+  streamMode: StreamMode.PROVISIONED,
+  shardCount: 1,
+  retentionPeriod: Duration.hours(48),
+});
+
+const dlq = new Queue(stack, "Dlq", {
+  fifo: true,
+  contentBasedDeduplication: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+new Queue(stack, "Work", {
+  fifo: true,
+  contentBasedDeduplication: true,
+  deduplicationScope: DeduplicationScope.MESSAGE_GROUP,
+  fifoThroughputLimit: FifoThroughputLimit.PER_MESSAGE_GROUP_ID,
+  deadLetterQueue: { queue: dlq, maxReceiveCount: 3 },
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new Topic(stack, "Notify", {
+  fifo: true,
+  contentBasedDeduplication: true,
+});
+
+new Dashboard(stack, "Board", {
+  dashboardName: "CdkRealDriftIntegRichFpBoard",
+  widgets: [[new TextWidget({ markdown: "# cdkrd rich-fp", width: 24, height: 2 })]],
+});
+
+new Secret(stack, "ApiKey", {
+  description: "cdkrd rich-fp test secret",
+  generateSecretString: {
+    secretStringTemplate: JSON.stringify({ username: "svc" }),
+    generateStringKey: "password",
+    excludeCharacters: '"@/\\',
+  },
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+app.synth();

--- a/tests/integration/rich-fp/cdk.json
+++ b/tests/integration/rich-fp/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rich-fp/package.json
+++ b/tests/integration/rich-fp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rich-fp",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rich-fp/verify.sh
+++ b/tests/integration/rich-fp/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Rich false-positive integration test (real AWS).
+#   deploy fixture -> record baseline -> check MUST be CLEAN.
+# A freshly deployed + recorded stack with NO out-of-band change must report no
+# drift; any drift reported here is a normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRichFp
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-rich-fp.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: check reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS"

--- a/tests/integration/s3-rich/app.ts
+++ b/tests/integration/s3-rich/app.ts
@@ -1,0 +1,59 @@
+// CDK app for the cdk-real-drift richly-configured S3 false-positive test.
+// S3 is the single most commonly deployed CDK resource; a richly configured bucket
+// exercises many normalization edges at once (lifecycle rules, CORS, KMS encryption
+// with bucket keys, intelligent tiering, object ownership, enforced SSL bucket
+// policy, public access block). A freshly deployed + recorded bucket with NO
+// out-of-band change MUST report CLEAN.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+  HttpMethods,
+  ObjectOwnership,
+  StorageClass,
+} from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3Rich");
+
+new Bucket(stack, "Data", {
+  versioned: true,
+  encryption: BucketEncryption.KMS,
+  bucketKeyEnabled: true,
+  enforceSSL: true,
+  objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+  cors: [
+    {
+      allowedMethods: [HttpMethods.GET, HttpMethods.HEAD],
+      allowedOrigins: ["https://example.com"],
+      allowedHeaders: ["*"],
+      maxAge: 3000,
+    },
+  ],
+  lifecycleRules: [
+    {
+      id: "archive",
+      enabled: true,
+      abortIncompleteMultipartUploadAfter: Duration.days(7),
+      transitions: [
+        { storageClass: StorageClass.INFREQUENT_ACCESS, transitionAfter: Duration.days(30) },
+        { storageClass: StorageClass.GLACIER, transitionAfter: Duration.days(90) },
+      ],
+      noncurrentVersionExpiration: Duration.days(365),
+      expiration: Duration.days(730),
+    },
+  ],
+  intelligentTieringConfigurations: [
+    {
+      name: "archive-tiers",
+      archiveAccessTierTime: Duration.days(90),
+      deepArchiveAccessTierTime: Duration.days(180),
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/s3-rich/cdk.json
+++ b/tests/integration/s3-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-rich/package.json
+++ b/tests/integration/s3-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-rich/verify.sh
+++ b/tests/integration/s3-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded stack with NO out-of-band change
+# must report no drift; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3Rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/vpc-common/app.ts
+++ b/tests/integration/vpc-common/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift VPC false-positive test.
+// A standard ec2.Vpc is one of the most commonly deployed CDK patterns and expands
+// to many resources with many AWS-populated defaults (VPC, subnets, route tables,
+// routes, IGW, NAT gateway, EIP, gateway endpoint). It is a dense stress test of
+// default-folding and undeclared-property classification across networking types.
+// A freshly deployed + recorded VPC with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  GatewayVpcEndpointAwsService,
+  IpAddresses,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegVpcCommon");
+
+new Vpc(stack, "Net", {
+  ipAddresses: IpAddresses.cidr("10.42.0.0/16"),
+  maxAzs: 2,
+  natGateways: 1,
+  subnetConfiguration: [
+    { name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 },
+    { name: "private", subnetType: SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },
+  ],
+  gatewayEndpoints: {
+    S3: { service: GatewayVpcEndpointAwsService.S3 },
+  },
+});
+
+app.synth();

--- a/tests/integration/vpc-common/cdk.json
+++ b/tests/integration/vpc-common/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/vpc-common/package.json
+++ b/tests/integration/vpc-common/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-vpc-common",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift vpc-common false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/vpc-common/verify.sh
+++ b/tests/integration/vpc-common/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded stack with NO out-of-band change
+# must report no drift; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegVpcCommon
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -473,6 +473,37 @@ describe('report', () => {
     });
   });
 
+  describe('unresolved tier (declared value depends on an unresolvable CFn intrinsic — folded, not drift)', () => {
+    const U = (path: string, resourceType = 'AWS::EC2::Subnet'): Finding => ({
+      tier: 'unresolved',
+      logicalId: 'L',
+      resourceType,
+      path,
+    });
+
+    it('folds into info: with a plain-English (not "GetAtt"-only) label, never sets exit 1', () => {
+      const { code, text } = run([
+        U('AvailabilityZone'),
+        U('AllocationId', 'AWS::EC2::NatGateway'),
+      ]);
+      expect(code).toBe(0);
+      expect(text).toMatch(/^result: CLEAN$/m);
+      // the message must explain WHY (unverifiable intrinsic) and must NOT claim every
+      // unresolved value is a Fn::GetAtt — a Subnet AZ is Fn::Select(Fn::GetAZs).
+      expect(text).toContain(
+        "info: unresolved=2 (declared values whose CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value — unverifiable, not drift)"
+      );
+      expect(text).not.toContain('GetAtt unresolved');
+    });
+
+    it('--verbose expands unresolved to a full section listing each declared path', () => {
+      const { text } = run([U('AvailabilityZone')], { verbose: true });
+      expect(text).toContain('[Unresolved: 1]');
+      expect(text).toContain('L.AvailabilityZone (AWS::EC2::Subnet)');
+      expect(text).not.toContain('info:');
+    });
+  });
+
   describe('R37 spacing', () => {
     const skipped: Finding = {
       tier: 'skipped',


### PR DESCRIPTION
## Summary

A real-AWS **bug-hunt round** (deploy uncovered, high-frequency resource types →
catch false positives + missed detection), plus the workflow codified as a
reusable skill with a teardown-guarantee gate.

### The fix
The `unresolved` info-line read `unresolved=N (GetAtt unresolved N)` — it echoed
the word and, worse, claimed every unresolved value is a `Fn::GetAtt`. The tier
covers ANY unresolvable intrinsic (a standard VPC subnet's `AvailabilityZone` is
`Fn::Select(Fn::GetAZs)`, not GetAtt). Now a plain-English explanation matching
its sibling tiers; verbose note + reason label made intrinsic-general. Unit tests
lock the message + the no-"GetAtt unresolved" wording; **live-verified on a real
VPC**.

### The round (6 stacks, all deleted)
| fixture | what | result |
|---|---|---|
| s3-rich / lambda-rich / vpc-common | most-deployed types, rich config | 0 declared FPs |
| rich-fp / notation-fp / niche-fp | Kinesis/FIFO/Secret/Dashboard, CFn intrinsics, ECR/SFN/WAFv2/Events | 0 FPs |
| lambda-rich/verify-detect.sh | console-edit (MemorySize/Timeout) | detect ✓ revert ✓ restore ✓ |

### Tooling
- **`/hunt-bugs`** skill (mirrors cdkd's `hunt-bugs`): the periodic round +
  baked-in gotchas (record hides undeclared FPs, immutable props can't drift,
  `set -e` aborts inline detect scripts, parallel ≤3–4, a clean result is a result).
- **Sentinel cleanup gate** (not trust): `bughunt-track.sh add` arms
  `.markgate-bughunt-pending` before any deploy; `bughunt-clean-gate.sh` blocks
  `git commit` / `gh pr create` / `gh pr merge` while non-empty; released only after
  every tracked stack is deleted (`delstack`) + `sweep-orphans.sh` SWEEP CLEAN. Hook
  smoke test 10/10.

## Test
- `vp run typecheck` / `vp check` / `vp run build` / `vp run test` (1267 tests) — pass
- `bughunt-clean-gate.test.sh` — 10/10
- live: VPC shows the new unresolved message; lambda detect+revert; all stacks deleted, SWEEP CLEAN
