### PR TITLE
test(integ): add logs-rich, wafv2-rich, backup-rich bug-hunt fixtures + corpus

### DIFF
--- a/tests/corpus/AWS__Logs__LogGroup.Lg419948D3.json
+++ b/tests/corpus/AWS__Logs__LogGroup.Lg419948D3.json
@@ -1,0 +1,110 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Lg419948D3",
+    "resourceType": "AWS::Logs::LogGroup",
+    "physicalId": "/cdkrd/logs-rich",
+    "constructPath": "CdkRealDriftIntegLogsRich/Lg",
+    "declared": {
+      "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/59007e9c-d875-4b2c-9f21-42516746acba",
+      "LogGroupName": "/cdkrd/logs-rich",
+      "RetentionInDays": 14,
+      "Tags": [
+        {
+          "Key": "app",
+          "Value": "cdkrd"
+        },
+        {
+          "Key": "env",
+          "Value": "test"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "FieldIndexPolicies": [],
+    "RetentionInDays": 14,
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/59007e9c-d875-4b2c-9f21-42516746acba",
+    "BearerTokenAuthenticationEnabled": false,
+    "LogGroupClass": "STANDARD",
+    "LogGroupName": "/cdkrd/logs-rich",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:log-group:/cdkrd/logs-rich:*",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "cdkrd",
+        "Key": "app"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLogsRich/cda3e030-6cdc-11f1-889e-123f20f98773",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "test",
+        "Key": "env"
+      },
+      {
+        "Value": "CdkRealDriftIntegLogsRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Lg419948D3",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "DataProtectionPolicy": {}
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName"],
+    "defaults": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    },
+    "defaultPaths": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Lg419948D3",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "BearerTokenAuthenticationEnabled",
+      "actual": false,
+      "physicalId": "/cdkrd/logs-rich",
+      "constructPath": "CdkRealDriftIntegLogsRich/Lg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Lg419948D3",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
+      "physicalId": "/cdkrd/logs-rich",
+      "constructPath": "CdkRealDriftIntegLogsRich/Lg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Lg419948D3",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "/cdkrd/logs-rich",
+      "constructPath": "CdkRealDriftIntegLogsRich/Lg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl.json
@@ -1,0 +1,176 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebAcl",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "cdkrd-wafv2-rich|2f1b4ddc-0149-4ee8-83a9-b3ca27f51a05|REGIONAL",
+    "constructPath": "CdkRealDriftIntegWafv2Rich/WebAcl",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Name": "cdkrd-wafv2-rich",
+      "Rules": [
+        {
+          "Name": "AWSCommon",
+          "OverrideAction": {
+            "None": {}
+          },
+          "Priority": 1,
+          "Statement": {
+            "ManagedRuleGroupStatement": {
+              "Name": "AWSManagedRulesCommonRuleSet",
+              "VendorName": "AWS"
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "AWSCommon",
+            "SampledRequestsEnabled": true
+          }
+        },
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "RateLimit",
+          "Priority": 2,
+          "Statement": {
+            "RateBasedStatement": {
+              "AggregateKeyType": "IP",
+              "Limit": 2000
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "RateLimit",
+            "SampledRequestsEnabled": true
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "cdkrdWebAcl",
+        "SampledRequestsEnabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "REGIONAL",
+    "Capacity": 702,
+    "Id": "2f1b4ddc-0149-4ee8-83a9-b3ca27f51a05",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-wafv2-rich/2f1b4ddc-0149-4ee8-83a9-b3ca27f51a05",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [
+      {
+        "Priority": 1,
+        "Statement": {
+          "ManagedRuleGroupStatement": {
+            "VendorName": "AWS",
+            "RuleActionOverrides": [],
+            "ManagedRuleGroupConfigs": [],
+            "ExcludedRules": [],
+            "Name": "AWSManagedRulesCommonRuleSet"
+          }
+        },
+        "OverrideAction": {
+          "None": {}
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "AWSCommon",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "AWSCommon"
+      },
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 2,
+        "Statement": {
+          "RateBasedStatement": {
+            "AggregateKeyType": "IP",
+            "Limit": 2000,
+            "EvaluationWindowSec": 300
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "RateLimit",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "RateLimit"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdWebAcl",
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:cdkrd-wafv2-rich:",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegWafv2Rich/d26c8bd0-6cdc-11f1-9613-0e4a7d53ffdb",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegWafv2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WebAcl",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-wafv2-rich"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "cdkrd-wafv2-rich|2f1b4ddc-0149-4ee8-83a9-b3ca27f51a05|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2Rich/WebAcl"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "Rules[RateLimit].Statement.RateBasedStatement.EvaluationWindowSec",
+      "actual": 300,
+      "nested": true,
+      "physicalId": "cdkrd-wafv2-rich|2f1b4ddc-0149-4ee8-83a9-b3ca27f51a05|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2Rich/WebAcl"
+    }
+  ]
+}

--- a/tests/integration/backup-rich/app.ts
+++ b/tests/integration/backup-rich/app.ts
@@ -1,0 +1,34 @@
+// CDK app for the cdk-real-drift AWS Backup false-positive test. A backup vault +
+// plan is the standard compliance/DR pattern. It exercises a BackupVault and a
+// BackupPlan whose nested BackupRules carry schedule expressions and a Lifecycle
+// (MoveToColdStorageAfterDays / DeleteAfterDays) — nested numeric/string config
+// AWS default-fills and re-serializes server-side. A freshly deployed + recorded
+// vault + plan with NO out-of-band change MUST report CLEAN.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { BackupPlan, BackupPlanRule, BackupVault } from "aws-cdk-lib/aws-backup";
+import { Schedule } from "aws-cdk-lib/aws-events";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegBackupRich");
+
+const vault = new BackupVault(stack, "Vault", {
+  backupVaultName: "cdkrd-backup-rich",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const plan = new BackupPlan(stack, "Plan", {
+  backupPlanName: "cdkrd-backup-rich",
+  backupVault: vault,
+});
+plan.addRule(
+  new BackupPlanRule({
+    ruleName: "Daily",
+    scheduleExpression: Schedule.cron({ hour: "5", minute: "0" }),
+    startWindow: Duration.hours(1),
+    completionWindow: Duration.hours(2),
+    moveToColdStorageAfter: Duration.days(30),
+    deleteAfter: Duration.days(120),
+  })
+);
+
+app.synth();

--- a/tests/integration/backup-rich/cdk.json
+++ b/tests/integration/backup-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/backup-rich/package.json
+++ b/tests/integration/backup-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-backup-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift backup-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/backup-rich/verify.sh
+++ b/tests/integration/backup-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. AWS Backup default-fills + re-serializes the nested plan rules;
+# any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegBackupRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/logs-rich/app.ts
+++ b/tests/integration/logs-rich/app.ts
@@ -1,0 +1,44 @@
+// CDK app for the cdk-real-drift CloudWatch Logs LogGroup false-positive test.
+// A KMS-encrypted log group with an explicit retention is one of the most common
+// "production logging" patterns. It exercises a customer KMS key (KmsKeyId on the
+// log group + a CloudWatch-Logs service-principal key policy with an Fn::Sub
+// region intrinsic), an explicit RetentionInDays, and tags. A freshly deployed +
+// recorded log group with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Effect, PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLogsRich");
+
+const key = new Key(stack, "LogsKey", {
+  enableKeyRotation: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+// CloudWatch Logs must be granted use of the CMK (regional service principal).
+key.addToResourcePolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    principals: [new ServicePrincipal(`logs.${stack.region}.amazonaws.com`)],
+    actions: [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*",
+    ],
+    resources: ["*"],
+  })
+);
+
+const lg = new LogGroup(stack, "Lg", {
+  logGroupName: "/cdkrd/logs-rich",
+  retention: RetentionDays.TWO_WEEKS,
+  encryptionKey: key,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+Tags.of(lg).add("app", "cdkrd");
+Tags.of(lg).add("env", "test");
+
+app.synth();

--- a/tests/integration/logs-rich/cdk.json
+++ b/tests/integration/logs-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/logs-rich/package.json
+++ b/tests/integration/logs-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-logs-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift logs-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/logs-rich/verify-detect.sh
+++ b/tests/integration/logs-rich/verify-detect.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# CloudWatch Logs detect + revert integration test (real AWS): the "someone
+# changed the retention in the console" scenario. Deploy -> record -> change the
+# DECLARED MUTABLE RetentionInDays (14->30) out of band -> check MUST DETECT
+# (exit 1) -> revert -> check MUST be CLEAN and the live value restored to 14.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLogsRich
+LG=/cdkrd/logs-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: RetentionInDays 14->30 (console-edit) ==="
+aws logs put-retention-policy --log-group-name "$LG" --retention-in-days 30 \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-logs-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "RetentionInDays" /tmp/cdkrd-logs-detect.out || fail "RetentionInDays not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live RetentionInDays MUST be restored to 14 ==="
+GOT="$(aws logs describe-log-groups --log-group-name-prefix "$LG" --region "$REGION" \
+  --query "logGroups[?logGroupName=='$LG'].retentionInDays | [0]" --output text)"
+[ "$GOT" = "14" ] || fail "live RetentionInDays not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/logs-rich/verify.sh
+++ b/tests/integration/logs-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLogsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/wafv2-rich/app.ts
+++ b/tests/integration/wafv2-rich/app.ts
@@ -1,0 +1,55 @@
+// CDK app for the cdk-real-drift WAFv2 WebACL false-positive test. A regional
+// WebACL is a daily-deployed protection for ALB/API Gateway/AppSync. It packs the
+// FP-prone surfaces: a managed rule group statement (AWS managed rules), a
+// rate-based rule, per-rule + top-level VisibilityConfig, and a defaultAction —
+// nested structures WAFv2 default-fills and re-serializes server-side. A freshly
+// deployed + recorded WebACL with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2Rich");
+
+new CfnWebACL(stack, "WebAcl", {
+  name: "cdkrd-wafv2-rich",
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdWebAcl",
+  },
+  rules: [
+    {
+      name: "AWSCommon",
+      priority: 1,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: "AWS",
+          name: "AWSManagedRulesCommonRuleSet",
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "AWSCommon",
+      },
+    },
+    {
+      name: "RateLimit",
+      priority: 2,
+      action: { block: {} },
+      statement: {
+        rateBasedStatement: { limit: 2000, aggregateKeyType: "IP" },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "RateLimit",
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/wafv2-rich/cdk.json
+++ b/tests/integration/wafv2-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-rich/package.json
+++ b/tests/integration/wafv2-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-rich/verify.sh
+++ b/tests/integration/wafv2-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. WAFv2 default-fills + re-serializes the nested rule/visibility
+# structures; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2Rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

A /hunt-bugs round over three common-but-untested daily-use types. **Clean result: zero false positives across all three; logs detect+revert verified on real AWS.** No cdkrd bug surfaced, so this lands the fixtures + harvested golden-corpus cases as committed offline regression coverage (the new hunt-bugs corpus step from #252).

| Fixture | Type(s) | FP (verify.sh) | FN detect+revert |
|---|---|---|---|
| logs-rich | KMS-encrypted CloudWatch LogGroup + retention + tags | CLEAN (atDefault=7) | RetentionInDays 14→30 → detect → revert → 14 ✅ |
| wafv2-rich | regional WAFv2 WebACL (AWS managed rule group + rate-based rule + VisibilityConfig) | CLEAN | n/a (FP-focused) |
| backup-rich | AWS Backup vault + plan (nested BackupRule lifecycle) | CLEAN | n/a (FP-focused) |

## Corpus (offline regression, no AWS)

`tests/corpus/*.json` are replayed by `corpus-replay.test.ts` in plain `vp run test`. Harvested during the live reads (via `CDKRD_CORPUS_DIR`):
- **AWS::WAFv2::WebACL** — a REGIONAL WebACL with a managed rule group + rate-based rule (the only existing WebACL case is CLOUDFRONT-scoped).
- **AWS::Logs::LogGroup** — a KMS-encrypted log group (existing LogGroup cases are unencrypted).

Backup `BackupPlan`/`BackupVault` cases collided with existing reviewed corpus entries (same construct-id hash), so they were **not** re-promoted (no overwrite of reviewed golden cases).

## Verification

Real AWS (us-east-1). All deployed, FP-checked (+ logs FN), deleted via `delstack`; `sweep-orphans.sh` reports SWEEP CLEAN. Local gates: typecheck / lint+format / build / **1271** unit tests (incl. 289 corpus-replay) all pass.