### PR TITLE
docs(skill): prioritize FP/FN hunting + add salvage-dedup gotcha to hunt-bugs

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -25,8 +25,13 @@ non-negotiable", which is enforced by a gate, not by trust.
    FunctionUrl/logGroup), VPC (subnets/NAT/routes/endpoints), DynamoDB, IAM, API
    Gateway, ECS/Fargate, RDS, SQS/SNS, CloudFront — over exotic edge cases. A bug
    in a daily pattern is worth ten niche ones.
-2. **The two signals.** A freshly deployed stack with NO out-of-band change is the
-   cleanest oracle:
+2. **The two signals ARE the priority — hunt FP and FN above all else.** False
+   positives (drift reported that isn't real) and false negatives (real drift
+   missed) are the bug classes this hunt exists to find; they are what actually
+   damages a user's trust in the tool. Prioritize provoking and confirming them over
+   incidental findings (a crash, a read-gap `skipped=`, cosmetic output) — those are
+   worth noting, but FP/FN are the target. A freshly deployed stack with NO
+   out-of-band change is the cleanest oracle:
    - **False positive (FP)** — the most user-damaging class. After `record`, a
      `check` MUST be CLEAN. Any `declared`-tier drift on a clean recorded stack
      means cdkrd's declared template value normalizes differently from the live
@@ -168,3 +173,14 @@ Recorded]` breakdown with `--verbose`.
 - **A clean result IS a result.** "6 common+rich stacks, zero FPs, detection+revert
   verified" is a legitimate, valuable outcome. Do NOT manufacture a fix to have
   something to show.
+- **Before salvaging leftover fixtures from an interrupted worktree, check for an
+  already-merged duplicate.** A half-finished prior hunt can leave uncommitted
+  fixtures in a stale worktree, and resuming them is tempting — but a PARALLEL
+  session may have already merged the identical dirs under a differently-ordered PR
+  title (this flow's `ecr-rich`/`kinesis-rich`/`secrets-rich` salvage collided with
+  the already-merged `#248 "kinesis-rich, secrets-rich, ecr-rich"`). Run
+  `gh pr list --state merged --search "<type-name>"` AND
+  `git ls-tree -d --name-only origin/main tests/integration/ | grep <name>` for the
+  fixture names FIRST — before any paid re-deploy — and abort if they already exist.
+  A clean abort (remove the worktree; the AWS side was already swept) beats burning a
+  deploy on a duplicate PR that will only conflict.


### PR DESCRIPTION
## What

Two durable additions to the `/hunt-bugs` skill, both from this session's experience:

1. **Reframe Core principle 2 to state FP/FN are the priority.** False positives (drift reported that isn't real) and false negatives (real drift missed) are the bug classes the hunt exists to find and the ones that actually damage user trust — so prioritize provoking + confirming them over incidental findings (a crash, a read-gap `skipped=`, cosmetic output).
2. **New Gotcha: dedup-check before salvaging leftover fixtures.** A half-finished prior hunt can leave uncommitted fixtures in a stale worktree. Before re-deploying them, `gh pr list --state merged` + `git ls-tree origin/main` for the fixture names — a parallel session may have already merged the identical dirs under a differently-ordered PR title (this session's ecr/kinesis/secrets salvage collided with the already-merged #248). Abort cleanly rather than burn a paid deploy on a duplicate.

## Why

This session resumed an interrupted hunt, re-deployed + verified ecr-rich/kinesis-rich/secrets-rich all CLEAN (zero FP, ECR detect+revert PASS), then found #248 had already merged the identical fixtures. No code bug — pure duplicate. Captured the lesson so the next sweep starts smarter.

## Scope

Docs-only (`.claude/skills/hunt-bugs/SKILL.md`) — no `src/**`. Outside both the `check` and `docs` marker scopes; markers set on a green tree (typecheck/lint/build/1267 tests all pass).