### PR TITLE
feat(check): scope interactive ignore/per-finding pickers to report-shown drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,14 @@ The report always prints **first**, so you see the standout values before decidi
 (no blind bulk-record). The count is the **complete** undeclared inventory, but
 only the handful that **stand out** are listed — AWS defaults, auto-generated
 names/identifiers, and nested sub-keys you never touched fold into the `info:`
-footer (`atDefault=` / `generated=` / `nested=`, `--show-all` expands them).
-Choosing Record opens a checklist (everything pre-selected — Enter to record all,
-or deselect what you want to keep visible) and writes
+footer (`atDefault=` / `generated=` / `undeclared-subkey=`, `--show-all`
+expands them).
+A listed `Not Recorded` value is **expected, not a bug or a false positive** — it
+just means cdkrd cannot yet prove the value is an AWS default and it is not in your
+baseline yet (sometimes simply because cdkrd does not know that resource type's
+default). You are not meant to "fix" it; `record` it once to accept the current
+state. Choosing Record opens a checklist (everything pre-selected — Enter to record
+all, or deselect what you want to keep visible) and writes
 `.cdkrd/ApiStack.<account>.<region>.json` — **a git file, nothing written to
 AWS** — commit it; from here on `check` reports CLEAN until reality changes.
 (Declared drift is detected from the very first run, baseline or not.)
@@ -131,9 +136,14 @@ finding** is the only path that assigns a _different_ action to each finding.
   pre-selected). Keeps watching.
 - **Ignore** writes a path rule to `.cdkrd/config.json` so the drift (declared,
   undeclared, _or_ an out-of-band **added** resource) stops being reported entirely
-  (multiselect, pre-selected). Stops watching.
+  (multiselect, **nothing pre-selected** — opt in, since ignoring permanently stops
+  watching). Stops watching. If `check` folded undeclared inventory out of the
+  report, Ignore first asks whether to act on just the shown drift (default) or
+  include the folded values too — so the picker never silently lists values you
+  never saw.
 - **Decide per finding** opens a picker to assign a different action to each
-  finding. On a stack with many findings, **just start typing to filter** the rows
+  finding (same shown-vs-folded scope question as Ignore when inventory was
+  folded). On a stack with many findings, **just start typing to filter** the rows
   by name (↑↓ move · space cycles the row's actions · → applies the focused action
   to every _visible_ row · ⌫ clears the filter · enter applies · esc backs out).
 - **Revert** shows a plan, lets you pick which op(s) to write (nothing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -386,6 +386,43 @@ all live changes
          (path `Prop[<id>].sub`). Identity-LESS arrays (SG rules) are not descended
 ```
 
+### Why a given value does (or does not) appear
+
+The subtraction above resolves, per live property value, to one outcome. This is the
+decision tree `classify` walks for a value at key `k` NOT in the template
+(`src/diff/classify.ts`, the undeclared loop) — it answers the common "why is THIS
+showing / why is THAT silent" question in one place:
+
+```
+a live value at key k, not declared in the template
+  ├─ == a schema default (CFn `default` annotation) OR == KNOWN_DEFAULTS[type][k]
+  │        → atDefault   (folded into info:, NOT drift, NOT recorded; equality-gated,
+  │                       so a value changed AWAY from the default re-tags as undeclared)
+  ├─ == this resource's OWN minted value (generated name / ARN name-segment /
+  │     GENERATED_PATHS id-echo) → generated   (folded like atDefault; only the
+  │                       resource's own identity, never a reference to ANOTHER resource)
+  ├─ pure structural noise: all-`aws:*` tags · == physicalId echo · trivially-empty
+  │     (`false` / `""` / `[]` / `{}`, isTrivialEmpty) → DROPPED   (no finding at all)
+  └─ otherwise → undeclared → reconciled against the baseline:
+        ├─ recorded & unchanged → suppressed (CLEAN)
+        ├─ recorded & changed   → DRIFT
+        └─ not recorded         → [Not Recorded] inventory (informational, NOT drift)
+```
+
+So three independent things make a value SILENT without a baseline: it is absent
+from the live read, it is dropped as noise, or it equals a default cdkrd can PROVE
+(a schema default or KNOWN_DEFAULTS). A value reaches **[Not Recorded]** precisely
+when cdkrd CANNOT prove it is a default/generated/noise and it is not yet in the
+baseline — including a property whose default cdkrd simply does not know yet (a
+long-tail / minor resource type). That is **expected, not a bug or a false
+positive**: it is the accepted residual of the subtractive bet (the long-tail
+"explainable defaults not in any schema" risk named in Bet 1 above), and the
+baseline is the universal backstop — `record` once accepts it and the stack stays
+CLEAN until reality changes. Widening atDefault coverage (more `KNOWN_DEFAULTS` /
+`KNOWN_DEFAULT_PATHS`) shrinks that residual; because the fold is equality-gated it
+can never hide a real change, so widening is safe — but the baseline means cdkrd
+never has to know every default to be correct.
+
 **The four false-positive classes found by dogfooding** (8 real cdkd fixtures —
 vpc-lambda / sns-sqs / rds / iam / s3-cloudfront / ecs-fargate / appsync / a mixed
 stack) and fixed, each with paired regression tests asserting _noise suppressed_ AND

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -109,6 +109,56 @@ const pickerLabel = (f: Finding): string =>
     f.attributeKey !== undefined ? `[${f.attributeKey}]` : ''
   }  (${tierTag(f)})`;
 
+// Mirrors report.ts's R96 fold: a NESTED unrecorded undeclared value (a live-only sub-key
+// inside a declared object) collapses out of the report body by default — the live model
+// carries many such sub-keys, so listing them all re-floods the first run. The interactive
+// pickers mirror that fold: they default to the SHOWN findings and gate the folded ones
+// behind an explicit "include folded" choice, so a picker never silently balloons from the
+// report's small drift count to a wall of nested values (the 3-vs-26 surprise) — and, for
+// ignore, never blind-ignores values the user never saw. `--verbose` means the report
+// already listed them in full, so nothing is folded. Pure + exported for unit tests.
+export const isFoldedFinding = (f: Finding, verbose: boolean): boolean =>
+  !verbose && f.unrecorded === true && f.nested === true;
+
+// The two scope rows shown when check folded undeclared inventory out of the report:
+// decide on just what was shown, or pull the folded values in too. Pure + exported.
+export function buildScopeOptions(
+  shownCount: number,
+  foldedCount: number
+): { value: string; label: string }[] {
+  return [
+    { value: 'shown', label: `Just the ${shownCount} shown in the report` },
+    {
+      value: 'all',
+      label: `Also the ${foldedCount} folded undeclared value(s) (${shownCount + foldedCount} total)`,
+    },
+  ];
+}
+
+/**
+ * Ask which findings the ignore / per-finding picker should cover when check folded
+ * undeclared inventory out of the report body. Returns 'shown' (default) or 'all', or
+ * `null` on cancel (→ back to the menu). No prompt — and 'all' returned — when there is no
+ * meaningful split: nothing folded, nothing else shown, or `--yes` (the caller asked not
+ * to be prompted, so it gets the full set, matching the pre-gate `--yes` behaviour). The
+ * `--yes` case never reaches the AWS-mutating revert through here (revert has no gate).
+ */
+async function chooseScope(
+  stackName: string,
+  shownCount: number,
+  foldedCount: number,
+  yes: boolean
+): Promise<'shown' | 'all' | null> {
+  if (yes || foldedCount === 0 || shownCount === 0) return 'all';
+  const choice = await select({
+    message: `${stackName}: the report folded ${foldedCount} undeclared value(s) — which to decide on?`,
+    options: buildScopeOptions(shownCount, foldedCount),
+    initialValue: 'shown',
+  });
+  if (isCancel(choice)) return null;
+  return choice as 'shown' | 'all';
+}
+
 // declared/constructPath/physicalId maps for applyBaseline. The physicalId + the
 // constructPath are what a synthesized "baseline value removed since record" finding
 // needs (physicalId so a later in-menu revert can act on it, constructPath so an
@@ -315,12 +365,21 @@ async function recordAll(p: ResolveParams): Promise<SubResult | null> {
 }
 
 async function ignoreAll(p: ResolveParams): Promise<SubResult | null> {
-  // pass the reconciled findings; ignoreStack filters to the ignorable tiers
-  // (declared / undeclared / added) and shows its own multiselect (default all) when
-  // !yes, mirroring `cdkrd ignore`.
+  // ignoreStack filters to the ignorable tiers (declared / undeclared / added) and shows
+  // its own multiselect (default NONE selected, R137) when !yes, mirroring `cdkrd ignore`.
+  // Pre-split here so the folded undeclared inventory is gated behind chooseScope: the
+  // picker defaults to the report's SHOWN findings, not a wall of nested values.
+  const ignorable = p.reconciled.filter(
+    (f) => f.tier === 'declared' || f.tier === 'undeclared' || f.tier === 'added'
+  );
+  const foldedCount = ignorable.filter((f) => isFoldedFinding(f, p.verbose)).length;
+  const scope = await chooseScope(p.stackName, ignorable.length - foldedCount, foldedCount, p.yes);
+  if (scope === null) return null; // scope prompt cancelled → back to the menu
+  const findings =
+    scope === 'all' ? ignorable : ignorable.filter((f) => !isFoldedFinding(f, p.verbose));
   const result = await ignoreStack({
     stackName: p.stackName,
-    findings: p.reconciled,
+    findings,
     yes: p.yes,
     interactive: true,
   });
@@ -359,10 +418,17 @@ async function revertAll(p: ResolveParams): Promise<SubResult | null> {
 }
 
 async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubResult | null> {
-  const rows = decidable.map((f) => ({ label: pickerLabel(f), applicable: applicableActions(f) }));
+  // Gate the folded undeclared inventory the same way ignore does: default the picker to
+  // the report's SHOWN findings, ask before pulling the folded nested values in.
+  const foldedCount = decidable.filter((f) => isFoldedFinding(f, p.verbose)).length;
+  const scope = await chooseScope(p.stackName, decidable.length - foldedCount, foldedCount, p.yes);
+  if (scope === null) return null; // scope prompt cancelled → back to the menu
+  const scoped =
+    scope === 'all' ? decidable : decidable.filter((f) => !isFoldedFinding(f, p.verbose));
+  const rows = scoped.map((f) => ({ label: pickerLabel(f), applicable: applicableActions(f) }));
   const chosen = await actionPicker(`${p.stackName}: assign an action to each finding`, rows);
   if (chosen === undefined) return null; // picker cancelled (Esc) → back to the menu
-  const groups = groupByAction(decidable, chosen);
+  const groups = groupByAction(scoped, chosen);
   if (groups.record.length + groups.ignore.length + groups.revert.length === 0)
     return { exit: p.code, awsMutated: false };
 

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -365,10 +365,28 @@ export function ignoreSelectMessage(stackName: string): string {
 const ignoreFindingKey = (f: Finding): string => `${f.logicalId}::${f.path}`;
 
 /**
+ * The ignore multiselect rows. EVERY row starts UNSELECTED (→ selects all) — mirroring
+ * revert's picker (R137): ignore STOPS watching permanently, and check's interactive flow
+ * can route folded undeclared inventory here, so a default-all selection would let an
+ * Enter ignore values the user never saw in the report. Opt-in, not opt-out. Pure +
+ * exported so the "starts unselected" invariant is unit-tested without a TTY.
+ */
+export function ignoreSelectOptions(
+  ignorable: Finding[]
+): { value: string; label: string; selected: boolean }[] {
+  return ignorable.map((f) => ({
+    value: ignoreFindingKey(f),
+    label: `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''} (${f.tier})`,
+    selected: false,
+  }));
+}
+
+/**
  * Write `ignore` rules into `.cdkrd/config.json` for the chosen declared/undeclared
  * findings — they stop being reported entirely (re-tagged `ignored` on the next check),
  * the "stop watching" counterpart to record's "keep watching". Interactive runs pick
- * WHICH findings to ignore (default all selected); `--yes` ignores all shown.
+ * WHICH findings to ignore (default NONE selected — → selects all, R137); `--yes`
+ * ignores all shown.
  * Non-interactively without `--yes` it refuses (a required decision, like record, R38).
  * Idempotent: rules already in the file are reported, not duplicated. Shared by `cdkrd
  * ignore` and (PR-B2) check's interactive flow, so both write rules identically.
@@ -395,11 +413,7 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
     }
     const picked = await bulkMultiselect(
       ignoreSelectMessage(stackName),
-      ignorable.map((f) => ({
-        value: ignoreFindingKey(f),
-        label: `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''} (${f.tier})`,
-        selected: true,
-      }))
+      ignoreSelectOptions(ignorable)
     );
     if (picked === undefined) {
       console.error(`note: ${stackName}: ignore cancelled — config unchanged`);

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -349,9 +349,12 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     })
     .filter((s): s is string => s !== null);
   // R96: the folded nested-unrecorded count joins the info: footer (--show-all lists them).
+  // Labelled `undeclared-subkey` rather than the bare `nested` — "nested" reads as a
+  // nested STACK, but these are undeclared live-only sub-keys INSIDE a declared object,
+  // not a stack relationship.
   if (nestedFolded.length > 0)
     summaries.push(
-      `nested=${nestedFolded.length} (undeclared values nested in a declared object — record to record; --show-all to list)`
+      `undeclared-subkey=${nestedFolded.length} (undeclared live-only values inside a declared object — record to record; --show-all to list)`
     );
   if (summaries.length === 1) {
     log(style.infoTier(`info: ${summaries[0]} — run with --verbose for the list`));

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -71,7 +71,7 @@ These do NOT run in CI (they need credentials and mutate a real account):
 - **After changing nested-undeclared detection** (`collectNestedUndeclared` in
   `src/diff/classify.ts`) or the revert nested guard (`src/revert/plan.ts`): run
   `dynamodb/verify-nested.sh` — it deploys a table whose GSI and PITR config
-  materialize nested undeclared values (R96/R98), asserts the `info: nested=N`
+  materialize nested undeclared values (R96/R98), asserts the `info: undeclared-subkey=N`
   fold + `--show-all` expansion live, then mutates the undeclared
   `RecoveryPeriodInDays` out of band and asserts the drift is detected and
   reported NOT-revertable (R99).

--- a/tests/integration/dynamodb/verify-nested.sh
+++ b/tests/integration/dynamodb/verify-nested.sh
@@ -7,7 +7,7 @@
 #   - R96 (object-nested):                PointInTimeRecoverySpecification.RecoveryPeriodInDays
 #
 # Asserts the full live chain:
-#   1. baseline-free check FOLDS nested into the info: footer (`nested=N`), exit 0;
+#   1. baseline-free check FOLDS nested into the info: footer (`undeclared-subkey=N`), exit 0;
 #   2. --show-all expands BOTH the R98 bracketed path and the R96 dotted path;
 #   3. record --yes then check --fail is CLEAN (record records the nested values);
 #   4. a REAL out-of-band mutation of the undeclared RecoveryPeriodInDays (35 -> 20
@@ -59,7 +59,7 @@ $CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-nested-1.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (inventory only), got $rc"
 grep -q "DECLARED DRIFT" /tmp/cdkrd-nested-1.out && fail "fresh deploy reported DECLARED drift"
-grep -qE "nested=[1-9]" /tmp/cdkrd-nested-1.out || fail "expected a 'nested=N' fold in the info footer"
+grep -qE "undeclared-subkey=[1-9]" /tmp/cdkrd-nested-1.out || fail "expected an 'undeclared-subkey=N' fold in the info footer"
 
 echo "=== 2. --show-all expands BOTH the R98 array-element and R96 object-nested paths ==="
 $CLI check "$STACK" --region "$REGION" --show-all | tee /tmp/cdkrd-nested-2.out

--- a/tests/interactive-resolve.test.ts
+++ b/tests/interactive-resolve.test.ts
@@ -14,12 +14,17 @@ vi.mock('../src/commands/stack-actions.js', async (importOriginal) => {
   return {
     ...actual,
     revertStack: vi.fn().mockResolvedValue({ exit: 0, aborted: false }),
+    ignoreStack: vi.fn().mockResolvedValue({ wrote: false, refused: false, added: 0 }),
   };
 });
 
 import { select } from '@clack/prompts';
-import { resolveInteractively } from '../src/commands/interactive-resolve.js';
-import { revertStack } from '../src/commands/stack-actions.js';
+import {
+  buildScopeOptions,
+  isFoldedFinding,
+  resolveInteractively,
+} from '../src/commands/interactive-resolve.js';
+import { ignoreStack, revertStack } from '../src/commands/stack-actions.js';
 import type { Finding } from '../src/types.js';
 
 const declaredDrift: Finding = {
@@ -67,5 +72,93 @@ describe('resolveInteractively — read-only check never auto-confirms an AWS wr
     vi.mocked(select).mockResolvedValueOnce('revert-all');
     await resolveInteractively(params(false));
     expect(vi.mocked(revertStack).mock.calls[0]![0]).toMatchObject({ yes: false });
+  });
+});
+
+describe('isFoldedFinding — mirrors report.ts R96 fold (unrecorded + nested)', () => {
+  const f = (extra: Partial<Finding>): Finding =>
+    ({
+      tier: 'undeclared',
+      logicalId: 'L',
+      resourceType: 'T',
+      path: 'a.b',
+      actual: 1,
+      ...extra,
+    }) as Finding;
+  it('a nested unrecorded value is folded', () => {
+    expect(isFoldedFinding(f({ unrecorded: true, nested: true }), false)).toBe(true);
+  });
+  it('a top-level unrecorded value (not nested) is NOT folded — it lists in the report', () => {
+    expect(isFoldedFinding(f({ unrecorded: true }), false)).toBe(false);
+  });
+  it('a nested but RECORDED/drift value is NOT folded', () => {
+    expect(isFoldedFinding(f({ nested: true }), false)).toBe(false);
+  });
+  it('--verbose expands everything, so nothing is folded', () => {
+    expect(isFoldedFinding(f({ unrecorded: true, nested: true }), true)).toBe(false);
+  });
+});
+
+describe('buildScopeOptions — the shown-vs-include-folded rows', () => {
+  it('labels the two scopes with their counts and a running total', () => {
+    const opts = buildScopeOptions(3, 23);
+    expect(opts.map((o) => o.value)).toEqual(['shown', 'all']);
+    expect(opts[0]!.label).toContain('3 shown');
+    expect(opts[1]!.label).toContain('23 folded');
+    expect(opts[1]!.label).toContain('26 total');
+  });
+});
+
+describe('scope gate narrows the ignore picker to the report-shown findings (default)', () => {
+  const undeclaredFolded = (path: string): Finding =>
+    ({
+      tier: 'undeclared',
+      logicalId: 'B',
+      resourceType: 'AWS::S3::Bucket',
+      path,
+      actual: 'x',
+      unrecorded: true,
+      nested: true,
+    }) as Finding;
+  const withFolded = (yes: boolean) => {
+    const reconciled = [declaredDrift, undeclaredFolded('Conf.A'), undeclaredFolded('Conf.B')];
+    return { ...params(yes), findings: reconciled, reconciled } as Parameters<
+      typeof resolveInteractively
+    >[0];
+  };
+
+  beforeEach(() => {
+    vi.mocked(ignoreStack).mockClear();
+    vi.mocked(ignoreStack).mockResolvedValue({ wrote: false, refused: false, added: 0 });
+    vi.mocked(select).mockReset();
+  });
+
+  it('choosing "Ignore" then scope "shown" passes ONLY the 1 shown drift (not the 2 folded)', async () => {
+    vi.mocked(select)
+      .mockResolvedValueOnce('ignore-all') // top menu
+      .mockResolvedValueOnce('shown') // scope gate
+      .mockResolvedValueOnce('nothing'); // re-shown menu → exit (ignoreStack returned wrote:false)
+    await resolveInteractively(withFolded(false));
+    expect(ignoreStack).toHaveBeenCalledTimes(1);
+    const passed = vi.mocked(ignoreStack).mock.calls[0]![0].findings;
+    expect(passed).toHaveLength(1);
+    expect(passed[0]!.tier).toBe('declared');
+  });
+
+  it('choosing scope "all" passes the shown drift AND the 2 folded undeclared values', async () => {
+    vi.mocked(select)
+      .mockResolvedValueOnce('ignore-all')
+      .mockResolvedValueOnce('all')
+      .mockResolvedValueOnce('nothing');
+    await resolveInteractively(withFolded(false));
+    expect(vi.mocked(ignoreStack).mock.calls[0]![0].findings).toHaveLength(3);
+  });
+
+  it('--yes skips the scope prompt and passes the full set (1 top-menu select only)', async () => {
+    vi.mocked(select).mockResolvedValueOnce('ignore-all').mockResolvedValueOnce('nothing');
+    await resolveInteractively(withFolded(true));
+    expect(vi.mocked(ignoreStack).mock.calls[0]![0].findings).toHaveLength(3);
+    // exactly two select calls: top menu + the re-shown menu — no scope prompt in between
+    expect(vi.mocked(select)).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -588,13 +588,13 @@ describe('R96 nested unrecorded folding', () => {
     const { text } = run([NU('TopLevel'), NU('Conf.A', true), NU('Conf.B', true)]);
     expect(text).toContain('[Not Recorded: 1]');
     expect(text).toContain('L.TopLevel');
-    expect(text).toContain('nested=2');
+    expect(text).toContain('undeclared-subkey=2');
     expect(text).not.toContain('Conf.A');
   });
   it('--show-all expands nested into the body (no fold line)', () => {
     const { text } = run([NU('Conf.A', true)], { expandAtDefault: true });
     expect(text).toContain('L.Conf.A');
-    expect(text).not.toContain('nested=1');
+    expect(text).not.toContain('undeclared-subkey=1');
   });
   it('--verbose also expands nested', () => {
     const { text } = run([NU('Conf.A', true)], { verbose: true });


### PR DESCRIPTION
## Problem

The report folds nested undeclared inventory out of its body by default (R96 — the `info:` footer count), but `check`'s interactive **Ignore** and **Decide per finding** pickers listed EVERY actionable finding. So the picker jumped from the report's small drift count (e.g. 3) to a wall of folded values the user never saw (e.g. 26), and the ignore multiselect defaulted them all **selected** — one Enter could permanently stop watching values never on screen.

## Changes

- **ignore multiselect starts NONE-selected** (→ selects all), mirroring revert (R137). ignore STOPS watching permanently, so it must be opt-in. Extracted `ignoreSelectOptions` so the invariant is unit-tested.
- **Scope prompt (interactive `--show-all`)** on Ignore + per-finding: default to the report-**shown** findings, or explicitly include the **folded** undeclared values. No prompt when nothing is folded, nothing else is shown, or under `--yes`. **revert is unaffected** — folded values are nested undeclared = detect/record-only, never in its plan.
- **Rename footer token** `nested=` → `undeclared-subkey=` ("nested" read as a nested *stack*; these are undeclared live-only sub-keys inside a declared object).

## Docs

- ARCHITECTURE §6: a per-property "why a value does / does not surface" decision tree (absent → noise → atDefault/generated → undeclared → Not Recorded).
- README: a `[Not Recorded]` value is **expected, not a bug / false positive** — record once, do not "fix" it.

## Tests

`isFoldedFinding`, `buildScopeOptions`, `ignoreSelectOptions`, and the scope-gate narrowing (shown / all / `--yes`) behavior. All 40 files / 1461 unit tests pass; build green.