### PR TITLE
test(integ): add logs-dataprotection + eventbridge-richpattern fixtures (CLEAN round)

### DIFF
--- a/tests/corpus/AWS__Events__Rule.Rule.json
+++ b/tests/corpus/AWS__Events__Rule.Rule.json
@@ -1,0 +1,163 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "cdkrd-integ-richpattern",
+    "constructPath": "CdkRealDriftIntegEventBridgeRichPattern/Rule",
+    "declared": {
+      "Description": "rich content-filtered pattern",
+      "EventPattern": {
+        "source": ["aws.s3", "custom.app"],
+        "detail-type": ["Object Created"],
+        "detail": {
+          "bucket": {
+            "name": [
+              {
+                "prefix": "cdkrd-"
+              }
+            ]
+          },
+          "object": {
+            "size": [
+              {
+                "numeric": [">", 1024]
+              }
+            ],
+            "key": [
+              {
+                "anything-but": ["tmp/", "cache/"]
+              }
+            ],
+            "etag": [
+              {
+                "exists": true
+              }
+            ]
+          }
+        }
+      },
+      "Name": "cdkrd-integ-richpattern",
+      "State": "ENABLED",
+      "Targets": [
+        {
+          "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEventBridgeRichPattern-Target3191CF44-FdVlZWey23Zh",
+          "DeadLetterConfig": {
+            "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEventBridgeRichPattern-DlqD1FAA4AD-yk2dYDxncxOe"
+          },
+          "Id": "queue",
+          "InputTransformer": {
+            "InputPathsMap": {
+              "bucketName": "$.detail.bucket.name",
+              "objectKey": "$.detail.object.key"
+            },
+            "InputTemplate": "{\"bucket\":<bucketName>,\"key\":<objectKey>}"
+          },
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 3600,
+            "MaximumRetryAttempts": 3
+          }
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "EventPattern": {
+      "detail-type": ["Object Created"],
+      "source": ["aws.s3", "custom.app"],
+      "detail": {
+        "bucket": {
+          "name": [
+            {
+              "prefix": "cdkrd-"
+            }
+          ]
+        },
+        "object": {
+          "size": [
+            {
+              "numeric": [">", 1024]
+            }
+          ],
+          "etag": [
+            {
+              "exists": true
+            }
+          ],
+          "key": [
+            {
+              "anything-but": ["tmp/", "cache/"]
+            }
+          ]
+        }
+      }
+    },
+    "Description": "rich content-filtered pattern",
+    "State": "ENABLED",
+    "Targets": [
+      {
+        "DeadLetterConfig": {
+          "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEventBridgeRichPattern-DlqD1FAA4AD-yk2dYDxncxOe"
+        },
+        "Id": "queue",
+        "InputTransformer": {
+          "InputPathsMap": {
+            "bucketName": "$.detail.bucket.name",
+            "objectKey": "$.detail.object.key"
+          },
+          "InputTemplate": "{\"bucket\":<bucketName>,\"key\":<objectKey>}"
+        },
+        "Arn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegEventBridgeRichPattern-Target3191CF44-FdVlZWey23Zh",
+        "RetryPolicy": {
+          "MaximumRetryAttempts": 3,
+          "MaximumEventAgeInSeconds": 3600
+        }
+      }
+    ],
+    "Id": "cdkrd-integ-richpattern",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/cdkrd-integ-richpattern",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEventBridgeRichPattern/122fc090-6ddf-11f1-83b9-0e7edd51f2dd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEventBridgeRichPattern",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Rule",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-richpattern"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Rule",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "cdkrd-integ-richpattern",
+      "constructPath": "CdkRealDriftIntegEventBridgeRichPattern/Rule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__LogGroup.Lg.json
+++ b/tests/corpus/AWS__Logs__LogGroup.Lg.json
@@ -1,0 +1,160 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Lg",
+    "resourceType": "AWS::Logs::LogGroup",
+    "physicalId": "/cdkrd/integ/dataprotection-rich",
+    "constructPath": "CdkRealDriftIntegLogsDataProtectionRich/Lg",
+    "declared": {
+      "DataProtectionPolicy": {
+        "Name": "cdkrd-data-protection",
+        "Description": "mask PII in logs",
+        "Version": "2021-06-01",
+        "Statement": [
+          {
+            "Sid": "audit",
+            "DataIdentifier": [
+              "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+              "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US"
+            ],
+            "Operation": {
+              "Audit": {
+                "FindingsDestination": {}
+              }
+            }
+          },
+          {
+            "Sid": "deidentify",
+            "DataIdentifier": [
+              "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+              "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US"
+            ],
+            "Operation": {
+              "Deidentify": {
+                "MaskConfig": {}
+              }
+            }
+          }
+        ]
+      },
+      "FieldIndexPolicies": [
+        {
+          "Fields": ["requestId", "eventName", "userIdentity.arn"]
+        }
+      ],
+      "LogGroupName": "/cdkrd/integ/dataprotection-rich",
+      "RetentionInDays": 7
+    }
+  },
+  "liveRaw": {
+    "FieldIndexPolicies": [
+      {
+        "Fields": ["requestId", "eventName", "userIdentity.arn"]
+      }
+    ],
+    "RetentionInDays": 7,
+    "BearerTokenAuthenticationEnabled": false,
+    "LogGroupClass": "STANDARD",
+    "LogGroupName": "/cdkrd/integ/dataprotection-rich",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:log-group:/cdkrd/integ/dataprotection-rich:*",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLogsDataProtectionRich/0e4a7010-6ddf-11f1-8736-0eacb13db4b5",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Lg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegLogsDataProtectionRich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "DataProtectionPolicy": {
+      "Description": "mask PII in logs",
+      "Version": "2021-06-01",
+      "Statement": [
+        {
+          "DataIdentifier": [
+            "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+            "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US"
+          ],
+          "Operation": {
+            "Audit": {
+              "FindingsDestination": {}
+            }
+          },
+          "Sid": "audit"
+        },
+        {
+          "DataIdentifier": [
+            "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+            "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US"
+          ],
+          "Operation": {
+            "Deidentify": {
+              "MaskConfig": {}
+            }
+          },
+          "Sid": "deidentify"
+        }
+      ],
+      "Name": "cdkrd-data-protection"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName"],
+    "defaults": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    },
+    "defaultPaths": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Lg",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "BearerTokenAuthenticationEnabled",
+      "actual": false,
+      "physicalId": "/cdkrd/integ/dataprotection-rich",
+      "constructPath": "CdkRealDriftIntegLogsDataProtectionRich/Lg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Lg",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
+      "physicalId": "/cdkrd/integ/dataprotection-rich",
+      "constructPath": "CdkRealDriftIntegLogsDataProtectionRich/Lg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Lg",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "/cdkrd/integ/dataprotection-rich",
+      "constructPath": "CdkRealDriftIntegLogsDataProtectionRich/Lg"
+    }
+  ]
+}

--- a/tests/integration/eventbridge-richpattern/app.ts
+++ b/tests/integration/eventbridge-richpattern/app.ts
@@ -1,0 +1,60 @@
+// CDK app for the cdk-real-drift EventBridge rich-EventPattern false-positive
+// test. EventBridge rules are extremely common, and a rich EventPattern with
+// content-based filtering (prefix / anything-but / exists / numeric) plus a rich
+// target (InputTransformer + RetryPolicy + DeadLetterConfig) is a "production"
+// shape the existing simple Events::Rule fixtures don't exercise. AWS may
+// reformat the EventPattern JSON or fold target defaults. A freshly deployed +
+// recorded rule with NO out-of-band change MUST report CLEAN.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { CfnRule } from "aws-cdk-lib/aws-events";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEventBridgeRichPattern");
+
+const target = new Queue(stack, "Target", {
+  retentionPeriod: Duration.days(1),
+});
+const dlq = new Queue(stack, "Dlq", {
+  retentionPeriod: Duration.days(1),
+});
+
+new CfnRule(stack, "Rule", {
+  name: "cdkrd-integ-richpattern",
+  description: "rich content-filtered pattern",
+  state: "ENABLED",
+  // Content-based filtering: prefix, anything-but, exists, numeric — a nested
+  // pattern AWS stores and echoes back, potentially reformatted/reordered.
+  eventPattern: {
+    source: ["aws.s3", "custom.app"],
+    "detail-type": ["Object Created"],
+    detail: {
+      bucket: { name: [{ prefix: "cdkrd-" }] },
+      object: {
+        size: [{ numeric: [">", 1024] }],
+        key: [{ "anything-but": ["tmp/", "cache/"] }],
+        etag: [{ exists: true }],
+      },
+    },
+  },
+  targets: [
+    {
+      id: "queue",
+      arn: target.queueArn,
+      deadLetterConfig: { arn: dlq.queueArn },
+      retryPolicy: {
+        maximumRetryAttempts: 3,
+        maximumEventAgeInSeconds: 3600,
+      },
+      inputTransformer: {
+        inputPathsMap: {
+          bucketName: "$.detail.bucket.name",
+          objectKey: "$.detail.object.key",
+        },
+        inputTemplate: '{"bucket":<bucketName>,"key":<objectKey>}',
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/eventbridge-richpattern/cdk.json
+++ b/tests/integration/eventbridge-richpattern/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eventbridge-richpattern/package.json
+++ b/tests/integration/eventbridge-richpattern/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-eventbridge-richpattern",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eventbridge-richpattern false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/eventbridge-richpattern/verify.sh
+++ b/tests/integration/eventbridge-richpattern/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be
+# CLEAN. Any drift on a freshly deployed + recorded stack is a normalization /
+# default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEventBridgeRichPattern
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] harvest corpus ==="; CDKRD_CORPUS_DIR="/tmp/corpus-eventbridge-richpattern" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/logs-dataprotection-rich/app.ts
+++ b/tests/integration/logs-dataprotection-rich/app.ts
@@ -1,0 +1,60 @@
+// CDK app for the cdk-real-drift CloudWatch Logs DataProtectionPolicy /
+// FieldIndexPolicies false-positive test. A LogGroup is one of the most common
+// resources, and a DataProtectionPolicy is a JSON document (audit + de-identify
+// statements) that AWS may re-serialize / reorder on store — the same JSON-doc
+// reformatting class that policy canonicalization handles for IAM, but on a
+// NON-IAM JSON property that has its own shape. FieldIndexPolicies is a second
+// JSON array AWS may echo back reformatted. A freshly deployed + recorded log
+// group with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLogsDataProtectionRich");
+
+const logGroup = new CfnLogGroup(stack, "Lg", {
+  logGroupName: "/cdkrd/integ/dataprotection-rich",
+  retentionInDays: 7,
+  // A data-protection policy: audit + de-identify EmailAddress/PhoneNumber. AWS
+  // stores this JSON and echoes it back, potentially reformatted/reordered.
+  dataProtectionPolicy: {
+    Name: "cdkrd-data-protection",
+    Description: "mask PII in logs",
+    Version: "2021-06-01",
+    Statement: [
+      {
+        Sid: "audit",
+        DataIdentifier: [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US",
+        ],
+        Operation: {
+          Audit: {
+            FindingsDestination: {},
+          },
+        },
+      },
+      {
+        Sid: "deidentify",
+        DataIdentifier: [
+          "arn:aws:dataprotection::aws:data-identifier/EmailAddress",
+          "arn:aws:dataprotection::aws:data-identifier/PhoneNumber-US",
+        ],
+        Operation: {
+          Deidentify: {
+            MaskConfig: {},
+          },
+        },
+      },
+    ],
+  },
+  // Field index policies — a second JSON array AWS may echo reformatted.
+  fieldIndexPolicies: [
+    {
+      Fields: ["requestId", "eventName", "userIdentity.arn"],
+    },
+  ],
+});
+logGroup.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/logs-dataprotection-rich/cdk.json
+++ b/tests/integration/logs-dataprotection-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/logs-dataprotection-rich/package.json
+++ b/tests/integration/logs-dataprotection-rich/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-logs-dataprotection-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift logs-dataprotection-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/logs-dataprotection-rich/verify.sh
+++ b/tests/integration/logs-dataprotection-rich/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be
+# CLEAN. Any drift on a freshly deployed + recorded stack is a normalization /
+# default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLogsDataProtectionRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] harvest corpus ==="; CDKRD_CORPUS_DIR="/tmp/corpus-logs-dataprotection-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
test(integ): add logs-dataprotection + eventbridge-richpattern fixtures (CLEAN round)

Two common resources with JSON-document properties AWS may re-serialize/reorder
on store — the JSON-doc reformatting class. Deployed both on real AWS to hunt a
normalization false positive; both came back CLEAN.

- logs-dataprotection-rich: a CloudWatch Logs LogGroup with a DataProtectionPolicy
  (audit + de-identify statements) and FieldIndexPolicies. AWS echoes the policy
  back with keys reordered but otherwise intact (Name preserved) — cdkrd's
  structural compare folds the reorder, no FP. Note these statements have no
  `Effect`, so they are NOT treated as IAM policy docs; the clean round proves the
  generic object compare handles them.
- eventbridge-richpattern: an Events::Rule with a content-filtered EventPattern
  (prefix / anything-but / exists / numeric) and a rich target (InputTransformer +
  RetryPolicy + DeadLetterConfig). Both EventPattern and Targets round-trip
  exactly — no FP.

Each ships fixture + a golden-corpus case harvested live (both `expected []`);
corpus-replay now 353 cases. Both INTEG PASS on real AWS; stacks deleted,
bughunt-track.sh verify + sweep-orphans.sh -> SWEEP CLEAN.

No src change (tests/fixtures only).
