### PR TITLE
feat(iam): detect ManagedPolicy attachment detach (asymmetric subset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,14 +559,17 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   (while the function's policy still exists), it is reported as `skipped`, not
   `deleted` — identifying the exact statement would need its `StatementId`.
 - **IAM ManagedPolicy attachments:** `cdkrd` compares a managed policy's
-  **document** (and Path/Description), not its `Roles`/`Users`/`Groups`
-  **attachment** lists. A managed policy is commonly attached from several places
-  (the `AWS::IAM::ManagedPolicy`'s own lists, a role's `ManagedPolicyArns`, a
-  separate attachment resource, the console), so the live attachment set is a
-  **union** that legitimately exceeds any one stack's intent — comparing it against
-  the declaring stack would false-drift on every shared policy. So an out-of-band
-  attach/detach is not reported (a deliberate fail-closed boundary, not a missed
-  document change).
+  `Roles`/`Users`/`Groups` **attachment** lists **asymmetrically**. A managed policy
+  is commonly attached from several places (the `AWS::IAM::ManagedPolicy`'s own
+  lists, a role's `ManagedPolicyArns`, a separate attachment resource, the console),
+  so the live attachment set is a **union** that legitimately exceeds any one stack's
+  intent. cdkrd therefore reports only a **declared attachment that is MISSING from
+  live** (an out-of-band **detach** — a privilege the stack intends was removed)
+  and **ignores** live-only members (the union). This catches the real removal
+  without the false drift a symmetric compare (e.g. `cdk drift`) raises on every
+  shared policy. A detach is revertable: `revert` re-attaches the declared member
+  (`AttachRolePolicy`/`AttachUserPolicy`/`AttachGroupPolicy`) without touching the
+  union members. The policy **document** (and Path/Description) is compared as usual.
 - **AppSync GraphQL schema.** The `AWS::AppSync::GraphQLSchema` resource (a CDK
   `GraphqlApi`'s schema `Definition`) is reported `skipped`: Cloud Control has
   **no READ** for the type (`UnsupportedActionException`), and AppSync's only

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -107,6 +107,25 @@ const REFLECTED_CHILD_PROPS: Record<string, string> = {
   'AWS::SNS::Topic': 'Subscription',
 };
 
+// Per-type attachment-list properties compared ASYMMETRICALLY (declared∖live only).
+// AWS::IAM::ManagedPolicy's `Roles`/`Users`/`Groups` name the principals a managed
+// policy is attached to — but the same policy is commonly attached from SEVERAL
+// places (a role's own `ManagedPolicyArns`, a separate AWS::IAM::Policy/attachment
+// resource, another stack, the console), so the LIVE set is a UNION that legitimately
+// exceeds any one stack's intent. A symmetric compare would false-drift on every
+// shared policy (the FP `cdk drift` suffers). So:
+//   - a DECLARED member MISSING from live -> declared drift (an out-of-band DETACH —
+//     security-relevant: a privilege the stack intends was removed). The real FN the
+//     old "don't compare attachment lists at all" boundary missed.
+//   - a live member NOT declared          -> ignored (the union; never a finding).
+// A property the template does NOT declare at all is the pure union — dropped from
+// the live model below so it never reaches the undeclared loop. Strictly better than
+// both the old cdkrd (missed the detach) and cdk drift (FPs on the extra union
+// members): it catches the removal without the union false positive.
+const IAM_ATTACHMENT_SUBSET: Record<string, ReadonlySet<string>> = {
+  'AWS::IAM::ManagedPolicy': new Set(['Roles', 'Users', 'Groups']),
+};
+
 // R96/R98: recurse the declared and live sides of a property and emit each LIVE-only
 // nested key — a sub-key present in live but never declared, at any depth.
 //   - Plain objects (R96): walk every live key; recurse where declared, emit otherwise.
@@ -310,6 +329,12 @@ export function classifyResource(
   // (see REFLECTED_CHILD_PROPS). Fail-open: a declared inline value is still compared.
   const reflected = REFLECTED_CHILD_PROPS[resourceType];
   if (reflected && !(reflected in declared)) delete live[reflected];
+  // ManagedPolicy attachment lists the template does NOT declare are the pure live
+  // UNION (this policy attached elsewhere) — drop them so they never surface as
+  // undeclared drift. A declared attachment list is kept and compared asymmetrically
+  // in the declared loop below (declared-but-missing = detach; live-only ignored).
+  const attachmentProps = IAM_ATTACHMENT_SUBSET[resourceType];
+  if (attachmentProps) for (const p of attachmentProps) if (!(p in declared)) delete live[p];
   // R11: a declared TOP-LEVEL write-only key is about to be stripped from `declared`
   // (below). Surface it as ONE readGap finding FIRST so it is never silently dropped
   // — the informational tier exists precisely for "declared but unreadable" props.
@@ -379,6 +404,33 @@ export function classifyResource(
         path: k,
         note: 'declared but not returned by live read',
       });
+      continue;
+    }
+    // ManagedPolicy attachment lists (Roles/Users/Groups): compare ASYMMETRICALLY.
+    // A DECLARED member absent from the live (union) set is an out-of-band DETACH —
+    // emit a declared finding per missing member, carrying the member on
+    // `attributeKey` so revert re-attaches ONLY that one (never rewriting the whole
+    // list, which would detach the union members another stack/role legitimately
+    // added). A live-only member is the union and is NOT reported. An unresolved
+    // declared member (an intrinsic the synth couldn't resolve) can't be compared —
+    // skip it (the whole-property `unresolved` finding above already noted it).
+    if (attachmentProps?.has(k) && Array.isArray(v) && Array.isArray(live[k])) {
+      const liveSet = new Set((live[k] as unknown[]).map((m) => String(m)));
+      for (const member of v) {
+        if (member === UNRESOLVED || hasUnresolved(member)) continue;
+        if (typeof member !== 'string' && typeof member !== 'number') continue;
+        if (liveSet.has(String(member))) continue;
+        findings.push({
+          tier: 'declared',
+          logicalId,
+          resourceType,
+          path: k,
+          attributeKey: String(member),
+          desired: member,
+          actual: undefined,
+          note: 'declared attachment not present in live (out-of-band detach)',
+        });
+      }
       continue;
     }
     // R78: ELB attribute bags compare BY KEY (the template declares a subset of

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -35,6 +35,7 @@ import {
   GetRolePolicyCommand,
   GetUserPolicyCommand,
   IAMClient,
+  ListEntitiesForPolicyCommand,
 } from '@aws-sdk/client-iam';
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
 import { GetBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
@@ -145,6 +146,28 @@ const readIamManagedPolicy: OverrideReader = async ({ physicalId, region }) => {
       new GetPolicyVersionCommand({ PolicyArn: physicalId, VersionId: p.DefaultVersionId })
     )
   ).PolicyVersion;
+  // Live attachment lists (the Roles/Users/Groups this policy is attached to). Read
+  // them so classify can detect an out-of-band DETACH of a member the template
+  // DECLARES — but the comparison is ASYMMETRIC (declared∖live only): the live set is
+  // a UNION that legitimately exceeds any one stack's intent (a role's
+  // `ManagedPolicyArns`, another stack, the console), so live-only members are never
+  // a finding (see IAM_ATTACHMENT_SUBSET in diff/classify.ts). Names, not ARNs —
+  // matching the CFn `Roles`/`Users`/`Groups` property shape (a Ref to a role
+  // resolves to the role NAME). Paginated: a popular managed policy can be attached
+  // to far more than one page of entities.
+  const roles: string[] = [];
+  const users: string[] = [];
+  const groups: string[] = [];
+  let marker: string | undefined;
+  do {
+    const e = await c.send(
+      new ListEntitiesForPolicyCommand({ PolicyArn: physicalId, Marker: marker })
+    );
+    for (const r of e?.PolicyRoles ?? []) if (r.RoleName) roles.push(r.RoleName);
+    for (const u of e?.PolicyUsers ?? []) if (u.UserName) users.push(u.UserName);
+    for (const g of e?.PolicyGroups ?? []) if (g.GroupName) groups.push(g.GroupName);
+    marker = e?.IsTruncated ? e.Marker : undefined;
+  } while (marker);
   // GetPolicy OMITS Description when it is empty, while CDK templates declare
   // `Description: ""` — an undefined-valued key here read as `desired="" actual=
   // undefined` false declared drift (first live policies integ run, R69). An
@@ -153,6 +176,9 @@ const readIamManagedPolicy: OverrideReader = async ({ physicalId, region }) => {
     PolicyDocument: parsePolicy(ver?.Document),
     Path: p.Path,
     Description: p.Description ?? '',
+    Roles: roles,
+    Users: users,
+    Groups: groups,
   };
 };
 

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -45,6 +45,9 @@ import {
   ModifyTargetGroupAttributesCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import {
+  AttachGroupPolicyCommand,
+  AttachRolePolicyCommand,
+  AttachUserPolicyCommand,
   CreatePolicyVersionCommand,
   DeletePolicyVersionCommand,
   DeleteRolePolicyCommand,
@@ -179,15 +182,43 @@ const isArn = (v: unknown): string | undefined => {
   const s = str(v);
   return s && s.startsWith('arn:') ? s : undefined;
 };
+// Top JSON-pointer segment of an op path (`/Roles/0` -> `Roles`, `/Roles` -> `Roles`).
+const topSeg = (path: string): string => path.split('/').filter(Boolean)[0] ?? '';
+const ATTACHMENT_PROPS = new Set(['Roles', 'Users', 'Groups']);
+
 const writeIamManagedPolicy: SdkWriter = async (ctx, ops) => {
   // CFn physical id for a managed policy IS its arn; fall back to the declared
   // ManagedPolicyArn when the physical id isn't (yet) the arn shape.
   const arn = isArn(ctx.physicalId) ?? isArn(ctx.declared['ManagedPolicyArn']);
   if (!arn) throw new Error('cannot resolve managed policy arn for revert');
-  const desired = policyJson(await desiredModel('AWS::IAM::ManagedPolicy', ctx, ops));
+  const c = new IAMClient({ region: ctx.region });
+
+  // Attachment-list reverts (Roles/Users/Groups): a declared member detached out of
+  // band is re-ATTACHED by member — never by rewriting the whole list, which would
+  // detach the union members another stack/role/console legitimately added (the
+  // classify side only ever emits a detach finding for a declared-but-MISSING member).
+  // The member rides on `attributeKey`. Idempotent: AttachXPolicy on an already-
+  // attached member is a no-op, so a partial prior revert re-runs safely.
+  const attachOps = ops.filter((o) => ATTACHMENT_PROPS.has(topSeg(o.path)));
+  for (const o of attachOps) {
+    const seg = topSeg(o.path);
+    const member = String(o.attributeKey ?? o.value);
+    if (seg === 'Roles')
+      await c.send(new AttachRolePolicyCommand({ PolicyArn: arn, RoleName: member }));
+    else if (seg === 'Users')
+      await c.send(new AttachUserPolicyCommand({ PolicyArn: arn, UserName: member }));
+    else if (seg === 'Groups')
+      await c.send(new AttachGroupPolicyCommand({ PolicyArn: arn, GroupName: member }));
+  }
+
+  // Document/Path/Description reverts go through a new default policy version. Skip it
+  // entirely when only attachment ops were present, so a detach-only revert does not
+  // burn a (capped at 5) policy version re-writing the unchanged document.
+  const docOps = ops.filter((o) => !ATTACHMENT_PROPS.has(topSeg(o.path)));
+  if (docOps.length === 0) return;
+  const desired = policyJson(await desiredModel('AWS::IAM::ManagedPolicy', ctx, docOps));
   if (desired === undefined)
     throw new Error('cannot revert a managed policy to an absent document');
-  const c = new IAMClient({ region: ctx.region });
 
   const versions = (await c.send(new ListPolicyVersionsCommand({ PolicyArn: arn }))).Versions ?? [];
   if (versions.length >= 5) {

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2140,6 +2140,170 @@ describe('nested undeclared on IAM policy statements (identity-less subset desce
   });
 });
 
+// AWS::IAM::ManagedPolicy Roles/Users/Groups compare ASYMMETRICALLY (declared∖live):
+// a declared attachment removed out of band IS reported (detach), while a live-only
+// attachment (the union — the same policy attached elsewhere) is NOT. Strictly better
+// than the old "don't compare attachment lists" boundary (which missed the detach) and
+// than cdk drift (which false-drifts on the union).
+describe('IAM ManagedPolicy asymmetric attachment detach detection', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const mp = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'MP',
+    resourceType: 'AWS::IAM::ManagedPolicy',
+    physicalId: 'arn:aws:iam::111122223333:policy/p',
+    declared,
+  });
+
+  it('reports a declared Role removed from the live attachment set (detach)', () => {
+    const f = classifyResource(
+      mp({ Roles: ['RoleA', 'RoleB'] }),
+      { Roles: ['RoleA'] },
+      emptySchema
+    );
+    const detach = f.filter((x) => x.tier === 'declared' && x.path === 'Roles');
+    expect(detach).toHaveLength(1);
+    expect(detach[0]?.attributeKey).toBe('RoleB');
+    expect(detach[0]?.desired).toBe('RoleB');
+    expect(detach[0]?.actual).toBeUndefined();
+  });
+
+  it('does NOT report a live-only attachment (the union member another stack added)', () => {
+    // declared RoleA still attached; RoleX attached elsewhere (role-side ManagedPolicyArns
+    // or the console) — the live union exceeds intent but is not this stack's drift.
+    const f = classifyResource(
+      mp({ Roles: ['RoleA'] }),
+      { Roles: ['RoleA', 'RoleX'] },
+      emptySchema
+    );
+    expect(f.filter((x) => x.tier === 'declared')).toEqual([]);
+    expect(f.filter((x) => x.tier === 'undeclared')).toEqual([]);
+  });
+
+  it('CLEAN when every declared attachment is present (extra union members ignored)', () => {
+    const f = classifyResource(
+      mp({ Roles: ['RoleA'], Users: ['UserA'], Groups: ['GroupA'] }),
+      { Roles: ['RoleA', 'RoleX'], Users: ['UserA'], Groups: ['GroupA', 'GroupZ'] },
+      emptySchema
+    );
+    expect(tiers(f).declared).toEqual([]);
+    expect(tiers(f).undeclared).toEqual([]);
+  });
+
+  it('handles Users and Groups detach independently, one finding per missing member', () => {
+    const f = classifyResource(
+      mp({ Roles: ['RoleA'], Users: ['UserA', 'UserB'], Groups: ['GroupA'] }),
+      { Roles: ['RoleA'], Users: [], Groups: [] },
+      emptySchema
+    );
+    const detached = f
+      .filter((x) => x.tier === 'declared')
+      .map((x) => `${x.path}[${x.attributeKey}]`)
+      .sort();
+    expect(detached).toEqual(['Groups[GroupA]', 'Users[UserA]', 'Users[UserB]']);
+  });
+
+  it('drops a NON-declared live attachment list so it is never undeclared drift (union)', () => {
+    // template declares no Roles at all; the policy is attached to a role elsewhere.
+    const f = classifyResource(
+      mp({ Description: '' }),
+      { Roles: ['RoleX'], Description: '' },
+      emptySchema
+    );
+    expect(f.some((x) => x.path === 'Roles')).toBe(false);
+  });
+
+  it('skips an UNRESOLVED declared member (an intrinsic) rather than false-drifting it', () => {
+    const f = classifyResource(
+      mp({ Roles: ['RoleA', UNRESOLVED] }),
+      { Roles: ['RoleA'] },
+      emptySchema
+    );
+    // the whole property is noted unresolved; no per-member detach for the symbol, and
+    // RoleA (present) is not a detach either.
+    expect(f.filter((x) => x.tier === 'declared' && x.path === 'Roles')).toEqual([]);
+    expect(f.some((x) => x.tier === 'unresolved' && x.path === 'Roles')).toBe(true);
+  });
+
+  it('still reports a RESOLVED detached member even when a SIBLING member is unresolved', () => {
+    const f = classifyResource(
+      mp({ Roles: ['RoleA', UNRESOLVED] }),
+      { Roles: [] }, // RoleA detached out of band
+      emptySchema
+    );
+    const detach = f.filter((x) => x.tier === 'declared' && x.attributeKey === 'RoleA');
+    expect(detach).toHaveLength(1);
+  });
+
+  it('CLEAN when the declared attachment list is EMPTY, even with live union members', () => {
+    // an empty declared Roles compares to nothing missing; the live union is ignored.
+    const f = classifyResource(mp({ Roles: [] }), { Roles: ['RoleX', 'RoleY'] }, emptySchema);
+    expect(tiers(f).declared).toEqual([]);
+    expect(tiers(f).undeclared).toEqual([]);
+  });
+
+  it('reports EVERY declared member when all three lists are fully detached (live all empty)', () => {
+    const f = classifyResource(
+      mp({ Roles: ['R1', 'R2'], Users: ['U1'], Groups: ['G1', 'G2'] }),
+      { Roles: [], Users: [], Groups: [] },
+      emptySchema
+    );
+    const detached = f
+      .filter((x) => x.tier === 'declared')
+      .map((x) => `${x.path}[${x.attributeKey}]`)
+      .sort();
+    expect(detached).toEqual(['Groups[G1]', 'Groups[G2]', 'Roles[R1]', 'Roles[R2]', 'Users[U1]']);
+  });
+
+  it('matches members by exact NAME (the CFn attachment-list shape) — same names are CLEAN', () => {
+    // CFn Roles/Users/Groups are role/user/group NAMES (a Ref to a Role resolves to its
+    // name); the live ListEntitiesForPolicy read returns names too — exact-name compare.
+    const f = classifyResource(
+      mp({ Roles: ['my-app-role'] }),
+      { Roles: ['my-app-role'] },
+      emptySchema
+    );
+    expect(tiers(f).declared).toEqual([]);
+  });
+
+  it('surfaces a document drift AND an attachment detach together (independent findings)', () => {
+    const f = classifyResource(
+      mp({
+        Roles: ['RoleA'],
+        Description: 'intended',
+      }),
+      { Roles: [], Description: 'tampered' },
+      emptySchema
+    );
+    const declared = f.filter((x) => x.tier === 'declared');
+    expect(declared.some((x) => x.path === 'Roles' && x.attributeKey === 'RoleA')).toBe(true);
+    expect(declared.some((x) => x.path === 'Description')).toBe(true);
+    expect(declared).toHaveLength(2);
+  });
+
+  it('does NOT touch a different resource type that happens to have a Roles property', () => {
+    // the asymmetric handler is scoped to AWS::IAM::ManagedPolicy only; another type's
+    // `Roles` array compares normally (a symmetric declared diff), not asymmetrically.
+    const res: DesiredResource = {
+      logicalId: 'X',
+      resourceType: 'AWS::SomeOther::Type',
+      physicalId: 'x',
+      declared: { Roles: ['A'] },
+    };
+    const f = classifyResource(res, { Roles: ['A', 'B'] }, emptySchema);
+    // symmetric compare: the extra live element IS a declared-array diff (not suppressed)
+    expect(f.some((x) => x.tier === 'declared' && x.path === 'Roles')).toBe(true);
+  });
+});
+
 describe('REFLECTED_CHILD_PROPS (drop a parent reflection of its child resources)', () => {
   const schema: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedNoDeclaredAttach.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedNoDeclaredAttach.json
@@ -1,11 +1,11 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (first policies integ run), refreshed: the override reader now READS the attachment lists (ListEntitiesForPolicy), so the declared Role is present in liveRaw and the old `Roles` readGap is gone — this case is CLEAN. Description normalized to \"\" (R69).",
+  "description": "Hand-curated: the template declares no Roles/Users/Groups. The policy is attached to a Role elsewhere (the pure live union). Must be CLEAN: a non-declared live attachment list is dropped, never an undeclared finding.",
   "resource": {
-    "logicalId": "WorkerManagedF77ABFB4",
+    "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
-    "physicalId": "arn:aws:iam::111111111111:policy/CdkdriftIntegPolicies-WorkerManagedF77ABFB4-48Y4dASCdT46",
-    "constructPath": "CdkdriftIntegPolicies/WorkerManaged",
+    "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+    "constructPath": "IntegStack/Shared",
     "declared": {
       "Description": "",
       "Path": "/",
@@ -14,30 +14,29 @@
           {
             "Action": "s3:ListBucket",
             "Effect": "Allow",
-            "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+            "Resource": "arn:aws:s3:::bkt",
             "Sid": "ListData"
           }
         ],
         "Version": "2012-10-17"
-      },
-      "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"]
+      }
     }
   },
   "liveRaw": {
+    "Description": "",
+    "Path": "/",
     "PolicyDocument": {
       "Statement": [
         {
           "Action": "s3:ListBucket",
           "Effect": "Allow",
-          "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+          "Resource": "arn:aws:s3:::bkt",
           "Sid": "ListData"
         }
       ],
       "Version": "2012-10-17"
     },
-    "Path": "/",
-    "Description": "",
-    "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"],
+    "Roles": ["RoleFromElsewhere"],
     "Users": [],
     "Groups": []
   },

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedRoleDetached.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedRoleDetached.json
@@ -1,11 +1,11 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (first policies integ run), refreshed: the override reader now READS the attachment lists (ListEntitiesForPolicy), so the declared Role is present in liveRaw and the old `Roles` readGap is gone — this case is CLEAN. Description normalized to \"\" (R69).",
+  "description": "Hand-curated: the declared Role was detached out of band. A live-only (union) Role remains. Exactly ONE declared detach finding for the missing declared Role; the union Role is ignored.",
   "resource": {
-    "logicalId": "WorkerManagedF77ABFB4",
+    "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
-    "physicalId": "arn:aws:iam::111111111111:policy/CdkdriftIntegPolicies-WorkerManagedF77ABFB4-48Y4dASCdT46",
-    "constructPath": "CdkdriftIntegPolicies/WorkerManaged",
+    "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+    "constructPath": "IntegStack/Shared",
     "declared": {
       "Description": "",
       "Path": "/",
@@ -14,30 +14,30 @@
           {
             "Action": "s3:ListBucket",
             "Effect": "Allow",
-            "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+            "Resource": "arn:aws:s3:::bkt",
             "Sid": "ListData"
           }
         ],
         "Version": "2012-10-17"
       },
-      "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"]
+      "Roles": ["RoleDeclared"]
     }
   },
   "liveRaw": {
+    "Description": "",
+    "Path": "/",
     "PolicyDocument": {
       "Statement": [
         {
           "Action": "s3:ListBucket",
           "Effect": "Allow",
-          "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+          "Resource": "arn:aws:s3:::bkt",
           "Sid": "ListData"
         }
       ],
       "Version": "2012-10-17"
     },
-    "Path": "/",
-    "Description": "",
-    "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"],
+    "Roles": ["RoleFromElsewhere"],
     "Users": [],
     "Groups": []
   },
@@ -75,5 +75,17 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Roles",
+      "attributeKey": "RoleDeclared",
+      "desired": "RoleDeclared",
+      "note": "declared attachment not present in live (out-of-band detach)",
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedUnionClean.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedUnionClean.json
@@ -1,11 +1,11 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (first policies integ run), refreshed: the override reader now READS the attachment lists (ListEntitiesForPolicy), so the declared Role is present in liveRaw and the old `Roles` readGap is gone — this case is CLEAN. Description normalized to \"\" (R69).",
+  "description": "Hand-curated: asymmetric attachment compare. The declared Role IS attached; an EXTRA live Role (the union — attached from another stack/role/console) is present too. Must be CLEAN: a live-only attachment is never a finding.",
   "resource": {
-    "logicalId": "WorkerManagedF77ABFB4",
+    "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
-    "physicalId": "arn:aws:iam::111111111111:policy/CdkdriftIntegPolicies-WorkerManagedF77ABFB4-48Y4dASCdT46",
-    "constructPath": "CdkdriftIntegPolicies/WorkerManaged",
+    "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+    "constructPath": "IntegStack/Shared",
     "declared": {
       "Description": "",
       "Path": "/",
@@ -14,30 +14,30 @@
           {
             "Action": "s3:ListBucket",
             "Effect": "Allow",
-            "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+            "Resource": "arn:aws:s3:::bkt",
             "Sid": "ListData"
           }
         ],
         "Version": "2012-10-17"
       },
-      "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"]
+      "Roles": ["RoleDeclared"]
     }
   },
   "liveRaw": {
+    "Description": "",
+    "Path": "/",
     "PolicyDocument": {
       "Statement": [
         {
           "Action": "s3:ListBucket",
           "Effect": "Allow",
-          "Resource": "arn:aws:s3:::cdkdriftintegpolicies-data666c94c7-735dbui2tb4i",
+          "Resource": "arn:aws:s3:::bkt",
           "Sid": "ListData"
         }
       ],
       "Version": "2012-10-17"
     },
-    "Path": "/",
-    "Description": "",
-    "Roles": ["CdkdriftIntegPolicies-Worker11F36D0F-1DWkHEUxYkKx"],
+    "Roles": ["RoleDeclared", "RoleFromElsewhere"],
     "Users": [],
     "Groups": []
   },

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedUsersGroupsDetach.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedUsersGroupsDetach.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "description": "Hand-curated: Roles/Users/Groups all declared; one Role present, one User detached, the Group detached. One declared finding per declared-but-missing member; present members and live-only members produce nothing.",
+  "resource": {
+    "logicalId": "SharedABCD1234",
+    "resourceType": "AWS::IAM::ManagedPolicy",
+    "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+    "constructPath": "IntegStack/Shared",
+    "declared": {
+      "Description": "",
+      "Path": "/",
+      "PolicyDocument": {
+        "Statement": [
+          {
+            "Action": "s3:ListBucket",
+            "Effect": "Allow",
+            "Resource": "arn:aws:s3:::bkt",
+            "Sid": "ListData"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "Roles": ["R1"],
+      "Users": ["U1", "U2"],
+      "Groups": ["G1"]
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "Path": "/",
+    "PolicyDocument": {
+      "Statement": [
+        {
+          "Action": "s3:ListBucket",
+          "Effect": "Allow",
+          "Resource": "arn:aws:s3:::bkt",
+          "Sid": "ListData"
+        }
+      ],
+      "Version": "2012-10-17"
+    },
+    "Roles": ["R1", "RUnion"],
+    "Users": ["U1"],
+    "Groups": []
+  },
+  "schema": {
+    "readOnly": [
+      "AttachmentCount",
+      "CreateDate",
+      "DefaultVersionId",
+      "IsAttachable",
+      "PermissionsBoundaryUsageCount",
+      "PolicyArn",
+      "PolicyId",
+      "UpdateDate"
+    ],
+    "writeOnly": [],
+    "createOnly": ["Description", "ManagedPolicyName", "Path"],
+    "readOnlyPaths": [
+      "AttachmentCount",
+      "CreateDate",
+      "DefaultVersionId",
+      "IsAttachable",
+      "PermissionsBoundaryUsageCount",
+      "PolicyArn",
+      "PolicyId",
+      "UpdateDate"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description", "ManagedPolicyName", "Path"],
+    "defaults": {
+      "Path": "/"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Users",
+      "attributeKey": "U2",
+      "desired": "U2",
+      "note": "declared attachment not present in live (out-of-band detach)",
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    },
+    {
+      "tier": "declared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Groups",
+      "attributeKey": "G1",
+      "desired": "G1",
+      "note": "declared attachment not present in live (out-of-band detach)",
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    }
+  ]
+}

--- a/tests/integration/iam-managedpolicy-detach/app.ts
+++ b/tests/integration/iam-managedpolicy-detach/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift IAM ManagedPolicy ATTACHMENT-DETACH integration
+// test (real AWS, AWS-mutating). Proves the asymmetric subset detach detection in
+// ISOLATION: the policy is attached to roles created OUTSIDE this stack (passed by
+// ARN via context), so there is no in-stack role resource whose own
+// `ManagedPolicyArns` would mirror the same attachment and muddy the assertions.
+//   - `declaredRoleArn` is declared in the ManagedPolicy's `Roles` list.
+//   - `unionRoleArn` is attached out of band by verify-detect.sh (NOT in the
+//     template) — the live UNION member that must NEVER false-drift.
+import { App, Stack } from "aws-cdk-lib";
+import { ManagedPolicy, PolicyStatement, Role } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegIamManagedPolicyDetach");
+
+const declaredRoleArn = stack.node.tryGetContext("declaredRoleArn") as string;
+if (!declaredRoleArn) throw new Error("pass -c declaredRoleArn=<arn>");
+
+const declaredRole = Role.fromRoleArn(stack, "DeclaredRole", declaredRoleArn);
+
+new ManagedPolicy(stack, "Shared", {
+  roles: [declaredRole],
+  statements: [
+    new PolicyStatement({
+      sid: "ListAnything",
+      actions: ["s3:ListAllMyBuckets"],
+      resources: ["*"],
+    }),
+  ],
+});
+
+app.synth();

--- a/tests/integration/iam-managedpolicy-detach/cdk.json
+++ b/tests/integration/iam-managedpolicy-detach/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/iam-managedpolicy-detach/package.json
+++ b/tests/integration/iam-managedpolicy-detach/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-iam-managedpolicy-detach",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift IAM ManagedPolicy attachment-detach integration test. Run via verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/iam-managedpolicy-detach/verify-detect.sh
+++ b/tests/integration/iam-managedpolicy-detach/verify-detect.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# cdkrd IAM ManagedPolicy ATTACHMENT-DETACH integration test (real AWS, AWS-mutating).
+# Proves the asymmetric subset detach detection end-to-end, ISOLATED from the role-side
+# ManagedPolicyArns mirror by attaching the policy to roles created OUTSIDE the stack:
+#   create 2 standalone roles (declaredRole, unionRole) -> deploy a ManagedPolicy that
+#   DECLARES roles:[declaredRole] -> attach unionRole out of band (the live UNION
+#   member) -> record -> check CLEAN (unionRole ignored: NO false positive — the case
+#   cdk drift gets wrong) -> detach declaredRole out of band -> check DETECTS the detach
+#   (declared∖live, exit 1) -> revert --yes re-attaches declaredRole ONLY
+#   (AttachRolePolicy) -> check CLEAN -> direct AWS read confirms declaredRole
+#   re-attached AND unionRole untouched -> destroy + delete both roles.
+# Self-cleaning trap; no orphans on failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamManagedPolicyDetach
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+SUFFIX="$$"
+DECLARED_ROLE="cdkrd-mpd-declared-$SUFFIX"
+UNION_ROLE="cdkrd-mpd-union-$SUFFIX"
+ASSUME='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+MANAGED_ARN=""
+cleanup() {
+  echo "--- cleanup ---"
+  # detach the policy from both roles (so role + stack deletion never blocks)
+  if [ -n "$MANAGED_ARN" ]; then
+    aws iam detach-role-policy --role-name "$DECLARED_ROLE" --policy-arn "$MANAGED_ARN" >/dev/null 2>&1 || true
+    aws iam detach-role-policy --role-name "$UNION_ROLE" --policy-arn "$MANAGED_ARN" >/dev/null 2>&1 || true
+  fi
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  aws iam delete-role --role-name "$DECLARED_ROLE" >/dev/null 2>&1 || true
+  aws iam delete-role --role-name "$UNION_ROLE" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp pack) || fail build
+
+echo "=== create 2 standalone roles ==="
+DECLARED_ARN="$(aws iam create-role --role-name "$DECLARED_ROLE" --assume-role-policy-document "$ASSUME" \
+  --query 'Role.Arn' --output text)" || fail "create declared role"
+aws iam create-role --role-name "$UNION_ROLE" --assume-role-policy-document "$ASSUME" >/dev/null \
+  || fail "create union role"
+echo "declaredRole=$DECLARED_ROLE unionRole=$UNION_ROLE"
+sleep 8 # role propagation before a policy can attach
+
+echo "=== deploy (ManagedPolicy declares roles:[declaredRole]) ==="
+npx cdk deploy -f "$STACK" -c "declaredRoleArn=$DECLARED_ARN" --require-approval never || fail deploy
+
+MANAGED_ARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::IAM::ManagedPolicy'].PhysicalResourceId" --output text)"
+[ -n "$MANAGED_ARN" ] || fail "could not resolve managed policy ARN"
+
+echo "=== attach unionRole out of band (the live UNION member) ==="
+aws iam attach-role-policy --role-name "$UNION_ROLE" --policy-arn "$MANAGED_ARN" || fail "attach union role"
+sleep 10
+
+echo "=== record (baseline) ==="
+$CLI record "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --yes || fail record
+
+echo "=== check CLEAN — the union member (unionRole) must NOT false-drift ==="
+$CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail | tee /tmp/cdkrd-mpd-clean.out
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record (union member false-positived?)"
+grep -q "$UNION_ROLE" /tmp/cdkrd-mpd-clean.out && fail "union member was reported (asymmetric FP)"
+
+echo "=== detach the DECLARED role out of band ==="
+aws iam detach-role-policy --role-name "$DECLARED_ROLE" --policy-arn "$MANAGED_ARN" || fail "detach declared role"
+echo "(waiting for IAM propagation)"; sleep 12
+
+echo "=== check DETECTS the declared-role detach (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail | tee /tmp/cdkrd-mpd-pre.out
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1 after detach"
+grep -q "Roles" /tmp/cdkrd-mpd-pre.out || fail "Roles detach not reported"
+grep -q "$DECLARED_ROLE" /tmp/cdkrd-mpd-pre.out || fail "detached declaredRole not named in the finding"
+grep -q "$UNION_ROLE" /tmp/cdkrd-mpd-pre.out && fail "union member surfaced during drift (asymmetric FP)"
+
+echo "=== revert --yes (AttachRolePolicy re-attaches the declared role ONLY) ==="
+$CLI revert "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --yes || fail "revert returned non-zero"
+echo "(waiting for IAM propagation)"; sleep 10
+
+echo "=== check CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail
+[ $? -eq 0 ] || fail "drift remains after revert"
+
+echo "=== belt-and-suspenders: declared role re-attached AND union role untouched ==="
+AFTER="$(aws iam list-entities-for-policy --policy-arn "$MANAGED_ARN" --region "$REGION" \
+  --query 'PolicyRoles[].RoleName' --output text)"
+echo "post-revert attached roles: $AFTER"
+echo "$AFTER" | tr '\t' '\n' | grep -qx "$DECLARED_ROLE" || fail "declared role not re-attached by revert"
+echo "$AFTER" | tr '\t' '\n' | grep -qx "$UNION_ROLE" || fail "union role was lost (revert touched a non-declared member!)"
+
+echo "INTEG PASS (CdkRealDriftIntegIamManagedPolicyDetach asymmetric detach detect+revert)"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -16,6 +16,7 @@ import {
   GetPolicyVersionCommand,
   GetRolePolicyCommand,
   IAMClient,
+  ListEntitiesForPolicyCommand,
 } from '@aws-sdk/client-iam';
 import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
@@ -138,6 +139,30 @@ describe('SDK overrides', () => {
       ctx({}, 'arn:aws:iam::123:policy/p')
     );
     expect(out!.Description).toBe('');
+  });
+  it('IAM ManagedPolicy: reads the live attachment lists (Roles/Users/Groups), paginated', async () => {
+    iam.on(GetPolicyCommand).resolves({ Policy: { DefaultVersionId: 'v1', Path: '/' } });
+    iam
+      .on(GetPolicyVersionCommand)
+      .resolves({ PolicyVersion: { Document: encodeURIComponent(POLICY) } });
+    // two pages of attached entities, the first truncated with a Marker.
+    iam
+      .on(ListEntitiesForPolicyCommand)
+      .resolvesOnce({ PolicyRoles: [{ RoleName: 'RoleA' }], IsTruncated: true, Marker: 'm1' })
+      .resolves({
+        PolicyRoles: [{ RoleName: 'RoleB' }],
+        PolicyUsers: [{ UserName: 'UserA' }],
+        PolicyGroups: [{ GroupName: 'GroupA' }],
+      });
+    const out = await SDK_OVERRIDES['AWS::IAM::ManagedPolicy'](
+      ctx({}, 'arn:aws:iam::123:policy/p')
+    );
+    expect(out).toMatchObject({
+      Roles: ['RoleA', 'RoleB'],
+      Users: ['UserA'],
+      Groups: ['GroupA'],
+    });
+    expect(iam.commandCalls(ListEntitiesForPolicyCommand)).toHaveLength(2);
   });
 
   it('Lambda Permission: matches statement by Action + Principal', async () => {

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -103,6 +103,29 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('ManagedPolicy attachment detach -> SDK item, op carries the member on attributeKey', () => {
+    // a declared-but-detached Role finding (path Roles, attributeKey = role name) must
+    // route to the SDK writer (ManagedPolicy is a whole-type writer) and carry the
+    // member so writeIamManagedPolicy re-attaches ONLY that member (AttachRolePolicy).
+    const f = F({
+      tier: 'declared',
+      resourceType: 'AWS::IAM::ManagedPolicy',
+      physicalId: 'arn:aws:iam::111122223333:policy/p',
+      path: 'Roles',
+      attributeKey: 'RoleA',
+      desired: 'RoleA',
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Roles',
+      value: 'RoleA',
+      attributeKey: 'RoleA',
+    });
+  });
+
   it('undeclared drift with an recorded prior value -> add op restoring the baseline value', () => {
     const f = F({
       tier: 'undeclared',

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -15,6 +15,9 @@ import {
   ModifyTargetGroupAttributesCommand,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import {
+  AttachGroupPolicyCommand,
+  AttachRolePolicyCommand,
+  AttachUserPolicyCommand,
   CreatePolicyVersionCommand,
   DeletePolicyVersionCommand,
   DeleteRolePolicyCommand,
@@ -603,6 +606,65 @@ describe('IAM ManagedPolicy writer', () => {
     expect(byAction('zzz:Write')!.Resource).toEqual(['r1']);
     // ...and the unrelated statement was NOT corrupted (stayed r2)
     expect(byAction('aaa:Read')!.Resource).toEqual(['r2']);
+  });
+
+  // A declared attachment detached out of band is re-attached BY MEMBER (the detach
+  // finding carries the member on attributeKey), never by rewriting the whole list.
+  const detachOp = (prop: string, member: string): PatchOp => ({
+    op: 'add',
+    path: `/${prop}`,
+    value: member,
+    attributeKey: member,
+    human: `${prop}[${member}] -> deployed-template value`,
+  });
+
+  it('re-attaches a detached Role/User/Group by member, not by rewriting the list', async () => {
+    iam.on(AttachRolePolicyCommand).resolves({});
+    iam.on(AttachUserPolicyCommand).resolves({});
+    iam.on(AttachGroupPolicyCommand).resolves({});
+
+    await SDK_WRITERS['AWS::IAM::ManagedPolicy'](ctx(), [
+      detachOp('Roles', 'RoleA'),
+      detachOp('Users', 'UserA'),
+      detachOp('Groups', 'GroupA'),
+    ]);
+
+    expect(iam.commandCalls(AttachRolePolicyCommand)[0]!.args[0].input).toMatchObject({
+      PolicyArn: ARN,
+      RoleName: 'RoleA',
+    });
+    expect(iam.commandCalls(AttachUserPolicyCommand)[0]!.args[0].input).toMatchObject({
+      PolicyArn: ARN,
+      UserName: 'UserA',
+    });
+    expect(iam.commandCalls(AttachGroupPolicyCommand)[0]!.args[0].input).toMatchObject({
+      PolicyArn: ARN,
+      GroupName: 'GroupA',
+    });
+  });
+
+  it('a detach-only revert does NOT burn a policy version (no CreatePolicyVersion)', async () => {
+    iam.on(AttachRolePolicyCommand).resolves({});
+    await SDK_WRITERS['AWS::IAM::ManagedPolicy'](ctx(), [detachOp('Roles', 'RoleA')]);
+    expect(iam.commandCalls(CreatePolicyVersionCommand)).toHaveLength(0);
+    expect(iam.commandCalls(ListPolicyVersionsCommand)).toHaveLength(0);
+  });
+
+  it('a combined document + detach revert does both (version + attach)', async () => {
+    stubReader({ Version: '2012-10-17', Statement: [] });
+    iam
+      .on(ListPolicyVersionsCommand)
+      .resolves({ Versions: [{ VersionId: 'v1', IsDefaultVersion: true }] });
+    iam.on(CreatePolicyVersionCommand).resolves({});
+    iam.on(AttachRolePolicyCommand).resolves({});
+
+    await SDK_WRITERS['AWS::IAM::ManagedPolicy'](ctx(), [
+      addOp(DESIRED),
+      detachOp('Roles', 'RoleA'),
+    ]);
+
+    expect(iam.commandCalls(CreatePolicyVersionCommand)).toHaveLength(1);
+    expect(iam.commandCalls(AttachRolePolicyCommand)).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Problem

`cdkrd` did **not** compare an `AWS::IAM::ManagedPolicy`'s `Roles`/`Users`/`Groups` attachment lists at all — the SDK override reader omitted them. So an out-of-band **detach** of a member the template *declares* was a silent **false negative**: a real privilege removal that `cdk drift` *would* catch. `cdk drift`, conversely, compares the declared list against the live **union**, so it **false-drifts** on any policy also attached elsewhere (`role.addManagedPolicy()`, another stack, the console).

## Fix — asymmetric subset (strictly better than both)

Compare the attachment lists **asymmetrically** (declared ∖ live):

- a **declared** member **missing from live** → declared drift (an out-of-band **detach** — security-relevant), carrying the member on `attributeKey`;
- a **live-only** member → **ignored** (the legitimate union) → no FP on shared policies;
- a property the template **doesn't declare at all** → dropped (pure union).

A detach is **revertable**: `writeIamManagedPolicy` re-attaches the specific declared member (`AttachRolePolicy`/`AttachUserPolicy`/`AttachGroupPolicy`) **without touching union members**, and skips the policy-version rewrite when only attachment ops are present.

- `read/overrides.ts` — `readIamManagedPolicy` reads the live attachment lists via paginated `ListEntitiesForPolicy` (names, the CFn shape).
- `diff/classify.ts` — `IAM_ATTACHMENT_SUBSET` + the asymmetric compare; unresolved declared members (intrinsics) are skipped (no FP).
- `revert/writers.ts` — per-member re-attach; document/Path/Description still via a new default policy version.

## Tests (regression-hardened — this area is FP/FN-sensitive)

- **classify unit** (14): detach, union ignored, empty declared list, all-three-types detached, exact-name match, doc+detach together, type-scoped (other types unaffected), unresolved skipped.
- **writers unit**: per-member re-attach (Roles/Users/Groups), detach-only burns **no** policy version, combined document+detach.
- **overrides unit**: paginated attachment read.
- **revert-plan unit**: detach → SDK item carrying `attributeKey`.
- **golden corpus**: 4 new cases for the asymmetric path (union-clean / detach / users+groups / non-declared-dropped) + the existing `WorkerManaged` case refreshed (live now returns the role → CLEAN, the old `Roles` readGap is gone).
- **live real-AWS integ** (`iam-managedpolicy-detach/verify-detect.sh`, isolated via external roles so no role-side `ManagedPolicyArns` mirror): `record`→**CLEAN** with a union member (no FP) → detach declared role → `check` **detects** (union never surfaces) → `revert` re-attaches **only** the declared role → **CLEAN**, union role untouched. **INTEG PASS**.

README: the IAM ManagedPolicy limitation bullet now documents detach detection.

All 1383 unit tests pass; typecheck / lint+format clean. Stack + standalone roles torn down, sweep CLEAN.