### PR TITLE
test(integ): add s3-replication-rich, ssm-association-rich, globalaccelerator-rich fixtures

### DIFF
--- a/tests/corpus/AWS__GlobalAccelerator__Accelerator.AccelFED3756B.json
+++ b/tests/corpus/AWS__GlobalAccelerator__Accelerator.AccelFED3756B.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AccelFED3756B",
+    "resourceType": "AWS::GlobalAccelerator::Accelerator",
+    "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229",
+    "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel",
+    "declared": {
+      "Enabled": true,
+      "Name": "cdkrd-accel"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "IPV4",
+    "IpAddresses": ["52.223.63.163", "166.117.191.65"],
+    "Ipv4Addresses": ["52.223.63.163", "166.117.191.65"],
+    "DnsName": "a2f206e44dd5e9650.awsglobalaccelerator.com",
+    "AcceleratorArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229",
+    "Enabled": true,
+    "Ipv6Addresses": [],
+    "Tags": [],
+    "Name": "cdkrd-accel"
+  },
+  "schema": {
+    "readOnly": ["AcceleratorArn", "DnsName", "DualStackDnsName", "Ipv4Addresses", "Ipv6Addresses"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "AcceleratorArn",
+      "DnsName",
+      "DualStackDnsName",
+      "Ipv4Addresses",
+      "Ipv6Addresses"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {
+      "IpAddressType": "IPV4",
+      "IpAddresses": null,
+      "Enabled": true,
+      "Ipv6Addresses": null
+    },
+    "defaultPaths": {
+      "IpAddressType": "IPV4",
+      "IpAddresses": null,
+      "Enabled": true,
+      "Ipv6Addresses": null
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AccelFED3756B",
+      "resourceType": "AWS::GlobalAccelerator::Accelerator",
+      "path": "IpAddressType",
+      "actual": "IPV4",
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AccelFED3756B",
+      "resourceType": "AWS::GlobalAccelerator::Accelerator",
+      "path": "IpAddresses",
+      "actual": ["52.223.63.163", "166.117.191.65"],
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GlobalAccelerator__EndpointGroup.AccelListenerGroupBA727A76.json
+++ b/tests/corpus/AWS__GlobalAccelerator__EndpointGroup.AccelListenerGroupBA727A76.json
@@ -1,0 +1,103 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AccelListenerGroupBA727A76",
+    "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
+    "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+    "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group",
+    "declared": {
+      "EndpointGroupRegion": "us-east-1",
+      "ListenerArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1",
+    "HealthCheckIntervalSeconds": 30,
+    "EndpointGroupRegion": "us-east-1",
+    "TrafficDialPercentage": 100,
+    "HealthCheckProtocol": "TCP",
+    "EndpointGroupArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+    "ThresholdCount": 3,
+    "HealthCheckPort": 80,
+    "EndpointConfigurations": []
+  },
+  "schema": {
+    "readOnly": ["EndpointGroupArn"],
+    "writeOnly": [],
+    "createOnly": ["EndpointGroupRegion", "ListenerArn"],
+    "readOnlyPaths": ["EndpointGroupArn"],
+    "writeOnlyPaths": ["EndpointConfigurations.*.AttachmentArn"],
+    "createOnlyPaths": ["EndpointGroupRegion", "ListenerArn"],
+    "defaults": {
+      "TrafficDialPercentage": 100,
+      "HealthCheckPort": -1,
+      "HealthCheckProtocol": "TCP",
+      "HealthCheckPath": "/",
+      "HealthCheckIntervalSeconds": 30,
+      "ThresholdCount": 3
+    },
+    "defaultPaths": {
+      "EndpointConfigurations.*.Weight": 100,
+      "EndpointConfigurations.*.ClientIPPreservationEnabled": true,
+      "TrafficDialPercentage": 100,
+      "HealthCheckPort": -1,
+      "HealthCheckProtocol": "TCP",
+      "HealthCheckPath": "/",
+      "HealthCheckIntervalSeconds": 30,
+      "ThresholdCount": 3
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AccelListenerGroupBA727A76",
+      "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AccelListenerGroupBA727A76",
+      "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
+      "path": "TrafficDialPercentage",
+      "actual": 100,
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AccelListenerGroupBA727A76",
+      "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "TCP",
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AccelListenerGroupBA727A76",
+      "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
+      "path": "ThresholdCount",
+      "actual": 3,
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AccelListenerGroupBA727A76",
+      "resourceType": "AWS::GlobalAccelerator::EndpointGroup",
+      "path": "HealthCheckPort",
+      "actual": 80,
+      "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1/endpoint-group/363328af8002",
+      "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener/Group"
+    }
+  ]
+}

--- a/tests/corpus/AWS__GlobalAccelerator__Listener.AccelListener01A586D7.json
+++ b/tests/corpus/AWS__GlobalAccelerator__Listener.AccelListener01A586D7.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AccelListener01A586D7",
+    "resourceType": "AWS::GlobalAccelerator::Listener",
+    "physicalId": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1",
+    "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel/Listener",
+    "declared": {
+      "AcceleratorArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229",
+      "ClientAffinity": "SOURCE_IP",
+      "PortRanges": [
+        {
+          "FromPort": 80,
+          "ToPort": 80
+        },
+        {
+          "FromPort": 443,
+          "ToPort": 443
+        }
+      ],
+      "Protocol": "TCP"
+    }
+  },
+  "liveRaw": {
+    "ListenerArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229/listener/98a22ab1",
+    "PortRanges": [
+      {
+        "FromPort": 80,
+        "ToPort": 80
+      },
+      {
+        "FromPort": 443,
+        "ToPort": 443
+      }
+    ],
+    "AcceleratorArn": "arn:aws:globalaccelerator::111111111111:accelerator/f47e18d9-8714-4e86-8c53-1794ea362229",
+    "Protocol": "TCP",
+    "ClientAffinity": "SOURCE_IP"
+  },
+  "schema": {
+    "readOnly": ["ListenerArn"],
+    "writeOnly": [],
+    "createOnly": ["AcceleratorArn"],
+    "readOnlyPaths": ["ListenerArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AcceleratorArn"],
+    "defaults": {
+      "Protocol": "TCP",
+      "ClientAffinity": "NONE"
+    },
+    "defaultPaths": {
+      "Protocol": "TCP",
+      "ClientAffinity": "NONE"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__Bucket.Source71E471F1.json
+++ b/tests/corpus/AWS__S3__Bucket.Source71E471F1.json
@@ -1,0 +1,233 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Source71E471F1",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+    "constructPath": "CdkRealDriftIntegS3ReplicationRich/Source",
+    "declared": {
+      "ReplicationConfiguration": {
+        "Role": "arn:aws:iam::111111111111:role/CDKReplicationRole",
+        "Rules": [
+          {
+            "DeleteMarkerReplication": {
+              "Status": "Disabled"
+            },
+            "Destination": {
+              "Bucket": "arn:aws:s3:::cdkrealdriftintegs3replicationrich-destc383b82a-hcib8c1nqpur",
+              "StorageClass": "STANDARD_IA"
+            },
+            "Filter": {
+              "Prefix": "logs/"
+            },
+            "Id": "logs-rule",
+            "Priority": 1,
+            "SourceSelectionCriteria": {
+              "ReplicaModifications": {
+                "Status": "Enabled"
+              }
+            },
+            "Status": "Enabled"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t.s3.dualstack.us-east-1.amazonaws.com",
+    "VersioningConfiguration": {
+      "Status": "Enabled"
+    },
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+    "RegionalDomainName": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+    "ReplicationConfiguration": {
+      "Role": "arn:aws:iam::111111111111:role/CDKReplicationRole",
+      "Rules": [
+        {
+          "Status": "Enabled",
+          "Destination": {
+            "Bucket": "arn:aws:s3:::cdkrealdriftintegs3replicationrich-destc383b82a-hcib8c1nqpur",
+            "StorageClass": "STANDARD_IA"
+          },
+          "Filter": {
+            "Prefix": "logs/"
+          },
+          "Priority": 1,
+          "SourceSelectionCriteria": {
+            "ReplicaModifications": {
+              "Status": "Enabled"
+            }
+          },
+          "Id": "logs-rule",
+          "DeleteMarkerReplication": {
+            "Status": "Disabled"
+          }
+        }
+      ]
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegS3ReplicationRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Source71E471F1",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3ReplicationRich/7aa5f210-6d90-11f1-93fd-0affc62f8665",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Source71E471F1",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+      "constructPath": "CdkRealDriftIntegS3ReplicationRich/Source"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Source71E471F1",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+      "constructPath": "CdkRealDriftIntegS3ReplicationRich/Source"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Source71E471F1",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+      "constructPath": "CdkRealDriftIntegS3ReplicationRich/Source"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Source71E471F1",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3replicationrich-source71e471f1-rn5nhidh5r0t",
+      "constructPath": "CdkRealDriftIntegS3ReplicationRich/Source"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SSM__Association.Assoc.json
+++ b/tests/corpus/AWS__SSM__Association.Assoc.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Assoc",
+    "resourceType": "AWS::SSM::Association",
+    "physicalId": "0e4258fb-3d68-48fd-9094-af868703f303",
+    "constructPath": "CdkRealDriftIntegSsmAssociationRich/Assoc",
+    "declared": {
+      "AssociationName": "cdkrd-assoc",
+      "ComplianceSeverity": "MEDIUM",
+      "MaxConcurrency": "1",
+      "MaxErrors": "1",
+      "Name": "AWS-UpdateSSMAgent",
+      "ScheduleExpression": "rate(7 days)",
+      "Targets": [
+        {
+          "Key": "tag:cdkrd",
+          "Values": ["true"]
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "AssociationName": "cdkrd-assoc",
+    "ScheduleExpression": "rate(7 days)",
+    "MaxErrors": "1",
+    "ApplyOnlyAtCronInterval": false,
+    "MaxConcurrency": "1",
+    "ComplianceSeverity": "MEDIUM",
+    "Targets": [
+      {
+        "Values": ["true"],
+        "Key": "tag:cdkrd"
+      }
+    ],
+    "DocumentVersion": "$DEFAULT",
+    "AssociationId": "0e4258fb-3d68-48fd-9094-af868703f303",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSsmAssociationRich/7ab3adb0-6d90-11f1-acfc-0afff087e099",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSsmAssociationRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Assoc",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "AWS-UpdateSSMAgent"
+  },
+  "schema": {
+    "readOnly": ["AssociationId"],
+    "writeOnly": ["WaitForSuccessTimeoutSeconds"],
+    "createOnly": [],
+    "readOnlyPaths": ["AssociationId"],
+    "writeOnlyPaths": ["WaitForSuccessTimeoutSeconds"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Assoc",
+      "resourceType": "AWS::SSM::Association",
+      "path": "DocumentVersion",
+      "actual": "$DEFAULT",
+      "physicalId": "0e4258fb-3d68-48fd-9094-af868703f303",
+      "constructPath": "CdkRealDriftIntegSsmAssociationRich/Assoc"
+    }
+  ]
+}

--- a/tests/integration/globalaccelerator-rich/app.ts
+++ b/tests/integration/globalaccelerator-rich/app.ts
@@ -1,0 +1,37 @@
+// CDK app for the cdk-real-drift Global Accelerator false-positive test. Global
+// Accelerator is a common front door for low-latency / failover traffic, and none
+// of AWS::GlobalAccelerator::Accelerator / ::Listener / ::EndpointGroup has been
+// exercised. The listener carries a PortRanges array + protocol + ClientAffinity,
+// and the endpoint group carries the health-check defaults (interval / threshold /
+// protocol / traffic-dial) AWS materializes — the KNOWN_DEFAULTS / nested-default
+// surface. The endpoint group has no endpoints (valid; we only read config). A
+// freshly deployed + recorded stack with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  Accelerator,
+  ClientAffinity,
+  ConnectionProtocol,
+} from "aws-cdk-lib/aws-globalaccelerator";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegGlobalAcceleratorRich");
+
+const accel = new Accelerator(stack, "Accel", {
+  acceleratorName: "cdkrd-accel",
+  enabled: true,
+});
+
+const listener = accel.addListener("Listener", {
+  portRanges: [
+    { fromPort: 80, toPort: 80 },
+    { fromPort: 443, toPort: 443 },
+  ],
+  protocol: ConnectionProtocol.TCP,
+  clientAffinity: ClientAffinity.SOURCE_IP,
+});
+
+listener.addEndpointGroup("Group", {
+  region: "us-east-1",
+});
+
+app.synth();

--- a/tests/integration/globalaccelerator-rich/cdk.json
+++ b/tests/integration/globalaccelerator-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/globalaccelerator-rich/package.json
+++ b/tests/integration/globalaccelerator-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-globalaccelerator-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift globalaccelerator-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/globalaccelerator-rich/verify.sh
+++ b/tests/integration/globalaccelerator-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGlobalAcceleratorRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-globalaccelerator-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-replication-rich/app.ts
+++ b/tests/integration/s3-replication-rich/app.ts
@@ -1,0 +1,38 @@
+// CDK app for the cdk-real-drift S3 cross-bucket replication false-positive test.
+// S3 is the most commonly deployed resource and the existing s3-rich fixture
+// covers CORS / lifecycle / intelligent-tiering — but NOT ReplicationConfiguration,
+// a notoriously normalization-heavy nested config (a Rules array with Filter /
+// Priority / Destination / StorageClass / DeleteMarkerReplication /
+// SourceSelectionCriteria, plus the auto-generated replication IAM role). A
+// freshly deployed + recorded source bucket with NO out-of-band change MUST report
+// CLEAN.
+import { App, RemovalPolicy, Stack, Tags } from "aws-cdk-lib";
+import { Bucket, StorageClass } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3ReplicationRich");
+
+const dest = new Bucket(stack, "Dest", {
+  versioned: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const source = new Bucket(stack, "Source", {
+  versioned: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+  replicationRules: [
+    {
+      destination: dest,
+      priority: 1,
+      id: "logs-rule",
+      storageClass: StorageClass.INFREQUENT_ACCESS,
+      deleteMarkerReplication: false,
+      replicaModifications: true,
+      filter: { prefix: "logs/" },
+    },
+  ],
+});
+
+Tags.of(source).add("team", "platform");
+
+app.synth();

--- a/tests/integration/s3-replication-rich/cdk.json
+++ b/tests/integration/s3-replication-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-replication-rich/package.json
+++ b/tests/integration/s3-replication-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-replication-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-replication-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-replication-rich/verify.sh
+++ b/tests/integration/s3-replication-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3ReplicationRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-s3-replication-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ssm-association-rich/app.ts
+++ b/tests/integration/ssm-association-rich/app.ts
@@ -1,0 +1,25 @@
+// CDK app for the cdk-real-drift SSM Association false-positive test. State Manager
+// Associations are a common fleet-management primitive, and AWS::SSM::Association has
+// not been exercised. The interesting surface is its nested config: a Targets array,
+// a ScheduleExpression, MaxConcurrency / MaxErrors (stringly-typed numbers), and
+// ComplianceSeverity — each its own normalization edge. The association points at a
+// built-in document and a tag target that matches no instances (it never runs, which
+// is fine — we only read its config). A freshly deployed + recorded association with
+// NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAssociation } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSsmAssociationRich");
+
+new CfnAssociation(stack, "Assoc", {
+  name: "AWS-UpdateSSMAgent",
+  associationName: "cdkrd-assoc",
+  scheduleExpression: "rate(7 days)",
+  targets: [{ key: "tag:cdkrd", values: ["true"] }],
+  maxConcurrency: "1",
+  maxErrors: "1",
+  complianceSeverity: "MEDIUM",
+});
+
+app.synth();

--- a/tests/integration/ssm-association-rich/cdk.json
+++ b/tests/integration/ssm-association-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ssm-association-rich/package.json
+++ b/tests/integration/ssm-association-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ssm-association-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ssm-association-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ssm-association-rich/verify-detect.sh
+++ b/tests/integration/ssm-association-rich/verify-detect.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# SSM Association detect + revert integration test (real AWS): the "someone changed
+# it in the console" scenario. Deploy -> record -> change the ScheduleExpression out
+# of band (a declared, MUTABLE property) -> check MUST DETECT the declared drift
+# (exit 1) -> revert -> check MUST be CLEAN and the live ScheduleExpression MUST be
+# restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSsmAssociationRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ASSOC="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SSM::Association'].PhysicalResourceId" --output text)"
+[ -n "$ASSOC" ] || fail "could not resolve association id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: change the ScheduleExpression (console-edit) ==="
+aws ssm update-association --association-id "$ASSOC" --region "$REGION" \
+  --schedule-expression "rate(14 days)" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ssm-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "ScheduleExpression" /tmp/cdkrd-ssm-detect.out || fail "ScheduleExpression drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live ScheduleExpression MUST be restored ==="
+GOT="$(aws ssm describe-association --association-id "$ASSOC" --region "$REGION" \
+  --query "AssociationDescription.ScheduleExpression" --output text)"
+[ "$GOT" = "rate(7 days)" ] || fail "live ScheduleExpression not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/ssm-association-rich/verify.sh
+++ b/tests/integration/ssm-association-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSsmAssociationRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-ssm-association-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A clean /hunt-bugs round — three commonly-deployed surfaces, all **false-positive-clean** on a fresh deploy → record → check:

- **AWS::S3::Bucket `ReplicationConfiguration`** — `s3-rich` covers CORS / lifecycle / intelligent-tiering but not replication, a notoriously normalization-heavy nested `Rules` array (Filter / Priority / Destination / StorageClass / DeleteMarkerReplication / SourceSelectionCriteria) plus the auto-generated replication IAM role. CLEAN — the captured corpus case has **zero declared findings**.
- **AWS::SSM::Association** — State Manager fleet association; nested `Targets`, `ScheduleExpression`, stringly-typed `MaxConcurrency`/`MaxErrors`, `ComplianceSeverity`. CLEAN. Also proves the **FN path**: `ScheduleExpression` changed out of band → `check` detects → `revert` → CLEAN → live restored (`verify-detect.sh`). _Note: 4 declared props surface as `readGap` (CC `GetResource` omits `AssociationName`/`MaxConcurrency`/`MaxErrors`/`ComplianceSeverity`) — honestly reported, an SDK-override candidate for a later wave._
- **AWS::GlobalAccelerator::Accelerator / ::Listener / ::EndpointGroup** — low-latency front door; `PortRanges` array, `ClientAffinity`, endpoint-group health-check defaults. CLEAN.

## Outcome

No source change — zero false positives across all three. Deliverable = the committed regression fixtures plus the golden-corpus cases harvested from the live reads (S3 replication Source bucket, SSM Association, GlobalAccelerator ×3). `corpus-replay` now 339 cases.

## Cleanup

All bug-hunt stacks deleted; `bughunt-track.sh verify` + `sweep-orphans.sh` → SWEEP CLEAN.

## Test plan
- `vp run typecheck` / `vp check` / `vp run build` / `vp run test` (40 files, 1400 tests) all green.