### PR TITLE
test: add alb/firehose/sqs-rich fixtures + corpus + #252 create-only invariant

### DIFF
--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.json
@@ -1,0 +1,224 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Alb16C2F182",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
+    "constructPath": "CdkRealDriftIntegAlbRich/Alb",
+    "declared": {
+      "LoadBalancerAttributes": [
+        {
+          "Key": "deletion_protection.enabled",
+          "Value": "false"
+        },
+        {
+          "Key": "routing.http2.enabled",
+          "Value": "true"
+        },
+        {
+          "Key": "idle_timeout.timeout_seconds",
+          "Value": "120"
+        }
+      ],
+      "Name": "cdkrd-alb-rich",
+      "Scheme": "internal",
+      "SecurityGroups": ["sg-06022922575f424a4"],
+      "Subnets": ["subnet-0c6cfbd2761ec8536", "subnet-0a6286029be181fd0"],
+      "Type": "application"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "SecurityGroups": ["sg-06022922575f424a4"],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "append",
+        "Key": "routing.http.xff_header_processing.mode"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "waf.fail_open.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "defensive",
+        "Key": "routing.http.desync_mitigation_mode"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.prefix"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.preserve_host_header.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "health_check_logs.s3.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.xff_client_port.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "3600",
+        "Key": "client_keep_alive.seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.drop_invalid_header_fields.enabled"
+      },
+      {
+        "Value": "120",
+        "Key": "idle_timeout.timeout_seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "connection_logs.s3.enabled"
+      }
+    ],
+    "Scheme": "internal",
+    "DNSName": "internal-cdkrd-alb-rich-1869884205.us-east-1.elb.amazonaws.com",
+    "Name": "cdkrd-alb-rich",
+    "LoadBalancerName": "cdkrd-alb-rich",
+    "Subnets": ["subnet-0a6286029be181fd0", "subnet-0c6cfbd2761ec8536"],
+    "Type": "application",
+    "CanonicalHostedZoneID": "Z35SXDOTRQ7X7K",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAlbRich/deec7f40-6d23-11f1-845a-0afff5b84213",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAlbRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Alb16C2F182",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "LoadBalancerFullName": "app/cdkrd-alb-rich/ad889bbaa8149b3c",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-0a6286029be181fd0"
+      },
+      {
+        "SubnetId": "subnet-0c6cfbd2761ec8536"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "defaultPaths": {
+      "EnableCapacityReservationProvisionStabilize": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
+      "constructPath": "CdkRealDriftIntegAlbRich/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
+      "constructPath": "CdkRealDriftIntegAlbRich/Alb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "SubnetMappings",
+      "actual": [
+        {
+          "SubnetId": "subnet-0a6286029be181fd0"
+        },
+        {
+          "SubnetId": "subnet-0c6cfbd2761ec8536"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
+      "constructPath": "CdkRealDriftIntegAlbRich/Alb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgBB611D2A.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgBB611D2A.json
@@ -1,0 +1,241 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TgBB611D2A",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+    "constructPath": "CdkRealDriftIntegAlbRich/Tg",
+    "declared": {
+      "HealthCheckIntervalSeconds": 30,
+      "HealthCheckPath": "/health",
+      "HealthyThresholdCount": 3,
+      "Name": "cdkrd-tg-rich",
+      "Port": 80,
+      "Protocol": "HTTP",
+      "TargetGroupAttributes": [
+        {
+          "Key": "deregistration_delay.timeout_seconds",
+          "Value": "30"
+        },
+        {
+          "Key": "stickiness.enabled",
+          "Value": "false"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-06cc5d11d0dad76e0"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [
+      "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c"
+    ],
+    "Matcher": {
+      "HttpCode": "200"
+    },
+    "HealthCheckPath": "/health",
+    "Port": 80,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "ProtocolVersion": "HTTP1",
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 5,
+    "Name": "cdkrd-tg-rich",
+    "VpcId": "vpc-06cc5d11d0dad76e0",
+    "TargetGroupFullName": "targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+    "HealthyThresholdCount": 3,
+    "HealthCheckProtocol": "HTTP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "lb_cookie",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.app_cookie.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "30",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.lb_cookie.duration_seconds"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "slow_start.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "off",
+        "Key": "load_balancing.algorithm.anomaly_mitigation"
+      },
+      {
+        "Value": "",
+        "Key": "stickiness.app_cookie.cookie_name"
+      },
+      {
+        "Value": "round_robin",
+        "Key": "load_balancing.algorithm.type"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "HTTP",
+    "TargetGroupName": "cdkrd-tg-rich",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAlbRich/deec7f40-6d23-11f1-845a-0afff5b84213",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAlbRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TgBB611D2A",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Matcher",
+      "actual": {
+        "HttpCode": "200"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "ProtocolVersion",
+      "actual": "HTTP1",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "HTTP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.json
@@ -1,0 +1,147 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Stream",
+    "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+    "physicalId": "cdkrd-firehose-rich",
+    "constructPath": "CdkRealDriftIntegFirehoseRich/Stream",
+    "declared": {
+      "DeliveryStreamName": "cdkrd-firehose-rich",
+      "DeliveryStreamType": "DirectPut",
+      "ExtendedS3DestinationConfiguration": {
+        "BucketARN": "arn:aws:s3:::cdkrealdriftintegfirehoserich-destc383b82a-xgmrlqjmbyei",
+        "BufferingHints": {
+          "IntervalInSeconds": 300,
+          "SizeInMBs": 5
+        },
+        "CloudWatchLoggingOptions": {
+          "Enabled": true,
+          "LogGroupName": "/cdkrd/firehose-rich",
+          "LogStreamName": "S3Delivery"
+        },
+        "CompressionFormat": "GZIP",
+        "EncryptionConfiguration": {
+          "NoEncryptionConfig": "NoEncryption"
+        },
+        "ErrorOutputPrefix": "errors/",
+        "Prefix": "data/",
+        "RoleARN": "arn:aws:iam::111111111111:role/CdkRealDriftIntegFirehoseRich-Role1ABCC5F0-VAW2lQzr56N2"
+      }
+    }
+  },
+  "liveRaw": {
+    "DeliveryStreamType": "DirectPut",
+    "DeliveryStreamName": "cdkrd-firehose-rich",
+    "Arn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/cdkrd-firehose-rich",
+    "ExtendedS3DestinationConfiguration": {
+      "ErrorOutputPrefix": "errors/",
+      "BucketARN": "arn:aws:s3:::cdkrealdriftintegfirehoserich-destc383b82a-xgmrlqjmbyei",
+      "BufferingHints": {
+        "IntervalInSeconds": 300,
+        "SizeInMBs": 5
+      },
+      "CompressionFormat": "GZIP",
+      "EncryptionConfiguration": {
+        "NoEncryptionConfig": "NoEncryption"
+      },
+      "Prefix": "data/",
+      "CloudWatchLoggingOptions": {
+        "LogStreamName": "S3Delivery",
+        "Enabled": true,
+        "LogGroupName": "/cdkrd/firehose-rich"
+      },
+      "RoleARN": "arn:aws:iam::111111111111:role/CdkRealDriftIntegFirehoseRich-Role1ABCC5F0-VAW2lQzr56N2",
+      "S3BackupMode": "Disabled"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "ElasticsearchDestinationConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration"
+    ],
+    "createOnly": [
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration"
+    ],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration",
+      "DatabaseSourceConfiguration",
+      "DirectPutSourceConfiguration.ThroughputHintInMBs",
+      "ElasticsearchDestinationConfiguration",
+      "ElasticsearchDestinationConfiguration.CloudWatchLoggingOptions.Enabled",
+      "ExtendedS3DestinationConfiguration.CustomTimeZone",
+      "ExtendedS3DestinationConfiguration.FileExtension",
+      "HttpEndpointDestinationConfiguration.EndpointConfiguration.AccessKey",
+      "HttpEndpointDestinationConfiguration.ProcessingConfiguration",
+      "HttpEndpointDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "HttpEndpointDestinationConfiguration.SecretsManagerConfiguration",
+      "IcebergDestinationConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "RedshiftDestinationConfiguration.Password",
+      "RedshiftDestinationConfiguration.ProcessingConfiguration",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3BackupConfiguration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.S3Configuration.EncryptionConfiguration.KMSEncryptionConfig.AWSKMSKeyARN",
+      "RedshiftDestinationConfiguration.S3Configuration.ErrorOutputPrefix",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.Enabled",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.RoleARN",
+      "RedshiftDestinationConfiguration.SecretsManagerConfiguration.SecretARN",
+      "S3DestinationConfiguration",
+      "SnowflakeDestinationConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration",
+      "SplunkDestinationConfiguration.BufferingHints",
+      "SplunkDestinationConfiguration.CloudWatchLoggingOptions",
+      "SplunkDestinationConfiguration.ProcessingConfiguration",
+      "SplunkDestinationConfiguration.S3Configuration.EncryptionConfiguration.NoEncryptionConfig",
+      "SplunkDestinationConfiguration.SecretsManagerConfiguration"
+    ],
+    "createOnlyPaths": [
+      "AmazonOpenSearchServerlessDestinationConfiguration.VpcConfiguration",
+      "AmazonopensearchserviceDestinationConfiguration.VpcConfiguration",
+      "DatabaseSourceConfiguration",
+      "DeliveryStreamName",
+      "DeliveryStreamType",
+      "DirectPutSourceConfiguration",
+      "ElasticsearchDestinationConfiguration.VpcConfiguration",
+      "IcebergDestinationConfiguration.CatalogConfiguration",
+      "KinesisStreamSourceConfiguration",
+      "MSKSourceConfiguration",
+      "SnowflakeDestinationConfiguration.SnowflakeVpcConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Stream",
+      "resourceType": "AWS::KinesisFirehose::DeliveryStream",
+      "path": "ExtendedS3DestinationConfiguration.S3BackupMode",
+      "actual": "Disabled",
+      "nested": true,
+      "physicalId": "cdkrd-firehose-rich",
+      "constructPath": "CdkRealDriftIntegFirehoseRich/Stream"
+    }
+  ]
+}

--- a/tests/integration/alb-rich/app.ts
+++ b/tests/integration/alb-rich/app.ts
@@ -1,0 +1,59 @@
+// CDK app for the cdk-real-drift Application Load Balancer false-positive test.
+// An internal ALB + target group + HTTP listener is one of the most common
+// networking patterns. It exercises the FP-prone LoadBalancerAttributes bag
+// (idle_timeout, http2.enabled, deletion_protection, desync mitigation) and the
+// TargetGroupAttributes bag (deregistration_delay, stickiness) plus a health
+// check — attribute key/value lists ELBv2 default-fills server-side. Internal +
+// isolated subnets keep it NAT-free and fast. A freshly deployed + recorded ALB
+// with NO out-of-band change MUST report CLEAN.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  ApplicationLoadBalancer,
+  ApplicationProtocol,
+  ApplicationTargetGroup,
+  TargetType,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAlbRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [
+    { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+  ],
+});
+
+const alb = new ApplicationLoadBalancer(stack, "Alb", {
+  vpc,
+  internetFacing: false,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  loadBalancerName: "cdkrd-alb-rich",
+  idleTimeout: Duration.seconds(120),
+  http2Enabled: true,
+  deletionProtection: false,
+});
+
+const tg = new ApplicationTargetGroup(stack, "Tg", {
+  vpc,
+  targetGroupName: "cdkrd-tg-rich",
+  port: 80,
+  protocol: ApplicationProtocol.HTTP,
+  targetType: TargetType.IP,
+  deregistrationDelay: Duration.seconds(30),
+  healthCheck: {
+    path: "/health",
+    interval: Duration.seconds(30),
+    healthyThresholdCount: 3,
+  },
+});
+
+alb.addListener("Listener", {
+  port: 80,
+  protocol: ApplicationProtocol.HTTP,
+  defaultTargetGroups: [tg],
+});
+
+app.synth();

--- a/tests/integration/alb-rich/cdk.json
+++ b/tests/integration/alb-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/alb-rich/package.json
+++ b/tests/integration/alb-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-alb-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift alb-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/alb-rich/verify-detect.sh
+++ b/tests/integration/alb-rich/verify-detect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ALB detect + revert integration test (real AWS): the "someone changed an LB
+# attribute in the console" scenario. Deploy -> record -> change a DECLARED
+# MUTABLE attribute (idle_timeout.timeout_seconds 120->240) out of band via
+# modify-load-balancer-attributes -> check MUST DETECT (exit 1) -> revert ->
+# check MUST be CLEAN and the live value restored to 120.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAlbRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ARN="$(aws elbv2 describe-load-balancers --names cdkrd-alb-rich --region "$REGION" \
+  --query "LoadBalancers[0].LoadBalancerArn" --output text)"
+[ -n "$ARN" ] || fail "could not resolve LB arn"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: idle_timeout 120->240 (console-edit) ==="
+aws elbv2 modify-load-balancer-attributes --load-balancer-arn "$ARN" \
+  --attributes Key=idle_timeout.timeout_seconds,Value=240 --region "$REGION" >/dev/null \
+  || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-alb-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "idle_timeout" /tmp/cdkrd-alb-detect.out || fail "idle_timeout not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live idle_timeout MUST be restored to 120 ==="
+GOT="$(aws elbv2 describe-load-balancer-attributes --load-balancer-arn "$ARN" --region "$REGION" \
+  --query "Attributes[?Key=='idle_timeout.timeout_seconds'].Value | [0]" --output text)"
+[ "$GOT" = "120" ] || fail "live idle_timeout not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/alb-rich/verify.sh
+++ b/tests/integration/alb-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ELBv2 default-fills the LoadBalancer/TargetGroup attribute bags;
+# any drift here is a normalization / default-folding FP. Slower: VPC + ALB.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAlbRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/firehose-rich/app.ts
+++ b/tests/integration/firehose-rich/app.ts
@@ -1,0 +1,57 @@
+// CDK app for the cdk-real-drift Kinesis Data Firehose false-positive test. A
+// DirectPut delivery stream to S3 (ExtendedS3DestinationConfiguration) is the
+// common log/event-to-S3 pipeline. It exercises a deeply nested destination
+// config — BufferingHints, CompressionFormat, prefixes, CloudWatchLoggingOptions,
+// EncryptionConfiguration — that Firehose default-fills + re-serializes server
+// side. A freshly deployed + recorded stream with NO out-of-band change MUST be
+// CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { LogGroup, LogStream, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegFirehoseRich");
+
+const bucket = new Bucket(stack, "Dest", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const role = new Role(stack, "Role", {
+  assumedBy: new ServicePrincipal("firehose.amazonaws.com"),
+});
+bucket.grantReadWrite(role);
+
+const logGroup = new LogGroup(stack, "Logs", {
+  logGroupName: "/cdkrd/firehose-rich",
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const logStream = new LogStream(stack, "LogStream", {
+  logGroup,
+  logStreamName: "S3Delivery",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new CfnDeliveryStream(stack, "Stream", {
+  deliveryStreamName: "cdkrd-firehose-rich",
+  deliveryStreamType: "DirectPut",
+  extendedS3DestinationConfiguration: {
+    bucketArn: bucket.bucketArn,
+    roleArn: role.roleArn,
+    bufferingHints: { intervalInSeconds: 300, sizeInMBs: 5 },
+    compressionFormat: "GZIP",
+    prefix: "data/",
+    errorOutputPrefix: "errors/",
+    cloudWatchLoggingOptions: {
+      enabled: true,
+      logGroupName: logGroup.logGroupName,
+      logStreamName: logStream.logStreamName,
+    },
+    encryptionConfiguration: { noEncryptionConfig: "NoEncryption" },
+  },
+});
+
+app.synth();

--- a/tests/integration/firehose-rich/cdk.json
+++ b/tests/integration/firehose-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/firehose-rich/package.json
+++ b/tests/integration/firehose-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-firehose-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift firehose-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/firehose-rich/verify.sh
+++ b/tests/integration/firehose-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Firehose default-fills + re-serializes the nested destination
+# config; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegFirehoseRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sqs-rich/app.ts
+++ b/tests/integration/sqs-rich/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift SQS false-positive test. The basic sqs fixture
+// covers a plain queue; this exercises the common "production queue" knobs at
+// once: SSE-SQS managed encryption (SqsManagedSseEnabled), a dead-letter queue
+// with a RedrivePolicy (a JSON-string attribute), long polling, and explicit
+// visibility/retention/delay — attributes SQS returns as a flat string bag that
+// must normalize without an FP. A freshly deployed + recorded queue with NO
+// out-of-band change MUST report CLEAN.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Queue, QueueEncryption } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSqsRich");
+
+const dlq = new Queue(stack, "Dlq", {
+  queueName: "cdkrd-sqs-rich-dlq",
+  retentionPeriod: Duration.days(14),
+  encryption: QueueEncryption.SQS_MANAGED,
+});
+
+new Queue(stack, "Main", {
+  queueName: "cdkrd-sqs-rich",
+  visibilityTimeout: Duration.seconds(60),
+  retentionPeriod: Duration.days(4),
+  receiveMessageWaitTime: Duration.seconds(10),
+  deliveryDelay: Duration.seconds(5),
+  encryption: QueueEncryption.SQS_MANAGED,
+  deadLetterQueue: { queue: dlq, maxReceiveCount: 5 },
+});
+
+app.synth();

--- a/tests/integration/sqs-rich/cdk.json
+++ b/tests/integration/sqs-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sqs-rich/package.json
+++ b/tests/integration/sqs-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sqs-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sqs-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sqs-rich/verify-detect.sh
+++ b/tests/integration/sqs-rich/verify-detect.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SQS detect + revert integration test (real AWS): the "someone changed the queue
+# settings in the console" scenario. Deploy -> record -> change the DECLARED
+# MUTABLE VisibilityTimeout (60->120) out of band -> check MUST DETECT (exit 1)
+# -> revert -> check MUST be CLEAN and the live value restored to 60.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSqsRich
+QNAME=cdkrd-sqs-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+QURL="$(aws sqs get-queue-url --queue-name "$QNAME" --region "$REGION" --query QueueUrl --output text)"
+[ -n "$QURL" ] || fail "could not resolve queue url"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: VisibilityTimeout 60->120 (console-edit) ==="
+aws sqs set-queue-attributes --queue-url "$QURL" --attributes VisibilityTimeout=120 \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sqs-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "VisibilityTimeout" /tmp/cdkrd-sqs-detect.out || fail "VisibilityTimeout not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live VisibilityTimeout MUST be restored to 60 ==="
+GOT="$(aws sqs get-queue-attributes --queue-url "$QURL" --attribute-names VisibilityTimeout \
+  --region "$REGION" --query "Attributes.VisibilityTimeout" --output text)"
+[ "$GOT" = "60" ] || fail "live VisibilityTimeout not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/sqs-rich/verify.sh
+++ b/tests/integration/sqs-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. SQS returns a flat string attribute bag (RedrivePolicy JSON,
+# SqsManagedSseEnabled); any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSqsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1,5 +1,9 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
+import { type CorpusCase, reviveSchema } from '../src/corpus/record.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import {
   buildRevertPlan,
@@ -983,5 +987,72 @@ describe('tagPreservingOps (revert must not strip aws:* managed tags — the SNS
       const ops = [op({ op: 'remove' })];
       expect(tagPreservingOps(ops, { Tags: { Team: 'x' } })).toBe(ops);
     });
+  });
+});
+
+// Data-driven guarantee for the #252 fix across EVERY real resource schema we have
+// captured. The bug class — a property that is BOTH write-only and create-only
+// being re-included into a Cloud Control UpdateResource patch and then hard-
+// rejected ("createOnlyProperties [...] cannot be updated") — is NOT specific to
+// ElastiCache: the golden corpus alone holds ~17 types with such an intersection
+// (RDS DBInstance, DynamoDB Table, EC2 EIP/Subnet/VPC, EFS MountTarget, S3 Bucket,
+// SNS Subscription, SSM Document, Lambda LayerVersion, Kinesis Firehose,
+// ApiGateway ApiKey, AutoScaling, ApplicationAutoScaling, ElastiCache, ...). This
+// test loads each corpus case's REAL schema, builds a declared model that sets a
+// value at every write-only path (so re-inclusion would fire), and asserts
+// writeOnlyReincludeOps emits NO op for any write-only∩create-only path — for ALL
+// of them. It self-extends: any future type added to the corpus is covered for
+// free. corpus-replay.test.ts covers the classify pipeline; this covers the revert
+// patch path, which corpus-replay does not.
+const corpusDir = join(dirname(fileURLToPath(import.meta.url)), 'corpus');
+
+function setDottedPath(model: Record<string, unknown>, path: string, value: unknown): void {
+  const segs = path.split('.');
+  let node = model;
+  for (let i = 0; i < segs.length - 1; i++) {
+    const seg = segs[i];
+    if (typeof node[seg] !== 'object' || node[seg] === null) node[seg] = {};
+    node = node[seg] as Record<string, unknown>;
+  }
+  node[segs[segs.length - 1]] = value;
+}
+
+// RFC6902 pointer for a non-wildcard dotted path (mirrors plan.ts toPointer for the
+// property names that appear here — plain identifiers, no `~`/`/`).
+const pointerOf = (path: string): string => `/${path.split('.').join('/')}`;
+
+describe('writeOnlyReincludeOps create-only invariant over all real corpus schemas (#252)', () => {
+  const corpusFiles = readdirSync(corpusDir).filter((f) => f.endsWith('.json'));
+
+  it('never re-includes a write-only property that is also create-only — every corpus type', () => {
+    let typesExercised = 0;
+    let propsAsserted = 0;
+    for (const file of corpusFiles) {
+      const c = JSON.parse(readFileSync(join(corpusDir, file), 'utf8')) as CorpusCase;
+      const schema = reviveSchema(c.schema);
+      const createOnly = new Set(schema.createOnlyPaths);
+      const intersection = schema.writeOnlyPaths.filter(
+        (p) => !p.includes('*') && createOnly.has(p)
+      );
+      if (intersection.length === 0) continue;
+      typesExercised++;
+      // Declared model with a value at EVERY non-wildcard write-only path, so the
+      // re-include loop fires for all of them — including the create-only ones,
+      // which the fix must then drop.
+      const declared: Record<string, unknown> = {};
+      for (const p of schema.writeOnlyPaths) {
+        if (p.includes('*')) continue;
+        setDottedPath(declared, p, 'cdkrd-test-value');
+      }
+      const emitted = new Set(writeOnlyReincludeOps(declared, schema, []).map((o) => o.path));
+      for (const p of intersection) {
+        expect(emitted.has(pointerOf(p))).toBe(false);
+        propsAsserted++;
+      }
+    }
+    // Guard the guard: if the corpus stops containing intersection types (e.g. a
+    // refactor drops the schema field), this surfaces it instead of passing vacuously.
+    expect(typesExercised).toBeGreaterThan(5);
+    expect(propsAsserted).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

A /hunt-bugs round over three daily-use types — **clean: 0 FPs across all three; ALB + SQS detect+revert verified on real AWS** — plus a hardening test the user asked for, proving the #252 create-only revert fix covers all affected types, not just ElastiCache.

| Fixture | Type | FP | FN detect+revert |
|---|---|---|---|
| alb-rich | internal ALB + TargetGroup + HTTP listener (attribute bags) | CLEAN | LoadBalancerAttributes[idle_timeout] 120→240→120 ✅ |
| firehose-rich | DirectPut → S3 ExtendedS3DestinationConfiguration | CLEAN | n/a (FP-focused) |
| sqs-rich | SSE-SQS + DLQ RedrivePolicy + long polling | CLEAN | VisibilityTimeout 60→120→60 ✅ |

## #252 generality — data-driven invariant test

The user asked whether the #252 create-only revert fix is covered for *other* types (not just ElastiCache). It wasn't tested generally: `corpus-replay` covers the **classify** pipeline; the bug is in the **revert** patch path. So this adds a data-driven invariant in `revert-plan.test.ts` that loads **every golden-corpus schema** (~17 real types with a write-only∩create-only intersection: RDS DBInstance, DynamoDB, EC2 EIP/Subnet/VPC, EFS MountTarget, S3, SNS Subscription, SSM Document, Lambda LayerVersion, Kinesis Firehose, ApiGateway, AutoScaling, ElastiCache, …) and asserts `writeOnlyReincludeOps` never re-includes a write-only∩create-only property — for all of them. It self-extends as the corpus grows. Confirmed it **fails without** the #252 fix and **passes with** it.

The fix is generic (keyed on `schema.writeOnlyPaths`∩`createOnlyPaths`), so the whole bug class is closed across those types. No src change in this PR — only the test (plan.ts already carries the fix from #252).

## Corpus

Added ELBv2 LoadBalancer, ELBv2 TargetGroup, Kinesis Firehose DeliveryStream golden cases (richer than the existing thinner captures). SQS/VPC/IAM/S3 boilerplate collided with reviewed entries → not re-promoted.

## Verification

Real AWS (us-east-1). All deployed, FP-checked (+ ALB/SQS FN), deleted via `delstack`; `sweep-orphans.sh` SWEEP CLEAN. Local gates: typecheck / lint+format / build / **1275** unit tests pass.