### PR TITLE
fix(revert): revert Logs LogGroup BearerTokenAuthenticationEnabled via PutBearerTokenAuthentication

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -589,7 +589,13 @@ only when non-zero — unrecorded values are named as such, never folded into
     emits one declared finding per changed Key (`Finding.attributeKey`), and the
     writer sends ONLY those `Key=Value`s — a CC index patch would misalign against
     the full live bag (the template declares a subset) and exceed ELB's
-    20-attribute-per-call cap. Scoped to the EXACT top-level path: deeper
+    20-attribute-per-call cap. A CloudWatch Logs log group's
+    `BearerTokenAuthenticationEnabled` reverts via `PutBearerTokenAuthentication`
+    (the dedicated control-plane API): CC `UpdateResource` FAILS on this newer
+    boolean — its LogGroup update handler's downstream call errors with "The
+    security token included in the request is invalid" (proven live) — so the
+    writer toggles it directly (a `remove` reverts to the schema default DISABLED;
+    an `add` carries the desired boolean). Scoped to the EXACT top-level path: deeper
     `Policies.*` declared drift still patches via CC. A resource with both kinds
     of findings splits into one `cc` item and one `sdk` item.
 - **Not revertable (reported honestly, never silently skipped)**:

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -26,6 +26,10 @@ import {
   GetDistributionConfigCommand,
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
+import {
+  CloudWatchLogsClient,
+  PutBearerTokenAuthenticationCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
 import { DocDBClient, ModifyDBClusterCommand } from '@aws-sdk/client-docdb';
 import {
   DescribeDomainConfigCommand,
@@ -601,6 +605,33 @@ const writeOpenSearchDomain: SdkWriter = async (ctx, ops) => {
   await c.send(new UpdateDomainConfigCommand(input as never));
 };
 
+// AWS::Logs::LogGroup.BearerTokenAuthenticationEnabled — Cloud Control CAN read this
+// type, but its UpdateResource FAILS on this (newer) boolean: the CC LogGroup update
+// handler's downstream CloudWatch Logs call errors with "The security token included in
+// the request is invalid" (proven live; the property has a dedicated control-plane API
+// the generic UpdateLogGroup path does not drive). CloudWatch Logs exposes
+// PutBearerTokenAuthentication for exactly this toggle, so route the revert through it.
+// The op is the BearerTokenAuthenticationEnabled toggle: a `remove` (undeclared, not in
+// baseline) reverts to the schema default of DISABLED; an `add` carries the desired
+// boolean (declared drift / recorded baseline value). The LogGroup physical id IS its
+// name, which PutBearerTokenAuthentication accepts as logGroupIdentifier.
+const writeLogGroupBearerTokenAuth: SdkWriter = async (ctx, ops) => {
+  const lg = str(ctx.physicalId) ?? str(ctx.declared['LogGroupName']);
+  if (!lg) throw new Error('cannot resolve log group name for revert');
+  const c = new CloudWatchLogsClient({ region: ctx.region });
+  for (const op of ops) {
+    // plan.ts groups this prop-scoped item to the single BearerTokenAuthenticationEnabled
+    // path, so there is one op; a `remove` means "back to default (disabled)".
+    const enabled = op.op === 'add' ? op.value === true : false;
+    await c.send(
+      new PutBearerTokenAuthenticationCommand({
+        logGroupIdentifier: lg,
+        bearerTokenAuthenticationEnabled: enabled,
+      })
+    );
+  }
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::OpenSearchService::Domain': writeOpenSearchDomain,
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
@@ -621,6 +652,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
 // drift at Policies.0...) still go through Cloud Control as before.
 export const SDK_PROP_WRITERS: Record<string, Record<string, SdkWriter>> = {
   'AWS::IAM::Role': { Policies: writeIamRoleInlinePolicies },
+  'AWS::Logs::LogGroup': { BearerTokenAuthenticationEnabled: writeLogGroupBearerTokenAuth },
   'AWS::ElasticLoadBalancingV2::LoadBalancer': {
     LoadBalancerAttributes: writeElbLoadBalancerAttributes,
   },

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -152,6 +152,23 @@ describe('buildRevertPlan', () => {
     expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/Roles[RoleX]' });
   });
 
+  it("an undeclared LogGroup BearerTokenAuthenticationEnabled drift -> a prop-scoped 'sdk' item (CC UpdateResource fails on it)", () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Logs::LogGroup',
+      physicalId: '/aws/lambda/my-fn',
+      path: 'BearerTokenAuthenticationEnabled',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'remove',
+      path: '/BearerTokenAuthenticationEnabled',
+    });
+  });
+
   it('undeclared drift with an recorded prior value -> add op restoring the baseline value', () => {
     const f = F({
       tier: 'undeclared',

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -40,6 +40,10 @@ import {
 } from '@aws-sdk/client-docdb';
 import { GetJobCommand, GlueClient, UpdateJobCommand } from '@aws-sdk/client-glue';
 import {
+  CloudWatchLogsClient,
+  PutBearerTokenAuthenticationCommand,
+} from '@aws-sdk/client-cloudwatch-logs';
+import {
   GetTopicAttributesCommand,
   SetTopicAttributesCommand,
   SNSClient,
@@ -70,6 +74,7 @@ const cloudfront = mockClient(CloudFrontClient);
 const wafv2 = mockClient(WAFV2Client);
 const opensearch = mockClient(OpenSearchClient);
 const glue = mockClient(GlueClient);
+const logs = mockClient(CloudWatchLogsClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -109,6 +114,7 @@ beforeEach(() => {
   wafv2.reset();
   opensearch.reset();
   glue.reset();
+  logs.reset();
 });
 
 describe('OpenSearch Domain writer (CC UpdateResource rejects on override_main_response_version)', () => {
@@ -922,5 +928,62 @@ describe('policy writers revert ALL attachment targets (not just the first)', ()
     expect(
       sqs.commandCalls(SetQueueAttributesCommand).map((c) => c.args[0].input.QueueUrl)
     ).toEqual(['https://sqs/q1', 'https://sqs/q2']);
+  });
+});
+
+describe('Logs LogGroup BearerTokenAuthenticationEnabled prop-scoped writer (CC UpdateResource fails on this property)', () => {
+  const LG = '/aws/lambda/my-fn';
+  const removeOp: PatchOp = {
+    op: 'remove',
+    path: '/BearerTokenAuthenticationEnabled',
+    prior: true,
+    human: 'BearerTokenAuthenticationEnabled -> remove (undeclared, not in baseline)',
+  };
+  const bearerAddOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/BearerTokenAuthenticationEnabled',
+    value,
+    human: 'BearerTokenAuthenticationEnabled -> deployed-template value',
+  });
+
+  it('resolveSdkWriter routes BearerTokenAuthenticationEnabled to the prop-scoped writer', () => {
+    expect(resolveSdkWriter('AWS::Logs::LogGroup', [removeOp])).toBeDefined();
+    // a deeper / other LogGroup path keeps going through Cloud Control (no SDK writer)
+    expect(
+      resolveSdkWriter('AWS::Logs::LogGroup', [
+        { op: 'remove', path: '/RetentionInDays', human: '' },
+      ])
+    ).toBeUndefined();
+  });
+
+  it('a remove (undeclared, not in baseline) DISABLES bearer-token auth via PutBearerTokenAuthentication', async () => {
+    logs.on(PutBearerTokenAuthenticationCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::Logs::LogGroup', [removeOp])!;
+    await writer(ctx({ physicalId: LG }), [removeOp]);
+    const calls = logs.commandCalls(PutBearerTokenAuthenticationCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args[0].input).toEqual({
+      logGroupIdentifier: LG,
+      bearerTokenAuthenticationEnabled: false,
+    });
+  });
+
+  it('an add carries the desired boolean (declared / baseline restore)', async () => {
+    logs.on(PutBearerTokenAuthenticationCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::Logs::LogGroup', [bearerAddOp(true)])!;
+    await writer(ctx({ physicalId: LG }), [bearerAddOp(true)]);
+    expect(logs.commandCalls(PutBearerTokenAuthenticationCommand)[0].args[0].input).toEqual({
+      logGroupIdentifier: LG,
+      bearerTokenAuthenticationEnabled: true,
+    });
+  });
+
+  it('falls back to declared LogGroupName when the physical id is absent', async () => {
+    logs.on(PutBearerTokenAuthenticationCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::Logs::LogGroup', [removeOp])!;
+    await writer(ctx({ physicalId: '', declared: { LogGroupName: LG } }), [removeOp]);
+    expect(
+      logs.commandCalls(PutBearerTokenAuthenticationCommand)[0].args[0].input.logGroupIdentifier
+    ).toBe(LG);
   });
 });


### PR DESCRIPTION
## Problem

Reverting an undeclared `BearerTokenAuthenticationEnabled` drift on an
`AWS::Logs::LogGroup` failed:

```
FAILED: .../ScoringApiLambdaLogGroup — The security token included in the request
is invalid (Service: CloudWatchLogs, Status Code: 400, ...)
```

The same profile reads fine (`check` succeeds, Cloud Control `GetResource` works),
so it is not a credential problem. The error surfaces from Cloud Control's
`AWS::Logs::LogGroup` **UpdateResource** handler: its downstream CloudWatch Logs
call fails on this newer property. `BearerTokenAuthenticationEnabled` has a
**dedicated control-plane API** (`PutBearerTokenAuthentication`) that the generic
`UpdateLogGroup` path Cloud Control drives does not use.

## Fix

Route the revert of `AWS::Logs::LogGroup.BearerTokenAuthenticationEnabled` through
a property-scoped SDK writer (`SDK_PROP_WRITERS`) calling
`PutBearerTokenAuthentication` directly — the same established pattern used for the
IAM Role inline `Policies` and ELB attribute-bag props:

- a `remove` (undeclared, not in baseline) → disable (the schema default `false`),
  which folds back to `atDefault` on the convergence re-read (CLEAN);
- an `add` (declared drift / recorded baseline restore) → the desired boolean.

The LogGroup physical id IS its name, accepted as `logGroupIdentifier` (falls back
to declared `LogGroupName`).

## Tests

- `tests/writers.test.ts`: routing + remove(→false) + add(→bool) + LogGroupName fallback.
- `tests/revert-plan.test.ts`: an undeclared BearerToken finding builds a prop-scoped `sdk` item.
- All 1447 unit tests pass; typecheck / lint / build green.

## Note on verification

The schema-level reasoning and unit tests cover the writer; the original
"security token invalid" failure was reproduced against real AWS only up to the
Cloud Control `GetResource` (the actual mutating `UpdateResource` was not run from
this session). A live `check → revert → check` on a LogGroup with this property
set is recommended before relying on it.
