### PR TITLE
feat(noise): record schema-default coverage + first-run-noise sweep for KNOWN_DEFAULTS

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -148,6 +148,28 @@ The `*-rich` fixtures are exactly the rich configs worth pinning this way, so a
 clean round still ships growing regression coverage — see the "A clean result IS a
 result" gotcha.
 
+### 5.5 First-run-noise sweep (shrink `[Not Recorded]` via KNOWN_DEFAULTS)
+
+After promoting new corpus, run the offline first-run-noise sweep — the newly
+harvested cases are exactly the fresh data it mines:
+
+```bash
+bash scripts/measure-noise.sh
+```
+
+It replays classify over `tests/corpus/*.json` and ranks every `undeclared`
+`(type, path)`, flagging the constant-looking ones as `CANDIDATE`s to promote into
+`KNOWN_DEFAULTS` (top-level) / `KNOWN_DEFAULT_PATHS` (nested) in
+`src/normalize/noise.ts`. This matters because the CFn schema annotates a `default`
+on only ~1% of properties (see `scripts/measure-schema-defaults.mjs` and
+docs/ARCHITECTURE.md § 6), so these hand tables — not the schema — are what keeps a
+first run's `[Not Recorded]` inventory small. Promote a candidate only when its
+value is a genuine CONSTANT service default (not a per-resource id/ARN/name/AZ/window
+the heuristic may over-flag); the fold is equality-gated, so a correct promotion can
+never hide a real change, and a recorded value that later moves off the default
+still surfaces. Add the entries + a `noise-and-strip` test in the SAME PR. This is a
+quality/noise pass, not a bug — skip it on a round that ships no new corpus.
+
 ### 6. On a confirmed bug: fix it — with a unit test (mandatory)
 
 When a finding is a real bug:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -423,6 +423,21 @@ CLEAN until reality changes. Widening atDefault coverage (more `KNOWN_DEFAULTS` 
 can never hide a real change, so widening is safe — but the baseline means cdkrd
 never has to know every default to be correct.
 
+How much of the fold does the SCHEMA carry on its own? Almost none. Measured over
+the public CloudFormation resource-schema set (1605 types, 2026-06-22 — re-run with
+`scripts/measure-schema-defaults.mjs`), only **~1% of properties carry a `default`
+annotation** (1.10% top-level, 1.34% incl. nested; just 5.5% of types have any —
+e.g. Lambda `MemorySize`/`Timeout` have none). So `schema.defaults` is negligible:
+the low-noise outcome comes overwhelmingly from (a) properties ABSENT from the live
+read when unset, (b) the `isTrivialEmpty` drop, and (c) the hand-maintained
+`KNOWN_DEFAULTS` / `KNOWN_DEFAULT_PATHS`. The hand tables are therefore the real
+lever, and growing them is done DATA-DRIVEN rather than by guessing: the offline
+first-run-noise sweep (`scripts/measure-noise.sh` →
+[tests/measure-noise.test.ts](../tests/measure-noise.test.ts)) replays classify over
+the golden corpus and ranks every `undeclared` `(type, path)`, flagging the
+constant-looking ones as `*_DEFAULTS` candidates; `/hunt-bugs` runs it after
+deploying uncovered types (recording fresh corpus) to surface new promotions.
+
 **The four false-positive classes found by dogfooding** (8 real cdkd fixtures —
 vpc-lambda / sns-sqs / rds / iam / s3-cloudfront / ecs-fargate / appsync / a mixed
 stack) and fixed, each with paired regression tests asserting _noise suppressed_ AND

--- a/scripts/measure-noise.sh
+++ b/scripts/measure-noise.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# First-run-noise sweep: replay the classify pipeline over the golden corpus and
+# print the undeclared (type, path) buckets, ranked so constant-looking values
+# (KNOWN_DEFAULTS / KNOWN_DEFAULT_PATHS candidates) come first. Use it to shrink
+# first-run [Not Recorded] noise — the fold is equality-gated, so a promoted
+# default can never hide a real change. See tests/measure-noise.test.ts and
+# docs/ARCHITECTURE.md § 6. The /hunt-bugs skill runs this after deploying
+# uncovered types (which record fresh corpus via CDKRD_CORPUS_DIR).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+out="$(mktemp -t cdkrd-noise.XXXXXX)"
+trap 'rm -f "$out"' EXIT
+# `vp test run` intercepts console output, so the spec writes the report to $out.
+CDKRD_MEASURE_NOISE=1 CDKRD_NOISE_OUT="$out" vp test run tests/measure-noise.test.ts
+echo
+echo "=== first-run-noise report ==="
+cat "$out"

--- a/scripts/measure-schema-defaults.mjs
+++ b/scripts/measure-schema-defaults.mjs
@@ -1,0 +1,83 @@
+// Measure how many CloudFormation resource-schema properties carry a `default`
+// annotation. This quantifies how much of cdkrd's `atDefault` fold the SCHEMA can
+// do on its own (`schema.defaults` / `schema.defaultPaths` in
+// src/schema/schema-strip.ts) vs how much must come from the hand-maintained
+// KNOWN_DEFAULTS / KNOWN_DEFAULT_PATHS tables — see docs/ARCHITECTURE.md § 6.
+//
+// Finding (2026-06-22, 1605 types): only ~1% of properties carry a `default`
+// (1.10% top-level, 1.34% incl. nested; 5.5% of types have any). So schema
+// defaults are negligible — the low-noise outcome comes from absent-when-unset
+// reads + isTrivialEmpty + KNOWN_DEFAULTS. Re-run after a CFn schema refresh to
+// confirm the number still holds before leaning on schema coverage.
+//
+// Usage:
+//   1. Download the public CloudFormation resource-schema set (no auth):
+//        curl -sS -o /tmp/cfnschema.zip \
+//          https://schema.cloudformation.us-east-1.amazonaws.com/CloudformationSchema.zip
+//        mkdir -p /tmp/cfnschema && unzip -q /tmp/cfnschema.zip -d /tmp/cfnschema
+//   2. node scripts/measure-schema-defaults.mjs /tmp/cfnschema
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dir = process.argv[2];
+if (!dir) {
+  console.error('usage: node scripts/measure-schema-defaults.mjs <dir-of-cfn-schema-json>');
+  console.error('(see the header comment for how to download the schema set)');
+  process.exit(2);
+}
+
+let topTotal = 0;
+let topDef = 0; // top-level properties (mirrors schema.defaults)
+let allTotal = 0;
+let allDef = 0; // every property node anywhere (mirrors defaultPaths reach)
+let types = 0;
+let typesWithAnyTopDefault = 0;
+
+// Count each child of a {name: schemaNode} `properties` map, recursing into nested
+// object properties and array-item properties (the shape collectDefaultPaths walks).
+function walkProps(props) {
+  if (!props || typeof props !== 'object') return;
+  for (const node of Object.values(props)) {
+    if (!node || typeof node !== 'object') continue;
+    allTotal++;
+    if ('default' in node) allDef++;
+    if (node.properties && typeof node.properties === 'object') walkProps(node.properties);
+    const items = node.items;
+    if (items && typeof items === 'object' && items.properties) walkProps(items.properties);
+  }
+}
+
+for (const file of readdirSync(dir).filter((f) => f.endsWith('.json'))) {
+  let schema;
+  try {
+    schema = JSON.parse(readFileSync(join(dir, file), 'utf8'));
+  } catch {
+    continue; // skip non-schema / malformed json
+  }
+  types++;
+  const props = schema.properties ?? {};
+  const defs = schema.definitions ?? {};
+
+  const tt = Object.keys(props).length;
+  const td = Object.values(props).filter(
+    (v) => v && typeof v === 'object' && 'default' in v
+  ).length;
+  topTotal += tt;
+  topDef += td;
+  if (td > 0) typesWithAnyTopDefault++;
+
+  walkProps(props);
+  for (const dv of Object.values(defs)) {
+    if (dv && typeof dv === 'object' && dv.properties) walkProps(dv.properties);
+  }
+}
+
+const pct = (n, d) => (d === 0 ? '0.00' : ((100 * n) / d).toFixed(2));
+console.log(`resource types analyzed:           ${types}`);
+console.log(
+  `types with >=1 top-level default:  ${typesWithAnyTopDefault}  (${pct(typesWithAnyTopDefault, types)}%)`
+);
+console.log(`TOP-LEVEL properties:              ${topTotal}`);
+console.log(`  with a \`default\`:                ${topDef}  (${pct(topDef, topTotal)}%)`);
+console.log(`ALL property nodes (incl. nested): ${allTotal}`);
+console.log(`  with a \`default\`:                ${allDef}  (${pct(allDef, allTotal)}%)`);

--- a/tests/measure-noise.test.ts
+++ b/tests/measure-noise.test.ts
@@ -1,0 +1,145 @@
+// First-run-noise measurement (the KNOWN_DEFAULTS-candidate finder).
+//
+// schema `default` annotations cover only ~1% of properties (see
+// scripts/measure-schema-defaults.mjs and docs/ARCHITECTURE.md § 6), so the
+// `undeclared` values that surface as [Not Recorded] on a first run are folded
+// to `atDefault` almost entirely by the HAND-maintained KNOWN_DEFAULTS /
+// KNOWN_DEFAULT_PATHS tables. This replays the real classify pipeline over the
+// golden corpus (the same inputs corpus-replay.test.ts asserts on) and buckets
+// every `undeclared` finding by (resourceType, path), so recurring constant-
+// looking values can be promoted into those tables — shrinking first-run noise.
+// The fold is equality-gated, so a promoted default can never hide a real change.
+//
+// This is the OFFLINE half of the loop: it mines whatever corpus exists today.
+// The /hunt-bugs skill is the data-gathering half — it deploys uncovered common
+// types (recording new corpus via CDKRD_CORPUS_DIR), then runs this to propose
+// KNOWN_DEFAULTS candidates.
+//
+// Run the full report (it is silent in the normal unit suite):
+//   CDKRD_MEASURE_NOISE=1 vp test run tests/measure-noise.test.ts
+//   # or the wrapper: bash scripts/measure-noise.sh
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vite-plus/test';
+import { type CorpusCase, decodeUnresolved, reviveSchema } from '../src/corpus/record.js';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource } from '../src/types.js';
+
+// Advisory triage of an undeclared value: is it a CONSTANT-looking service default
+// (a KNOWN_DEFAULTS candidate) or resource-specific INVENTORY (an id/ARN/name that
+// must stay undeclared → baseline)? `review` = a structure to eyeball by hand.
+// Pure + exercised below so the heuristic is regression-guarded. Conservative: when
+// unsure it does NOT say `candidate`, so nothing FP-prone is auto-suggested.
+export type Triage = 'candidate' | 'inventory' | 'review';
+export function triageValue(value: unknown, physicalId: string | undefined): Triage {
+  if (typeof value === 'boolean' || typeof value === 'number') return 'candidate';
+  if (typeof value === 'string') {
+    if (value.length === 0) return 'inventory'; // empty is dropped upstream anyway
+    if (value.startsWith('arn:')) return 'inventory';
+    if (physicalId && value.includes(physicalId)) return 'inventory';
+    if (/^\d{12}$/.test(value)) return 'inventory'; // account id
+    // an id/hash-looking token (uuid, generated suffix, long hex) → resource-specific
+    if (/[0-9a-f]{8}-[0-9a-f]{4}/i.test(value) || /-[0-9a-z]{8,}$/i.test(value)) return 'inventory';
+    return 'candidate'; // short enum-like string (e.g. "ACTIVE", "GP2")
+  }
+  return 'review'; // object / array — a nested default block to inspect by hand
+}
+
+interface Bucket {
+  resourceType: string;
+  path: string;
+  nested: boolean;
+  count: number;
+  example: unknown;
+  triage: Triage;
+}
+
+const corpusDir = join(dirname(fileURLToPath(import.meta.url)), 'corpus');
+
+function mineUndeclared(): Bucket[] {
+  const byKey = new Map<string, Bucket>();
+  for (const file of readdirSync(corpusDir).filter((f) => f.endsWith('.json'))) {
+    const c = JSON.parse(readFileSync(join(corpusDir, file), 'utf8')) as CorpusCase;
+    if (c.corpusVersion !== 1) continue;
+    const resource = {
+      ...c.resource,
+      declared: decodeUnresolved(c.resource.declared),
+    } as DesiredResource;
+    let findings;
+    try {
+      findings = classifyResource(
+        resource,
+        structuredClone(c.liveRaw),
+        reviveSchema(c.schema),
+        c.opts
+      );
+    } catch {
+      continue; // a malformed case never blocks the sweep
+    }
+    for (const f of findings) {
+      if (f.tier !== 'undeclared') continue;
+      const key = `${f.resourceType}\t${f.path}`;
+      const existing = byKey.get(key);
+      if (existing) {
+        existing.count++;
+        continue;
+      }
+      byKey.set(key, {
+        resourceType: f.resourceType,
+        path: f.path,
+        nested: f.nested === true,
+        count: 1,
+        example: f.actual,
+        triage: triageValue(f.actual, c.resource.physicalId),
+      });
+    }
+  }
+  // candidates first, then by frequency — the highest-value promotions on top
+  const rank = (t: Triage): number => (t === 'candidate' ? 0 : t === 'review' ? 1 : 2);
+  return [...byKey.values()].sort(
+    (a, b) => rank(a.triage) - rank(b.triage) || b.count - a.count || (a.path < b.path ? -1 : 1)
+  );
+}
+
+function formatReport(buckets: Bucket[]): string {
+  const line = (b: Bucket): string =>
+    `  ${b.triage.toUpperCase().padEnd(9)} x${b.count}  ${b.resourceType}  ${b.path}` +
+    `${b.nested ? ' (nested → KNOWN_DEFAULT_PATHS)' : ' (top → KNOWN_DEFAULTS)'}` +
+    `  e.g. ${JSON.stringify(b.example)?.slice(0, 80)}`;
+  const cands = buckets.filter((b) => b.triage === 'candidate');
+  const review = buckets.filter((b) => b.triage === 'review');
+  return [
+    `first-run-noise sweep: ${buckets.length} distinct undeclared (type, path) across the corpus`,
+    `  CANDIDATE (constant-looking → promote to a *_DEFAULTS table): ${cands.length}`,
+    `  REVIEW (nested structures to inspect): ${review.length}`,
+    `  INVENTORY (resource-specific, leave undeclared): ${buckets.length - cands.length - review.length}`,
+    '',
+    ...buckets.map(line),
+  ].join('\n');
+}
+
+describe('first-run-noise measurement', () => {
+  it('triageValue: constants are candidates, ids/ARNs are inventory, structures are review', () => {
+    expect(triageValue(false, 'p')).toBe('candidate');
+    expect(triageValue(30, 'p')).toBe('candidate');
+    expect(triageValue('GP2', 'p')).toBe('candidate');
+    expect(triageValue('arn:aws:iam::1:role/x', 'p')).toBe('inventory');
+    expect(triageValue('my-bucket-name', 'my-bucket-name')).toBe('inventory');
+    expect(triageValue('123456789012', 'p')).toBe('inventory');
+    expect(triageValue('a1b2c3d4-e5f6-7890-ab12-cd34ef56', 'p')).toBe('inventory');
+    expect(triageValue({ Foo: 1 }, 'p')).toBe('review');
+  });
+
+  it('mines the corpus and writes the candidate report (only under CDKRD_MEASURE_NOISE)', () => {
+    const buckets = mineUndeclared();
+    expect(Array.isArray(buckets)).toBe(true);
+    // `vp test run` intercepts console output, so write the report to a file the
+    // wrapper (scripts/measure-noise.sh) then prints, rather than console.log.
+    if (process.env.CDKRD_MEASURE_NOISE) {
+      const out = process.env.CDKRD_NOISE_OUT ?? join(tmpdir(), 'cdkrd-noise-report.txt');
+      writeFileSync(out, `${formatReport(buckets)}\n`);
+    }
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to the picker-scope PR (#301) discussion. Verified a key noise-model fact and recorded it **in the repo** (memory alone is lost on a new machine):

The CloudFormation schema annotates a `default` on **only ~1% of properties** (measured over the public schema set, **1605 types**): **1.10%** top-level, **1.34%** incl. nested; just **5.5%** of types have any (Lambda `MemorySize`/`Timeout` have none). So `schema.defaults` is negligible — a first run's `[Not Recorded]` inventory is kept small almost entirely by **absent-when-unset reads + `isTrivialEmpty` + the hand-maintained `KNOWN_DEFAULTS` / `KNOWN_DEFAULT_PATHS`**. Those hand tables are the real lever, so growing them should be **data-driven**.

## What

- **`scripts/measure-schema-defaults.mjs`** — repeatable schema-default coverage measurement (reads a dir of CFn schemas; header documents the one-line public-zip download). Reproduces the numbers above.
- **`tests/measure-noise.test.ts` + `scripts/measure-noise.sh`** — offline first-run-noise sweep: replays `classifyResource` over the golden corpus, ranks every `undeclared` (type, path), and flags constant-looking values as `KNOWN_DEFAULTS` (top) / `KNOWN_DEFAULT_PATHS` (nested) candidates. The fold is equality-gated, so a promotion can never hide a real change. Silent in the unit suite (writes a report file the wrapper prints). `triageValue` heuristic is unit-tested. Current corpus: 219 candidate / 67 review / 30 inventory across 316 distinct (type, path) — surfaces e.g. SQS `MaximumMessageSize`, Cognito `UserPoolTier`, the ELB attribute-bag defaults.
- **docs/ARCHITECTURE.md section 6** — records the ~1% finding and the data-driven widening loop.
- **/hunt-bugs section 5.5** — run the sweep after harvesting fresh corpus to propose promotions.

## Scope

Docs/tooling only — no `src/` change (scripts/, tests/, docs/, skill). All 41 files / 1463 unit tests pass; build green.
