### PR TITLE
fix(revert): never re-include a write-only prop that is also create-only

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -92,7 +92,44 @@ For at least one common type, mutate a declared MUTABLE property out of band and
 assert `check` detects → `revert` → `check` CLEAN → live value restored
 (`lambda-rich/verify-detect.sh` is the reference).
 
-### 5. On a confirmed bug: fix it — with a unit test (mandatory)
+### 5. Harvest the live read into the golden corpus (EVERY round — bug or not)
+
+This is the asset a hunt leaves behind even when it finds no bug. Every live read
+you just paid for is a real `normalize`→`classify` pipeline input; capturing it as
+a golden-corpus case turns this one-time deploy into a permanent **offline**
+regression that runs in plain `vp run test` (no AWS) forever — `tests/corpus/*.json`
+is replayed by `tests/corpus-replay.test.ts`, which re-runs `classifyResource` on
+the recorded inputs and asserts the findings reproduce exactly (R63). A future
+normalization change that would silently re-introduce an FP/FN on this resource
+then fails a unit test instead of waiting for the next paid hunt.
+
+So while a tracked stack is still deployed, record the corpus by setting
+`CDKRD_CORPUS_DIR` on a `check` (it writes one sanitized case per readable
+resource — account ids are stripped at record time):
+
+```bash
+CDKRD_CORPUS_DIR=/tmp/corpus-<name> node "$ROOT/dist/cli.js" check "$STACK" --region "$REGION"
+```
+
+Record on the FRESH deploy BEFORE `record` (no baseline) so the case captures the
+full classification — the `atDefault`/undeclared folding, not a baseline-snapshotted
+clean. Then promote the cases that add coverage into `tests/corpus/`:
+
+- Each file is named `AWS__<Service>__<Type>.<LogicalId>.json`. Copy in the cases
+  for types **not already present** — `ls tests/corpus/ | grep <Type>` first.
+  Genuinely-new resource types are the win; skip near-duplicates of types already
+  covered (VPC/subnet/route-table boilerplate a fixture drags along is usually
+  already represented — don't flood the corpus with it).
+- Run `vp run test` and confirm the new `corpus-replay` cases pass. Commit the new
+  corpus JSONs in the SAME PR as the fixture (and the fix, if any). An intended
+  behavior change updates a case's `expected` in the same diff, making the semantic
+  change reviewable.
+
+The `*-rich` fixtures are exactly the rich configs worth pinning this way, so a
+clean round still ships growing regression coverage — see the "A clean result IS a
+result" gotcha.
+
+### 6. On a confirmed bug: fix it — with a unit test (mandatory)
 
 When a finding is a real bug:
 
@@ -109,12 +146,12 @@ When a finding is a real bug:
 5. **Keep the fixture** as a committed regression integ under
    `tests/integration/<name>/`, in the SAME PR as the fix — never defer the integ.
 
-### 6. Cleanup — non-negotiable (see below), then ship
+### 7. Cleanup — non-negotiable (see below), then ship
 
 Delete every tracked stack, run `bughunt-track.sh verify`, then `clear`. Then
 `/check` + `/check-docs` markers → commit → push → `/verify-pr` → `gh pr create`.
 
-### 7. Merge + remove the worktree
+### 8. Merge + remove the worktree
 
 Take it all the way to merged — do not leave a green PR hanging:
 
@@ -127,7 +164,7 @@ Take it all the way to merged — do not leave a green PR hanging:
    and `git worktree prune`. Confirm with `git worktree list` — only the main
    checkout should remain. (Mirror of CLAUDE.md's integrate-then-remove rule.)
 
-### 8. Record what you learned
+### 9. Record what you learned
 
 Save a memory for any recurring surprise (a whole _class_ of latent bug, a
 verification gotcha) so the next sweep starts smarter.
@@ -170,9 +207,12 @@ Recorded]` breakdown with `--verbose`.
   `|| fail`), or guard with `set +e`.
 - **Always `npm install` + `cdk synth` before deploy** — a synth-time TS error is
   free to catch; a half-failed deploy is not.
-- **A clean result IS a result.** "6 common+rich stacks, zero FPs, detection+revert
-  verified" is a legitimate, valuable outcome. Do NOT manufacture a fix to have
-  something to show.
+- **A clean result IS a result — but it must still leave an asset.** "6 common+rich
+  stacks, zero FPs, detection+revert verified" is a legitimate, valuable outcome. Do
+  NOT manufacture a fix to have something to show. The deliverable of a bug-free
+  round is the committed `*-rich` fixtures PLUS the golden-corpus cases harvested
+  from their live reads (step 5) — that is how a clean round still grows permanent
+  offline regression coverage instead of evaporating when the stacks are torn down.
 - **Before salvaging leftover fixtures from an interrupted worktree, check for an
   already-merged duplicate.** A half-finished prior hunt can leave uncommitted
   fixtures in a stale worktree, and resuming them is tempting — but a PARALLEL

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -413,6 +413,17 @@ export function writeOnlyReincludeOps(
   // present in the declared model from its template intent.
   for (const path of schema.writeOnlyPaths) {
     if (path.includes('*')) continue; // a wildcard (array-element) write-only — no single value to re-include
+    // A property that is write-only AND create-only must NEVER enter an update patch:
+    // Cloud Control hard-rejects any op on a create-only path ("createOnlyProperties
+    // [...] cannot be updated"), failing the WHOLE revert at apply time — even though
+    // the op only re-includes the property to satisfy the read-modify-write contract.
+    // Omitting it is also safe: a create-only property is fixed at creation, so the
+    // provider's update handler preserves it regardless of whether the patch carries it
+    // (unlike a mutable write-only prop, it cannot silently vanish). Live-proven by an
+    // AWS::ElastiCache::ReplicationGroup revert: CacheSubnetGroupName is both write-only
+    // and create-only, so re-including it made every revert fail "createOnlyProperties
+    // [/properties/CacheSubnetGroupName] cannot be updated".
+    if (isUnderCreateOnly(path, schema.createOnlyPaths)) continue;
     const value = valueAtDottedPath(declared, path);
     if (value === undefined || value === UNRESOLVED || hasUnresolved(value)) continue;
     const pointer = toPointer(path);

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
@@ -1,0 +1,265 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ReplicationGroup",
+    "resourceType": "AWS::ElastiCache::ReplicationGroup",
+    "physicalId": "cdkrd-ec-rich",
+    "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup",
+    "declared": {
+      "AtRestEncryptionEnabled": true,
+      "AutomaticFailoverEnabled": false,
+      "CacheNodeType": "cache.t3.micro",
+      "CacheSubnetGroupName": "cdkrd-elasticache-rich",
+      "Engine": "redis",
+      "NumCacheClusters": 1,
+      "Port": 6379,
+      "ReplicationGroupDescription": "cdkrd elasticache rich",
+      "ReplicationGroupId": "cdkrd-ec-rich",
+      "SecurityGroupIds": ["sg-0803d3c52fa6a8bce"],
+      "SnapshotRetentionLimit": 1,
+      "TransitEncryptionEnabled": true
+    }
+  },
+  "liveRaw": {
+    "ReadEndPoint": {
+      "Addresses": "[cdkrd-ec-rich-001.cdkrd-ec-rich.jzgy0l.use1.cache.amazonaws.com]",
+      "PortsList": ["6379"],
+      "AddressesList": ["cdkrd-ec-rich-001.cdkrd-ec-rich.jzgy0l.use1.cache.amazonaws.com"],
+      "Ports": "[6379]"
+    },
+    "ClusterMode": "disabled",
+    "Port": 6379,
+    "ReaderEndPoint": {
+      "Address": "replica.cdkrd-ec-rich.jzgy0l.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "AutomaticFailoverEnabled": false,
+    "ReplicasPerNodeGroup": 0,
+    "ReplicationGroupDescription": "cdkrd elasticache rich",
+    "MultiAZEnabled": false,
+    "TransitEncryptionEnabled": true,
+    "NetworkType": "ipv4",
+    "ReplicationGroupId": "cdkrd-ec-rich",
+    "Engine": "redis",
+    "Tags": [],
+    "NumCacheClusters": 1,
+    "ConfigurationEndPoint": {},
+    "AtRestEncryptionEnabled": true,
+    "AutoMinorVersionUpgrade": true,
+    "SnapshotWindow": "05:00-06:00",
+    "TransitEncryptionMode": "required",
+    "CacheNodeType": "cache.t3.micro",
+    "SnapshotRetentionLimit": 1,
+    "UserGroupIds": [],
+    "SnapshottingClusterId": "cdkrd-ec-rich-001",
+    "IpDiscovery": "ipv4",
+    "DataTieringEnabled": false,
+    "LogDeliveryConfigurations": [],
+    "PrimaryEndPoint": {
+      "Address": "master.cdkrd-ec-rich.jzgy0l.use1.cache.amazonaws.com",
+      "Port": "6379"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "ConfigurationEndPoint",
+      "EffectiveDurability",
+      "PrimaryEndPoint",
+      "ReadEndPoint",
+      "ReaderEndPoint"
+    ],
+    "writeOnly": [
+      "AuthToken",
+      "CacheParameterGroupName",
+      "CacheSecurityGroupNames",
+      "CacheSubnetGroupName",
+      "EngineVersion",
+      "KmsKeyId",
+      "NodeGroupConfiguration",
+      "NotificationTopicArn",
+      "NumNodeGroups",
+      "PreferredCacheClusterAZs",
+      "PreferredMaintenanceWindow",
+      "PrimaryClusterId",
+      "SecurityGroupIds",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnly": [
+      "AtRestEncryptionEnabled",
+      "AuthToken",
+      "CacheSubnetGroupName",
+      "DataTieringEnabled",
+      "GlobalReplicationGroupId",
+      "KmsKeyId",
+      "NetworkType",
+      "NodeGroupConfiguration",
+      "Port",
+      "PreferredCacheClusterAZs",
+      "ReplicationGroupId",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "readOnlyPaths": [
+      "ConfigurationEndPoint",
+      "ConfigurationEndPoint.Address",
+      "ConfigurationEndPoint.Port",
+      "EffectiveDurability",
+      "PrimaryEndPoint",
+      "PrimaryEndPoint.Address",
+      "PrimaryEndPoint.Port",
+      "ReadEndPoint",
+      "ReadEndPoint.Addresses",
+      "ReadEndPoint.AddressesList",
+      "ReadEndPoint.Ports",
+      "ReadEndPoint.PortsList",
+      "ReaderEndPoint",
+      "ReaderEndPoint.Address",
+      "ReaderEndPoint.Port"
+    ],
+    "writeOnlyPaths": [
+      "AuthToken",
+      "CacheParameterGroupName",
+      "CacheSecurityGroupNames",
+      "CacheSubnetGroupName",
+      "EngineVersion",
+      "KmsKeyId",
+      "NodeGroupConfiguration",
+      "NotificationTopicArn",
+      "NumNodeGroups",
+      "PreferredCacheClusterAZs",
+      "PreferredMaintenanceWindow",
+      "PrimaryClusterId",
+      "SecurityGroupIds",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "AtRestEncryptionEnabled",
+      "AuthToken",
+      "CacheSubnetGroupName",
+      "DataTieringEnabled",
+      "GlobalReplicationGroupId",
+      "KmsKeyId",
+      "NetworkType",
+      "NodeGroupConfiguration",
+      "Port",
+      "PreferredCacheClusterAZs",
+      "ReplicationGroupId",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "defaults": {
+      "NumNodeGroups": 1,
+      "AutomaticFailoverEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "SnapshotRetentionLimit": 0
+    },
+    "defaultPaths": {
+      "NumNodeGroups": 1,
+      "AutomaticFailoverEnabled": false,
+      "TransitEncryptionEnabled": false,
+      "AtRestEncryptionEnabled": false,
+      "SnapshotRetentionLimit": 0
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "CacheSubnetGroupName",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SecurityGroupIds",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "ClusterMode",
+      "actual": "disabled",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "ReplicasPerNodeGroup",
+      "actual": 0,
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SnapshotWindow",
+      "actual": "05:00-06:00",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "TransitEncryptionMode",
+      "actual": "required",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "SnapshottingClusterId",
+      "actual": "cdkrd-ec-rich-001",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ReplicationGroup",
+      "resourceType": "AWS::ElastiCache::ReplicationGroup",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-ec-rich",
+      "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
+    }
+  ]
+}

--- a/tests/integration/elasticache-rich/app.ts
+++ b/tests/integration/elasticache-rich/app.ts
@@ -1,0 +1,51 @@
+// CDK app for the cdk-real-drift ElastiCache Redis ReplicationGroup test.
+// ElastiCache is a common managed-cache choice and a "slow stateful" resource:
+// the ReplicationGroup carries many server-default-filled knobs (Port,
+// SnapshotRetentionLimit, AutoMinorVersionUpgrade, SnapshotWindow,
+// PreferredMaintenanceWindow, encryption flags) plus a VPC + cache subnet group
+// + security group. It is deliberately run as its own round (VPC-dependent,
+// multi-minute deploy/teardown). A freshly deployed + recorded replication group
+// with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnReplicationGroup, CfnSubnetGroup } from "aws-cdk-lib/aws-elasticache";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElastiCacheRich");
+
+// No NAT, isolated subnets only — ElastiCache needs no internet egress, and this
+// keeps the deploy fast and cheap.
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [
+    { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+  ],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc, allowAllOutbound: true });
+
+const subnetGroup = new CfnSubnetGroup(stack, "SubnetGroup", {
+  description: "cdkrd elasticache subnet group",
+  subnetIds: vpc.selectSubnets({ subnetType: SubnetType.PRIVATE_ISOLATED }).subnetIds,
+  cacheSubnetGroupName: "cdkrd-elasticache-rich",
+});
+
+const rg = new CfnReplicationGroup(stack, "ReplicationGroup", {
+  replicationGroupId: "cdkrd-ec-rich",
+  replicationGroupDescription: "cdkrd elasticache rich",
+  engine: "redis",
+  cacheNodeType: "cache.t3.micro",
+  numCacheClusters: 1,
+  automaticFailoverEnabled: false,
+  cacheSubnetGroupName: "cdkrd-elasticache-rich",
+  securityGroupIds: [sg.securityGroupId],
+  atRestEncryptionEnabled: true,
+  transitEncryptionEnabled: true,
+  snapshotRetentionLimit: 1,
+  port: 6379,
+});
+rg.addDependency(subnetGroup);
+rg.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/elasticache-rich/cdk.json
+++ b/tests/integration/elasticache-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elasticache-rich/package.json
+++ b/tests/integration/elasticache-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elasticache-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elasticache-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elasticache-rich/verify-detect.sh
+++ b/tests/integration/elasticache-rich/verify-detect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ElastiCache detect + revert integration test (real AWS): the "someone changed a
+# cache setting in the console" scenario. Deploy -> record -> change a DECLARED
+# MUTABLE scalar (SnapshotRetentionLimit 1->5) out of band via
+# modify-replication-group -> check MUST DETECT (exit 1) -> revert -> check MUST
+# be CLEAN and the live value restored to 1. Slow: each modify settles via the
+# replication-group-available waiter.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElastiCacheRich
+RG=cdkrd-ec-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: SnapshotRetentionLimit 1->5 (console-edit) ==="
+aws elasticache modify-replication-group --replication-group-id "$RG" \
+  --snapshot-retention-limit 5 --apply-immediately --region "$REGION" >/dev/null \
+  || fail "inject drift"
+aws elasticache wait replication-group-available --replication-group-id "$RG" --region "$REGION"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-elasticache-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "SnapshotRetentionLimit" /tmp/cdkrd-elasticache-detect.out || fail "SnapshotRetentionLimit not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+aws elasticache wait replication-group-available --replication-group-id "$RG" --region "$REGION"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live SnapshotRetentionLimit MUST be restored to 1 ==="
+GOT="$(aws elasticache describe-replication-groups --replication-group-id "$RG" \
+  --region "$REGION" --query "ReplicationGroups[0].SnapshotRetentionLimit" --output text)"
+[ "$GOT" = "1" ] || fail "live SnapshotRetentionLimit not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/elasticache-rich/verify.sh
+++ b/tests/integration/elasticache-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ElastiCache server-default-fills many ReplicationGroup knobs;
+# any drift here is a normalization / default-folding FP. Slow: VPC + Redis
+# replication group, multi-minute deploy/teardown.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElastiCacheRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -771,6 +771,42 @@ describe('writeOnlyReincludeOps (Cloud Control read-modify-write contract, cdkd 
     expect(writeOnlyReincludeOps(declared, undefined, [])).toEqual([]);
   });
 
+  it('does NOT re-include a write-only prop that is ALSO create-only (ElastiCache CacheSubnetGroupName) — CC rejects an op on a create-only path', () => {
+    // AWS::ElastiCache::ReplicationGroup: CacheSubnetGroupName is in BOTH writeOnlyPaths
+    // and createOnlyPaths. Re-including it to satisfy the read-modify-write contract made
+    // every revert fail at apply time ("createOnlyProperties [/properties/
+    // CacheSubnetGroupName] cannot be updated"), e.g. reverting an out-of-band
+    // SnapshotRetentionLimit change. The create-only prop must be omitted from the patch.
+    const ecSchema: SchemaInfo = {
+      readOnly: new Set<string>(),
+      writeOnly: new Set(['CacheSubnetGroupName', 'PreferredMaintenanceWindow']),
+      createOnly: new Set(['CacheSubnetGroupName']),
+      readOnlyPaths: [],
+      writeOnlyPaths: ['CacheSubnetGroupName', 'PreferredMaintenanceWindow'],
+      createOnlyPaths: ['CacheSubnetGroupName'],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const ecDeclared = {
+      SnapshotRetentionLimit: 1,
+      CacheSubnetGroupName: 'cdkrd-elasticache-rich',
+      PreferredMaintenanceWindow: 'sun:05:00-sun:06:00',
+    };
+    const ops = writeOnlyReincludeOps(ecDeclared, ecSchema, [
+      { op: 'add', path: '/SnapshotRetentionLimit', value: 1, human: '' },
+    ]);
+    // The mutable write-only prop is still re-included; the create-only one is not.
+    expect(ops).toEqual([
+      {
+        op: 'add',
+        path: '/PreferredMaintenanceWindow',
+        value: 'sun:05:00-sun:06:00',
+        human:
+          'PreferredMaintenanceWindow -> re-include write-only (Cloud Control read-modify-write contract)',
+      },
+    ]);
+  });
+
   it('re-includes a NESTED write-only prop (IAM User LoginProfile.Password) — no credential reset (WAVE24)', () => {
     // AWS::IAM::User has only the NESTED write-only path LoginProfile.Password; the
     // top-level write-only set is EMPTY, so the old top-level-only loop re-included


### PR DESCRIPTION
## Summary

A /hunt-bugs round on ElastiCache (deferred slow round) surfaced a **real revert bug** affecting any common stateful type whose schema marks a property as both write-only and create-only.

cc-kind reverts re-include top-level **write-only** properties into the Cloud Control `UpdateResource` patch so they survive CC's read-modify-write contract (cdkd #812). But a property that is write-only **and** create-only must never enter an update patch — Cloud Control hard-rejects any op on a create-only path, failing the **whole** revert at apply time, even though the op only re-includes the property to preserve it.

**Live repro** (`elasticache-rich`): reverting an out-of-band `SnapshotRetentionLimit` change on a Redis `ReplicationGroup` failed with:
```
FAILED: ... Invalid patch update: createOnlyProperties [/properties/CacheSubnetGroupName] cannot be updated
... 1 drift(s) remain.
```
`CacheSubnetGroupName` (also `AuthToken`, `KmsKeyId`, `NodeGroupConfiguration`, `PreferredCacheClusterAZs`, `SnapshotArns/Name`) is in **both** `writeOnlyPaths` and `createOnlyPaths`.

## Fix

In `writeOnlyReincludeOps` (`src/revert/plan.ts`), skip any write-only path that is also under a create-only path (`isUnderCreateOnly`). Omitting it is safe: a create-only property is fixed at creation, so the provider preserves it regardless of whether the patch carries it (unlike a mutable write-only prop, it cannot silently vanish).

This does **not** change the existing "create-only drift is not revertable" behavior (separate guard) or any README claim — it only stops a create-only *sibling* from breaking an unrelated mutable revert.

## Verification (real AWS, us-east-1)

- **Before fix**: revert FAILED, 1 drift remained.
- **After fix (live re-deploy + re-run)**: FP CLEAN → detect `SnapshotRetentionLimit` → **reverted** → CLEAN after revert → live value restored → **ALL PASS**.
- Unit test pins it (fails without the fix, passes with it). Full suite: **1269** tests green.

## Also in this PR

- **test(integ)**: `elasticache-rich` fixture (FP clean + detect/revert) as committed regression coverage.
- **test(corpus)**: golden case for `AWS::ElastiCache::ReplicationGroup` (a previously-uncovered type) — replayed offline by `corpus-replay.test.ts`.
- **docs(skill)**: add a corpus-harvest step to `/hunt-bugs` so every round (bug or not) grows the offline regression corpus from the live read it already paid for.

Stacks deleted via `delstack`; `sweep-orphans.sh` reports SWEEP CLEAN.