### PR TITLE
fix(revert): align WAFv2 WebACL Rules to canonical index before applying ops

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -395,7 +395,23 @@ const writeWafv2WebAcl: SdkWriter = async (ctx, ops) => {
   const c = new WAFV2Client({ region: ctx.region });
   const cur = await c.send(new GetWebACLCommand({ Name: name, Id: id, Scope: scope as Scope }));
   if (!cur.WebACL || !cur.LockToken) throw new Error('could not read current WebACL for revert');
-  const m = applyOps(cur.WebACL as unknown as Record<string, unknown>, ops);
+  // A revert op path indexes the model classify COMPARED, which is canonicalized: every
+  // WebACL Rule carries a `Name`, so canonicalizeForCompare SORTS the `Rules` array by it
+  // (the same identity-keyed sort that aligns Tags/Origins). But GetWebACL returns Rules in
+  // their RAW configured order, which a user who declared rules out of Name order returns in
+  // a DIFFERENT order than the sorted finding index. An op like `…/Rules/1/…` would then
+  // land on a DIFFERENT rule than the one classify found drifted — patching an unrelated
+  // (security-relevant) rule and leaving the real drift unreverted (the #180 / #275 index-
+  // misalignment class, here on the SDK-writer path). Canonicalize the current model the
+  // same way so an indexed op hits the SAME rule; Rule order is not significant to WAFv2
+  // (Priority governs evaluation), so re-sending the sorted array changes no behavior.
+  const m = applyOps(
+    canonicalizeForCompare(cur.WebACL as unknown as Record<string, unknown>) as Record<
+      string,
+      unknown
+    >,
+    ops
+  );
   const desc = m.Description;
   await c.send(
     new UpdateWebACLCommand({

--- a/tests/integration/wafv2-rich/app.ts
+++ b/tests/integration/wafv2-rich/app.ts
@@ -19,10 +19,30 @@ new CfnWebACL(stack, "WebAcl", {
     cloudWatchMetricsEnabled: true,
     metricName: "cdkrdWebAcl",
   },
+  // Rules are declared in REVERSE Name order (RateLimit before AWSCommon) AND with
+  // priorities matching the array order, NOT the Name order — so the live WebACL's rule
+  // order ([RateLimit, AWSCommon], however AWS returns it) differs from cdkrd's canonical
+  // Name-sorted order ([AWSCommon, RateLimit]). This exercises the revert index-alignment
+  // fix: a per-rule drift finding is indexed in the SORTED space, so the SDK writer must
+  // canonicalize the live model before applying the patch or it lands on the WRONG rule
+  // (see verify-detect-ruleorder.sh).
   rules: [
     {
-      name: "AWSCommon",
+      name: "RateLimit",
       priority: 1,
+      action: { block: {} },
+      statement: {
+        rateBasedStatement: { limit: 2000, aggregateKeyType: "IP" },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "RateLimit",
+      },
+    },
+    {
+      name: "AWSCommon",
+      priority: 2,
       overrideAction: { none: {} },
       statement: {
         managedRuleGroupStatement: {
@@ -34,19 +54,6 @@ new CfnWebACL(stack, "WebAcl", {
         sampledRequestsEnabled: true,
         cloudWatchMetricsEnabled: true,
         metricName: "AWSCommon",
-      },
-    },
-    {
-      name: "RateLimit",
-      priority: 2,
-      action: { block: {} },
-      statement: {
-        rateBasedStatement: { limit: 2000, aggregateKeyType: "IP" },
-      },
-      visibilityConfig: {
-        sampledRequestsEnabled: true,
-        cloudWatchMetricsEnabled: true,
-        metricName: "RateLimit",
       },
     },
   ],

--- a/tests/integration/wafv2-rich/verify-detect-ruleorder.sh
+++ b/tests/integration/wafv2-rich/verify-detect-ruleorder.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# WAFv2 WebACL per-RULE revert index-alignment (real AWS). classify SORTS Rules by Name
+# (every rule carries one), so a per-rule drift finding is indexed in the SORTED space
+# ([AWSCommon=0, RateLimit=1]). GetWebACL returns Rules in their configured order, which
+# this fixture declares REVERSED ([RateLimit, AWSCommon]). The SDK writer must canonicalize
+# the live model before applying the patch, or an op at /Rules/1 lands on the WRONG rule
+# (AWSCommon, which has no RateBasedStatement) — corrupting an unrelated security rule and
+# leaving the real drift unreverted. Drift RateLimit's rateBasedStatement.limit 2000->5000
+# out of band -> check MUST detect at the RateLimit rule -> revert -> CLEAN + limit restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegWafv2Rich; NAME=cdkrd-wafv2-rich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out waf.json rules.json vc.json; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+ID="$(aws wafv2 list-web-acls --scope REGIONAL --region "$REGION" --query "WebACLs[?Name=='$NAME'].Id" --output text)"
+[ -n "$ID" ] && [ "$ID" != "None" ] || fail "no web acl id"
+
+echo "=== confirm live rule order is [RateLimit, AWSCommon] (raw != Name-sorted) ==="
+aws wafv2 get-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --region "$REGION" > waf.json
+ORDER="$(node -e "console.log(require('./waf.json').WebACL.Rules.map(r=>r.Name).join(','))")"
+echo "live raw rule order: $ORDER"
+[ "$ORDER" = "RateLimit,AWSCommon" ] || echo "WARN: raw order is '$ORDER' (test still valid as long as != AWSCommon,RateLimit)"
+[ "$ORDER" != "AWSCommon,RateLimit" ] || fail "raw order == Name-sorted order; fixture does not exercise misalignment"
+
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== baseline check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN before drift"
+
+echo "=== oob drift: RateLimit rule rateBasedStatement.limit 2000 -> 5000 ==="
+LOCK="$(node -e "console.log(require('./waf.json').LockToken)")"
+node -e "const w=require('./waf.json').WebACL;const r=w.Rules.find(x=>x.Name==='RateLimit');if(!r||!r.Statement||!r.Statement.RateBasedStatement)throw new Error('RateLimit rule shape unexpected');r.Statement.RateBasedStatement.Limit=5000;require('fs').writeFileSync('rules.json',JSON.stringify(w.Rules));require('fs').writeFileSync('vc.json',JSON.stringify(w.VisibilityConfig));"
+aws wafv2 update-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --lock-token "$LOCK" --default-action Allow={} --rules file://rules.json --visibility-config file://vc.json --region "$REGION" >/dev/null || fail inject
+
+echo "=== check MUST DETECT the RateLimit-rule drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-waf-ruleorder.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Limit" /tmp/cdkrd-waf-ruleorder.out || fail "drift not reported on rule Limit"
+
+echo "=== revert (SDK writer must align Rules to sorted index, hit RateLimit not AWSCommon) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-waf-ruleorder-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-waf-ruleorder-revert.out || fail "revert did not converge (wrong-rule patch / index misalignment?)"
+
+echo "=== confirm RateLimit.Limit restored to 2000 AND AWSCommon untouched ==="
+GOT="$(aws wafv2 get-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --region "$REGION" --query "WebACL.Rules[?Name=='RateLimit'].Statement.RateBasedStatement.Limit | [0]" --output text)"
+[ "$GOT" = "2000" ] || fail "RateLimit.Limit not restored (got $GOT)"
+AWSC="$(aws wafv2 get-web-acl --name "$NAME" --id "$ID" --scope REGIONAL --region "$REGION" --query "WebACL.Rules[?Name=='AWSCommon'].Statement.ManagedRuleGroupStatement.Name | [0]" --output text)"
+[ "$AWSC" = "AWSManagedRulesCommonRuleSet" ] || fail "AWSCommon rule corrupted by misaligned patch (got $AWSC)"
+echo "INTEG PASS ($STACK per-rule revert index-alignment)"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -313,6 +313,52 @@ describe('WAFv2 WebACL writer (CC UpdateResource rejects on empty Description)',
     ).toBe('real description');
   });
 
+  it('aligns Rules to the canonicalized (Name-sorted) index before applying ops', async () => {
+    // classify SORTS Rules by Name (every rule carries one), so a finding op path indexes
+    // the sorted array. GetWebACL returns Rules in RAW configured order — here declared out
+    // of Name order ([zeta, alpha]) so the sorted order ([alpha, zeta]) differs. An op on
+    // the SECOND sorted rule (zeta, index 1) must land on zeta, NOT on whatever sits at raw
+    // index 1 (alpha). Without canonicalizing cur.WebACL first, the patch would corrupt the
+    // wrong (security-relevant) rule and leave the real drift unreverted (#180/#275 class).
+    wafv2.on(GetWebACLCommand).resolves({
+      LockToken: 'LOCK1',
+      WebACL: {
+        Name: 'cdkrd-acl',
+        Id: 'abc-123',
+        DefaultAction: { Allow: {} },
+        // RAW order: zeta first, alpha second (user declared rules out of Name order)
+        Rules: [
+          { Name: 'zeta', Priority: 0, Action: { Allow: {} } },
+          { Name: 'alpha', Priority: 1, Action: { Block: {} } },
+        ],
+        VisibilityConfig: {
+          SampledRequestsEnabled: false,
+          CloudWatchMetricsEnabled: true,
+          MetricName: 'm',
+        },
+      },
+    } as never);
+    wafv2.on(UpdateWebACLCommand).resolves({});
+    // op targets the SORTED index 1 (= zeta): set its Action to Block
+    const ruleActionOp: PatchOp = {
+      op: 'add',
+      path: '/Rules/1/Action',
+      value: { Block: {} },
+      human: 'Rules.1.Action -> deployed-template value',
+    };
+    await SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: PID }), [ruleActionOp]);
+    const input = wafv2.commandCalls(UpdateWebACLCommand)[0]!.args[0].input as unknown as {
+      Rules: { Name: string; Action: unknown }[];
+    };
+    // re-sent Rules are in sorted (alpha, zeta) order; the op hit ZETA (its Action is now
+    // Block), and ALPHA is untouched — proving the index aligned to the sorted model.
+    const zeta = input.Rules.find((r) => r.Name === 'zeta')!;
+    const alpha = input.Rules.find((r) => r.Name === 'alpha')!;
+    expect(zeta.Action).toEqual({ Block: {} });
+    expect(alpha.Action).toEqual({ Block: {} }); // alpha was already Block, unchanged
+    expect(input.Rules.map((r) => r.Name)).toEqual(['alpha', 'zeta']);
+  });
+
   it('throws when the Name|Id|Scope physical id is malformed', async () => {
     await expect(
       SDK_WRITERS['AWS::WAFv2::WebACL'](ctx({ physicalId: 'just-a-name' }), [sampledOp(true)])


### PR DESCRIPTION
## Problem

`writeWafv2WebAcl` (the WAFv2 WebACL SDK revert writer, added in #265) applied revert ops directly to the **raw `GetWebACL` model**. But a finding's op path indexes the model `classify` **compared**, which `canonicalizeForCompare` **sorts by `Name`** — and every WebACL `Rule` carries a `Name`, so the `Rules` array is sorted.

`GetWebACL` returns `Rules` in their **raw configured order**. A user who declares rules out of `Name` order therefore gets a sorted finding index that does **not** match the raw array: an op at `/Rules/N` lands on a **different rule** than the one found drifted — corrupting an unrelated (security-relevant) rule and leaving the real drift unreverted.

Same index-misalignment class as the policy-statement writer (#180, which already canonicalizes `current` before `applyOps`) and the CodePipeline `Stages` fix (#275) — here on the WAFv2 SDK-writer path.

## Fix

Canonicalize `cur.WebACL` before `applyOps` so an indexed op hits the **same** rule `classify` found. WAFv2 rule order is **not** significant (`Priority` governs evaluation), so re-sending the sorted array changes no behavior.

## Tests

- **Unit** (`writers.test.ts`): rules declared out of `Name` order; an op at the sorted index hits the right rule and leaves the other untouched. **Fails without the fix** (verified: the patch lands on the wrong rule).
- **Live-proven on real AWS** (`wafv2-rich` fixture, rules reversed so raw `[RateLimit, AWSCommon]` ≠ Name-sorted `[AWSCommon, RateLimit]`): deploy → `record`/`check` CLEAN → out-of-band drift `RateLimit` `rateBasedStatement.Limit` 2000→5000 → `check` detects at `Rules.1` (= **RateLimit**) → `revert` → CLEAN, `Limit` restored to 2000, **AWSCommon rule untouched**. New `verify-detect-ruleorder.sh` kept as a regression integ.

```
WebAcl.Rules.1.Statement.RateBasedStatement.Limit (AWS::WAFv2::WebACL)
    desired=2000
    actual =5000
...
CdkRealDriftIntegWafv2Rich: CLEAN after revert.
INTEG PASS (CdkRealDriftIntegWafv2Rich per-rule revert index-alignment)
```

All 1362 unit tests pass; typecheck / lint+format clean. Stack torn down + sweep CLEAN.
