### PR TITLE
test(integ): add ddb-rich, sfn-express, sns-fifo bug-hunt fixtures

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -398,10 +398,14 @@ exit 0); `lambda-rich/verify-detect.sh` adds the false-NEGATIVE half.
 | `rich-fp`     | Kinesis, SQS FIFO, SNS FIFO, CloudWatch Dashboard, Secrets Manager | JSON-string bodies, FIFO flags, generated secrets             |
 | `notation-fp` | SNS/SQS via L1 + `Fn::FindInMap` / `Fn::Sub` map / `Fn::If` / `Fn::Select`+`Fn::Split` | CloudFormation intrinsic resolution against live values       |
 | `niche-fp`    | ECR, Step Functions, WAFv2 WebACL (regional), EventBridge Rule | nested rule/visibility configs, JSON LifecyclePolicy/Definition |
+| `ddb-rich`    | DynamoDB Table (SIA table-class, TTL, stream, PITR, contributor-insights, LSI + 2 GSI) | rich DynamoDB knobs default-folded at once; `verify-detect.sh` = nested-property (PITR) detect+revert |
+| `sfn-express` | Step Functions EXPRESS SM (CloudWatch LoggingConfiguration + X-Ray tracing) | EXPRESS logging-destination array + tracing default-folding |
+| `sns-fifo`    | SNS FIFO Topic (content-based-dedup + KMS SSE) | FIFO flags + `KmsMasterKeyId` intrinsic ref on a FIFO topic |
 
 ```bash
 cd s3-rich && npm install && bash verify.sh   # …and likewise for each fixture above
 cd lambda-rich && npm install && bash verify-detect.sh   # the detect+revert half
+cd ddb-rich && npm install && bash verify-detect.sh   # nested-property (PITR) detect+revert
 ```
 
 Cleanup after any of these is mandatory and gate-enforced. `/hunt-bugs` arms a

--- a/tests/integration/ddb-rich/app.ts
+++ b/tests/integration/ddb-rich/app.ts
@@ -1,0 +1,55 @@
+// CDK app for the cdk-real-drift richly-configured DynamoDB false-positive test.
+// DynamoDB is among the most commonly deployed CDK resources. The existing
+// `dynamodb` fixture covers the basic table (KeySchema / one GSI / tags); this one
+// piles on the "production" knobs that each add their own normalization edge:
+// a TTL spec, a DynamoDB Stream, a STANDARD_INFREQUENT_ACCESS table class,
+// contributor insights, point-in-time recovery, a local secondary index, and a
+// second GSI with a KEYS_ONLY projection. A freshly deployed + recorded table with
+// NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import {
+  AttributeType,
+  BillingMode,
+  ProjectionType,
+  StreamViewType,
+  Table,
+  TableClass,
+} from "aws-cdk-lib/aws-dynamodb";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegDdbRich");
+
+const table = new Table(stack, "Data", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  sortKey: { name: "sk", type: AttributeType.STRING },
+  billingMode: BillingMode.PAY_PER_REQUEST,
+  tableClass: TableClass.STANDARD_INFREQUENT_ACCESS,
+  pointInTimeRecovery: true,
+  contributorInsightsEnabled: true,
+  stream: StreamViewType.NEW_AND_OLD_IMAGES,
+  timeToLiveAttribute: "ttl",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+table.addLocalSecondaryIndex({
+  indexName: "lsi1",
+  sortKey: { name: "lsi1sk", type: AttributeType.NUMBER },
+  projectionType: ProjectionType.ALL,
+});
+
+table.addGlobalSecondaryIndex({
+  indexName: "gsi1",
+  partitionKey: { name: "gsi1pk", type: AttributeType.STRING },
+  sortKey: { name: "gsi1sk", type: AttributeType.NUMBER },
+});
+
+table.addGlobalSecondaryIndex({
+  indexName: "gsi2",
+  partitionKey: { name: "gsi2pk", type: AttributeType.STRING },
+  projectionType: ProjectionType.KEYS_ONLY,
+});
+
+Tags.of(table).add("team", "platform");
+Tags.of(table).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/ddb-rich/cdk.json
+++ b/tests/integration/ddb-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ddb-rich/package.json
+++ b/tests/integration/ddb-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ddb-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ddb-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ddb-rich/verify-detect.sh
+++ b/tests/integration/ddb-rich/verify-detect.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# DynamoDB detect + revert integration test (real AWS): the "someone changed it in
+# the console" scenario. Deploy -> record -> disable point-in-time recovery out of
+# band (a declared, MUTABLE, nested property) -> check MUST DETECT the declared
+# drift (exit 1) -> revert -> check MUST be CLEAN and the live PITR MUST be
+# re-enabled. PITR toggles are near-instant and never put the table in UPDATING,
+# so this is a fast, reliable detection oracle for a nested declared property.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDdbRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+TBL="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::DynamoDB::Table'].PhysicalResourceId" --output text)"
+[ -n "$TBL" ] || fail "could not resolve table physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: disable point-in-time recovery (console-edit) ==="
+aws dynamodb update-continuous-backups --table-name "$TBL" --region "$REGION" \
+  --point-in-time-recovery-specification PointInTimeRecoveryEnabled=false >/dev/null \
+  || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ddb-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "PointInTimeRecovery" /tmp/cdkrd-ddb-detect.out || fail "PITR drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live PITR MUST be re-enabled ==="
+GOT="$(aws dynamodb describe-continuous-backups --table-name "$TBL" --region "$REGION" \
+  --query "ContinuousBackupsDescription.PointInTimeRecoveryDescription.PointInTimeRecoveryStatus" --output text)"
+[ "$GOT" = "ENABLED" ] || fail "live PITR not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/ddb-rich/verify.sh
+++ b/tests/integration/ddb-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDdbRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sfn-express/app.ts
+++ b/tests/integration/sfn-express/app.ts
@@ -1,0 +1,42 @@
+// CDK app for the cdk-real-drift EXPRESS Step Functions false-positive test.
+// The existing `stepfunctions` fixture is a STANDARD state machine with no logging.
+// An EXPRESS machine with a CloudWatch LoggingConfiguration and X-Ray tracing is a
+// different, very common production shape: LoggingConfiguration nests a
+// Destinations array of LogGroup ARN refs + a Level + IncludeExecutionData boolean,
+// and TracingConfiguration is a single-key object that AWS may default-fold. A
+// freshly deployed + recorded machine with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import {
+  DefinitionBody,
+  LogLevel,
+  Pass,
+  StateMachine,
+  StateMachineType,
+  Succeed,
+} from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSfnExpress");
+
+const logGroup = new LogGroup(stack, "Logs", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const start = new Pass(stack, "Start", { comment: "a pass state" });
+const done = new Succeed(stack, "Done");
+
+const sm = new StateMachine(stack, "Machine", {
+  stateMachineType: StateMachineType.EXPRESS,
+  definitionBody: DefinitionBody.fromChainable(start.next(done)),
+  tracingEnabled: true,
+  logs: {
+    destination: logGroup,
+    level: LogLevel.ALL,
+    includeExecutionData: true,
+  },
+});
+Tags.of(sm).add("team", "platform");
+
+app.synth();

--- a/tests/integration/sfn-express/cdk.json
+++ b/tests/integration/sfn-express/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sfn-express/package.json
+++ b/tests/integration/sfn-express/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sfn-express",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sfn-express false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sfn-express/verify.sh
+++ b/tests/integration/sfn-express/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSfnExpress
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sns-fifo/app.ts
+++ b/tests/integration/sns-fifo/app.ts
@@ -1,0 +1,27 @@
+// CDK app for the cdk-real-drift FIFO SNS topic false-positive test.
+// The existing SNS fixtures cover a standard topic's tags / subscriptions; a FIFO
+// topic exercises a fresh cluster of declared properties at once: FifoTopic=true,
+// ContentBasedDeduplication=true, a server-side-encryption KmsMasterKeyId (an
+// intrinsic ref to a customer key), and the .fifo-suffixed TopicName. A freshly
+// deployed + recorded topic with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsFifo");
+
+const key = new Key(stack, "TopicKey", {
+  enableKeyRotation: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const topic = new Topic(stack, "Events", {
+  fifo: true,
+  contentBasedDeduplication: true,
+  masterKey: key,
+});
+Tags.of(topic).add("team", "platform");
+Tags.of(topic).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/sns-fifo/cdk.json
+++ b/tests/integration/sns-fifo/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-fifo/package.json
+++ b/tests/integration/sns-fifo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sns-fifo",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sns-fifo false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sns-fifo/verify.sh
+++ b/tests/integration/sns-fifo/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsFifo
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

Periodic `/hunt-bugs` round — deployed three previously-untested but high-frequency CDK configs against real AWS and asserted a freshly recorded stack reports CLEAN (no false positive). **No cdkrd bug surfaced this round**; the fixtures are committed as additive regression coverage, matching the existing `s3-rich`/`lambda-rich` FP harnesses.

| fixture | config exercised | check result |
| --- | --- | --- |
| `ddb-rich` | DynamoDB Table: STANDARD_INFREQUENT_ACCESS table class, TTL, stream, PITR, contributor-insights, LSI + 2 GSI | CLEAN (atDefault=1) |
| `sfn-express` | Step Functions **EXPRESS** SM + CloudWatch LoggingConfiguration + X-Ray tracing | CLEAN (atDefault=7, generated=1) |
| `sns-fifo` | SNS **FIFO** Topic + content-based-dedup + KMS SSE (`KmsMasterKeyId` intrinsic) | CLEAN (atDefault=4) |

No `skipped=`/`unresolved=` read-gaps on any of the three.

## Detection (false-negative) half
`ddb-rich/verify-detect.sh` covers a **nested** declared property: disable point-in-time recovery out of band → `check` detects `PointInTimeRecoverySpecification.PointInTimeRecoveryEnabled` drift (exit 1) → `revert` restores it → `check` CLEAN → live PITR re-enabled. **PASS.**

## Test plan
- All three `verify.sh` ran on real AWS (us-east-1): INTEG PASS, CLEAN.
- `ddb-rich/verify-detect.sh`: INTEG PASS (detect + revert).
- Local gates: typecheck / lint+format / build / 1267 unit tests green.
- All stacks deleted + `bughunt-track.sh verify` SWEEP CLEAN before commit.

No `src/**` changes — pure integ-fixture + integ-README coverage.