### PR TITLE
fix: ELBv2 ListenerRule Conditions reorder FP + AutoScaling LifecycleHook read-gap

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -830,6 +830,15 @@ export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
 // canonical JSON before the positional diff — a genuine rule change still differs.
 export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   'AWS::EC2::SecurityGroup': new Set(['SecurityGroupIngress', 'SecurityGroupEgress']),
+  // ListenerRule `Conditions` is a SET keyed by Field (path-pattern / host-header /
+  // http-header / …) that AWS returns REORDERED relative to the template, so a
+  // positional compare false-flags every condition. Sorting both sides by canonical
+  // JSON aligns them by Field (the first sorted key), and a genuine condition change
+  // still differs. (`Actions` is NOT listed — its element Order is semantic.) The live
+  // model also adds a legacy top-level `Values` mirror to each condition; that is
+  // handled separately as undeclared nested inventory (subset descent walks only the
+  // declared *Config keys). Observed live on a fresh elbv2-listenerrule-rich deploy.
+  'AWS::ElasticLoadBalancingV2::ListenerRule': new Set(['Conditions']),
 };
 
 // Per-type NESTED object-array paths AWS returns reordered (dotted from the resource

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -84,6 +84,12 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   'AWS::ApiGateway::Authorizer': compositeWith('RestApiId'),
   'AWS::Cognito::UserPoolDomain': compositeWith('UserPoolId'),
   'AWS::Cognito::UserPoolResourceServer': compositeWith('UserPoolId'),
+  // AutoScaling LifecycleHook primaryIdentifier is [AutoScalingGroupName,
+  // LifecycleHookName] — parent-first. The CFn physical id is the bare
+  // LifecycleHookName; the ASG name comes from the resolved declared Ref. Without this
+  // a declared hook ValidationException-skips (read-gap). Verified live
+  // (autoscaling-lifecyclehook-rich).
+  'AWS::AutoScaling::LifecycleHook': compositeWith('AutoScalingGroupName'),
   // ApiGateway::Deployment is the odd one out: its primaryIdentifier is
   // `[DeploymentId, RestApiId]` — CHILD first (verified live R129: `RestApiId|DeploymentId`
   // returns not-found; only `DeploymentId|RestApiId` reads). The CFn physical id is the

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1261,6 +1261,39 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('ELBv2 ListenerRule Conditions (reordered set, found by elbv2-listenerrule-rich)', () => {
+    const T = 'AWS::ElasticLoadBalancingV2::ListenerRule';
+    const declared = {
+      Conditions: [
+        { Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*', '/v2/*'] } },
+        { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+        { Field: 'http-header', HttpHeaderConfig: { HttpHeaderName: 'X-Custom', Values: ['a'] } },
+      ],
+    };
+
+    it('AWS returning the Conditions in a different order is NOT drift', () => {
+      const live = {
+        Conditions: [
+          { Field: 'http-header', HttpHeaderConfig: { HttpHeaderName: 'X-Custom', Values: ['a'] } },
+          { Field: 'path-pattern', PathPatternConfig: { Values: ['/api/*', '/v2/*'] } },
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine condition value change still surfaces (even when reordered)', () => {
+      const live = {
+        Conditions: [
+          { Field: 'http-header', HttpHeaderConfig: { HttpHeaderName: 'X-Custom', Values: ['a'] } },
+          { Field: 'path-pattern', PathPatternConfig: { Values: ['/changed/*', '/v2/*'] } },
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('Bedrock Guardrail nested policy-config arrays (reordered, found by bedrock-guardrail-rich)', () => {
     const T = 'AWS::Bedrock::Guardrail';
     const declared = {

--- a/tests/corpus/AWS__AutoScaling__LifecycleHook.Hook.json
+++ b/tests/corpus/AWS__AutoScaling__LifecycleHook.Hook.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Hook",
+    "resourceType": "AWS::AutoScaling::LifecycleHook",
+    "physicalId": "cdkrd-launch-hook",
+    "constructPath": "CdkRealDriftIntegAutoScalingLifecycleHookRich/Hook",
+    "declared": {
+      "AutoScalingGroupName": "CdkRealDriftIntegAutoScalingLifecycleHookRich-AsgASGD1D7B4E2-JOfZ142k6UON",
+      "DefaultResult": "CONTINUE",
+      "HeartbeatTimeout": 300,
+      "LifecycleHookName": "cdkrd-launch-hook",
+      "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING"
+    }
+  },
+  "liveRaw": {
+    "LifecycleHookName": "cdkrd-launch-hook",
+    "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING",
+    "AutoScalingGroupName": "CdkRealDriftIntegAutoScalingLifecycleHookRich-AsgASGD1D7B4E2-JOfZ142k6UON",
+    "HeartbeatTimeout": 300,
+    "DefaultResult": "CONTINUE"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["AutoScalingGroupName", "LifecycleHookName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AutoScalingGroupName", "LifecycleHookName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.json
@@ -1,0 +1,111 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule4C995B7F",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-ZOGq8SCU7OMY/ae1fe96c6ac55de6/7a6edcf8edb8f8b6/f7898cec75295d48",
+    "constructPath": "CdkRealDriftIntegElbv2ListenerRuleRich/Rule",
+    "declared": {
+      "Actions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "MessageBody": "ok",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "path-pattern",
+          "PathPatternConfig": {
+            "Values": ["/api/*", "/v2/*"]
+          }
+        },
+        {
+          "Field": "host-header",
+          "HostHeaderConfig": {
+            "Values": ["example.com", "www.example.com"]
+          }
+        },
+        {
+          "Field": "http-header",
+          "HttpHeaderConfig": {
+            "HttpHeaderName": "X-Custom",
+            "Values": ["a"]
+          }
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkRea-Alb16-ZOGq8SCU7OMY/ae1fe96c6ac55de6/7a6edcf8edb8f8b6",
+      "Priority": 10
+    }
+  },
+  "liveRaw": {
+    "IsDefault": false,
+    "Actions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200",
+          "MessageBody": "ok"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Priority": 10,
+    "RuleArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-ZOGq8SCU7OMY/ae1fe96c6ac55de6/7a6edcf8edb8f8b6/f7898cec75295d48",
+    "Transforms": [],
+    "Conditions": [
+      {
+        "Field": "path-pattern",
+        "Values": ["/api/*", "/v2/*"],
+        "PathPatternConfig": {
+          "Values": ["/api/*", "/v2/*"]
+        }
+      },
+      {
+        "Field": "http-header",
+        "HttpHeaderConfig": {
+          "Values": ["a"],
+          "HttpHeaderName": "X-Custom"
+        },
+        "Values": []
+      },
+      {
+        "Field": "host-header",
+        "Values": ["example.com", "www.example.com"],
+        "HostHeaderConfig": {
+          "Values": ["example.com", "www.example.com"]
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["IsDefault", "RuleArn"],
+    "writeOnly": ["ListenerArn"],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["IsDefault", "RuleArn"],
+    "writeOnlyPaths": ["Actions.*.AuthenticateOidcConfig.ClientSecret", "ListenerArn"],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Rule4C995B7F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "path": "ListenerArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-ZOGq8SCU7OMY/ae1fe96c6ac55de6/7a6edcf8edb8f8b6/f7898cec75295d48",
+      "constructPath": "CdkRealDriftIntegElbv2ListenerRuleRich/Rule"
+    }
+  ]
+}

--- a/tests/integration/autoscaling-lifecyclehook-rich/app.ts
+++ b/tests/integration/autoscaling-lifecyclehook-rich/app.ts
@@ -1,0 +1,54 @@
+// CDK app for the cdk-real-drift Auto Scaling lifecycle-hook false-positive +
+// read-gap test. A lifecycle hook on an Auto Scaling group is a common pattern
+// (drain/bootstrap on launch/terminate), but a DECLARED AWS::AutoScaling::
+// LifecycleHook has never been read via the normal CC path. Its CC primaryIdentifier
+// is the composite [AutoScalingGroupName, LifecycleHookName] while the CFn physical
+// id is the bare LifecycleHookName, so without a CC_IDENTIFIER_ADAPTERS entry it is
+// silently `skipped`. The ASG is sized to zero instances (nothing launches). A
+// freshly deployed + recorded stack with NO out-of-band change MUST report CLEAN —
+// and the hook MUST be read (skipped=0).
+import { App, Stack } from "aws-cdk-lib";
+import { AutoScalingGroup, CfnLifecycleHook } from "aws-cdk-lib/aws-autoscaling";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  LaunchTemplate,
+  MachineImage,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAutoScalingLifecycleHookRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+// Launch CONFIGURATIONS are no longer creatable in new accounts; the ASG must use a
+// launch template.
+const launchTemplate = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023(),
+});
+
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  launchTemplate,
+  minCapacity: 0,
+  maxCapacity: 1,
+});
+
+new CfnLifecycleHook(stack, "Hook", {
+  autoScalingGroupName: asg.autoScalingGroupName,
+  lifecycleHookName: "cdkrd-launch-hook",
+  lifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING",
+  defaultResult: "CONTINUE",
+  heartbeatTimeout: 300,
+});
+
+app.synth();

--- a/tests/integration/autoscaling-lifecyclehook-rich/cdk.json
+++ b/tests/integration/autoscaling-lifecyclehook-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/autoscaling-lifecyclehook-rich/package.json
+++ b/tests/integration/autoscaling-lifecyclehook-rich/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-autoscaling-lifecyclehook-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift autoscaling-lifecyclehook-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/autoscaling-lifecyclehook-rich/verify-detect.sh
+++ b/tests/integration/autoscaling-lifecyclehook-rich/verify-detect.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# AutoScaling LifecycleHook detect + revert integration test (real AWS): the "someone
+# changed it in the console" scenario, which also exercises the new composite
+# AutoScalingGroupName|LifecycleHookName CC identifier read path end to end. Deploy ->
+# record -> change HeartbeatTimeout out of band (a declared, MUTABLE property) -> check
+# MUST DETECT the declared drift (exit 1) -> revert -> check MUST be CLEAN and the live
+# timeout MUST be restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAutoScalingLifecycleHookRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ASG="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::AutoScaling::AutoScalingGroup'].PhysicalResourceId" --output text)"
+[ -n "$ASG" ] || fail "could not resolve ASG name"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: change HeartbeatTimeout 300 -> 120 (console-edit) ==="
+aws autoscaling put-lifecycle-hook --auto-scaling-group-name "$ASG" --region "$REGION" \
+  --lifecycle-hook-name cdkrd-launch-hook \
+  --lifecycle-transition autoscaling:EC2_INSTANCE_LAUNCHING \
+  --heartbeat-timeout 120 >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-hook-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "HeartbeatTimeout" /tmp/cdkrd-hook-detect.out || fail "HeartbeatTimeout drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live HeartbeatTimeout MUST be restored ==="
+GOT="$(aws autoscaling describe-lifecycle-hooks --auto-scaling-group-name "$ASG" --region "$REGION" \
+  --query "LifecycleHooks[?LifecycleHookName=='cdkrd-launch-hook'].HeartbeatTimeout | [0]" --output text)"
+[ "$GOT" = "300" ] || fail "live HeartbeatTimeout not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/autoscaling-lifecyclehook-rich/verify.sh
+++ b/tests/integration/autoscaling-lifecyclehook-rich/verify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAutoScalingLifecycleHookRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] harvest corpus ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-autoscaling-lifecyclehook-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== [$STACK] record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elbv2-listenerrule-rich/app.ts
+++ b/tests/integration/elbv2-listenerrule-rich/app.ts
@@ -1,0 +1,47 @@
+// CDK app for the cdk-real-drift ALB listener-rule false-positive test. A declared
+// AWS::ElasticLoadBalancingV2::ListenerRule with multiple conditions is a very
+// common routing pattern, but only the out-of-band `added`-tier path has been
+// exercised (elbv2-listenerrule-added). Its CC primaryIdentifier is the single
+// RuleArn (read directly, no adapter), so the interesting surface is the nested
+// Conditions array — each condition carries its own values array (PathPatternConfig,
+// HostHeaderConfig, HttpHeaderConfig) that AWS may return reordered or enriched with
+// the legacy `Values` mirror. A freshly deployed + recorded rule with NO out-of-band
+// change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  ApplicationListenerRule,
+  ApplicationLoadBalancer,
+  ListenerAction,
+  ListenerCondition,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElbv2ListenerRuleRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const alb = new ApplicationLoadBalancer(stack, "Alb", { vpc, internetFacing: false });
+
+const listener = alb.addListener("Listener", {
+  port: 80,
+  defaultAction: ListenerAction.fixedResponse(404, { contentType: "text/plain", messageBody: "nf" }),
+});
+
+new ApplicationListenerRule(stack, "Rule", {
+  listener,
+  priority: 10,
+  // AWS caps a rule at 5 condition values total (across all conditions).
+  conditions: [
+    ListenerCondition.pathPatterns(["/api/*", "/v2/*"]),
+    ListenerCondition.hostHeaders(["example.com", "www.example.com"]),
+    ListenerCondition.httpHeader("X-Custom", ["a"]),
+  ],
+  action: ListenerAction.fixedResponse(200, { contentType: "text/plain", messageBody: "ok" }),
+});
+
+app.synth();

--- a/tests/integration/elbv2-listenerrule-rich/cdk.json
+++ b/tests/integration/elbv2-listenerrule-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elbv2-listenerrule-rich/package.json
+++ b/tests/integration/elbv2-listenerrule-rich/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-elbv2-listenerrule-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elbv2-listenerrule-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/elbv2-listenerrule-rich/verify.sh
+++ b/tests/integration/elbv2-listenerrule-rich/verify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElbv2ListenerRuleRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] harvest corpus ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-elbv2-listenerrule-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== [$STACK] record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -272,6 +272,21 @@ describe('readLive (CC identifier adapters, R74)', () => {
     });
   }
 
+  it('AutoScaling LifecycleHook: builds the AutoScalingGroupName|LifecycleHookName composite', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::AutoScaling::LifecycleHook',
+        physicalId: 'my-hook',
+        declared: { AutoScalingGroupName: 'my-asg' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('my-asg|my-hook');
+  });
+
   for (const t of [
     'AWS::Cognito::UserPoolDomain',
     'AWS::Cognito::UserPoolResourceServer',


### PR DESCRIPTION
## What

A /hunt-bugs round on two common, previously-unexercised declared resources. Two real bugs found live on real AWS.

### 1. False positive — ELBv2 ListenerRule `Conditions` reorder
A declared `AWS::ElasticLoadBalancingV2::ListenerRule` false-flagged **4 declared drifts** on `Conditions`: AWS returns the condition set **reordered** relative to the template (it's a set keyed by `Field`), and cdkrd compared the array positionally. Added `Conditions` to `UNORDERED_OBJECT_ARRAY_PROPS`, so both sides sort by canonical JSON (which aligns by `Field`, the first sorted key) before the positional diff; a genuine condition change still differs. `Actions` is deliberately **not** sorted (its element `Order` is semantic). The live model's legacy top-level `Values` mirror on each condition is handled separately as undeclared nested inventory (subset descent walks only the declared `*Config` keys).

### 2. Read-gap — AutoScaling LifecycleHook
`AWS::AutoScaling::LifecycleHook` was silently `skipped` (CC `ValidationException`): its primaryIdentifier is the composite `[AutoScalingGroupName, LifecycleHookName]` but the CFn physical id is the bare `LifecycleHookName`. Added the parent-first `compositeWith('AutoScalingGroupName')` adapter.

## Verification
- Unit tests for both fixes, each **confirmed to fail without the fix** (classify Conditions reorder; router LifecycleHook composite).
- Golden-corpus cases harvested from the live reads (AutoScaling LifecycleHook, ELBv2 ListenerRule) — `corpus-replay` now 347 cases.
- Live-proven: both CLEAN (ListenerRule FP gone; LifecycleHook `skipped=0`), plus a `detect -> revert -> CLEAN` cycle on the hook's `HeartbeatTimeout` (exercises the new composite-id **read and revert**).
- All bug-hunt stacks deleted; `bughunt-track.sh verify` + `sweep-orphans.sh` -> SWEEP CLEAN.

## Note
The fixtures also caught two CDK/AWS deploy constraints (fixed in the fixtures, not cdkrd): the ASG L2 must use a LaunchTemplate (LaunchConfigurations are no longer creatable in new accounts), and an ALB rule is capped at 5 condition values.

## Test plan
- `vp run typecheck` / `vp check` / `vp run build` / `vp run test` (40 files, 1422 tests) all green.
