### PR TITLE
fix(revert): CloudFront Distribution revert via UpdateDistribution SDK writer + CloudFront/S3/SFN hunt integs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -541,7 +541,17 @@ only when non-zero — unrecorded values are named as such, never folded into
     ([apply-ops.ts](../src/revert/apply-ops.ts), pure) → SDK `Put*`. Covers
     `AWS::S3::BucketPolicy`, `AWS::SNS::TopicPolicy`, `AWS::SQS::QueuePolicy`,
     `AWS::IAM::Policy`, and `AWS::IAM::ManagedPolicy` (`CreatePolicyVersion` +
-    SetAsDefault, pruning the oldest version at the 5-version cap).
+    SetAsDefault, pruning the oldest version at the 5-version cap),
+    `AWS::ServiceDiscovery::HttpNamespace` (`UpdateHttpNamespace`),
+    `AWS::DocDB::DBCluster` (`ModifyDBCluster`), and
+    `AWS::CloudFront::Distribution` — CloudFront is CC-READABLE but its
+    `UpdateResource` REJECTS even a minimal single-property patch (applying it
+    re-validates the whole distribution and the default ViewerCertificate trips a
+    `SslSupportMethod` validation, proven live — EVERY CloudFront revert failed),
+    so revert reads `GetDistributionConfig`, applies the ops, and re-submits the
+    full config via `UpdateDistribution(IfMatch=ETag)` so AWS's own
+    ViewerCertificate round-trips verbatim (robust for the common scalar
+    `DistributionConfig` drifts: Comment / DefaultRootObject / Enabled / …).
   - **Property-scoped SDK writers** (`SDK_PROP_WRITERS`): a CC-writable type where
     ONE property must bypass Cloud Control. An IAM Role's top-level `Policies`
     finding reverts per entry (`DeleteRolePolicy` / `PutRolePolicy` by

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@aws-sdk/client-budgets": "^3.1065.0",
     "@aws-sdk/client-cloudcontrol": "^3.1065.0",
     "@aws-sdk/client-cloudformation": "^3.1065.0",
+    "@aws-sdk/client-cloudfront": "^3.1073.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1066.0",
     "@aws-sdk/client-codebuild": "^3.1068.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1069.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@aws-sdk/client-cloudformation':
         specifier: ^3.1065.0
         version: 3.1066.0
+      '@aws-sdk/client-cloudfront':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-cloudwatch-logs':
         specifier: ^3.1066.0
         version: 3.1066.0
@@ -279,6 +282,10 @@ packages:
 
   '@aws-sdk/client-cloudformation@3.1066.0':
     resolution: {integrity: sha512-SQZuF/4iFaW6VEqsU/2W78x3Mp98olccKlFiQG8VsrtAc8rIMTmvhQtU5cugeOVGpOXDDuXPSyVaxmOaGafeww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudfront@3.1073.0':
+    resolution: {integrity: sha512-D6SXls6EO/ncFPV6D6p5M8D0vwoZFp/UpOFUL2QRf8cswfU0Z4wAz32ozGsGhITyCFKWCj4s3LWqnsex8FyOcQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cloudwatch-logs@3.1066.0':
@@ -3725,6 +3732,19 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/credential-provider-node': 3.972.55
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudfront@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -21,6 +21,11 @@
 //     reconstruction would be missing the required limit and would wipe the cost
 //     filters/types on write. Too divergent from the reader to revert safely ->
 //     left not-revertable.
+import {
+  CloudFrontClient,
+  GetDistributionConfigCommand,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
 import { DocDBClient, ModifyDBClusterCommand } from '@aws-sdk/client-docdb';
 import {
   ElasticLoadBalancingV2Client,
@@ -318,7 +323,41 @@ const writeDocDbCluster: SdkWriter = async (ctx, ops) => {
   await new DocDBClient({ region: ctx.region }).send(new ModifyDBClusterCommand(input));
 };
 
+// AWS::CloudFront::Distribution — Cloud Control CAN read this type, but its
+// UpdateResource REJECTS even a minimal single-property patch: applying the patch
+// re-validates the WHOLE distribution and the default ViewerCertificate
+// representation trips "IamCertificateId or AcmCertificateArn can be specified only
+// if SslSupportMethod must also be specified and vice-versa" (proven live — EVERY
+// CloudFront revert failed). Route revert through CloudFront's own GetDistributionConfig
+// -> apply ops -> UpdateDistribution(IfMatch=ETag) instead: a full-config round-trip
+// re-submits AWS's own ViewerCertificate verbatim, so it validates. The revert ops are
+// CFn-pointer paths (`/DistributionConfig/<prop>`); applying a SCALAR op to the freshly
+// read SDK config touches only that property, so the CFn-vs-SDK array-shape difference
+// (Origins as `[...]` vs `{Quantity,Items}`) is irrelevant for the common scalar drifts
+// (Comment / DefaultRootObject / Enabled / PriceClass / HttpVersion / WebACLId / …).
+const writeCloudFrontDistribution: SdkWriter = async (ctx, ops) => {
+  const id = str(ctx.physicalId);
+  if (!id) throw new Error('cannot resolve distribution id for revert');
+  const c = new CloudFrontClient({ region: ctx.region });
+  const cur = await c.send(new GetDistributionConfigCommand({ Id: id }));
+  if (!cur.DistributionConfig || !cur.ETag)
+    throw new Error('could not read current distribution config for revert');
+  const reverted = applyOps({ DistributionConfig: cur.DistributionConfig }, ops) as {
+    DistributionConfig: Record<string, unknown>;
+  };
+  await c.send(
+    new UpdateDistributionCommand({
+      Id: id,
+      IfMatch: cur.ETag,
+      // the SDK DistributionConfig shape is preserved verbatim except for the scalar
+      // properties the revert ops set, so it round-trips validly.
+      DistributionConfig: reverted.DistributionConfig as never,
+    })
+  );
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
+  'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
   'AWS::DocDB::DBCluster': writeDocDbCluster,
   'AWS::ServiceDiscovery::HttpNamespace': writeServiceDiscoveryHttpNamespace,
   'AWS::S3::BucketPolicy': writeS3BucketPolicy,

--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD_rich.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD_rich.json
@@ -1,0 +1,401 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cdn9963B1AD",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "E1F4NTU2OKBTYE",
+    "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn",
+    "declared": {
+      "DistributionConfig": {
+        "CacheBehaviors": [
+          {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "PathPattern": "/api/*",
+            "TargetOriginId": "CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2",
+            "ViewerProtocolPolicy": "https-only"
+          }
+        ],
+        "Comment": "cdkrd cloudfront rich",
+        "DefaultCacheBehavior": {
+          "AllowedMethods": ["GET", "HEAD"],
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+          "Compress": true,
+          "TargetOriginId": "CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363",
+          "ViewerProtocolPolicy": "redirect-to-https"
+        },
+        "Enabled": true,
+        "HttpVersion": "http2",
+        "IPV6Enabled": true,
+        "Origins": [
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "OriginSSLProtocols": ["TLSv1.2"]
+            },
+            "DomainName": "origin1.example.com",
+            "Id": "CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363"
+          },
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "OriginSSLProtocols": ["TLSv1.2"]
+            },
+            "DomainName": "origin2.example.com",
+            "Id": "CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2"
+          }
+        ],
+        "PriceClass": "PriceClass_100"
+      }
+    }
+  },
+  "liveRaw": {
+    "DistributionConfig": {
+      "Logging": {
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+      },
+      "Comment": "cdkrd cloudfront rich",
+      "DefaultRootObject": "",
+      "Origins": [
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "origin1.example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["TLSv1.2"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        },
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "origin2.example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["TLSv1.2"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        }
+      ],
+      "ViewerCertificate": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "PriceClass": "PriceClass_100",
+      "DefaultCacheBehavior": {
+        "Compress": true,
+        "FunctionAssociations": [],
+        "LambdaFunctionAssociations": [],
+        "TargetOriginId": "CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "GrpcConfig": {
+          "Enabled": false
+        },
+        "TrustedSigners": [],
+        "FieldLevelEncryptionId": "",
+        "TrustedKeyGroups": [],
+        "AllowedMethods": ["HEAD", "GET"],
+        "CachedMethods": ["HEAD", "GET"],
+        "SmoothStreaming": false,
+        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+      },
+      "Staging": false,
+      "CustomErrorResponses": [],
+      "ContinuousDeploymentPolicyId": "",
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "Enabled": true,
+      "Aliases": [],
+      "IPV6Enabled": true,
+      "WebACLId": "",
+      "HttpVersion": "http2",
+      "Restrictions": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "CacheBehaviors": [
+        {
+          "Compress": true,
+          "FunctionAssociations": [],
+          "LambdaFunctionAssociations": [],
+          "TargetOriginId": "CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2",
+          "ViewerProtocolPolicy": "https-only",
+          "GrpcConfig": {
+            "Enabled": false
+          },
+          "TrustedSigners": [],
+          "FieldLevelEncryptionId": "",
+          "TrustedKeyGroups": [],
+          "AllowedMethods": ["HEAD", "GET"],
+          "PathPattern": "/api/*",
+          "CachedMethods": ["HEAD", "GET"],
+          "SmoothStreaming": false,
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+        }
+      ]
+    },
+    "DomainName": "dvwv4twtfsi80.cloudfront.net",
+    "Id": "E1F4NTU2OKBTYE",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["DomainName", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["DomainName", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "DistributionConfig.CacheBehaviors.*.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.Compress": false,
+      "DistributionConfig.CacheBehaviors.*.DefaultTTL": 86400,
+      "DistributionConfig.CacheBehaviors.*.FieldLevelEncryptionId": "",
+      "DistributionConfig.CacheBehaviors.*.MaxTTL": 31536000,
+      "DistributionConfig.CacheBehaviors.*.MinTTL": 0,
+      "DistributionConfig.CacheBehaviors.*.SmoothStreaming": false,
+      "DistributionConfig.Comment": "",
+      "DistributionConfig.CustomErrorResponses.*.ErrorCachingMinTTL": 300,
+      "DistributionConfig.CustomOrigin.HTTPPort": 80,
+      "DistributionConfig.CustomOrigin.HTTPSPort": 443,
+      "DistributionConfig.DefaultCacheBehavior.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.Compress": false,
+      "DistributionConfig.DefaultCacheBehavior.DefaultTTL": 86400,
+      "DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId": "",
+      "DistributionConfig.DefaultCacheBehavior.MaxTTL": 31536000,
+      "DistributionConfig.DefaultCacheBehavior.MinTTL": 0,
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.RealtimeLogConfigArn": "",
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.SmoothStreaming": false,
+      "DistributionConfig.DefaultRootObject": "",
+      "DistributionConfig.HttpVersion": "http1.1",
+      "DistributionConfig.Logging.IncludeCookies": false,
+      "DistributionConfig.Logging.Prefix": "",
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPPort": 80,
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPSPort": 443,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginSSLProtocols": ["TLSv1", "SSLv3"],
+      "DistributionConfig.Origins.*.OriginPath": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginAccessIdentity": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.PriceClass": "PriceClass_All",
+      "DistributionConfig.S3Origin.OriginAccessIdentity": "",
+      "DistributionConfig.WebACLId": ""
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin1751E1363].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontRichCdnOrigin2D6A423A2].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.CachedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.OriginGroups",
+      "actual": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Restrictions",
+      "actual": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "nested": true,
+      "physicalId": "E1F4NTU2OKBTYE",
+      "constructPath": "CdkRealDriftIntegCloudfrontRich/Cdn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.B08E7C7AF.json
+++ b/tests/corpus/AWS__S3__Bucket.B08E7C7AF.json
@@ -1,0 +1,204 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "B08E7C7AF",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrd-s3-events-fixture",
+    "constructPath": "CdkRealDriftIntegS3Events/B",
+    "declared": {
+      "AccelerateConfiguration": {
+        "AccelerationStatus": "Enabled"
+      },
+      "BucketEncryption": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "BucketName": "cdkrd-s3-events-fixture",
+      "MetricsConfigurations": [
+        {
+          "Id": "EntireBucket"
+        }
+      ],
+      "OwnershipControls": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ],
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrd-s3-events-fixture.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrd-s3-events-fixture.s3-website-us-east-1.amazonaws.com",
+    "NotificationConfiguration": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaConfigurations": [],
+      "EventBridgeConfiguration": {
+        "EventBridgeEnabled": true
+      }
+    },
+    "DualStackDomainName": "cdkrd-s3-events-fixture.s3.dualstack.us-east-1.amazonaws.com",
+    "VersioningConfiguration": {
+      "Status": "Enabled"
+    },
+    "MetricsConfigurations": [
+      {
+        "Id": "EntireBucket"
+      }
+    ],
+    "AbacStatus": "Disabled",
+    "AccelerateConfiguration": {
+      "AccelerationStatus": "Enabled"
+    },
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrd-s3-events-fixture",
+    "RegionalDomainName": "cdkrd-s3-events-fixture.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkrd-s3-events-fixture",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegS3Events",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "B08E7C7AF",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3Events/81253c10-6d48-11f1-b8e5-0e1487cb39e7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "B08E7C7AF",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "NotificationConfiguration",
+      "actual": {
+        "TopicConfigurations": [],
+        "QueueConfigurations": [],
+        "LambdaConfigurations": [],
+        "EventBridgeConfiguration": {
+          "EventBridgeEnabled": true
+        }
+      },
+      "physicalId": "cdkrd-s3-events-fixture",
+      "constructPath": "CdkRealDriftIntegS3Events/B"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "B08E7C7AF",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrd-s3-events-fixture",
+      "constructPath": "CdkRealDriftIntegS3Events/B"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "B08E7C7AF",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrd-s3-events-fixture",
+      "constructPath": "CdkRealDriftIntegS3Events/B"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__BucketPolicy.BPolicy3F02723E.json
+++ b/tests/corpus/AWS__S3__BucketPolicy.BPolicy3F02723E.json
@@ -1,0 +1,96 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BPolicy3F02723E",
+    "resourceType": "AWS::S3::BucketPolicy",
+    "physicalId": "cdkrd-s3-events-fixture",
+    "constructPath": "CdkRealDriftIntegS3Events/B/Policy",
+    "declared": {
+      "Bucket": "cdkrd-s3-events-fixture",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": "s3:*",
+            "Condition": {
+              "Bool": {
+                "aws:SecureTransport": "false"
+              }
+            },
+            "Effect": "Deny",
+            "Principal": {
+              "AWS": "*"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkrd-s3-events-fixture",
+              "arn:aws:s3:::cdkrd-s3-events-fixture/*"
+            ]
+          },
+          {
+            "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/CdkRealDriftIntegS3Events-CustomS3AutoDeleteObjects-3s9P8yV3jIbm"
+            },
+            "Resource": [
+              "arn:aws:s3:::cdkrd-s3-events-fixture",
+              "arn:aws:s3:::cdkrd-s3-events-fixture/*"
+            ]
+          }
+        ],
+        "Version": "2012-10-17"
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkrd-s3-events-fixture",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Deny",
+          "Principal": {
+            "AWS": "*"
+          },
+          "Action": "s3:*",
+          "Resource": [
+            "arn:aws:s3:::cdkrd-s3-events-fixture",
+            "arn:aws:s3:::cdkrd-s3-events-fixture/*"
+          ],
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "false"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/CdkRealDriftIntegS3Events-CustomS3AutoDeleteObjects-3s9P8yV3jIbm"
+          },
+          "Action": ["s3:PutBucketPolicy", "s3:GetBucket*", "s3:List*", "s3:DeleteObject*"],
+          "Resource": [
+            "arn:aws:s3:::cdkrd-s3-events-fixture",
+            "arn:aws:s3:::cdkrd-s3-events-fixture/*"
+          ]
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.SM934E715A.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.SM934E715A.json
@@ -1,0 +1,98 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SM934E715A",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:cdkrd-sfn-standard",
+    "constructPath": "CdkRealDriftIntegSfnStandard/SM",
+    "declared": {
+      "DefinitionString": "{\"StartAt\":\"P\",\"States\":{\"P\":{\"Type\":\"Pass\",\"End\":true}}}",
+      "LoggingConfiguration": {
+        "Destinations": [
+          {
+            "CloudWatchLogsLogGroup": {
+              "LogGroupArn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkRealDriftIntegSfnStandard-Logs6819BB44-rIU7E4SKgtxS:*"
+            }
+          }
+        ],
+        "IncludeExecutionData": true,
+        "Level": "ALL"
+      },
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSfnStandard-SMRole49C19C48-DJxV3EchRGIW",
+      "StateMachineName": "cdkrd-sfn-standard",
+      "StateMachineType": "STANDARD",
+      "TracingConfiguration": {
+        "Enabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "DefinitionString": "{\"StartAt\":\"P\",\"States\":{\"P\":{\"Type\":\"Pass\",\"End\":true}}}",
+    "EncryptionConfiguration": {
+      "Type": "AWS_OWNED_KEY"
+    },
+    "LoggingConfiguration": {
+      "IncludeExecutionData": true,
+      "Destinations": [
+        {
+          "CloudWatchLogsLogGroup": {
+            "LogGroupArn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkRealDriftIntegSfnStandard-Logs6819BB44-rIU7E4SKgtxS:*"
+          }
+        }
+      ],
+      "Level": "ALL"
+    },
+    "StateMachineRevisionId": "fe2d772f-09b2-47b5-a6f7-7994e6e1bc36",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:cdkrd-sfn-standard",
+    "StateMachineName": "cdkrd-sfn-standard",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSfnStandard-SMRole49C19C48-DJxV3EchRGIW",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSfnStandard/85aa9d20-6d48-11f1-962f-0e40573c42e5",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSfnStandard",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SM934E715A",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-sfn-standard",
+    "StateMachineType": "STANDARD",
+    "TracingConfiguration": {
+      "Enabled": true
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnly": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnly": ["StateMachineName", "StateMachineType"],
+    "readOnlyPaths": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnlyPaths": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnlyPaths": ["StateMachineName", "StateMachineType"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SM934E715A",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "Type": "AWS_OWNED_KEY"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:cdkrd-sfn-standard",
+      "constructPath": "CdkRealDriftIntegSfnStandard/SM"
+    }
+  ]
+}

--- a/tests/integration/cloudfront-rich/app.ts
+++ b/tests/integration/cloudfront-rich/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift cloudfront-rich FP + detect integration test.
+// CloudFront Distribution (read NATIVELY via Cloud Control) nests identity-keyed
+// arrays (Origins[].Id, CacheBehaviors[].PathPattern) inside DistributionConfig — a
+// bug-prone NESTED-array surface. The mutable Comment is the declared detect/revert
+// subject; the verify-detect script also adds an out-of-band ORIGIN to probe whether a
+// live-only nested-array element is caught (the differentiator at depth). HTTP origins
+// keep the stack self-contained (no S3 bucket needed).
+import { App, Stack } from "aws-cdk-lib";
+import { AllowedMethods, Distribution, PriceClass, ViewerProtocolPolicy } from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCloudfrontRich");
+
+new Distribution(stack, "Cdn", {
+  comment: "cdkrd cloudfront rich",
+  priceClass: PriceClass.PRICE_CLASS_100,
+  defaultBehavior: {
+    origin: new HttpOrigin("origin1.example.com"),
+    viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+    allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
+  },
+  additionalBehaviors: {
+    "/api/*": {
+      origin: new HttpOrigin("origin2.example.com"),
+      viewerProtocolPolicy: ViewerProtocolPolicy.HTTPS_ONLY,
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/cloudfront-rich/cdk.json
+++ b/tests/integration/cloudfront-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-rich/package.json
+++ b/tests/integration/cloudfront-rich/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-rich",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/cloudfront-rich/verify-detect.sh
+++ b/tests/integration/cloudfront-rich/verify-detect.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# CloudFront detect + revert (real AWS). The revert is the point: CloudFront's Cloud
+# Control UpdateResource REJECTS a partial patch (ViewerCertificate re-validation), so
+# revert goes through the GetDistributionConfig->UpdateDistribution SDK writer. Mutate
+# the declared MUTABLE Comment out of band -> check MUST DETECT -> revert (SDK writer)
+# -> check MUST be CLEAN and Comment restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegCloudfrontRich; COMMENT="cdkrd cloudfront rich"; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out cfg.json cfg2.json; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+DID="$(aws cloudfront list-distributions --query "DistributionList.Items[?Comment=='$COMMENT'].Id" --output text)"
+[ -n "$DID" ] && [ "$DID" != "None" ] || fail "no distribution id"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob Comment -> DRIFTED (full-config update) ==="
+aws cloudfront get-distribution-config --id "$DID" > cfg.json
+ETAG="$(node -e "console.log(require('./cfg.json').ETag)")"
+node -e "const fs=require('fs');const j=require('./cfg.json');j.DistributionConfig.Comment='DRIFTED OUT OF BAND';fs.writeFileSync('cfg2.json',JSON.stringify(j.DistributionConfig));"
+aws cloudfront update-distribution --id "$DID" --distribution-config file://cfg2.json --if-match "$ETAG" >/dev/null || fail "inject"
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cf-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Comment" /tmp/cdkrd-cf-detect.out || fail "Comment drift not reported"
+echo "=== revert (SDK writer: UpdateDistribution) ==="; $CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-cf-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-cf-revert.out || fail "revert did not converge (CC-patch regression?)"
+GOT="$(aws cloudfront get-distribution-config --id "$DID" --query 'DistributionConfig.Comment' --output text)"
+[ "$GOT" = "$COMMENT" ] || fail "Comment not restored (got: $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/cloudfront-rich/verify.sh
+++ b/tests/integration/cloudfront-rich/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegCloudfrontRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected CLEAN got $rc"
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-events/app.ts
+++ b/tests/integration/s3-events/app.ts
@@ -1,0 +1,22 @@
+// cdk-real-drift s3-events FP integration test. Exercises S3 config surfaces NOT in
+// s3-rich: EventBridge notifications, transfer acceleration, a metrics configuration,
+// BUCKET_OWNER_ENFORCED ownership, and the enforceSSL bucket policy — all default- and
+// nested-config-heavy, a strong false-positive oracle for a very common resource.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Bucket, BucketEncryption, ObjectOwnership } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3Events");
+new Bucket(stack, "B", {
+  bucketName: "cdkrd-s3-events-fixture",
+  eventBridgeEnabled: true,
+  transferAcceleration: true,
+  versioned: true,
+  enforceSSL: true,
+  encryption: BucketEncryption.S3_MANAGED,
+  objectOwnership: ObjectOwnership.BUCKET_OWNER_ENFORCED,
+  metrics: [{ id: "EntireBucket" }],
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+app.synth();

--- a/tests/integration/s3-events/cdk.json
+++ b/tests/integration/s3-events/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-events/package.json
+++ b/tests/integration/s3-events/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-s3-events",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/s3-events/verify-detect.sh
+++ b/tests/integration/s3-events/verify-detect.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# S3 detect + revert (real AWS): flip the declared MUTABLE transfer-acceleration
+# Enabled->Suspended out of band -> check MUST DETECT -> revert -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegS3Events; BUCKET=cdkrd-s3-events-fixture; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob accel Enabled->Suspended ==="
+aws s3api put-bucket-accelerate-configuration --bucket "$BUCKET" --accelerate-configuration Status=Suspended --region "$REGION" || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-s3ev-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Accelerat" /tmp/cdkrd-s3ev-detect.out || fail "acceleration drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws s3api get-bucket-accelerate-configuration --bucket "$BUCKET" --region "$REGION" --query Status --output text)"
+[ "$GOT" = "Enabled" ] || fail "acceleration not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/s3-events/verify.sh
+++ b/tests/integration/s3-events/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegS3Events; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected CLEAN got $rc"
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sfn-standard/app.ts
+++ b/tests/integration/sfn-standard/app.ts
@@ -1,0 +1,19 @@
+// cdk-real-drift sfn-standard FP + detect integration test. A STANDARD (not express)
+// Step Functions state machine with CloudWatch logging + X-Ray tracing — exercises
+// LoggingConfiguration (nested) + TracingConfiguration defaults. The mutable
+// TracingConfiguration.Enabled is the declared detect/revert subject.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { LogGroup } from "aws-cdk-lib/aws-logs";
+import { DefinitionBody, LogLevel, Pass, StateMachine, StateMachineType } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSfnStandard");
+const lg = new LogGroup(stack, "Logs", { removalPolicy: RemovalPolicy.DESTROY });
+new StateMachine(stack, "SM", {
+  stateMachineName: "cdkrd-sfn-standard",
+  stateMachineType: StateMachineType.STANDARD,
+  definitionBody: DefinitionBody.fromChainable(new Pass(stack, "P")),
+  tracingEnabled: true,
+  logs: { destination: lg, level: LogLevel.ALL, includeExecutionData: true },
+});
+app.synth();

--- a/tests/integration/sfn-standard/cdk.json
+++ b/tests/integration/sfn-standard/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sfn-standard/package.json
+++ b/tests/integration/sfn-standard/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-sfn-standard",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/sfn-standard/verify-detect.sh
+++ b/tests/integration/sfn-standard/verify-detect.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Step Functions detect + revert (real AWS): flip the declared MUTABLE
+# TracingConfiguration.Enabled true->false out of band -> check MUST DETECT -> revert
+# -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegSfnStandard; NAME=cdkrd-sfn-standard; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+SMARN="$(aws stepfunctions list-state-machines --region "$REGION" --query "stateMachines[?name=='$NAME'].stateMachineArn" --output text)"
+[ -n "$SMARN" ] && [ "$SMARN" != "None" ] || fail "no state machine arn"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob tracing true->false ==="
+aws stepfunctions update-state-machine --state-machine-arn "$SMARN" --tracing-configuration enabled=false --region "$REGION" >/dev/null || fail inject
+sleep 3
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sfn-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Tracing" /tmp/cdkrd-sfn-detect.out || fail "tracing drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws stepfunctions describe-state-machine --state-machine-arn "$SMARN" --region "$REGION" --query 'tracingConfiguration.enabled' --output text)"
+[ "$GOT" = "True" ] || fail "tracing not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/sfn-standard/verify.sh
+++ b/tests/integration/sfn-standard/verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegSfnStandard; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected CLEAN got $rc"
+echo "INTEG PASS ($STACK)"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1,4 +1,9 @@
 import {
+  CloudFrontClient,
+  GetDistributionConfigCommand,
+  UpdateDistributionCommand,
+} from '@aws-sdk/client-cloudfront';
+import {
   ElasticLoadBalancingV2Client,
   ModifyLoadBalancerAttributesCommand,
   ModifyTargetGroupAttributesCommand,
@@ -48,6 +53,7 @@ const sns = mockClient(SNSClient);
 const sqs = mockClient(SQSClient);
 const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
+const cloudfront = mockClient(CloudFrontClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -83,6 +89,62 @@ beforeEach(() => {
   sqs.reset();
   serviceDiscovery.reset();
   docdb.reset();
+  cloudfront.reset();
+});
+
+describe('CloudFront Distribution writer (CC UpdateResource rejects partial patch)', () => {
+  const ID = 'E123ABC';
+  const commentOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/DistributionConfig/Comment',
+    value,
+    human: 'Comment -> deployed-template value',
+  });
+  it('reverts via GetDistributionConfig -> apply ops -> UpdateDistribution(IfMatch=ETag)', async () => {
+    // GetDistributionConfig returns the DRIFTED live config + ETag; UpdateDistribution
+    // re-submits the SAME config with only the reverted scalar changed (round-trips the
+    // default ViewerCertificate verbatim, which the CC partial patch could not).
+    cloudfront.on(GetDistributionConfigCommand).resolves({
+      ETag: 'ETAG1',
+      // partial live config stub (the writer round-trips it verbatim) — cast past the
+      // full DistributionConfig required-field type for the test.
+      DistributionConfig: {
+        CallerReference: 'r',
+        Comment: 'DRIFTED',
+        Enabled: true,
+        ViewerCertificate: { CloudFrontDefaultCertificate: true },
+        Origins: { Quantity: 1, Items: [{ Id: 'o1', DomainName: 'a.example.com' }] },
+      } as never,
+    });
+    cloudfront.on(UpdateDistributionCommand).resolves({});
+    await SDK_WRITERS['AWS::CloudFront::Distribution'](ctx({ physicalId: ID }), [
+      commentOp('the desired comment'),
+    ]);
+    const calls = cloudfront.commandCalls(UpdateDistributionCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input as {
+      Id: string;
+      IfMatch: string;
+      DistributionConfig: { Comment: string; ViewerCertificate: unknown; Origins: unknown };
+    };
+    expect(input.Id).toBe(ID);
+    expect(input.IfMatch).toBe('ETAG1');
+    // only Comment changed; the rest of the live config round-trips verbatim
+    expect(input.DistributionConfig.Comment).toBe('the desired comment');
+    expect(input.DistributionConfig.ViewerCertificate).toEqual({
+      CloudFrontDefaultCertificate: true,
+    });
+    expect(input.DistributionConfig.Origins).toEqual({
+      Quantity: 1,
+      Items: [{ Id: 'o1', DomainName: 'a.example.com' }],
+    });
+  });
+
+  it('throws when the distribution id is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::CloudFront::Distribution'](ctx({ physicalId: '' }), [commentOp('x')])
+    ).rejects.toThrow(/distribution id/);
+  });
 });
 
 describe('DocDB DBCluster writer (CC read+write gap)', () => {


### PR DESCRIPTION
## The bug (real, live-proven)

`AWS::CloudFront::Distribution` is Cloud-Control **readable**, but its `UpdateResource` **rejects even a minimal single-property patch**: applying the patch re-validates the whole distribution and the default `ViewerCertificate` trips `IamCertificateId or AcmCertificateArn can be specified only if SslSupportMethod must also be specified and vice-versa`. **Proven live: every CloudFront revert failed** — a console-edited `Comment` was detected but could never be reverted.

## Fix

Route CloudFront revert through an SDK writer: `GetDistributionConfig` → `applyOps` → `UpdateDistribution(IfMatch=ETag)`. The full-config round-trip re-submits AWS's own ViewerCertificate verbatim, so it validates. A scalar op touches only that property, so the CFn-vs-SDK array-shape difference is irrelevant for the common scalar drifts (Comment / DefaultRootObject / Enabled / PriceClass / …).

**Live-verified:** Comment detect → revert (SDK writer) → CLEAN, config restored. Unit test asserts the round-trip preserves ViewerCertificate/Origins verbatim and changes only the reverted scalar.

## From this bug-hunt round (user-requested, common resources)

All live-proven; only CloudFront had a bug:
- **cloudfront-rich**: Distribution FP-free record→check; Comment detect+revert (the fix).
- **s3-events**: S3 EventBridge/transfer-acceleration/ownership/enforceSSL FP-free; acceleration detect+revert.
- **sfn-standard**: Step Functions **STANDARD** logging/tracing FP-free; TracingConfiguration detect+revert.

Also confirmed (offline probe): a live-only element of a **nested** identity-keyed array (e.g. an out-of-band CloudFront Origin) IS caught as declared drift — the ELB attribute-bag FN (fixed in #263) was the unique special-case, not a broad class.

## Tests
Unit (CloudFront writer round-trip), 4 new corpus (CF `_rich` suffixed to avoid the existing fixture's logical-id collision; S3 bucket+policy; SFN), 3 integ fixtures. Full suite 1336 passing; all stacks deleted + SWEEP CLEAN.