### PR TITLE
fix(check): fold typed<->string coercion in a whole-emitted free-form map (Glue Parameters)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -364,7 +364,7 @@ all live changes
   − tag-list / id-array / method-set ORDER → canonicalized (see below)
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)
   − stringly-typed scalar (true vs "true", 5432 vs "5432") → equal (isStringlyEqualScalar)
-    (scalars only — a typed vs string *array* like [80,443] vs ["80","443"] still reports; fail-safe noise)
+    (scalars only — a typed vs string *array* like [80,443] vs ["80","443"] folds element-wise via isStringlyEqualScalarArray; a whole free-form `Map<String,String>` emitted as ONE record because a key holds a `.` — Glue Table `Parameters` `projection.enabled:true` vs live `"true"` — folds recursively via isStringlyEqualDeep, key-order-insensitive; a real key add/remove or value change still reports; fail-safe noise)
   − declared object vs its JSON-STRING live form (SSM Document.Content, R75) → equal (isJsonStringStructEqual)
   − PEM-armored value with only surrounding-whitespace differences (CloudFront PublicKey EncodedKey — AWS appends a trailing newline after the END marker, R125) → equal (isPemEqual); both sides must be PEM-armored, so a genuine key/cert change still differs
   − declared SUBSET of an ELB attribute bag (Load/TargetGroupAttributes) → DECLARED keys compared BY KEY (ELB_ATTRIBUTE_BAGS, R78); the live-only keys (the ~20 server defaults + any out-of-band custom attribute) are emitted as nested `undeclared` inventory — fail-closed like every other identity-keyed array — so `record` snapshots them and a later out-of-band change to an UNDECLARED attribute surfaces as drift instead of being silently dropped. NB (R95): the full-live compare is generic — every identity-keyed array (Tags, Origins, ELB bags, …) reports an out-of-band ADDED/CHANGED element rather than suppressing it

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -27,6 +27,7 @@ import {
   isPemEqual,
   isStringlyEqualScalar,
   isStringlyEqualScalarArray,
+  isStringlyEqualDeep,
   isGeneratedName,
   isPhysicalIdSegment,
   isTrailingDotEqual,
@@ -623,6 +624,13 @@ export function classifyResource(
       // declared `[80, 443]` vs live `["80", "443"]`. Same typed<->string collapse,
       // element-wise; a genuine element change still differs.
       if (isStringlyEqualScalarArray(d.stateValue, d.awsValue)) continue;
+      // CFn free-form `Map<String,String>` (Glue Table Parameters, DockerLabels,
+      // Lambda env Variables, map Tags) emitted WHOLE at its parent path because a
+      // key holds a `.` — its values are all live STRINGS while CDK declares some
+      // typed (boolean `projection.enabled`, numeric counts). Fold the whole-map
+      // typed<->string coercion recursively; a real key add/remove or value change
+      // still differs. Not Glue-specific — any whole-emitted free-form map.
+      if (isStringlyEqualDeep(d.stateValue, d.awsValue)) continue;
       // A declared object whose live form is the same value as a JSON STRING
       // (R75: SSM Document.Content) — equal after parse, key-order-insensitive.
       if (isJsonStringStructEqual(d.stateValue, d.awsValue)) continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -982,6 +982,36 @@ export function isStringlyEqualScalarArray(a: unknown, b: unknown): boolean {
   return a.every((v, i) => v === b[i] || isStringlyEqualScalar(v, b[i]));
 }
 
+// A whole OBJECT/MAP whose only differences are typed<->string scalar coercions is
+// not drift. A free-form `Map<String,String>` (Glue Table/Database `Parameters`,
+// DockerLabels, Lambda env `Variables`, map `Tags`) whose KEYS contain the path
+// grammar's separators (a Glue `projection.enabled` key) is emitted by the
+// drift-calculator as ONE parent-path record carrying the WHOLE map — it never
+// descends, so the per-leaf `isStringlyEqualScalar` never sees the values. CDK emits
+// the typed JSON form for some values (boolean `projection.enabled: true`, a numeric
+// `skip.header.line.count: 2`) while AWS stores every map value as a STRING
+// (`"true"`, `"2"`), so a single such value makes the strict `deepEqual` fail and the
+// whole map false-drifts. This recurses both sides key-by-key (order-insensitive),
+// folding each leaf via the same typed<->string collapse. A genuinely
+// added/removed key, or a real value change, still differs — so real drift is kept.
+// Not Glue-specific: it folds the coercion for ANY whole-emitted free-form map.
+export function isStringlyEqualDeep(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (isStringlyEqualScalar(a, b)) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((v, i) => isStringlyEqualDeep(v, b[i]));
+  }
+  if (typeof a === 'object' && typeof b === 'object' && a !== null && b !== null) {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const ak = Object.keys(ao);
+    if (ak.length !== Object.keys(bo).length) return false;
+    return ak.every((k) => Object.hasOwn(bo, k) && isStringlyEqualDeep(ao[k], bo[k]));
+  }
+  return false;
+}
+
 // A1: trivially-empty/off values AWS returns for unset features. Objects recurse:
 // a struct whose EVERY value is itself trivially empty is a feature-off struct —
 // e.g. the empty VpcConfig ({Ipv6AllowedForDualStack:false, SecurityGroupIds:[],

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -123,6 +123,78 @@ describe('classifyResource (the heart)', () => {
     );
     expect(drifted.declared).toEqual(['Ports']);
   });
+
+  // Reported bug: a Glue Table's `TableInput.Parameters` is a free-form
+  // Map<String,String> whose keys hold a `.` (`projection.enabled`), so the
+  // drift-calculator emits the WHOLE map as one record. CDK declares some values
+  // typed (boolean `projection.enabled: true`) while AWS stores every value as a
+  // string ("true") — the strict deepEqual then false-drifts the whole map. The
+  // typed<->string coercion must fold across the whole map; a real key add/remove
+  // or value change still surfaces.
+  it('whole free-form map typed<->string coercion is not declared drift, real change still is', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const res: DesiredResource = {
+      logicalId: 'LogsTable',
+      resourceType: 'AWS::Glue::Table',
+      physicalId: 'logs-table',
+      declared: {
+        TableInput: {
+          Parameters: {
+            'projection.enabled': true, // CDK emits a typed boolean
+            'skip.header.line.count': 2, // CDK emits a typed number
+            'projection.date.type': 'date',
+            'projection.date.range': '2024/04/01/00, NOW',
+          },
+        },
+      },
+    };
+    // AWS returns every Map<String,String> value as a string, keys reordered.
+    const clean = tiers(
+      classifyResource(
+        res,
+        {
+          TableInput: {
+            Parameters: {
+              'projection.date.type': 'date',
+              'projection.date.range': '2024/04/01/00, NOW',
+              'skip.header.line.count': '2',
+              'projection.enabled': 'true',
+            },
+          },
+        },
+        emptySchema
+      )
+    );
+    expect(clean.declared).toEqual([]);
+    // A genuine value change in one map entry still surfaces as declared drift.
+    const drifted = tiers(
+      classifyResource(
+        res,
+        {
+          TableInput: {
+            Parameters: {
+              'projection.date.type': 'date',
+              'projection.date.range': 'CHANGED, NOW',
+              'skip.header.line.count': '2',
+              'projection.enabled': 'true',
+            },
+          },
+        },
+        emptySchema
+      )
+    );
+    // the whole free-form map is one record, so the drift path is the map property
+    expect(drifted.declared).toEqual(['TableInput.Parameters']);
+  });
 });
 
 // R10: classifyResource threads optional { accountId, region } into isArnNameMatch.

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -289,6 +289,35 @@ describe('noise suppressors', () => {
     expect(isStringlyEqualScalarArray(80, '80')).toBe(false);
   });
 
+  it('isStringlyEqualDeep: whole free-form map typed<->string coercion folds, real drift kept', async () => {
+    const { isStringlyEqualDeep } = await import('../src/normalize/noise.js');
+    // the reported repro: Glue Parameters map emitted whole — one boolean value
+    // declared typed by CDK but stored as a string by Glue (Map<String,String>)
+    expect(
+      isStringlyEqualDeep(
+        { 'projection.enabled': true, 'skip.header.line.count': 2, 'projection.date.type': 'date' },
+        {
+          'projection.date.type': 'date',
+          'skip.header.line.count': '2',
+          'projection.enabled': 'true',
+        }
+      )
+    ).toBe(true);
+    // numeric formatting variants fold per-leaf (R67) too
+    expect(isStringlyEqualDeep({ a: 5 }, { a: '5.0' })).toBe(true);
+    // nested objects / arrays recurse
+    expect(isStringlyEqualDeep({ a: { b: [80, 443] } }, { a: { b: ['80', '443'] } })).toBe(true);
+    // a genuine value change still differs (real drift preserved)
+    expect(isStringlyEqualDeep({ a: true }, { a: 'false' })).toBe(false);
+    // an added/removed key is real drift — NOT folded
+    expect(isStringlyEqualDeep({ a: '1', b: '2' }, { a: '1' })).toBe(false);
+    expect(isStringlyEqualDeep({ a: '1' }, { a: '1', b: '2' })).toBe(false);
+    // disjoint-key object swap (WAFv2 DefaultAction) is not folded
+    expect(isStringlyEqualDeep({ Allow: {} }, { Block: {} })).toBe(false);
+    // array order still matters
+    expect(isStringlyEqualDeep([80, 443], ['443', '80'])).toBe(false);
+  });
+
   it('isAllAwsTags: every element an aws:* {Key,Value}', () => {
     expect(isAllAwsTags([{ Key: 'aws:cloudformation:stack-id', Value: 'x' }])).toBe(true);
     expect(


### PR DESCRIPTION
## Problem

A user touched only an IAM Role's `ServiceRole.Policies` out of band, yet `check`
reported three **CFn-Declared Drift** findings on unrelated `AWS::Glue::Table`
resources — `TableInput.Parameters`:

```
desired = …"projection.enabled":true,…
actual  = …"projection.enabled":"true",…
```

Glue `Parameters` is a `Map<String,String>` — AWS stores **every** value as a
string. CDK declares some values typed (boolean `projection.enabled: true`,
numeric counts), so `true` != `"true"` makes the strict `deepEqual` fail and the
whole map false-drifts. (Key-order differences are already order-insensitive, so
they were never the cause.)

## Root cause

A free-form map whose key contains a `.` (`projection.date.range`) trips
`hasPathUnsafeKey` in the drift-calculator, which deliberately emits the **whole
map as one parent-path record** (so a revert rewrites it as a unit, never
mis-splitting the path). That whole-map record reaches classify's declared loop
as an **object**, where neither `isStringlyEqualScalar` (scalars) nor
`isStringlyEqualScalarArray` (scalar arrays) applies — so the typed<->string
coercion is never folded.

Not Glue-specific: any whole-emitted free-form map (DockerLabels, Lambda env
`Variables`, map `Tags`) with a typed value hits the same FP.

## Fix

Add `isStringlyEqualDeep` — recurse both sides key-by-key (order-insensitive),
folding each leaf via the existing typed<->string collapse. Wired into classify's
declared loop alongside the existing folds. A genuinely added/removed key, or a
real value change (`true` vs `"false"`), still differs — real drift preserved.

## Verification

- **Real-AWS live-test** against the reporting account/stack: with the fix the
  three Glue findings disappear and `check` reports **`result: CLEAN`** (the
  out-of-band `ServiceRole.Policies` edit stays correctly classified as
  unrecorded — not drift).
- New `isStringlyEqualDeep` unit test + a `classifyResource` end-to-end repro
  (typed map folds to no declared drift; a real value change still reports at
  `TableInput.Parameters`).
- `vp test run` 1453 passed · typecheck · lint · build all green.
- `docs/ARCHITECTURE.md` noise-subtraction ladder updated.
