### PR TITLE
test(integ): add cognito-userpool, apigw-rest, appsync-graphqlapi rich bug-hunt fixtures

### DIFF
--- a/tests/corpus/AWS__ApiGateway__Deployment.ApiDeploymentB17BE62Dba7acbf1af74a3eadf05ad1a398840e5.json
+++ b/tests/corpus/AWS__ApiGateway__Deployment.ApiDeploymentB17BE62Dba7acbf1af74a3eadf05ad1a398840e5.json
@@ -1,0 +1,35 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiDeploymentB17BE62Dba7acbf1af74a3eadf05ad1a398840e5",
+    "resourceType": "AWS::ApiGateway::Deployment",
+    "physicalId": "usd4d2",
+    "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Deployment",
+    "declared": {
+      "Description": "cdkrd integ stage",
+      "RestApiId": "we41awg0n3"
+    }
+  },
+  "liveRaw": {
+    "DeploymentId": "usd4d2",
+    "Description": "cdkrd integ stage",
+    "RestApiId": "we41awg0n3"
+  },
+  "schema": {
+    "readOnly": ["DeploymentId"],
+    "writeOnly": ["DeploymentCanarySettings", "StageDescription", "StageName"],
+    "createOnly": ["DeploymentCanarySettings", "RestApiId"],
+    "readOnlyPaths": ["DeploymentId"],
+    "writeOnlyPaths": ["DeploymentCanarySettings", "StageDescription", "StageName"],
+    "createOnlyPaths": ["DeploymentCanarySettings", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__Method.ApiitemsGET2CEFDB25.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiitemsGET2CEFDB25.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiitemsGET2CEFDB25",
+    "resourceType": "AWS::ApiGateway::Method",
+    "physicalId": "we41awg0n3|to60x5|GET",
+    "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/GET",
+    "declared": {
+      "AuthorizationType": "NONE",
+      "HttpMethod": "GET",
+      "Integration": {
+        "IntegrationResponses": [
+          {
+            "StatusCode": "200"
+          }
+        ],
+        "PassthroughBehavior": "NEVER",
+        "RequestTemplates": {
+          "application/json": "{ \"statusCode\": 200 }"
+        },
+        "Type": "MOCK"
+      },
+      "MethodResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "ResourceId": "to60x5",
+      "RestApiId": "we41awg0n3"
+    }
+  },
+  "liveRaw": {
+    "MethodResponses": [
+      {
+        "StatusCode": "200"
+      }
+    ],
+    "Integration": {
+      "CacheNamespace": "to60x5",
+      "Type": "MOCK",
+      "IntegrationResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "RequestTemplates": {
+        "application/json": "{ \"statusCode\": 200 }"
+      },
+      "ResponseTransferMode": "BUFFERED",
+      "TimeoutInMillis": 29000,
+      "PassthroughBehavior": "NEVER"
+    },
+    "ResourceId": "to60x5",
+    "RestApiId": "we41awg0n3",
+    "ApiKeyRequired": false,
+    "AuthorizationType": "NONE",
+    "HttpMethod": "GET"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["HttpMethod", "ResourceId", "RestApiId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HttpMethod", "ResourceId", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {
+      "Integration.ResponseTransferMode": "BUFFERED"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "ApiitemsGET2CEFDB25",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.CacheNamespace",
+      "actual": "to60x5",
+      "nested": true,
+      "physicalId": "we41awg0n3|to60x5|GET",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/GET"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsGET2CEFDB25",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.ResponseTransferMode",
+      "actual": "BUFFERED",
+      "nested": true,
+      "physicalId": "we41awg0n3|to60x5|GET",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/GET"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsGET2CEFDB25",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.TimeoutInMillis",
+      "actual": 29000,
+      "nested": true,
+      "physicalId": "we41awg0n3|to60x5|GET",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/GET"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__Method.ApiitemsPOST55EC2F9D.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiitemsPOST55EC2F9D.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiitemsPOST55EC2F9D",
+    "resourceType": "AWS::ApiGateway::Method",
+    "physicalId": "we41awg0n3|to60x5|POST",
+    "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/POST",
+    "declared": {
+      "AuthorizationType": "NONE",
+      "HttpMethod": "POST",
+      "Integration": {
+        "IntegrationResponses": [
+          {
+            "StatusCode": "200"
+          }
+        ],
+        "PassthroughBehavior": "NEVER",
+        "RequestTemplates": {
+          "application/json": "{ \"statusCode\": 200 }"
+        },
+        "Type": "MOCK"
+      },
+      "MethodResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "ResourceId": "to60x5",
+      "RestApiId": "we41awg0n3"
+    }
+  },
+  "liveRaw": {
+    "MethodResponses": [
+      {
+        "StatusCode": "200"
+      }
+    ],
+    "Integration": {
+      "CacheNamespace": "to60x5",
+      "Type": "MOCK",
+      "IntegrationResponses": [
+        {
+          "StatusCode": "200"
+        }
+      ],
+      "RequestTemplates": {
+        "application/json": "{ \"statusCode\": 200 }"
+      },
+      "ResponseTransferMode": "BUFFERED",
+      "TimeoutInMillis": 29000,
+      "PassthroughBehavior": "NEVER"
+    },
+    "ResourceId": "to60x5",
+    "RestApiId": "we41awg0n3",
+    "ApiKeyRequired": false,
+    "AuthorizationType": "NONE",
+    "HttpMethod": "POST"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["HttpMethod", "ResourceId", "RestApiId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["HttpMethod", "ResourceId", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {
+      "Integration.ResponseTransferMode": "BUFFERED"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "ApiitemsPOST55EC2F9D",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.CacheNamespace",
+      "actual": "to60x5",
+      "nested": true,
+      "physicalId": "we41awg0n3|to60x5|POST",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/POST"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsPOST55EC2F9D",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.ResponseTransferMode",
+      "actual": "BUFFERED",
+      "nested": true,
+      "physicalId": "we41awg0n3|to60x5|POST",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/POST"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsPOST55EC2F9D",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.TimeoutInMillis",
+      "actual": 29000,
+      "nested": true,
+      "physicalId": "we41awg0n3|to60x5|POST",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/POST"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__Resource.Apiitems8F0ED6C4.json
+++ b/tests/corpus/AWS__ApiGateway__Resource.Apiitems8F0ED6C4.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Apiitems8F0ED6C4",
+    "resourceType": "AWS::ApiGateway::Resource",
+    "physicalId": "to60x5",
+    "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items",
+    "declared": {
+      "ParentId": "p5qr1hna0d",
+      "PathPart": "items",
+      "RestApiId": "we41awg0n3"
+    }
+  },
+  "liveRaw": {
+    "ParentId": "p5qr1hna0d",
+    "PathPart": "items",
+    "ResourceId": "to60x5",
+    "RestApiId": "we41awg0n3"
+  },
+  "schema": {
+    "readOnly": ["ResourceId"],
+    "writeOnly": [],
+    "createOnly": ["ParentId", "PathPart", "RestApiId"],
+    "readOnlyPaths": ["ResourceId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ParentId", "PathPart", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD_rest_rich.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD_rest_rich.json
@@ -1,0 +1,98 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiF70053CD",
+    "resourceType": "AWS::ApiGateway::RestApi",
+    "physicalId": "we41awg0n3",
+    "constructPath": "CdkRealDriftIntegApigwRestRich/Api",
+    "declared": {
+      "BinaryMediaTypes": ["application/octet-stream", "image/*"],
+      "EndpointConfiguration": {
+        "Types": ["REGIONAL"]
+      },
+      "MinimumCompressionSize": 1024,
+      "Name": "cdkrd-apigw-rest-rich"
+    }
+  },
+  "liveRaw": {
+    "MinimumCompressionSize": 1024,
+    "RootResourceId": "p5qr1hna0d",
+    "SecurityPolicy": "TLS_1_0",
+    "RestApiId": "we41awg0n3",
+    "ApiKeySourceType": "HEADER",
+    "EndpointConfiguration": {
+      "IpAddressType": "ipv4",
+      "Types": ["REGIONAL"]
+    },
+    "DisableExecuteApiEndpoint": false,
+    "Tags": [
+      {
+        "Value": "ApiF70053CD",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApigwRestRich/6d1e7cb0-6d28-11f1-8024-0e2b461e5e2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegApigwRestRich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "BinaryMediaTypes": ["application/octet-stream", "image/*"],
+    "Name": "cdkrd-apigw-rest-rich"
+  },
+  "schema": {
+    "readOnly": ["RestApiId", "RootResourceId"],
+    "writeOnly": ["Body", "BodyS3Location", "CloneFrom", "FailOnWarnings", "Mode", "Parameters"],
+    "createOnly": [],
+    "readOnlyPaths": ["RestApiId", "RootResourceId"],
+    "writeOnlyPaths": [
+      "Body",
+      "BodyS3Location",
+      "CloneFrom",
+      "FailOnWarnings",
+      "Mode",
+      "Parameters"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "we41awg0n3",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "ApiKeySourceType",
+      "actual": "HEADER",
+      "physicalId": "we41awg0n3",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "EndpointConfiguration.IpAddressType",
+      "actual": "ipv4",
+      "nested": true,
+      "physicalId": "we41awg0n3",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGateway__Stage.ApiDeploymentStageprod3EB9684E.json
+++ b/tests/corpus/AWS__ApiGateway__Stage.ApiDeploymentStageprod3EB9684E.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiDeploymentStageprod3EB9684E",
+    "resourceType": "AWS::ApiGateway::Stage",
+    "physicalId": "prod",
+    "constructPath": "CdkRealDriftIntegApigwRestRich/Api/DeploymentStage.prod",
+    "declared": {
+      "DeploymentId": "usd4d2",
+      "Description": "cdkrd integ stage",
+      "MethodSettings": [
+        {
+          "DataTraceEnabled": false,
+          "HttpMethod": "*",
+          "ResourcePath": "/*",
+          "ThrottlingBurstLimit": 50,
+          "ThrottlingRateLimit": 100
+        }
+      ],
+      "RestApiId": "we41awg0n3",
+      "StageName": "prod",
+      "TracingEnabled": false
+    }
+  },
+  "liveRaw": {
+    "DeploymentId": "usd4d2",
+    "Description": "cdkrd integ stage",
+    "StageName": "prod",
+    "TracingEnabled": false,
+    "RestApiId": "we41awg0n3",
+    "MethodSettings": [
+      {
+        "CacheTtlInSeconds": 300,
+        "ResourcePath": "/*",
+        "CacheDataEncrypted": false,
+        "DataTraceEnabled": false,
+        "ThrottlingBurstLimit": 50,
+        "CachingEnabled": false,
+        "MetricsEnabled": false,
+        "HttpMethod": "*",
+        "ThrottlingRateLimit": 100
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "ApiDeploymentStageprod3EB9684E",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApigwRestRich/6d1e7cb0-6d28-11f1-8024-0e2b461e5e2d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegApigwRestRich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "CacheClusterEnabled": false
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["RestApiId", "StageName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RestApiId", "StageName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppSync__GraphQLApi.ApiF70053CD.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.ApiF70053CD.json
@@ -1,0 +1,134 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiF70053CD",
+    "resourceType": "AWS::AppSync::GraphQLApi",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+    "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api",
+    "declared": {
+      "AdditionalAuthenticationProviders": [
+        {
+          "AuthenticationType": "AWS_IAM"
+        }
+      ],
+      "AuthenticationType": "API_KEY",
+      "Name": "cdkrd-appsync-rich",
+      "XrayEnabled": true
+    }
+  },
+  "liveRaw": {
+    "QueryDepthLimit": 0,
+    "IntrospectionConfig": "ENABLED",
+    "RealtimeDns": "y67jbjrda5exrm3rxe4v5vjscq.appsync-realtime-api.us-east-1.amazonaws.com",
+    "ResolverCountLimit": 0,
+    "AdditionalAuthenticationProviders": [
+      {
+        "AuthenticationType": "AWS_IAM"
+      }
+    ],
+    "Name": "cdkrd-appsync-rich",
+    "RealtimeUrl": "wss://y67jbjrda5exrm3rxe4v5vjscq.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+    "EnvironmentVariables": {},
+    "GraphQLUrl": "https://y67jbjrda5exrm3rxe4v5vjscq.appsync-api.us-east-1.amazonaws.com/graphql",
+    "GraphQLDns": "y67jbjrda5exrm3rxe4v5vjscq.appsync-api.us-east-1.amazonaws.com",
+    "ApiType": "GRAPHQL",
+    "XrayEnabled": true,
+    "Visibility": "GLOBAL",
+    "Arn": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+    "ApiId": "grvgnxnodjfqtehtxqjettkuya",
+    "Tags": [],
+    "AuthenticationType": "API_KEY",
+    "GraphQLEndpointArn": "arn:aws:appsync:us-east-1:111111111111:endpoints/graphql-api/y67jbjrda5exrm3rxe4v5vjscq"
+  },
+  "schema": {
+    "readOnly": [
+      "ApiId",
+      "Arn",
+      "GraphQLDns",
+      "GraphQLEndpointArn",
+      "GraphQLUrl",
+      "RealtimeDns",
+      "RealtimeUrl"
+    ],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "ApiId",
+      "Arn",
+      "GraphQLDns",
+      "GraphQLEndpointArn",
+      "GraphQLUrl",
+      "RealtimeDns",
+      "RealtimeUrl"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "LambdaAuthorizerConfig.AuthorizerResultTtlInSeconds",
+      "LambdaAuthorizerConfig.AuthorizerUri",
+      "LambdaAuthorizerConfig.IdentityValidationExpression",
+      "OpenIDConnectConfig.AuthTTL",
+      "OpenIDConnectConfig.ClientId",
+      "OpenIDConnectConfig.IatTTL",
+      "OpenIDConnectConfig.Issuer",
+      "UserPoolConfig.AppIdClientRegex",
+      "UserPoolConfig.AwsRegion",
+      "UserPoolConfig.DefaultAction",
+      "UserPoolConfig.UserPoolId"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "QueryDepthLimit",
+      "actual": 0,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+      "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "IntrospectionConfig",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+      "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "ResolverCountLimit",
+      "actual": 0,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+      "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "ApiType",
+      "actual": "GRAPHQL",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+      "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "Visibility",
+      "actual": "GLOBAL",
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/grvgnxnodjfqtehtxqjettkuya",
+      "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
@@ -1,0 +1,846 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PoolD3F588B8",
+    "resourceType": "AWS::Cognito::UserPool",
+    "physicalId": "us-east-1_DPFFObGj8",
+    "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool",
+    "declared": {
+      "AccountRecoverySetting": {
+        "RecoveryMechanisms": [
+          {
+            "Name": "verified_email",
+            "Priority": 1
+          }
+        ]
+      },
+      "AdminCreateUserConfig": {
+        "AllowAdminCreateUserOnly": false
+      },
+      "AliasAttributes": ["email"],
+      "AutoVerifiedAttributes": ["email"],
+      "DeletionProtection": "INACTIVE",
+      "DeviceConfiguration": {
+        "ChallengeRequiredOnNewDevice": true,
+        "DeviceOnlyRememberedOnUserPrompt": true
+      },
+      "EmailVerificationMessage": "The verification code to your new account is {####}",
+      "EmailVerificationSubject": "Verify your new account",
+      "EnabledMfas": ["SOFTWARE_TOKEN_MFA"],
+      "MfaConfiguration": "OPTIONAL",
+      "Policies": {
+        "PasswordPolicy": {
+          "MinimumLength": 12,
+          "RequireLowercase": true,
+          "RequireNumbers": true,
+          "RequireSymbols": true,
+          "RequireUppercase": true,
+          "TemporaryPasswordValidityDays": 3
+        }
+      },
+      "Schema": [
+        {
+          "Mutable": true,
+          "Name": "email",
+          "Required": true
+        },
+        {
+          "Mutable": true,
+          "Name": "name",
+          "Required": false
+        }
+      ],
+      "SmsVerificationMessage": "The verification code to your new account is {####}",
+      "UserPoolName": "cdkrd-userpool-rich",
+      "UsernameConfiguration": {
+        "CaseSensitive": false
+      },
+      "VerificationMessageTemplate": {
+        "DefaultEmailOption": "CONFIRM_WITH_CODE",
+        "EmailMessage": "The verification code to your new account is {####}",
+        "EmailSubject": "Verify your new account",
+        "SmsMessage": "The verification code to your new account is {####}"
+      }
+    }
+  },
+  "liveRaw": {
+    "UserPoolTags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegCognitoUserPoolRich",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCognitoUserPoolRich/6a8de6c0-6d28-11f1-9ffc-0affc1cb51fd",
+      "aws:cloudformation:logical-id": "PoolD3F588B8"
+    },
+    "Policies": {
+      "PasswordPolicy": {
+        "RequireNumbers": true,
+        "MinimumLength": 12,
+        "TemporaryPasswordValidityDays": 3,
+        "RequireUppercase": true,
+        "RequireLowercase": true,
+        "RequireSymbols": true
+      },
+      "SignInPolicy": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      }
+    },
+    "Schema": [
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "profile"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "address"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "10",
+          "MaxLength": "10"
+        },
+        "Required": false,
+        "Name": "birthdate"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "gender"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "preferred_username"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Number",
+        "Required": false,
+        "NumberAttributeConstraints": {
+          "MinValue": "0"
+        },
+        "Name": "updated_at"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "website"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "picture"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {},
+        "Required": false,
+        "Name": "identities"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": false,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "1",
+          "MaxLength": "2048"
+        },
+        "Required": true,
+        "Name": "sub"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "phone_number"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "phone_number_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "zoneinfo"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "locale"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": true,
+        "Name": "email"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "email_verified"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "given_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "family_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "middle_name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "name"
+      },
+      {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "nickname"
+      }
+    ],
+    "AdminCreateUserConfig": {
+      "UnusedAccountValidityDays": 3,
+      "AllowAdminCreateUserOnly": false
+    },
+    "UserPoolTier": "ESSENTIALS",
+    "UsernameConfiguration": {
+      "CaseSensitive": false
+    },
+    "UserPoolName": "cdkrd-userpool-rich",
+    "SmsVerificationMessage": "The verification code to your new account is {####}",
+    "UserAttributeUpdateSettings": {
+      "AttributesRequireVerificationBeforeUpdate": []
+    },
+    "EmailConfiguration": {
+      "EmailSendingAccount": "COGNITO_DEFAULT"
+    },
+    "EmailVerificationSubject": "Verify your new account",
+    "AccountRecoverySetting": {
+      "RecoveryMechanisms": [
+        {
+          "Priority": 1,
+          "Name": "verified_email"
+        }
+      ]
+    },
+    "VerificationMessageTemplate": {
+      "EmailMessage": "The verification code to your new account is {####}",
+      "SmsMessage": "The verification code to your new account is {####}",
+      "EmailSubject": "Verify your new account",
+      "DefaultEmailOption": "CONFIRM_WITH_CODE"
+    },
+    "ProviderURL": "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_DPFFObGj8",
+    "MfaConfiguration": "OPTIONAL",
+    "DeletionProtection": "INACTIVE",
+    "WebAuthnFactorConfiguration": "SINGLE_FACTOR",
+    "ProviderName": "cognito-idp.us-east-1.amazonaws.com/us-east-1_DPFFObGj8",
+    "UserPoolId": "us-east-1_DPFFObGj8",
+    "AliasAttributes": ["email"],
+    "LambdaConfig": {},
+    "Arn": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_DPFFObGj8",
+    "UsernameAttributes": [],
+    "AutoVerifiedAttributes": ["email"],
+    "DeviceConfiguration": {
+      "DeviceOnlyRememberedOnUserPrompt": true,
+      "ChallengeRequiredOnNewDevice": true
+    },
+    "EmailVerificationMessage": "The verification code to your new account is {####}"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnly": ["EnabledMfas"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "ProviderName", "ProviderURL", "UserPoolId"],
+    "writeOnlyPaths": ["EnabledMfas"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EnabledMfas",
+      "note": "write-only — cannot be read back",
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[address]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "address"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[birthdate]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "10",
+          "MaxLength": "10"
+        },
+        "Required": false,
+        "Name": "birthdate"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[email_verified]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "email_verified"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[family_name]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "family_name"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[gender]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "gender"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[given_name]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "given_name"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[identities]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {},
+        "Required": false,
+        "Name": "identities"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[locale]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "locale"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[middle_name]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "middle_name"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[nickname]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "nickname"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[phone_number]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "phone_number"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[phone_number_verified]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Boolean",
+        "Required": false,
+        "Name": "phone_number_verified"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[picture]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "picture"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[preferred_username]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "preferred_username"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[profile]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "profile"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[sub]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": false,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "1",
+          "MaxLength": "2048"
+        },
+        "Required": true,
+        "Name": "sub"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[updated_at]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "Number",
+        "Required": false,
+        "NumberAttributeConstraints": {
+          "MinValue": "0"
+        },
+        "Name": "updated_at"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[website]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "website"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[zoneinfo]",
+      "actual": {
+        "DeveloperOnlyAttribute": false,
+        "Mutable": true,
+        "AttributeDataType": "String",
+        "StringAttributeConstraints": {
+          "MinLength": "0",
+          "MaxLength": "2048"
+        },
+        "Required": false,
+        "Name": "zoneinfo"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "WebAuthnFactorConfiguration",
+      "actual": "SINGLE_FACTOR",
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Policies.SignInPolicy",
+      "actual": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[email].AttributeDataType",
+      "actual": "String",
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[email].StringAttributeConstraints",
+      "actual": {
+        "MinLength": "0",
+        "MaxLength": "2048"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[name].AttributeDataType",
+      "actual": "String",
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "Schema[name].StringAttributeConstraints",
+      "actual": {
+        "MinLength": "0",
+        "MaxLength": "2048"
+      },
+      "nested": true,
+      "physicalId": "us-east-1_DPFFObGj8",
+      "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
+    }
+  ]
+}

--- a/tests/integration/apigw-rest-rich/app.ts
+++ b/tests/integration/apigw-rest-rich/app.ts
@@ -1,0 +1,46 @@
+// CDK app for the cdk-real-drift apigw-rest-rich false-positive integration test.
+// The existing apigw/restapi-* fixtures only exercise the `added` tier (out-of-band
+// child resources). This one stresses the property-RICH RestApi body a large fraction
+// of CDK users deploy: a REGIONAL endpoint configuration, binary media types, a
+// minimum compression size, two MOCK-integrated methods, and a deployed Stage with
+// X-Ray tracing + throttling MethodSettings. AWS folds the stage's MethodSettings
+// ("*/*") and the endpoint config into its own model with defaults — a clean
+// `record`->`check` is a strong false-positive oracle. MOCK integrations keep the
+// stack Lambda-free (fast, no /aws/lambda/* orphan log group).
+import { App, RemovalPolicy, Size, Stack } from "aws-cdk-lib";
+import {
+  EndpointType,
+  MockIntegration,
+  PassthroughBehavior,
+  RestApi,
+} from "aws-cdk-lib/aws-apigateway";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegApigwRestRich");
+
+const api = new RestApi(stack, "Api", {
+  restApiName: "cdkrd-apigw-rest-rich",
+  endpointConfiguration: { types: [EndpointType.REGIONAL] },
+  binaryMediaTypes: ["application/octet-stream", "image/*"],
+  minCompressionSize: Size.bytes(1024),
+  deployOptions: {
+    stageName: "prod",
+    tracingEnabled: false,
+    throttlingRateLimit: 100,
+    throttlingBurstLimit: 50,
+    description: "cdkrd integ stage",
+  },
+});
+api.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+const mock = new MockIntegration({
+  integrationResponses: [{ statusCode: "200" }],
+  passthroughBehavior: PassthroughBehavior.NEVER,
+  requestTemplates: { "application/json": '{ "statusCode": 200 }' },
+});
+
+const items = api.root.addResource("items");
+items.addMethod("GET", mock, { methodResponses: [{ statusCode: "200" }] });
+items.addMethod("POST", mock, { methodResponses: [{ statusCode: "200" }] });
+
+app.synth();

--- a/tests/integration/apigw-rest-rich/cdk.json
+++ b/tests/integration/apigw-rest-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/apigw-rest-rich/package.json
+++ b/tests/integration/apigw-rest-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-apigw-rest-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift apigw-rest-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/apigw-rest-rich/verify-detect.sh
+++ b/tests/integration/apigw-rest-rich/verify-detect.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# API Gateway REST detect + revert integration test (real AWS): the "someone toggled
+# X-Ray tracing on the stage in the console" scenario. Deploy -> record -> flip the
+# DECLARED MUTABLE Stage TracingEnabled (false->true) out of band -> check MUST DETECT
+# (exit 1) -> revert -> check MUST be CLEAN and the live value restored to false.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApigwRestRich
+APINAME=cdkrd-apigw-rest-rich
+STAGE=prod
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+APIID="$(aws apigateway get-rest-apis --region "$REGION" \
+  --query "items[?name=='$APINAME'].id | [0]" --output text)"
+[ -n "$APIID" ] && [ "$APIID" != "None" ] || fail "could not resolve rest-api id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: Stage TracingEnabled false->true (console-edit) ==="
+aws apigateway update-stage --rest-api-id "$APIID" --stage-name "$STAGE" \
+  --patch-operations op=replace,path=/tracingEnabled,value=true \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-apigw-rest-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "TracingEnabled" /tmp/cdkrd-apigw-rest-detect.out || fail "TracingEnabled not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live TracingEnabled MUST be restored to false ==="
+GOT="$(aws apigateway get-stage --rest-api-id "$APIID" --stage-name "$STAGE" \
+  --region "$REGION" --query "tracingEnabled" --output text)"
+[ "$GOT" = "False" ] || fail "live TracingEnabled not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/apigw-rest-rich/verify.sh
+++ b/tests/integration/apigw-rest-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A property-rich RestApi folds endpoint config / binary media types /
+# minimum compression size and the deployed Stage's MethodSettings ("*/*") into AWS's
+# own model with defaults. Any drift on a clean recorded stack is a normalization /
+# default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApigwRestRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/appsync-graphqlapi-rich/app.ts
+++ b/tests/integration/appsync-graphqlapi-rich/app.ts
@@ -1,0 +1,41 @@
+// CDK app for the cdk-real-drift appsync-graphqlapi-rich false-positive integration
+// test. The existing appsync-* fixtures only exercise the `added` tier (out-of-band
+// DataSources / Resolvers / Functions). This one stresses the property-RICH
+// GraphqlApi body a large fraction of CDK users deploy: X-Ray tracing, a default
+// API_KEY authorization with an auto-created key, and an additional IAM auth mode.
+// AWS folds the auth config into AdditionalAuthenticationProviders + its own defaults
+// — a clean `record`->`check` is a strong false-positive oracle. Field logging is
+// deliberately NOT enabled: AppSync would create a /aws/appsync/apis/<id> log group
+// outside the stack (an orphan the cdkrd-token sweep cannot reach).
+import { fileURLToPath } from "node:url";
+import { App, Duration, Expiration, Stack } from "aws-cdk-lib";
+import {
+  AuthorizationType,
+  Definition,
+  GraphqlApi,
+} from "aws-cdk-lib/aws-appsync";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAppsyncGraphqlapiRich");
+
+const schemaPath = fileURLToPath(new URL("./schema.graphql", import.meta.url));
+
+new GraphqlApi(stack, "Api", {
+  name: "cdkrd-appsync-rich",
+  definition: Definition.fromFile(schemaPath),
+  xrayEnabled: true,
+  authorizationConfig: {
+    defaultAuthorization: {
+      authorizationType: AuthorizationType.API_KEY,
+      apiKeyConfig: {
+        name: "cdkrd-default-key",
+        expires: Expiration.after(Duration.days(30)),
+      },
+    },
+    additionalAuthorizationModes: [
+      { authorizationType: AuthorizationType.IAM },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/appsync-graphqlapi-rich/cdk.json
+++ b/tests/integration/appsync-graphqlapi-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/appsync-graphqlapi-rich/package.json
+++ b/tests/integration/appsync-graphqlapi-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-appsync-graphqlapi-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift appsync-graphqlapi-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/appsync-graphqlapi-rich/schema.graphql
+++ b/tests/integration/appsync-graphqlapi-rich/schema.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String
+}

--- a/tests/integration/appsync-graphqlapi-rich/verify.sh
+++ b/tests/integration/appsync-graphqlapi-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A property-rich AppSync GraphqlApi folds X-Ray tracing, the default
+# API_KEY auth, and an additional IAM auth mode into AWS's own model
+# (AdditionalAuthenticationProviders + defaults). Any drift on a clean recorded stack
+# is a normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAppsyncGraphqlapiRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cognito-userpool-rich/app.ts
+++ b/tests/integration/cognito-userpool-rich/app.ts
@@ -1,0 +1,51 @@
+// CDK app for the cdk-real-drift cognito-userpool-rich false-positive integration
+// test. The existing `cognito` fixture covers a thin pool + client + group; this one
+// stresses the property-RICH UserPool surface a large fraction of CDK users deploy:
+// MFA config, a full password policy, account recovery, multiple sign-in aliases,
+// standard attributes, user verification, and device tracking. Each of these folds
+// into AWS's flat UserPool model with its own defaults — so a clean `record`->`check`
+// is a strong false-positive oracle for the Cognito normalization / default-folding
+// path.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  AccountRecovery,
+  Mfa,
+  UserPool,
+  VerificationEmailStyle,
+} from "aws-cdk-lib/aws-cognito";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCognitoUserPoolRich");
+
+new UserPool(stack, "Pool", {
+  userPoolName: "cdkrd-userpool-rich",
+  removalPolicy: RemovalPolicy.DESTROY,
+  deletionProtection: false,
+  selfSignUpEnabled: true,
+  signInAliases: { email: true, username: true },
+  signInCaseSensitive: false,
+  mfa: Mfa.OPTIONAL,
+  mfaSecondFactor: { sms: false, otp: true },
+  passwordPolicy: {
+    minLength: 12,
+    requireLowercase: true,
+    requireUppercase: true,
+    requireDigits: true,
+    requireSymbols: true,
+    tempPasswordValidity: Duration.days(3),
+  },
+  accountRecovery: AccountRecovery.EMAIL_ONLY,
+  standardAttributes: {
+    email: { required: true, mutable: true },
+    fullname: { required: false, mutable: true },
+  },
+  userVerification: {
+    emailStyle: VerificationEmailStyle.CODE,
+  },
+  deviceTracking: {
+    challengeRequiredOnNewDevice: true,
+    deviceOnlyRememberedOnUserPrompt: true,
+  },
+});
+
+app.synth();

--- a/tests/integration/cognito-userpool-rich/cdk.json
+++ b/tests/integration/cognito-userpool-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cognito-userpool-rich/package.json
+++ b/tests/integration/cognito-userpool-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cognito-userpool-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cognito-userpool-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cognito-userpool-rich/verify.sh
+++ b/tests/integration/cognito-userpool-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A property-rich Cognito UserPool folds MFA / password policy /
+# account recovery / sign-in aliases / standard attributes / device tracking into
+# AWS's flat pool model, each with its own server-side default. Any drift on a clean
+# recorded stack is a normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCognitoUserPoolRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

Wave 1 of the next `/hunt-bugs` round — three high-frequency, previously uncovered **rich** fixtures, each a false-positive oracle, plus their live reads harvested into the golden corpus for offline regression.

| Fixture | Surface | FP (record→check) | Detect+revert |
|---|---|---|---|
| `cognito-userpool-rich` | MFA / password policy / account recovery / sign-in aliases / standard attributes / device tracking | **CLEAN** (atDefault=1, readGap=1 write-only) | — |
| `apigw-rest-rich` | REGIONAL endpoint, binary media types, min compression, MOCK methods, deployed stage throttling MethodSettings | **CLEAN** (atDefault=9) | **PASS** — Stage `TracingEnabled` flipped out of band → check DETECTS → revert → CLEAN → live restored |
| `appsync-graphqlapi-rich` | X-Ray, default API_KEY auth + additional IAM auth | **CLEAN** | — |

## Result: clean round (no cdkrd bug)

All three deployed against real AWS (us-east-1), recorded, and re-checked CLEAN — no false positive. `apigw-rest-rich` additionally proves detection + revert live. A clean result is a valid result; the value banked is the regression coverage.

## Known read-gap (not a bug)

`appsync-graphqlapi-rich` reports `skipped=2`: the AppSync **ApiKey** and **GraphQLSchema** child resources return a Cloud Control `UnsupportedActionException` on read, so cdkrd transparently reports them as `skipped` (coverage incomplete) rather than guessing. The `GraphQLApi` itself **is** read via CC and compared (CLEAN). A future SDK-override could close this gap; deferred (low drift-rate, FP-prone to project).

## Corpus assets (+8 cases)

Live reads harvested via `CDKRD_CORPUS_DIR`: RestApi / Stage / Method×2 / Resource / Deployment / AppSync GraphQLApi, plus suffixed **rich RestApi** and **rich UserPool** variants (their generic `Api`/`Pool` construct ids collide with existing thin cases by logical-id, so they are added as independent replay cases). Corpus replay now **300 cases**, all green. Account ids sanitized at record time.

## Local gates

typecheck / lint+format / build / unit tests (1283) all green; corpus replay 300 green. Test-only diff (no `src/**`) → `verify-pr-gate` exempt. Cleanup gate: all three stacks deleted, `bughunt-track.sh verify` = gone + SWEEP CLEAN.