### PR TITLE
fix(revert): restore a removed-since-record value (was "no physical id")

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -411,6 +411,14 @@ export interface ApplyBaselineOptions {
   // "baseline value removed since record" finding so a constructPath-form ignore rule
   // matches it (a RecordedEntry carries no constructPath of its own).
   constructPathByLogical?: Map<string, string>;
+  // logicalId -> live physical id. Used to restore physicalId onto the synthetic
+  // "baseline value removed since record" finding. A RecordedEntry stores no physical
+  // id, and unlike a LIVE finding (which classifyResource stamps with
+  // resource.physicalId) this one is synthesized here — so without this it reaches
+  // `revert` with NO physical id and buildRevertPlan rejects it ("no physical id"),
+  // making a recorded value removed out of band UN-revertable (a real revert FN: the
+  // value the user chose to keep disappeared, yet `revert` refuses to restore it).
+  physicalIdByLogical?: Map<string, string>;
   warn?: (s: string) => void; // stderr note channel for the promotion case
 }
 
@@ -614,6 +622,11 @@ export function applyBaseline(
       ...(opts.constructPathByLogical?.get(a.logicalId) !== undefined && {
         constructPath: opts.constructPathByLogical.get(a.logicalId),
       }),
+      // physical id so `revert` can act on it (a synthesized finding has no
+      // resource.physicalId source — without this it is rejected as "no physical id").
+      ...(opts.physicalIdByLogical?.get(a.logicalId) !== undefined && {
+        physicalId: opts.physicalIdByLogical.get(a.logicalId),
+      }),
       path: a.path,
       desired: a.value,
       actual: undefined,
@@ -651,6 +664,17 @@ export function constructPathsByLogical(
 ): Map<string, string> {
   const m = new Map<string, string>();
   for (const r of resources) if (r.constructPath !== undefined) m.set(r.logicalId, r.constructPath);
+  return m;
+}
+
+// logicalId -> live physical id, for resources that resolved one. Feeds
+// ApplyBaselineOptions.physicalIdByLogical so the synthetic removed-since-record
+// finding carries a physical id and `revert` can restore the removed value.
+export function physicalIdsByLogical(
+  resources: { logicalId: string; physicalId?: string | undefined }[]
+): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const r of resources) if (r.physicalId !== undefined) m.set(r.logicalId, r.physicalId);
   return m;
 }
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -13,6 +13,7 @@ import {
   constructPathsByLogical,
   declaredKeysByLogical,
   loadBaseline,
+  physicalIdsByLogical,
   warnBaselineSchemaV1,
   warnTemplateHashDrift,
 } from '../baseline/baseline-file.js';
@@ -315,6 +316,7 @@ export async function runCheck(args: string[]): Promise<number> {
           : applyBaseline(findings, baseline, {
               declaredByLogical: declaredKeysByLogical(desired.resources),
               constructPathByLogical: constructPathsByLogical(desired.resources),
+              physicalIdByLogical: physicalIdsByLogical(desired.resources),
               warn: (s: string) => {
                 if (!a.json) console.error(s);
               },

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -12,10 +12,13 @@
 import { isCancel, select } from '@clack/prompts';
 import {
   applyBaseline,
+  type ApplyBaselineOptions,
   type BaselineFile,
   buildRecorded,
+  constructPathsByLogical,
   declaredKeysByLogical,
   loadBaseline,
+  physicalIdsByLogical,
   recordedKey,
 } from '../baseline/baseline-file.js';
 import { applyIgnores, type CdkrdConfig, loadConfig } from '../config/config-file.js';
@@ -106,6 +109,16 @@ const pickerLabel = (f: Finding): string =>
     f.attributeKey !== undefined ? `[${f.attributeKey}]` : ''
   }  (${tierTag(f)})`;
 
+// declared/constructPath/physicalId maps for applyBaseline. The physicalId + the
+// constructPath are what a synthesized "baseline value removed since record" finding
+// needs (physicalId so a later in-menu revert can act on it, constructPath so an
+// ignore rule matches); shared so every re-reconciliation here matches stack-actions.
+const baselineOpts = (p: ResolveParams): ApplyBaselineOptions => ({
+  declaredByLogical: declaredKeysByLogical(p.desired.resources),
+  constructPathByLogical: constructPathsByLogical(p.desired.resources),
+  physicalIdByLogical: physicalIdsByLogical(p.desired.resources),
+});
+
 /**
  * Re-evaluate check's exit WITHOUT re-reading AWS: reload the (possibly just-written)
  * baseline + config and re-apply them to the original gather findings. Declared/deleted
@@ -117,9 +130,7 @@ async function recomputeExit(p: ResolveParams, resolvedKeys: Set<string>): Promi
   const nb = await loadBaseline(p.stackName, p.desired.accountId, p.region);
   const nc = await loadConfig();
   const reEval = applyIgnores(
-    applyBaseline(p.findings, nb, {
-      declaredByLogical: declaredKeysByLogical(p.desired.resources),
-    }),
+    applyBaseline(p.findings, nb, baselineOpts(p)),
     p.stackName,
     p.region,
     nc
@@ -199,7 +210,7 @@ export function resolveMenuMessage(stackName: string, code: number, establishOnl
 }
 
 export async function resolveInteractively(p: ResolveParams): Promise<number> {
-  const declaredByLogical = declaredKeysByLogical(p.desired.resources);
+  const opts = baselineOpts(p);
   // Whether undeclared REMOVE ops belong in a revert plan — true in a gated TTY prompt.
   const includeRemovals = includeUnrecordedRemovals(p.removeUnrecorded, true, p.yes);
   // Chain state: a record/ignore mutates only local files, so after one runs we reload
@@ -249,7 +260,7 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
     baseline = await loadBaseline(p.stackName, p.desired.accountId, p.region);
     config = await loadConfig();
     reconciled = applyIgnores(
-      applyBaseline(p.findings, baseline, { declaredByLogical }),
+      applyBaseline(p.findings, baseline, opts),
       p.stackName,
       p.region,
       config
@@ -277,9 +288,7 @@ async function recordAll(p: ResolveParams): Promise<SubResult | null> {
   // deleted drift is outside record's reach and keeps exit 1. Say what remains plainly.
   const nb = await loadBaseline(p.stackName, p.desired.accountId, p.region);
   const reEval = applyIgnores(
-    applyBaseline(p.findings, nb, {
-      declaredByLogical: declaredKeysByLogical(p.desired.resources),
-    }),
+    applyBaseline(p.findings, nb, baselineOpts(p)),
     p.stackName,
     p.region,
     p.config

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -10,8 +10,10 @@ import {
   type BaselineFile,
   buildRecorded,
   carryForwardUnreadable,
+  constructPathsByLogical,
   declaredKeysByLogical,
   loadBaseline,
+  physicalIdsByLogical,
   selectRecorded,
   splitRecordedByBaseline,
   writeBaseline,
@@ -578,8 +580,15 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // it still requires the explicit flag.
   const includeRemovals = includeUnrecordedRemovals(removeUnrecorded, interactive, yes);
   const declaredByLogical = declaredKeysByLogical(gathered.desired.resources);
+  // physicalId + constructPath maps so a synthesized "baseline value removed since
+  // record" finding carries them — physicalId lets `revert` actually restore the
+  // removed value (else buildRevertPlan rejects it "no physical id"); constructPath
+  // lets a constructPath-form ignore rule match it during applyIgnores.
+  const physicalIdByLogical = physicalIdsByLogical(gathered.desired.resources);
+  const constructPathByLogical = constructPathsByLogical(gathered.desired.resources);
+  const baselineOpts = { declaredByLogical, physicalIdByLogical, constructPathByLogical };
   const drifted = applyIgnores(
-    applyBaseline(gathered.findings, baseline, { declaredByLogical, warn: console.error }),
+    applyBaseline(gathered.findings, baseline, { ...baselineOpts, warn: console.error }),
     stackName,
     region,
     config
@@ -727,12 +736,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     '\n' + style.infoTier(`verifying convergence (re-reading ${touched.size} resource(s))...`)
   );
   const reconcile = (findings: Finding[]): Finding[] =>
-    applyIgnores(
-      applyBaseline(findings, baseline, { declaredByLogical }),
-      stackName,
-      region,
-      config
-    );
+    applyIgnores(applyBaseline(findings, baseline, baselineOpts), stackName, region, config);
   // regatherTouched drops every `touched` finding (including the synthesized-id `added`
   // deletes) and re-reads only template resources — so a FAILED delete's finding is gone
   // from `post` though the resource still lives. Re-add the failed ones so convergence

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -11,6 +11,7 @@ import {
   buildRecorded,
   carryForwardUnreadable,
   constructPathsByLogical,
+  physicalIdsByLogical,
   formatPromotedStaleNote,
   identityArrayDelta,
   checkBaselineAccount,
@@ -729,6 +730,36 @@ describe('baseline', () => {
       { logicalId: 'B' }, // no construct path
     ]);
     expect(m.get('A')).toBe('MyStack/A');
+    expect(m.has('B')).toBe(false);
+  });
+
+  it('restores physicalId onto the removed-since-record finding (so revert can act on it)', () => {
+    // Without physicalId the synthesized finding reaches buildRevertPlan with no id and
+    // is rejected "no physical id" — making a removed recorded value un-revertable.
+    const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+    const out = applyBaseline([], b, {
+      physicalIdByLogical: new Map([['A', 'phys-A']]),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      path: 'P',
+      physicalId: 'phys-A',
+      note: 'baseline value removed since record',
+    });
+  });
+
+  it('omits physicalId when the resource has no map entry', () => {
+    const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+    const out = applyBaseline([], b, { physicalIdByLogical: new Map() });
+    expect(out[0]!.physicalId).toBeUndefined();
+  });
+
+  it('physicalIdsByLogical maps only resources that resolved a physical id', () => {
+    const m = physicalIdsByLogical([
+      { logicalId: 'A', physicalId: 'phys-A' },
+      { logicalId: 'B' }, // no physical id
+    ]);
+    expect(m.get('A')).toBe('phys-A');
     expect(m.has('B')).toBe(false);
   });
 

--- a/tests/integration/revert-removed-since-record/app.ts
+++ b/tests/integration/revert-removed-since-record/app.ts
@@ -1,0 +1,16 @@
+// CDK app for the cdk-real-drift "revert a removed-since-record value" integration
+// test (real AWS, AWS-mutating). A minimal S3 bucket with NO declared tags: verify.sh
+// sets an undeclared bucket tag out of band, records it, then deletes it out of band
+// and reverts — proving a recorded UNDECLARED value that disappears can be RESTORED by
+// `revert` (it previously failed with "no physical id": the synthesized
+// removed-since-record finding carried no physical id). The bucket stays empty so
+// destroy needs no autoDeleteObjects custom resource (no /aws/lambda log-group orphan).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRevertRemoved");
+
+new Bucket(stack, "Data", { removalPolicy: RemovalPolicy.DESTROY });
+
+app.synth();

--- a/tests/integration/revert-removed-since-record/cdk.json
+++ b/tests/integration/revert-removed-since-record/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/revert-removed-since-record/package.json
+++ b/tests/integration/revert-removed-since-record/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-revert-removed-since-record",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift removed-since-record revert integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/revert-removed-since-record/verify.sh
+++ b/tests/integration/revert-removed-since-record/verify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# cdkrd REMOVED-SINCE-RECORD REVERT integration test (real AWS, AWS-mutating).
+# Proves a recorded UNDECLARED value that DISAPPEARS out of band can be RESTORED by
+# `revert` — previously it failed with "no physical id" (the synthesized
+# "baseline value removed since record" finding carried no physical id).
+# Flow: deploy an S3 bucket (no website config declared) -> set an undeclared
+# WebsiteConfiguration out of band -> record (baseline now has it) -> check CLEAN ->
+# DELETE the website config out of band -> check DETECTS "baseline value removed since
+# record" (exit 1) -> revert --yes (re-adds it) -> check CLEAN -> direct AWS read
+# confirms the website config is back -> destroy.
+# Self-cleaning trap; no orphans on failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRevertRemoved
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp pack) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+BUCKET="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)"
+[ -n "$BUCKET" ] || fail "could not resolve bucket name"
+
+echo "=== set an undeclared WebsiteConfiguration out of band ==="
+aws s3api put-bucket-website --bucket "$BUCKET" --region "$REGION" \
+  --website-configuration '{"IndexDocument":{"Suffix":"index.html"}}' || fail "put-bucket-website"
+sleep 5
+
+echo "=== record (baseline captures the undeclared website config) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail record
+
+echo "=== check CLEAN (the website config is now recorded) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-rr-clean.out
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected CLEAN after record"
+
+echo "=== DELETE the website config out of band ==="
+aws s3api delete-bucket-website --bucket "$BUCKET" --region "$REGION" || fail "delete-bucket-website"
+sleep 5
+
+echo "=== check DETECTS the removed-since-record value (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-rr-pre.out
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1 after website-config removal"
+grep -q "removed since record" /tmp/cdkrd-rr-pre.out || fail "removed-since-record not reported"
+
+echo "=== revert --yes (must restore the config — NOT 'no physical id') ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-rr-revert.out || fail "revert returned non-zero"
+grep -qi "no physical id" /tmp/cdkrd-rr-revert.out && fail "revert still says 'no physical id' (the bug)"
+sleep 5
+
+echo "=== check CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "drift remains after revert"
+
+echo "=== belt-and-suspenders: the website config is back on the bucket ==="
+SUFFIX="$(aws s3api get-bucket-website --bucket "$BUCKET" --region "$REGION" \
+  --query 'IndexDocument.Suffix' --output text 2>/dev/null)"
+echo "live IndexDocument.Suffix: '$SUFFIX'"
+[ "$SUFFIX" = "index.html" ] || fail "website config not restored by revert (got '$SUFFIX')"
+
+echo "INTEG PASS (CdkRealDriftIntegRevertRemoved removed-since-record revert restores the value)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -188,6 +188,41 @@ describe('buildRevertPlan', () => {
     expect(plan.notRevertable).toHaveLength(0);
   });
 
+  it('a removed-since-record undeclared finding WITH a physical id is revertable (re-adds the value)', () => {
+    // applyBaseline now stamps the synthesized "baseline value removed since record"
+    // finding with the live physical id, so revert can restore the value it carries.
+    const f = F({
+      tier: 'undeclared',
+      path: 'AccelerateConfiguration',
+      desired: { AccelerationStatus: 'Enabled' },
+      actual: undefined,
+      note: 'baseline value removed since record',
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AccelerateConfiguration',
+      value: { AccelerationStatus: 'Enabled' },
+    });
+  });
+
+  it('the SAME finding WITHOUT a physical id is notRevertable ("no physical id") — the bug this fixes', () => {
+    const f = F({
+      tier: 'undeclared',
+      physicalId: undefined,
+      path: 'AccelerateConfiguration',
+      desired: { AccelerationStatus: 'Enabled' },
+      actual: undefined,
+      note: 'baseline value removed since record',
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(0);
+    expect(plan.notRevertable).toHaveLength(1);
+    expect(plan.notRevertable[0]!.reason).toContain('no physical id');
+  });
+
   it('a read-override type that is CC-mutable (Scheduler::Schedule) IS revertable via CC', () => {
     // Found live by the scheduler-rich bug-hunt fixture: AWS::Scheduler::Schedule has an
     // SDK READ override (its CC read handler only looks in the default group) but is CC


### PR DESCRIPTION
## Problem

When a recorded **undeclared** value disappears out of band, `applyBaseline` synthesizes a **"baseline value removed since record"** finding. Unlike a LIVE finding (which `classifyResource` stamps with `resource.physicalId`), this one is synthesized from a `RecordedEntry` — which stores **no physical id** — so it reached `buildRevertPlan` with no `physicalId` and was rejected **"no physical id"**.

Result: a recorded value the user chose to keep could be **detected** as removed but **not restored** by `revert` — a real revert false-negative. Observed live in the prior PR's work: an IAM ManagedPolicy's *in-stack* role detached out of band → the role-side `ManagedPolicyArns` removed-since-record finding was un-revertable.

## Fix

Plumb the live physical id onto the synthesized finding, mirroring the existing `constructPathByLogical` plumbing:

- `baseline-file.ts` — `ApplyBaselineOptions.physicalIdByLogical` + set `physicalId` on the synthesized finding; new `physicalIdsByLogical(resources)` helper.
- `stack-actions.ts` (`revertStack` + the post-revert convergence reconcile), `check.ts`, `interactive-resolve.ts` — pass `physicalIdByLogical` (+ `constructPath` on the revert path so a constructPath-form ignore rule also matches the removed finding there). This covers the standalone `revert`, the in-menu **Revert all** (routes through `revertStack`), and the menu's revert-availability (`canResolve`).

## Tests

- **baseline unit**: physicalId restored onto the removed finding / omitted with no map entry / `physicalIdsByLogical` maps only resources that resolved an id.
- **revert-plan unit**: a removed-since-record undeclared finding **WITH** a physical id is revertable (re-adds the value); the **SAME** finding **WITHOUT** one is `notRevertable` "no physical id" (pins the bug).
- **live real-AWS integ** (`revert-removed-since-record`): deploy an S3 bucket → set an undeclared `WebsiteConfiguration` out of band → `record` → delete it out of band → `check` detects **"baseline value removed since record"** → `revert` **restores** it (NOT "no physical id") → `check` CLEAN → AWS read confirms the config is back. **INTEG PASS**.

All 1405 unit tests pass; typecheck / lint+format clean. Stack torn down, sweep CLEAN.
