### PR TITLE
fix(normalize): don't sort order-significant CodePipeline Stages/Actions (revert index misalignment)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -267,7 +267,8 @@ export function normalizeLiveModel(
 ): Record<string, unknown> {
   const oaiMap = opts.oaiCanonicalIds ?? {};
   const live = canonicalizeForCompare(
-    rewriteOaiPrincipalsDeep(stripAwsTagsDeep(stripCcApiAwsManagedFields(liveRaw)), oaiMap)
+    rewriteOaiPrincipalsDeep(stripAwsTagsDeep(stripCcApiAwsManagedFields(liveRaw)), oaiMap),
+    opts.resourceType
   ) as Record<string, unknown>;
   deepStripPaths(live, schema.readOnlyPaths);
   deepStripPaths(live, schema.writeOnlyPaths);
@@ -299,10 +300,10 @@ export function classifyResource(
   // normalize identically (see pipeline.ts).
   const oaiMap = opts.oaiCanonicalIds ?? {};
   const live = normalizeLiveModel(liveRaw, schema, { oaiCanonicalIds: oaiMap, resourceType });
-  const declared = canonicalizeForCompare(rewriteOaiPrincipalsDeep(declaredIn, oaiMap)) as Record<
-    string,
-    unknown
-  >;
+  const declared = canonicalizeForCompare(
+    rewriteOaiPrincipalsDeep(declaredIn, oaiMap),
+    resourceType
+  ) as Record<string, unknown>;
   // Drop a parent's reflected child-aggregate property (e.g. SNS Topic.Subscription)
   // UNLESS the template declares it inline — cdkrd tracks those children as their own
   // resources (+ the `added` enumerator), so comparing the reflection would double-report

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -463,9 +463,35 @@ export function identityField(arr: unknown[]): string | undefined {
     )
   );
 }
-export function canonicalizeTagListsDeep(v: unknown): unknown {
+// Identity-keyed OBJECT arrays that carry a per-element `Name` (so `identityField`
+// would otherwise sort them) but whose ARRAY ORDER is SEMANTICALLY SIGNIFICANT.
+// Sorting such an array is doubly wrong: (a) it MASKS a genuine reorder as no-drift
+// (FP/FN), and (b) the drift finding's array index then points into the SORTED model
+// while the revert (Cloud Control `UpdateResource`) patch addresses the RAW UNSORTED
+// live model — so the patch lands on the WRONG element and the revert silently no-ops
+// (the same index-misalignment class as the policy-statement bug, but CC-side).
+// Keyed by resourceType -> the set of property KEY NAMES (at ANY depth) whose array
+// value must stay in declared order. CodePipeline Stages execute top-to-bottom, and
+// each stage's Actions are returned by Cloud Control in declared order; both compare
+// positionally. The exclusion is type-scoped (only applied when canonicalizeForCompare
+// is given this resourceType), so a same-named array on an unrelated type is unaffected.
+export const ORDER_SIGNIFICANT_ARRAY_KEYS: Record<string, ReadonlySet<string>> = {
+  'AWS::CodePipeline::Pipeline': new Set(['Stages', 'Actions']),
+};
+export function canonicalizeTagListsDeep(v: unknown, orderSig?: ReadonlySet<string>): unknown {
+  return canonicalizeTagLists(v, orderSig, undefined);
+}
+// `keyHere` is the property name the value `v` sits under (undefined at the root and
+// for array ELEMENTS), so an array directly under an order-significant key is left in
+// place while its elements still recurse for nested tag/id-list canonicalization.
+function canonicalizeTagLists(
+  v: unknown,
+  orderSig: ReadonlySet<string> | undefined,
+  keyHere: string | undefined
+): unknown {
   if (Array.isArray(v)) {
-    const mapped = v.map(canonicalizeTagListsDeep);
+    const mapped = v.map((el) => canonicalizeTagLists(el, orderSig, undefined));
+    if (keyHere !== undefined && orderSig?.has(keyHere)) return mapped;
     const idf = mapped.length > 0 ? identityField(mapped) : undefined;
     if (idf) {
       return [...mapped].sort((a, b) => {
@@ -480,7 +506,7 @@ export function canonicalizeTagListsDeep(v: unknown): unknown {
   if (v && typeof v === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, val] of Object.entries(v as Record<string, unknown>))
-      out[k] = canonicalizeTagListsDeep(val);
+      out[k] = canonicalizeTagLists(val, orderSig, k);
     return out;
   }
   return v;

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -10,9 +10,20 @@
 // lists (unordered set -> sorted by Key), then AWS-id arrays (unordered set ->
 // sorted). It does NOT strip AWS-managed fields / aws:* tags / schema paths — those
 // are live-only concerns the caller applies before this.
-import { canonicalizeIdArraysDeep, canonicalizeTagListsDeep } from './noise.js';
+import {
+  canonicalizeIdArraysDeep,
+  canonicalizeTagListsDeep,
+  ORDER_SIGNIFICANT_ARRAY_KEYS,
+} from './noise.js';
 import { normalizePoliciesDeep } from './policy-canonical.js';
 
-export function canonicalizeForCompare(v: unknown): unknown {
-  return canonicalizeIdArraysDeep(canonicalizeTagListsDeep(normalizePoliciesDeep(v)));
+// `resourceType` is optional: when given, identity-keyed object arrays the type marks
+// as ORDER-significant (ORDER_SIGNIFICANT_ARRAY_KEYS — e.g. CodePipeline Stages/Actions)
+// are NOT sorted, so both compare sides keep declared order and a finding's array index
+// stays aligned with the raw live model the revert patches. classify passes the type
+// for BOTH its live and declared sides; the type-less callers (baseline/writers) operate
+// on undeclared snapshot values, which never carry an order-significant declared array.
+export function canonicalizeForCompare(v: unknown, resourceType?: string): unknown {
+  const orderSig = resourceType ? ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType] : undefined;
+  return canonicalizeIdArraysDeep(canonicalizeTagListsDeep(normalizePoliciesDeep(v), orderSig));
 }

--- a/tests/integration/codepipeline-rich/verify-detect.sh
+++ b/tests/integration/codepipeline-rich/verify-detect.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Detection + revert integration test (real AWS) for the CodePipeline sorted-array
+# index-misalignment fix. CodePipeline Stages/Actions carry a per-element Name, so the
+# generic identity-keyed sort USED to reorder them (Build < Source) — but the array
+# order is semantically significant AND the Cloud Control revert patch addresses the
+# RAW (unsorted) live model by index. Drifting a DECLARED, MUTABLE property in the
+# SOURCE stage (raw index 0, but sorted to index 1) proves the finding index now aligns
+# with the raw model: detect -> revert -> re-check CLEAN -> live value restored.
+# Without the fix the revert patch lands on the WRONG stage (Build) and the drift
+# silently survives ("1 drift remains").
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodepipelineRich
+REGION="${AWS_REGION:-us-east-1}"
+PIPELINE=cdkrd-pipeline-rich
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (snapshot undeclared) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] baseline check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN before drift"
+
+echo "=== [$STACK] out-of-band drift: Source action S3ObjectKey source.zip -> drifted.zip ==="
+# get-pipeline -> mutate the Source stage's S3 action Configuration.S3ObjectKey -> update-pipeline
+aws codepipeline get-pipeline --name "$PIPELINE" --region "$REGION" --query pipeline > /tmp/cp-pipeline.json || fail "get-pipeline"
+node -e '
+  const fs = require("fs");
+  const p = JSON.parse(fs.readFileSync("/tmp/cp-pipeline.json", "utf8"));
+  const src = p.stages.find((s) => s.name === "Source");
+  const act = src.actions.find((a) => a.name === "S3Source");
+  if (act.configuration.S3ObjectKey !== "source.zip") throw new Error("unexpected pre-drift value: " + act.configuration.S3ObjectKey);
+  act.configuration.S3ObjectKey = "drifted.zip";
+  fs.writeFileSync("/tmp/cp-pipeline-drifted.json", JSON.stringify({ pipeline: p }));
+' || fail "mutate pipeline json"
+aws codepipeline update-pipeline --cli-input-json file:///tmp/cp-pipeline-drifted.json --region "$REGION" >/dev/null || fail "update-pipeline"
+
+echo "=== [$STACK] check MUST DETECT the drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift detected (exit 1), got $rc"
+grep -q "S3ObjectKey" "/tmp/cdkrd-$STACK-detect.out" || fail "drift output did not mention S3ObjectKey"
+
+echo "=== [$STACK] revert MUST restore the value ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== [$STACK] re-check MUST be CLEAN (revert hit the right stage) ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert — index misalignment would leave drift here"
+
+echo "=== [$STACK] confirm live value restored to source.zip ==="
+live=$(aws codepipeline get-pipeline --name "$PIPELINE" --region "$REGION" \
+  --query "pipeline.stages[?name=='Source'].actions[0].configuration.S3ObjectKey | [0]" --output text)
+[ "$live" = "source.zip" ] || fail "live S3ObjectKey is '$live', expected 'source.zip'"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -14,7 +14,9 @@ import {
   VERSION_PREFIX_PATHS,
   isTrailingDotEqual,
   TRAILING_DOT_PATHS,
+  ORDER_SIGNIFICANT_ARRAY_KEYS,
 } from '../src/normalize/noise.js';
+import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
 import { parseSchema } from '../src/schema/schema-strip.js';
 
 describe('noise suppressors', () => {
@@ -101,6 +103,86 @@ describe('noise suppressors', () => {
       ],
     };
     expect(canonicalizeTagListsDeep(declared)).not.toEqual(canonicalizeTagListsDeep(changed));
+  });
+
+  it('canonicalizeTagListsDeep: order-significant Name-keyed arrays are NOT sorted (CodePipeline)', () => {
+    // CodePipeline Stages/Actions carry a per-element Name (so identityField would sort
+    // them) but their order is semantically significant AND the revert patch addresses
+    // the raw live model by index — sorting would misalign the finding index. With the
+    // type's order-significant key set, the array must stay in DECLARED order.
+    const orderSig = ORDER_SIGNIFICANT_ARRAY_KEYS['AWS::CodePipeline::Pipeline'];
+    const pipeline = {
+      Stages: [
+        { Name: 'Source', Actions: [{ Name: 'Src', Configuration: { x: '1' } }] },
+        { Name: 'Build', Actions: [{ Name: 'Bld', Configuration: { x: '2' } }] },
+      ],
+    };
+    // default (no orderSig) WOULD reorder Build before Source — proving the regression risk
+    expect(
+      (canonicalizeTagListsDeep(pipeline) as { Stages: { Name: string }[] }).Stages.map(
+        (s) => s.Name
+      )
+    ).toEqual(['Build', 'Source']);
+    // with orderSig, Stages keep declared order (index stays aligned with the raw model)
+    expect(
+      (canonicalizeTagListsDeep(pipeline, orderSig) as { Stages: { Name: string }[] }).Stages.map(
+        (s) => s.Name
+      )
+    ).toEqual(['Source', 'Build']);
+  });
+
+  it('canonicalizeTagListsDeep: order-significant exclusion still recurses into elements (nested Tags sorted)', () => {
+    // the array under an order-significant key is not sorted, but its ELEMENTS still get
+    // canonicalized — a Tags list inside a Stage is still sorted by Key.
+    const orderSig = ORDER_SIGNIFICANT_ARRAY_KEYS['AWS::CodePipeline::Pipeline'];
+    const out = canonicalizeTagListsDeep(
+      {
+        Stages: [
+          {
+            Name: 'B',
+            Tags: [
+              { Key: 'z', Value: '1' },
+              { Key: 'a', Value: '2' },
+            ],
+          },
+          { Name: 'A' },
+        ],
+      },
+      orderSig
+    ) as { Stages: { Name: string; Tags?: { Key: string }[] }[] };
+    expect(out.Stages.map((s) => s.Name)).toEqual(['B', 'A']); // stage order preserved
+    expect(out.Stages[0].Tags?.map((t) => t.Key)).toEqual(['a', 'z']); // nested Tags sorted
+  });
+
+  it('canonicalizeForCompare: passes a type through so CodePipeline Stages compare positionally', () => {
+    const declared = {
+      Stages: [
+        { Name: 'Source', Actions: [{ Name: 'S' }] },
+        { Name: 'Build', Actions: [{ Name: 'B' }] },
+      ],
+    };
+    // type-aware: declared order preserved (no false reorder, index aligned for revert)
+    expect(
+      (
+        canonicalizeForCompare(declared, 'AWS::CodePipeline::Pipeline') as {
+          Stages: { Name: string }[];
+        }
+      ).Stages.map((s) => s.Name)
+    ).toEqual(['Source', 'Build']);
+    // type-LESS (e.g. baseline/writers callers) keeps the legacy sort — unchanged behavior
+    expect(
+      (canonicalizeForCompare(declared) as { Stages: { Name: string }[] }).Stages.map((s) => s.Name)
+    ).toEqual(['Build', 'Source']);
+    // a genuine reorder of stages is now DETECTABLE (type-aware sides differ)
+    const reordered = {
+      Stages: [
+        { Name: 'Build', Actions: [{ Name: 'B' }] },
+        { Name: 'Source', Actions: [{ Name: 'S' }] },
+      ],
+    };
+    expect(canonicalizeForCompare(declared, 'AWS::CodePipeline::Pipeline')).not.toEqual(
+      canonicalizeForCompare(reordered, 'AWS::CodePipeline::Pipeline')
+    );
   });
 
   it('canonicalizeIdArraysDeep: sorts resource-id/ARN arrays (SubnetIds) but not plain scalars', () => {


### PR DESCRIPTION
## Problem

`canonicalizeTagListsDeep` sorts **any** identity-keyed object array whose every element carries a `Name`/`Key`/`Id`/`AttributeName`/`IndexName`. But **CodePipeline `Stages`** and each stage's **`Actions`** carry a `Name` *and* are **order-significant** (the pipeline executes top-to-bottom).

Sorting them (e.g. `Build` < `Source`) caused a drift finding to be indexed into the **sorted** model, while the Cloud Control `UpdateResource` revert patch addresses the **raw, unsorted** live model. The patch therefore landed on the **wrong element** — the revert silently no-opped and the drift survived ("1 drift remains"). It is the CC-side twin of the policy-statement index-misalignment class (#180). It also **masked a genuine stage/action reorder** as no-drift (latent FP/FN).

## Fix

- `ORDER_SIGNIFICANT_ARRAY_KEYS` (resourceType → the set of property key names whose array value must keep declared order). `AWS::CodePipeline::Pipeline` → `{Stages, Actions}`.
- Threaded through `canonicalizeForCompare(v, resourceType?)` and applied on **both** the live and declared sides in `classify`.
- **Type-scoped**: a same-named array on an unrelated type is unaffected. Type-less callers (baseline/writers, which operate on undeclared snapshots that never carry an order-significant declared array) keep prior behavior.
- Order-significant arrays now compare **positionally**, so the finding index aligns with the raw model the revert patches **and** a reorder is now detected.

## Tests

- Unit tests in `noise-and-strip.test.ts`: exclusion keeps declared order; nested elements still recurse (inner `Tags` still sorted); `canonicalizeForCompare` type-aware vs type-less; reorder now distinguishable.
- **Live-proven on real AWS**: deploy CodePipeline → `record`/`check` CLEAN → out-of-band drift the Source action `S3ObjectKey` (raw index 0, would sort to 1) → `check` detects at `Stages.0` (= **Source**, proving no sort) → `revert` → re-`check` CLEAN → live value restored. New `codepipeline-rich/verify-detect.sh` kept as a regression integ.

```
CdkRealDriftIntegCodepipelineRich/Pipeline.Stages.0.Actions.0.Configuration.S3ObjectKey (AWS::CodePipeline::Pipeline)
    desired="source.zip"
    actual ="drifted.zip"
...
CdkRealDriftIntegCodepipelineRich: CLEAN after revert.
INTEG PASS (CdkRealDriftIntegCodepipelineRich)
```

All 1361 unit tests pass; typecheck / lint+format clean. Stacks torn down + sweep CLEAN.
