### PR TITLE
test(integ): add kinesis-rich, secrets-rich, ecr-rich bug-hunt fixtures

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -401,11 +401,15 @@ exit 0); `lambda-rich/verify-detect.sh` adds the false-NEGATIVE half.
 | `ddb-rich`    | DynamoDB Table (SIA table-class, TTL, stream, PITR, contributor-insights, LSI + 2 GSI) | rich DynamoDB knobs default-folded at once; `verify-detect.sh` = nested-property (PITR) detect+revert |
 | `sfn-express` | Step Functions EXPRESS SM (CloudWatch LoggingConfiguration + X-Ray tracing) | EXPRESS logging-destination array + tracing default-folding |
 | `sns-fifo`    | SNS FIFO Topic (content-based-dedup + KMS SSE) | FIFO flags + `KmsMasterKeyId` intrinsic ref on a FIFO topic |
+| `kinesis-rich` | Kinesis Data Stream (PROVISIONED mode, 2 shards, 48h retention, KMS SSE) | `StreamModeDetails` + non-default `RetentionPeriodHours` + `StreamEncryption` key ref default-folding |
+| `secrets-rich` | Secrets Manager Secret (`GenerateSecretString`, customer KMS key, description) | minted `SecretString` is opaque/NoEcho on read (a write-only `readGap`) + `KmsKeyId` intrinsic ref |
+| `ecr-rich` | ECR Repository (scan-on-push, IMMUTABLE tags, KMS encryption, lifecycle policy) | JSON `LifecyclePolicy` re-serialization edge; `verify-detect.sh` = `ImageTagMutability` enum detect+revert |
 
 ```bash
 cd s3-rich && npm install && bash verify.sh   # …and likewise for each fixture above
 cd lambda-rich && npm install && bash verify-detect.sh   # the detect+revert half
 cd ddb-rich && npm install && bash verify-detect.sh   # nested-property (PITR) detect+revert
+cd ecr-rich && npm install && bash verify-detect.sh   # ImageTagMutability enum detect+revert
 ```
 
 Cleanup after any of these is mandatory and gate-enforced. `/hunt-bugs` arms a

--- a/tests/integration/ecr-rich/app.ts
+++ b/tests/integration/ecr-rich/app.ts
@@ -1,0 +1,39 @@
+// CDK app for the cdk-real-drift richly-configured ECR repository false-positive
+// test. ECR repositories are a near-universal companion to any container workload;
+// existing coverage is only incidental (harvest corpus / mutation fixtures), never a
+// deploy-verified FP integ. This one exercises the knobs that each add a
+// normalization edge: ImageScanningConfiguration (ScanOnPush nested boolean),
+// ImageTagMutability (a MUTABLE enum — the FN oracle below toggles it), a
+// LifecyclePolicy (CFn stores it as a STRINGIFIED JSON document — the classic
+// free-form / re-serialization edge), and KMS EncryptionConfiguration (an intrinsic
+// key ref). A freshly deployed + recorded repository with NO out-of-band change MUST
+// report CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import {
+  Repository,
+  RepositoryEncryption,
+  TagMutability,
+} from "aws-cdk-lib/aws-ecr";
+import { Key } from "aws-cdk-lib/aws-kms";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEcrRich");
+
+const key = new Key(stack, "RepoKey", {
+  enableKeyRotation: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const repo = new Repository(stack, "Images", {
+  imageScanOnPush: true,
+  imageTagMutability: TagMutability.IMMUTABLE,
+  encryption: RepositoryEncryption.KMS,
+  encryptionKey: key,
+  emptyOnDelete: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+repo.addLifecycleRule({ maxImageCount: 10, description: "keep last 10 images" });
+Tags.of(repo).add("team", "platform");
+Tags.of(repo).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/ecr-rich/cdk.json
+++ b/tests/integration/ecr-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecr-rich/package.json
+++ b/tests/integration/ecr-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecr-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecr-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecr-rich/verify-detect.sh
+++ b/tests/integration/ecr-rich/verify-detect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ECR detect + revert integration test (real AWS): the "someone changed it in the
+# console" scenario. Deploy -> record -> flip ImageTagMutability IMMUTABLE->MUTABLE
+# out of band (a declared, MUTABLE property) -> check MUST DETECT the declared drift
+# (exit 1) -> revert -> check MUST be CLEAN and the live mutability MUST be back to
+# IMMUTABLE. The tag-mutability flip is near-instant, so this is a fast, reliable
+# detection oracle for a declared top-level enum property.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcrRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+REPO="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::ECR::Repository'].PhysicalResourceId" --output text)"
+[ -n "$REPO" ] || fail "could not resolve repository physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: flip image tag mutability to MUTABLE (console-edit) ==="
+aws ecr put-image-tag-mutability --repository-name "$REPO" --region "$REGION" \
+  --image-tag-mutability MUTABLE >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ecr-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "ImageTagMutability" /tmp/cdkrd-ecr-detect.out || fail "ImageTagMutability drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live mutability MUST be back to IMMUTABLE ==="
+GOT="$(aws ecr describe-repositories --repository-names "$REPO" --region "$REGION" \
+  --query "repositories[0].imageTagMutability" --output text)"
+[ "$GOT" = "IMMUTABLE" ] || fail "live mutability not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/ecr-rich/verify.sh
+++ b/tests/integration/ecr-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcrRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/kinesis-rich/app.ts
+++ b/tests/integration/kinesis-rich/app.ts
@@ -1,0 +1,32 @@
+// CDK app for the cdk-real-drift richly-configured Kinesis Data Stream
+// false-positive test. Kinesis is a common streaming primitive; the existing
+// coverage only exists inside the normalization corpus (harvest fixtures), never as
+// a deploy-verified FP integ. This one piles on the production knobs that each add a
+// normalization edge: a PROVISIONED StreamModeDetails (CDK now defaults to ON_DEMAND,
+// so the explicit mode is a fresh shape), an explicit shard count, a non-default
+// 48-hour retention period (RetentionPeriodHours folds a 24h default), and KMS
+// server-side encryption (a StreamEncryption sub-object with an intrinsic key ref). A
+// freshly deployed + recorded stream with NO out-of-band change MUST report CLEAN.
+import { App, Duration, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { Stream, StreamEncryption, StreamMode } from "aws-cdk-lib/aws-kinesis";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegKinesisRich");
+
+const key = new Key(stack, "StreamKey", {
+  enableKeyRotation: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const stream = new Stream(stack, "Events", {
+  streamMode: StreamMode.PROVISIONED,
+  shardCount: 2,
+  retentionPeriod: Duration.hours(48),
+  encryption: StreamEncryption.KMS,
+  encryptionKey: key,
+});
+Tags.of(stream).add("team", "platform");
+Tags.of(stream).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/kinesis-rich/cdk.json
+++ b/tests/integration/kinesis-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/kinesis-rich/package.json
+++ b/tests/integration/kinesis-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-kinesis-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift kinesis-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/kinesis-rich/verify.sh
+++ b/tests/integration/kinesis-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegKinesisRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/secrets-rich/app.ts
+++ b/tests/integration/secrets-rich/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift richly-configured Secrets Manager secret
+// false-positive test. Secrets are deployed by a large fraction of CDK apps; the
+// existing coverage is only incidental (harvest corpus / readgap), never a
+// deploy-verified FP integ for the production shape. This one exercises the
+// GenerateSecretString block (a structured object CFn uses to MINT the value, whose
+// live SecretString is then opaque/NoEcho — a normalization edge cdkrd must not
+// false-positive on), a customer-managed KmsKeyId (intrinsic ref), and a
+// Description. A freshly deployed + recorded secret with NO out-of-band change MUST
+// report CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSecretsRich");
+
+const key = new Key(stack, "SecretKey", {
+  enableKeyRotation: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const secret = new Secret(stack, "DbCreds", {
+  description: "rich secret fixture for cdk-real-drift",
+  encryptionKey: key,
+  generateSecretString: {
+    secretStringTemplate: JSON.stringify({ username: "admin" }),
+    generateStringKey: "password",
+    excludeCharacters: '"@/\\',
+    passwordLength: 24,
+  },
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+Tags.of(secret).add("team", "platform");
+Tags.of(secret).add("cost-center", "1234");
+
+app.synth();

--- a/tests/integration/secrets-rich/cdk.json
+++ b/tests/integration/secrets-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/secrets-rich/package.json
+++ b/tests/integration/secrets-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-secrets-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift secrets-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/secrets-rich/verify.sh
+++ b/tests/integration/secrets-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSecretsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

A fresh `/hunt-bugs` wave covering three high-frequency, previously deploy-unverified rich-config resource types. All three were deployed to real AWS (us-east-1, acct 531991745243), `record`ed, and `check`ed — **CLEAN with zero false positives**. No `src/` change was needed: this is a clean-result wave (like #246), landing the fixtures as committed regression integs.

| Fixture | Resource | Edge exercised |
| --- | --- | --- |
| `kinesis-rich` | Kinesis Data Stream (PROVISIONED, 2 shards, 48h retention, KMS SSE) | `StreamModeDetails` + non-default `RetentionPeriodHours` + `StreamEncryption` key ref default-folding |
| `secrets-rich` | Secrets Manager Secret (`GenerateSecretString`, customer KMS key) | minted `SecretString` opaque/NoEcho on read (write-only `readGap`) + `KmsKeyId` intrinsic ref |
| `ecr-rich` | ECR Repository (scan-on-push, IMMUTABLE tags, KMS, lifecycle policy) | JSON `LifecyclePolicy` re-serialization edge |

## False-negative (detection) half

`ecr-rich/verify-detect.sh` flips `ImageTagMutability` IMMUTABLE→MUTABLE out of band and asserts the full cycle on real AWS:
- `check` **detects** the declared drift (exit 1, reports `ImageTagMutability`)
- `revert` writes the declared value back
- post-revert `check` is **CLEAN** and the live value is back to `IMMUTABLE`

## Live results
- kinesis-rich: `INTEG PASS` (atDefault=5, no FP)
- secrets-rich: `INTEG PASS` (atDefault=4, readGap=1 write-only, no FP)
- ecr-rich: `INTEG PASS (detect+revert)` — full cycle verified

## Cleanup
All three stacks deleted via `delstack`; `bughunt-track.sh verify` → every tracked stack GONE + `sweep-orphans.sh` SWEEP CLEAN.

## Test plan
- [x] `vp run typecheck`
- [x] `vp check --fix` (lint + format)
- [x] `vp run build`
- [x] `vp run test` (40 files, 1267 tests)
- [x] Live deploy → record → check CLEAN on all three (real AWS)
- [x] ecr-rich detect → revert → re-check CLEAN (real AWS)