### PR TITLE
docs: enable README badges and drop the requirements line

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 Drift detection for AWS CDK that sees what your template can't — including the
 **properties you never declared**. Detect it, record it, or revert it.
 
-<!-- badges (enable on publish):
 [![npm](https://img.shields.io/npm/v/cdk-real-drift)](https://www.npmjs.com/package/cdk-real-drift)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
--->
 
 > **Day to day you run one command — `cdkrd check`.** It finds drift and offers
 > **Record / Revert / Ignore** right there; the other verbs are just its non-TTY/CI
@@ -62,9 +60,6 @@ Then act on what `check` prints, from its own interactive prompt:
    inline.
 3. **In CI** — `npx cdkrd check --fail` (read-only, never prompts, exits 1 on
    drift).
-
-Requirements: Node.js >= 20, AWS credentials via the standard SDK chain
-(env vars, `--profile`, SSO).
 
 ### First run: record a baseline
 


### PR DESCRIPTION
## What

Ahead of the first public release, two README header cleanups:

1. **Enable the npm + license badges** — they were committed but commented out behind an `enable on publish` marker.
2. **Drop the `Requirements: Node.js >= 20, AWS credentials …` line** from Quick start. The Node floor is already enforced by `package.json` `engines` (`>=20.0.0`) at install time, and AWS credentials are implicit for a CDK / CloudFormation tool — so the line added weight without adding information.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_