### PR TITLE
feat(noise): promote 16 constant AWS defaults to KNOWN_DEFAULTS (data-driven from the noise sweep)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -116,6 +116,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ThroughputMode: 'bursting',
     BackupPolicy: { Status: 'DISABLED' },
     FileSystemProtection: { ReplicationOverwriteProtection: 'ENABLED' },
+    PerformanceMode: 'generalPurpose', // R-noise-sweep: default; switching to maxIO no longer matches and surfaces
   },
   'AWS::StepFunctions::StateMachine': {
     StateMachineType: 'STANDARD',
@@ -139,6 +140,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // values, no large/evolving config blobs like Athena WorkGroupConfiguration).
   'AWS::ApiGatewayV2::Api': {
     RouteSelectionExpression: '$request.method $request.path',
+    IpAddressType: 'ipv4', // R-noise-sweep: default; flipping to dualstack no longer matches and surfaces
   },
   'AWS::ApiGatewayV2::Integration': {
     ConnectionType: 'INTERNET',
@@ -155,6 +157,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::ECR::Repository': {
     EncryptionConfiguration: { EncryptionType: 'AES256' },
+    ImageTagMutability: 'MUTABLE', // R-noise-sweep: default; switching to IMMUTABLE no longer matches and surfaces
   },
   'AWS::Kinesis::Stream': {
     MaxRecordSizeInKiB: 1024,
@@ -167,6 +170,42 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::SNS::Subscription': {
     FilterPolicyScope: 'MessageAttributes',
+  },
+  // R-noise-sweep (data-driven from scripts/measure-noise.sh over the golden corpus):
+  // constant, documented AWS defaults for common types — never names/ids/ARNs, never
+  // region-/account-/AZ-/time-specific values, never engine-derived (RDS windows/port/
+  // option-group). Equality-gated like every entry: flip the value out of band and it
+  // no longer matches, so it re-surfaces as real undeclared drift.
+  'AWS::Cognito::UserPool': {
+    MfaConfiguration: 'OFF',
+    DeletionProtection: 'INACTIVE',
+    UserPoolTier: 'ESSENTIALS',
+  },
+  'AWS::Cognito::UserPoolClient': {
+    EnableTokenRevocation: true,
+    AuthSessionValidity: 3,
+  },
+  'AWS::ECS::Service': {
+    SchedulingStrategy: 'REPLICA',
+  },
+  'AWS::AppSync::GraphQLApi': {
+    ApiType: 'GRAPHQL',
+    Visibility: 'GLOBAL',
+    IntrospectionConfig: 'ENABLED',
+  },
+  'AWS::KMS::Key': {
+    Enabled: true,
+  },
+  'AWS::IAM::Group': {
+    Path: '/',
+  },
+  'AWS::IAM::InstanceProfile': {
+    Path: '/',
+  },
+  'AWS::Scheduler::Schedule': {
+    GroupName: 'default',
+    ActionAfterCompletion: 'NONE',
+    ScheduleExpressionTimezone: 'UTC',
   },
 };
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -603,6 +603,25 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t({ VisibilityTimeout: 60 }).undeclared).toEqual(['VisibilityTimeout']);
   });
 
+  it('noise-sweep batch: the default folds, a flipped (security-relevant) value surfaces', () => {
+    const t = (rt: string, live: Record<string, unknown>) =>
+      tiers(classifyResource(bare(rt), live, emptySchema));
+    // Cognito DeletionProtection: default INACTIVE folds; turning it ON is meaningful → surfaces
+    expect(t('AWS::Cognito::UserPool', { DeletionProtection: 'INACTIVE' }).atDefault).toEqual([
+      'DeletionProtection',
+    ]);
+    expect(t('AWS::Cognito::UserPool', { DeletionProtection: 'ACTIVE' }).undeclared).toEqual([
+      'DeletionProtection',
+    ]);
+    // KMS Key Enabled: default true folds. (Enabled:false is dropped upstream as
+    // trivially-empty, pre-existing — not this batch's concern.)
+    expect(t('AWS::KMS::Key', { Enabled: true }).atDefault).toEqual(['Enabled']);
+    // ECR mutability: default MUTABLE folds; IMMUTABLE surfaces
+    expect(t('AWS::ECR::Repository', { ImageTagMutability: 'IMMUTABLE' }).undeclared).toEqual([
+      'ImageTagMutability',
+    ]);
+  });
+
   it('R104: StateMachineType STANDARD folds, EXPRESS stays undeclared (equality-gated curation)', () => {
     const t = (v: string) =>
       tiers(

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
@@ -63,7 +63,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGatewayV2::Api",
       "path": "IpAddressType",

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD_http_rich.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD_http_rich.json
@@ -79,7 +79,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGatewayV2::Api",
       "path": "IpAddressType",

--- a/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
@@ -78,7 +78,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HttpApi",
       "resourceType": "AWS::ApiGatewayV2::Api",
       "path": "IpAddressType",

--- a/tests/corpus/AWS__AppSync__GraphQLApi.ApiF70053CD.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.ApiF70053CD.json
@@ -95,7 +95,7 @@
       "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "IntrospectionConfig",
@@ -113,7 +113,7 @@
       "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "ApiType",
@@ -122,7 +122,7 @@
       "constructPath": "CdkRealDriftIntegAppsyncGraphqlapiRich/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "Visibility",

--- a/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
@@ -74,7 +74,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "ApiType",
@@ -83,7 +83,7 @@
       "constructPath": "CdkrdIntegHarvest3/Graph"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "IntrospectionConfig",
@@ -110,7 +110,7 @@
       "constructPath": "CdkrdIntegHarvest3/Graph"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "Visibility",

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -342,7 +342,7 @@
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "DeletionProtection",
@@ -362,7 +362,7 @@
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "MfaConfiguration",
@@ -630,7 +630,7 @@
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolTier",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -343,7 +343,7 @@
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "DeletionProtection",
@@ -363,7 +363,7 @@
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "MfaConfiguration",
@@ -631,7 +631,7 @@
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolTier",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
@@ -746,7 +746,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolTier",

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -355,7 +355,7 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "DeletionProtection",
@@ -375,7 +375,7 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "MfaConfiguration",
@@ -622,7 +622,7 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolTier",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client.callbackurls.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client.callbackurls.json
@@ -71,7 +71,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Client",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "AuthSessionValidity",
@@ -89,7 +89,7 @@
       "constructPath": "CdkRealDriftIntegCognitoCallbackUrls/Client"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Client",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "EnableTokenRevocation",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
@@ -61,7 +61,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "AuthSessionValidity",
@@ -79,7 +79,7 @@
       "constructPath": "CdkRealDriftIntegCognito/Client"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "EnableTokenRevocation",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
@@ -60,7 +60,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "AuthSessionValidity",
@@ -78,7 +78,7 @@
       "constructPath": "CdkrdIntegHarvest3/WebClient"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "EnableTokenRevocation",

--- a/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
+++ b/tests/corpus/AWS__ECR__Repository.Images2D38C313.json
@@ -92,7 +92,7 @@
       "constructPath": "CdkrdIntegHarvest/Images"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Images2D38C313",
       "resourceType": "AWS::ECR::Repository",
       "path": "ImageTagMutability",

--- a/tests/corpus/AWS__ECS__Service.ServiceD69D759B.json
+++ b/tests/corpus/AWS__ECS__Service.ServiceD69D759B.json
@@ -156,7 +156,7 @@
       "constructPath": "CdkdriftIntegHarvest10/Service/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ServiceD69D759B",
       "resourceType": "AWS::ECS::Service",
       "path": "SchedulingStrategy",

--- a/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
@@ -92,7 +92,7 @@
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "PerformanceMode",

--- a/tests/corpus/AWS__IAM__Group.GroupC77FDACD.json
+++ b/tests/corpus/AWS__IAM__Group.GroupC77FDACD.json
@@ -28,7 +28,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "GroupC77FDACD",
       "resourceType": "AWS::IAM::Group",
       "path": "Path",

--- a/tests/corpus/AWS__IAM__InstanceProfile.Profile6F32097C.json
+++ b/tests/corpus/AWS__IAM__InstanceProfile.Profile6F32097C.json
@@ -32,7 +32,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Profile6F32097C",
       "resourceType": "AWS::IAM::InstanceProfile",
       "path": "Path",

--- a/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
+++ b/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
@@ -123,7 +123,7 @@
       "constructPath": "CdkrdIntegHarvest3/DataKey"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DataKey17AFBB84",
       "resourceType": "AWS::KMS::Key",
       "path": "Enabled",

--- a/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
@@ -54,7 +54,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HourlyPing",
       "resourceType": "AWS::Scheduler::Schedule",
       "path": "ActionAfterCompletion",
@@ -63,7 +63,7 @@
       "constructPath": "CdkrdIntegHarvest3/HourlyPing"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HourlyPing",
       "resourceType": "AWS::Scheduler::Schedule",
       "path": "ScheduleExpressionTimezone",

--- a/tests/corpus/AWS__Scheduler__Schedule.Schedule.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.Schedule.json
@@ -60,7 +60,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Schedule",
       "resourceType": "AWS::Scheduler::Schedule",
       "path": "GroupName",
@@ -69,7 +69,7 @@
       "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Schedule",
       "resourceType": "AWS::Scheduler::Schedule",
       "path": "ScheduleExpressionTimezone",
@@ -78,7 +78,7 @@
       "constructPath": "CdkRealDriftIntegSchedulerRich/Schedule"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Schedule",
       "resourceType": "AWS::Scheduler::Schedule",
       "path": "ActionAfterCompletion",


### PR DESCRIPTION
## Why

First fruit of the first-run-noise sweep (`scripts/measure-noise.sh`, #302). The sweep ranks `undeclared` `(type, path)` across the golden corpus and flags constant-looking values as `KNOWN_DEFAULTS` candidates. This promotes a curated, **high-confidence** batch.

Carefully filtered — the heuristic over-flags, so each entry was verified against the corpus value and AWS docs, and these were **excluded**:
- resource/account/region/AZ/time-specific: RDS `AvailabilityZone`/`Preferred*Window`, EFS/NAT IPs, Subnet `AvailabilityZoneId`, EIP `NetworkBorderGroup`
- engine-derived: RDS `Port`/`OptionGroupName`/`DBParameterGroupName`
- already-rejected (R104): SQS `MaximumMessageSize`
- non-default corpus values: DynamoDB `TableClass=STANDARD_INFREQUENT_ACCESS` (default is `STANDARD`)

## Additions (all equality-gated — flip any out of band and it re-surfaces as drift)

| Type | Default(s) |
|---|---|
| Cognito::UserPool | `MfaConfiguration=OFF`, `DeletionProtection=INACTIVE`, `UserPoolTier=ESSENTIALS` |
| Cognito::UserPoolClient | `EnableTokenRevocation=true`, `AuthSessionValidity=3` |
| AppSync::GraphQLApi | `ApiType=GRAPHQL`, `Visibility=GLOBAL`, `IntrospectionConfig=ENABLED` |
| ECS::Service | `SchedulingStrategy=REPLICA` |
| KMS::Key | `Enabled=true` |
| IAM::Group / IAM::InstanceProfile | `Path=/` |
| ApiGatewayV2::Api | `IpAddressType=ipv4` |
| ECR::Repository | `ImageTagMutability=MUTABLE` |
| EFS::FileSystem | `PerformanceMode=generalPurpose` |
| Scheduler::Schedule | `GroupName=default`, `ActionAfterCompletion=NONE`, `ScheduleExpressionTimezone=UTC` |

## Proof

Folds **36 undeclared values → atDefault across 20 golden-corpus cases** — the corpus is real live data, so this is the validation (diff is tier-only). Covered by the generic `KNOWN_DEFAULTS` fold test + a security-relevant equality-gate test (`DeletionProtection=ACTIVE` and `ECR IMMUTABLE` still surface). 41 files / 1475 unit tests pass; build green.
