### PR TITLE
test(integ): add efs-rich, athena-rich, glue-rich bug-hunt fixtures

### DIFF
--- a/tests/integration/athena-rich/app.ts
+++ b/tests/integration/athena-rich/app.ts
@@ -1,0 +1,45 @@
+// CDK app for the cdk-real-drift richly-configured Athena work group false-positive
+// test. Athena work groups are a daily driver for every analytics / data team, yet
+// existing coverage is only the harvest snapshot corpus — never a deploy-verified FP
+// integ. This one exercises the knobs that each add a normalization edge:
+// WorkGroupConfiguration nests several sub-objects (ResultConfiguration with an S3
+// OutputLocation + EncryptionConfiguration, EnforceWorkGroupConfiguration /
+// PublishCloudWatchMetricsEnabled booleans, BytesScannedCutoffPerQuery numeric,
+// EngineVersion enum). Description is a top-level MUTABLE scalar — the FN oracle in
+// verify-detect.sh edits it out of band. A freshly deployed + recorded work group
+// with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+import { Bucket, BucketEncryption } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAthenaRich");
+
+const results = new Bucket(stack, "Results", {
+  encryption: BucketEncryption.S3_MANAGED,
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+new CfnWorkGroup(stack, "WorkGroup", {
+  name: "cdkrd-integ-athena-rich",
+  description: "cdkrd athena-rich test work group",
+  recursiveDeleteOption: true,
+  state: "ENABLED",
+  workGroupConfiguration: {
+    enforceWorkGroupConfiguration: true,
+    publishCloudWatchMetricsEnabled: true,
+    bytesScannedCutoffPerQuery: 10_000_000,
+    engineVersion: { selectedEngineVersion: "Athena engine version 3" },
+    resultConfiguration: {
+      outputLocation: results.s3UrlForObject("athena-results/"),
+      encryptionConfiguration: { encryptionOption: "SSE_S3" },
+    },
+  },
+  tags: [
+    { key: "team", value: "platform" },
+    { key: "cost-center", value: "1234" },
+  ],
+});
+
+app.synth();

--- a/tests/integration/athena-rich/cdk.json
+++ b/tests/integration/athena-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/athena-rich/package.json
+++ b/tests/integration/athena-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-athena-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift athena-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/athena-rich/verify-detect.sh
+++ b/tests/integration/athena-rich/verify-detect.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Athena detect + revert integration test (real AWS): the "someone changed it in the
+# console" scenario. Deploy -> record -> edit the work group Description out of band
+# (a declared, MUTABLE top-level scalar) -> check MUST DETECT the declared drift
+# (exit 1) -> revert -> check MUST be CLEAN and the live description MUST be restored.
+# The description edit is instant, so this is a fast, reliable detection oracle for a
+# declared scalar property.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAthenaRich
+REGION="${AWS_REGION:-us-east-1}"
+WG=cdkrd-integ-athena-rich
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: edit work group description (console-edit) ==="
+aws athena update-work-group --work-group "$WG" --region "$REGION" \
+  --description "drifted out of band" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-athena-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "Description" /tmp/cdkrd-athena-detect.out || fail "Description drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live description MUST be restored ==="
+GOT="$(aws athena get-work-group --work-group "$WG" --region "$REGION" \
+  --query "WorkGroup.Description" --output text)"
+[ "$GOT" = "cdkrd athena-rich test work group" ] || fail "live description not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/athena-rich/verify.sh
+++ b/tests/integration/athena-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAthenaRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/efs-rich/app.ts
+++ b/tests/integration/efs-rich/app.ts
@@ -1,0 +1,47 @@
+// CDK app for the cdk-real-drift richly-configured EFS file system false-positive
+// test. EFS is a near-universal companion to Fargate / Lambda / EC2 workloads, yet
+// existing coverage is only the mount-target child enumerator (efs-mounttarget-added)
+// and the harvest snapshot corpus — never a deploy-verified FP integ of the file
+// system resource itself. This one exercises the knobs that each add a normalization
+// edge: a BackupPolicy (a nested {Status} sub-object that AWS stores as a SEPARATE
+// associated resource yet CFn surfaces inline — the FN oracle in verify-detect.sh
+// toggles it), LifecyclePolicies (an ARRAY of single-key objects — the classic
+// array/ordering edge), Encrypted + a KMS key intrinsic ref, PerformanceMode /
+// ThroughputMode enums, and FileSystemProtection (a nested ReplicationOverwrite
+// protection enum). A freshly deployed + recorded file system with NO out-of-band
+// change MUST report CLEAN.
+//
+// Uses the L1 CfnFileSystem directly: a bare file system needs no VPC and no mount
+// targets (those are the efs-mounttarget-added fixture's job), so it deploys in
+// seconds and keeps the test focused on the resource's own property normalization.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnFileSystem } from "aws-cdk-lib/aws-efs";
+import { Key } from "aws-cdk-lib/aws-kms";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEfsRich");
+
+const key = new Key(stack, "FsKey", {
+  enableKeyRotation: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const fs = new CfnFileSystem(stack, "Fs", {
+  encrypted: true,
+  kmsKeyId: key.keyArn,
+  performanceMode: "generalPurpose",
+  throughputMode: "bursting",
+  backupPolicy: { status: "ENABLED" },
+  lifecyclePolicies: [
+    { transitionToIa: "AFTER_30_DAYS" },
+    { transitionToPrimaryStorageClass: "AFTER_1_ACCESS" },
+  ],
+  fileSystemProtection: { replicationOverwriteProtection: "ENABLED" },
+  fileSystemTags: [
+    { key: "team", value: "platform" },
+    { key: "cost-center", value: "1234" },
+  ],
+});
+fs.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/efs-rich/cdk.json
+++ b/tests/integration/efs-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/efs-rich/package.json
+++ b/tests/integration/efs-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-efs-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift efs-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/efs-rich/verify-detect.sh
+++ b/tests/integration/efs-rich/verify-detect.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# EFS detect + revert integration test (real AWS): the "someone changed it in the
+# console" scenario. Deploy -> record -> disable the BackupPolicy out of band
+# (ENABLED -> DISABLED, a declared, MUTABLE property stored by AWS as a separate
+# associated resource) -> check MUST DETECT the declared drift (exit 1) -> revert ->
+# check MUST be CLEAN and the live backup policy MUST be back to ENABLED. The backup
+# policy flip is near-instant, so this is a fast, reliable detection oracle for a
+# declared nested property that AWS materializes out-of-line.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEfsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FS="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::EFS::FileSystem'].PhysicalResourceId" --output text)"
+[ -n "$FS" ] || fail "could not resolve file system physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: disable backup policy (console-edit) ==="
+aws efs put-backup-policy --file-system-id "$FS" --region "$REGION" \
+  --backup-policy Status=DISABLED >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-efs-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "BackupPolicy\|Status" /tmp/cdkrd-efs-detect.out || fail "BackupPolicy drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live backup policy MUST be back to ENABLED ==="
+GOT="$(aws efs describe-backup-policy --file-system-id "$FS" --region "$REGION" \
+  --query "BackupPolicy.Status" --output text)"
+[ "$GOT" = "ENABLED" ] || fail "live backup policy not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/efs-rich/verify.sh
+++ b/tests/integration/efs-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEfsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/glue-rich/app.ts
+++ b/tests/integration/glue-rich/app.ts
@@ -1,0 +1,59 @@
+// CDK app for the cdk-real-drift richly-configured Glue job false-positive test.
+// Glue jobs are a daily driver for every data / ETL team, yet existing coverage is
+// only the harvest snapshot corpus — never a deploy-verified FP integ. The headline
+// hunting ground here is DefaultArguments: a FREE-FORM string->string map (arbitrary
+// user keys like "--enable-metrics", "--job-bookmark-option") — exactly the
+// free-form-map class where cdkrd has historically re-serialized / reordered values
+// and produced false positives. It also exercises Command (nested {Name,
+// ScriptLocation, PythonVersion}), ExecutionProperty (MaxConcurrentRuns), a Role
+// intrinsic ref, GlueVersion / WorkerType / NumberOfWorkers / Timeout / MaxRetries
+// scalars, and Tags. A freshly deployed + recorded job with NO out-of-band change
+// MUST report CLEAN — most importantly the DefaultArguments map must round-trip
+// verbatim.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnJob } from "aws-cdk-lib/aws-glue";
+import { Role, ServicePrincipal, ManagedPolicy } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegGlueRich");
+
+const scripts = new Bucket(stack, "Scripts", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const role = new Role(stack, "GlueRole", {
+  assumedBy: new ServicePrincipal("glue.amazonaws.com"),
+  managedPolicies: [
+    ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSGlueServiceRole"),
+  ],
+});
+
+new CfnJob(stack, "Job", {
+  name: "cdkrd-integ-glue-rich",
+  role: role.roleArn,
+  glueVersion: "4.0",
+  workerType: "G.1X",
+  numberOfWorkers: 2,
+  timeout: 10,
+  maxRetries: 1,
+  description: "cdkrd glue-rich test job",
+  command: {
+    name: "glueetl",
+    pythonVersion: "3",
+    scriptLocation: scripts.s3UrlForObject("scripts/etl.py"),
+  },
+  executionProperty: { maxConcurrentRuns: 1 },
+  // Free-form string->string map with arbitrary user keys: the FP hunting ground.
+  defaultArguments: {
+    "--job-language": "python",
+    "--enable-metrics": "true",
+    "--enable-continuous-cloudwatch-log": "true",
+    "--job-bookmark-option": "job-bookmark-enable",
+    "--TempDir": scripts.s3UrlForObject("tmp/"),
+  },
+  tags: { team: "platform", "cost-center": "1234" },
+});
+
+app.synth();

--- a/tests/integration/glue-rich/cdk.json
+++ b/tests/integration/glue-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/glue-rich/package.json
+++ b/tests/integration/glue-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-glue-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift glue-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/glue-rich/verify.sh
+++ b/tests/integration/glue-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive. The headline assertion is that the
+# free-form DefaultArguments map round-trips verbatim (no re-serialization FP).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGlueRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug-hunt round: EFS / Athena / Glue

Three common, daily-driver AWS resource types that had **no deploy-verified
false-positive integ** (only incidental harvest-corpus coverage). Each new
fixture is a real-AWS deploy → record → check oracle.

| Fixture | Type | clean-FP | detect+revert | Result |
|---|---|---|---|---|
| `efs-rich` | `AWS::EFS::FileSystem` | PASS | PASS (`BackupPolicy.Status` ENABLED→DISABLED) | no bug |
| `athena-rich` | `AWS::Athena::WorkGroup` | PASS | PASS (`Description` scalar) | no bug |
| `glue-rich` | `AWS::Glue::Job` | PASS | — (clean-FP only) | no bug |

### What each exercises
- **efs-rich** — `BackupPolicy` is a nested `{Status}` that AWS materializes as a
  *separate associated resource*, yet Cloud Control reads it back inline and
  reverts it correctly. Also covers `LifecyclePolicies` (array of single-key
  objects), `FileSystemProtection`, `Encrypted` + a KMS key intrinsic ref.
- **athena-rich** — full `WorkGroupConfiguration` (ResultConfiguration + S3
  output + SSE_S3 encryption, enforce/metrics booleans, bytes-scanned cutoff,
  engine version). Detection oracle on the mutable `Description` scalar.
- **glue-rich** — the headline target is the free-form `DefaultArguments`
  string→string map (arbitrary `--enable-metrics` style user keys) — the
  historical re-serialization / reordering FP surface. It round-trips verbatim.

### Outcome
Zero false positives, zero missed detections, **zero bugs** — a clean round.
Fixtures kept as committed regression integs. All stacks deployed to real AWS,
deleted via `delstack`, and `sweep-orphans.sh` reports SWEEP CLEAN (3 expected
`/aws/lambda/*` autoDelete log groups swept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)