### PR TITLE
test(integ): detect+revert coverage for Lambda + Secrets Manager

### DIFF
--- a/tests/integration/lambda/verify-detect.sh
+++ b/tests/integration/lambda/verify-detect.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Lambda Function detect + revert (real AWS): flip the declared MUTABLE Description out
+# of band (update-function-configuration) -> check MUST DETECT -> revert (CC) -> CLEAN
+# + restored. (Lambda is the most common compute resource; revert via Cloud Control.)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegLambda; DESIRED="cdk-real-drift Lambda integration test function"; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+FN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text | head -1)"
+[ -n "$FN" ] && [ "$FN" != "None" ] || fail "no function name"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob Description -> DRIFTED ==="
+aws lambda update-function-configuration --function-name "$FN" --description "DRIFTED DESC" --region "$REGION" >/dev/null || fail inject
+sleep 4
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-lambda-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Description" /tmp/cdkrd-lambda-detect.out || fail "Description drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+sleep 4
+GOT="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" --query Description --output text)"
+[ "$GOT" = "$DESIRED" ] || fail "Description not restored (got: $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/secrets-rich/verify-detect.sh
+++ b/tests/integration/secrets-rich/verify-detect.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Secrets Manager Secret detect + revert (real AWS): flip the declared MUTABLE
+# Description out of band (update-secret) -> check MUST DETECT -> revert (CC) -> CLEAN
+# + restored. (Revert via Cloud Control UpdateResource.)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegSecretsRich; DESIRED="rich secret fixture for cdk-real-drift"; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+SID="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" --query "StackResources[?ResourceType=='AWS::SecretsManager::Secret'].PhysicalResourceId" --output text | head -1)"
+[ -n "$SID" ] && [ "$SID" != "None" ] || fail "no secret id"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob Description -> DRIFTED ==="
+aws secretsmanager update-secret --secret-id "$SID" --description "DRIFTED DESC" --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-secrets-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Description" /tmp/cdkrd-secrets-detect.out || fail "Description drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws secretsmanager describe-secret --secret-id "$SID" --region "$REGION" --query Description --output text)"
+[ "$GOT" = "$DESIRED" ] || fail "Description not restored (got: $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"


### PR DESCRIPTION
Adds `verify-detect.sh` for two of the most common resources whose **revert** was previously untested. Both live-proven this round to revert cleanly via Cloud Control UpdateResource (no full-model re-validation conflict, unlike the CloudFront #264 / WAFv2 #265 / Glue #266 Class-2 bugs):

- **lambda**: Description detect → revert → CLEAN.
- **secrets-rich**: Description detect → revert → CLEAN.

No source change — regression integ scripts only. Stacks deleted + SWEEP CLEAN.