### PR TITLE
fix: read declared AutoScaling ScheduledAction (CC composite read-gap)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -90,6 +90,16 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // a declared hook ValidationException-skips (read-gap). Verified live
   // (autoscaling-lifecyclehook-rich).
   'AWS::AutoScaling::LifecycleHook': compositeWith('AutoScalingGroupName'),
+  // AutoScaling ScheduledAction primaryIdentifier is [ScheduledActionName,
+  // AutoScalingGroupName] — CHILD-first, the REVERSE of its sibling LifecycleHook
+  // (parent-first). The CFn physical id is the bare ScheduledActionName; the ASG name
+  // comes from the resolved declared Ref. Without this a declared scheduled action
+  // ValidationException-skips (read-gap). Verified live (autoscaling-scheduledaction-rich).
+  'AWS::AutoScaling::ScheduledAction': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const asg = declared.AutoScalingGroupName;
+    return typeof asg === 'string' && asg.length > 0 ? `${pid}|${asg}` : undefined;
+  },
   // ApiGateway::Deployment is the odd one out: its primaryIdentifier is
   // `[DeploymentId, RestApiId]` — CHILD first (verified live R129: `RestApiId|DeploymentId`
   // returns not-found; only `DeploymentId|RestApiId` reads). The CFn physical id is the

--- a/tests/corpus/AWS__AutoScaling__ScheduledAction.Schedule.json
+++ b/tests/corpus/AWS__AutoScaling__ScheduledAction.Schedule.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Schedule",
+    "resourceType": "AWS::AutoScaling::ScheduledAction",
+    "physicalId": "CdkRea-Sched-Y8TVCVCJA9P3",
+    "constructPath": "CdkRealDriftIntegAutoScalingScheduledActionRich/Schedule",
+    "declared": {
+      "AutoScalingGroupName": "CdkRealDriftIntegAutoScalingScheduledActionRich-AsgASGD1D7B4E2-u32lj4u16UO0",
+      "DesiredCapacity": 1,
+      "MaxSize": 2,
+      "MinSize": 1,
+      "Recurrence": "0 9 * * MON-FRI",
+      "TimeZone": "UTC"
+    }
+  },
+  "liveRaw": {
+    "MinSize": 1,
+    "Recurrence": "0 9 * * MON-FRI",
+    "ScheduledActionName": "CdkRea-Sched-Y8TVCVCJA9P3",
+    "TimeZone": "UTC",
+    "EndTime": "null",
+    "AutoScalingGroupName": "CdkRealDriftIntegAutoScalingScheduledActionRich-AsgASGD1D7B4E2-u32lj4u16UO0",
+    "StartTime": "2026-06-22T09:00:00Z",
+    "DesiredCapacity": 1,
+    "MaxSize": 2
+  },
+  "schema": {
+    "readOnly": ["ScheduledActionName"],
+    "writeOnly": [],
+    "createOnly": ["AutoScalingGroupName"],
+    "readOnlyPaths": ["ScheduledActionName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AutoScalingGroupName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Schedule",
+      "resourceType": "AWS::AutoScaling::ScheduledAction",
+      "path": "EndTime",
+      "actual": "null",
+      "physicalId": "CdkRea-Sched-Y8TVCVCJA9P3",
+      "constructPath": "CdkRealDriftIntegAutoScalingScheduledActionRich/Schedule"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Schedule",
+      "resourceType": "AWS::AutoScaling::ScheduledAction",
+      "path": "StartTime",
+      "actual": "2026-06-22T09:00:00Z",
+      "physicalId": "CdkRea-Sched-Y8TVCVCJA9P3",
+      "constructPath": "CdkRealDriftIntegAutoScalingScheduledActionRich/Schedule"
+    }
+  ]
+}

--- a/tests/integration/autoscaling-scheduledaction-rich/app.ts
+++ b/tests/integration/autoscaling-scheduledaction-rich/app.ts
@@ -1,0 +1,55 @@
+// CDK app for the cdk-real-drift Auto Scaling scheduled-action false-positive +
+// read-gap test. Scheduled scaling is a common cost pattern, but a DECLARED
+// AWS::AutoScaling::ScheduledAction has never been read via the normal CC path. Its
+// CC primaryIdentifier is the composite [ScheduledActionName, AutoScalingGroupName]
+// — CHILD-first, the REVERSE of the sibling LifecycleHook ([AutoScalingGroupName,
+// LifecycleHookName] parent-first) — while the CFn physical id is the bare
+// ScheduledActionName, so without a CC_IDENTIFIER_ADAPTERS entry it is silently
+// `skipped`. The ASG is sized to zero instances (nothing launches). A freshly
+// deployed + recorded stack with NO out-of-band change MUST report CLEAN — and the
+// scheduled action MUST be read (skipped=0).
+import { App, Stack } from "aws-cdk-lib";
+import { AutoScalingGroup, CfnScheduledAction } from "aws-cdk-lib/aws-autoscaling";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  LaunchTemplate,
+  MachineImage,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAutoScalingScheduledActionRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const launchTemplate = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023(),
+});
+
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  launchTemplate,
+  minCapacity: 0,
+  maxCapacity: 2,
+});
+
+new CfnScheduledAction(stack, "Schedule", {
+  autoScalingGroupName: asg.autoScalingGroupName,
+  scheduledActionName: "cdkrd-scale-up",
+  recurrence: "0 9 * * MON-FRI",
+  minSize: 1,
+  maxSize: 2,
+  desiredCapacity: 1,
+  timeZone: "UTC",
+});
+
+app.synth();

--- a/tests/integration/autoscaling-scheduledaction-rich/cdk.json
+++ b/tests/integration/autoscaling-scheduledaction-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/autoscaling-scheduledaction-rich/package.json
+++ b/tests/integration/autoscaling-scheduledaction-rich/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-autoscaling-scheduledaction-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift autoscaling-scheduledaction-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/autoscaling-scheduledaction-rich/verify.sh
+++ b/tests/integration/autoscaling-scheduledaction-rich/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegAutoScalingScheduledActionRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] harvest corpus ==="; CDKRD_CORPUS_DIR="/tmp/corpus-autoscaling-scheduledaction-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -287,6 +287,36 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('my-asg|my-hook');
   });
 
+  it('AutoScaling ScheduledAction: builds the ScheduledActionName|AutoScalingGroupName composite — CHILD first (reverse of LifecycleHook)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::AutoScaling::ScheduledAction',
+        physicalId: 'my-action',
+        declared: { AutoScalingGroupName: 'my-asg' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('my-action|my-asg');
+  });
+
+  it('AutoScaling ScheduledAction: an unresolved ASG name falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::AutoScaling::ScheduledAction',
+        physicalId: 'my-action',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('my-action');
+  });
+
   for (const t of [
     'AWS::Cognito::UserPoolDomain',
     'AWS::Cognito::UserPoolResourceServer',


### PR DESCRIPTION
## What

A /hunt-bugs round closing one more composite read-gap. A declared `AWS::AutoScaling::ScheduledAction` was silently `skipped` (CC `ValidationException`): its CC primaryIdentifier is the composite `[ScheduledActionName, AutoScalingGroupName]` — **child-first**, the reverse of its sibling `LifecycleHook` (`[AutoScalingGroupName, LifecycleHookName]` parent-first) — while the CFn physical id is the bare `ScheduledActionName`. Added a child-first adapter (`ScheduledActionName|AutoScalingGroupName`), like ECS Service / ApiGatewayV2 Authorizer.

Scheduled scaling is a common cost pattern, so reading it closes a real coverage gap — its `Recurrence` / `MinSize` / `MaxSize` / `DesiredCapacity` / `TimeZone` are now watched.

## Verification
- Router unit test **confirmed to fail without the fix** (child-first composite).
- Golden-corpus case harvested from the live read (AutoScaling ScheduledAction) — `corpus-replay` now 348 cases.
- Live-proven: the fixture reads CLEAN with `skipped=0`.
- All bug-hunt stacks deleted; `bughunt-track.sh verify` + `sweep-orphans.sh` -> SWEEP CLEAN.

## Test plan
- `vp run typecheck` / `vp check` / `vp run build` / `vp run test` (40 files, 1425 tests) all green.
