### PR TITLE
docs(readme): document AppSync GraphQLSchema as a known skipped-coverage limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,15 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   the declaring stack would false-drift on every shared policy. So an out-of-band
   attach/detach is not reported (a deliberate fail-closed boundary, not a missed
   document change).
+- **AppSync GraphQL schema.** The `AWS::AppSync::GraphQLSchema` resource (a CDK
+  `GraphqlApi`'s schema `Definition`) is reported `skipped`: Cloud Control has
+  **no READ** for the type (`UnsupportedActionException`), and AppSync's only
+  schema-read API returns the **compiled introspection** form — AWS scalars /
+  directives / built-in types expanded — not the source SDL you declared, so a
+  faithful comparison is not possible without false drift. The rest of the API
+  **is** checked (the `GraphqlApi` body — auth / X-Ray / logging — plus its
+  DataSources, Resolvers and Functions via the out-of-band added-resource
+  enumerators); only the raw schema text is out of scope.
 - **Stack state.** A stack with no meaningful deployed reality is **skipped with a
   clear note**, not compared to a meaningless CLEAN: `REVIEW_IN_PROGRESS` (a change
   set created but never deployed) and a delete in progress. A stack mid-operation


### PR DESCRIPTION
## What

Records, in README `## Limitations`, that `AWS::AppSync::GraphQLSchema` (a CDK `GraphqlApi`'s schema `Definition`) is reported `skipped` — and why this is a deliberate, evidence-backed boundary rather than an unfinished gap.

## Why (verified live)

- **Cloud Control has no READ** for `AWS::AppSync::GraphQLSchema`: `GetResource` returns `UnsupportedActionException` (probed live on a deployed schema; `describe-type` lists the props but the CC handler does not implement READ).
- **No SDK override can fix it faithfully**: AppSync's only schema-read API, `GetIntrospectionSchema`, returns the **compiled introspection** SDL (AWS scalars / directives / built-in types expanded, reordered) — a different representation from the source SDL the user declares. Comparing it to `Definition` would false-drift on every check.
- Therefore schema-text drift is **not detectable without false positives** → correctly `skipped`.

## Scope clarified

The rest of the AppSync API **is** checked: the `GraphqlApi` body (auth / X-Ray / logging) plus its DataSources, Resolvers and Functions via the out-of-band added-resource enumerators. Only the raw schema SDL text is out of scope.

Docs-only (README). No src change; `check` + `docs` markers set.