### PR TITLE
fix(diff): revert a disjoint-key object (one-of union) by replacing it whole

### DIFF
--- a/src/diff/drift-calculator.ts
+++ b/src/diff/drift-calculator.ts
@@ -51,6 +51,20 @@ function diffAt(
       out.push({ path, stateValue: sv, awsValue: av });
       return;
     }
+    // Mutually-exclusive / wholesale object swap: when the desired and live objects
+    // share NO keys, the subset descent below (which walks only desired keys) would
+    // emit the desired-only keys to ADD but never the live-only keys to REMOVE — so a
+    // revert leaves BOTH and AWS rejects it (e.g. WAFv2 DefaultAction `{Allow:{}}` vs
+    // live `{Block:{}}` → "exactly one value" for a one-of field; the live `Block` is
+    // an empty `{}` so collectNestedUndeclared also suppresses it as trivial-empty,
+    // leaving it entirely unreverted). Emit the WHOLE object at the parent path so the
+    // revert REPLACES it wholesale. Gated on fully-disjoint keys, so every overlapping-
+    // key case (the common partial-object drift) keeps the subset semantics unchanged.
+    const svKeys = Object.keys(sv);
+    if (svKeys.length > 0 && Object.keys(av).length > 0 && !svKeys.some((k) => k in av)) {
+      out.push({ path, stateValue: sv, awsValue: av });
+      return;
+    }
     // Subset semantics: only walk keys present in the desired (state) side, so an
     // AWS-added nested key the template never set is not a DECLARED-side change here.
     // (R96: such live-only nested keys are instead caught by classify's

--- a/tests/drift-calculator.test.ts
+++ b/tests/drift-calculator.test.ts
@@ -80,4 +80,37 @@ describe('calculateResourceDrift', () => {
     expect(deepEqual({ a: [1, 2] }, { a: [1, 2] })).toBe(true);
     expect(deepEqual({ a: [1, 2] }, { a: [2, 1] })).toBe(false);
   });
+
+  describe('mutually-exclusive / disjoint-key object swap (union one-of fields)', () => {
+    it('emits the WHOLE object (not a leaf) when desired + live share no keys', () => {
+      // WAFv2 DefaultAction: desired {Allow:{}} vs live {Block:{}} — a one-of union.
+      // Descending would emit `DefaultAction.Allow` (add) and never remove live Block,
+      // so a revert leaves BOTH. Emit the whole object so the revert REPLACES it.
+      const d = calculateResourceDrift(
+        { DefaultAction: { Allow: {} } },
+        { DefaultAction: { Block: {} } }
+      );
+      expect(d).toEqual([
+        { path: 'DefaultAction', stateValue: { Allow: {} }, awsValue: { Block: {} } },
+      ]);
+    });
+
+    it('still descends (subset semantics) when keys OVERLAP', () => {
+      // common key `Mode` → descend as before; the extra desired key is an add, the
+      // live-only key is left to collectNestedUndeclared (not this calculator).
+      const d = calculateResourceDrift(
+        { Cfg: { Mode: 'A', Extra: 1 } },
+        { Cfg: { Mode: 'B', Other: 9 } }
+      );
+      expect(d).toEqual([
+        { path: 'Cfg.Mode', stateValue: 'A', awsValue: 'B' },
+        { path: 'Cfg.Extra', stateValue: 1, awsValue: undefined },
+      ]);
+    });
+
+    it('an empty desired or empty live object is not treated as a disjoint swap', () => {
+      // empty desired {} vs live {X:1}: nothing declared to compare -> no drift (subset).
+      expect(calculateResourceDrift({ P: {} }, { P: { X: 1 } })).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## The bug (real, live-proven)

The drift calculator descends into a declared object with **subset semantics** (walks only desired keys). For a mutually-exclusive **one-of union** — WAFv2 `DefaultAction` desired `{Allow:{}}` vs live `{Block:{}}` — it emits a leaf finding `DefaultAction.Allow` (add) and never removes the live-only `Block`, so the CC revert patch leaves **both** branches → AWS rejects ("exactly one value"). Proven live: a WAF DefaultAction Allow⇄Block revert left the drift in place.

## Fix

When the desired & live objects share **no keys** (fully disjoint), emit the **whole** object at the parent path so the revert **replaces** it wholesale. Gated on disjoint keys → every overlapping-key case (the common partial-object drift) keeps subset semantics unchanged.

**Live-verified:** WAFv2 DefaultAction Allow⇄Block now reverts clean (with the #265 WAF SDK writer). Unit tests added. Full suite 1346 passing.