### PR TITLE
fix(record): use --verbose (not --show-all) to itemize the folded record picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Nothing` (see [Day to day](#day-to-day-act-on-drift)). Each option appears only
   (new + changed values, pre-selected); already-recorded unchanged values are
   auto-kept. Deselect a suspicious one and it stays reported by `check`. Only the
   **standout** values are listed; the folded nested sub-keys (`undeclared-subkey`)
-  are **always recorded** and the picker header discloses their count (`--show-all`
+  are **always recorded** and the picker header discloses their count (`--verbose`
   itemizes each). `record` writes only undeclared + added state — any declared /
   deleted drift is NOT written and `record` prints a note that it still stands
   (resolve with `revert` or `cdk deploy`).

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -53,7 +53,7 @@ export async function runRecord(args: string[]): Promise<number> {
         findings: applyIgnores(findings, stackName, region, config),
         yes: a.yes,
         interactive: isInteractive(),
-        expandNested: a.showAll || a.verbose, // itemize nested sub-keys instead of folding them
+        expandNested: a.verbose, // --verbose itemizes the nested sub-keys (--show-all is the separate inventory mode, not a picker-detail flag)
       });
       // a non-interactive record that needed a decision but had no --yes refuses (R38)
       if (result.refused) worst = Math.max(worst, 2);

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -101,7 +101,7 @@ export function formatSurvivingDrift(remaining: Finding[], cap = 10): string[] {
 export function recordSelectMessage(stackName: string, foldedCount = 0): string {
   const fold =
     foldedCount > 0
-      ? `; +${foldedCount} folded sub-key(s) ALWAYS recorded too (--show-all to itemize)`
+      ? `; +${foldedCount} folded sub-key(s) ALWAYS recorded too (--verbose to itemize)`
       : '';
   return `${stackName}: select undeclared value(s) to record (unselected stay reported)${fold}`;
 }
@@ -110,8 +110,8 @@ export function recordSelectMessage(stackName: string, foldedCount = 0): string 
  * Split the to-record delta into STANDOUT (itemized in the record multiselect) and FOLDED
  * (nested live-only sub-keys — the `undeclared-subkey` mass the report folds, R96). Folded
  * entries are auto-recorded as a summarized count instead of dozens of rows. `expandNested`
- * (--show-all / --verbose) turns the fold off so every nested value is itemized. An entry is
- * folded when its matching gather finding is a `nested` undeclared value. Pure + exported.
+ * (--verbose) turns the fold off so every nested value is itemized. An entry is folded when
+ * its matching gather finding is a `nested` undeclared value. Pure + exported.
  */
 export function splitFoldedNested<T extends { logicalId: string; path: string }>(
   changed: T[],
@@ -238,8 +238,9 @@ export interface RecordStackParams {
   // Mirror the report's R96 fold: by default the record multiselect itemizes only the
   // STANDOUT (non-nested) undeclared values and auto-records the nested live-only sub-keys
   // (the `undeclared-subkey` mass the report folds) as a summarized count, instead of
-  // listing dozens of nested rows. `--show-all` / `--verbose` sets this true to itemize
-  // every nested value individually (the report's --show-all parity).
+  // listing dozens of nested rows. `--verbose` sets this true to itemize every nested
+  // value individually (mirrors the report's --verbose fold-expansion; --show-all is the
+  // separate inventory mode and suppresses the interactive prompt, so it never reaches here).
   expandNested?: boolean;
 }
 
@@ -314,14 +315,15 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
         // header discloses the count. They are deliberately NOT individually deselectable —
         // "record only the standout, keep the folded reported" has no use case (the folded
         // would just nag forever), while deselecting a standout to "record the rest" stays
-        // possible (the folded still record). To record nothing, cancel (esc). `--show-all`/
-        // `--verbose` (expandNested) itemizes every nested value as its own row instead.
+        // possible (the folded still record). To record nothing, cancel (esc). `--verbose`
+        // (expandNested) itemizes every nested value as its own row instead (`--show-all` is
+        // the separate inventory mode — it suppresses this prompt, so it can't itemize here).
         const { standout, folded } = splitFoldedNested(changed, findings, expandNested);
         if (standout.length === 0) {
           // Nothing to itemize (every changed value is a folded nested sub-key — the common
           // all-nested first run). A Yes/No commit replaces the empty multiselect.
           const proceed = await confirm({
-            message: `${stackName}: record ${folded.length} undeclared sub-key value(s)? (--show-all to itemize each)`,
+            message: `${stackName}: record ${folded.length} undeclared sub-key value(s)? (--verbose to itemize each)`,
             initialValue: true,
           });
           if (isCancel(proceed) || !proceed) {

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -713,7 +713,7 @@ describe('splitFoldedNested (record mirrors the report R96 fold)', () => {
     expect(folded.map((e) => e.path)).toEqual(['Conf.Sub', 'Conf.Other']);
   });
 
-  it('expandNested itemizes everything (nothing folded) — the --show-all parity', () => {
+  it('expandNested itemizes everything (nothing folded) — the --verbose fold-expansion', () => {
     const changed = [entry('A', 'Top'), entry('A', 'Conf.Sub')];
     const findings = [fnd('A', 'Top'), fnd('A', 'Conf.Sub', true)];
     const { standout, folded } = splitFoldedNested(changed, findings, true);
@@ -925,7 +925,8 @@ describe('recordSelectMessage (R49, R116 — bulkMultiselect renders the key hin
   it('discloses that folded sub-keys are ALWAYS recorded when foldedCount > 0', () => {
     const msg = recordSelectMessage('ApiStack', 23);
     expect(msg).toContain('23 folded sub-key(s) ALWAYS recorded');
-    expect(msg).toContain('--show-all');
+    expect(msg).toContain('--verbose');
+    expect(msg).not.toContain('--show-all'); // --show-all is the separate inventory mode
     expect(msg).not.toContain('\n'); // still a single-line header
   });
 


### PR DESCRIPTION
## Why

Follow-up to #307. The record picker hint said `(--show-all to itemize)`, but the two flags are different modes and `--show-all` is wrong here:

| | `--verbose` | `--show-all` |
|---|---|---|
| baseline | applied (normal) | **ignored** (inventory mode) |
| expands | readGap/skipped/unresolved + nested | atDefault (the big list) + nested |
| interactive record/ignore/revert | **shown** | **suppressed** |

So `check --show-all` suppresses the interactive prompt entirely — from check's Record picker, "use --show-all to itemize" gives you no picker at all (just the printed inventory). The flag that itemizes the folded sub-keys **in place** is `--verbose` (works in both check's interactive picker via `p.verbose` and the standalone `record` verb).

## What

- Record picker header + all-folded confirm now say `(--verbose to itemize)`.
- `record`'s `expandNested` is now `a.verbose` only (was `a.showAll || a.verbose`), so the flags stay cleanly separated: `--show-all` = baseline-blind inventory mode, `--verbose` = expand the folded detail.
- Report/inventory uses of `--show-all` are unchanged (those are legitimate).
- Docs + the `recordSelectMessage` disclosure test updated to `--verbose`.

41 files / 1480 unit tests pass; build green.
