### PR TITLE
feat(iam): detach an unexpected ManagedPolicy attachment via --remove-unrecorded

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,9 +570,9 @@ plus, for the SDK-written types: `s3:PutBucketPolicy` / `s3:DeleteBucketPolicy`,
   - a **live-only** member (the union) is surfaced as an **undeclared** value,
     not a false drift — `record` it to accept the current attachments, and a
     **new, unexpected** attachment (e.g. a console grant to another principal)
-    then shows up as drift against the baseline. Detection-only: like every
-    nested undeclared value it is reported and recordable but not auto-reverted,
-    so detach an unwanted one yourself (`aws iam detach-role-policy`).
+    then shows up as drift against the baseline. Detach an unwanted one with
+    `revert --remove-unrecorded` (the opt-in for removing any unrecorded live
+    value); a plain `revert` never auto-detaches a union member.
 
   So both a removed declared attachment and an added unexpected one are caught,
   without the union false positive. The policy **document** (and

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -21,7 +21,7 @@
 // and unit-tested; the prompt is a thin rendering/key shell.
 import { isCancel, Prompt } from '@clack/core';
 import { S_BAR, S_BAR_END, S_BAR_START } from '@clack/prompts';
-import { isNestedUndeclared } from '../revert/plan.js';
+import { isManagedPolicyAttachmentMember, isNestedUndeclared } from '../revert/plan.js';
 import type { Finding } from '../types.js';
 import { style } from '../report/style.js';
 
@@ -46,7 +46,9 @@ export type FindingAction = 'record' | 'ignore' | 'revert' | 'skip';
  */
 export function applicableActions(finding: Finding): FindingAction[] {
   if (finding.tier === 'undeclared')
-    return isNestedUndeclared(finding) ? ['record', 'ignore'] : ['record', 'ignore', 'revert'];
+    return isNestedUndeclared(finding) && !isManagedPolicyAttachmentMember(finding)
+      ? ['record', 'ignore']
+      : ['record', 'ignore', 'revert'];
   if (finding.tier === 'added')
     // A `modelReadFailed` added finding carries only an identity snippet (its full model
     // could not be read this run). buildRecorded DROPS it, so offering `record` is a

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -40,6 +40,21 @@ export function isNestedUndeclared(f: Finding): boolean {
   );
 }
 
+// An out-of-band ManagedPolicy attachment member (a live-only `Roles[x]`/`Users[x]`/
+// `Groups[x]` — the union, surfaced as nested undeclared). Unlike a generic nested
+// undeclared value, this one HAS a precise, flat SDK op to undo it (DetachX-Policy by
+// member), so writeIamManagedPolicy can revert it exactly — it is NOT subject to the
+// "nested undeclared is record-only" bar (which exists because a flat patch can't
+// safely target a deep sub-field). Removal still requires --remove-unrecorded like any
+// unrecorded undeclared value (the unrecorded guard below), so it never auto-detaches.
+export function isManagedPolicyAttachmentMember(f: Finding): boolean {
+  return (
+    f.tier === 'undeclared' &&
+    f.resourceType === 'AWS::IAM::ManagedPolicy' &&
+    /^(Roles|Users|Groups)\[.+\]$/.test(f.path)
+  );
+}
+
 export interface PatchOp {
   op: 'add' | 'remove';
   path: string; // RFC6902 JSON pointer into the resource Properties model
@@ -225,7 +240,7 @@ export function buildRevertPlan(
     // reconstructed (baseline-file.ts) WITHOUT the flag, but keeps its nested path. A
     // top-level undeclared path is a single key (never contains '.'/'['), and declared
     // drift is a different tier — so this never blocks a top-level revert.
-    if (isNestedUndeclared(f)) {
+    if (isNestedUndeclared(f) && !isManagedPolicyAttachmentMember(f)) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -49,6 +49,9 @@ import {
   AttachRolePolicyCommand,
   AttachUserPolicyCommand,
   CreatePolicyVersionCommand,
+  DetachGroupPolicyCommand,
+  DetachRolePolicyCommand,
+  DetachUserPolicyCommand,
   DeletePolicyVersionCommand,
   DeleteRolePolicyCommand,
   IAMClient,
@@ -185,6 +188,20 @@ const isArn = (v: unknown): string | undefined => {
 // Top JSON-pointer segment of an op path (`/Roles/0` -> `Roles`, `/Roles` -> `Roles`).
 const topSeg = (path: string): string => path.split('/').filter(Boolean)[0] ?? '';
 const ATTACHMENT_PROPS = new Set(['Roles', 'Users', 'Groups']);
+// Resolve an op into a ManagedPolicy attachment (prop + member) from EITHER encoding the
+// revert plan emits: a declared DETACH revert (re-attach) arrives as path `Roles` with
+// the member on `attributeKey`; an unexpected-attach removal (--remove-unrecorded) of a
+// live-only member arrives as the nested path `Roles[member]`. Returns undefined for a
+// document op (PolicyDocument/Path/Description), which routes to the version path below.
+const parseAttachmentOp = (o: PatchOp): { prop: string; member: string } | undefined => {
+  const seg = topSeg(o.path);
+  if (ATTACHMENT_PROPS.has(seg)) {
+    const member = o.attributeKey ?? (typeof o.value === 'string' ? o.value : undefined);
+    return member !== undefined ? { prop: seg, member: String(member) } : undefined;
+  }
+  const m = /^(Roles|Users|Groups)\[(.+)\]$/.exec(seg);
+  return m ? { prop: m[1] as string, member: m[2] as string } : undefined;
+};
 
 const writeIamManagedPolicy: SdkWriter = async (ctx, ops) => {
   // CFn physical id for a managed policy IS its arn; fall back to the declared
@@ -193,28 +210,43 @@ const writeIamManagedPolicy: SdkWriter = async (ctx, ops) => {
   if (!arn) throw new Error('cannot resolve managed policy arn for revert');
   const c = new IAMClient({ region: ctx.region });
 
-  // Attachment-list reverts (Roles/Users/Groups): a declared member detached out of
-  // band is re-ATTACHED by member — never by rewriting the whole list, which would
-  // detach the union members another stack/role/console legitimately added (the
-  // classify side only ever emits a detach finding for a declared-but-MISSING member).
-  // The member rides on `attributeKey`. Idempotent: AttachXPolicy on an already-
-  // attached member is a no-op, so a partial prior revert re-runs safely.
-  const attachOps = ops.filter((o) => ATTACHMENT_PROPS.has(topSeg(o.path)));
-  for (const o of attachOps) {
-    const seg = topSeg(o.path);
-    const member = String(o.attributeKey ?? o.value);
-    if (seg === 'Roles')
-      await c.send(new AttachRolePolicyCommand({ PolicyArn: arn, RoleName: member }));
-    else if (seg === 'Users')
-      await c.send(new AttachUserPolicyCommand({ PolicyArn: arn, UserName: member }));
-    else if (seg === 'Groups')
-      await c.send(new AttachGroupPolicyCommand({ PolicyArn: arn, GroupName: member }));
+  // Attachment-list reverts (Roles/Users/Groups), per member — never by rewriting the
+  // whole list (that would touch the union members another stack/role/console
+  // legitimately added):
+  //   - an `add` op re-ATTACHES a declared member detached out of band (AttachXPolicy);
+  //   - a `remove` op DETACHES a live-only (unexpected) member the user chose to remove
+  //     via --remove-unrecorded (DetachXPolicy).
+  // AttachXPolicy on an already-attached member is a no-op, so a partial prior revert
+  // re-runs safely.
+  for (const o of ops) {
+    const parsed = parseAttachmentOp(o);
+    if (!parsed) continue;
+    const { prop, member } = parsed;
+    const detach = o.op === 'remove';
+    if (prop === 'Roles')
+      await c.send(
+        detach
+          ? new DetachRolePolicyCommand({ PolicyArn: arn, RoleName: member })
+          : new AttachRolePolicyCommand({ PolicyArn: arn, RoleName: member })
+      );
+    else if (prop === 'Users')
+      await c.send(
+        detach
+          ? new DetachUserPolicyCommand({ PolicyArn: arn, UserName: member })
+          : new AttachUserPolicyCommand({ PolicyArn: arn, UserName: member })
+      );
+    else if (prop === 'Groups')
+      await c.send(
+        detach
+          ? new DetachGroupPolicyCommand({ PolicyArn: arn, GroupName: member })
+          : new AttachGroupPolicyCommand({ PolicyArn: arn, GroupName: member })
+      );
   }
 
   // Document/Path/Description reverts go through a new default policy version. Skip it
   // entirely when only attachment ops were present, so a detach-only revert does not
   // burn a (capped at 5) policy version re-writing the unchanged document.
-  const docOps = ops.filter((o) => !ATTACHMENT_PROPS.has(topSeg(o.path)));
+  const docOps = ops.filter((o) => parseAttachmentOp(o) === undefined);
   if (docOps.length === 0) return;
   const desired = policyJson(await desiredModel('AWS::IAM::ManagedPolicy', ctx, docOps));
   if (desired === undefined)

--- a/tests/integration/iam-managedpolicy-detach/verify-unexpected-attach.sh
+++ b/tests/integration/iam-managedpolicy-detach/verify-unexpected-attach.sh
@@ -71,4 +71,21 @@ $CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail
 grep -q "$INTRUDER_ROLE" /tmp/cdkrd-mpa.out || fail "intruder attachment not reported"
 grep -q "appeared since record" /tmp/cdkrd-mpa.out || fail "not flagged as appeared-since-record drift"
 
-echo "INTEG PASS (CdkRealDriftIntegIamManagedPolicyDetach unexpected-attach detected since record)"
+echo "=== revert --remove-unrecorded --yes (DETACH the unexpected member) ==="
+$CLI revert "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --remove-unrecorded --yes \
+  | tee /tmp/cdkrd-mpa-revert.out || fail "revert returned non-zero"
+grep -qi "no physical id\|not revertable" /tmp/cdkrd-mpa-revert.out && fail "intruder reported not-revertable"
+echo "(waiting for IAM propagation)"; sleep 10
+
+echo "=== check CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" -c "declaredRoleArn=$DECLARED_ARN" --fail
+[ $? -eq 0 ] || fail "drift remains after revert"
+
+echo "=== confirm the intruder is DETACHED and the declared role untouched ==="
+AFTER="$(aws iam list-entities-for-policy --policy-arn "$MANAGED_ARN" --region "$REGION" \
+  --query 'PolicyRoles[].RoleName' --output text)"
+echo "post-revert attached roles: $AFTER"
+echo "$AFTER" | tr '\t' '\n' | grep -qx "$INTRUDER_ROLE" && fail "intruder still attached (detach did not run)"
+echo "$AFTER" | tr '\t' '\n' | grep -qx "$DECLARED_ROLE" || fail "declared role was wrongly detached"
+
+echo "INTEG PASS (CdkRealDriftIntegIamManagedPolicyDetach unexpected-attach detect + --remove-unrecorded detach)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -126,6 +126,32 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('an unexpected ManagedPolicy attachment (live-only) is removable ONLY with --remove-unrecorded', () => {
+    // a live-only member is nested undeclared (Roles[member]) — normally record-only —
+    // but ManagedPolicy has a precise DetachXPolicy op, so it IS revertable, gated by
+    // the unrecorded opt-in like any unrecorded undeclared value.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::IAM::ManagedPolicy',
+      physicalId: 'arn:aws:iam::111122223333:policy/p',
+      path: 'Roles[RoleX]',
+      actual: 'RoleX',
+      nested: true,
+      unrecorded: true,
+    });
+    // default revert refuses (unrecorded), but NOT with the "nested, not revertable" reason
+    const noFlag = buildRevertPlan([f], undefined);
+    expect(noFlag.items).toHaveLength(0);
+    expect(noFlag.notRevertable).toHaveLength(1);
+    expect(noFlag.notRevertable[0]!.reason).toContain('unrecorded');
+    expect(noFlag.notRevertable[0]!.reason).not.toContain('nested');
+    // --remove-unrecorded enables the detach (a remove op routed to the SDK writer)
+    const plan = buildRevertPlan([f], undefined, { removeUnrecorded: true });
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/Roles[RoleX]' });
+  });
+
   it('undeclared drift with an recorded prior value -> add op restoring the baseline value', () => {
     const f = F({
       tier: 'undeclared',

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -19,6 +19,9 @@ import {
   AttachRolePolicyCommand,
   AttachUserPolicyCommand,
   CreatePolicyVersionCommand,
+  DetachGroupPolicyCommand,
+  DetachRolePolicyCommand,
+  DetachUserPolicyCommand,
   DeletePolicyVersionCommand,
   DeleteRolePolicyCommand,
   GetPolicyCommand,
@@ -665,6 +668,43 @@ describe('IAM ManagedPolicy writer', () => {
 
     expect(iam.commandCalls(CreatePolicyVersionCommand)).toHaveLength(1);
     expect(iam.commandCalls(AttachRolePolicyCommand)).toHaveLength(1);
+  });
+
+  // An unexpected (live-only) attachment removed via --remove-unrecorded arrives as a
+  // REMOVE op on the nested path `Roles[member]` — detach that member by parsing the path.
+  const removeMemberOp = (prop: string, member: string): PatchOp => ({
+    op: 'remove',
+    path: `/${prop}[${member}]`,
+    prior: member,
+    human: `${prop}[${member}] -> remove (undeclared, not in baseline)`,
+  });
+
+  it('detaches an unexpected member from a `remove` op on the nested Prop[member] path', async () => {
+    iam.on(DetachRolePolicyCommand).resolves({});
+    iam.on(DetachUserPolicyCommand).resolves({});
+    iam.on(DetachGroupPolicyCommand).resolves({});
+
+    await SDK_WRITERS['AWS::IAM::ManagedPolicy'](ctx(), [
+      removeMemberOp('Roles', 'RoleX'),
+      removeMemberOp('Users', 'UserX'),
+      removeMemberOp('Groups', 'GroupX'),
+    ]);
+
+    expect(iam.commandCalls(DetachRolePolicyCommand)[0]!.args[0].input).toMatchObject({
+      PolicyArn: ARN,
+      RoleName: 'RoleX',
+    });
+    expect(iam.commandCalls(DetachUserPolicyCommand)[0]!.args[0].input).toMatchObject({
+      PolicyArn: ARN,
+      UserName: 'UserX',
+    });
+    expect(iam.commandCalls(DetachGroupPolicyCommand)[0]!.args[0].input).toMatchObject({
+      PolicyArn: ARN,
+      GroupName: 'GroupX',
+    });
+    // never re-attaches, and a detach-only revert burns no policy version
+    expect(iam.commandCalls(AttachRolePolicyCommand)).toHaveLength(0);
+    expect(iam.commandCalls(CreatePolicyVersionCommand)).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Problem

#286 surfaced a live-only (unexpected) ManagedPolicy attachment as nested undeclared inventory — **detect/record-only**. Removing a rogue attachment meant a manual `aws iam detach-role-policy`. Attaching is a common operation and an unexpected grant is security-relevant, so make it removable in-tool.

## Fix

A nested undeclared value is normally record-only because a flat patch can't safely target a deep sub-field — but a ManagedPolicy attachment member has a **precise, flat SDK op** (`DetachX-Policy` by member), so it can be reverted exactly.

- `plan.ts` — `isManagedPolicyAttachmentMember` exempts these findings from the nested-undeclared revert bar. The existing **unrecorded guard still applies**, so removal needs the explicit `--remove-unrecorded` (a plain `revert` never auto-detaches a union member). The action picker offers `revert` for them too.
- `writers.ts` — `writeIamManagedPolicy` now parses **both** op encodings: a declared detach re-attach (`add` on `Roles`, member on `attributeKey` → `AttachXPolicy`) and an unexpected-attach removal (`remove` on the nested `Roles[member]` path → `DetachXPolicy`). A detach-only revert still burns no policy version.

## Tests

- **plan unit**: a live-only member is `notRevertable` without `--remove-unrecorded` (reason "unrecorded", **not** "nested"), and a removable SDK `remove` op with it.
- **writer unit**: a `remove` op on `Roles[member]`/`Users[member]`/`Groups[member]` issues `DetachRole/User/GroupPolicy`, never re-attaches, burns no version.
- **live real-AWS integ** (`verify-unexpected-attach.sh` extended): attach an intruder role out of band → `check` detects → `revert --remove-unrecorded` **detaches** it → CLEAN, the declared role untouched. **INTEG PASS**. The detach integ (`verify-detect.sh`) still passes (regression-checked live).

README: the unexpected-attach note now documents removal via `--remove-unrecorded` (supersedes #287's "manual only").

All 1428 unit tests pass; typecheck / lint+format clean. Stack + standalone roles torn down, sweep CLEAN.
