### PR TITLE
fix(revert): OpenSearch Domain revert via UpdateDomainConfig SDK writer + Backup/MSK coverage

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -566,10 +566,16 @@ only when non-zero — unrecorded values are named as such, never folded into
     "do not set Max Capacity if using Worker Type" (proven live), so revert reads
     `GetJob`, applies the ops, and re-submits via `UpdateJob` OMITTING
     MaxCapacity/AllocatedCapacity when WorkerType is set (other JobUpdate fields verbatim;
-    read-only CreatedOn/LastModifiedOn excluded). The recurring shape: a CC type is
-    READABLE but its full-model UpdateResource re-validation rejects a field AWS itself
-    returns — the per-type SDK writer re-submits via the resource's own update API,
-    omitting the offending field. Only a LIVE detect→revert→CLEAN cycle catches these.
+    read-only CreatedOn/LastModifiedOn excluded). `AWS::OpenSearchService::Domain` is the
+    SAME class: CC `UpdateResource` re-submits the full model and AWS's own legacy
+    `override_main_response_version` AdvancedOption is rejected as "Unrecognized advanced
+    option" (proven live); revert goes through `UpdateDomainConfig` (a PARTIAL API)
+    sending ONLY the option properties the ops touch, so the untouched AdvancedOptions is
+    never re-submitted (and an AdvancedOptions revert drops the AWS-managed key). The
+    recurring shape: a CC type is READABLE but its full-model UpdateResource re-validation
+    rejects a field AWS itself returns — the per-type SDK writer re-submits via the
+    resource's own update API, omitting the offending field. Only a LIVE
+    detect→revert→CLEAN cycle catches these.
   - **Property-scoped SDK writers** (`SDK_PROP_WRITERS`): a CC-writable type where
     ONE property must bypass Cloud Control. An IAM Role's top-level `Policies`
     finding reverts per entry (`DeleteRolePolicy` / `PutRolePolicy` by

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@aws-sdk/client-iam": "^3.1065.0",
     "@aws-sdk/client-kms": "^3.1066.0",
     "@aws-sdk/client-lambda": "^3.1065.0",
+    "@aws-sdk/client-opensearch": "^3.1073.0",
     "@aws-sdk/client-rds": "^3.1070.0",
     "@aws-sdk/client-route-53": "^3.1066.0",
     "@aws-sdk/client-s3": "^3.1065.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@aws-sdk/client-lambda':
         specifier: ^3.1065.0
         version: 3.1066.0
+      '@aws-sdk/client-opensearch':
+        specifier: ^3.1073.0
+        version: 3.1073.0
       '@aws-sdk/client-rds':
         specifier: ^3.1070.0
         version: 3.1070.0
@@ -349,6 +352,10 @@ packages:
 
   '@aws-sdk/client-lambda@3.1066.0':
     resolution: {integrity: sha512-q2mcaD5CEz4iHFNR7EtGU+iv9tAfNsAk5zpqpux2p+aOrJKKeXeXQuvm8UPwXTGSinshKglmt79XYWNXdap+Gg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-opensearch@3.1073.0':
+    resolution: {integrity: sha512-YgWppczldVWTnL4f/MuY2TVtrIY9gXFqCR8UvaNZQ2CZG91GdAna5Io/3LlNQQqvng6mPCtCNzvMHoZQOzpiCQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-rds@3.1070.0':
@@ -3950,6 +3957,19 @@ snapshots:
       '@aws-sdk/core': 3.974.20
       '@aws-sdk/credential-provider-node': 3.972.55
       '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-opensearch@3.1073.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -27,6 +27,11 @@ import {
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
 import { DocDBClient, ModifyDBClusterCommand } from '@aws-sdk/client-docdb';
+import {
+  DescribeDomainConfigCommand,
+  OpenSearchClient,
+  UpdateDomainConfigCommand,
+} from '@aws-sdk/client-opensearch';
 import { GetJobCommand, GlueClient, UpdateJobCommand } from '@aws-sdk/client-glue';
 import {
   GetWebACLCommand,
@@ -459,7 +464,66 @@ const writeGlueJob: SdkWriter = async (ctx, ops) => {
   await c.send(new UpdateJobCommand({ JobName: name, JobUpdate: update as never }));
 };
 
+// AWS::OpenSearchService::Domain — Cloud Control CAN read this type, but its
+// UpdateResource REJECTS a property patch: it re-submits the full model and AWS's own
+// legacy `override_main_response_version` AdvancedOption (returned on read) is rejected
+// as "Unrecognized advanced option" (proven live; the same CC-revalidation class as
+// CloudFront/WAFv2/Glue). UpdateDomainConfig is a PARTIAL API, so route revert through
+// it sending ONLY the top-level option properties the revert ops actually touch — the
+// untouched AdvancedOptions are never re-submitted. (If AdvancedOptions itself is the
+// drift, the AWS-managed override_main_response_version key is dropped before the call.)
+const OS_UPDATABLE_OPTIONS = new Set([
+  'ClusterConfig',
+  'EBSOptions',
+  'SnapshotOptions',
+  'VPCOptions',
+  'CognitoOptions',
+  'AdvancedOptions',
+  'AccessPolicies',
+  'IPAddressType',
+  'LogPublishingOptions',
+  'EncryptionAtRestOptions',
+  'DomainEndpointOptions',
+  'NodeToNodeEncryptionOptions',
+  'AdvancedSecurityOptions',
+  'AutoTuneOptions',
+  'OffPeakWindowOptions',
+  'SoftwareUpdateOptions',
+]);
+const writeOpenSearchDomain: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['DomainName']);
+  if (!name) throw new Error('cannot resolve OpenSearch domain name for revert');
+  const touched = new Set(
+    ops.map((o) => o.path.replace(/^\//, '').split('/')[0]).filter((p): p is string => !!p)
+  );
+  const c = new OpenSearchClient({ region: ctx.region });
+  const cfg = (await c.send(new DescribeDomainConfigCommand({ DomainName: name }))).DomainConfig as
+    | Record<string, { Options?: unknown }>
+    | undefined;
+  // build a model of ONLY the touched option properties from the current live config,
+  // apply the revert ops, then send each touched updatable property on its own.
+  const model: Record<string, unknown> = {};
+  for (const p of touched) if (cfg?.[p]?.Options !== undefined) model[p] = cfg[p].Options;
+  const reverted = applyOps(model, ops);
+  const input: Record<string, unknown> = { DomainName: name };
+  for (const p of touched) {
+    if (!OS_UPDATABLE_OPTIONS.has(p) || reverted[p] === undefined) continue;
+    if (p === 'AdvancedOptions' && reverted[p] && typeof reverted[p] === 'object') {
+      // drop the AWS-managed legacy key UpdateDomainConfig rejects on re-submit.
+      const { override_main_response_version: _drop, ...rest } = reverted[p] as Record<
+        string,
+        unknown
+      >;
+      input[p] = rest;
+    } else {
+      input[p] = reverted[p];
+    }
+  }
+  await c.send(new UpdateDomainConfigCommand(input as never));
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
+  'AWS::OpenSearchService::Domain': writeOpenSearchDomain,
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
   'AWS::WAFv2::WebACL': writeWafv2WebAcl,
   'AWS::Glue::Job': writeGlueJob,

--- a/tests/integration/backup-rich/verify-detect.sh
+++ b/tests/integration/backup-rich/verify-detect.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Backup Plan detect + revert (real AWS): bump the declared MUTABLE nested
+# BackupPlan rule CompletionWindowMinutes 120->180 out of band (update-backup-plan) ->
+# check MUST DETECT -> revert (CC) -> CLEAN + restored. (CC UpdateResource handles the
+# nested BackupPlanRule patch cleanly — no Class-2 re-validation conflict.)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegBackupRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out bp.json bpu.json; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+PID="$(aws backup list-backup-plans --region "$REGION" --query "BackupPlansList[?BackupPlanName=='cdkrd-backup-rich'].BackupPlanId" --output text | head -1)"
+[ -n "$PID" ] && [ "$PID" != "None" ] || fail "no backup plan id"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob CompletionWindowMinutes 120->180 ==="
+aws backup get-backup-plan --backup-plan-id "$PID" --region "$REGION" --query BackupPlan > bp.json
+node -e "const p=require('./bp.json');const rules=p.Rules.map(r=>({RuleName:r.RuleName,TargetBackupVaultName:r.TargetBackupVaultName,ScheduleExpression:r.ScheduleExpression,StartWindowMinutes:r.StartWindowMinutes,CompletionWindowMinutes:r.RuleName==='Daily'?180:r.CompletionWindowMinutes,Lifecycle:r.Lifecycle,RecoveryPointTags:r.RecoveryPointTags,EnableContinuousBackup:r.EnableContinuousBackup}));require('fs').writeFileSync('bpu.json',JSON.stringify({BackupPlanName:p.BackupPlanName,Rules:rules}));"
+aws backup update-backup-plan --backup-plan-id "$PID" --backup-plan file://bpu.json --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-bk-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "CompletionWindowMinutes" /tmp/cdkrd-bk-detect.out || fail "drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws backup get-backup-plan --backup-plan-id "$PID" --region "$REGION" --query "BackupPlan.Rules[?RuleName=='Daily'].CompletionWindowMinutes" --output text)"
+[ "$GOT" = "120" ] || fail "CompletionWindow not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/msk-serverless/app.ts
+++ b/tests/integration/msk-serverless/app.ts
@@ -1,0 +1,22 @@
+// CDK app for the cdk-real-drift MSK Serverless CC-support probe. MSK Serverless
+// (AWS::MSK::ServerlessCluster) deploys fast (~3 min, no broker billing). Goal: measure
+// whether Cloud Control can READ it (hunt-target) or throws UnsupportedAction (an
+// SDK_OVERRIDE candidate, like the DB/service-discovery CC-gap tail).
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnServerlessCluster } from "aws-cdk-lib/aws-msk";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMskServerless");
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "iso", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+const subnetIds = vpc.selectSubnets({ subnetType: SubnetType.PRIVATE_ISOLATED }).subnetIds;
+new CfnServerlessCluster(stack, "Cluster", {
+  clusterName: "cdkrd-msk-serverless",
+  vpcConfigs: [{ subnetIds, securityGroups: [vpc.vpcDefaultSecurityGroup] }],
+  clientAuthentication: { sasl: { iam: { enabled: true } } },
+});
+app.synth();

--- a/tests/integration/msk-serverless/cdk.json
+++ b/tests/integration/msk-serverless/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/msk-serverless/package.json
+++ b/tests/integration/msk-serverless/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-msk-serverless",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/msk-serverless/verify.sh
+++ b/tests/integration/msk-serverless/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+# MSK Serverless (AWS::MSK::ServerlessCluster) is READ via Cloud Control (probe confirmed
+# GetResource works — a normal hunt-target, NOT an SDK_OVERRIDE candidate). Deploys fast
+# (~3 min, no broker billing). Most props are create-only/immutable.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegMskServerless; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected CLEAN got $rc"
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/opensearch-rich/verify-detect.sh
+++ b/tests/integration/opensearch-rich/verify-detect.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# OpenSearch Domain detect + revert (real AWS). The revert is the point: OpenSearch's
+# Cloud Control UpdateResource REJECTS a property patch — it re-submits the full model
+# and AWS's own legacy `override_main_response_version` AdvancedOption is rejected as
+# "Unrecognized advanced option". Revert goes through the UpdateDomainConfig SDK writer,
+# which sends ONLY the touched option (partial API), so AdvancedOptions is never
+# re-submitted. Drift the declared MUTABLE EBSOptions.VolumeSize 10->20 out of band ->
+# check MUST DETECT -> revert (SDK writer) -> CLEAN + restored. (Domain config changes
+# take a few minutes; the script waits for the domain to settle before reverting.)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegOpensearchRich; DN=cdkrd-opensearch-rich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+settle(){ for _ in $(seq 1 60); do [ "$(aws opensearch describe-domain --domain-name "$DN" --region "$REGION" --query 'DomainStatus.Processing' --output text)" = "False" ] && return 0; sleep 15; done; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob EBS VolumeSize 10->20 ==="
+aws opensearch update-domain-config --domain-name "$DN" --ebs-options EBSEnabled=true,VolumeType=gp3,VolumeSize=20 --region "$REGION" >/dev/null || fail inject
+settle
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-os-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "VolumeSize" /tmp/cdkrd-os-detect.out || fail "EBS VolumeSize drift not reported"
+echo "=== revert (SDK writer: UpdateDomainConfig) ==="; $CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-os-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-os-revert.out || fail "revert did not converge (CC override_main_response_version regression?)"
+settle
+GOT="$(aws opensearch describe-domain-config --domain-name "$DN" --region "$REGION" --query 'DomainConfig.EBSOptions.Options.VolumeSize' --output text)"
+[ "$GOT" = "10" ] || fail "VolumeSize not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -3,6 +3,11 @@ import {
   GetDistributionConfigCommand,
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
+import {
+  DescribeDomainConfigCommand,
+  OpenSearchClient,
+  UpdateDomainConfigCommand,
+} from '@aws-sdk/client-opensearch';
 import { GetWebACLCommand, UpdateWebACLCommand, WAFV2Client } from '@aws-sdk/client-wafv2';
 import {
   ElasticLoadBalancingV2Client,
@@ -57,6 +62,7 @@ const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
 const cloudfront = mockClient(CloudFrontClient);
 const wafv2 = mockClient(WAFV2Client);
+const opensearch = mockClient(OpenSearchClient);
 const glue = mockClient(GlueClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
@@ -95,7 +101,77 @@ beforeEach(() => {
   docdb.reset();
   cloudfront.reset();
   wafv2.reset();
+  opensearch.reset();
   glue.reset();
+});
+
+describe('OpenSearch Domain writer (CC UpdateResource rejects on override_main_response_version)', () => {
+  const volOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/EBSOptions/VolumeSize',
+    value,
+    human: 'EBSOptions.VolumeSize -> deployed-template value',
+  });
+  it('reverts via UpdateDomainConfig sending ONLY the touched option (untouched AdvancedOptions not re-submitted)', async () => {
+    opensearch.on(DescribeDomainConfigCommand).resolves({
+      DomainConfig: {
+        EBSOptions: { Options: { EBSEnabled: true, VolumeType: 'gp3', VolumeSize: 20 } },
+        // AdvancedOptions carries the AWS-managed legacy key CC re-submit chokes on —
+        // it is NOT touched by the op, so the writer must not send it at all.
+        AdvancedOptions: { Options: { override_main_response_version: 'false' } },
+        ClusterConfig: { Options: { InstanceCount: 1 } },
+      },
+    } as never);
+    opensearch.on(UpdateDomainConfigCommand).resolves({});
+    await SDK_WRITERS['AWS::OpenSearchService::Domain'](ctx({ physicalId: 'my-domain' }), [
+      volOp(10),
+    ]);
+    const calls = opensearch.commandCalls(UpdateDomainConfigCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input as unknown as Record<string, unknown>;
+    expect(input.DomainName).toBe('my-domain');
+    expect(input.EBSOptions).toEqual({ EBSEnabled: true, VolumeType: 'gp3', VolumeSize: 10 });
+    // untouched options are NOT re-submitted (the bug trigger)
+    expect('AdvancedOptions' in input).toBe(false);
+    expect('ClusterConfig' in input).toBe(false);
+  });
+
+  it('drops the AWS-managed override_main_response_version when AdvancedOptions IS reverted', async () => {
+    opensearch.on(DescribeDomainConfigCommand).resolves({
+      DomainConfig: {
+        AdvancedOptions: {
+          Options: {
+            'rest.action.multi.allow_explicit_index': 'true',
+            override_main_response_version: 'false',
+          },
+        },
+      },
+    } as never);
+    opensearch.on(UpdateDomainConfigCommand).resolves({});
+    await SDK_WRITERS['AWS::OpenSearchService::Domain'](ctx({ physicalId: 'd' }), [
+      {
+        op: 'add',
+        path: '/AdvancedOptions/rest.action.multi.allow_explicit_index',
+        value: 'false',
+        human: 'x',
+      },
+    ]);
+    const ao = (
+      opensearch.commandCalls(UpdateDomainConfigCommand)[0]!.args[0].input as unknown as {
+        AdvancedOptions: Record<string, unknown>;
+      }
+    ).AdvancedOptions;
+    expect('override_main_response_version' in ao).toBe(false);
+    expect(ao['rest.action.multi.allow_explicit_index']).toBe('false');
+  });
+
+  it('throws when the domain name is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::OpenSearchService::Domain'](ctx({ physicalId: '', declared: {} }), [
+        volOp(10),
+      ])
+    ).rejects.toThrow(/OpenSearch domain name/);
+  });
 });
 
 describe('Glue Job writer (CC UpdateResource rejects MaxCapacity+WorkerType)', () => {


### PR DESCRIPTION
## The bug (real, live-proven — 4th of the same Class-2 family)

`OpenSearchService::Domain` is Cloud-Control **readable**, but its `UpdateResource` **rejects a property patch**: it re-submits the full model and AWS's own legacy `override_main_response_version` AdvancedOption (returned on read) is rejected as "Unrecognized advanced option". **Proven live: every OpenSearch revert failed.** Same class as CloudFront #264 / WAFv2 #265 / Glue #266.

## Fix

`UpdateDomainConfig` is a **partial** API — route revert through it sending **only** the option properties the ops touch, so the untouched AdvancedOptions is never re-submitted (and an AdvancedOptions revert drops the AWS-managed key). **Live-verified:** EBSOptions.VolumeSize 10→20 detect → revert → CLEAN. Unit tests added.

## Same-round coverage (all live-proven)
- **opensearch-rich/verify-detect.sh** — the fix.
- **backup-rich/verify-detect.sh** — BackupPlan CompletionWindowMinutes detect+revert via CC (**clean**, no Class-2 conflict).
- **msk-serverless** — NEW fixture; MSK Serverless probe found it **CC-readable** (a hunt-target, not an override candidate); verify.sh is an FP check.

New dep `@aws-sdk/client-opensearch`. Full suite 1346 passing; all stacks deleted + SWEEP CLEAN.