### PR TITLE
test(integ): add codeartifact-rich, transitgateway-rich, secret-rotation-rich fixtures

### DIFF
--- a/tests/corpus/AWS__CodeArtifact__Domain.Domain.json
+++ b/tests/corpus/AWS__CodeArtifact__Domain.Domain.json
@@ -1,0 +1,96 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Domain",
+    "resourceType": "AWS::CodeArtifact::Domain",
+    "physicalId": "arn:aws:codeartifact:us-east-1:111111111111:domain/cdkrd-ca-domain",
+    "constructPath": "CdkRealDriftIntegCodeArtifactRich/Domain",
+    "declared": {
+      "DomainName": "cdkrd-ca-domain",
+      "PermissionsPolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "ReadFromDomain",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Action": [
+              "codeartifact:GetDomainPermissionsPolicy",
+              "codeartifact:ListRepositoriesInDomain",
+              "codeartifact:GetAuthorizationToken"
+            ],
+            "Resource": "*"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Owner": "111111111111",
+    "PermissionsPolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": [
+            "codeartifact:GetDomainPermissionsPolicy",
+            "codeartifact:ListRepositoriesInDomain",
+            "codeartifact:GetAuthorizationToken"
+          ],
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "ReadFromDomain"
+        }
+      ]
+    },
+    "DomainName": "cdkrd-ca-domain",
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:key/f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+    "Arn": "arn:aws:codeartifact:us-east-1:111111111111:domain/cdkrd-ca-domain",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCodeArtifactRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Domain",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCodeArtifactRich/f1cac490-6d8d-11f1-beb2-0ea31a62190d",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "cdkrd-ca-domain"
+  },
+  "schema": {
+    "readOnly": ["Arn", "EncryptionKey", "Name", "Owner"],
+    "writeOnly": [],
+    "createOnly": ["DomainName", "EncryptionKey"],
+    "readOnlyPaths": ["Arn", "EncryptionKey", "Name", "Owner"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName", "EncryptionKey"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CodeArtifact__Repository.Repo.json
+++ b/tests/corpus/AWS__CodeArtifact__Repository.Repo.json
@@ -1,0 +1,93 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Repo",
+    "resourceType": "AWS::CodeArtifact::Repository",
+    "physicalId": "arn:aws:codeartifact:us-east-1:111111111111:repository/cdkrd-ca-domain/cdkrd-ca-repo",
+    "constructPath": "CdkRealDriftIntegCodeArtifactRich/Repo",
+    "declared": {
+      "Description": "cdk-real-drift integ repository",
+      "DomainName": "cdkrd-ca-domain",
+      "ExternalConnections": ["public:npmjs"],
+      "PermissionsPolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "ReadFromRepo",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Action": ["codeartifact:ReadFromRepository", "codeartifact:GetRepositoryEndpoint"],
+            "Resource": "*"
+          }
+        ]
+      },
+      "RepositoryName": "cdkrd-ca-repo",
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdk-real-drift integ repository",
+    "PermissionsPolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["codeartifact:ReadFromRepository", "codeartifact:GetRepositoryEndpoint"],
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "ReadFromRepo"
+        }
+      ]
+    },
+    "DomainName": "cdkrd-ca-domain",
+    "RepositoryName": "cdkrd-ca-repo",
+    "ExternalConnections": ["public:npmjs"],
+    "Arn": "arn:aws:codeartifact:us-east-1:111111111111:repository/cdkrd-ca-domain/cdkrd-ca-repo",
+    "DomainOwner": "111111111111",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCodeArtifactRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Repo",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCodeArtifactRich/f1cac490-6d8d-11f1-beb2-0ea31a62190d",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "cdkrd-ca-repo"
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainOwner", "Name"],
+    "writeOnly": [],
+    "createOnly": ["DomainName", "DomainOwner", "RepositoryName"],
+    "readOnlyPaths": ["Arn", "DomainOwner", "Name"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DomainName", "DomainOwner", "RepositoryName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__TransitGateway.Tgw.json
+++ b/tests/corpus/AWS__EC2__TransitGateway.Tgw.json
@@ -1,0 +1,105 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Tgw",
+    "resourceType": "AWS::EC2::TransitGateway",
+    "physicalId": "tgw-0d23de2f49222f09f",
+    "constructPath": "CdkRealDriftIntegTransitGatewayRich/Tgw",
+    "declared": {
+      "AmazonSideAsn": 64512,
+      "AutoAcceptSharedAttachments": "disable",
+      "DefaultRouteTableAssociation": "enable",
+      "DefaultRouteTablePropagation": "enable",
+      "Description": "cdk-real-drift integ transit gateway",
+      "DnsSupport": "enable",
+      "MulticastSupport": "disable",
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "network"
+        }
+      ],
+      "VpnEcmpSupport": "enable"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdk-real-drift integ transit gateway",
+    "EncryptionSupportState": "disabled",
+    "AssociationDefaultRouteTableId": "tgw-rtb-0507484a86237d0ae",
+    "AutoAcceptSharedAttachments": "disable",
+    "TransitGatewayArn": "arn:aws:ec2:us-east-1:111111111111:transit-gateway/tgw-0d23de2f49222f09f",
+    "DefaultRouteTablePropagation": "enable",
+    "TransitGatewayCidrBlocks": [],
+    "PropagationDefaultRouteTableId": "tgw-rtb-0507484a86237d0ae",
+    "DefaultRouteTableAssociation": "enable",
+    "Id": "tgw-0d23de2f49222f09f",
+    "VpnEcmpSupport": "enable",
+    "SecurityGroupReferencingSupport": "disable",
+    "DnsSupport": "enable",
+    "MulticastSupport": "disable",
+    "AmazonSideAsn": 64512,
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegTransitGatewayRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Tgw",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "network",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegTransitGatewayRich/f1c98c10-6d8d-11f1-bc5c-129b1c47b1f9",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["EncryptionSupportState", "Id", "TransitGatewayArn"],
+    "writeOnly": ["EncryptionSupport"],
+    "createOnly": ["AmazonSideAsn", "MulticastSupport"],
+    "readOnlyPaths": ["EncryptionSupportState", "Id", "TransitGatewayArn"],
+    "writeOnlyPaths": ["EncryptionSupport"],
+    "createOnlyPaths": ["AmazonSideAsn", "MulticastSupport"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Tgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "AssociationDefaultRouteTableId",
+      "actual": "tgw-rtb-0507484a86237d0ae",
+      "physicalId": "tgw-0d23de2f49222f09f",
+      "constructPath": "CdkRealDriftIntegTransitGatewayRich/Tgw"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Tgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "PropagationDefaultRouteTableId",
+      "actual": "tgw-rtb-0507484a86237d0ae",
+      "physicalId": "tgw-0d23de2f49222f09f",
+      "constructPath": "CdkRealDriftIntegTransitGatewayRich/Tgw"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Tgw",
+      "resourceType": "AWS::EC2::TransitGateway",
+      "path": "SecurityGroupReferencingSupport",
+      "actual": "disable",
+      "physicalId": "tgw-0d23de2f49222f09f",
+      "constructPath": "CdkRealDriftIntegTransitGatewayRich/Tgw"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SecretsManager__RotationSchedule.Rotation9515E0C5.json
+++ b/tests/corpus/AWS__SecretsManager__RotationSchedule.Rotation9515E0C5.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rotation9515E0C5",
+    "resourceType": "AWS::SecretsManager::RotationSchedule",
+    "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g",
+    "constructPath": "CdkRealDriftIntegSecretRotationRich/Rotation",
+    "declared": {
+      "RotateImmediatelyOnUpdate": false,
+      "RotationLambdaARN": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegSecretRotation-RotationFnF5FD23F8-B5DTUQkxTYwv",
+      "RotationRules": {
+        "ScheduleExpression": "rate(30 days)"
+      },
+      "SecretId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g"
+    }
+  },
+  "liveRaw": {
+    "SecretId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g",
+    "Id": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g",
+    "RotationLambdaARN": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegSecretRotation-RotationFnF5FD23F8-B5DTUQkxTYwv",
+    "RotationRules": {
+      "ScheduleExpression": "rate(30 days)",
+      "AutomaticallyAfterDays": 30
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["HostedRotationLambda", "RotateImmediatelyOnUpdate"],
+    "createOnly": ["SecretId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [
+      "HostedRotationLambda",
+      "HostedRotationLambda.ExcludeCharacters",
+      "HostedRotationLambda.KmsKeyArn",
+      "HostedRotationLambda.MasterSecretArn",
+      "HostedRotationLambda.MasterSecretKmsKeyArn",
+      "HostedRotationLambda.RotationLambdaName",
+      "HostedRotationLambda.RotationType",
+      "HostedRotationLambda.Runtime",
+      "HostedRotationLambda.SuperuserSecretArn",
+      "HostedRotationLambda.SuperuserSecretKmsKeyArn",
+      "HostedRotationLambda.VpcSecurityGroupIds",
+      "HostedRotationLambda.VpcSubnetIds",
+      "RotateImmediatelyOnUpdate"
+    ],
+    "createOnlyPaths": ["SecretId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Rotation9515E0C5",
+      "resourceType": "AWS::SecretsManager::RotationSchedule",
+      "path": "RotateImmediatelyOnUpdate",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g",
+      "constructPath": "CdkRealDriftIntegSecretRotationRich/Rotation"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Rotation9515E0C5",
+      "resourceType": "AWS::SecretsManager::RotationSchedule",
+      "path": "RotationRules.AutomaticallyAfterDays",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:SecretA720EF05-me1CSgxlkGMO-hAz79g",
+      "constructPath": "CdkRealDriftIntegSecretRotationRich/Rotation"
+    }
+  ]
+}

--- a/tests/integration/codeartifact-rich/app.ts
+++ b/tests/integration/codeartifact-rich/app.ts
@@ -1,0 +1,56 @@
+// CDK app for the cdk-real-drift CodeArtifact false-positive test. CodeArtifact is
+// a common managed package registry (npm/PyPI/Maven/NuGet proxy), and neither
+// AWS::CodeArtifact::Domain nor ::Repository has been exercised. Both carry a
+// resource policy (PermissionsPolicyDocument — runs through cdkrd's policy
+// canonicalization) and the repository adds ExternalConnections / Upstreams /
+// Description, each its own normalization edge. A freshly deployed + recorded
+// stack with NO out-of-band change MUST report CLEAN.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnDomain, CfnRepository } from "aws-cdk-lib/aws-codeartifact";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCodeArtifactRich");
+
+const domain = new CfnDomain(stack, "Domain", {
+  domainName: "cdkrd-ca-domain",
+  permissionsPolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "ReadFromDomain",
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${stack.account}:root` },
+        Action: [
+          "codeartifact:GetDomainPermissionsPolicy",
+          "codeartifact:ListRepositoriesInDomain",
+          "codeartifact:GetAuthorizationToken",
+        ],
+        Resource: "*",
+      },
+    ],
+  },
+});
+
+const repo = new CfnRepository(stack, "Repo", {
+  repositoryName: "cdkrd-ca-repo",
+  domainName: domain.domainName,
+  description: "cdk-real-drift integ repository",
+  externalConnections: ["public:npmjs"],
+  permissionsPolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "ReadFromRepo",
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${stack.account}:root` },
+        Action: ["codeartifact:ReadFromRepository", "codeartifact:GetRepositoryEndpoint"],
+        Resource: "*",
+      },
+    ],
+  },
+});
+repo.addDependency(domain);
+
+Tags.of(stack).add("team", "platform");
+
+app.synth();

--- a/tests/integration/codeartifact-rich/cdk.json
+++ b/tests/integration/codeartifact-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codeartifact-rich/package.json
+++ b/tests/integration/codeartifact-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-codeartifact-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift codeartifact-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/codeartifact-rich/verify.sh
+++ b/tests/integration/codeartifact-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodeArtifactRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-codeartifact-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/secret-rotation-rich/app.ts
+++ b/tests/integration/secret-rotation-rich/app.ts
@@ -1,0 +1,34 @@
+// CDK app for the cdk-real-drift Secrets Manager rotation false-positive test.
+// Automatic rotation is a common best practice, and AWS::SecretsManager::
+// RotationSchedule has not been exercised. The interesting surface is the nested
+// RotationRules (AutomaticallyAfterDays / Duration / ScheduleExpression) plus
+// RotateImmediatelyOnUpdate — a small nested config block with service defaults
+// that is exactly the shape that has produced false positives elsewhere. A dummy
+// rotation Lambda backs the schedule (it is never actually invoked here:
+// rotateImmediatelyOnUpdate is false). A freshly deployed + recorded stack with NO
+// out-of-band change MUST report CLEAN.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+import { RotationSchedule, Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSecretRotationRich");
+
+const secret = new Secret(stack, "Secret", {
+  description: "cdk-real-drift integ rotated secret",
+});
+
+const rotationFn = new Function(stack, "RotationFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ ok: true });"),
+});
+
+new RotationSchedule(stack, "Rotation", {
+  secret,
+  rotationLambda: rotationFn,
+  automaticallyAfter: Duration.days(30),
+  rotateImmediatelyOnUpdate: false,
+});
+
+app.synth();

--- a/tests/integration/secret-rotation-rich/cdk.json
+++ b/tests/integration/secret-rotation-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/secret-rotation-rich/package.json
+++ b/tests/integration/secret-rotation-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-secret-rotation-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift secret-rotation-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/secret-rotation-rich/verify.sh
+++ b/tests/integration/secret-rotation-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSecretRotationRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-secret-rotation-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/transitgateway-rich/app.ts
+++ b/tests/integration/transitgateway-rich/app.ts
@@ -1,0 +1,29 @@
+// CDK app for the cdk-real-drift Transit Gateway false-positive test. A Transit
+// Gateway is the common hub for multi-VPC / hybrid connectivity, and
+// AWS::EC2::TransitGateway has not been exercised. It is interesting for the FP
+// hunt because almost all of its properties are string-valued enum toggles
+// (`enable`/`disable`) with service-applied defaults — exactly the
+// KNOWN_DEFAULTS / enum-normalization surface that produced false positives on
+// other types. This fixture declares a few explicitly and leaves the rest to
+// default. A freshly deployed + recorded TGW with NO out-of-band change MUST
+// report CLEAN.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { CfnTransitGateway } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegTransitGatewayRich");
+
+const tgw = new CfnTransitGateway(stack, "Tgw", {
+  amazonSideAsn: 64512,
+  description: "cdk-real-drift integ transit gateway",
+  autoAcceptSharedAttachments: "disable",
+  defaultRouteTableAssociation: "enable",
+  defaultRouteTablePropagation: "enable",
+  dnsSupport: "enable",
+  vpnEcmpSupport: "enable",
+  multicastSupport: "disable",
+});
+
+Tags.of(tgw).add("team", "network");
+
+app.synth();

--- a/tests/integration/transitgateway-rich/cdk.json
+++ b/tests/integration/transitgateway-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/transitgateway-rich/package.json
+++ b/tests/integration/transitgateway-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-transitgateway-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift transitgateway-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/transitgateway-rich/verify-detect.sh
+++ b/tests/integration/transitgateway-rich/verify-detect.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Transit Gateway detect + revert integration test (real AWS): the "someone changed
+# it in the console" scenario. Deploy -> record -> change the Description out of band
+# (a declared, MUTABLE top-level property) -> check MUST DETECT the declared drift
+# (exit 1) -> revert -> check MUST be CLEAN and the live Description MUST be restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegTransitGatewayRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+TGW="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::EC2::TransitGateway'].PhysicalResourceId" --output text)"
+[ -n "$TGW" ] || fail "could not resolve transit gateway id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: change the Description (console-edit) ==="
+aws ec2 modify-transit-gateway --transit-gateway-id "$TGW" --region "$REGION" \
+  --description "drifted out of band" >/dev/null || fail "inject drift"
+
+echo "=== wait for TGW to settle (modifying -> available) ==="
+for i in $(seq 1 30); do
+  ST="$(aws ec2 describe-transit-gateways --transit-gateway-ids "$TGW" --region "$REGION" \
+    --query "TransitGateways[0].State" --output text 2>/dev/null)"
+  [ "$ST" = "available" ] && break
+  sleep 10
+done
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-tgw-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "Description" /tmp/cdkrd-tgw-detect.out || fail "Description drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live Description MUST be restored ==="
+GOT="$(aws ec2 describe-transit-gateways --transit-gateway-ids "$TGW" --region "$REGION" \
+  --query "TransitGateways[0].Description" --output text)"
+[ "$GOT" = "cdk-real-drift integ transit gateway" ] || fail "live Description not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/transitgateway-rich/verify.sh
+++ b/tests/integration/transitgateway-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegTransitGatewayRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-transitgateway-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A clean /hunt-bugs round — three commonly-deployed, previously-unexercised resource types, all **false-positive-clean** on a fresh deploy → record → check:

- **AWS::CodeArtifact::Domain + ::Repository** — managed package registry; both carry a `PermissionsPolicyDocument` (exercises policy canonicalization), the repository adds `ExternalConnections` / `Description`. CLEAN.
- **AWS::EC2::TransitGateway** — multi-VPC hub; almost all properties are `enable`/`disable` enum toggles with service defaults (the KNOWN_DEFAULTS / enum-normalization surface). CLEAN. Also proves the **FN path**: `Description` changed out of band → `check` detects → `revert` → `check` CLEAN → live value restored (`verify-detect.sh`).
- **AWS::SecretsManager::RotationSchedule** — automatic rotation (a common best practice); nested `RotationRules`. CLEAN.

## Outcome

No source change — **zero false positives and zero read-gaps** across all three types. Per the hunt-bugs playbook, a clean round's deliverable is the committed regression fixtures **plus** the golden-corpus cases harvested from the live reads (CodeArtifact Domain/Repository, EC2 TransitGateway, SecretsManager RotationSchedule). `corpus-replay` is now 334 cases — permanent offline regression coverage for these types.

## Cleanup

All bug-hunt stacks deleted; `bughunt-track.sh verify` + `sweep-orphans.sh` report SWEEP CLEAN (incl. the rotation Lambda's auto-created log group.

## Test plan
- VITE+ - The Unified Toolchain for the Web

$ tsgo --project tsconfig.json --noEmit ◉ cache hit, replaying

---
vp run: cache hit, 921ms saved. / VITE+ - The Unified Toolchain for the Web

[1m[94mpass:[39m[0m All 449 files are correctly formatted [2m(585ms, 12 threads)[0m
! vitest(require-mock-type-parameters): Missing type parameters on mock function call
   ,-[tests/interactive-resolve.test.ts:6:34]
 5 |   const actual = (await importOriginal()) as Record<string, unknown>;
 6 |   return { ...actual, select: vi.fn(), isCancel: () => false };
   :                                  ^^
 7 | });
   `----
  help: Add a type parameter to the mock function, e.g. `vi.fn<() => void>()`.

  ! vitest(require-mock-type-parameters): Missing type parameters on mock function call
    ,-[tests/interactive-resolve.test.ts:16:21]
 15 |     ...actual,
 16 |     revertStack: vi.fn().mockResolvedValue({ exit: 0, aborted: false }),
    :                     ^^
 17 |   };
    `----
  help: Add a type parameter to the mock function, e.g. `vi.fn<() => void>()`.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
    ,-[tests/policy-canonical.test.ts:90:11]
 89 |       Other: 5,
 90 |     }) as any;
    :           ^^^
 91 |     expect(out.Other).toBe(5);
    `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
     ,-[tests/policy-canonical.test.ts:294:30]
 293 |     });
 294 |     expect((out.Statement as any[])[0].Condition).toBe('weird');
     :                              ^^^
 295 |   });
     `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
     ,-[tests/policy-canonical.test.ts:360:10]
 359 |       map
 360 |     ) as any;
     :          ^^^
 361 |     const p = out.Statement[0].Principal;
     `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
    ,-[src/desired/template-adapter.ts:36:28]
 35 | export function buildResolverContext(
 36 |   template: Record<string, any>,
    :                            ^^^
 37 |   stackParams: Record<string, string>,
    `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
     ,-[src/desired/template-adapter.ts:160:5]
 159 |     string,
 160 |     any
     :     ^^^
 161 |   >;
     `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
     ,-[src/desired/template-adapter.ts:211:50]
 210 |   for (const [logicalId, res] of Object.entries(
 211 |     (template.Resources ?? {}) as Record<string, any>
     :                                                  ^^^
 212 |   )) {
     `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
     ,-[src/desired/template-adapter.ts:246:29]
 245 | export function collectRolesWithSiblingPolicies(
 246 |   resources: Record<string, any>,
     :                             ^^^
 247 |   ctx?: ResolverContext
     `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
    ,-[tests/yaml-cfn.test.ts:25:21]
 24 |       Cond: !If [C, a, b]`);
 25 |     const p = (t as any).Resources.B.Properties;
    :                     ^^^
 26 |     expect(p.BucketName).toEqual({ Ref: 'MyParam' });
    `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! typescript(no-explicit-any): Unexpected `any`. Specify a different type.
    ,-[tests/yaml-cfn.test.ts:46:21]
 45 |       Good: !GetAtt Foo.Arn`);
 46 |     const p = (t as any).Resources.B.Properties;
    :                     ^^^
 47 |     expect(p.Bad).toEqual({ 'Fn::GetAtt': ['JustALogicalId'] }); // 1-element -> UNRESOLVED downstream
    `----
  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.

  ! vitest(require-to-throw-message): Require a message for "toThrow".
    ,-[tests/yaml-cfn.test.ts:33:45]
 32 |   it('rejects a non-object root', () => {
 33 |     expect(() => parseCfnTemplate('[1,2]')).toThrow();
    :                                             ^^^^^^^
 34 |   });
    `----
  help: Add an error message to "toThrow"

  ! vitest(valid-title): Title must be a string
    ,-[tests/corpus-replay.test.ts:33:8]
 32 |   for (const file of files) {
 33 |     it(file, () => {
    :        ^^^^
 34 |       const c = JSON.parse(readFileSync(join(corpusDir, file), 'utf8')) as CorpusCase;
    `----
  help: Replace your title with a string

Found 0 errors and 13 warnings in 84 files (1.0s, 12 threads) / VITE+ - The Unified Toolchain for the Web

$ vp pack ⊘ cache disabled
ℹ entry: src/cli.ts
ℹ target: node20
ℹ tsconfig: tsconfig.json
ℹ Build start
ℹ Cleaning 2 files
ℹ Granting execute permission to dist/cli.js
ℹ dist/cli.js      293.73 kB │ gzip:  75.84 kB
ℹ dist/cli.js.map  843.10 kB │ gzip: 227.96 kB
ℹ 2 files, total: 1.14 MB
✔ Build complete in 40ms / VITE+ - The Unified Toolchain for the Web

$ vp test run
 RUN  /Users/goto/pc/github/cdk-real-drift/.worktrees/wave2

 ✓ tests/report.test.ts (56 tests) 9ms
 ✓ tests/noise-and-strip.test.ts (38 tests) 7ms
 ✓ tests/classify.test.ts (152 tests) 48ms
 ✓ tests/baseline.test.ts (88 tests) 85ms
 ✓ tests/intrinsic-resolver.test.ts (26 tests) 5ms
 ✓ tests/policy-canonical.test.ts (28 tests) 5ms
 ✓ tests/template-adapter.test.ts (16 tests) 40ms
 ✓ tests/child-enumerators.test.ts (104 tests) 39ms
 ✓ tests/overrides.test.ts (69 tests) 150ms
 ✓ tests/cli-args.test.ts (22 tests) 11ms
 ✓ tests/revert-plan.test.ts (63 tests) 67ms
 ✓ tests/writers.test.ts (39 tests) 54ms
 ✓ tests/config-file.test.ts (53 tests) 119ms
 ✓ tests/drift-calculator.test.ts (14 tests) 4ms
 ✓ tests/arn-identity.test.ts (29 tests) 5ms
 ✓ tests/glob-match.test.ts (12 tests) 3ms
 ✓ tests/router.test.ts (37 tests) 18ms
 ✓ tests/corpus-record.test.ts (5 tests) 3ms
 ✓ tests/invariants.test.ts (5 tests) 174ms
stdout | tests/stack-actions.test.ts > recordStack non-interactive refusal (R38) > yes:true → records ALL undeclared values with no prompt (regression)
baseline written: .cdkrd/R38YesStack.999988887777.r38-yes-region.json (1 recorded entry(ies))

stdout | tests/stack-actions.test.ts > recordStack preselectedKeys (R121 — per-finding path skips the multiselect) > records exactly the preselected undeclared values, no prompt
baseline written: .cdkrd/R121Stack.999988887777.r121-region.json (1 recorded entry(ies))

stdout | tests/stack-actions.test.ts > ignoreStack (PR-B — write config.json ignore rules; declared + undeclared) > no declared/undeclared findings → nothing to ignore, no file written
S: no ignorable drift to ignore.

stdout | tests/stack-actions.test.ts > ignoreStack (PR-B — write config.json ignore rules; declared + undeclared) > yes:true → writes a rule for every declared + undeclared finding
ignore rule(s) added: .cdkrd/config.json (2 new)

stdout | tests/stack-actions.test.ts > ignoreStack (PR-B — write config.json ignore rules; declared + undeclared) > yes:true is idempotent — re-ignoring already-present rules writes nothing new
ignore rule(s) added: .cdkrd/config.json (1 new)

stdout | tests/stack-actions.test.ts > ignoreStack (PR-B — write config.json ignore rules; declared + undeclared) > yes:true is idempotent — re-ignoring already-present rules writes nothing new
S: all 1 selected rule(s) already present — config unchanged

 ✓ tests/stack-actions.test.ts (60 tests) 75ms
 ✓ tests/aws-errors.test.ts (10 tests) 4ms
stdout | tests/_audit.test.ts > suppression audit: each must still DETECT a real change > runs
AUDIT json-string(SSM Content changed): detected ["declared:Content"]
AUDIT unordered-scalar(Cognito flow changed): detected ["declared:ExplicitAuthFlows"]
AUDIT case-insensitive(Route53 DNS changed): detected ["declared:AliasTarget.DNSName"]
AUDIT stringly(Port 5432->9999): detected ["declared:Port"]
AUDIT arn-name(role myrole->othername): detected ["declared:RoleRef"]
AUDIT unordered-obj(SG rule REMOVED): detected ["declared:SecurityGroupIngress"]
AUDIT atDefault(Lambda Tracing default->Active): detected ["undeclared:TracingConfig"]

 ✓ tests/_audit.test.ts (1 test) 4ms
stdout | tests/_audit2.test.ts > audit2: removal / nested-undeclared / type-mismatch / deep > runs
AUDIT2 tag REMOVED (declared[A,B] live[A]): detected ["declared:Tags"]
AUDIT2 inline-policy stmt REMOVED: detected ["declared:Policies.0.PolicyDocument.Statement"]
AUDIT2 NESTED undeclared (declared{A:{x:1}} live{A:{x:1,y:2}}): detected ["undeclared:Conf.Destination"]
AUDIT2 top-level undeclared (sanity): detected ["undeclared:Extra"]
AUDIT2 DEEP nested change (A.B.C 1->2): detected ["declared:A.B.C"]
AUDIT2 type mismatch (declared array, live scalar): detected ["declared:P"]
AUDIT2 declared scalar, live object: detected ["declared:P"]
AUDIT2 declared key, live MISSING it (removed/null): *** MISSED (BUG) *** []

 ✓ tests/_audit2.test.ts (1 test) 5ms
 ✓ tests/bulk-multiselect.test.ts (7 tests) 3ms
 ✓ tests/action-picker.test.ts (29 tests) 4ms
 ✓ tests/style.test.ts (5 tests) 6ms
 ✓ tests/kms-aliases.test.ts (5 tests) 11ms
 ✓ tests/path-strip.test.ts (5 tests) 3ms
 ✓ tests/yaml-cfn.test.ts (5 tests) 7ms
stdout | tests/_audit3.test.ts > audit3 full tiers > runs
A3 nested-undeclared ALL=["undeclared:Conf.Destination"]
A3 declared-missing ALL=["readGap:P/declared but not returned by live read"]
A3 nested-undeclared-array (declared list of obj, live obj has extra nested key)=["undeclared:Items[a].Extra"]

 ✓ tests/eip-reader.test.ts (7 tests) 11ms
 ✓ tests/_audit3.test.ts (1 test) 4ms
 ✓ tests/apply-ops.test.ts (5 tests) 3ms
 ✓ tests/no-direct-tty.test.ts (5 tests) 3ms
 ✓ tests/corpus-replay.test.ts (334 tests) 134ms
stdout | tests/_probe.test.ts > probe2 > added tag
ADDED2=["declared:Tags"]

 ✓ tests/_probe.test.ts (1 test) 3ms
 ✓ tests/apply.test.ts (5 tests) 4ms
 ✓ tests/check.test.ts (37 tests) 5ms
 ✓ tests/interactive-resolve.test.ts (2 tests) 3ms
 ✓ tests/gather.test.ts (9 tests) 706ms
     ✓ re-reads the Route with the composite id, so it is NOT falsely deleted  630ms
 ✓ tests/io-host.test.ts (5 tests) 2ms

 Test Files  40 passed (40)
      Tests  1395 passed (1395)
   Start at  01:39:27
   Duration  1.82s (transform 2.45s, setup 0ms, import 10.97s, tests 1.84s, environment 2ms)


---
vp run: cdk-real-drift#test not cached because it modified its input. (Run `vp run --last-details` for full details) (40 files, 1395 tests) all green.
EOF
)