### PR TITLE
fix(hunt-bugs): make cleanup sentinel parallel-safe (per-owner files)

### DIFF
--- a/.claude/hooks/bughunt-clean-gate.sh
+++ b/.claude/hooks/bughunt-clean-gate.sh
@@ -56,30 +56,45 @@ if [ -n "$git_common" ]; then
 else
   main_root="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "$target_dir")"
 fi
-sentinel="${main_root}/.markgate-bughunt-pending"
+# Parallel-safe aggregation: each owner tracks ONLY its own file under
+# .markgate-bughunt-pending.d/<owner-key> (bughunt-track.sh), so one owner's `clear`
+# can never release another's pending resources. The gate blocks while ANY owner has
+# pending stacks — the safe direction. The legacy flat file is still honored for
+# back-compat (a session armed before this change, or a stray hand-written file).
+pending_dir="${main_root}/.markgate-bughunt-pending.d"
+legacy="${main_root}/.markgate-bughunt-pending"
 
-# Sentinel absent or empty → no pending bug-hunt resources → pass.
-[ -s "$sentinel" ] || exit 0
+sources=()
+if [ -d "$pending_dir" ]; then
+  while IFS= read -r f; do
+    [ -s "$f" ] && sources+=("$f")
+  done < <(find "$pending_dir" -type f 2>/dev/null)
+fi
+[ -s "$legacy" ] && sources+=("$legacy")
 
-pending=$(grep -cvE '^[[:space:]]*$' "$sentinel" 2>/dev/null || echo 0)
+# No owner files (and no legacy file) with content → nothing pending → pass.
+[ "${#sources[@]}" -gt 0 ] || exit 0
+
+pending=$(cat "${sources[@]}" 2>/dev/null | grep -cvE '^[[:space:]]*$' || echo 0)
 [ "$pending" -gt 0 ] || exit 0
 
 {
   echo "Blocked by bughunt-clean-gate: a /hunt-bugs session still has"
-  echo "${pending} un-deleted stack(s) tracked in:"
-  echo "  ${sentinel}"
+  echo "${pending} un-deleted stack(s) tracked under:"
+  echo "  ${pending_dir}/ (per-owner)"
   echo
   echo "Pending stacks:"
-  sed 's/^/  - /' "$sentinel"
+  cat "${sources[@]}" 2>/dev/null | grep -vE '^[[:space:]]*$' | sed 's/^/  - /'
   echo
-  echo "Required action — delete every tracked stack, verify zero orphans,"
-  echo "then release the gate:"
+  echo "Required action — from the SAME worktree you armed from (or with the same"
+  echo "\$CDKRD_BUGHUNT_OWNER), delete every tracked stack, verify zero orphans,"
+  echo "then release the gate for your owner:"
   echo "  delstack cdk -a cdk.out -r <region> -f -y          # from each fixture dir"
   echo "  .claude/skills/hunt-bugs/bughunt-track.sh verify --region <region>"
   echo "  .claude/skills/hunt-bugs/bughunt-track.sh clear"
   echo
-  echo "Do NOT delete the sentinel by hand to bypass this — the whole point is"
-  echo "that bug-hunt resources cannot be forgotten. Clear it only after the"
+  echo "Do NOT delete the pending files by hand to bypass this — the whole point is"
+  echo "that bug-hunt resources cannot be forgotten. Clear only after the"
   echo "delete + orphan-zero verification actually passed."
 } >&2
 exit 2

--- a/.claude/hooks/bughunt-clean-gate.test.sh
+++ b/.claude/hooks/bughunt-clean-gate.test.sh
@@ -67,6 +67,102 @@ run "armed + git push passes"             1 "git push origin main"  0
 run "armed + echo mentioning git commit"  1 "echo 'run git commit later'"           0
 run "armed + echo mentioning gh pr merge" 1 "echo 'remember to gh pr merge soon'"   0
 
+# ---------------------------------------------------------------------------
+# Parallel-safe (per-owner) coverage + the SPOF regression.
+#
+# The tracker resolves REPO_ROOT from its OWN location (SCRIPT_DIR), so to drive it
+# against a throwaway repo we copy it into that repo's skill path and run the COPY —
+# then the tracker and the cwd-resolving gate agree on the temp repo root. The
+# tracker under test defaults to this worktree's copy, but can be overridden to the
+# OLD single-file tracker via BUGHUNT_TRACKER_OVERRIDE to prove the SPOF case fails
+# against pre-port code.
+# ---------------------------------------------------------------------------
+TRACKER="${BUGHUNT_TRACKER_OVERRIDE:-$(cd "$(dirname "$0")/../skills/hunt-bugs" && pwd)/bughunt-track.sh}"
+
+# gate_exit <tmp> <cmd> -> echoes the hook's exit code
+gate_exit() {
+  local tmp="$1" cmd="$2" payload code
+  payload="{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)},\"cwd\":\"$tmp\"}"
+  set +e
+  printf '%s' "$payload" | bash "$HOOK" >/dev/null 2>&1
+  code=$?
+  set -e
+  printf '%s' "$code"
+}
+
+# check <name> <actual> <expect>
+check() {
+  if [ "$2" -eq "$3" ]; then
+    PASS=$((PASS + 1)); echo "ok   - $1 (exit $2)"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL - $1 (got $2, expected $3)"
+  fi
+}
+
+# assert_file <name> <test-expr...> (e.g. -s path / ! -e path)
+assert_file() {
+  local name="$1"; shift
+  if [ "$@" ]; then
+    PASS=$((PASS + 1)); echo "ok   - $name"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL - $name"
+  fi
+}
+
+# Make a throwaway repo with a copy of the tracker at its skill path.
+spof_setup() {
+  local tmp; tmp=$(mktemp -d)
+  (
+    cd "$tmp"
+    git init -q -b main
+    git config user.email t@t
+    git config user.name t
+    : > seed
+    git add -A
+    git commit -q -m init
+  )
+  mkdir -p "$tmp/.claude/skills/hunt-bugs"
+  cp "$TRACKER" "$tmp/.claude/skills/hunt-bugs/bughunt-track.sh"
+  printf '%s' "$tmp"
+}
+
+# Empty .d/ → pass.
+T=$(spof_setup)
+mkdir -p "$T/.markgate-bughunt-pending.d"
+check "empty .d/ passes git commit" "$(gate_exit "$T" "git commit -m x")" 0
+rm -rf "$T"
+
+# Armed via .d/ (per-owner) → block all three gated commands.
+T=$(spof_setup)
+TR="$T/.claude/skills/hunt-bugs/bughunt-track.sh"
+CDKRD_BUGHUNT_OWNER=ownerA bash "$TR" add CdkRealDriftIntegA >/dev/null
+check "armed via .d/ blocks git commit"   "$(gate_exit "$T" "git commit -m x")"        2
+check "armed via .d/ blocks gh pr create" "$(gate_exit "$T" "gh pr create --fill")"    2
+check "armed via .d/ blocks gh pr merge"  "$(gate_exit "$T" "gh pr merge 5 --squash")" 2
+rm -rf "$T"
+
+# SPOF regression: two distinct owners; A's clear must NOT release B's pending stacks.
+T=$(spof_setup)
+TR="$T/.claude/skills/hunt-bugs/bughunt-track.sh"
+CDKRD_BUGHUNT_OWNER=ownerA bash "$TR" add CdkRealDriftIntegA >/dev/null
+CDKRD_BUGHUNT_OWNER=ownerB bash "$TR" add CdkRealDriftIntegB >/dev/null
+check "both owners armed -> gate blocks" "$(gate_exit "$T" "git commit -m x")" 2
+CDKRD_BUGHUNT_OWNER=ownerA bash "$TR" clear >/dev/null
+# THE proof the SPOF is closed — fails on the old single-file tracker (A's clear
+# wiped the whole file, releasing B), passes on the per-owner port.
+check "after A clears, B still pending -> gate STILL blocks" "$(gate_exit "$T" "git commit -m x")" 2
+assert_file "B's owner file survived A's clear" -s "$T/.markgate-bughunt-pending.d/ownerB"
+assert_file "A's owner file removed by A's clear" ! -e "$T/.markgate-bughunt-pending.d/ownerA"
+CDKRD_BUGHUNT_OWNER=ownerB bash "$TR" clear >/dev/null
+check "after both owners clear -> gate releases" "$(gate_exit "$T" "git commit -m x")" 0
+rm -rf "$T"
+
+# Legacy flat file still honored (back-compat with a session armed pre-port).
+T=$(spof_setup)
+printf 'CdkRealDriftIntegLegacy\n' > "$T/.markgate-bughunt-pending"
+check "legacy flat file still blocks" "$(gate_exit "$T" "git commit -m x")" 2
+rm -rf "$T"
+
 echo
 echo "bughunt-clean-gate: ${PASS} passed, ${FAIL} failed"
 [ "$FAIL" -eq 0 ]

--- a/.claude/skills/hunt-bugs/bughunt-track.sh
+++ b/.claude/skills/hunt-bugs/bughunt-track.sh
@@ -4,9 +4,9 @@
 #
 # The /hunt-bugs skill deploys real AWS resources (CloudFormation stacks via the
 # integ fixtures). To make "always delete them" a structural guarantee — not a
-# matter of remembering — every deployed stack is tracked in a gitignored sentinel
-# file. The bughunt-clean-gate hook (.claude/hooks/bughunt-clean-gate.sh) blocks
-# `git commit` / `gh pr create` / `gh pr merge` while that sentinel is non-empty,
+# matter of remembering — every deployed stack is tracked in a gitignored sentinel.
+# The bughunt-clean-gate hook (.claude/hooks/bughunt-clean-gate.sh) blocks
+# `git commit` / `gh pr create` / `gh pr merge` while ANY pending stack remains,
 # so a bug-hunt session cannot land any commit until its stacks are deleted and
 # verified gone.
 #
@@ -15,13 +15,29 @@
 #   verify [--region R]         Assert each tracked stack is GONE from
 #                               CloudFormation AND sweep-orphans.sh is CLEAN.
 #                               Non-zero exit if anything remains. Does NOT clear.
-#   clear                       Empty the sentinel (releases the gate). Run ONLY
-#                               after verify passes (delete + orphan-zero).
-#   list                        Print the currently-tracked stacks.
+#   clear                       Empty THIS owner's pending list (releases the gate
+#                               for this owner). Run ONLY after verify passes.
+#   list [--all]                Print this owner's tracked stacks (--all: every
+#                               owner's, plus any legacy flat file).
 #
-# The sentinel lives at the SHARED main-tree root (via --git-common-dir) so the
+# PARALLEL-SAFE design (per-owner files). The old single shared file
+# `.markgate-bughunt-pending` was a SPOF: `clear` did `rm -f` on the WHOLE file, so
+# one agent's clear wiped a CONCURRENT agent's still-pending stacks — releasing the
+# gate while live AWS resources remained (the exact accident the gate prevents).
+# Instead each owner writes ONLY its own file under
+# `.markgate-bughunt-pending.d/<owner-key>`, so a clear can never release another
+# owner's pending resources. The gate AGGREGATES across all owner files (+ the
+# legacy flat file for back-compat): it blocks while ANY owner is pending — the safe
+# direction (cross-owner contention over-blocks; it never premature-releases).
+# Destructive ops (clear) are per-owner; the block decision is repo-wide. No file
+# locking is needed (each owner appends only to its own file; append is atomic),
+# which also dodges macOS's missing `flock`.
+#
+# Everything is resolved at the SHARED main-tree root (via --git-common-dir) so the
 # deploy-time tracker and the gate hook — which may run from different worktrees —
-# agree on one path.
+# agree on one location. The OWNER KEY is $CDKRD_BUGHUNT_OWNER if set, else the
+# per-worktree toplevel path (so parallel agents in their own worktrees get distinct
+# owners automatically), sanitized to a safe filename.
 
 set -euo pipefail
 
@@ -32,8 +48,16 @@ if [ -n "${GIT_COMMON_DIR}" ]; then
 else
   REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 fi
-SENTINEL="${REPO_ROOT}/.markgate-bughunt-pending"
+PENDING_DIR="${REPO_ROOT}/.markgate-bughunt-pending.d"
+LEGACY_SENTINEL="${REPO_ROOT}/.markgate-bughunt-pending" # honored by gate; cleared by this owner
 SWEEP="${REPO_ROOT}/tests/integration/sweep-orphans.sh"
+
+owner_raw="${CDKRD_BUGHUNT_OWNER:-}"
+if [ -z "${owner_raw}" ]; then
+  owner_raw="$(git -C "${SCRIPT_DIR}" rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+OWNER_KEY="$(printf '%s' "${owner_raw}" | sed 's#[^A-Za-z0-9._-]#_#g')"
+OWNER_FILE="${PENDING_DIR}/${OWNER_KEY}"
 
 cmd="${1:-}"
 shift || true
@@ -44,20 +68,41 @@ case "${cmd}" in
       echo "usage: bughunt-track.sh add <Stack> [<Stack> ...]" >&2
       exit 2
     fi
-    touch "${SENTINEL}"
+    mkdir -p "${PENDING_DIR}"
+    touch "${OWNER_FILE}"
     for stack in "$@"; do
-      if ! grep -qxF "${stack}" "${SENTINEL}" 2>/dev/null; then
-        echo "${stack}" >>"${SENTINEL}"
+      if ! grep -qxF "${stack}" "${OWNER_FILE}" 2>/dev/null; then
+        echo "${stack}" >>"${OWNER_FILE}"
       fi
     done
-    echo "tracked $# stack(s); bughunt-clean gate is now ARMED"
+    echo "tracked $# stack(s) for owner ${OWNER_KEY}; bughunt-clean gate is now ARMED"
     ;;
 
   list)
-    if [ -s "${SENTINEL}" ]; then
-      cat "${SENTINEL}"
+    if [ "${1:-}" = "--all" ]; then
+      shown=0
+      if [ -d "${PENDING_DIR}" ]; then
+        for f in "${PENDING_DIR}"/*; do
+          [ -s "${f}" ] || continue
+          while IFS= read -r stack; do
+            [ -z "${stack}" ] && continue
+            echo "$(basename "${f}"): ${stack}"
+            shown=1
+          done <"${f}"
+        done
+      fi
+      if [ -s "${LEGACY_SENTINEL}" ]; then
+        while IFS= read -r stack; do
+          [ -z "${stack}" ] && continue
+          echo "(legacy): ${stack}"
+          shown=1
+        done <"${LEGACY_SENTINEL}"
+      fi
+      [ "${shown}" -eq 1 ] || echo "(no tracked stacks)"
+    elif [ -s "${OWNER_FILE}" ]; then
+      cat "${OWNER_FILE}"
     else
-      echo "(no tracked stacks)"
+      echo "(no tracked stacks for owner ${OWNER_KEY})"
     fi
     ;;
 
@@ -69,8 +114,8 @@ case "${cmd}" in
         *) echo "unknown arg: $1" >&2; exit 2 ;;
       esac
     done
-    if [ ! -s "${SENTINEL}" ]; then
-      echo "no tracked stacks — nothing to verify"
+    if [ ! -s "${OWNER_FILE}" ]; then
+      echo "no tracked stacks for owner ${OWNER_KEY} — nothing to verify"
       exit 0
     fi
     fail=0
@@ -85,7 +130,7 @@ case "${cmd}" in
         echo "STILL PRESENT: stack ${stack} is ${status} — delete it (delstack cdk -a cdk.out -r ${region} -f -y)" >&2
         fail=1
       fi
-    done <"${SENTINEL}"
+    done <"${OWNER_FILE}"
     # 2) no stack-EXTERNAL orphans may remain (log groups, RETAIN resources, etc.).
     if [ -x "${SWEEP}" ]; then
       sweep_out="$(AWS_REGION="${region}" bash "${SWEEP}" 2>&1 || true)"
@@ -108,8 +153,13 @@ case "${cmd}" in
     ;;
 
   clear)
-    rm -f "${SENTINEL}"
-    echo "sentinel cleared; bughunt-clean gate is now RELEASED"
+    # Remove ONLY this owner's file (+ the legacy flat file this owner may have
+    # armed). NEVER `rm -rf` the whole dir — that would release a CONCURRENT owner's
+    # still-pending stacks (the SPOF this design fixes).
+    rm -f "${OWNER_FILE}" "${LEGACY_SENTINEL}"
+    # Tidy the dir if this was the last owner (cosmetic; harmless if it is not empty).
+    rmdir "${PENDING_DIR}" 2>/dev/null || true
+    echo "cleared owner ${OWNER_KEY}; bughunt-clean gate is now RELEASED for this owner"
     ;;
 
   *)

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ cdk.context.json
 # by bughunt-track.sh add, cleared by bughunt-track.sh clear after delete +
 # orphan-zero verification.
 .markgate-bughunt-pending
+.markgate-bughunt-pending.d/
 
 # cdkd-parity tracking-issue sentinel (per-worktree; written by /check-cdkd-parity)
 .cdkd-parity-issue


### PR DESCRIPTION
## Summary

The `/hunt-bugs` cleanup gate used a **single shared sentinel file** `.markgate-bughunt-pending`, which is a **SPOF under parallel hunts** (multiple agents/worktrees). `bughunt-track.sh clear` did `rm -f` on the WHOLE file, so one owner's clear **wiped a concurrent owner's still-pending stacks** — releasing the gate while live AWS resources remained (the exact accident the gate exists to prevent).

Ports the structural fix from cdkd's `fix-bughunt-parallel-safe` while **keeping cdkrd's own `verify`** (CloudFormation `describe-stacks` + `sweep-orphans.sh`, not cdkd's S3 `state.json` check).

## Design — per-owner files (lock-free)

Replace the single file with a directory `.markgate-bughunt-pending.d/<owner-key>`:

- **Owner key** = `$CDKRD_BUGHUNT_OWNER`, else the per-worktree `git rev-parse --show-toplevel`, sanitized → parallel agents in their own worktrees get distinct owners automatically.
- **`add` / `verify` / `clear` touch ONLY the caller's own owner file** → one owner's clear can never release another's pending resources. `clear` removes just the owner file (+ the legacy flat file this owner may have armed); it **never `rm -rf`s the dir**.
- **The gate AGGREGATES** across all owner files + the legacy flat file and blocks while **ANY** owner is pending — the safe direction (cross-owner contention over-blocks; never premature-releases).
- **No locking** (each owner appends only to its own file; append is atomic) — also dodges macOS's missing `flock`.
- **Legacy flat file still honored** for back-compat (a session armed pre-port).

> Asymmetry: destructive ops (clear) are per-owner; the read-only block decision is repo-wide.

## Verification

`bash .claude/hooks/bughunt-clean-gate.test.sh` → **20/20 pass**, including the SPOF regression:

> **after owner A clears, owner B still pending → gate STILL blocks**

Proven to **FAIL on the old single-file tracker** (`got 0, expected 2` — A's clear released B; B's file did not survive) and **PASS on the per-owner port** — concrete proof the SPOF is closed. Also covers: empty `.d/` passes, armed-via-`.d/` blocks commit/pr-create/pr-merge, B's file survives A's clear, both-clear releases, and legacy flat file still blocks.

## Files

- `.claude/skills/hunt-bugs/bughunt-track.sh` — per-owner add/verify/clear/list (+`--all`); verify keeps CFn + sweep.
- `.claude/hooks/bughunt-clean-gate.sh` — directory aggregation + legacy fallback.
- `.claude/hooks/bughunt-clean-gate.test.sh` — +10 cases incl. SPOF regression.
- `.gitignore` — ignore `.markgate-bughunt-pending.d/`.

Tooling-only (no `src/**`) → `verify-pr-gate` exempt; `check` + `docs` markers set.