### PR TITLE
fix(revert): collapse a resource's cc+sdk revert items into one plan block and one reverted line

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -456,9 +456,29 @@ export function formatPlan(
       '      if they should be REMOVED, re-run revert with --remove-unrecorded.'
     );
   }
+  // A resource can split into MORE THAN ONE plan item (a Cloud Control `cc` item plus a
+  // prop-scoped `sdk` item route through different writers — e.g. a Logs LogGroup whose
+  // RetentionInDays reverts via CC while BearerTokenAuthenticationEnabled reverts via the
+  // SDK writer). Merge them into ONE block per resource so the listing reads per-resource,
+  // not per-writer-group (two identical-header blocks for the same resource is confusing).
+  const planByResource = new Map<
+    string,
+    { displayId: string; resourceType: string; humans: string[] }
+  >();
   for (const item of plan.items) {
-    lines.push(`\n  ${item.displayId} (${item.resourceType})`);
-    for (const op of item.ops) lines.push(`    - ${op.human}`);
+    const g = planByResource.get(item.logicalId);
+    const humans = item.ops.map((op) => op.human);
+    if (g) g.humans.push(...humans);
+    else
+      planByResource.set(item.logicalId, {
+        displayId: item.displayId,
+        resourceType: item.resourceType,
+        humans,
+      });
+  }
+  for (const g of planByResource.values()) {
+    lines.push(`\n  ${g.displayId} (${g.resourceType})`);
+    for (const h of g.humans) lines.push(`    - ${h}`);
   }
   if (plan.notRevertable.length > 0) {
     if (opts.verbose) {
@@ -480,6 +500,31 @@ export function formatPlan(
     }
   }
   return lines;
+}
+
+/** Collapse per-item apply results into ONE outcome per resource (logical id). A
+ *  resource that split into a `cc` item and a prop-scoped `sdk` item produced two
+ *  results; print a single `reverted:` line for it when every item succeeded, and a
+ *  single `FAILED:` line (joining the failing writers' errors) when any did not — so a
+ *  fully reverted resource never prints twice and a partial failure is never shown as a
+ *  plain success. Insertion order (first item per resource) is preserved. */
+export function summarizeRevertResults(
+  applied: readonly { logicalId: string; displayId: string; ok: boolean; error?: string }[]
+): { displayId: string; ok: boolean; error?: string }[] {
+  const byResource = new Map<string, { displayId: string; ok: boolean; errors: string[] }>();
+  for (const a of applied) {
+    const g = byResource.get(a.logicalId) ?? { displayId: a.displayId, ok: true, errors: [] };
+    if (!a.ok) {
+      g.ok = false;
+      if (a.error) g.errors.push(a.error);
+    }
+    byResource.set(a.logicalId, g);
+  }
+  return [...byResource.values()].map((g) =>
+    g.ok
+      ? { displayId: g.displayId, ok: true }
+      : { displayId: g.displayId, ok: false, error: g.errors.join('; ') }
+  );
 }
 
 function printPlan(
@@ -675,6 +720,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // correctly vanishes from `post`, but a FAILED one would vanish too (reading as CLEAN).
   // Track the failed ones and re-add their findings so they still count as drift.
   const failedDeleteIds = new Set<string>();
+  const applied: { logicalId: string; displayId: string; ok: boolean; error?: string }[] = [];
   for (const item of plan.items) {
     let r: { ok: boolean; error?: string };
     if (item.kind === 'delete') {
@@ -719,12 +765,22 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       const ccItem = { ...item, ops: extra.length > 0 ? [...tagged, ...extra] : tagged };
       r = await applyRevertItem(cc, ccItem, identifier);
     }
-    console.log(
-      r.ok
-        ? style.ok(`  reverted: ${item.displayId}`)
-        : style.fail(`  FAILED: ${item.displayId} — ${r.error}`)
-    );
+    applied.push({
+      logicalId: item.logicalId,
+      displayId: item.displayId,
+      ok: r.ok,
+      ...(r.error !== undefined && { error: r.error }),
+    });
     if (!r.ok) worst = Math.max(worst, 2);
+  }
+  // Print ONE outcome per resource (a resource that split into a `cc` + `sdk` item
+  // produced two results) so a fully reverted resource never prints `reverted:` twice.
+  for (const s of summarizeRevertResults(applied)) {
+    console.log(
+      s.ok
+        ? style.ok(`  reverted: ${s.displayId}`)
+        : style.fail(`  FAILED: ${s.displayId} — ${s.error}`)
+    );
   }
 
   // Re-check convergence — scoped to the resources the revert just touched (R44).

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -29,6 +29,7 @@ import {
   revertConfirmMessage,
   revertSelectOptions,
   revertStack,
+  summarizeRevertResults,
 } from '../src/commands/stack-actions.js';
 
 describe('includeUnrecordedRemovals (R113 — surface undeclared REMOVE in a gated prompt)', () => {
@@ -267,6 +268,82 @@ describe('formatPlan (R35 — NOT-revertable folds to a per-reason summary)', ()
     );
     expect(lines[2]).toContain('If the live values are RIGHT, record them');
     expect(lines[3]).toContain('REMOVED, re-run revert with --remove-unrecorded');
+  });
+
+  it('a resource split into a cc item + a prop-scoped sdk item renders ONE block (not two)', () => {
+    // e.g. a Logs LogGroup whose RetentionInDays reverts via Cloud Control while
+    // BearerTokenAuthenticationEnabled reverts via the SDK writer — two plan items, same
+    // logical id. The listing must merge them into one header + all ops.
+    const plan: RevertPlan = {
+      items: [
+        {
+          logicalId: 'LG',
+          displayId: 'Stack/LogGroup',
+          resourceType: 'AWS::Logs::LogGroup',
+          physicalId: '/aws/lambda/fn',
+          kind: 'cc',
+          ops: [
+            {
+              op: 'add',
+              path: '/RetentionInDays',
+              value: 731,
+              human: 'RetentionInDays -> deployed-template value',
+            },
+          ],
+        },
+        {
+          logicalId: 'LG',
+          displayId: 'Stack/LogGroup',
+          resourceType: 'AWS::Logs::LogGroup',
+          physicalId: '/aws/lambda/fn',
+          kind: 'sdk',
+          ops: [
+            {
+              op: 'remove',
+              path: '/BearerTokenAuthenticationEnabled',
+              human: 'BearerTokenAuthenticationEnabled -> remove (undeclared, not in baseline)',
+            },
+          ],
+        },
+      ],
+      notRevertable: [],
+    };
+    const lines = formatPlan('s', 'r', plan, {});
+    expect(lines.filter((l) => l === '\n  Stack/LogGroup (AWS::Logs::LogGroup)')).toHaveLength(1);
+    expect(lines).toContain('    - RetentionInDays -> deployed-template value');
+    expect(lines).toContain(
+      '    - BearerTokenAuthenticationEnabled -> remove (undeclared, not in baseline)'
+    );
+  });
+});
+
+describe('summarizeRevertResults (one outcome per resource even when it split into cc+sdk items)', () => {
+  it('all items for a resource ok -> a single reverted entry', () => {
+    const out = summarizeRevertResults([
+      { logicalId: 'LG', displayId: 'Stack/LogGroup', ok: true },
+      { logicalId: 'LG', displayId: 'Stack/LogGroup', ok: true },
+    ]);
+    expect(out).toEqual([{ displayId: 'Stack/LogGroup', ok: true }]);
+  });
+
+  it('any item failing -> a single FAILED entry joining the errors (never a duplicate success)', () => {
+    const out = summarizeRevertResults([
+      { logicalId: 'LG', displayId: 'Stack/LogGroup', ok: true },
+      { logicalId: 'LG', displayId: 'Stack/LogGroup', ok: false, error: 'boom' },
+    ]);
+    expect(out).toEqual([{ displayId: 'Stack/LogGroup', ok: false, error: 'boom' }]);
+  });
+
+  it('distinct resources keep distinct entries in first-seen order', () => {
+    const out = summarizeRevertResults([
+      { logicalId: 'B', displayId: 'Stack/B', ok: true },
+      { logicalId: 'A', displayId: 'Stack/A', ok: false, error: 'e1' },
+      { logicalId: 'A', displayId: 'Stack/A', ok: false, error: 'e2' },
+    ]);
+    expect(out).toEqual([
+      { displayId: 'Stack/B', ok: true },
+      { displayId: 'Stack/A', ok: false, error: 'e1; e2' },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Problem

When a single resource has drift that routes through **both** Cloud Control and a
prop-scoped SDK writer, it splits into two revert plan items (one `cc`, one `sdk`)
with the same logical id. The revert output then shows the resource twice — two
identical plan blocks and two identical `reverted:` lines:

```
  .../ScoringApiLambdaLogGroup (AWS::Logs::LogGroup)
    - RetentionInDays -> deployed-template value
    - DeletionProtectionEnabled -> remove (undeclared, not in baseline)

  .../ScoringApiLambdaLogGroup (AWS::Logs::LogGroup)
    - BearerTokenAuthenticationEnabled -> remove (undeclared, not in baseline)
...
  reverted: .../ScoringApiLambdaLogGroup
  reverted: .../ScoringApiLambdaLogGroup
```

(Surfaced by the new Logs LogGroup `BearerTokenAuthenticationEnabled` SDK writer in
#297: `RetentionInDays`/`DeletionProtectionEnabled` go via CC while
`BearerTokenAuthenticationEnabled` goes via the SDK writer — so the LogGroup splits.)

## Fix

Present per **resource**, not per writer-group:

- `formatPlan` merges plan items sharing a logical id into ONE block with all ops.
- The apply loop collects per-item results and prints ONE outcome per resource via a
  new pure helper `summarizeRevertResults`: `reverted:` once when every item for the
  resource succeeded; a single `FAILED:` (joining the failing writers' errors) when
  any did not — so a fully reverted resource never prints twice, and a partial
  failure is never shown as a plain success (the convergence re-read still stands).

The per-op picker is unchanged (each op is already a distinct row).

## Tests

- `formatPlan`: a cc+sdk split renders exactly one block.
- `summarizeRevertResults`: all-ok → one `reverted`; any failure → one `FAILED`
  joining errors; distinct resources keep distinct first-seen-ordered entries.
- All 1451 unit tests pass; typecheck / lint / build green.
