### PR TITLE
fix(diff): align EC2 Instance BlockDeviceMappings by DeviceName, not whole-array

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -91,6 +91,19 @@ interface SubsetArraySpec {
 const stripCognitoAttrPrefix = (id: string): string => id.replace(/^(custom|dev):/, '');
 const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpec>> = {
   'AWS::Cognito::UserPool': { Schema: { idField: 'Name', normalizeId: stripCognitoAttrPrefix } },
+  // An EC2 Instance's BlockDeviceMappings is a SET keyed by DeviceName, and the live
+  // model is a SUPERSET of the template's in two ways: (1) the API enriches each declared
+  // mapping's `Ebs` block with defaults the template never set (SnapshotId, the encrypting
+  // KmsKeyId, the resolved Iops/Throughput); (2) a volume ATTACHED out of band — or via a
+  // sibling AWS::EC2::VolumeAttachment — appears as an EXTRA mapping (e.g. `/dev/sdf`) the
+  // Instance template never declared. A positional/whole-array compare then false-flags the
+  // entire BlockDeviceMappings as declared drift on every fresh deploy. Aligning declared
+  // mappings to live BY DeviceName lets each declared mapping subset-compare against its live
+  // twin (the enriched Ebs keys are an undeclared superset, not a declared change) and emits
+  // each live-only mapping as nested undeclared inventory. A genuinely removed declared
+  // mapping (no live DeviceName match) still surfaces as declared drift. Observed live on a
+  // fresh ec2-instance-rich deploy (a gp3 root volume + an attached data volume).
+  'AWS::EC2::Instance': { BlockDeviceMappings: { idField: 'DeviceName' } },
 };
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
   !!t &&

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2833,6 +2833,102 @@ describe('Cognito UserPool Schema identity-keyed subset (WAVE23 — declared att
   });
 });
 
+describe('EC2 Instance BlockDeviceMappings identity-keyed subset (found by ec2-instance-rich)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const inst = (declared: Record<string, unknown>) => ({
+    logicalId: 'Host',
+    resourceType: 'AWS::EC2::Instance',
+    physicalId: 'i-0abc',
+    declared,
+  });
+  // The template declares only the root mapping with a minimal Ebs block.
+  const declaredRoot = {
+    DeviceName: '/dev/xvda',
+    Ebs: { DeleteOnTermination: true, Encrypted: true, VolumeSize: 8, VolumeType: 'gp3' },
+  };
+  // AWS enriches the matching live mapping with defaults the template never set
+  // (SnapshotId, the encrypting KmsKeyId, the resolved Iops) and may reorder the keys.
+  const liveRoot = {
+    Ebs: {
+      SnapshotId: 'snap-08bb176df19e6f6ca',
+      VolumeType: 'gp3',
+      KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc',
+      Encrypted: true,
+      Iops: 3000,
+      VolumeSize: 8,
+      DeleteOnTermination: true,
+    },
+    DeviceName: '/dev/xvda',
+  };
+  // A volume attached out of band / via a sibling VolumeAttachment appears as an EXTRA
+  // live mapping the Instance template never declared.
+  const liveAttached = {
+    Ebs: {
+      SnapshotId: '',
+      VolumeType: 'gp3',
+      KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc',
+      Encrypted: true,
+      Iops: 3000,
+      VolumeSize: 10,
+      DeleteOnTermination: false,
+    },
+    DeviceName: '/dev/sdf',
+  };
+
+  it('a subset root mapping + an extra live mapping does NOT false-drift the whole array', () => {
+    const findings = classifyResource(
+      inst({ BlockDeviceMappings: [declaredRoot] }),
+      { BlockDeviceMappings: [liveRoot, liveAttached] },
+      bare
+    );
+    // the enriched Ebs keys + the extra /dev/sdf mapping must NOT be a declared drift
+    expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+    // the live-only mapping surfaces as nested undeclared inventory, keyed by DeviceName
+    const undeclared = findings.filter(
+      (f) => f.tier === 'undeclared' && f.path === 'BlockDeviceMappings[/dev/sdf]'
+    );
+    expect(undeclared).toHaveLength(1);
+  });
+
+  it('an out-of-band change to a DECLARED Ebs sub-value is reported as declared drift', () => {
+    const declaredDrift = classifyResource(
+      inst({ BlockDeviceMappings: [declaredRoot] }),
+      // root volume grown out of band 8 -> 16
+      {
+        BlockDeviceMappings: [
+          { ...liveRoot, Ebs: { ...liveRoot.Ebs, VolumeSize: 16 } },
+          liveAttached,
+        ],
+      },
+      bare
+    ).filter((f) => f.tier === 'declared');
+    expect(declaredDrift).toHaveLength(1);
+    expect(declaredDrift[0]).toMatchObject({
+      path: 'BlockDeviceMappings.0.Ebs.VolumeSize',
+      desired: 8,
+      actual: 16,
+    });
+  });
+
+  it('a declared mapping absent from live (DeviceName removed) is declared drift', () => {
+    const declaredDrift = classifyResource(
+      inst({ BlockDeviceMappings: [declaredRoot] }),
+      { BlockDeviceMappings: [liveAttached] }, // /dev/xvda no longer present
+      bare
+    ).filter((f) => f.tier === 'declared');
+    expect(declaredDrift).toHaveLength(1);
+  });
+});
+
 describe('Name-keyed object arrays are identity-aligned (WAVE24 — ECS env vars, Alarm dimensions)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -1,0 +1,480 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HostB4E45AD7",
+    "resourceType": "AWS::EC2::Instance",
+    "physicalId": "i-0b7c750351d0a5aa6",
+    "constructPath": "CdkRealDriftIntegEc2Rich/Host",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "BlockDeviceMappings": [
+        {
+          "DeviceName": "/dev/xvda",
+          "Ebs": {
+            "DeleteOnTermination": true,
+            "Encrypted": true,
+            "VolumeSize": 8,
+            "VolumeType": "gp3"
+          }
+        }
+      ],
+      "CreditSpecification": {
+        "CPUCredits": "standard"
+      },
+      "IamInstanceProfile": "CdkRealDriftIntegEc2Rich-HostInstanceProfileFDE6399F-teTG6yYesSw7",
+      "ImageId": "ami-0521cb2d60cfbb1a6",
+      "InstanceType": "t3.micro",
+      "LaunchTemplate": {
+        "LaunchTemplateName": "HostLaunchTemplate",
+        "Version": "1"
+      },
+      "Monitoring": true,
+      "SecurityGroupIds": ["sg-027bb24dfa8eb1b48"],
+      "SubnetId": "subnet-012053df57a833e72",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegEc2Rich/Host"
+        },
+        {
+          "Key": "role",
+          "Value": "bastion"
+        }
+      ],
+      "UserData": "__cdkrd_corpus_unresolved__"
+    }
+  },
+  "liveRaw": {
+    "Tenancy": "default",
+    "SecurityGroups": ["CdkRealDriftIntegEc2Rich-SgD4954771-nA4Jj877L60k"],
+    "PrivateDnsName": "ip-10-0-0-216.ec2.internal",
+    "PrivateIpAddress": "10.0.0.216",
+    "UserData": "IyEvYmluL2Jhc2gKZWNobyAnY2RrcmQgZWMyLWluc3RhbmNlLXJpY2ggZml4dHVyZScgPiAvdG1wL2hlbGxv",
+    "BlockDeviceMappings": [
+      {
+        "Ebs": {
+          "SnapshotId": "snap-08bb176df19e6f6ca",
+          "VolumeType": "gp3",
+          "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+          "Encrypted": true,
+          "Iops": 3000,
+          "VolumeSize": 8,
+          "DeleteOnTermination": true
+        },
+        "DeviceName": "/dev/xvda"
+      },
+      {
+        "Ebs": {
+          "SnapshotId": "",
+          "VolumeType": "gp3",
+          "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+          "Encrypted": true,
+          "Iops": 3000,
+          "VolumeSize": 10,
+          "DeleteOnTermination": false
+        },
+        "DeviceName": "/dev/sdf"
+      }
+    ],
+    "IamInstanceProfile": "CdkRealDriftIntegEc2Rich-HostInstanceProfileFDE6399F-teTG6yYesSw7",
+    "SubnetId": "subnet-012053df57a833e72",
+    "EbsOptimized": false,
+    "Volumes": [
+      {
+        "VolumeId": "vol-094cd4ee2e33c8e54",
+        "Device": "/dev/xvda"
+      },
+      {
+        "VolumeId": "vol-010c7274153ce356a",
+        "Device": "/dev/sdf"
+      }
+    ],
+    "PrivateIp": "10.0.0.216",
+    "EnclaveOptions": {
+      "Enabled": false
+    },
+    "NetworkInterfaces": [
+      {
+        "AssociateCarrierIpAddress": false,
+        "PrivateIpAddress": "10.0.0.216",
+        "PrivateIpAddresses": [
+          {
+            "PrivateIpAddress": "10.0.0.216",
+            "Primary": true
+          }
+        ],
+        "SecondaryPrivateIpAddressCount": 0,
+        "DeviceIndex": "0",
+        "Ipv6AddressCount": 0,
+        "GroupSet": ["sg-027bb24dfa8eb1b48"],
+        "Ipv6Addresses": [],
+        "SubnetId": "subnet-012053df57a833e72",
+        "AssociatePublicIpAddress": true,
+        "NetworkInterfaceId": "eni-0a9b2c526ff5b36ae",
+        "DeleteOnTermination": true
+      }
+    ],
+    "ImageId": "ami-0521cb2d60cfbb1a6",
+    "InstanceType": "t3.micro",
+    "Monitoring": true,
+    "Tags": [
+      {
+        "Value": "1",
+        "Key": "aws:ec2launchtemplate:version"
+      },
+      {
+        "Value": "lt-06e16b72ba5fc8034",
+        "Key": "aws:ec2launchtemplate:id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEc2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HostB4E45AD7",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "bastion",
+        "Key": "role"
+      },
+      {
+        "Value": "CdkRealDriftIntegEc2Rich/Host",
+        "Key": "Name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEc2Rich/dfa8dfd0-6e33-11f1-a317-0e5947b3b911",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "HibernationOptions": {
+      "Configured": false
+    },
+    "MetadataOptions": {
+      "HttpPutResponseHopLimit": 2,
+      "HttpProtocolIpv6": "disabled",
+      "HttpTokens": "required",
+      "InstanceMetadataTags": "disabled",
+      "HttpEndpoint": "enabled"
+    },
+    "InstanceId": "i-0b7c750351d0a5aa6",
+    "PublicIp": "3.238.9.127",
+    "InstanceInitiatedShutdownBehavior": "stop",
+    "CpuOptions": {
+      "ThreadsPerCore": 2,
+      "CoreCount": 1
+    },
+    "AvailabilityZone": "us-east-1a",
+    "PrivateDnsNameOptions": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "PublicDnsName": "ec2-3-238-9-127.compute-1.amazonaws.com",
+    "SecurityGroupIds": ["sg-027bb24dfa8eb1b48"],
+    "DisableApiTermination": false,
+    "SourceDestCheck": true,
+    "PlacementGroupName": "",
+    "VpcId": "vpc-0801bdee9d9d4d668",
+    "State": {
+      "Code": "16",
+      "Name": "running"
+    },
+    "CreditSpecification": {
+      "CPUCredits": "standard"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "InstanceId",
+      "PrivateDnsName",
+      "PrivateIp",
+      "PublicDnsName",
+      "PublicIp",
+      "State",
+      "VpcId"
+    ],
+    "writeOnly": [
+      "AdditionalInfo",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "LaunchTemplate",
+      "LicenseSpecification",
+      "PropagateTagsToVolumeOnCreation"
+    ],
+    "createOnly": [
+      "AdditionalInfo",
+      "Affinity",
+      "AvailabilityZone",
+      "BlockDeviceMappings",
+      "CpuOptions",
+      "EbsOptimized",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "EnclaveOptions",
+      "HibernationOptions",
+      "HostId",
+      "HostResourceGroupArn",
+      "ImageId",
+      "InstanceType",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "KernelId",
+      "KeyName",
+      "LaunchTemplate",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "PlacementGroupName",
+      "PrivateDnsNameOptions",
+      "PrivateIpAddress",
+      "RamdiskId",
+      "SecurityGroupIds",
+      "SecurityGroups",
+      "SubnetId",
+      "Tenancy",
+      "UserData"
+    ],
+    "readOnlyPaths": [
+      "InstanceId",
+      "PrivateDnsName",
+      "PrivateIp",
+      "PublicDnsName",
+      "PublicIp",
+      "State",
+      "VpcId"
+    ],
+    "writeOnlyPaths": [
+      "AdditionalInfo",
+      "BlockDeviceMappings.*.NoDevice",
+      "BlockDeviceMappings.*.VirtualName",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "LaunchTemplate",
+      "LicenseSpecification",
+      "PropagateTagsToVolumeOnCreation"
+    ],
+    "createOnlyPaths": [
+      "AdditionalInfo",
+      "Affinity",
+      "AvailabilityZone",
+      "BlockDeviceMappings",
+      "CpuOptions",
+      "EbsOptimized",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "EnclaveOptions",
+      "HibernationOptions",
+      "HostId",
+      "HostResourceGroupArn",
+      "ImageId",
+      "InstanceType",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "KernelId",
+      "KeyName",
+      "LaunchTemplate",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "PlacementGroupName",
+      "PrivateDnsNameOptions",
+      "PrivateIpAddress",
+      "RamdiskId",
+      "SecurityGroupIds",
+      "SecurityGroups",
+      "SubnetId",
+      "Tenancy",
+      "UserData"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "HibernationOptions.Configured": false,
+      "MetadataOptions.HttpPutResponseHopLimit": 1
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "LaunchTemplate",
+      "note": "write-only — cannot be read back",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "AvailabilityZone",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "BlockDeviceMappings[/dev/sdf]",
+      "actual": {
+        "Ebs": {
+          "SnapshotId": "",
+          "VolumeType": "gp3",
+          "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+          "Encrypted": true,
+          "Iops": 3000,
+          "VolumeSize": 10,
+          "DeleteOnTermination": false
+        },
+        "DeviceName": "/dev/sdf"
+      },
+      "nested": true,
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "UserData",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Tenancy",
+      "actual": "default",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SecurityGroups",
+      "actual": ["CdkRealDriftIntegEc2Rich-SgD4954771-nA4Jj877L60k"],
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.216",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Volumes",
+      "actual": [
+        {
+          "VolumeId": "vol-094cd4ee2e33c8e54",
+          "Device": "/dev/xvda"
+        },
+        {
+          "VolumeId": "vol-010c7274153ce356a",
+          "Device": "/dev/sdf"
+        }
+      ],
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "NetworkInterfaces",
+      "actual": [
+        {
+          "AssociateCarrierIpAddress": false,
+          "PrivateIpAddress": "10.0.0.216",
+          "PrivateIpAddresses": [
+            {
+              "PrivateIpAddress": "10.0.0.216",
+              "Primary": true
+            }
+          ],
+          "SecondaryPrivateIpAddressCount": 0,
+          "DeviceIndex": "0",
+          "Ipv6AddressCount": 0,
+          "GroupSet": ["sg-027bb24dfa8eb1b48"],
+          "Ipv6Addresses": [],
+          "SubnetId": "subnet-012053df57a833e72",
+          "AssociatePublicIpAddress": true,
+          "NetworkInterfaceId": "eni-0a9b2c526ff5b36ae",
+          "DeleteOnTermination": true
+        }
+      ],
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "CpuOptions",
+      "actual": {
+        "ThreadsPerCore": 2,
+        "CoreCount": 1
+      },
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Volume.Data666C94C7.json
+++ b/tests/corpus/AWS__EC2__Volume.Data666C94C7.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Data666C94C7",
+    "resourceType": "AWS::EC2::Volume",
+    "physicalId": "vol-010c7274153ce356a",
+    "constructPath": "CdkRealDriftIntegEc2Rich/Data",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "Encrypted": true,
+      "Iops": 3000,
+      "MultiAttachEnabled": false,
+      "Size": 10,
+      "Tags": [
+        {
+          "Key": "role",
+          "Value": "data"
+        }
+      ],
+      "Throughput": 150,
+      "VolumeType": "gp3"
+    }
+  },
+  "liveRaw": {
+    "MultiAttachEnabled": false,
+    "VolumeId": "vol-010c7274153ce356a",
+    "VolumeType": "gp3",
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+    "Encrypted": true,
+    "Size": 10,
+    "AutoEnableIO": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "Throughput": 150,
+    "Iops": 3000,
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegEc2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "data",
+        "Key": "role"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEc2Rich/dfa8dfd0-6e33-11f1-a317-0e5947b3b911",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Data666C94C7",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VolumeId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["VolumeId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZone",
+      "physicalId": "vol-010c7274153ce356a",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+      "physicalId": "vol-010c7274153ce356a",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "vol-010c7274153ce356a",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Data"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VolumeAttachment.DataAttach.json
+++ b/tests/corpus/AWS__EC2__VolumeAttachment.DataAttach.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DataAttach",
+    "resourceType": "AWS::EC2::VolumeAttachment",
+    "physicalId": "vol-010c7274153ce356a|i-0b7c750351d0a5aa6",
+    "constructPath": "CdkRealDriftIntegEc2Rich/DataAttach",
+    "declared": {
+      "Device": "/dev/sdf",
+      "InstanceId": "i-0b7c750351d0a5aa6",
+      "VolumeId": "vol-010c7274153ce356a"
+    }
+  },
+  "liveRaw": {
+    "VolumeId": "vol-010c7274153ce356a",
+    "InstanceId": "i-0b7c750351d0a5aa6",
+    "Device": "/dev/sdf",
+    "EbsCardIndex": 0
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Device", "EbsCardIndex", "InstanceId", "VolumeId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Device", "EbsCardIndex", "InstanceId", "VolumeId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "DataAttach",
+      "resourceType": "AWS::EC2::VolumeAttachment",
+      "path": "EbsCardIndex",
+      "actual": 0,
+      "physicalId": "vol-010c7274153ce356a|i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/DataAttach"
+    }
+  ]
+}

--- a/tests/integration/ec2-instance-rich/app.ts
+++ b/tests/integration/ec2-instance-rich/app.ts
@@ -1,0 +1,85 @@
+// CDK app for the cdk-real-drift EC2 Instance / EBS Volume false-positive +
+// detection integration test. EC2 Instance is a daily-driver type cdkrd had NOT
+// exercised before this fixture (no prior corpus/fixture). It DECLARES a stack of
+// normalization-prone properties whose live AWS form is textually different but
+// semantically equal:
+//   - UserData      — CDK renders an Fn::Base64; the live read returns the base64 blob.
+//   - MetadataOptions (IMDSv2 `HttpTokens=required`) — a nested object many users set.
+//   - BlockDeviceMappings — an array of {DeviceName, Ebs:{...}} the API may reorder /
+//     enrich (SnapshotId, KmsKeyId, the default Encrypted flag).
+//   - Detailed monitoring (`Monitoring=true`) + CreditSpecification (t3 burstable).
+//   - A standalone EBS Volume (gp3 with explicit Iops/Throughput) + VolumeAttachment.
+// A minimal single-AZ VPC with no NAT keeps it cheap and self-cleaning.
+import { App, Size, Stack, Tags } from "aws-cdk-lib";
+import {
+  AmazonLinuxCpuType,
+  BlockDeviceVolume,
+  CpuCredits,
+  EbsDeviceVolumeType,
+  Instance,
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  MachineImage,
+  SecurityGroup,
+  SubnetType,
+  UserData,
+  Volume,
+  CfnVolumeAttachment,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEc2Rich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc, allowAllOutbound: true });
+
+const userData = UserData.forLinux();
+userData.addCommands("echo 'cdkrd ec2-instance-rich fixture' > /tmp/hello");
+
+const instance = new Instance(stack, "Host", {
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PUBLIC },
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023({ cpuType: AmazonLinuxCpuType.X86_64 }),
+  securityGroup: sg,
+  userData,
+  requireImdsv2: true, // MetadataOptions.HttpTokens = required
+  detailedMonitoring: true, // Monitoring = true
+  creditSpecification: CpuCredits.STANDARD,
+  blockDevices: [
+    {
+      deviceName: "/dev/xvda",
+      volume: BlockDeviceVolume.ebs(8, {
+        volumeType: EbsDeviceVolumeType.GP3,
+        encrypted: true,
+        deleteOnTermination: true,
+      }),
+    },
+  ],
+});
+Tags.of(instance).add("role", "bastion");
+
+const dataVolume = new Volume(stack, "Data", {
+  availabilityZone: vpc.publicSubnets[0]!.availabilityZone,
+  size: Size.gibibytes(10),
+  volumeType: EbsDeviceVolumeType.GP3,
+  iops: 3000,
+  throughput: 150, // non-default (gp3 default is 125) so it stays a DECLARED prop, not atDefault
+  encrypted: true,
+});
+Tags.of(dataVolume).add("role", "data");
+
+new CfnVolumeAttachment(stack, "DataAttach", {
+  device: "/dev/sdf",
+  instanceId: instance.instanceId,
+  volumeId: dataVolume.volumeId,
+});
+
+app.synth();

--- a/tests/integration/ec2-instance-rich/cdk.json
+++ b/tests/integration/ec2-instance-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ec2-instance-rich/package.json
+++ b/tests/integration/ec2-instance-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ec2-instance-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift EC2 Instance / EBS Volume false-positive + detection integration test. Run via verify.sh / verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ec2-instance-rich/verify-detect.sh
+++ b/tests/integration/ec2-instance-rich/verify-detect.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# EC2 EBS Volume detect (+ revert) integration test (real AWS): the "someone changed
+# it in the console" scenario. Deploy -> record -> change a DECLARED MUTABLE property
+# (the data Volume's Throughput, 150 -> 250) out of band -> check MUST DETECT the
+# declared drift (exit 1) -> revert -> check MUST be CLEAN and the live value restored.
+# This is the false-negative / detection half that verify.sh does not exercise.
+#
+# Throughput is chosen because a gp3 volume's throughput is freely modifiable in BOTH
+# directions (unlike Size, which can only grow — so it could not be reverted down).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEc2Rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+VOL="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::EC2::Volume'].PhysicalResourceId" --output text)"
+[ -n "$VOL" ] || fail "could not resolve volume physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: Volume Throughput 150 -> 250 (console-edit) ==="
+aws ec2 modify-volume --volume-id "$VOL" --throughput 250 --region "$REGION" >/dev/null || fail "inject drift"
+# modify-volume is async; wait until the optimization completes and Throughput settles.
+for _ in $(seq 1 30); do
+  TP="$(aws ec2 describe-volumes --volume-ids "$VOL" --region "$REGION" --query "Volumes[0].Throughput" --output text)"
+  [ "$TP" = "250" ] && break
+  sleep 5
+done
+[ "$TP" = "250" ] || fail "modify-volume did not settle to 250 (got $TP)"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ec2-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "Throughput" /tmp/cdkrd-ec2-detect.out || fail "Throughput not reported"
+
+echo "=== revert (write declared value back) ==="
+if $CLI revert "$STACK" --region "$REGION" --yes; then
+  echo "=== check MUST be CLEAN after revert ==="
+  $CLI check "$STACK" --region "$REGION" --fail
+  [ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+  for _ in $(seq 1 30); do
+    TP="$(aws ec2 describe-volumes --volume-ids "$VOL" --region "$REGION" --query "Volumes[0].Throughput" --output text)"
+    [ "$TP" = "150" ] && break
+    sleep 5
+  done
+  [ "$TP" = "150" ] || fail "live throughput not restored to 150 (got $TP)"
+  echo "INTEG PASS ($STACK detect+revert)"
+else
+  echo "NOTE: revert not supported for AWS::EC2::Volume (SDK_WRITERS candidate); detection PASS only"
+  echo "INTEG PASS ($STACK detect-only)"
+fi

--- a/tests/integration/ec2-instance-rich/verify.sh
+++ b/tests/integration/ec2-instance-rich/verify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# cdk-real-drift EC2 Instance / EBS Volume false-positive integration test (real AWS).
+#
+# EC2 Instance is a daily-driver type cdkrd had not exercised. The fixture DECLARES
+# normalization-prone properties (UserData base64, MetadataOptions/IMDSv2,
+# BlockDeviceMappings, detailed monitoring, a gp3 Volume with explicit Iops/Throughput)
+# whose live AWS form is textually different but semantically equal. The strong
+# assertion: with NO baseline, `check --fail` must exit 0 — there is no declared drift,
+# because every declared value normalizes equal to live. A normalizer regression turns
+# one into a false declared drift and fails here. Then record + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/ec2-instance-rich && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEc2Rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ec2-rich-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "DECLARED DRIFT" /tmp/cdkrd-ec2-rich-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## What

Fixes a **false positive**: a freshly deployed `AWS::EC2::Instance` reported its
entire `BlockDeviceMappings` as **declared drift** on every `check`, with no
out-of-band change.

An Instance's `BlockDeviceMappings` is a SET keyed by `DeviceName` whose live
model is a SUPERSET of the template's in two ways:
1. AWS enriches each declared mapping's `Ebs` block with defaults the template
   never set (`SnapshotId`, the encrypting `KmsKeyId`, the resolved `Iops`/`Throughput`).
2. A volume attached out of band — or via a sibling `AWS::EC2::VolumeAttachment`
   (the common "extra data volume" pattern) — appears as an EXTRA mapping (e.g. `/dev/sdf`).

The positional/whole-array compare in `drift-calculator` only subset-descends when
the arrays are the SAME length and positionally aligned, so the length mismatch
(declared 1, live 2) fell through to a whole-array declared drift.

## Fix

Add `AWS::EC2::Instance` `BlockDeviceMappings` to `IDENTITY_KEYED_SUBSET_ARRAYS`
(`idField: DeviceName`) — the same mechanism `AWS::Cognito::UserPool.Schema`
already uses. Declared mappings align to live BY `DeviceName`, each subset-compares
against its live twin (enriched `Ebs` keys are an undeclared superset, not a
declared change), and each live-only mapping surfaces as **nested undeclared
inventory** (`BlockDeviceMappings[/dev/sdf]`, recordable). A genuinely removed
declared mapping (no live `DeviceName` match) still surfaces as declared drift.

## How it was found

A new `tests/integration/ec2-instance-rich` fixture — EC2 Instance was an untested
daily-driver type (no prior fixture/corpus). Live-proven on a fresh deploy:

- **FP**: before the fix `check` reported `BlockDeviceMappings` declared drift; after,
  `check` is CLEAN and `record → check` stays CLEAN.
- **FN**: mutated the gp3 data Volume's `Throughput` 150→250 out of band → `check`
  DETECTED (exit 1) → `revert` → `check` CLEAN → live restored to 150. (EC2 Volume
  is revertable via Cloud Control `UpdateResource`.)

## Tests / regression assets

- 3 unit tests in `classify.test.ts` (subset alignment is not drift; a declared
  `Ebs` value change IS declared drift; a removed mapping IS declared drift).
- 3 golden-corpus cases (`EC2::Instance`, `EC2::Volume`, `EC2::VolumeAttachment`)
  replaying the real live read offline via `corpus-replay`.
- Committed `ec2-instance-rich` fixture (`verify.sh` FP + `verify-detect.sh`
  detect/revert).

Stack torn down via `delstack`; `bughunt-track.sh verify` reports SWEEP CLEAN.