### PR TITLE
docs: clarify README tagline and drop mid-sentence code quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cdk-real-drift (`cdkrd`)
 
-Drift detection for AWS CDK — including the **undeclared properties `cdk drift`
-can't see**. Detect it, record it, or revert it.
+Drift detection for AWS CDK that sees what your template can't — including the
+**properties you never declared**. Detect it, record it, or revert it.
 
 <!-- badges (enable on publish):
 [![npm](https://img.shields.io/npm/v/cdk-real-drift)](https://www.npmjs.com/package/cdk-real-drift)


### PR DESCRIPTION
## What

Reword the README tagline so it's shorter, more direct, and easier to read.

Before:
> Drift detection for AWS CDK — including the **undeclared properties `cdk drift` can't see**. Detect it, record it, or revert it.

After:
> Drift detection for AWS CDK that sees what your template can't — including the **properties you never declared**. Detect it, record it, or revert it.

## Why

- The mid-sentence backtick-quoted `cdk drift` read awkwardly.
- Leads with the differentiator (properties you never declared) using "what your template can't (see)" as the hook, conveying the appeal more directly.

Docs-only change — no command/flag/revert surface is touched, so the wording stays consistent with the rest of the README and CLAUDE.md's "undeclared properties" framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CrRBH3s9K2JATm9wo6R9t

---
_Generated by [Claude Code](https://claude.ai/code/session_015CrRBH3s9K2JATm9wo6R9t)_