### PR TITLE
test(integ): add lambda-loggingconfig-rich fixture + corpus (CLEAN round)

### DIFF
--- a/tests/corpus/AWS__Lambda__Function.Handler886CB40B.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler886CB40B.json
@@ -1,0 +1,171 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Handler886CB40B",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+    "constructPath": "CdkRealDriftIntegLambdaLoggingConfigRich/Handler",
+    "declared": {
+      "Architectures": ["arm64"],
+      "Code": {
+        "ZipFile": "export const handler = async () => ({ ok: true });"
+      },
+      "Description": "cdkrd lambda-loggingconfig-rich test handler",
+      "Environment": {
+        "Variables": {
+          "STAGE": "test"
+        }
+      },
+      "Handler": "index.handler",
+      "LoggingConfig": {
+        "ApplicationLogLevel": "INFO",
+        "LogFormat": "JSON",
+        "LogGroup": "CdkRealDriftIntegLambdaLoggingConfigRich-Logs6819BB44-BKy3Rq440Dre",
+        "SystemLogLevel": "WARN"
+      },
+      "MemorySize": 256,
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaLo-HandlerServiceRoleFCDC14A-yJwCvmjE6v2Q",
+      "Runtime": "nodejs20.x",
+      "Timeout": 10
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 256,
+    "Description": "cdkrd lambda-loggingconfig-rich test handler",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 10,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaLo-HandlerServiceRoleFCDC14A-yJwCvmjE6v2Q",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "JSON",
+      "ApplicationLogLevel": "INFO",
+      "LogGroup": "CdkRealDriftIntegLambdaLoggingConfigRich-Logs6819BB44-BKy3Rq440Dre",
+      "SystemLogLevel": "WARN"
+    },
+    "RecursiveLoop": "Terminate",
+    "Environment": {
+      "Variables": {
+        "STAGE": "test"
+      }
+    },
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambdaLoggingConfigRich/84fd7880-6ddd-11f1-a2e2-0affcc0b1caf",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegLambdaLoggingConfigRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Handler886CB40B",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["arm64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+      "constructPath": "CdkRealDriftIntegLambdaLoggingConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+      "constructPath": "CdkRealDriftIntegLambdaLoggingConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+      "constructPath": "CdkRealDriftIntegLambdaLoggingConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+      "constructPath": "CdkRealDriftIntegLambdaLoggingConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambdaLoggingConf-Handler886CB40B-2tX1VUrkUBaw",
+      "constructPath": "CdkRealDriftIntegLambdaLoggingConfigRich/Handler"
+    }
+  ]
+}

--- a/tests/integration/lambda-loggingconfig-rich/app.ts
+++ b/tests/integration/lambda-loggingconfig-rich/app.ts
@@ -1,0 +1,48 @@
+// CDK app for the cdk-real-drift Lambda LoggingConfig false-positive test.
+// Lambda is the most commonly deployed CDK resource, and structured (JSON)
+// logging with per-level controls + an explicit log group is a now-standard
+// "production" config that the existing lambda fixtures do NOT exercise (none
+// declare LoggingConfig). This emits AWS::Lambda::Function.LoggingConfig
+// {LogFormat: JSON, ApplicationLogLevel, SystemLogLevel, LogGroup} — values AWS
+// may normalize or pair with defaults. A freshly deployed + recorded function
+// with NO out-of-band change MUST report CLEAN.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  ApplicationLogLevel,
+  Architecture,
+  Code,
+  Function as LambdaFunction,
+  LoggingFormat,
+  Runtime,
+  SystemLogLevel,
+} from "aws-cdk-lib/aws-lambda";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaLoggingConfigRich");
+
+const logGroup = new LogGroup(stack, "Logs", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new LambdaFunction(stack, "Handler", {
+  runtime: Runtime.NODEJS_20_X,
+  architecture: Architecture.ARM_64,
+  handler: "index.handler",
+  code: Code.fromInline("export const handler = async () => ({ ok: true });"),
+  memorySize: 256,
+  timeout: Duration.seconds(10),
+  description: "cdkrd lambda-loggingconfig-rich test handler",
+  // Structured JSON logging with explicit application/system log levels and a
+  // customer-owned log group — the LoggingConfig the existing fixtures lack.
+  loggingFormat: LoggingFormat.JSON,
+  applicationLogLevelV2: ApplicationLogLevel.INFO,
+  systemLogLevelV2: SystemLogLevel.WARN,
+  logGroup,
+  environment: {
+    STAGE: "test",
+  },
+});
+
+app.synth();

--- a/tests/integration/lambda-loggingconfig-rich/cdk.json
+++ b/tests/integration/lambda-loggingconfig-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-loggingconfig-rich/package.json
+++ b/tests/integration/lambda-loggingconfig-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-loggingconfig-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-loggingconfig-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-loggingconfig-rich/verify-detect.sh
+++ b/tests/integration/lambda-loggingconfig-rich/verify-detect.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Lambda LoggingConfig detect + revert integration test (real AWS): the "someone
+# changed the log level in the console" scenario. Deploy -> record -> change the
+# DECLARED MUTABLE LoggingConfig out of band (ApplicationLogLevel INFO->DEBUG,
+# SystemLogLevel WARN->INFO) -> check MUST DETECT the declared drift (exit 1) ->
+# revert -> check MUST be CLEAN and the live LoggingConfig MUST be restored. This
+# is the false-negative / detection half (a nested LoggingConfig property), which
+# the plain record->check->CLEAN verify.sh does not exercise.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaLoggingConfigRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN" ] || fail "could not resolve function physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: LoggingConfig ApplicationLogLevel INFO->DEBUG, SystemLogLevel WARN->INFO ==="
+aws lambda update-function-configuration --function-name "$FN" --region "$REGION" \
+  --logging-config "LogFormat=JSON,ApplicationLogLevel=DEBUG,SystemLogLevel=INFO" >/dev/null \
+  || fail "inject drift"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-lambda-logging-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "ApplicationLogLevel" /tmp/cdkrd-lambda-logging-detect.out || fail "ApplicationLogLevel not reported"
+
+echo "=== revert (write declared LoggingConfig back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live LoggingConfig MUST be restored to INFO / WARN ==="
+GOT="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" \
+  --query "LoggingConfig.[ApplicationLogLevel,SystemLogLevel]" --output text)"
+[ "$GOT" = "INFO	WARN" ] || fail "live LoggingConfig not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/lambda-loggingconfig-rich/verify.sh
+++ b/tests/integration/lambda-loggingconfig-rich/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded function is a
+# normalization / default-folding false positive — here on the LoggingConfig
+# (JSON format + per-level log controls + customer log group) the existing
+# lambda fixtures never declared.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaLoggingConfigRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-lambda-loggingconfig-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
test(integ): add lambda-loggingconfig-rich fixture + corpus (CLEAN round)

Lambda is the most commonly deployed CDK resource, but no existing fixture or
corpus case declared a LoggingConfig — structured JSON logging with per-level
controls (ApplicationLogLevel/SystemLogLevel) and a customer-owned log group is
now a standard "production" config. Deployed it on real AWS to hunt a
normalization/default-folding false positive.

Result: CLEAN — no FP. AWS stores the declared LoggingConfig verbatim (the
LogGroup Ref resolves to the group name, key order differs but matches), and the
Lambda AWS defaults (TracingConfig/RuntimeManagementConfig/RecursiveLoop/
EphemeralStorage/PackageType) fold to atDefault. Ships as permanent offline
regression coverage for the most common resource's logging config.

- verify.sh: deploy -> record -> check CLEAN (FP half) — INTEG PASS
- verify-detect.sh: out-of-band LoggingConfig change (ApplicationLogLevel
  INFO->DEBUG, SystemLogLevel WARN->INFO) -> check DETECTS 3 declared drifts ->
  revert -> check CLEAN -> live restored to INFO/WARN (FN/detect half) — INTEG PASS
- golden-corpus case harvested live (AWS__Lambda__Function, LoggingConfig
  declared==live, expected []); corpus-replay grows accordingly
- stack deleted; bughunt-track.sh verify + sweep-orphans.sh -> SWEEP CLEAN

No src change (tests/fixtures only).
