### PR TITLE
feat(iam): surface unexpected ManagedPolicy attachments as undeclared inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,18 +558,25 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
 - **Lambda Permission:** if only the specific statement was removed out of band
   (while the function's policy still exists), it is reported as `skipped`, not
   `deleted` — identifying the exact statement would need its `StatementId`.
-- **IAM ManagedPolicy attachments:** `cdkrd` compares a managed policy's
-  `Roles`/`Users`/`Groups` **attachment** lists **asymmetrically**. A managed policy
-  is commonly attached from several places (the `AWS::IAM::ManagedPolicy`'s own
-  lists, a role's `ManagedPolicyArns`, a separate attachment resource, the console),
-  so the live attachment set is a **union** that legitimately exceeds any one stack's
-  intent. cdkrd therefore reports only a **declared attachment that is MISSING from
-  live** (an out-of-band **detach** — a privilege the stack intends was removed)
-  and **ignores** live-only members (the union). This catches the real removal
-  without the false drift a symmetric compare (e.g. `cdk drift`) raises on every
-  shared policy. A detach is revertable: `revert` re-attaches the declared member
-  (`AttachRolePolicy`/`AttachUserPolicy`/`AttachGroupPolicy`) without touching the
-  union members. The policy **document** (and Path/Description) is compared as usual.
+- **IAM ManagedPolicy attachments:** `cdkrd` tiers a managed policy's
+  `Roles`/`Users`/`Groups` **attachment** lists per member. A managed policy is
+  commonly attached from several places (its own lists, a role's
+  `ManagedPolicyArns`, a separate attachment resource, the console), so the live
+  set is a **union** that legitimately exceeds any one stack's intent — a
+  symmetric compare (e.g. `cdk drift`) false-drifts on every shared policy. So:
+  - a **declared** attachment **missing** from live is an out-of-band **detach**
+    — reported (a privilege the stack intends was removed) and **revertable**:
+    `revert` re-attaches that one member without touching the union;
+  - a **live-only** member (the union) is surfaced as an **undeclared** value,
+    not a false drift — `record` it to accept the current attachments, and a
+    **new, unexpected** attachment (e.g. a console grant to another principal)
+    then shows up as drift against the baseline (detection-only; remove one with
+    `--remove-unrecorded`).
+
+  So both a removed declared attachment and an added unexpected one are caught,
+  without the union false positive. The policy **document** (and
+  Path/Description) is compared as usual.
+
 - **AppSync GraphQL schema.** The `AWS::AppSync::GraphQLSchema` resource (a CDK
   `GraphqlApi`'s schema `Definition`) is reported `skipped`: Cloud Control has
   **no READ** for the type (`UnsupportedActionException`), and AppSync's only

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -109,21 +109,27 @@ const REFLECTED_CHILD_PROPS: Record<string, string> = {
   'AWS::SNS::Topic': 'Subscription',
 };
 
-// Per-type attachment-list properties compared ASYMMETRICALLY (declared∖live only).
+// Per-type attachment-list properties handled by tier rather than a positional compare.
 // AWS::IAM::ManagedPolicy's `Roles`/`Users`/`Groups` name the principals a managed
-// policy is attached to — but the same policy is commonly attached from SEVERAL
-// places (a role's own `ManagedPolicyArns`, a separate AWS::IAM::Policy/attachment
-// resource, another stack, the console), so the LIVE set is a UNION that legitimately
-// exceeds any one stack's intent. A symmetric compare would false-drift on every
-// shared policy (the FP `cdk drift` suffers). So:
+// policy is attached to — but the same policy is commonly attached from SEVERAL places
+// (a role's own `ManagedPolicyArns`, a separate AWS::IAM::Policy/attachment resource,
+// another stack, the console), so the LIVE set is a UNION that legitimately exceeds any
+// one stack's intent. A symmetric compare would false-DRIFT on every shared policy (the
+// FP `cdk drift` raises). So each member is tiered by WHO declared it:
 //   - a DECLARED member MISSING from live -> declared drift (an out-of-band DETACH —
-//     security-relevant: a privilege the stack intends was removed). The real FN the
-//     old "don't compare attachment lists at all" boundary missed.
-//   - a live member NOT declared          -> ignored (the union; never a finding).
-// A property the template does NOT declare at all is the pure union — dropped from
-// the live model below so it never reaches the undeclared loop. Strictly better than
-// both the old cdkrd (missed the detach) and cdk drift (FPs on the extra union
-// members): it catches the removal without the union false positive.
+//     security-relevant: a privilege the stack intends was removed). Revertable
+//     (re-attach the one member). The real FN the old "don't compare attachment lists"
+//     boundary missed.
+//   - a live member NOT declared          -> UNDECLARED inventory (recordable), NOT a
+//     positional FP — the SAME treatment every other undeclared property + identity-
+//     keyed subset array (ELB attribute bags, Cognito Schema) gets. So a known union
+//     member is folded/recordable on a first run, and a NEW unexpected attachment
+//     (a console/rogue grant of the policy's permissions to another principal) then
+//     surfaces as drift vs the recorded baseline — detection cdk drift only matches by
+//     ALSO false-drifting every legitimate union member. record-only (we never auto-
+//     detach a member another owner added; --remove-unrecorded is the explicit opt-in).
+// Catches BOTH a removed declared attachment and an added unexpected one, without the
+// symmetric-compare false drift.
 const IAM_ATTACHMENT_SUBSET: Record<string, ReadonlySet<string>> = {
   'AWS::IAM::ManagedPolicy': new Set(['Roles', 'Users', 'Groups']),
 };
@@ -331,12 +337,14 @@ export function classifyResource(
   // (see REFLECTED_CHILD_PROPS). Fail-open: a declared inline value is still compared.
   const reflected = REFLECTED_CHILD_PROPS[resourceType];
   if (reflected && !(reflected in declared)) delete live[reflected];
-  // ManagedPolicy attachment lists the template does NOT declare are the pure live
-  // UNION (this policy attached elsewhere) — drop them so they never surface as
-  // undeclared drift. A declared attachment list is kept and compared asymmetrically
-  // in the declared loop below (declared-but-missing = detach; live-only ignored).
+  // ManagedPolicy attachment lists (Roles/Users/Groups). A DECLARED list is handled
+  // per-member in the declared loop below (declared-but-missing = detach; live-only =
+  // undeclared inventory). A list the template does NOT declare at all is left in `live`
+  // so it flows to the undeclared loop as ordinary undeclared inventory (recordable) —
+  // NOT dropped: dropping it hid an unexpected attachment entirely (no record, no later
+  // drift). It is inventory, never a positional FP, so it does not reintroduce the
+  // cdk-drift union false positive.
   const attachmentProps = IAM_ATTACHMENT_SUBSET[resourceType];
-  if (attachmentProps) for (const p of attachmentProps) if (!(p in declared)) delete live[p];
   // R11: a declared TOP-LEVEL write-only key is about to be stripped from `declared`
   // (below). Surface it as ONE readGap finding FIRST so it is never silently dropped
   // — the informational tier exists precisely for "declared but unreadable" props.
@@ -408,19 +416,24 @@ export function classifyResource(
       });
       continue;
     }
-    // ManagedPolicy attachment lists (Roles/Users/Groups): compare ASYMMETRICALLY.
-    // A DECLARED member absent from the live (union) set is an out-of-band DETACH —
-    // emit a declared finding per missing member, carrying the member on
+    // ManagedPolicy attachment lists (Roles/Users/Groups): tier each member by WHO
+    // declared it. A DECLARED member absent from the live (union) set is an out-of-band
+    // DETACH — emit a declared finding per missing member, carrying the member on
     // `attributeKey` so revert re-attaches ONLY that one (never rewriting the whole
-    // list, which would detach the union members another stack/role legitimately
-    // added). A live-only member is the union and is NOT reported. An unresolved
+    // list, which would detach the union members another stack/role legitimately added).
+    // A live member NOT declared is the union — emit it as nested UNDECLARED inventory
+    // (recordable), NOT a positional FP: a known union member folds/records, and a NEW
+    // unexpected attachment then surfaces as drift vs the baseline. An unresolved
     // declared member (an intrinsic the synth couldn't resolve) can't be compared —
     // skip it (the whole-property `unresolved` finding above already noted it).
     if (attachmentProps?.has(k) && Array.isArray(v) && Array.isArray(live[k])) {
-      const liveSet = new Set((live[k] as unknown[]).map((m) => String(m)));
+      const liveArr = live[k] as unknown[];
+      const liveSet = new Set(liveArr.map((m) => String(m)));
+      const declaredSet = new Set<string>();
       for (const member of v) {
         if (member === UNRESOLVED || hasUnresolved(member)) continue;
         if (typeof member !== 'string' && typeof member !== 'number') continue;
+        declaredSet.add(String(member));
         if (liveSet.has(String(member))) continue;
         findings.push({
           tier: 'declared',
@@ -431,6 +444,18 @@ export function classifyResource(
           desired: member,
           actual: undefined,
           note: 'declared attachment not present in live (out-of-band detach)',
+        });
+      }
+      for (const member of liveArr) {
+        if (typeof member !== 'string' && typeof member !== 'number') continue;
+        if (declaredSet.has(String(member))) continue;
+        findings.push({
+          tier: 'undeclared',
+          logicalId,
+          resourceType,
+          path: `${k}[${String(member)}]`,
+          actual: member,
+          nested: true,
         });
       }
       continue;

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2196,12 +2196,14 @@ describe('nested undeclared on IAM policy statements (identity-less subset desce
   });
 });
 
-// AWS::IAM::ManagedPolicy Roles/Users/Groups compare ASYMMETRICALLY (declared∖live):
-// a declared attachment removed out of band IS reported (detach), while a live-only
-// attachment (the union — the same policy attached elsewhere) is NOT. Strictly better
-// than the old "don't compare attachment lists" boundary (which missed the detach) and
-// than cdk drift (which false-drifts on the union).
-describe('IAM ManagedPolicy asymmetric attachment detach detection', () => {
+// AWS::IAM::ManagedPolicy Roles/Users/Groups are tiered per member: a DECLARED member
+// removed out of band IS reported (detach, declared tier), while a live-only member
+// (the union — the same policy attached elsewhere) surfaces as UNDECLARED inventory
+// (recordable) — not a positional FP, and not dropped, so a NEW unexpected attachment
+// later surfaces as drift vs the baseline. Better than the old "don't compare" boundary
+// (missed the detach), the first cut (dropped the union, missed an unexpected attach),
+// and cdk drift (false-drifts the whole union).
+describe('IAM ManagedPolicy attachment tiering (declared detach + undeclared union)', () => {
   const emptySchema: SchemaInfo = {
     readOnly: new Set(),
     writeOnly: new Set(),
@@ -2232,26 +2234,29 @@ describe('IAM ManagedPolicy asymmetric attachment detach detection', () => {
     expect(detach[0]?.actual).toBeUndefined();
   });
 
-  it('does NOT report a live-only attachment (the union member another stack added)', () => {
+  it('reports a live-only attachment as UNDECLARED inventory (recordable), not declared drift', () => {
     // declared RoleA still attached; RoleX attached elsewhere (role-side ManagedPolicyArns
-    // or the console) — the live union exceeds intent but is not this stack's drift.
+    // or the console) — the union member is NOT a declared FP, but it IS surfaced as
+    // undeclared inventory so it can be recorded and a NEW attachment later drifts.
     const f = classifyResource(
       mp({ Roles: ['RoleA'] }),
       { Roles: ['RoleA', 'RoleX'] },
       emptySchema
     );
-    expect(f.filter((x) => x.tier === 'declared')).toEqual([]);
-    expect(f.filter((x) => x.tier === 'undeclared')).toEqual([]);
+    expect(f.filter((x) => x.tier === 'declared')).toEqual([]); // RoleA present -> no detach
+    const undeclared = f.filter((x) => x.tier === 'undeclared');
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0]).toMatchObject({ path: 'Roles[RoleX]', actual: 'RoleX', nested: true });
   });
 
-  it('CLEAN when every declared attachment is present (extra union members ignored)', () => {
+  it('declared members CLEAN; every extra union member surfaces as undeclared inventory', () => {
     const f = classifyResource(
       mp({ Roles: ['RoleA'], Users: ['UserA'], Groups: ['GroupA'] }),
       { Roles: ['RoleA', 'RoleX'], Users: ['UserA'], Groups: ['GroupA', 'GroupZ'] },
       emptySchema
     );
-    expect(tiers(f).declared).toEqual([]);
-    expect(tiers(f).undeclared).toEqual([]);
+    expect(tiers(f).declared).toEqual([]); // all declared members present
+    expect(tiers(f).undeclared).toEqual(['Groups[GroupZ]', 'Roles[RoleX]']); // the union extras
   });
 
   it('handles Users and Groups detach independently, one finding per missing member', () => {
@@ -2267,14 +2272,19 @@ describe('IAM ManagedPolicy asymmetric attachment detach detection', () => {
     expect(detached).toEqual(['Groups[GroupA]', 'Users[UserA]', 'Users[UserB]']);
   });
 
-  it('drops a NON-declared live attachment list so it is never undeclared drift (union)', () => {
+  it('a NON-declared live attachment list surfaces as undeclared inventory (recordable)', () => {
     // template declares no Roles at all; the policy is attached to a role elsewhere.
+    // It is NOT dropped (that hid an unexpected attachment) — it flows to the undeclared
+    // loop as ordinary undeclared inventory so it can be recorded + watched.
     const f = classifyResource(
       mp({ Description: '' }),
       { Roles: ['RoleX'], Description: '' },
       emptySchema
     );
-    expect(f.some((x) => x.path === 'Roles')).toBe(false);
+    const undeclared = f.filter((x) => x.tier === 'undeclared');
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0]).toMatchObject({ path: 'Roles', actual: ['RoleX'] });
+    expect(f.some((x) => x.tier === 'declared')).toBe(false);
   });
 
   it('skips an UNRESOLVED declared member (an intrinsic) rather than false-drifting it', () => {
@@ -2299,11 +2309,21 @@ describe('IAM ManagedPolicy asymmetric attachment detach detection', () => {
     expect(detach).toHaveLength(1);
   });
 
-  it('CLEAN when the declared attachment list is EMPTY, even with live union members', () => {
-    // an empty declared Roles compares to nothing missing; the live union is ignored.
+  it('an EMPTY declared list reports no detach; live union members are undeclared inventory', () => {
+    // an empty declared Roles has nothing to detach; the live members are all the union.
     const f = classifyResource(mp({ Roles: [] }), { Roles: ['RoleX', 'RoleY'] }, emptySchema);
     expect(tiers(f).declared).toEqual([]);
-    expect(tiers(f).undeclared).toEqual([]);
+    expect(tiers(f).undeclared).toEqual(['Roles[RoleX]', 'Roles[RoleY]']);
+  });
+
+  it('reports a detach AND an unexpected attach at once (declared RoleA gone, RoleB appeared)', () => {
+    const f = classifyResource(mp({ Roles: ['RoleA'] }), { Roles: ['RoleB'] }, emptySchema);
+    const detach = f.filter((x) => x.tier === 'declared' && x.path === 'Roles');
+    expect(detach).toHaveLength(1);
+    expect(detach[0]?.attributeKey).toBe('RoleA'); // declared member removed
+    const undeclared = f.filter((x) => x.tier === 'undeclared');
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0]).toMatchObject({ path: 'Roles[RoleB]', actual: 'RoleB', nested: true }); // unexpected attach
   });
 
   it('reports EVERY declared member when all three lists are fully detached (live all empty)', () => {

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedNoDeclaredAttach.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedNoDeclaredAttach.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "Hand-curated: the template declares no Roles/Users/Groups. The policy is attached to a Role elsewhere (the pure live union). Must be CLEAN: a non-declared live attachment list is dropped, never an undeclared finding.",
+  "description": "Hand-curated: the template declares no Roles/Users/Groups. The policy is attached to a Role elsewhere — surfaced as ordinary UNDECLARED inventory (recordable), NOT dropped, so an unexpected attachment is visible and a later one drifts.",
   "resource": {
     "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
@@ -74,5 +74,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Roles",
+      "actual": ["RoleFromElsewhere"],
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedRoleDetached.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedRoleDetached.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "Hand-curated: the declared Role was detached out of band. A live-only (union) Role remains. Exactly ONE declared detach finding for the missing declared Role; the union Role is ignored.",
+  "description": "Hand-curated: the declared Role was detached out of band (declared detach finding); a different live-only (union) Role surfaces as undeclared inventory. One declared finding for the missing declared Role + one undeclared for the union member.",
   "resource": {
     "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
@@ -84,6 +84,16 @@
       "attributeKey": "RoleDeclared",
       "desired": "RoleDeclared",
       "note": "declared attachment not present in live (out-of-band detach)",
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Roles[RoleFromElsewhere]",
+      "actual": "RoleFromElsewhere",
+      "nested": true,
       "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
       "constructPath": "IntegStack/Shared"
     }

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedUnionInventory.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedUnionInventory.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "Hand-curated: asymmetric attachment compare. The declared Role IS attached; an EXTRA live Role (the union — attached from another stack/role/console) is present too. Must be CLEAN: a live-only attachment is never a finding.",
+  "description": "Hand-curated: the declared Role IS attached; an EXTRA live Role (the union — attached from another stack/role/console) surfaces as nested UNDECLARED inventory (recordable), NOT a declared FP. Records the known union member so a NEW attachment later drifts.",
   "resource": {
     "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
@@ -75,5 +75,16 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Roles[RoleFromElsewhere]",
+      "actual": "RoleFromElsewhere",
+      "nested": true,
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__ManagedPolicy.SharedUsersGroupsDetach.json
+++ b/tests/corpus/AWS__IAM__ManagedPolicy.SharedUsersGroupsDetach.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "Hand-curated: Roles/Users/Groups all declared; one Role present, one User detached, the Group detached. One declared finding per declared-but-missing member; present members and live-only members produce nothing.",
+  "description": "Hand-curated: Roles/Users/Groups declared; one Role present (+ a live-only union Role), one User detached, the Group detached. Declared findings per missing declared member; the union Role is undeclared inventory.",
   "resource": {
     "logicalId": "SharedABCD1234",
     "resourceType": "AWS::IAM::ManagedPolicy",
@@ -78,6 +78,16 @@
     "kmsAliasTargets": {}
   },
   "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "SharedABCD1234",
+      "resourceType": "AWS::IAM::ManagedPolicy",
+      "path": "Roles[RUnion]",
+      "actual": "RUnion",
+      "nested": true,
+      "physicalId": "arn:aws:iam::111111111111:policy/SharedExample",
+      "constructPath": "IntegStack/Shared"
+    },
     {
       "tier": "declared",
       "logicalId": "SharedABCD1234",

--- a/tests/integration/iam-managedpolicy-detach/verify-unexpected-attach.sh
+++ b/tests/integration/iam-managedpolicy-detach/verify-unexpected-attach.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# cdkrd UNEXPECTED-ATTACH detection integration test (real AWS, AWS-mutating).
+# Proves the OTHER half of ManagedPolicy attachment tiering: a live-only attachment
+# (a member NOT declared) is surfaced as UNDECLARED inventory, so after `record` a NEW,
+# unexpected attachment (e.g. a console/rogue grant of the policy to another principal)
+# is DETECTED as drift vs the baseline — something cdk drift only matches by ALSO
+# false-drifting every legitimate union member.
+# Flow: create 2 standalone roles (declaredRole, intruderRole) -> deploy a ManagedPolicy
+# declaring roles:[declaredRole] -> record (baseline, intruder NOT yet attached) ->
+# check CLEAN -> attach intruderRole out of band (the unexpected grant) -> check DETECTS
+# it (undeclared, appeared since record, exit 1) -> destroy + delete both roles.
+# Self-cleaning trap; no orphans on failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamManagedPolicyDetach
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+SUFFIX="$$"
+DECLARED_ROLE="cdkrd-mpa-declared-$SUFFIX"
+INTRUDER_ROLE="cdkrd-mpa-intruder-$SUFFIX"
+ASSUME='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+MANAGED_ARN=""
+cleanup() {
+  echo "--- cleanup ---"
+  if [ -n "$MANAGED_ARN" ]; then
+    aws iam detach-role-policy --role-name "$DECLARED_ROLE" --policy-arn "$MANAGED_ARN" >/dev/null 2>&1 || true
+    aws iam detach-role-policy --role-name "$INTRUDER_ROLE" --policy-arn "$MANAGED_ARN" >/dev/null 2>&1 || true
+  fi
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  aws iam delete-role --role-name "$DECLARED_ROLE" >/dev/null 2>&1 || true
+  aws iam delete-role --role-name "$INTRUDER_ROLE" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp pack) || fail build
+
+echo "=== create 2 standalone roles ==="
+DECLARED_ARN="$(aws iam create-role --role-name "$DECLARED_ROLE" --assume-role-policy-document "$ASSUME" \
+  --query 'Role.Arn' --output text)" || fail "create declared role"
+aws iam create-role --role-name "$INTRUDER_ROLE" --assume-role-policy-document "$ASSUME" >/dev/null \
+  || fail "create intruder role"
+echo "declaredRole=$DECLARED_ROLE intruderRole=$INTRUDER_ROLE"
+sleep 8
+
+echo "=== deploy (ManagedPolicy declares roles:[declaredRole]) ==="
+npx cdk deploy -f "$STACK" -c "declaredRoleArn=$DECLARED_ARN" --require-approval never || fail deploy
+
+MANAGED_ARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::IAM::ManagedPolicy'].PhysicalResourceId" --output text)"
+[ -n "$MANAGED_ARN" ] || fail "could not resolve managed policy ARN"
+
+echo "=== record (baseline — intruder NOT attached yet) ==="
+$CLI record "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --yes || fail record
+
+echo "=== check CLEAN ==="
+$CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail
+[ $? -eq 0 ] || fail "expected CLEAN after record"
+
+echo "=== attach intruderRole out of band (the unexpected grant) ==="
+aws iam attach-role-policy --role-name "$INTRUDER_ROLE" --policy-arn "$MANAGED_ARN" || fail "attach intruder"
+echo "(waiting for IAM propagation)"; sleep 12
+
+echo "=== check DETECTS the unexpected attachment (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail | tee /tmp/cdkrd-mpa.out
+[ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1 for the unexpected attach"
+grep -q "$INTRUDER_ROLE" /tmp/cdkrd-mpa.out || fail "intruder attachment not reported"
+grep -q "appeared since record" /tmp/cdkrd-mpa.out || fail "not flagged as appeared-since-record drift"
+
+echo "INTEG PASS (CdkRealDriftIntegIamManagedPolicyDetach unexpected-attach detected since record)"


### PR DESCRIPTION
## Problem

#278 detected a **declared** ManagedPolicy attachment removed out of band (a **detach**), but **dropped** every live-only member entirely. So an **unexpected attachment** — a console/rogue grant of the policy's permissions to another principal — was **completely invisible**: no record, no later drift. `cdk drift` catches that, but only by **also** false-drifting every legitimate union member. Attaching is a common operation, so the silent miss is a real gap.

## Fix — tier each member instead of dropping the union

- a **declared** member missing from live → **declared drift (detach)**, revertable (unchanged from #278);
- a **live-only** member → nested **undeclared inventory** (recordable), **not** a positional FP — the same treatment every other undeclared property and identity-keyed subset array (ELB attribute bags, Cognito Schema) already gets. A known union member folds/records; a **new, unexpected** attachment then surfaces as **drift vs the baseline**. Detection-only (we never auto-detach a member another owner added; `--remove-unrecorded` is the explicit opt-in);
- a **non-declared** attachment list is no longer dropped either — it flows to the undeclared loop as ordinary inventory, so an unexpected attach on a policy that declares no lists is visible too.

This closes the gap **without** reintroducing the cdk-drift union false positive (undeclared inventory is never a positional drift). Both a removed declared attachment **and** an added unexpected one are now caught.

## Tests

- **classify unit**: union member → undeclared inventory (not declared FP) / declared CLEAN + extras undeclared / non-declared list → undeclared / empty declared list / **combined detach + unexpected attach**.
- **golden corpus**: regenerated the 4 attachment cases (`SharedUnionClean` → `SharedUnionInventory`; detach / users-groups / no-declared now carry the union member as undeclared).
- **live real-AWS integ** (`verify-unexpected-attach.sh`): deploy an MP declaring `[declaredRole]` → `record` → attach an **intruder** role out of band → `check` **DETECTS** it (`Roles[intruder]` undeclared, *appeared since record*, exit 1). **INTEG PASS**. The existing detach integ (`verify-detect.sh`) still passes (regression-checked live).

README: the IAM ManagedPolicy limitation now documents both halves (detach + unexpected-attach detection).

All 1418 unit tests pass; typecheck / lint+format clean. Stack + standalone roles torn down, sweep CLEAN.
