### PR TITLE
fix: read declared API Gateway REST + HTTP API authorizers (CC composite read-gap)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -52,6 +52,17 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   'AWS::ApiGatewayV2::Stage': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Route': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Integration': compositeWith('ApiId'),
+  // ApiGatewayV2::Authorizer primaryIdentifier is [AuthorizerId, ApiId] — CHILD
+  // first, the REVERSE of its v2 siblings (Stage/Route/Integration are [ApiId,
+  // <child>] parent-first). The CFn physical id is the bare AuthorizerId; ApiId comes
+  // from the resolved declared Ref. Verified live (httpapi-authorizer-rich): the bare
+  // id ValidationException-skips until paired as `AuthorizerId|ApiId`. Child-first like
+  // ECS Service, so not `compositeWith` (that is parent-first).
+  'AWS::ApiGatewayV2::Authorizer': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const apiId = declared.ApiId;
+    return typeof apiId === 'string' && apiId.length > 0 ? `${pid}|${apiId}` : undefined;
+  },
   'AWS::AppConfig::Environment': compositeWith('ApplicationId'),
   'AWS::AppConfig::ConfigurationProfile': compositeWith('ApplicationId'),
   // ApiGateway v1 (REST) parent-first composites `[RestApiId, <child>]` and Cognito
@@ -66,6 +77,11 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   'AWS::ApiGateway::RequestValidator': compositeWith('RestApiId'),
   'AWS::ApiGateway::Resource': compositeWith('RestApiId'),
   'AWS::ApiGateway::Stage': compositeWith('RestApiId'),
+  // Authorizer primaryIdentifier is [RestApiId, AuthorizerId] — parent-first like the
+  // rest of the v1 family. The CFn physical id is the bare AuthorizerId; without this
+  // a DECLARED Lambda/Cognito authorizer ValidationException-skips (read-gap). Verified
+  // live (restapi-authorizer-rich).
+  'AWS::ApiGateway::Authorizer': compositeWith('RestApiId'),
   'AWS::Cognito::UserPoolDomain': compositeWith('UserPoolId'),
   'AWS::Cognito::UserPoolResourceServer': compositeWith('UserPoolId'),
   // ApiGateway::Deployment is the odd one out: its primaryIdentifier is

--- a/tests/corpus/AWS__ApiGatewayV2__Authorizer.Authorizer.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Authorizer.Authorizer.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Authorizer",
+    "resourceType": "AWS::ApiGatewayV2::Authorizer",
+    "physicalId": "i4ca08",
+    "constructPath": "CdkRealDriftIntegHttpApiAuthorizerRich/Authorizer",
+    "declared": {
+      "ApiId": "totpua68e1",
+      "AuthorizerType": "JWT",
+      "IdentitySource": ["$request.header.Authorization"],
+      "JwtConfiguration": {
+        "Audience": ["cdkrd-audience"],
+        "Issuer": "https://accounts.google.com"
+      },
+      "Name": "cdkrd-jwt-auth"
+    }
+  },
+  "liveRaw": {
+    "AuthorizerType": "JWT",
+    "JwtConfiguration": {
+      "Issuer": "https://accounts.google.com",
+      "Audience": ["cdkrd-audience"]
+    },
+    "AuthorizerId": "i4ca08",
+    "IdentitySource": ["$request.header.Authorization"],
+    "ApiId": "totpua68e1",
+    "Name": "cdkrd-jwt-auth"
+  },
+  "schema": {
+    "readOnly": ["AuthorizerId"],
+    "writeOnly": [
+      "AuthorizerCredentialsArn",
+      "AuthorizerPayloadFormatVersion",
+      "AuthorizerResultTtlInSeconds",
+      "AuthorizerUri",
+      "EnableSimpleResponses"
+    ],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["AuthorizerId"],
+    "writeOnlyPaths": [
+      "AuthorizerCredentialsArn",
+      "AuthorizerPayloadFormatVersion",
+      "AuthorizerResultTtlInSeconds",
+      "AuthorizerUri",
+      "EnableSimpleResponses"
+    ],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGateway__Authorizer.AuthorizerBD825682.json
+++ b/tests/corpus/AWS__ApiGateway__Authorizer.AuthorizerBD825682.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AuthorizerBD825682",
+    "resourceType": "AWS::ApiGateway::Authorizer",
+    "physicalId": "hne9qm",
+    "constructPath": "CdkRealDriftIntegRestApiAuthorizerRich/Authorizer",
+    "declared": {
+      "AuthorizerResultTtlInSeconds": 300,
+      "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegRestApiAuthorizerR-AuthFnE7829713-magW45Sajha5/invocations",
+      "IdentitySource": "method.request.header.Authorization",
+      "Name": "CdkRealDriftIntegRestApiAuthorizerRichAuthorizerA82D1513",
+      "RestApiId": "p2w35ndg13",
+      "Type": "TOKEN"
+    }
+  },
+  "liveRaw": {
+    "ProviderARNs": [],
+    "Type": "TOKEN",
+    "AuthorizerUri": "arn:aws:apigateway:us-east-1:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegRestApiAuthorizerR-AuthFnE7829713-magW45Sajha5/invocations",
+    "AuthorizerId": "hne9qm",
+    "AuthorizerResultTtlInSeconds": 300,
+    "RestApiId": "p2w35ndg13",
+    "IdentitySource": "method.request.header.Authorization",
+    "AuthType": "custom",
+    "Name": "CdkRealDriftIntegRestApiAuthorizerRichAuthorizerA82D1513"
+  },
+  "schema": {
+    "readOnly": ["AuthorizerId"],
+    "writeOnly": [],
+    "createOnly": ["RestApiId"],
+    "readOnlyPaths": ["AuthorizerId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RestApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "AuthorizerBD825682",
+      "resourceType": "AWS::ApiGateway::Authorizer",
+      "path": "AuthType",
+      "actual": "custom",
+      "physicalId": "hne9qm",
+      "constructPath": "CdkRealDriftIntegRestApiAuthorizerRich/Authorizer"
+    }
+  ]
+}

--- a/tests/integration/httpapi-authorizer-rich/app.ts
+++ b/tests/integration/httpapi-authorizer-rich/app.ts
@@ -1,0 +1,32 @@
+// CDK app for the cdk-real-drift HTTP API (v2) JWT-authorizer false-positive +
+// read-gap test. A JWT authorizer on an HTTP API is a very common auth pattern, but
+// a DECLARED AWS::ApiGatewayV2::Authorizer has never been read via the normal CC
+// path. Its CC primaryIdentifier is the composite [AuthorizerId, ApiId] — CHILD
+// first, the REVERSE of the REST authorizer's [RestApiId, AuthorizerId] — while the
+// CFn physical id is the bare AuthorizerId, so without a CC_IDENTIFIER_ADAPTERS entry
+// it is silently `skipped`. The authorizer also carries an IdentitySource array and a
+// nested JwtConfiguration (Issuer + Audience array). A freshly deployed + recorded API
+// with NO out-of-band change MUST report CLEAN — and the Authorizer MUST be read
+// (skipped=0).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAuthorizer, HttpApi } from "aws-cdk-lib/aws-apigatewayv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegHttpApiAuthorizerRich");
+
+const api = new HttpApi(stack, "Api");
+
+new CfnAuthorizer(stack, "Authorizer", {
+  apiId: api.apiId,
+  authorizerType: "JWT",
+  name: "cdkrd-jwt-auth",
+  identitySource: ["$request.header.Authorization"],
+  jwtConfiguration: {
+    // A real OIDC issuer is required: API Gateway validates the issuer's
+    // /.well-known/openid-configuration discovery endpoint at create time.
+    issuer: "https://accounts.google.com",
+    audience: ["cdkrd-audience"],
+  },
+});
+
+app.synth();

--- a/tests/integration/httpapi-authorizer-rich/cdk.json
+++ b/tests/integration/httpapi-authorizer-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/httpapi-authorizer-rich/package.json
+++ b/tests/integration/httpapi-authorizer-rich/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-httpapi-authorizer-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift httpapi-authorizer-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/httpapi-authorizer-rich/verify.sh
+++ b/tests/integration/httpapi-authorizer-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegHttpApiAuthorizerRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-httpapi-authorizer-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/restapi-authorizer-rich/app.ts
+++ b/tests/integration/restapi-authorizer-rich/app.ts
@@ -1,0 +1,48 @@
+// CDK app for the cdk-real-drift REST API Lambda-authorizer false-positive +
+// read-gap test. A Lambda (custom) authorizer on a REST API is a very common auth
+// pattern, but a DECLARED AWS::ApiGateway::Authorizer has never been read via the
+// normal CC path (the existing restapi-authorizer-added fixture exercises only the
+// out-of-band `added`-tier enumerator). Its CC primaryIdentifier is the composite
+// [RestApiId, AuthorizerId] while the CFn physical id is the bare AuthorizerId, so
+// without a CC_IDENTIFIER_ADAPTERS entry it is silently `skipped`. A freshly deployed
+// + recorded API with NO out-of-band change MUST report CLEAN — and the Authorizer
+// MUST be read (skipped=0).
+import { App, Duration, Stack } from "aws-cdk-lib";
+import {
+  MockIntegration,
+  PassthroughBehavior,
+  RestApi,
+  TokenAuthorizer,
+} from "aws-cdk-lib/aws-apigateway";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRestApiAuthorizerRich");
+
+const authFn = new Function(stack, "AuthFn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline(
+    "exports.handler = async () => ({ principalId: 'u', policyDocument: {} });"
+  ),
+});
+
+const api = new RestApi(stack, "Api");
+
+const authorizer = new TokenAuthorizer(stack, "Authorizer", {
+  handler: authFn,
+  identitySource: "method.request.header.Authorization",
+  resultsCacheTtl: Duration.minutes(5),
+});
+
+api.root.addMethod(
+  "GET",
+  new MockIntegration({
+    integrationResponses: [{ statusCode: "200" }],
+    passthroughBehavior: PassthroughBehavior.NEVER,
+    requestTemplates: { "application/json": '{"statusCode": 200}' },
+  }),
+  { authorizer, methodResponses: [{ statusCode: "200" }] }
+);
+
+app.synth();

--- a/tests/integration/restapi-authorizer-rich/cdk.json
+++ b/tests/integration/restapi-authorizer-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/restapi-authorizer-rich/package.json
+++ b/tests/integration/restapi-authorizer-rich/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-restapi-authorizer-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift restapi-authorizer-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/restapi-authorizer-rich/verify-detect.sh
+++ b/tests/integration/restapi-authorizer-rich/verify-detect.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# REST API Authorizer detect + revert integration test (real AWS): the "someone
+# changed it in the console" scenario, which also exercises the new composite
+# RestApiId|AuthorizerId CC identifier read path end to end. Deploy -> record ->
+# change AuthorizerResultTtlInSeconds out of band (a declared, MUTABLE property) ->
+# check MUST DETECT the declared drift (exit 1) -> revert -> check MUST be CLEAN and
+# the live TTL MUST be restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRestApiAuthorizerRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+API="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::ApiGateway::RestApi'].PhysicalResourceId" --output text)"
+AUTH="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::ApiGateway::Authorizer'].PhysicalResourceId" --output text)"
+[ -n "$API" ] && [ -n "$AUTH" ] || fail "could not resolve api/authorizer id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: change AuthorizerResultTtlInSeconds 300 -> 60 (console-edit) ==="
+aws apigateway update-authorizer --rest-api-id "$API" --authorizer-id "$AUTH" --region "$REGION" \
+  --patch-operations op=replace,path=/authorizerResultTtlInSeconds,value=60 >/dev/null \
+  || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-restauth-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "AuthorizerResultTtlInSeconds" /tmp/cdkrd-restauth-detect.out || fail "TTL drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live TTL MUST be restored ==="
+GOT="$(aws apigateway get-authorizer --rest-api-id "$API" --authorizer-id "$AUTH" --region "$REGION" \
+  --query "authorizerResultTtlInSeconds" --output text)"
+[ "$GOT" = "300" ] || fail "live TTL not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/restapi-authorizer-rich/verify.sh
+++ b/tests/integration/restapi-authorizer-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRestApiAuthorizerRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-restapi-authorizer-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -198,6 +198,32 @@ describe('readLive (CC identifier adapters, R74)', () => {
     });
   }
 
+  it('ApiGatewayV2 Authorizer: builds the AuthorizerId|ApiId composite — CHILD first (reverse of its siblings)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::Authorizer',
+        physicalId: 'auth123',
+        declared: { ApiId: 'api456' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('auth123|api456');
+  });
+
+  it('ApiGatewayV2 Authorizer: an unresolved ApiId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::ApiGatewayV2::Authorizer', physicalId: 'auth123', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('auth123');
+  });
+
   it('ApiGatewayV2 Stage: an unresolved ApiId falls back to the raw physical id', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(
@@ -232,6 +258,7 @@ describe('readLive (CC identifier adapters, R74)', () => {
     'AWS::ApiGateway::RequestValidator',
     'AWS::ApiGateway::Resource',
     'AWS::ApiGateway::Stage',
+    'AWS::ApiGateway::Authorizer',
   ]) {
     it(`${t}: builds the RestApiId|<child> composite identifier`, async () => {
       cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });


### PR DESCRIPTION
## What

A /hunt-bugs round on declared API Gateway authorizers — a very common, security-relevant auth pattern. Two read-gaps found live on real AWS.

### 1. AWS::ApiGateway::Authorizer (REST) was silently `skipped`
Its CC primaryIdentifier is the composite `[RestApiId, AuthorizerId]`, but the CFn physical id is the bare `AuthorizerId`, so CC `GetResource` returned a `ValidationException` and the authorizer was never read (the existing `restapi-authorizer-added` fixture only exercised the out-of-band `added`-tier enumerator). Added the parent-first `compositeWith('RestApiId')` adapter the rest of the v1 family already uses.

### 2. AWS::ApiGatewayV2::Authorizer (HTTP API) was silently `skipped`
Its primaryIdentifier is `[AuthorizerId, ApiId]` — **CHILD-first**, the reverse of its v2 Stage/Route/Integration siblings (which are `[ApiId, <child>]` parent-first). Added a child-first adapter (`AuthorizerId|ApiId`), like ECS Service / ApiGateway Deployment. Both orders verified live: the bare id skipped until paired, then both fixtures read CLEAN with `skipped=0`.

A declared authorizer is security-relevant and invisible to `cdk`/CFn drift, so reading it closes a real coverage gap — its `IdentitySource`, `AuthorizerUri` / `JwtConfiguration`, and result TTL are now watched.

## Verification
- Router unit tests for both adapters, each **confirmed to fail without the fix** (REST parent-first; V2 child-first).
- Golden-corpus cases harvested from the live reads (ApiGateway Authorizer, ApiGatewayV2 Authorizer) — `corpus-replay` now 345 cases.
- Live-proven end to end: both CLEAN with `skipped=0`, plus a `detect -> revert -> CLEAN` cycle on the REST authorizer's `AuthorizerResultTtlInSeconds` (exercises the new composite-id **read and revert**).
- All bug-hunt stacks deleted; `bughunt-track.sh verify` + `sweep-orphans.sh` -> SWEEP CLEAN.

## Test plan
- `vp run typecheck` / `vp check` / `vp run build` / `vp run test` (40 files, 1417 tests) all green.
