### PR TITLE
test(integ): detect+revert coverage for SQS Queue + SNS FIFO Topic

### DIFF
--- a/tests/integration/sns-fifo/verify-detect.sh
+++ b/tests/integration/sns-fifo/verify-detect.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SNS FIFO Topic detect + revert (real AWS): flip the declared MUTABLE
+# ContentBasedDeduplication true->false out of band (set-topic-attributes) -> check
+# MUST DETECT -> revert (CC) -> CLEAN + restored. (Revert via Cloud Control.)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegSnsFifo; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+TARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" --query "StackResources[?ResourceType=='AWS::SNS::Topic'].PhysicalResourceId" --output text | head -1)"
+[ -n "$TARN" ] && [ "$TARN" != "None" ] || fail "no topic arn"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob ContentBasedDeduplication true->false ==="
+aws sns set-topic-attributes --topic-arn "$TARN" --attribute-name ContentBasedDeduplication --attribute-value false --region "$REGION" || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-snsfifo-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "ContentBasedDeduplication" /tmp/cdkrd-snsfifo-detect.out || fail "CBD drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws sns get-topic-attributes --topic-arn "$TARN" --region "$REGION" --query 'Attributes.ContentBasedDeduplication' --output text)"
+[ "$GOT" = "true" ] || fail "CBD not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/sqs-rich/verify-detect.sh
+++ b/tests/integration/sqs-rich/verify-detect.sh
@@ -1,55 +1,24 @@
 #!/usr/bin/env bash
-# SQS detect + revert integration test (real AWS): the "someone changed the queue
-# settings in the console" scenario. Deploy -> record -> change the DECLARED
-# MUTABLE VisibilityTimeout (60->120) out of band -> check MUST DETECT (exit 1)
-# -> revert -> check MUST be CLEAN and the live value restored to 60.
+# SQS Queue detect + revert (real AWS): flip the declared MUTABLE VisibilityTimeout
+# 60->120 on the MAIN queue out of band (set-queue-attributes) -> check MUST DETECT ->
+# revert (CC) -> CLEAN + restored. (Foundational messaging resource; revert via Cloud
+# Control UpdateResource.)
 set -uo pipefail
-HERE="$(cd "$(dirname "$0")" && pwd)"
-ROOT="$(cd "$HERE/../../.." && pwd)"
-cd "$HERE"
-STACK=CdkRealDriftIntegSqsRich
-QNAME=cdkrd-sqs-rich
-REGION="${AWS_REGION:-us-east-1}"
-CLI="node $ROOT/dist/cli.js"
-
-cleanup() {
-  echo "--- cleanup ($STACK) ---"
-  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
-  rm -rf .cdkrd cdk.out
-}
-trap cleanup EXIT
-
-fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
-
-echo "=== deploy fixture ==="
-npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
-
-QURL="$(aws sqs get-queue-url --queue-name "$QNAME" --region "$REGION" --query QueueUrl --output text)"
-[ -n "$QURL" ] || fail "could not resolve queue url"
-
-echo "=== record baseline ==="
-$CLI record "$STACK" --region "$REGION" --yes || fail "record"
-
-echo "=== out-of-band: VisibilityTimeout 60->120 (console-edit) ==="
-aws sqs set-queue-attributes --queue-url "$QURL" --attributes VisibilityTimeout=120 \
-  --region "$REGION" >/dev/null || fail "inject drift"
-
-echo "=== check MUST DETECT declared drift ==="
-$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sqs-detect.out
-rc=${PIPESTATUS[0]}
-[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
-grep -q "VisibilityTimeout" /tmp/cdkrd-sqs-detect.out || fail "VisibilityTimeout not reported"
-
-echo "=== revert (write declared value back) ==="
-$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
-
-echo "=== check MUST be CLEAN after revert ==="
-$CLI check "$STACK" --region "$REGION" --fail
-[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
-
-echo "=== live VisibilityTimeout MUST be restored to 60 ==="
-GOT="$(aws sqs get-queue-attributes --queue-url "$QURL" --attribute-names VisibilityTimeout \
-  --region "$REGION" --query "Attributes.VisibilityTimeout" --output text)"
-[ "$GOT" = "60" ] || fail "live VisibilityTimeout not restored (got: $GOT)"
-
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegSqsRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+QURL="$(aws sqs list-queues --region "$REGION" --query "QueueUrls[?contains(@,'cdkrd-sqs-rich')]" --output text | tr '\t' '\n' | grep -v dlq | head -1)"
+[ -n "$QURL" ] || fail "no main queue url"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob VisibilityTimeout 60->120 ==="
+aws sqs set-queue-attributes --queue-url "$QURL" --attributes VisibilityTimeout=120 --region "$REGION" || fail inject
+sleep 2
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sqs-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "VisibilityTimeout" /tmp/cdkrd-sqs-detect.out || fail "VisibilityTimeout drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws sqs get-queue-attributes --queue-url "$QURL" --attribute-names VisibilityTimeout --region "$REGION" --query 'Attributes.VisibilityTimeout' --output text)"
+[ "$GOT" = "60" ] || fail "VisibilityTimeout not restored (got $GOT)"
 echo "INTEG PASS ($STACK detect+revert)"


### PR DESCRIPTION
Adds `verify-detect.sh` for two foundational messaging resources whose **revert** was previously untested. Both live-proven clean via Cloud Control UpdateResource:

- **sqs-rich**: main queue VisibilityTimeout 60→120 detect → revert → CLEAN.
- **sns-fifo**: ContentBasedDeduplication true→false detect → revert → CLEAN.

No source change — regression integ only. Stacks deleted + SWEEP CLEAN.