### PR TITLE
fix(revert): Glue Job revert via UpdateJob SDK writer (CC MaxCapacity+WorkerType conflict)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -561,6 +561,15 @@ only when non-zero — unrecorded values are named as such, never folded into
     mutually-exclusive union) still fails — the per-leaf revert op adds the desired
     branch without removing the live one ("exactly one value" error); that union-op
     granularity is a plan-level gap affecting the CC path too, deferred.
+    `AWS::Glue::Job` is the SAME class for a WorkerType job: AWS returns a computed
+    `MaxCapacity` and CC `UpdateResource` re-submits it alongside `WorkerType`, failing
+    "do not set Max Capacity if using Worker Type" (proven live), so revert reads
+    `GetJob`, applies the ops, and re-submits via `UpdateJob` OMITTING
+    MaxCapacity/AllocatedCapacity when WorkerType is set (other JobUpdate fields verbatim;
+    read-only CreatedOn/LastModifiedOn excluded). The recurring shape: a CC type is
+    READABLE but its full-model UpdateResource re-validation rejects a field AWS itself
+    returns — the per-type SDK writer re-submits via the resource's own update API,
+    omitting the offending field. Only a LIVE detect→revert→CLEAN cycle catches these.
   - **Property-scoped SDK writers** (`SDK_PROP_WRITERS`): a CC-writable type where
     ONE property must bypass Cloud Control. An IAM Role's top-level `Policies`
     finding reverts per entry (`DeleteRolePolicy` / `PutRolePolicy` by

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -27,6 +27,7 @@ import {
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
 import { DocDBClient, ModifyDBClusterCommand } from '@aws-sdk/client-docdb';
+import { GetJobCommand, GlueClient, UpdateJobCommand } from '@aws-sdk/client-glue';
 import {
   GetWebACLCommand,
   type Scope,
@@ -408,9 +409,60 @@ const writeWafv2WebAcl: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// AWS::Glue::Job — Cloud Control CAN read this type, but its UpdateResource REJECTS a
+// property patch when the job uses WorkerType + NumberOfWorkers: AWS ALSO returns a
+// computed `MaxCapacity` (and the deprecated `AllocatedCapacity`) on read, and
+// re-submitting BOTH MaxCapacity and WorkerType fails "Please do not set Max Capacity
+// if using Worker Type and Number of Workers" (proven live; the same CC-revalidation
+// class as CloudFront/WAFv2). Route revert through Glue's own GetJob -> apply ops ->
+// UpdateJob, OMITTING MaxCapacity/AllocatedCapacity when WorkerType is set (update-job
+// accepts their absence). Read-only fields (CreatedOn / LastModifiedOn / Name) are not
+// part of JobUpdate and are dropped by the explicit field copy.
+const GLUE_JOB_UPDATE_FIELDS = [
+  'JobMode',
+  'JobRunQueuingEnabled',
+  'Description',
+  'LogUri',
+  'Role',
+  'ExecutionProperty',
+  'Command',
+  'DefaultArguments',
+  'NonOverridableArguments',
+  'Connections',
+  'MaxRetries',
+  'Timeout',
+  'WorkerType',
+  'NumberOfWorkers',
+  'SecurityConfiguration',
+  'NotificationProperty',
+  'GlueVersion',
+  'CodeGenConfigurationNodes',
+  'ExecutionClass',
+  'SourceControlDetails',
+  'MaintenanceWindow',
+] as const;
+const writeGlueJob: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['Name']);
+  if (!name) throw new Error('cannot resolve Glue job name for revert');
+  const c = new GlueClient({ region: ctx.region });
+  const got = await c.send(new GetJobCommand({ JobName: name }));
+  if (!got.Job) throw new Error('could not read current Glue job for revert');
+  const m = applyOps(got.Job as unknown as Record<string, unknown>, ops);
+  const update: Record<string, unknown> = {};
+  for (const k of GLUE_JOB_UPDATE_FIELDS) if (m[k] !== undefined) update[k] = m[k];
+  // MaxCapacity / AllocatedCapacity are mutually exclusive with WorkerType — include
+  // them ONLY for a non-WorkerType job (else update-job rejects sending both).
+  if (m.WorkerType === undefined) {
+    if (m.MaxCapacity !== undefined) update.MaxCapacity = m.MaxCapacity;
+    if (m.AllocatedCapacity !== undefined) update.AllocatedCapacity = m.AllocatedCapacity;
+  }
+  await c.send(new UpdateJobCommand({ JobName: name, JobUpdate: update as never }));
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
   'AWS::WAFv2::WebACL': writeWafv2WebAcl,
+  'AWS::Glue::Job': writeGlueJob,
   'AWS::DocDB::DBCluster': writeDocDbCluster,
   'AWS::ServiceDiscovery::HttpNamespace': writeServiceDiscoveryHttpNamespace,
   'AWS::S3::BucketPolicy': writeS3BucketPolicy,

--- a/tests/integration/glue-rich/verify-detect.sh
+++ b/tests/integration/glue-rich/verify-detect.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Glue Job detect + revert (real AWS). The revert is the point: Glue::Job's Cloud
+# Control UpdateResource REJECTS a property patch for a WorkerType job — AWS returns a
+# computed MaxCapacity and re-submitting it with WorkerType fails "do not set Max
+# Capacity if using Worker Type". Revert goes through the GetJob->UpdateJob SDK writer
+# (which omits MaxCapacity when WorkerType is set). Drift the declared MUTABLE Timeout
+# 10->20 out of band -> check MUST DETECT -> revert (SDK writer) -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegGlueRich; JOB=cdkrd-integ-glue-rich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out job.json ju.json; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob Timeout 10->20 (update-job) ==="
+aws glue get-job --job-name "$JOB" --region "$REGION" --query Job > job.json
+node -e "const j=require('./job.json');const u={Role:j.Role,Command:j.Command,Timeout:20,GlueVersion:j.GlueVersion,WorkerType:j.WorkerType,NumberOfWorkers:j.NumberOfWorkers,MaxRetries:j.MaxRetries,Description:j.Description};require('fs').writeFileSync('ju.json',JSON.stringify(u));"
+aws glue update-job --job-name "$JOB" --job-update file://ju.json --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-glue-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Timeout" /tmp/cdkrd-glue-detect.out || fail "Timeout drift not reported"
+echo "=== revert (SDK writer: UpdateJob, omits MaxCapacity) ==="; $CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-glue-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-glue-revert.out || fail "revert did not converge (CC MaxCapacity+WorkerType regression?)"
+GOT="$(aws glue get-job --job-name "$JOB" --region "$REGION" --query 'Job.Timeout' --output text)"
+[ "$GOT" = "10" ] || fail "Timeout not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -27,6 +27,7 @@ import {
   DocDBClient,
   ModifyDBClusterCommand,
 } from '@aws-sdk/client-docdb';
+import { GetJobCommand, GlueClient, UpdateJobCommand } from '@aws-sdk/client-glue';
 import {
   GetTopicAttributesCommand,
   SetTopicAttributesCommand,
@@ -56,6 +57,7 @@ const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
 const cloudfront = mockClient(CloudFrontClient);
 const wafv2 = mockClient(WAFV2Client);
+const glue = mockClient(GlueClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -93,6 +95,73 @@ beforeEach(() => {
   docdb.reset();
   cloudfront.reset();
   wafv2.reset();
+  glue.reset();
+});
+
+describe('Glue Job writer (CC UpdateResource rejects MaxCapacity+WorkerType)', () => {
+  const timeoutOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/Timeout',
+    value,
+    human: 'Timeout -> deployed-template value',
+  });
+  it('reverts via GetJob -> UpdateJob, OMITTING MaxCapacity/AllocatedCapacity for a WorkerType job', async () => {
+    // AWS returns a computed MaxCapacity for a WorkerType job; re-sending both via CC
+    // UpdateResource fails "do not set Max Capacity if using Worker Type". The writer
+    // drops MaxCapacity/AllocatedCapacity when WorkerType is set.
+    glue.on(GetJobCommand).resolves({
+      Job: {
+        Name: 'j',
+        Role: 'arn:aws:iam::111111111111:role/r',
+        Command: { Name: 'glueetl', ScriptLocation: 's3://b/s.py' },
+        Timeout: 20,
+        WorkerType: 'G.1X',
+        NumberOfWorkers: 2,
+        GlueVersion: '4.0',
+        MaxCapacity: 0.0625, // AWS-computed, must be dropped
+        AllocatedCapacity: 2, // deprecated alias, dropped
+        CreatedOn: new Date(0), // read-only, not in JobUpdate
+      },
+    } as never);
+    glue.on(UpdateJobCommand).resolves({});
+    await SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: 'j' }), [timeoutOp(10)]);
+    const calls = glue.commandCalls(UpdateJobCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input as unknown as {
+      JobName: string;
+      JobUpdate: Record<string, unknown>;
+    };
+    expect(input.JobName).toBe('j');
+    expect(input.JobUpdate.Timeout).toBe(10); // reverted scalar
+    expect(input.JobUpdate.WorkerType).toBe('G.1X'); // round-tripped
+    expect('MaxCapacity' in input.JobUpdate).toBe(false); // dropped (the bug trigger)
+    expect('AllocatedCapacity' in input.JobUpdate).toBe(false);
+    expect('CreatedOn' in input.JobUpdate).toBe(false); // read-only excluded
+  });
+
+  it('KEEPS MaxCapacity for a non-WorkerType job', async () => {
+    glue.on(GetJobCommand).resolves({
+      Job: {
+        Name: 'j',
+        Role: 'arn:aws:iam::111111111111:role/r',
+        Command: { Name: 'glueetl' },
+        Timeout: 20,
+        MaxCapacity: 10,
+      },
+    } as never);
+    glue.on(UpdateJobCommand).resolves({});
+    await SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: 'j' }), [timeoutOp(10)]);
+    const input = glue.commandCalls(UpdateJobCommand)[0]!.args[0].input as unknown as {
+      JobUpdate: Record<string, unknown>;
+    };
+    expect(input.JobUpdate.MaxCapacity).toBe(10);
+  });
+
+  it('throws when the job name is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::Glue::Job'](ctx({ physicalId: '', declared: {} }), [timeoutOp(10)])
+    ).rejects.toThrow(/Glue job name/);
+  });
 });
 
 describe('WAFv2 WebACL writer (CC UpdateResource rejects on empty Description)', () => {


### PR DESCRIPTION
## The bug (real, live-proven — 3rd of the same class)

`AWS::Glue::Job` is Cloud-Control **readable**, but its `UpdateResource` **rejects a property patch** for a WorkerType job: AWS returns a computed `MaxCapacity` on read and CC re-submits it alongside `WorkerType`+`NumberOfWorkers`, failing `Please do not set Max Capacity if using Worker Type and Number of Workers`. **Proven live: every WorkerType Glue Job revert failed.** Same CC-revalidation class as CloudFront (#264) and WAFv2 (#265).

## Fix

SDK writer: `GetJob` → `applyOps` → `UpdateJob`, **omitting MaxCapacity/AllocatedCapacity when WorkerType is set** (update-job accepts their absence); other JobUpdate fields round-trip verbatim, read-only CreatedOn/LastModifiedOn excluded. **Live-verified:** Timeout 10→20 detect → revert → CLEAN, restored.

## The recurring shape (CloudFront / WAFv2 / Glue)

A CC-**readable** type whose full-model `UpdateResource` re-validation rejects a field AWS itself returns (empty Description, default ViewerCertificate, computed MaxCapacity). The per-type SDK writer re-submits via the resource's own update API, omitting the offending field. **Only a live detect→revert→CLEAN cycle catches these** — this round live-tested the previously-untested revert on 5 complex CC types: CloudFront/WAFv2/Glue were broken (fixed), AppSync (XrayEnabled) + Cognito (MFA) were clean. Firehose/CodePipeline revert deferred (heavy drift scripting).

## Tests
Unit (writers.test.ts): WorkerType omit, non-WorkerType keep, unresolvable name. `glue-rich/verify-detect.sh` added. Full suite 1343 passing; all 3 stacks deleted + SWEEP CLEAN.