### PR TITLE
fix(check): drop "all" from interactive Revert/Ignore/Record menu labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ info:
 
 ApiStack: unrecorded values found — what do you want to do?
   ❯ Nothing (decide later)
-    Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
-    Ignore all — stop reporting it (writes .cdkrd/config.json)
-    Decide per finding — pick an action for each
+    Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
+    Ignore — stop reporting it (writes .cdkrd/config.json)
+    Decide per finding — assign a different action to each
 ```
 
 The report always prints **first**, so you see the standout values before deciding
@@ -93,24 +93,30 @@ reports it and asks right there:
 ```console
 ApiStack: drift found — what do you want to do?
   ❯ Nothing (decide later)
-    Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
-    Revert all — write the desired values to AWS
-    Ignore all — stop reporting it (writes .cdkrd/config.json)
-    Decide per finding — pick an action for each
+    Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
+    Revert — write the desired values back to AWS
+    Ignore — stop reporting it (writes .cdkrd/config.json)
+    Decide per finding — assign a different action to each
 ```
 
-- **Record all** records the undeclared values — and any out-of-band **added**
+Each of **Record / Revert / Ignore** applies that ONE action; its multiselect then
+lets you narrow **which** findings (and which ops) it touches. **Decide per
+finding** is the only path that assigns a _different_ action to each finding.
+
+- **Record** records the undeclared values — and any out-of-band **added**
   resources — in the baseline, so `check` stays CLEAN until they change again (a
-  multiselect lets you record some and keep reporting others). Keeps watching.
-- **Ignore all** writes a path rule to `.cdkrd/config.json` so the drift (declared,
-  undeclared, _or_ an out-of-band **added** resource) stops being reported entirely.
-  Stops watching.
+  multiselect lets you record some and keep reporting others; everything is
+  pre-selected). Keeps watching.
+- **Ignore** writes a path rule to `.cdkrd/config.json` so the drift (declared,
+  undeclared, _or_ an out-of-band **added** resource) stops being reported entirely
+  (multiselect, pre-selected). Stops watching.
 - **Decide per finding** opens a picker to assign a different action to each
   finding. On a stack with many findings, **just start typing to filter** the rows
   by name (↑↓ move · space cycles the row's actions · → applies the focused action
   to every _visible_ row · ⌫ clears the filter · enter applies · esc backs out).
-- **Revert all** shows a plan, lets you pick which op(s) to write, confirms, then
-  writes the desired values back to AWS:
+- **Revert** shows a plan, lets you pick which op(s) to write (nothing
+  pre-selected — opt in to each AWS write), confirms, then writes the desired
+  values back to AWS:
 
 ```console
 === cdkrd revert: ApiStack (us-east-1) ===
@@ -295,8 +301,8 @@ the line) are errors (exit `2`) — a typo'd flag never silently becomes a stack
 
 ### Interactive prompts (TTY only — CI is never prompted)
 
-- **`check` with drift** offers `Record all / Revert all / Ignore all / Decide
-per finding / Nothing` inline (shown above). Each option appears only when it
+- **`check` with drift** offers `Record / Revert / Ignore / Decide per finding /
+Nothing` inline (shown above). Each option appears only when it
   applies (no Revert if nothing is revertable; "Decide per finding" only with >1
   finding). `Nothing` is the default; Enter keeps plain-check behavior. Every
   option runs exactly the same code as the standalone commands — including the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -146,11 +146,12 @@ lives per stack/account/region; the `ignore` rules live once, app-wide, in
 `applyIgnores` reads).
 
 In a TTY, `check` offers to resolve the drift **inline** (R28, extended R121/R125):
-after reporting it prompts `Nothing / Record all / Revert all / Ignore all / Decide
+after reporting it prompts `Nothing / Record / Revert / Ignore / Decide
 per finding` (Nothing is FIRST so the safe no-op is the default cursor; each bulk
 option shown only when ≥1 finding can take it; "Decide per finding" only when >1
 finding is decidable). A cancelled sub-prompt (Esc) returns to this menu (R125). The bulk options apply one
-action to every applicable finding (each leads to that verb's own multiselect);
+action to applicable findings (each leads to that verb's own multiselect, which
+narrows WHICH findings — revert starts fully unselected, R137);
 "Decide per finding" opens the per-finding **action picker**
 ([action-picker.ts](../src/commands/action-picker.ts) — `↑↓` move, `space` cycle
 the focused row's applicable actions, `→` set every row to the focused action,
@@ -260,8 +261,8 @@ checked.
     standalone verbs and check's interactive prompt (`recordStack` / `ignoreStack` /
     `revertStack`), so they can never diverge.
   - **interactive-resolve.ts** — check's after-report resolution (R28/R121/R125): the
-    top-level select (Nothing first as the safe default, then Record all / Revert all /
-    Ignore all / Decide per finding) looped so a cancelled sub-prompt returns to the
+    top-level select (Nothing first as the safe default, then Record / Revert /
+    Ignore / Decide per finding) looped so a cancelled sub-prompt returns to the
     menu (Esc = back), and the per-finding dispatch into the stack actions; returns the
     re-evaluated exit code.
   - **action-picker.ts** — the per-finding action picker (R121), built on `@clack/core`'s

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -1,6 +1,6 @@
 // Per-finding action picker for check's interactive "Decide per finding" path (R121).
 //
-// The bulk options (Record all / Ignore all / Revert all) apply ONE action to every
+// The bulk options (Record / Ignore / Revert) apply ONE action to every
 // applicable finding. When a stack mixes findings that each deserve a different verb,
 // this picker assigns an action PER finding in a single screen:
 //   ↑↓ = move · space = cycle the focused row's action · → = set every VISIBLE row to

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -336,7 +336,7 @@ export async function runCheck(args: string[]): Promise<number> {
       const hasUnrecorded = reconciled.some((f) => f.unrecorded === true);
 
       // R28 (extended R121): drift found in a TTY → offer to resolve it inline
-      // (Record all / Revert all / Ignore all / Decide per finding / Nothing) instead
+      // (Record / Revert / Ignore / Decide per finding / Nothing) instead
       // of making the user re-run a separate verb. Skipped for --json (machine output),
       // --show-all (baseline not applied — record would mean something else), and
       // --pre-deploy (declared-only, baseline-untouched contract). UNRECORDED values do

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -1,10 +1,10 @@
 // check's interactive after-report resolution (R28, extended R121). After `check`
 // reports drift in a TTY, it offers to resolve it inline instead of making the user
 // re-run a separate verb. The top-level choice is:
-//   Record all / Revert all / Ignore all  — one action applied to every applicable
-//                                            finding (each leads to its own multiselect)
-//   Decide per finding                     — assign an action PER finding (the picker)
-//   Nothing                                — leave it (default)
+//   Record / Revert / Ignore  — ONE action; its multiselect then narrows which findings
+//                                (and which ops) it applies to
+//   Decide per finding         — assign a DIFFERENT action PER finding (the picker)
+//   Nothing                    — leave it (default)
 // Each bulk option appears only when >=1 finding can take that action; "Decide per
 // finding" appears only when >1 finding is decidable (with one, the bulk option already
 // IS per-finding). All paths route through the SAME stack-actions code as the standalone
@@ -185,17 +185,25 @@ export function buildResolveOptions(
       // initial baseline (marks the stack reviewed) — name that, not "all undeclared".
       label: establishOnly
         ? 'Record current state as the .cdkrd baseline (marks this stack reviewed)'
-        : 'Record all undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)',
+        : 'Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)',
     });
   if (actions.revert)
-    options.push({ value: 'revert-all', label: 'Revert all — write the desired values to AWS' });
+    options.push({ value: 'revert-all', label: 'Revert — write the desired values back to AWS' });
   if (actions.ignore)
     options.push({
       value: 'ignore-all',
-      label: 'Ignore all — stop reporting it (writes .cdkrd/config.json)',
+      label: 'Ignore — stop reporting it (writes .cdkrd/config.json)',
     });
+  // The bulk options above each apply ONE action (the picker then narrows WHICH findings,
+  // and which ops within a finding); "Decide per finding" is the only path that assigns a
+  // DIFFERENT action to each finding — say that, so the contrast is explicit (the values
+  // are 'revert-all'/'ignore-all' for back-compat, but the labels no longer say "all"
+  // since revert's picker starts fully UNSELECTED, R137).
   if (decidableCount > 1)
-    options.push({ value: 'per-finding', label: 'Decide per finding — pick an action for each' });
+    options.push({
+      value: 'per-finding',
+      label: 'Decide per finding — assign a different action to each',
+    });
   return options;
 }
 

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -132,7 +132,7 @@ describe('buildResolveOptions (R133 — the chain menu surface)', () => {
         .label;
     expect(label(true)).toContain('Record current state as the .cdkrd baseline');
     expect(label(true)).not.toContain('undeclared');
-    expect(label(false)).toContain('Record all undeclared');
+    expect(label(false)).toContain('Record undeclared');
   });
 });
 


### PR DESCRIPTION
The interactive after-report menu listed `Revert all` / `Ignore all` / `Record all`, but **revert's multiselect starts fully UNSELECTED** (R137 — revert is the one AWS-mutating verb, so nothing is pre-armed; you opt in to each write). So "Revert **all**" contradicted a picker where nothing was selected. (`record` / `ignore` default the picker to all-selected, so their "all" was at least truthful — but for consistency they move too.)

## Change

Rename the three bulk options to the bare verb, and sharpen the per-finding label so the distinction stays explicit:

```
● Nothing (decide later)
○ Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
○ Revert — write the desired values back to AWS
○ Ignore — stop reporting it (writes .cdkrd/config.json)
○ Decide per finding — assign a different action to each
```

- **Record / Revert / Ignore** = apply ONE action; the multiselect then narrows WHICH findings (and which ops).
- **Decide per finding** = assign a DIFFERENT action to each finding.

Internal option `value`s (`revert-all` / `ignore-all`) are unchanged for back-compat — only the user-facing labels change.

## Touched

- `src/commands/interactive-resolve.ts` — labels + a comment explaining the bulk-vs-per-finding contrast.
- `src/commands/check.ts`, `src/commands/action-picker.ts` — comment follow-ups.
- `tests/check.test.ts` — `Record all undeclared` → `Record undeclared`.
- `README.md`, `docs/ARCHITECTURE.md` — menu examples + note that revert is opt-in (nothing pre-selected) while record/ignore are pre-selected.

## Checks

typecheck / lint+format / build / **1440 unit tests** all pass. Docs verified consistent with the code labels.