### PR TITLE
fix: Synthetics rate() expression FP + Scheduler CC-revert despite read-override (bug-hunt)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -22,6 +22,7 @@ import {
   isCaseInsensitiveEqualScalarSet,
   isCaseInsensitiveScalarEqual,
   isEqualUnorderedScalarSet,
+  isEquivalentRateExpression,
   isJsonStringStructEqual,
   isPemEqual,
   isStringlyEqualScalar,
@@ -36,6 +37,7 @@ import {
   GENERATED_TOPLEVEL_PATHS,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
+  RATE_EXPRESSION_PATHS,
   resolveGeneratedDefault,
   sortUnorderedObjectArray,
   stripAwsTagsDeep,
@@ -516,6 +518,14 @@ export function classifyResource(
       if (
         CASE_INSENSITIVE_ARRAY_PATHS[resourceType]?.has(d.path) &&
         isCaseInsensitiveEqualScalarSet(d.stateValue, d.awsValue)
+      )
+        continue;
+      // Per-type rate() schedule-expression paths (Synthetics canary Schedule.Expression
+      // — AWS rewrites `rate(60 minutes)` to `rate(1 hour)`): the same total duration is
+      // not drift; a genuine interval change still differs.
+      if (
+        RATE_EXPRESSION_PATHS[resourceType]?.has(d.path) &&
+        isEquivalentRateExpression(d.stateValue, d.awsValue)
       )
         continue;
       // Per-type DNS-FQDN paths whose trailing `.` is optional (Route53 HostedZone Name:

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -581,6 +581,38 @@ export function isCaseInsensitiveEqualScalarSet(a: unknown, b: unknown): boolean
   return na.every((v, i) => v === nb[i]);
 }
 
+// Per-type property paths whose value is a `rate(N unit)` schedule expression that the
+// SERVICE canonicalizes to whole units. CloudWatch Synthetics rewrites a canary's
+// `rate(60 minutes)` to `rate(1 hour)` (CDK's Canary emits the minutes form from
+// `Duration.hours(1)`), so a string compare false-flags declared drift on every check.
+// Compared by NUMERIC DURATION, so an equivalent expression is not drift but a genuine
+// interval change still differs. Observed SYNTHETICS-SPECIFIC: EventBridge Scheduler
+// (and Events::Rule) echo the rate expression VERBATIM (proven live — a scheduler
+// fixture declaring `rate(1 hour)` read back identically), so they are deliberately NOT
+// listed; only paths where the service is observed to rewrite belong here.
+export const RATE_EXPRESSION_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::Synthetics::Canary': new Set(['Schedule.Expression']),
+};
+const RATE_RE = /^rate\(\s*(\d+)\s+(minute|minutes|hour|hours|day|days)\s*\)$/i;
+const RATE_UNIT_MIN: Record<string, number> = { minute: 1, hour: 60, day: 1440 };
+// True when both values are `rate(N unit)` expressions of the SAME total duration
+// (e.g. `rate(60 minutes)` == `rate(1 hour)`). Only the rate() form is parsed — a
+// cron() expression or any unparseable string returns false (strict compare), so a
+// genuine schedule change still surfaces.
+export function isEquivalentRateExpression(a: unknown, b: unknown): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const minutes = (s: string): number | undefined => {
+    const m = RATE_RE.exec(s.trim());
+    if (!m || m[1] === undefined || m[2] === undefined) return undefined;
+    const unit = m[2].toLowerCase().replace(/s$/, '');
+    const per = RATE_UNIT_MIN[unit];
+    return per === undefined ? undefined : Number(m[1]) * per;
+  };
+  const ma = minutes(a);
+  const mb = minutes(b);
+  return ma !== undefined && mb !== undefined && ma === mb;
+}
+
 // Per-type property paths where a value is a DNS FQDN whose trailing `.` is
 // OPTIONAL and semantically meaningless: AWS::Route53::HostedZone `Name` is declared
 // `example.com` in the template but Cloud Control returns it `example.com.` (the

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -16,6 +16,16 @@ import { SDK_OVERRIDES } from '../read/overrides.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { SDK_PROP_WRITERS, SDK_WRITERS } from './writers.js';
 
+// SDK-override types that are nonetheless Cloud Control FULLY_MUTABLE — their override
+// exists only to work around a READ quirk, NOT because CC cannot UPDATE them, so a CC
+// UpdateResource revert is valid and they are EXEMPT from the "read-override => not
+// revertable" rule below. AWS::Scheduler::Schedule is the case: its CC read handler
+// only looks in the DEFAULT schedule group (the override reads via Scheduler
+// GetSchedule with the declared GroupName), but CC can update it fine. Verified live —
+// a schedule State revert via CC succeeds for the common default-group case. (A
+// non-default-group schedule would fail at apply with a clear AWS error, not silently.)
+const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>(['AWS::Scheduler::Schedule']);
+
 /**
  * A nested undeclared value (a live sub-key inside a declared object, R96/R98) is
  * detect/record-only — never revertable (toPointer can't build a safe RFC6902 patch for
@@ -234,8 +244,14 @@ export function buildRevertPlan(
       });
       continue;
     }
-    // CC-gap types are revertable only when we have a type-specific SDK writer
-    if (SDK_OVERRIDES[f.resourceType] && !SDK_WRITERS[f.resourceType]) {
+    // CC-gap types are revertable only when we have a type-specific SDK writer — UNLESS
+    // the override is a mere READ workaround on a CC-mutable type (see the set above),
+    // in which case a CC UpdateResource revert is valid and we fall through to it.
+    if (
+      SDK_OVERRIDES[f.resourceType] &&
+      !SDK_WRITERS[f.resourceType] &&
+      !CC_REVERTABLE_DESPITE_READ_OVERRIDE.has(f.resourceType)
+    ) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -994,6 +994,57 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       ).toEqual(['DeploymentId']);
     });
   });
+
+  // Found live by the synthetics-rich bug-hunt fixture: AWS Synthetics rewrites a
+  // canary's rate() schedule to whole units (CDK emits `rate(60 minutes)` from
+  // Duration.hours(1); AWS returns `rate(1 hour)`), false-flagging declared drift.
+  describe('rate() schedule-expression equivalence (Synthetics Canary Schedule.Expression)', () => {
+    const T = 'AWS::Synthetics::Canary';
+    const sched = (expr: string) => ({ Schedule: { Expression: expr } });
+
+    it('rate(60 minutes) vs rate(1 hour) is NOT drift (same duration)', () => {
+      expect(
+        classifyResource(res(T, sched('rate(60 minutes)')), sched('rate(1 hour)'), emptySchema)
+      ).toEqual([]);
+    });
+
+    it('rate(1440 minutes) vs rate(1 day) is NOT drift', () => {
+      expect(
+        classifyResource(res(T, sched('rate(1440 minutes)')), sched('rate(1 day)'), emptySchema)
+      ).toEqual([]);
+    });
+
+    it('a genuinely different interval is still drift', () => {
+      expect(
+        tiers(classifyResource(res(T, sched('rate(1 hour)')), sched('rate(2 hours)'), emptySchema))
+          .declared
+      ).toEqual(['Schedule.Expression']);
+    });
+
+    it('a cron() expression is compared strictly (only rate() is folded)', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res(T, sched('cron(0 10 * * ? *)')),
+            sched('cron(0 12 * * ? *)'),
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['Schedule.Expression']);
+    });
+
+    it('the rate fold is scoped per-type+path (other types stay strict)', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res('AWS::Scheduler::Schedule', { ScheduleExpression: 'rate(60 minutes)' }),
+            { ScheduleExpression: 'rate(1 hour)' },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['ScheduleExpression']);
+    });
+  });
 });
 
 describe('unordered-array declared false positives (R88, found by the wave-2 integ fixtures)', () => {

--- a/tests/corpus/AWS__Scheduler__Schedule.Schedule.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.Schedule.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Schedule",
+    "resourceType": "AWS::Scheduler::Schedule",
+    "physicalId": "cdkrd-schedule-rich",
+    "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule",
+    "declared": {
+      "Description": "cdkrd scheduler rich",
+      "FlexibleTimeWindow": {
+        "Mode": "OFF"
+      },
+      "Name": "cdkrd-schedule-rich",
+      "ScheduleExpression": "rate(1 hour)",
+      "State": "ENABLED",
+      "Target": {
+        "Arn": "arn:aws:sqs:us-east-1:111111111111:cdkrd-scheduler-target",
+        "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSchedulerRich-SchedRole812B2F5C-MfSZzr2FgUhy"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-schedule-rich",
+    "GroupName": "default",
+    "ScheduleExpression": "rate(1 hour)",
+    "ScheduleExpressionTimezone": "UTC",
+    "FlexibleTimeWindow": {
+      "Mode": "OFF"
+    },
+    "State": "ENABLED",
+    "Description": "cdkrd scheduler rich",
+    "ActionAfterCompletion": "NONE",
+    "Target": {
+      "Arn": "arn:aws:sqs:us-east-1:111111111111:cdkrd-scheduler-target",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSchedulerRich-SchedRole812B2F5C-MfSZzr2FgUhy",
+      "RetryPolicy": {
+        "MaximumEventAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 185
+      }
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {
+      "Target.EcsParameters.CapacityProviderStrategy.*.Weight": 0,
+      "Target.EcsParameters.CapacityProviderStrategy.*.Base": 0
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Schedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "GroupName",
+      "actual": "default",
+      "physicalId": "cdkrd-schedule-rich",
+      "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Schedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "ScheduleExpressionTimezone",
+      "actual": "UTC",
+      "physicalId": "cdkrd-schedule-rich",
+      "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Schedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "ActionAfterCompletion",
+      "actual": "NONE",
+      "physicalId": "cdkrd-schedule-rich",
+      "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Schedule",
+      "resourceType": "AWS::Scheduler::Schedule",
+      "path": "Target.RetryPolicy",
+      "actual": {
+        "MaximumEventAgeInSeconds": 86400,
+        "MaximumRetryAttempts": 185
+      },
+      "nested": true,
+      "physicalId": "cdkrd-schedule-rich",
+      "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
+++ b/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
@@ -1,0 +1,151 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Canary11957FE2",
+    "resourceType": "AWS::Synthetics::Canary",
+    "physicalId": "cdkrd-canary",
+    "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary",
+    "declared": {
+      "ArtifactS3Location": "s3://cdkrealdriftintegsynthetic-canaryartifacts16b34762-icjww5o7gj2r",
+      "Code": {
+        "Handler": "index.handler",
+        "Script": "exports.handler = async function () { return 'cdkrd canary ok'; };"
+      },
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSyntheti-CanaryServiceRoleD132250E-sVivB1VUdKXs",
+      "Name": "cdkrd-canary",
+      "RuntimeVersion": "syn-nodejs-puppeteer-16.1",
+      "Schedule": {
+        "DurationInSeconds": "0",
+        "Expression": "rate(60 minutes)"
+      },
+      "StartCanaryAfterCreation": true
+    }
+  },
+  "liveRaw": {
+    "SuccessRetentionPeriod": 31,
+    "RuntimeVersion": "syn-nodejs-puppeteer-16.1",
+    "RunConfig": {
+      "TimeoutInSeconds": 840,
+      "MemoryInMB": 1500,
+      "EphemeralStorage": 1024,
+      "ActiveTracing": false
+    },
+    "FailureRetentionPeriod": 31,
+    "Code": {
+      "Handler": "index.handler"
+    },
+    "Name": "cdkrd-canary",
+    "ProvisionedResourceCleanup": "AUTOMATIC",
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSyntheti-CanaryServiceRoleD132250E-sVivB1VUdKXs",
+    "State": "RUNNING",
+    "Schedule": {
+      "DurationInSeconds": "0",
+      "RetryConfig": {
+        "MaxRetries": 0
+      },
+      "Expression": "rate(1 hour)"
+    },
+    "Id": "ba5b9411-9326-4dd4-adf9-80e9673b4d6b",
+    "ArtifactS3Location": "s3://cdkrealdriftintegsynthetic-canaryartifacts16b34762-icjww5o7gj2r",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Id", "State"],
+    "writeOnly": [
+      "DeleteLambdaResourcesOnCanaryDeletion",
+      "DryRunAndUpdate",
+      "ResourcesToReplicateTags",
+      "StartCanaryAfterCreation",
+      "VisualReference",
+      "VisualReferences"
+    ],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Code.SourceLocationArn", "Id", "State"],
+    "writeOnlyPaths": [
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.Script",
+      "DeleteLambdaResourcesOnCanaryDeletion",
+      "DryRunAndUpdate",
+      "ResourcesToReplicateTags",
+      "RunConfig.EnvironmentVariables",
+      "StartCanaryAfterCreation",
+      "VisualReference",
+      "VisualReferences"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Canary11957FE2",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "StartCanaryAfterCreation",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-canary",
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Canary11957FE2",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "SuccessRetentionPeriod",
+      "actual": 31,
+      "physicalId": "cdkrd-canary",
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Canary11957FE2",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "RunConfig",
+      "actual": {
+        "TimeoutInSeconds": 840,
+        "MemoryInMB": 1500,
+        "EphemeralStorage": 1024,
+        "ActiveTracing": false
+      },
+      "physicalId": "cdkrd-canary",
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Canary11957FE2",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "FailureRetentionPeriod",
+      "actual": 31,
+      "physicalId": "cdkrd-canary",
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Canary11957FE2",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "ProvisionedResourceCleanup",
+      "actual": "AUTOMATIC",
+      "physicalId": "cdkrd-canary",
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Canary11957FE2",
+      "resourceType": "AWS::Synthetics::Canary",
+      "path": "Schedule.RetryConfig",
+      "actual": {
+        "MaxRetries": 0
+      },
+      "nested": true,
+      "physicalId": "cdkrd-canary",
+      "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
+    }
+  ]
+}

--- a/tests/integration/scheduler-rich/app.ts
+++ b/tests/integration/scheduler-rich/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift scheduler-rich false-positive integration test.
+// EventBridge Scheduler (AWS::Scheduler::Schedule) is a common cron/rate replacement
+// for CloudWatch Events rules. A schedule folds a FlexibleTimeWindow, a Target
+// (Arn/RoleArn + defaulted RetryPolicy), and State into AWS's model — a clean
+// `record`->`check` is a strong false-positive oracle. The target is an SQS queue
+// (with a scheduler-assumable role) so the stack is self-contained.
+import { App, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnSchedule } from "aws-cdk-lib/aws-scheduler";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSchedulerRich");
+
+const queue = new Queue(stack, "Target", { queueName: "cdkrd-scheduler-target" });
+const role = new Role(stack, "SchedRole", {
+  assumedBy: new ServicePrincipal("scheduler.amazonaws.com"),
+});
+queue.grantSendMessages(role);
+
+new CfnSchedule(stack, "Schedule", {
+  name: "cdkrd-schedule-rich",
+  description: "cdkrd scheduler rich",
+  state: "ENABLED",
+  flexibleTimeWindow: { mode: "OFF" },
+  scheduleExpression: "rate(1 hour)",
+  target: { arn: queue.queueArn, roleArn: role.roleArn },
+});
+
+app.synth();

--- a/tests/integration/scheduler-rich/cdk.json
+++ b/tests/integration/scheduler-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/scheduler-rich/package.json
+++ b/tests/integration/scheduler-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-scheduler-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift scheduler-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/scheduler-rich/verify-detect.sh
+++ b/tests/integration/scheduler-rich/verify-detect.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# EventBridge Scheduler detect + revert integration test (real AWS): the "someone
+# disabled the schedule in the console" scenario. Deploy -> record -> flip the
+# DECLARED MUTABLE State ENABLED->DISABLED out of band -> check MUST DETECT (exit 1)
+# -> revert -> check MUST be CLEAN and State restored to ENABLED.
+#
+# `update-schedule` is PUT-style (it replaces the whole schedule), so the out-of-band
+# edit re-asserts the SAME config the fixture declares and only flips --state. The
+# config values are known from app.ts, so this stays deterministic.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSchedulerRich
+NAME=cdkrd-schedule-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+# Resolve the target + role arns the schedule was created with (to re-assert on update).
+TARGET_ARN="$(aws scheduler get-schedule --name "$NAME" --region "$REGION" --query 'Target.Arn' --output text)"
+ROLE_ARN="$(aws scheduler get-schedule --name "$NAME" --region "$REGION" --query 'Target.RoleArn' --output text)"
+[ -n "$TARGET_ARN" ] && [ "$TARGET_ARN" != "None" ] || fail "could not resolve schedule target arn"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: State ENABLED->DISABLED (console-edit) ==="
+aws scheduler update-schedule --name "$NAME" --region "$REGION" \
+  --schedule-expression "rate(1 hour)" \
+  --flexible-time-window Mode=OFF \
+  --target "Arn=$TARGET_ARN,RoleArn=$ROLE_ARN" \
+  --state DISABLED >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-scheduler-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "State" /tmp/cdkrd-scheduler-detect.out || fail "State not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live State MUST be restored to ENABLED ==="
+GOT="$(aws scheduler get-schedule --name "$NAME" --region "$REGION" --query "State" --output text)"
+[ "$GOT" = "ENABLED" ] || fail "live State not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/scheduler-rich/verify.sh
+++ b/tests/integration/scheduler-rich/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. An EventBridge Scheduler schedule folds FlexibleTimeWindow + Target (defaulted RetryPolicy) + State into AWS's model; any drift on a clean recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSchedulerRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/synthetics-rich/app.ts
+++ b/tests/integration/synthetics-rich/app.ts
@@ -1,0 +1,42 @@
+// CDK app for the cdk-real-drift synthetics-rich false-positive integration test.
+// A CloudWatch Synthetics Canary is a common uptime/API monitor. It folds a RunConfig,
+// a Schedule, ArtifactS3Location, and Code into AWS's model with defaults — a clean
+// `record`->`check` is a false-positive oracle for the Synthetics path. The runtime is
+// pinned via the escape hatch (`new Runtime(...)`) to a CURRENTLY non-deprecated
+// version (named CDK enum consts drift / deprecate, like the OpenSearch/RDS lesson);
+// verify with `aws synthetics describe-runtime-versions`. The canary uses its OWN
+// autoDelete artifacts bucket so teardown leaves no orphan (its custom-resource Lambda
+// log group + the canary's cwsyn-* log group both carry the cdkrd token for the sweep).
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import {
+  Canary,
+  Code,
+  Runtime,
+  RuntimeFamily,
+  Schedule,
+  Test,
+} from "aws-cdk-lib/aws-synthetics";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSyntheticsRich");
+
+const artifacts = new Bucket(stack, "CanaryArtifacts", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+new Canary(stack, "Canary", {
+  canaryName: "cdkrd-canary",
+  runtime: new Runtime("syn-nodejs-puppeteer-16.1", RuntimeFamily.NODEJS),
+  artifactsBucketLocation: { bucket: artifacts },
+  schedule: Schedule.rate(Duration.hours(1)),
+  test: Test.custom({
+    handler: "index.handler",
+    code: Code.fromInline(
+      "exports.handler = async function () { return 'cdkrd canary ok'; };"
+    ),
+  }),
+});
+
+app.synth();

--- a/tests/integration/synthetics-rich/cdk.json
+++ b/tests/integration/synthetics-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/synthetics-rich/package.json
+++ b/tests/integration/synthetics-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-synthetics-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift synthetics-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/synthetics-rich/verify.sh
+++ b/tests/integration/synthetics-rich/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A Synthetics canary folds RunConfig + Schedule + ArtifactS3Location + Code into AWS's model with defaults; any drift on a clean recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSyntheticsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -165,6 +165,24 @@ describe('buildRevertPlan', () => {
     expect(plan.notRevertable).toHaveLength(0);
   });
 
+  it('a read-override type that is CC-mutable (Scheduler::Schedule) IS revertable via CC', () => {
+    // Found live by the scheduler-rich bug-hunt fixture: AWS::Scheduler::Schedule has an
+    // SDK READ override (its CC read handler only looks in the default group) but is CC
+    // FULLY_MUTABLE, so a State revert via CC UpdateResource is valid — it must NOT be
+    // classified "type not revertable yet".
+    const f = F({
+      resourceType: 'AWS::Scheduler::Schedule',
+      path: 'State',
+      desired: 'ENABLED',
+      actual: 'DISABLED',
+      physicalId: 'cdkrd-schedule-rich',
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]).toMatchObject({ kind: 'cc', resourceType: 'AWS::Scheduler::Schedule' });
+  });
+
   it('an `added` resource -> a `delete`-kind item keyed on its CC identifier', () => {
     const f = F({
       tier: 'added',


### PR DESCRIPTION
## Summary

Wave 3 of the `/hunt-bugs` round. The `synthetics-rich` and `scheduler-rich` fixtures each surfaced a **real bug**, both fixed with unit tests + live-proven regression fixtures.

## Bug 1 — Synthetics canary `rate()` schedule FALSE POSITIVE

AWS Synthetics **rewrites** a canary's `rate()` schedule to whole units: CDK's `Canary` emits `rate(60 minutes)` (from `Duration.hours(1)`), AWS returns `rate(1 hour)` → false **declared** drift on `Schedule.Expression` every check.

**Fix:** `RATE_EXPRESSION_PATHS` + `isEquivalentRateExpression` compare the `rate()` form by **numeric duration**; a genuine interval change still differs. **Scoped Synthetics-specific** — EventBridge Scheduler echoes the rate expression *verbatim* (proven live: a scheduler fixture declaring `rate(1 hour)` read back identically), so it is deliberately NOT folded, keeping the rule FP-safe.

## Bug 2 — `AWS::Scheduler::Schedule` drift was NOT revertable

The revert plan classified **every** SDK-override type without an SDK writer as `type not revertable yet`. But `Scheduler::Schedule`'s override is only a **READ** workaround (its CC read handler looks only in the *default* schedule group) — the type is CC **FULLY_MUTABLE**, so a CC `UpdateResource` revert is valid.

**Fix:** `CC_REVERTABLE_DESPITE_READ_OVERRIDE` exempts such types so the CC revert runs. **Live-proven:** State `ENABLED`→`DISABLED` → detect → revert → CLEAN → restored to `ENABLED`.

## Live verification (real AWS, us-east-1)

| Fixture | record→check | detect+revert |
|---|---|---|
| synthetics-rich | **CLEAN** (was: rate() FP) | — |
| scheduler-rich | **CLEAN** | **PASS** — State out of band → detect → revert → CLEAN → restored (was: `not revertable`) |

## Tests

- Unit: 5 `classify.test.ts` rate-equivalence cases (60min≡1hr, 1440min≡1day, genuine-change drift, cron strict, per-type scope) + 1 `revert-plan.test.ts` case (Scheduler is CC-revertable). Proven to fail without each fix.
- Corpus: +2 cases (Scheduler Schedule; Synthetics Canary whose `rate(60 minutes)` vs `rate(1 hour)` yields **no** `Schedule.Expression` finding — the offline guard for fix 1). Replay **1306 green**.
- typecheck / lint+format / build / full suite green.

## Not committed: cloudmap-http

A Cloud Map HTTP namespace + service fixture was deployed and probed but **not committed** — both `AWS::ServiceDiscovery::HttpNamespace` and `Service` are CC `UnsupportedAction` on read (everything `skipped`), so the fixture has no FP/FN regression value. Recorded as an SDK_OVERRIDES candidate for later.

## Cleanup

All three stacks deleted; verify = gone + SWEEP CLEAN (4 orphan log groups — 2 autoDelete custom-resource + 2 `cwsyn-cdkrd-canary` — swept via the cdkrd token). Dogfooded the new per-owner cleanup gate (#258).