### PR TITLE
docs(readme): explain that recording the baseline arms undeclared/added detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,28 @@ or deselect what you want to keep visible) and writes
 AWS** — commit it; from here on `check` reports CLEAN until reality changes.
 (Declared drift is detected from the very first run, baseline or not.)
 
+**Recording the baseline is what arms undeclared / added detection** — the
+headline feature. Until you record, every live-only value and out-of-band added
+resource is reported as `unrecorded` (informational, **CLEAN**, never fails
+`--fail`); there is nothing to compare it to yet. Record once, and from then
+on a later out-of-band change to any of them surfaces as failing drift. So the
+normal first step on a freshly deployed stack is to record — even when the run
+is fully clean and nothing stands out. In that case the prompt is just two
+options (everything undeclared is already at an AWS default, nothing to list):
+
+```console
+result: CLEAN
+
+ApiStack: no .cdkrd baseline yet — record the current state as your baseline?
+  ❯ Nothing (decide later)
+    Record current state as the .cdkrd baseline (marks this stack reviewed)
+```
+
+**Nothing** is the cursor default only so Enter is always a harmless no-op (it
+never writes); it is not the recommendation. Choosing **Nothing** leaves this
+stack unwatched for undeclared / added drift until you record. (`check --fail` in
+CI never writes a baseline — you record locally and commit the file.)
+
 **Day to day** — someone changes something from the console; the next `check`
 reports it and asks right there:
 
@@ -174,7 +196,12 @@ code or reverting.
   to git. A PR that changes it is a visible, reviewable change to "what real
   state we record". Account id and region are part of the filename, so the same
   stack deployed to several accounts never collides (gitignore personal-account
-  baselines if you prefer).
+  baselines if you prefer). **Recording the baseline is the switch that arms
+  undeclared / added detection**: with no baseline, a live-only value or added
+  resource is `unrecorded` (informational, CLEAN, never fails `--fail`) — there
+  is nothing to compare it to. Once recorded, a later out-of-band change to it is
+  failing drift. So the headline feature is inert on a stack until its first
+  `record`; declared-property and out-of-band-delete detection need no baseline.
 - There is **no watch-list to maintain**. Every `check` snapshots the full live
   model (Cloud Control API + SDK readers for the gap types) and subtracts
   everything explainable — schema read-only/write-only/defaults, AWS-managed


### PR DESCRIPTION
## Why

A user running `cdkrd check` for the first time on a fully clean stack saw the
two-option establish prompt (`Nothing` / `Record current state as the .cdkrd
baseline`) and asked: is recording the normal thing to do even when there is no
drift, and is that explained in the README?

It is the normal first step — but the README never stated the cause-and-effect
that makes it so: **recording the baseline is the switch that arms the headline
undeclared / added detection.** Without a baseline, every live-only value and
out-of-band added resource is `unrecorded` (informational, CLEAN, never fails
`--fail`); the differentiator feature is inert until the first `record`. The
README sold undeclared detection as the headline yet framed recording as an
optional afterthought, and the clean-first-run two-option screen wasn't shown at
all.

## What

Docs-only (README.md):

1. **"First run"** — add a paragraph + the clean-run two-option prompt example,
   stating that recording arms detection and that `Nothing` is the cursor default
   only for Enter-safety, not the recommendation.
2. **"How it works"** (undeclared bullet) — add the arming/contrast sentence: no
   baseline -> `unrecorded`/CLEAN/never-fails; recorded -> later change is failing
   drift; declared + out-of-band-delete need no baseline.

Claims verified against `src/baseline/baseline-file.ts` ("with NO baseline at
all, every undeclared finding is unrecorded") and the prompt text copied verbatim
from `src/commands/interactive-resolve.ts` (`establishOnly`).

## Checks

- typecheck / lint+format / build / 1440 unit tests — all pass (`docs` + `check`
  markers set)
- Docs-only PR (no `src/**`): `verify-pr-gate` exempt
