### PR TITLE
feat(record): fold nested sub-keys in the record picker, mirroring the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ finding** is the only path that assigns a _different_ action to each finding.
 - **Record** records the undeclared values — and any out-of-band **added**
   resources — in the baseline, so `check` stays CLEAN until they change again (a
   multiselect lets you record some and keep reporting others; everything is
-  pre-selected). Keeps watching.
+  pre-selected). Mirroring the report, only the **standout** values are itemized;
+  the folded nested sub-keys (`undeclared-subkey`) are recorded as a summarized
+  count (`--show-all` itemizes each). Keeps watching.
 - **Ignore** writes a path rule to `.cdkrd/config.json` so the drift (declared,
   undeclared, _or_ an out-of-band **added** resource) stops being reported entirely
   (multiselect, **nothing pre-selected** — opt in, since ignoring permanently stops
@@ -363,7 +365,10 @@ Nothing` inline (shown above). Each option appears only when it
   unchanged values are auto-kept and surfaced with a
   `keeping N already-recorded unchanged value(s)` note. Deselect a suspicious one
   and it stays reported by `check` — record the intentional changes without
-  rubber-stamping the rest. With no baseline yet, the full set is shown.
+  rubber-stamping the rest. With no baseline yet, the full delta is shown. As in
+  the report, only **standout** values are itemized; the folded nested sub-keys
+  are recorded as a summarized count (when every value is folded, a single confirm
+  replaces the list) — `--show-all` / `--verbose` itemizes each instead.
   `record` snapshots **undeclared** state and out-of-band **added** resources —
   it does not "approve everything". Any **declared / deleted** drift (divergence
   from your template intent) is NOT written to the baseline and cannot be silenced

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -337,6 +337,7 @@ async function recordAll(p: ResolveParams): Promise<SubResult | null> {
     findings: applyIgnores(p.findings, p.stackName, p.region, p.config),
     yes: p.yes,
     interactive: true,
+    expandNested: p.verbose, // --show-all skips the interactive flow, so only --verbose expands here
   });
   // !wrote in this interactive path means the multiselect was cancelled (nothing
   // written) — signal "back to the menu" rather than exit.

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -53,6 +53,7 @@ export async function runRecord(args: string[]): Promise<number> {
         findings: applyIgnores(findings, stackName, region, config),
         yes: a.yes,
         interactive: isInteractive(),
+        expandNested: a.showAll || a.verbose, // itemize nested sub-keys instead of folding them
       });
       // a non-interactive record that needed a decision but had no --yes refuses (R38)
       if (result.refused) worst = Math.max(worst, 2);

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -98,6 +98,28 @@ export function recordSelectMessage(stackName: string): string {
 }
 
 /**
+ * Split the to-record delta into STANDOUT (itemized in the record multiselect) and FOLDED
+ * (nested live-only sub-keys — the `undeclared-subkey` mass the report folds, R96). Folded
+ * entries are auto-recorded as a summarized count instead of dozens of rows. `expandNested`
+ * (--show-all / --verbose) turns the fold off so every nested value is itemized. An entry is
+ * folded when its matching gather finding is a `nested` undeclared value. Pure + exported.
+ */
+export function splitFoldedNested<T extends { logicalId: string; path: string }>(
+  changed: T[],
+  findings: Finding[],
+  expandNested: boolean | undefined
+): { standout: T[]; folded: T[] } {
+  if (expandNested) return { standout: changed, folded: [] };
+  const nestedKeys = new Set(
+    findings
+      .filter((f) => f.nested === true && f.tier === 'undeclared')
+      .map((f) => `${f.logicalId}::${f.path}`)
+  );
+  const isFolded = (e: T): boolean => nestedKeys.has(`${e.logicalId}::${e.path}`);
+  return { standout: changed.filter((e) => !isFolded(e)), folded: changed.filter(isFolded) };
+}
+
+/**
  * Post-record scope note (or undefined). `record` snapshots UNDECLARED state and (PR4)
  * out-of-band `added` resources into the baseline — but it CANNOT silence DECLARED or
  * DELETED drift, which is divergence from your template intent a baseline does not
@@ -204,6 +226,12 @@ export interface RecordStackParams {
   // records exactly these (keyed by recordedKey). Already-recorded unchanged values are
   // still auto-kept, so this never drops the rest of the baseline.
   preselectedKeys?: Set<string>;
+  // Mirror the report's R96 fold: by default the record multiselect itemizes only the
+  // STANDOUT (non-nested) undeclared values and auto-records the nested live-only sub-keys
+  // (the `undeclared-subkey` mass the report folds) as a summarized count, instead of
+  // listing dozens of nested rows. `--show-all` / `--verbose` sets this true to itemize
+  // every nested value individually (the report's --show-all parity).
+  expandNested?: boolean;
 }
 
 /**
@@ -232,7 +260,8 @@ export interface RecordResult {
  * interactive prompt — neither re-gathers.)
  */
 export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
-  const { stackName, region, desired, findings, yes, interactive, preselectedKeys } = p;
+  const { stackName, region, desired, findings, yes, interactive, preselectedKeys, expandNested } =
+    p;
   const existing = await loadBaseline(stackName, desired.accountId, region);
   if (!yes && existing)
     console.error(
@@ -271,22 +300,47 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
       if (preselectedKeys) {
         picked = changed.map((e) => recordedKey(e)).filter((k) => preselectedKeys.has(k));
       } else {
-        const fromPrompt = await bulkMultiselect(
-          recordSelectMessage(stackName),
-          // default = all selected (→/← bulk-toggle from there)
-          changed.map((e) => ({
-            value: recordedKey(e),
-            // an `added`-resource entry (PR4) has an empty path — the whole resource is
-            // the value — so omit the trailing dot and tag it as a resource snapshot.
-            label: e.path ? `${e.logicalId}.${e.path}` : `${e.logicalId} (added resource)`,
-            selected: true,
-          }))
-        );
-        if (fromPrompt === undefined) {
-          console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
-          return { wrote: false, refused: false };
+        // Mirror the report's R96 fold: itemize only the STANDOUT (non-nested) values;
+        // the nested live-only sub-keys (the `undeclared-subkey` mass) are auto-recorded
+        // as a summarized count rather than dozens of rows. `--show-all`/`--verbose`
+        // (expandNested) lists every nested value individually instead.
+        const { standout, folded } = splitFoldedNested(changed, findings, expandNested);
+        if (standout.length === 0) {
+          // Nothing to itemize (every changed value is a folded nested sub-key — the
+          // common all-nested first run). Confirm the bulk record instead of showing an
+          // empty multiselect; the folded count is the decision.
+          const proceed = await confirm({
+            message: `${stackName}: record ${folded.length} undeclared sub-key value(s)? (--show-all to itemize each)`,
+            initialValue: true,
+          });
+          if (isCancel(proceed) || !proceed) {
+            console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
+            return { wrote: false, refused: false };
+          }
+          picked = changed.map((e) => recordedKey(e));
+        } else {
+          const fromPrompt = await bulkMultiselect(
+            recordSelectMessage(stackName),
+            // default = all selected (→/← bulk-toggle from there)
+            standout.map((e) => ({
+              value: recordedKey(e),
+              // an `added`-resource entry (PR4) has an empty path — the whole resource is
+              // the value — so omit the trailing dot and tag it as a resource snapshot.
+              label: e.path ? `${e.logicalId}.${e.path}` : `${e.logicalId} (added resource)`,
+              selected: true,
+            }))
+          );
+          if (fromPrompt === undefined) {
+            console.error(`note: ${stackName}: record cancelled — baseline unchanged`);
+            return { wrote: false, refused: false };
+          }
+          // the folded nested values are always recorded alongside the picked standouts
+          picked = [...fromPrompt, ...folded.map((e) => recordedKey(e))];
         }
-        picked = fromPrompt;
+        if (folded.length > 0)
+          console.error(
+            `note: ${stackName}: +${folded.length} folded undeclared sub-key value(s) recorded (--show-all to itemize)`
+          );
       }
       const selectedChanged = selectRecorded(findings, new Set(picked));
       recorded = [...unchanged, ...selectedChanged]; // auto-kept unchanged + the user's picks

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -20,6 +20,7 @@ import {
   recordScopeNote,
   recordSelectMessage,
   recordStack,
+  splitFoldedNested,
   availableActions,
   filterRevertPlan,
   formatPlan,
@@ -689,6 +690,42 @@ describe('recordStack non-interactive refusal (R38)', () => {
     } finally {
       if (existsSync(path)) rmSync(path);
     }
+  });
+});
+
+describe('splitFoldedNested (record mirrors the report R96 fold)', () => {
+  const fnd = (logicalId: string, path: string, nested?: boolean): Finding =>
+    ({
+      tier: 'undeclared',
+      logicalId,
+      resourceType: 'T',
+      path,
+      actual: 1,
+      ...(nested ? { nested: true } : {}),
+    }) as Finding;
+  const entry = (logicalId: string, path: string) => ({ logicalId, path });
+
+  it('folds nested undeclared values, itemizes the standouts', () => {
+    const changed = [entry('A', 'Top'), entry('A', 'Conf.Sub'), entry('A', 'Conf.Other')];
+    const findings = [fnd('A', 'Top'), fnd('A', 'Conf.Sub', true), fnd('A', 'Conf.Other', true)];
+    const { standout, folded } = splitFoldedNested(changed, findings, false);
+    expect(standout.map((e) => e.path)).toEqual(['Top']);
+    expect(folded.map((e) => e.path)).toEqual(['Conf.Sub', 'Conf.Other']);
+  });
+
+  it('expandNested itemizes everything (nothing folded) — the --show-all parity', () => {
+    const changed = [entry('A', 'Top'), entry('A', 'Conf.Sub')];
+    const findings = [fnd('A', 'Top'), fnd('A', 'Conf.Sub', true)];
+    const { standout, folded } = splitFoldedNested(changed, findings, true);
+    expect(standout).toHaveLength(2);
+    expect(folded).toHaveLength(0);
+  });
+
+  it('an added-resource / top-level value is never folded (no nested finding)', () => {
+    const changed = [entry('A', '')]; // added-resource entry (empty path)
+    const { standout, folded } = splitFoldedNested(changed, [], false);
+    expect(standout).toHaveLength(1);
+    expect(folded).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Why

Follow-up to the picker-scope discussion (#301). The **record** multiselect listed EVERY undeclared value as a pre-selected row — including the nested live-only sub-keys the report deliberately folds (`undeclared-subkey=N`). So a config-dense first run dumped dozens of nested rows the user just scrolls past, even though recording them is the intended, safe action.

`record` was deliberately NOT given the ignore/per-finding scope gate (it is the folded inventory's home, and recording is non-destructive + keeps watching). But that left the open question the user raised: *then why itemize the 23 nested values one-by-one at all?*

## What

Mirror the report's R96 fold in the record picker:
- Itemize only the **standout** (non-nested) undeclared/added values for opt-out.
- Auto-record the folded nested sub-keys as a **summarized count** (`+N folded undeclared sub-key value(s) recorded`).
- When **every** value is folded (the common all-nested first run), a single **confirm** replaces the empty multiselect.
- `--show-all` / `--verbose` itemizes each nested value instead (parity with the report's `--show-all`).

record-all stays one keystroke; folded values are always recorded (safe — `record` KEEPS watching, so a later out-of-band change re-surfaces as drift). `--yes` is unaffected (it never shows the multiselect). The KNOWN_DEFAULTS batch (#305) already shrank this list; this removes the residual nested clutter.

## Tests

New pure `splitFoldedNested` is unit-tested (folds nested / `expandNested` itemizes all / added-resource never folded); threaded via a new `expandNested` param from the `record` verb (`a.showAll || a.verbose`) and check's interactive record (`p.verbose`). 41 files / 1478 unit tests pass; build green.
