### PR TITLE
fix(diff): fold apigwv2 CORS header case + AutoDeploy Stage DeploymentId (bug-hunt)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -15,9 +15,11 @@ import {
 import { stripCcApiAwsManagedFields } from '../normalize/cc-api-strip.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
+  CASE_INSENSITIVE_ARRAY_PATHS,
   CASE_INSENSITIVE_PATHS,
   isAllAwsTags,
   identityField,
+  isCaseInsensitiveEqualScalarSet,
   isCaseInsensitiveScalarEqual,
   isEqualUnorderedScalarSet,
   isJsonStringStructEqual,
@@ -31,6 +33,7 @@ import {
   isVersionPrefixMatch,
   TRAILING_DOT_PATHS,
   GENERATED_PATHS,
+  GENERATED_TOPLEVEL_PATHS,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
   resolveGeneratedDefault,
@@ -507,6 +510,14 @@ export function classifyResource(
         isCaseInsensitiveScalarEqual(d.stateValue, d.awsValue)
       )
         continue;
+      // Per-type case-insensitive HEADER-NAME array paths (apigwv2 CORS
+      // AllowHeaders/ExposeHeaders — AWS lowercases header names): the same header
+      // set modulo case/order is not drift; a genuine header add/remove still differs.
+      if (
+        CASE_INSENSITIVE_ARRAY_PATHS[resourceType]?.has(d.path) &&
+        isCaseInsensitiveEqualScalarSet(d.stateValue, d.awsValue)
+      )
+        continue;
       // Per-type DNS-FQDN paths whose trailing `.` is optional (Route53 HostedZone Name:
       // declared `example.com`, CC returns `example.com.`) — equal once stripped.
       if (
@@ -586,6 +597,14 @@ export function classifyResource(
     // recorded — for ANY type, without a per-type GENERATED_DEFAULTS entry. The bare
     // physical-id echo (value === physicalId) is left to the structural drop below.
     if (isGeneratedName(v, physicalId)) {
+      findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // A top-level key that is ALWAYS a service-minted generated id (value-independent):
+    // the ApiGatewayV2 AutoDeploy Stage's DeploymentId, re-minted on every auto-deploy
+    // and un-settable. Folded as `generated` (never drift, recorded, or reverted) so it
+    // does not churn into false undeclared drift after any out-of-band API edit.
+    if (GENERATED_TOPLEVEL_PATHS[resourceType]?.has(k)) {
       findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
       continue;
     }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -310,6 +310,22 @@ export const GENERATED_PATHS: Record<string, string[]> = {
   'AWS::ApiGateway::Method': ['Integration.CacheNamespace'],
 };
 
+// Top-level UNDECLARED keys that are ALWAYS a service-minted, AWS-managed generated
+// id — value-INDEPENDENT (unlike GENERATED_PATHS/isPhysicalIdSegment, the value is an
+// opaque churning id, not derivable from the physical id). An ApiGatewayV2 Stage with
+// AutoDeploy=true (the CDK HttpApi default) has its `DeploymentId` minted and re-minted
+// by the service on every auto-deployment; the user cannot set it (a manual set is
+// rejected: "Deployment ID cannot be set ... because AutoDeploy is enabled"). It is
+// live-only ONLY in the AutoDeploy case — a non-AutoDeploy stage DECLARES DeploymentId,
+// so it never reaches the undeclared loop — so folding it as `generated` (inventory:
+// never drift, never recorded, never reverted) is safe AND necessary: otherwise the id
+// churns into a false undeclared drift after ANY out-of-band API edit, and a revert of
+// it fails (AutoDeploy rejects the write) so the stack never converges. Observed live on
+// a fresh apigwv2-http-rich deploy.
+export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::ApiGatewayV2::Stage': new Set(['DeploymentId']),
+};
+
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.
 // Folds a GENERATED_PATHS value only when it ECHOES an id AWS minted (an ApiGateway
 // Method's CacheNamespace = the parent Resource id, the middle segment of
@@ -536,6 +552,33 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
 };
 export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+}
+
+// Per-type property paths whose value is a set of HTTP HEADER NAMES, which AWS
+// stores/echoes LOWERCASED (header names are case-insensitive per RFC 9110). The
+// template keeps the author's casing (CDK CORS `AllowHeaders:
+// ["Content-Type","Authorization"]`), but the live read returns them lowercased
+// (`["content-type","authorization"]`), so a positional/case-sensitive diff
+// reports false declared drift on every check. Compared case- AND order-
+// insensitively (a CORS header list is an unordered set); a genuine header
+// add/remove still differs. Observed live on a fresh apigwv2-http-rich deploy.
+export const CASE_INSENSITIVE_ARRAY_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::ApiGatewayV2::Api': new Set([
+    'CorsConfiguration.AllowHeaders',
+    'CorsConfiguration.ExposeHeaders',
+  ]),
+};
+// True when both values are string arrays holding the same multiset of values
+// modulo ASCII case (order- and case-insensitive). Non-string-array inputs never
+// match — header sets only.
+export function isCaseInsensitiveEqualScalarSet(a: unknown, b: unknown): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+  if (!a.every((v) => typeof v === 'string') || !b.every((v) => typeof v === 'string'))
+    return false;
+  const norm = (arr: unknown[]): string[] => (arr as string[]).map((s) => s.toLowerCase()).sort();
+  const na = norm(a);
+  const nb = norm(b);
+  return na.every((v, i) => v === nb[i]);
 }
 
 // Per-type property paths where a value is a DNS FQDN whose trailing `.` is

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -881,6 +881,119 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       ).toEqual(['Name']);
     });
   });
+
+  // Found live by the apigwv2-http-rich bug-hunt fixture: AWS lowercases CORS
+  // header names (case-insensitive per RFC 9110), so a declared
+  // `AllowHeaders: ["Content-Type","Authorization"]` read back as
+  // `["content-type","authorization"]` false-flagged declared drift.
+  describe('case-insensitive header-name array path (apigwv2 CORS AllowHeaders/ExposeHeaders)', () => {
+    const T = 'AWS::ApiGatewayV2::Api';
+    const cors = (headers: string[]) => ({
+      CorsConfiguration: { AllowHeaders: headers, AllowMethods: ['GET', 'POST'] },
+    });
+
+    it('mixed-case declared vs lowercase live CORS AllowHeaders is NOT drift', () => {
+      expect(
+        classifyResource(
+          res(T, cors(['Content-Type', 'Authorization'])),
+          cors(['content-type', 'authorization']),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a header set in a different order is NOT drift (unordered)', () => {
+      expect(
+        classifyResource(
+          res(T, cors(['Content-Type', 'Authorization'])),
+          cors(['authorization', 'content-type']),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a genuinely changed header (same length) is still drift', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res(T, cors(['Content-Type', 'Authorization'])),
+            cors(['content-type', 'x-api-key']),
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['CorsConfiguration.AllowHeaders']);
+    });
+
+    it('ExposeHeaders is folded case-insensitively too', () => {
+      const expose = (h: string[]) => ({ CorsConfiguration: { ExposeHeaders: h } });
+      expect(
+        classifyResource(
+          res(T, expose(['X-Custom', 'X-Total'])),
+          expose(['x-total', 'x-custom']),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('the header-fold rule is scoped per-type+path (other string arrays stay strict)', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res('AWS::S3::Bucket', { CorsConfiguration: { AllowHeaders: ['Content-Type'] } }),
+            { CorsConfiguration: { AllowHeaders: ['content-type'] } },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['CorsConfiguration.AllowHeaders']);
+    });
+  });
+
+  // Found live by the apigwv2-http-rich bug-hunt fixture: the CDK HttpApi $default
+  // stage runs AutoDeploy=true, so AWS mints (and re-mints on every auto-deploy) the
+  // stage's DeploymentId. It is live-only (the user can't declare it under AutoDeploy),
+  // so without folding it records as undeclared, churns into a false drift after any
+  // out-of-band API edit, and a revert of it FAILS ("Deployment ID cannot be set ...
+  // because AutoDeploy is enabled") so the stack never converges.
+  describe('value-independent generated top-level path (apigwv2 AutoDeploy Stage DeploymentId)', () => {
+    const T = 'AWS::ApiGatewayV2::Stage';
+    const stage = (deploymentId: string) => ({
+      StageName: '$default',
+      AutoDeploy: true,
+      DeploymentId: deploymentId,
+    });
+
+    it('a live-only AutoDeploy Stage DeploymentId folds as generated (not undeclared/drift)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { StageName: '$default', AutoDeploy: true }),
+          stage('abc123def'),
+          emptySchema
+        )
+      );
+      expect(t.generated).toEqual(['DeploymentId']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('a DIFFERENT generated id still folds (value-independent — it churns)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { StageName: '$default', AutoDeploy: true }),
+          stage('zzz999new'),
+          emptySchema
+        )
+      );
+      expect(t.generated).toEqual(['DeploymentId']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('the fold is scoped per-type (a DeploymentId on another type stays undeclared)', () => {
+      expect(
+        tiers(
+          classifyResource(res('AWS::S3::Bucket', {}), { DeploymentId: 'abc123def' }, emptySchema)
+        ).undeclared
+      ).toEqual(['DeploymentId']);
+    });
+  });
 });
 
 describe('unordered-array declared false positives (R88, found by the wave-2 integ fixtures)', () => {

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD_http_rich.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD_http_rich.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiF70053CD",
+    "resourceType": "AWS::ApiGatewayV2::Api",
+    "physicalId": "z1mf4h761f",
+    "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api",
+    "declared": {
+      "CorsConfiguration": {
+        "AllowHeaders": ["Content-Type", "Authorization"],
+        "AllowMethods": ["GET", "POST"],
+        "AllowOrigins": ["https://example.com"],
+        "MaxAge": 86400
+      },
+      "Description": "cdkrd http api rich",
+      "Name": "cdkrd-httpapi-rich",
+      "ProtocolType": "HTTP"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "RouteSelectionExpression": "$request.method $request.path",
+    "Description": "cdkrd http api rich",
+    "CorsConfiguration": {
+      "AllowOrigins": ["https://example.com"],
+      "ExposeHeaders": [],
+      "AllowHeaders": ["content-type", "authorization"],
+      "MaxAge": 86400,
+      "AllowMethods": ["GET", "POST"]
+    },
+    "ProtocolType": "HTTP",
+    "ApiEndpoint": "https://z1mf4h761f.execute-api.us-east-1.amazonaws.com",
+    "DisableExecuteApiEndpoint": false,
+    "ApiId": "z1mf4h761f",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegApigwv2HttpRich",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApigwv2HttpRich/1cc87090-6d2d-11f1-8b6e-0e3eb015ac49",
+      "aws:cloudformation:logical-id": "ApiF70053CD"
+    },
+    "Name": "cdkrd-httpapi-rich"
+  },
+  "schema": {
+    "readOnly": ["ApiEndpoint", "ApiId"],
+    "writeOnly": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnly": ["ProtocolType"],
+    "readOnlyPaths": ["ApiEndpoint", "ApiId"],
+    "writeOnlyPaths": [
+      "BasePath",
+      "Body",
+      "BodyS3Location",
+      "BodyS3Location.Bucket",
+      "BodyS3Location.Etag",
+      "BodyS3Location.Key",
+      "BodyS3Location.Version",
+      "CredentialsArn",
+      "DisableSchemaValidation",
+      "FailOnWarnings",
+      "RouteKey",
+      "Target"
+    ],
+    "createOnlyPaths": ["ProtocolType"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "z1mf4h761f",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "RouteSelectionExpression",
+      "actual": "$request.method $request.path",
+      "physicalId": "z1mf4h761f",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.ApiGETitemsItemsProxy62C95830.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.ApiGETitemsItemsProxy62C95830.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiGETitemsItemsProxy62C95830",
+    "resourceType": "AWS::ApiGatewayV2::Integration",
+    "physicalId": "md6my1q",
+    "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/GET--items/ItemsProxy",
+    "declared": {
+      "ApiId": "z1mf4h761f",
+      "IntegrationMethod": "ANY",
+      "IntegrationType": "HTTP_PROXY",
+      "IntegrationUri": "https://example.com",
+      "PayloadFormatVersion": "1.0"
+    }
+  },
+  "liveRaw": {
+    "IntegrationUri": "https://example.com",
+    "PayloadFormatVersion": "1.0",
+    "ConnectionType": "INTERNET",
+    "RequestTemplates": {},
+    "ResponseParameters": {},
+    "TimeoutInMillis": 30000,
+    "IntegrationId": "md6my1q",
+    "ApiId": "z1mf4h761f",
+    "IntegrationMethod": "ANY",
+    "IntegrationType": "HTTP_PROXY"
+  },
+  "schema": {
+    "readOnly": ["IntegrationId"],
+    "writeOnly": [],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["IntegrationId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiGETitemsItemsProxy62C95830",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "ConnectionType",
+      "actual": "INTERNET",
+      "physicalId": "md6my1q",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/GET--items/ItemsProxy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiGETitemsItemsProxy62C95830",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "TimeoutInMillis",
+      "actual": 30000,
+      "physicalId": "md6my1q",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/GET--items/ItemsProxy"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Route.ApiGETitems28A279F0.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Route.ApiGETitems28A279F0.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiGETitems28A279F0",
+    "resourceType": "AWS::ApiGatewayV2::Route",
+    "physicalId": "s2sushb",
+    "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/GET--items",
+    "declared": {
+      "ApiId": "z1mf4h761f",
+      "AuthorizationType": "NONE",
+      "RouteKey": "GET /items",
+      "Target": "integrations/md6my1q"
+    }
+  },
+  "liveRaw": {
+    "Target": "integrations/md6my1q",
+    "RequestModels": {},
+    "AuthorizationScopes": [],
+    "ApiKeyRequired": false,
+    "RouteKey": "GET /items",
+    "RouteId": "s2sushb",
+    "AuthorizationType": "NONE",
+    "ApiId": "z1mf4h761f"
+  },
+  "schema": {
+    "readOnly": ["RouteId"],
+    "writeOnly": ["AuthorizerId", "RequestParameters"],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["RouteId"],
+    "writeOnlyPaths": ["AuthorizerId", "RequestParameters"],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Stage.ApiDefaultStage189A7074.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Stage.ApiDefaultStage189A7074.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiDefaultStage189A7074",
+    "resourceType": "AWS::ApiGatewayV2::Stage",
+    "physicalId": "$default",
+    "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/DefaultStage",
+    "declared": {
+      "ApiId": "z1mf4h761f",
+      "AutoDeploy": true,
+      "StageName": "$default"
+    }
+  },
+  "liveRaw": {
+    "DeploymentId": "1axai8",
+    "AutoDeploy": true,
+    "RouteSettings": {},
+    "StageName": "$default",
+    "StageVariables": {},
+    "ApiId": "z1mf4h761f",
+    "DefaultRouteSettings": {
+      "DetailedMetricsEnabled": false
+    },
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegApigwv2HttpRich",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApigwv2HttpRich/1cc87090-6d2d-11f1-8b6e-0e3eb015ac49",
+      "aws:cloudformation:logical-id": "ApiDefaultStage189A7074"
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApiId", "StageName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId", "StageName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "ApiDefaultStage189A7074",
+      "resourceType": "AWS::ApiGatewayV2::Stage",
+      "path": "DeploymentId",
+      "actual": "1axai8",
+      "physicalId": "$default",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/DefaultStage"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ApiGatewayV2__Stage.Live.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Stage.Live.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest4 + R76 ApiGatewayV2 CC-identifier adapters): fresh-deploy AWS::ApiGatewayV2::Stage model — now READABLE via the ApiId|<child> composite identifier (was a CC ValidationException skip before R76). A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "description": "RECORDED LIVE (harvest4 + R76 ApiGatewayV2 CC-identifier adapters): fresh-deploy AWS::ApiGatewayV2::Stage model \u2014 now READABLE via the ApiId|<child> composite identifier (was a CC ValidationException skip before R76). A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
   "resource": {
     "logicalId": "Live",
     "resourceType": "AWS::ApiGatewayV2::Stage",
@@ -50,7 +50,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Live",
       "resourceType": "AWS::ApiGatewayV2::Stage",
       "path": "DeploymentId",

--- a/tests/corpus/AWS__CodeBuild__Project.Build45A36621.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build45A36621.json
@@ -1,0 +1,142 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Build45A36621",
+    "resourceType": "AWS::CodeBuild::Project",
+    "physicalId": "cdkrd-pipeline-build",
+    "constructPath": "CdkRealDriftIntegCodepipelineRich/Build",
+    "declared": {
+      "Artifacts": {
+        "Type": "CODEPIPELINE"
+      },
+      "Cache": {
+        "Type": "NO_CACHE"
+      },
+      "EncryptionKey": "alias/aws/s3",
+      "Environment": {
+        "ComputeType": "BUILD_GENERAL1_SMALL",
+        "Image": "aws/codebuild/standard:7.0",
+        "ImagePullCredentialsType": "CODEBUILD",
+        "PrivilegedMode": false,
+        "Type": "LINUX_CONTAINER"
+      },
+      "Name": "cdkrd-pipeline-build",
+      "ServiceRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipelineRich-BuildRoleB7C66CB2-boSD5hU2L0yj",
+      "Source": {
+        "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"echo hello\"\n      ]\n    }\n  }\n}",
+        "Type": "CODEPIPELINE"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-pipeline-build",
+    "ServiceRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipelineRich-BuildRoleB7C66CB2-boSD5hU2L0yj",
+    "TimeoutInMinutes": 60,
+    "QueuedTimeoutInMinutes": 480,
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+    "Source": {
+      "Type": "CODEPIPELINE",
+      "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"echo hello\"\n      ]\n    }\n  }\n}",
+      "InsecureSsl": false
+    },
+    "Artifacts": {
+      "Type": "CODEPIPELINE",
+      "Name": "cdkrd-pipeline-build",
+      "Packaging": "NONE",
+      "EncryptionDisabled": false
+    },
+    "Environment": {
+      "Type": "LINUX_CONTAINER",
+      "ComputeType": "BUILD_GENERAL1_SMALL",
+      "Image": "aws/codebuild/standard:7.0",
+      "PrivilegedMode": false,
+      "ImagePullCredentialsType": "CODEBUILD",
+      "EnvironmentVariables": []
+    },
+    "Visibility": "PRIVATE",
+    "BadgeEnabled": false,
+    "Cache": {
+      "Type": "NO_CACHE"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Build45A36621",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "TimeoutInMinutes",
+      "actual": 60,
+      "physicalId": "cdkrd-pipeline-build",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Build45A36621",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "QueuedTimeoutInMinutes",
+      "actual": 480,
+      "physicalId": "cdkrd-pipeline-build",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Build45A36621",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Visibility",
+      "actual": "PRIVATE",
+      "physicalId": "cdkrd-pipeline-build",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Build45A36621",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Artifacts.Name",
+      "actual": "cdkrd-pipeline-build",
+      "nested": true,
+      "physicalId": "cdkrd-pipeline-build",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Build45A36621",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Artifacts.Packaging",
+      "actual": "NONE",
+      "nested": true,
+      "physicalId": "cdkrd-pipeline-build",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodePipeline__Pipeline.PipelineC660917D.json
+++ b/tests/corpus/AWS__CodePipeline__Pipeline.PipelineC660917D.json
@@ -1,0 +1,200 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PipelineC660917D",
+    "resourceType": "AWS::CodePipeline::Pipeline",
+    "physicalId": "cdkrd-pipeline-rich",
+    "constructPath": "CdkRealDriftIntegCodepipelineRich/Pipeline",
+    "declared": {
+      "ArtifactStore": {
+        "Location": "cdkrealdriftintegcodepipelineric-artifacts82dd59a1-8kr0plrd95pv",
+        "Type": "S3"
+      },
+      "Name": "cdkrd-pipeline-rich",
+      "PipelineType": "V2",
+      "RestartExecutionOnUpdate": false,
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipelineR-PipelineRoleD68726F7-l0p742trfc42",
+      "Stages": [
+        {
+          "Actions": [
+            {
+              "ActionTypeId": {
+                "Category": "Source",
+                "Owner": "AWS",
+                "Provider": "S3",
+                "Version": "1"
+              },
+              "Configuration": {
+                "S3Bucket": "cdkrealdriftintegcodepipelineric-artifacts82dd59a1-8kr0plrd95pv",
+                "S3ObjectKey": "source.zip"
+              },
+              "Name": "S3Source",
+              "OutputArtifacts": [
+                {
+                  "Name": "Artifact_Source_S3Source"
+                }
+              ],
+              "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineSourceS3SourceCod-q1Iw340CCx9D",
+              "RunOrder": 1
+            }
+          ],
+          "Name": "Source"
+        },
+        {
+          "Actions": [
+            {
+              "ActionTypeId": {
+                "Category": "Build",
+                "Owner": "AWS",
+                "Provider": "CodeBuild",
+                "Version": "1"
+              },
+              "Configuration": {
+                "ProjectName": "cdkrd-pipeline-build"
+              },
+              "InputArtifacts": [
+                {
+                  "Name": "Artifact_Source_S3Source"
+                }
+              ],
+              "Name": "Build",
+              "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineBuildCodePipeline-yIxaSVx63jq0",
+              "RunOrder": 1
+            }
+          ],
+          "Name": "Build"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Variables": [],
+    "ArtifactStores": [],
+    "Version": "1",
+    "ArtifactStore": {
+      "Type": "S3",
+      "Location": "cdkrealdriftintegcodepipelineric-artifacts82dd59a1-8kr0plrd95pv"
+    },
+    "DisableInboundStageTransitions": [],
+    "Stages": [
+      {
+        "Blockers": [],
+        "Actions": [
+          {
+            "ActionTypeId": {
+              "Owner": "AWS",
+              "Category": "Source",
+              "Version": "1",
+              "Provider": "S3"
+            },
+            "Configuration": {
+              "S3Bucket": "cdkrealdriftintegcodepipelineric-artifacts82dd59a1-8kr0plrd95pv",
+              "S3ObjectKey": "source.zip"
+            },
+            "InputArtifacts": [],
+            "OutputArtifacts": [
+              {
+                "Files": [],
+                "Name": "Artifact_Source_S3Source"
+              }
+            ],
+            "Commands": [],
+            "OutputVariables": [],
+            "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineSourceS3SourceCod-q1Iw340CCx9D",
+            "RunOrder": 1,
+            "Name": "S3Source"
+          }
+        ],
+        "Name": "Source"
+      },
+      {
+        "Blockers": [],
+        "Actions": [
+          {
+            "ActionTypeId": {
+              "Owner": "AWS",
+              "Category": "Build",
+              "Version": "1",
+              "Provider": "CodeBuild"
+            },
+            "Configuration": {
+              "ProjectName": "cdkrd-pipeline-build"
+            },
+            "InputArtifacts": [
+              {
+                "Name": "Artifact_Source_S3Source"
+              }
+            ],
+            "OutputArtifacts": [],
+            "Commands": [],
+            "OutputVariables": [],
+            "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineBuildCodePipeline-yIxaSVx63jq0",
+            "RunOrder": 1,
+            "Name": "Build"
+          }
+        ],
+        "Name": "Build"
+      }
+    ],
+    "PipelineType": "V2",
+    "ExecutionMode": "SUPERSEDED",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipelineR-PipelineRoleD68726F7-l0p742trfc42",
+    "Tags": [],
+    "Name": "cdkrd-pipeline-rich"
+  },
+  "schema": {
+    "readOnly": ["Version"],
+    "writeOnly": ["RestartExecutionOnUpdate"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Version"],
+    "writeOnlyPaths": ["RestartExecutionOnUpdate"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {
+      "ExecutionMode": "SUPERSEDED"
+    },
+    "defaultPaths": {
+      "ExecutionMode": "SUPERSEDED"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "PipelineC660917D",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "RestartExecutionOnUpdate",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-pipeline-rich",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Pipeline"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipelineC660917D",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "ExecutionMode",
+      "actual": "SUPERSEDED",
+      "physicalId": "cdkrd-pipeline-rich",
+      "constructPath": "CdkRealDriftIntegCodepipelineRich/Pipeline"
+    }
+  ]
+}

--- a/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
@@ -1,0 +1,263 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Domain66AC69E0",
+    "resourceType": "AWS::OpenSearchService::Domain",
+    "physicalId": "cdkrd-opensearch-rich",
+    "constructPath": "CdkRealDriftIntegOpensearchRich/Domain",
+    "declared": {
+      "ClusterConfig": {
+        "DedicatedMasterEnabled": false,
+        "InstanceCount": 1,
+        "InstanceType": "t3.small.search",
+        "MultiAZWithStandbyEnabled": false,
+        "ZoneAwarenessEnabled": false
+      },
+      "DomainEndpointOptions": {
+        "EnforceHTTPS": true,
+        "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+      },
+      "DomainName": "cdkrd-opensearch-rich",
+      "EBSOptions": {
+        "EBSEnabled": true,
+        "VolumeSize": 10,
+        "VolumeType": "gp3"
+      },
+      "EncryptionAtRestOptions": {
+        "Enabled": true
+      },
+      "EngineVersion": "OpenSearch_2.13",
+      "LogPublishingOptions": {},
+      "NodeToNodeEncryptionOptions": {
+        "Enabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "SnapshotOptions": {
+      "AutomatedSnapshotStartHour": 0
+    },
+    "NodeToNodeEncryptionOptions": {
+      "Enabled": true
+    },
+    "DomainEndpoints": {},
+    "DomainEndpointOptions": {
+      "CustomEndpointEnabled": false,
+      "EnforceHTTPS": true,
+      "TLSSecurityPolicy": "Policy-Min-TLS-1-2-2019-07"
+    },
+    "DomainArn": "arn:aws:es:us-east-1:111111111111:domain/cdkrd-opensearch-rich",
+    "CognitoOptions": {
+      "Enabled": false
+    },
+    "AdvancedOptions": {
+      "override_main_response_version": "false",
+      "rest.action.multi.allow_explicit_index": "true"
+    },
+    "IPAddressType": "ipv4",
+    "EBSOptions": {
+      "EBSEnabled": true,
+      "VolumeType": "gp3",
+      "Throughput": 125,
+      "Iops": 3000,
+      "VolumeSize": 10
+    },
+    "Tags": [],
+    "EngineVersion": "OpenSearch_2.13",
+    "SoftwareUpdateOptions": {
+      "AutoSoftwareUpdateEnabled": false
+    },
+    "DomainName": "cdkrd-opensearch-rich",
+    "LogPublishingOptions": {},
+    "AIMLOptions": {
+      "S3VectorsEngine": {
+        "Enabled": false
+      },
+      "ServerlessVectorAcceleration": {
+        "Enabled": false
+      }
+    },
+    "AutomatedSnapshotPauseOptions": {
+      "Enabled": false
+    },
+    "DeploymentStrategyOptions": {
+      "DeploymentStrategy": "CapacityOptimized"
+    },
+    "AdvancedSecurityOptions": {
+      "AnonymousAuthEnabled": false,
+      "InternalUserDatabaseEnabled": false,
+      "Enabled": false,
+      "AnonymousAuthDisableDate": "null"
+    },
+    "DomainEndpoint": "search-cdkrd-opensearch-rich-hmatpq2gdqbiuvdyzaoalwlaei.us-east-1.es.amazonaws.com",
+    "ServiceSoftwareOptions": {
+      "NewVersion": "",
+      "UpdateStatus": "COMPLETED",
+      "Description": "There is no software update available for this domain.",
+      "Cancellable": false,
+      "CurrentVersion": "OpenSearch_2_13_R20260428",
+      "AutomatedUpdateDate": "1970-01-01T00:00:00Z",
+      "UpdateAvailable": false,
+      "OptionalDeployment": true
+    },
+    "IdentityCenterOptions": {},
+    "Id": "111111111111/cdkrd-opensearch-rich",
+    "Arn": "arn:aws:es:us-east-1:111111111111:domain/cdkrd-opensearch-rich",
+    "EncryptionAtRestOptions": {
+      "KmsKeyId": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "Enabled": true
+    },
+    "OffPeakWindowOptions": {
+      "OffPeakWindow": {
+        "WindowStartTime": {
+          "Hours": 2,
+          "Minutes": 0
+        }
+      },
+      "Enabled": true
+    },
+    "ClusterConfig": {
+      "InstanceCount": 1,
+      "MultiAZWithStandbyEnabled": false,
+      "WarmEnabled": false,
+      "DedicatedMasterEnabled": false,
+      "ColdStorageOptions": {
+        "Enabled": false
+      },
+      "InstanceType": "t3.small.search",
+      "ZoneAwarenessEnabled": false
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnly": [],
+    "createOnly": ["DomainName", "EncryptionAtRestOptions"],
+    "readOnlyPaths": [
+      "AdvancedSecurityOptions.AnonymousAuthDisableDate",
+      "Arn",
+      "DomainArn",
+      "DomainEndpoint",
+      "DomainEndpointV2",
+      "DomainEndpoints",
+      "Id",
+      "IdentityCenterOptions.IdentityCenterApplicationARN",
+      "IdentityCenterOptions.IdentityStoreId",
+      "ServiceSoftwareOptions"
+    ],
+    "writeOnlyPaths": [
+      "AdvancedSecurityOptions.JWTOptions.PublicKey",
+      "AdvancedSecurityOptions.MasterUserOptions",
+      "AdvancedSecurityOptions.SAMLOptions.MasterBackendRole",
+      "AdvancedSecurityOptions.SAMLOptions.MasterUserName"
+    ],
+    "createOnlyPaths": ["AdvancedSecurityOptions.Enabled", "DomainName", "EncryptionAtRestOptions"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "SnapshotOptions",
+      "actual": {
+        "AutomatedSnapshotStartHour": 0
+      },
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "AdvancedOptions",
+      "actual": {
+        "override_main_response_version": "false",
+        "rest.action.multi.allow_explicit_index": "true"
+      },
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "IPAddressType",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "DeploymentStrategyOptions",
+      "actual": {
+        "DeploymentStrategy": "CapacityOptimized"
+      },
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "OffPeakWindowOptions",
+      "actual": {
+        "OffPeakWindow": {
+          "WindowStartTime": {
+            "Hours": 2,
+            "Minutes": 0
+          }
+        },
+        "Enabled": true
+      },
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Throughput",
+      "actual": 125,
+      "nested": true,
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EBSOptions.Iops",
+      "actual": 3000,
+      "nested": true,
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Domain66AC69E0",
+      "resourceType": "AWS::OpenSearchService::Domain",
+      "path": "EncryptionAtRestOptions.KmsKeyId",
+      "actual": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "nested": true,
+      "physicalId": "cdkrd-opensearch-rich",
+      "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
+    }
+  ]
+}

--- a/tests/integration/apigwv2-http-rich/app.ts
+++ b/tests/integration/apigwv2-http-rich/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift apigwv2-http-rich false-positive integration test.
+// The existing apigwv2-* fixtures only exercise the `added` tier (out-of-band routes /
+// integrations / stages). This one stresses the property-RICH HTTP Api body a large
+// fraction of CDK users deploy: a CORS preflight config (origins / methods / headers /
+// max-age), an API description, and a route backed by an HTTP_PROXY integration. AWS
+// folds the CORS config + the auto-created $default stage into its own model with
+// defaults — a clean `record`->`check` is a strong false-positive oracle.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import {
+  CorsHttpMethod,
+  HttpApi,
+  HttpMethod,
+} from "aws-cdk-lib/aws-apigatewayv2";
+import { HttpUrlIntegration } from "aws-cdk-lib/aws-apigatewayv2-integrations";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegApigwv2HttpRich");
+
+const api = new HttpApi(stack, "Api", {
+  apiName: "cdkrd-httpapi-rich",
+  description: "cdkrd http api rich",
+  corsPreflight: {
+    allowOrigins: ["https://example.com"],
+    allowMethods: [CorsHttpMethod.GET, CorsHttpMethod.POST],
+    allowHeaders: ["Content-Type", "Authorization"],
+    maxAge: Duration.days(1),
+  },
+});
+
+api.addRoutes({
+  path: "/items",
+  methods: [HttpMethod.GET],
+  integration: new HttpUrlIntegration("ItemsProxy", "https://example.com"),
+});
+
+app.synth();

--- a/tests/integration/apigwv2-http-rich/cdk.json
+++ b/tests/integration/apigwv2-http-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/apigwv2-http-rich/package.json
+++ b/tests/integration/apigwv2-http-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-apigwv2-http-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift apigwv2-http-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/apigwv2-http-rich/verify-detect.sh
+++ b/tests/integration/apigwv2-http-rich/verify-detect.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# HTTP Api detect + revert integration test (real AWS): the "someone edited the API
+# description in the console" scenario. Deploy -> record -> change the DECLARED MUTABLE
+# Api Description out of band -> check MUST DETECT (exit 1) -> revert -> check MUST be
+# CLEAN and the live value restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApigwv2HttpRich
+APINAME=cdkrd-httpapi-rich
+WANT="cdkrd http api rich"
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+APIID="$(aws apigatewayv2 get-apis --region "$REGION" \
+  --query "Items[?Name=='$APINAME'].ApiId | [0]" --output text)"
+[ -n "$APIID" ] && [ "$APIID" != "None" ] || fail "could not resolve http api id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: Api Description -> 'changed by console' ==="
+aws apigatewayv2 update-api --api-id "$APIID" --description "changed by console" \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-httpapi-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "Description" /tmp/cdkrd-httpapi-detect.out || fail "Description not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live Description MUST be restored ==="
+GOT="$(aws apigatewayv2 get-api --api-id "$APIID" --region "$REGION" --query "Description" --output text)"
+[ "$GOT" = "$WANT" ] || fail "live Description not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/apigwv2-http-rich/verify.sh
+++ b/tests/integration/apigwv2-http-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A property-rich HTTP Api folds CORS (origins / methods / headers /
+# max-age), the API description, and the auto-created $default stage into AWS's own
+# model with defaults. Any drift on a clean recorded stack is a normalization /
+# default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApigwv2HttpRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/codepipeline-rich/app.ts
+++ b/tests/integration/codepipeline-rich/app.ts
@@ -1,0 +1,67 @@
+// CDK app for the cdk-real-drift codepipeline-rich false-positive integration test.
+// A CodePipeline is a property-RICH CI/CD resource a large fraction of CDK users
+// deploy: a V2 pipeline with an S3 artifact store, an S3 source stage and a CodeBuild
+// build stage, each contributing nested config (ArtifactStore, Stages[].Actions[]
+// with ActionTypeId / Configuration maps) that AWS folds into its own model with
+// defaults (RunOrder, Region, Namespace, ExecutionMode). A clean `record`->`check`
+// is a strong false-positive oracle for those nested CodePipeline structures. The
+// artifact bucket uses autoDeleteObjects so teardown leaves no orphan (its custom
+// resource Lambda log group carries the stack token and is swept).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { BuildSpec, PipelineProject } from "aws-cdk-lib/aws-codebuild";
+import { Artifact, Pipeline, PipelineType } from "aws-cdk-lib/aws-codepipeline";
+import {
+  CodeBuildAction,
+  S3SourceAction,
+} from "aws-cdk-lib/aws-codepipeline-actions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCodepipelineRich");
+
+const bucket = new Bucket(stack, "Artifacts", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const project = new PipelineProject(stack, "Build", {
+  projectName: "cdkrd-pipeline-build",
+  buildSpec: BuildSpec.fromObject({
+    version: "0.2",
+    phases: { build: { commands: ["echo hello"] } },
+  }),
+});
+
+const sourceOutput = new Artifact();
+
+new Pipeline(stack, "Pipeline", {
+  pipelineName: "cdkrd-pipeline-rich",
+  artifactBucket: bucket,
+  pipelineType: PipelineType.V2,
+  restartExecutionOnUpdate: false,
+  stages: [
+    {
+      stageName: "Source",
+      actions: [
+        new S3SourceAction({
+          actionName: "S3Source",
+          bucket,
+          bucketKey: "source.zip",
+          output: sourceOutput,
+        }),
+      ],
+    },
+    {
+      stageName: "Build",
+      actions: [
+        new CodeBuildAction({
+          actionName: "Build",
+          project,
+          input: sourceOutput,
+        }),
+      ],
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/codepipeline-rich/cdk.json
+++ b/tests/integration/codepipeline-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codepipeline-rich/package.json
+++ b/tests/integration/codepipeline-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-codepipeline-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift codepipeline-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/codepipeline-rich/verify.sh
+++ b/tests/integration/codepipeline-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A V2 CodePipeline folds an S3 artifact store + an S3 source stage +
+# a CodeBuild build stage (nested Stages[].Actions[] with ActionTypeId / Configuration
+# and defaulted RunOrder / Region / ExecutionMode) into AWS's own model. Any drift on
+# a clean recorded stack is a normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodepipelineRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/opensearch-rich/app.ts
+++ b/tests/integration/opensearch-rich/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift opensearch-rich false-positive integration test.
+// An OpenSearch Service Domain is a property-RICH, security-sensitive resource a large
+// fraction of search/log users deploy: a cluster config, an EBS volume, node-to-node
+// encryption, encryption-at-rest, and enforced HTTPS / a domain endpoint TLS policy.
+// AWS folds each of these into its own model with server-side defaults (e.g. a default
+// TLSSecurityPolicy, an auto-generated KMS key for at-rest encryption, software-update
+// options) — so a clean `record`->`check` is a strong false-positive oracle for the
+// OpenSearch normalization / default-folding path. Single data node + small EBS keep
+// the (slow ~10-15 min) deploy as cheap as a real domain allows.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { EbsDeviceVolumeType } from "aws-cdk-lib/aws-ec2";
+import { Domain, EngineVersion } from "aws-cdk-lib/aws-opensearchservice";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegOpensearchRich");
+
+new Domain(stack, "Domain", {
+  domainName: "cdkrd-opensearch-rich",
+  version: EngineVersion.OPENSEARCH_2_13,
+  removalPolicy: RemovalPolicy.DESTROY,
+  capacity: {
+    dataNodes: 1,
+    dataNodeInstanceType: "t3.small.search",
+    multiAzWithStandbyEnabled: false,
+  },
+  ebs: {
+    volumeSize: 10,
+    volumeType: EbsDeviceVolumeType.GP3,
+  },
+  zoneAwareness: { enabled: false },
+  nodeToNodeEncryption: true,
+  encryptionAtRest: { enabled: true },
+  enforceHttps: true,
+});
+
+app.synth();

--- a/tests/integration/opensearch-rich/cdk.json
+++ b/tests/integration/opensearch-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/opensearch-rich/package.json
+++ b/tests/integration/opensearch-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-opensearch-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift opensearch-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/opensearch-rich/verify.sh
+++ b/tests/integration/opensearch-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A property-rich OpenSearch Domain folds cluster config / EBS /
+# node-to-node encryption / encryption-at-rest / enforced HTTPS into AWS's own model,
+# each with a server-side default (TLS policy, auto KMS key, software-update options).
+# Any drift on a clean recorded stack is a normalization / default-folding false
+# positive. NOTE: OpenSearch domains take ~10-15 min to create and delete.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegOpensearchRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture (slow ~10-15 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

Wave 2 of the `/hunt-bugs` round. The property-rich **apigwv2-http-rich** fixture surfaced **two real bugs** (a false positive and an un-revertible revert), both fixed with unit tests + the live fixture kept as regression. OpenSearch + CodePipeline were clean rounds.

## Bug 1 — CORS header-name case FALSE POSITIVE

AWS lowercases CORS header **names** (case-insensitive per RFC 9110). A declared `AllowHeaders: ["Content-Type","Authorization"]` reads back as `["content-type","authorization"]` → false **declared** drift on every check.

**Fix:** `CASE_INSENSITIVE_ARRAY_PATHS` + `isCaseInsensitiveEqualScalarSet` fold `CorsConfiguration.AllowHeaders`/`ExposeHeaders` **case- and order-insensitively**; a genuine header add/remove still differs.

## Bug 2 — AutoDeploy Stage `DeploymentId` churn + un-revertible revert

The CDK `HttpApi` `$default` stage runs `AutoDeploy=true`, so AWS mints (and re-mints on every auto-deploy) the stage `DeploymentId`. It is live-only, so it: recorded as undeclared, **churned into a false drift after any out-of-band API edit**, and a revert of it **FAILED** (`Deployment ID cannot be set ... because AutoDeploy is enabled`) leaving the stack non-converged.

**Fix:** `GENERATED_TOPLEVEL_PATHS` folds it as `generated` (never drift, recorded, or reverted). Safe: a non-AutoDeploy stage **declares** `DeploymentId`, so it never reaches the undeclared loop. The existing real-data corpus case `AWS__ApiGatewayV2__Stage.Live.json` flips `undeclared`→`generated`, confirming the fix against data harvested from a real AutoDeploy stage.

## Live verification (real AWS, us-east-1)

| Fixture | record→check | detect+revert |
|---|---|---|
| apigwv2-http-rich | **CLEAN** (was: CORS FP) | **PASS** — Api Description out of band → detect → revert → CLEAN → restored (was: revert failed on DeploymentId) |
| opensearch-rich | **CLEAN** | — (clean round) |
| codepipeline-rich | **CLEAN** | — (clean round) |

## Tests

- Unit: 8 new `classify.test.ts` cases (CORS case/order fold + scoping; DeploymentId value-independent generated fold + scoping). Proven to fail without each fix.
- Corpus: +8 golden cases (OpenSearch Domain, CodePipeline Pipeline, CodeBuild Project, apigwv2 Stage/Integration/Route, suffixed rich Api). Replay **1298 green**.
- typecheck / lint+format / build / full unit suite all green.

## Cleanup

All three stacks deleted; `bughunt-track.sh verify` = gone + SWEEP CLEAN (a CodePipeline autoDelete Lambda log group orphan was swept).