### PR TITLE
feat(noise): fold 3 constant EC2 Instance defaults to atDefault (data-driven from the noise sweep)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -135,6 +135,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       EnableResourceNameDnsAAAARecord: false,
     },
   },
+  // R-noise-sweep (found by the ec2-instance-rich hunt, PR #310 follow-up): a fresh
+  // EC2 Instance reports these three constant service defaults as undeclared on every
+  // first run. They are documented account-/instance-independent defaults — Tenancy
+  // "default" (vs dedicated/host), SourceDestCheck on (the routing default), and the
+  // "stop" shutdown behavior. Resource-specific live values the same read returns
+  // (PrivateIpAddress, SecurityGroups, Volumes, NetworkInterfaces, CpuOptions which is
+  // instance-type-derived, …) are deliberately NOT listed — they are genuine undeclared
+  // inventory. Equality-gated: flip any out of band and it no longer matches, so it
+  // re-surfaces as real undeclared drift.
+  'AWS::EC2::Instance': {
+    Tenancy: 'default',
+    SourceDestCheck: true,
+    InstanceInitiatedShutdownBehavior: 'stop',
+  },
   // R105 (second dogfood-audit wave): more top-level constant service defaults
   // (same exclusions as R104 — no names/ids/ARNs, no region-/account-specific
   // values, no large/evolving config blobs like Athena WorkGroupConfiguration).

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -345,7 +345,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "Tenancy",
@@ -434,7 +434,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "InstanceInitiatedShutdownBehavior",
@@ -468,7 +468,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "SourceDestCheck",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -360,6 +360,18 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULTS['AWS::IAM::Role'].MaxSessionDuration).toBe(3600);
   });
 
+  it('EC2 Instance known defaults present — the 3 constant defaults a fresh instance reports (PR #310 follow-up)', () => {
+    // Tenancy/SourceDestCheck/InstanceInitiatedShutdownBehavior are account-/
+    // instance-independent constant defaults; the ec2-instance-rich corpus case
+    // exercises the fold. Resource-specific live values (PrivateIpAddress,
+    // SecurityGroups, CpuOptions, …) are deliberately NOT folded.
+    expect(KNOWN_DEFAULTS['AWS::EC2::Instance']).toEqual({
+      Tenancy: 'default',
+      SourceDestCheck: true,
+      InstanceInitiatedShutdownBehavior: 'stop',
+    });
+  });
+
   it('S3 suspended versioning is a known default — the off state a revert lands on (R46)', () => {
     expect(KNOWN_DEFAULTS['AWS::S3::Bucket'].VersioningConfiguration).toEqual({
       Status: 'Suspended',


### PR DESCRIPTION
## What

Promote three constant `AWS::EC2::Instance` service defaults to `KNOWN_DEFAULTS` so a fresh instance no longer reports them as `undeclared` `[Not Recorded]` on every first run:

```
Tenancy: 'default'
SourceDestCheck: true
InstanceInitiatedShutdownBehavior: 'stop'
```

## Why

Follow-up to #310 (which deployed the first `ec2-instance-rich` fixture and fixed the BlockDeviceMappings whole-array FP). The same live read surfaced these three as first-run noise. They are account-/instance-independent constant defaults — confirmed `CANDIDATE` by `scripts/measure-noise.sh` over the golden corpus. Resource-specific live values the same read returns (`PrivateIpAddress`, `SecurityGroups`, `Volumes`, `NetworkInterfaces`, `CpuOptions` which is instance-type-derived, …) are deliberately **not** folded — they are genuine undeclared inventory.

## Safety

Equality-gated like every `KNOWN_DEFAULTS` entry: flip any of the three out of band and the live value no longer matches the listed default, so it re-surfaces as real undeclared drift. A correct promotion can never hide a real change.

## Verification

- `tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json` expected updated `undeclared`→`atDefault` for the three props; `corpus-replay` (364 cases) re-runs `classifyResource` on the **real live read captured in #310** and proves the fold offline — no live re-deploy needed (the live values were already proven in #310's full integration sweep).
- New `noise-and-strip` unit test asserting the table entry.
- typecheck / lint+format / build / 1487 unit tests all pass.

This is the offline first-run-noise quality pass described in the `/hunt-bugs` skill §5.5.