### PR TITLE
fix(revert): WAFv2 WebACL revert via UpdateWebACL SDK writer + revert coverage for WAF/AppSync/Cognito

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -552,6 +552,15 @@ only when non-zero — unrecorded values are named as such, never folded into
     full config via `UpdateDistribution(IfMatch=ETag)` so AWS's own
     ViewerCertificate round-trips verbatim (robust for the common scalar
     `DistributionConfig` drifts: Comment / DefaultRootObject / Enabled / …).
+    `AWS::WAFv2::WebACL` is the SAME CC-revalidation class: its `UpdateResource`
+    re-validates the whole WebACL and AWS's own empty `Description` ("") fails the
+    schema's Description pattern (proven live — every WebACL revert failed), so revert
+    reads `GetWebACL` (Name|Id|Scope physical id), applies the ops, and re-submits via
+    `UpdateWebACL(LockToken)` OMITTING an empty Description (every other updatable field
+    round-trips verbatim). KNOWN LIMITATION: a `DefaultAction` revert (the Allow⇄Block
+    mutually-exclusive union) still fails — the per-leaf revert op adds the desired
+    branch without removing the live one ("exactly one value" error); that union-op
+    granularity is a plan-level gap affecting the CC path too, deferred.
   - **Property-scoped SDK writers** (`SDK_PROP_WRITERS`): a CC-writable type where
     ONE property must bypass Cloud Control. An IAM Role's top-level `Policies`
     finding reverts per entry (`DeleteRolePolicy` / `PutRolePolicy` by

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@aws-sdk/client-servicediscovery": "^3.1073.0",
     "@aws-sdk/client-sns": "^3.1065.0",
     "@aws-sdk/client-sqs": "^3.1065.0",
+    "@aws-sdk/client-wafv2": "^3.1073.0",
     "@clack/core": "^1.4.1",
     "@clack/prompts": "^1.5.1",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@aws-sdk/client-sqs':
         specifier: ^3.1065.0
         version: 3.1066.0
+      '@aws-sdk/client-wafv2':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@clack/core':
         specifier: ^1.4.1
         version: 1.4.1
@@ -390,6 +393,10 @@ packages:
 
   '@aws-sdk/client-sts@3.1066.0':
     resolution: {integrity: sha512-a24RbDdy7L67IzvMjiYRhfoNRljU5mfbjZyKLJlrEpyj4A5ryDqLP1dJS6GU/dtbaSqGd+LUoRTsFkqA7BEcmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-wafv2@3.1073.0':
+    resolution: {integrity: sha512-U6x3zH45ac+GNC0ECH5ymIUjAuwAT9uLt6WaunJ+eE0HhAJpTh8gESdmqhpTSVN7KUQoYgAEt8KrXzztrKTfIg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.20':
@@ -4094,6 +4101,19 @@ snapshots:
       '@aws-sdk/credential-provider-node': 3.972.55
       '@aws-sdk/signature-v4-multi-region': 3.996.34
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-wafv2@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -28,6 +28,12 @@ import {
 } from '@aws-sdk/client-cloudfront';
 import { DocDBClient, ModifyDBClusterCommand } from '@aws-sdk/client-docdb';
 import {
+  GetWebACLCommand,
+  type Scope,
+  UpdateWebACLCommand,
+  WAFV2Client,
+} from '@aws-sdk/client-wafv2';
+import {
   ElasticLoadBalancingV2Client,
   ModifyLoadBalancerAttributesCommand,
   ModifyTargetGroupAttributesCommand,
@@ -356,8 +362,55 @@ const writeCloudFrontDistribution: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// AWS::WAFv2::WebACL — Cloud Control CAN read this type, but its UpdateResource
+// REJECTS a property patch: applying the patch re-validates the WHOLE WebACL against
+// the CFn schema, and AWS's own live `Description: ""` (empty when none was set) fails
+// the schema's Description pattern constraint — "#/Description: failed validation
+// constraint for keyword [pattern]" (proven live; the same CC re-validation class as
+// CloudFront). Route revert through WAFv2's own GetWebACL -> apply ops -> UpdateWebACL
+// (Name|Id|Scope physical id + LockToken). update-web-acl accepts the absence of
+// Description, so OMIT an empty/invalid one; every other updatable field is re-sent
+// verbatim so nothing is dropped.
+const WAF_UPDATABLE_PASSTHROUGH = [
+  'Rules',
+  'CustomResponseBodies',
+  'CaptchaConfig',
+  'ChallengeConfig',
+  'TokenDomains',
+  'AssociationConfig',
+  'DataProtectionConfig',
+  'OnSourceDDoSProtectionConfig',
+  'ApplicationConfig',
+  'MonetizationConfig',
+] as const;
+const writeWafv2WebAcl: SdkWriter = async (ctx, ops) => {
+  const [name, id, scope] = (str(ctx.physicalId) ?? '').split('|');
+  if (!name || !id || !scope) throw new Error('cannot resolve WebACL Name|Id|Scope for revert');
+  const c = new WAFV2Client({ region: ctx.region });
+  const cur = await c.send(new GetWebACLCommand({ Name: name, Id: id, Scope: scope as Scope }));
+  if (!cur.WebACL || !cur.LockToken) throw new Error('could not read current WebACL for revert');
+  const m = applyOps(cur.WebACL as unknown as Record<string, unknown>, ops);
+  const desc = m.Description;
+  await c.send(
+    new UpdateWebACLCommand({
+      Name: name,
+      Id: id,
+      Scope: scope as Scope,
+      LockToken: cur.LockToken,
+      DefaultAction: m.DefaultAction as never,
+      VisibilityConfig: m.VisibilityConfig as never,
+      // OMIT an empty Description — AWS returns "" but the schema pattern rejects it.
+      ...(typeof desc === 'string' && desc.length > 0 ? { Description: desc } : {}),
+      ...Object.fromEntries(
+        WAF_UPDATABLE_PASSTHROUGH.filter((k) => m[k] !== undefined).map((k) => [k, m[k]])
+      ),
+    } as never)
+  );
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
+  'AWS::WAFv2::WebACL': writeWafv2WebAcl,
   'AWS::DocDB::DBCluster': writeDocDbCluster,
   'AWS::ServiceDiscovery::HttpNamespace': writeServiceDiscoveryHttpNamespace,
   'AWS::S3::BucketPolicy': writeS3BucketPolicy,

--- a/tests/integration/appsync-graphqlapi-rich/verify-detect.sh
+++ b/tests/integration/appsync-graphqlapi-rich/verify-detect.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# AppSync GraphQLApi detect + revert (real AWS): flip the declared MUTABLE xrayEnabled
+# true->false out of band -> check MUST DETECT -> revert (CC) -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegAppsyncGraphqlapiRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+APIID="$(aws appsync list-graphql-apis --region "$REGION" --query "graphqlApis[?name=='cdkrd-appsync-rich'].apiId" --output text)"
+[ -n "$APIID" ] && [ "$APIID" != "None" ] || fail "no api id"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob xrayEnabled true->false ==="
+aws appsync update-graphql-api --api-id "$APIID" --name cdkrd-appsync-rich --authentication-type API_KEY --no-xray-enabled --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-appsync-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Xray" /tmp/cdkrd-appsync-detect.out || fail "xray drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws appsync get-graphql-api --api-id "$APIID" --region "$REGION" --query 'graphqlApi.xrayEnabled' --output text)"
+[ "$GOT" = "True" ] || fail "xray not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/cognito-userpool-rich/verify-detect.sh
+++ b/tests/integration/cognito-userpool-rich/verify-detect.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Cognito UserPool detect + revert (real AWS): flip the declared MUTABLE MFA config
+# OPTIONAL->OFF out of band (dedicated set-user-pool-mfa-config API, no collateral) ->
+# check MUST DETECT -> revert (CC) -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegCognitoUserPoolRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+PID="$(aws cognito-idp list-user-pools --max-results 50 --region "$REGION" --query "UserPools[?Name=='cdkrd-userpool-rich'].Id" --output text)"
+[ -n "$PID" ] && [ "$PID" != "None" ] || fail "no user pool id"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob MFA OPTIONAL->OFF ==="
+aws cognito-idp set-user-pool-mfa-config --user-pool-id "$PID" --mfa-configuration OFF --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cog-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Mfa" /tmp/cdkrd-cog-detect.out || fail "mfa drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws cognito-idp get-user-pool-mfa-config --user-pool-id "$PID" --region "$REGION" --query 'MfaConfiguration' --output text)"
+[ "$GOT" = "OPTIONAL" ] || fail "mfa not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/wafv2-rich/verify-detect.sh
+++ b/tests/integration/wafv2-rich/verify-detect.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# WAFv2 WebACL detect + revert (real AWS). The revert is the point: CloudFront-style,
+# WAFv2's Cloud Control UpdateResource REJECTS a property patch — it re-validates the
+# whole WebACL and AWS's own empty Description trips the schema pattern. Revert goes
+# through the GetWebACL->UpdateWebACL SDK writer (which omits the empty Description).
+# Drift the declared MUTABLE VisibilityConfig.SampledRequestsEnabled true->false out of
+# band (a scalar; DefaultAction is a mutually-exclusive union and is a separate case) ->
+# check MUST DETECT -> revert (SDK writer) -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegWafv2Rich; NAME=cdkrd-wafv2-rich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out waf.json rules.json vc.json; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+ID="$(aws wafv2 list-web-acls --scope REGIONAL --region "$REGION" --query "WebACLs[?Name=='$NAME'].Id" --output text)"
+[ -n "$ID" ] && [ "$ID" != "None" ] || fail "no web acl id"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob SampledRequestsEnabled true->false (full-config update) ==="
+aws wafv2 get-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --region "$REGION" > waf.json
+LOCK="$(node -e "console.log(require('./waf.json').LockToken)")"
+node -e "const w=require('./waf.json').WebACL;require('fs').writeFileSync('rules.json',JSON.stringify(w.Rules));require('fs').writeFileSync('vc.json',JSON.stringify({...w.VisibilityConfig,SampledRequestsEnabled:false}));"
+aws wafv2 update-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --lock-token "$LOCK" --default-action Allow={} --rules file://rules.json --visibility-config file://vc.json --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-waf-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "SampledRequestsEnabled" /tmp/cdkrd-waf-detect.out || fail "drift not reported"
+echo "=== revert (SDK writer: UpdateWebACL, omits empty Description) ==="; $CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-waf-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-waf-revert.out || fail "revert did not converge (CC-revalidation regression?)"
+GOT="$(aws wafv2 get-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --region "$REGION" --query 'WebACL.VisibilityConfig.SampledRequestsEnabled' --output text)"
+[ "$GOT" = "True" ] || fail "SampledRequestsEnabled not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -3,6 +3,7 @@ import {
   GetDistributionConfigCommand,
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
+import { GetWebACLCommand, UpdateWebACLCommand, WAFV2Client } from '@aws-sdk/client-wafv2';
 import {
   ElasticLoadBalancingV2Client,
   ModifyLoadBalancerAttributesCommand,
@@ -54,6 +55,7 @@ const sqs = mockClient(SQSClient);
 const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
 const cloudfront = mockClient(CloudFrontClient);
+const wafv2 = mockClient(WAFV2Client);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -90,6 +92,87 @@ beforeEach(() => {
   serviceDiscovery.reset();
   docdb.reset();
   cloudfront.reset();
+  wafv2.reset();
+});
+
+describe('WAFv2 WebACL writer (CC UpdateResource rejects on empty Description)', () => {
+  const PID = 'cdkrd-acl|abc-123|REGIONAL';
+  const sampledOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/VisibilityConfig/SampledRequestsEnabled',
+    value,
+    human: 'VisibilityConfig.SampledRequestsEnabled -> deployed-template value',
+  });
+  it('reverts via GetWebACL -> apply ops -> UpdateWebACL, OMITTING the empty Description', async () => {
+    // AWS returns Description: "" (empty); re-sending it via CC UpdateResource fails the
+    // schema pattern. The writer omits it and re-sends every other updatable field.
+    wafv2.on(GetWebACLCommand).resolves({
+      LockToken: 'LOCK1',
+      WebACL: {
+        Name: 'cdkrd-acl',
+        Id: 'abc-123',
+        ARN: 'arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-acl/abc-123',
+        Description: '',
+        DefaultAction: { Allow: {} },
+        Rules: [{ Name: 'r1', Priority: 0 }],
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'm',
+        },
+      },
+    } as never);
+    wafv2.on(UpdateWebACLCommand).resolves({});
+    await SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: PID }), [sampledOp(true)]);
+    const calls = wafv2.commandCalls(UpdateWebACLCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input as unknown as Record<string, unknown>;
+    expect(input.Name).toBe('cdkrd-acl');
+    expect(input.Id).toBe('abc-123');
+    expect(input.Scope).toBe('REGIONAL');
+    expect(input.LockToken).toBe('LOCK1');
+    // the empty Description is OMITTED (the bug trigger)
+    expect('Description' in input).toBe(false);
+    // the reverted scalar is applied; Rules/DefaultAction round-trip verbatim
+    expect(
+      (input.VisibilityConfig as { SampledRequestsEnabled: boolean }).SampledRequestsEnabled
+    ).toBe(true);
+    expect(input.DefaultAction).toEqual({ Allow: {} });
+    expect(input.Rules).toEqual([{ Name: 'r1', Priority: 0 }]);
+  });
+
+  it('keeps a NON-empty Description (only the empty one is dropped)', async () => {
+    wafv2.on(GetWebACLCommand).resolves({
+      LockToken: 'LOCK1',
+      WebACL: {
+        Name: 'cdkrd-acl',
+        Id: 'abc-123',
+        Description: 'real description',
+        DefaultAction: { Allow: {} },
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'm',
+        },
+      },
+    } as never);
+    wafv2.on(UpdateWebACLCommand).resolves({});
+    await SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: PID }), [sampledOp(true)]);
+    expect(
+      (
+        wafv2.commandCalls(UpdateWebACLCommand)[0]!.args[0].input as unknown as Record<
+          string,
+          unknown
+        >
+      ).Description
+    ).toBe('real description');
+  });
+
+  it('throws when the Name|Id|Scope physical id is malformed', async () => {
+    await expect(
+      SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: 'just-a-name' }), [sampledOp(true)])
+    ).rejects.toThrow(/Name\|Id\|Scope/);
+  });
 });
 
 describe('CloudFront Distribution writer (CC UpdateResource rejects partial patch)', () => {


### PR DESCRIPTION
## The bug (real, live-proven — same class as #264 CloudFront)

`AWS::WAFv2::WebACL` is Cloud-Control **readable**, but its `UpdateResource` **rejects a property patch**: applying it re-validates the whole WebACL and AWS's own live `Description: ""` (empty when none set) fails the CFn schema's Description pattern — `#/Description: failed validation constraint for keyword [pattern]`. **Proven live: every WebACL revert failed.**

## Fix

SDK writer: `GetWebACL` (Name|Id|Scope physical id) → `applyOps` → `UpdateWebACL(LockToken)`, **omitting an empty Description** (update-web-acl accepts its absence); every other updatable field round-trips verbatim. **Live-verified:** `VisibilityConfig.SampledRequestsEnabled` detect → revert → CLEAN, restored.

**Known limitation (documented, deferred):** a `DefaultAction` revert (the Allow⇄Block mutually-exclusive union) still fails `exactly one value` — the per-leaf revert op adds the desired branch without removing the live one. That union-op granularity is a plan-level gap affecting the CC path too; out of scope here.

## Revert coverage for the Class-2 gap (untested revert on complex CC types)

This round live-tested the **revert** half (previously untested) on 3 complex CC types — only WAF had a bug:
- **wafv2-rich**: the fix above.
- **appsync-graphqlapi-rich**: `XrayEnabled` detect+revert via CC — clean.
- **cognito-userpool-rich**: MFA `OPTIONAL→OFF` detect+revert via CC — clean.

## Tests
Unit (writers.test.ts): the round-trip omits an empty Description, keeps a non-empty one, rejects a malformed physical id. 3 new `verify-detect.sh`. Full suite 1340 passing; all 3 stacks deleted + SWEEP CLEAN.