### PR TITLE
test(integ): add autoscale, dashboard, cloudtrail, glue-crawler, ecs-taskdef rich bug-hunt fixtures

### DIFF
--- a/tests/integration/autoscale-rich/app.ts
+++ b/tests/integration/autoscale-rich/app.ts
@@ -1,0 +1,29 @@
+// CDK app for the cdk-real-drift Application Auto Scaling false-positive test.
+// DynamoDB read/write auto scaling is one of the most commonly deployed CDK
+// patterns: a PROVISIONED table with target-tracking scaling on both read and
+// write capacity. This emits two AWS::ApplicationAutoScaling::ScalableTarget and
+// two AWS::ApplicationAutoScaling::ScalingPolicy resources, each carrying nested
+// target-tracking config (PredefinedMetricSpecification, cooldowns) whose
+// defaults are exactly the kind cdkrd must fold without raising a false positive.
+// A freshly deployed + recorded stack with NO out-of-band change MUST be CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { AttributeType, BillingMode, Table } from "aws-cdk-lib/aws-dynamodb";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAutoScaleRich");
+
+const table = new Table(stack, "Table", {
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  billingMode: BillingMode.PROVISIONED,
+  readCapacity: 5,
+  writeCapacity: 5,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const readScaling = table.autoScaleReadCapacity({ minCapacity: 5, maxCapacity: 50 });
+readScaling.scaleOnUtilization({ targetUtilizationPercent: 70 });
+
+const writeScaling = table.autoScaleWriteCapacity({ minCapacity: 5, maxCapacity: 50 });
+writeScaling.scaleOnUtilization({ targetUtilizationPercent: 70 });
+
+app.synth();

--- a/tests/integration/autoscale-rich/cdk.json
+++ b/tests/integration/autoscale-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/autoscale-rich/package.json
+++ b/tests/integration/autoscale-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-autoscale-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift autoscale-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/autoscale-rich/verify-detect.sh
+++ b/tests/integration/autoscale-rich/verify-detect.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Application Auto Scaling detect + revert integration test (real AWS): the
+# "someone bumped the scaling ceiling in the console" scenario. Deploy -> record
+# -> change a DECLARED MUTABLE prop (the read ScalableTarget MaxCapacity 50->100)
+# out of band -> check MUST DETECT the declared drift (exit 1) -> revert -> check
+# MUST be CLEAN and the live MaxCapacity MUST be restored to 50.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAutoScaleRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+TABLE="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::DynamoDB::Table'].PhysicalResourceId" --output text)"
+[ -n "$TABLE" ] || fail "could not resolve table physical id"
+RES_ID="table/$TABLE"
+DIM="dynamodb:table:ReadCapacityUnits"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: read MaxCapacity 50->100 (console-edit) ==="
+aws application-autoscaling register-scalable-target --service-namespace dynamodb \
+  --resource-id "$RES_ID" --scalable-dimension "$DIM" \
+  --min-capacity 5 --max-capacity 100 --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-autoscale-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "MaxCapacity" /tmp/cdkrd-autoscale-detect.out || fail "MaxCapacity not reported"
+
+echo "=== revert (write declared values back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live MaxCapacity MUST be restored to 50 ==="
+GOT="$(aws application-autoscaling describe-scalable-targets --service-namespace dynamodb \
+  --resource-ids "$RES_ID" --region "$REGION" \
+  --query "ScalableTargets[?ScalableDimension=='$DIM'].MaxCapacity" --output text)"
+[ "$GOT" = "50" ] || fail "live MaxCapacity not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/autoscale-rich/verify.sh
+++ b/tests/integration/autoscale-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded stack with NO out-of-band change
+# must report no drift; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAutoScaleRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cloudtrail-rich/app.ts
+++ b/tests/integration/cloudtrail-rich/app.ts
@@ -1,0 +1,27 @@
+// CDK app for the cdk-real-drift CloudTrail false-positive test. A CloudTrail
+// trail is a common audit/compliance resource with several boolean/enum knobs
+// (IncludeGlobalServiceEvents, IsMultiRegionTrail, EnableLogFileValidation) plus
+// an auto-managed S3 destination bucket + bucket policy. CloudTrail has never
+// been exercised by a focused fixture. A freshly deployed + recorded trail with
+// NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Trail } from "aws-cdk-lib/aws-cloudtrail";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCloudTrailRich");
+
+const bucket = new Bucket(stack, "TrailBucket", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+new Trail(stack, "Trail", {
+  bucket,
+  trailName: "cdkrd-cloudtrail-rich",
+  includeGlobalServiceEvents: true,
+  isMultiRegionTrail: false,
+  enableFileValidation: true,
+});
+
+app.synth();

--- a/tests/integration/cloudtrail-rich/cdk.json
+++ b/tests/integration/cloudtrail-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudtrail-rich/package.json
+++ b/tests/integration/cloudtrail-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudtrail-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cloudtrail-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudtrail-rich/verify-detect.sh
+++ b/tests/integration/cloudtrail-rich/verify-detect.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# CloudTrail detect + revert integration test (real AWS): the "someone toggled a
+# trail setting in the console" scenario. Deploy -> record -> flip a DECLARED
+# MUTABLE prop (IncludeGlobalServiceEvents true->false) out of band -> check MUST
+# DETECT (exit 1) -> revert -> check MUST be CLEAN and the live value restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCloudTrailRich
+TRAIL=cdkrd-cloudtrail-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: IncludeGlobalServiceEvents true->false (console-edit) ==="
+aws cloudtrail update-trail --name "$TRAIL" --no-include-global-service-events \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cloudtrail-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "IncludeGlobalServiceEvents" /tmp/cdkrd-cloudtrail-detect.out || fail "IncludeGlobalServiceEvents not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live IncludeGlobalServiceEvents MUST be restored to true ==="
+GOT="$(aws cloudtrail get-trail --name "$TRAIL" --region "$REGION" \
+  --query "Trail.IncludeGlobalServiceEvents" --output text)"
+[ "$GOT" = "True" ] || fail "live value not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/cloudtrail-rich/verify.sh
+++ b/tests/integration/cloudtrail-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCloudTrailRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/dashboard-rich/app.ts
+++ b/tests/integration/dashboard-rich/app.ts
@@ -1,0 +1,44 @@
+// CDK app for the cdk-real-drift CloudWatch Dashboard false-positive test.
+// A Dashboard's entire content is a single DashboardBody JSON string in the
+// template; CloudWatch re-serializes and default-fills that JSON server-side
+// (injecting "region", widget "view"/"stacked" defaults, metric stat/period
+// defaults), so a naive string compare of declared-vs-live body is a classic
+// false-positive trap. A freshly deployed + recorded dashboard with NO
+// out-of-band change MUST report CLEAN.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import {
+  Dashboard,
+  GraphWidget,
+  Metric,
+  SingleValueWidget,
+  TextWidget,
+} from "aws-cdk-lib/aws-cloudwatch";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegDashboardRich");
+
+const invocations = new Metric({
+  namespace: "AWS/Lambda",
+  metricName: "Invocations",
+  statistic: "Sum",
+  period: Duration.minutes(5),
+});
+const errors = new Metric({
+  namespace: "AWS/Lambda",
+  metricName: "Errors",
+  statistic: "Sum",
+  period: Duration.minutes(5),
+});
+
+new Dashboard(stack, "Dash", {
+  dashboardName: "cdkrd-dashboard-rich",
+  widgets: [
+    [new TextWidget({ markdown: "# cdkrd dashboard-rich", width: 24, height: 2 })],
+    [
+      new GraphWidget({ title: "Invocations", left: [invocations], width: 12, height: 6 }),
+      new SingleValueWidget({ title: "Errors", metrics: [errors], width: 12, height: 6 }),
+    ],
+  ],
+});
+
+app.synth();

--- a/tests/integration/dashboard-rich/cdk.json
+++ b/tests/integration/dashboard-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dashboard-rich/package.json
+++ b/tests/integration/dashboard-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dashboard-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift dashboard-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dashboard-rich/verify-detect.sh
+++ b/tests/integration/dashboard-rich/verify-detect.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# CloudWatch Dashboard detect + revert integration test (real AWS): the "someone
+# edited a widget in the console" scenario. Deploy -> record -> overwrite the live
+# DashboardBody out of band -> check MUST DETECT the declared drift (exit 1) ->
+# revert -> check MUST be CLEAN and the live body MUST be restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDashboardRich
+DASH=cdkrd-dashboard-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: overwrite DashboardBody (console-edit) ==="
+aws cloudwatch put-dashboard --dashboard-name "$DASH" --region "$REGION" \
+  --dashboard-body '{"widgets":[{"type":"text","x":0,"y":0,"width":24,"height":2,"properties":{"markdown":"# EDITED IN CONSOLE"}}]}' \
+  >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-dashboard-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "DashboardBody" /tmp/cdkrd-dashboard-detect.out || fail "DashboardBody not reported"
+
+echo "=== revert (write declared body back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live body MUST again contain the declared TextWidget markdown ==="
+aws cloudwatch get-dashboard --dashboard-name "$DASH" --region "$REGION" \
+  --query DashboardBody --output text | grep -q "cdkrd dashboard-rich" \
+  || fail "live dashboard body not restored"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/dashboard-rich/verify.sh
+++ b/tests/integration/dashboard-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. The DashboardBody JSON is re-serialized + default-filled by
+# CloudWatch; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDashboardRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ecs-taskdef-rich/app.ts
+++ b/tests/integration/ecs-taskdef-rich/app.ts
@@ -1,0 +1,39 @@
+// CDK app for the cdk-real-drift ECS Fargate TaskDefinition false-positive test.
+// The -added ECS fixtures cover child enumeration, but the TaskDefinition body
+// itself — the most FP-prone ECS surface — was untested. A task definition packs
+// a ContainerDefinitions JSON array that ECS heavily default-fills server-side
+// (cpu/memory shares, mountPoints/volumesFrom empty arrays, logConfiguration
+// option keys), plus task-level Cpu/Memory/NetworkMode/RequiresCompatibilities.
+// No VPC or running service is needed, so it deploys near-instantly. A freshly
+// deployed + recorded task definition with NO out-of-band change MUST be CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { ContainerImage, FargateTaskDefinition, LogDrivers } from "aws-cdk-lib/aws-ecs";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEcsTaskDefRich");
+
+const logGroup = new LogGroup(stack, "Logs", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const taskDef = new FargateTaskDefinition(stack, "TaskDef", {
+  family: "cdkrd-ecs-taskdef-rich",
+  cpu: 256,
+  memoryLimitMiB: 512,
+});
+
+taskDef.addContainer("app", {
+  image: ContainerImage.fromRegistry("public.ecr.aws/nginx/nginx:latest"),
+  memoryReservationMiB: 256,
+  essential: true,
+  environment: {
+    STAGE: "test",
+    FEATURE_FLAG: "on",
+  },
+  portMappings: [{ containerPort: 80 }],
+  logging: LogDrivers.awsLogs({ streamPrefix: "app", logGroup }),
+});
+
+app.synth();

--- a/tests/integration/ecs-taskdef-rich/cdk.json
+++ b/tests/integration/ecs-taskdef-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecs-taskdef-rich/package.json
+++ b/tests/integration/ecs-taskdef-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecs-taskdef-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecs-taskdef-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecs-taskdef-rich/verify.sh
+++ b/tests/integration/ecs-taskdef-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsTaskDefRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/glue-crawler-rich/app.ts
+++ b/tests/integration/glue-crawler-rich/app.ts
@@ -1,0 +1,45 @@
+// CDK app for the cdk-real-drift Glue Crawler test. The existing glue-rich
+// fixture covers clean-FP only; an AWS::Glue::Crawler adds a detection (FN)
+// oracle the Glue Job cannot, because UpdateCrawler supports partial in-place
+// updates of mutable scalars (e.g. TablePrefix) — unlike UpdateJob's full
+// replace. This fixture provides both: a clean-FP check (verify.sh) over the
+// crawler's nested config (SchemaChangePolicy, S3 targets) and a detect+revert
+// check (verify-detect.sh) over TablePrefix.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnCrawler, CfnDatabase } from "aws-cdk-lib/aws-glue";
+import { ManagedPolicy, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegGlueCrawlerRich");
+
+const dataBucket = new Bucket(stack, "Data", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const db = new CfnDatabase(stack, "Db", {
+  catalogId: stack.account,
+  databaseInput: { name: "cdkrd_crawler_db" },
+});
+
+const role = new Role(stack, "CrawlerRole", {
+  assumedBy: new ServicePrincipal("glue.amazonaws.com"),
+  managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSGlueServiceRole")],
+});
+dataBucket.grantRead(role);
+
+const crawler = new CfnCrawler(stack, "Crawler", {
+  name: "cdkrd-crawler-rich",
+  role: role.roleArn,
+  databaseName: "cdkrd_crawler_db",
+  targets: { s3Targets: [{ path: `s3://${dataBucket.bucketName}/data/` }] },
+  schemaChangePolicy: {
+    updateBehavior: "UPDATE_IN_DATABASE",
+    deleteBehavior: "DEPRECATE_IN_DATABASE",
+  },
+  tablePrefix: "cdkrd_",
+});
+crawler.addDependency(db);
+
+app.synth();

--- a/tests/integration/glue-crawler-rich/cdk.json
+++ b/tests/integration/glue-crawler-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/glue-crawler-rich/package.json
+++ b/tests/integration/glue-crawler-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-glue-crawler-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift glue-crawler-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/glue-crawler-rich/verify-detect.sh
+++ b/tests/integration/glue-crawler-rich/verify-detect.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Glue Crawler detect + revert integration test (real AWS): the "someone changed
+# the crawler config in the console" scenario. Deploy -> record -> change a
+# DECLARED MUTABLE scalar (TablePrefix) out of band via update-crawler (a partial
+# in-place update) -> check MUST DETECT (exit 1) -> revert -> check MUST be CLEAN
+# and the live value restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGlueCrawlerRich
+CRAWLER=cdkrd-crawler-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: TablePrefix cdkrd_ -> edited_ (console-edit) ==="
+aws glue update-crawler --name "$CRAWLER" --table-prefix "edited_" \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-glue-crawler-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "TablePrefix" /tmp/cdkrd-glue-crawler-detect.out || fail "TablePrefix not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live TablePrefix MUST be restored to cdkrd_ ==="
+GOT="$(aws glue get-crawler --name "$CRAWLER" --region "$REGION" \
+  --query "Crawler.TablePrefix" --output text)"
+[ "$GOT" = "cdkrd_" ] || fail "live TablePrefix not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/glue-crawler-rich/verify.sh
+++ b/tests/integration/glue-crawler-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGlueCrawlerRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

A /hunt-bugs round over five common-but-untested AWS resource types. **Clean result: zero false positives across all five, detection+revert verified on all four mutable types** — no cdkrd bug surfaced, so this PR lands the fixtures as committed regression integs.

| Fixture | Type(s) | FP (verify.sh) | FN detect+revert (verify-detect.sh) |
|---|---|---|---|
| autoscale-rich | DynamoDB Application Auto Scaling (ScalableTarget + ScalingPolicy) | CLEAN | read MaxCapacity 50→100 → detect → revert → 50 ✅ |
| dashboard-rich | CloudWatch Dashboard (DashboardBody JSON) | CLEAN | body overwrite → detect → revert → restored ✅ |
| cloudtrail-rich | CloudTrail Trail + S3 bucket | CLEAN (autoDelete CR skipped) | IncludeGlobalServiceEvents true→false → detect → revert → true ✅ |
| glue-crawler-rich | Glue Crawler (partial UpdateCrawler) | CLEAN (autoDelete CR skipped) | TablePrefix → detect → revert → restored ✅ |
| ecs-taskdef-rich | Fargate TaskDefinition container body | CLEAN (atDefault=9 folded) | n/a (immutable, FP-only) |

## Why these

Daily-deployed types with no focused `*-rich` fixture yet. Notable non-FPs proven on real AWS:
- **DashboardBody** JSON (re-serialized + default-filled by CloudWatch) normalized clean — the highest FP risk here.
- **ECS** ContainerDefinitions default-fill folded (9 atDefault) without FP.
- **glue-crawler** adds the FN/detection oracle the existing `glue-rich` (Job, full-replace update) couldn't provide, via partial `UpdateCrawler`.

## Verification

Real AWS (us-east-1). All stacks deployed, FP+FN checked, deleted via `delstack`, and `sweep-orphans.sh` reports SWEEP CLEAN (the autoDeleteObjects Lambda log groups were swept).

Local gates: typecheck / lint+format / build / 1267 unit tests all pass.

> ElastiCache ReplicationGroup is deferred to a dedicated round (VPC-dependent, slow deploy/teardown — better isolated).