### PR TITLE
docs: move badges to the top and drop the intro blockquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # cdk-real-drift (`cdkrd`)
 
-Drift detection for AWS CDK that sees what your template can't — including the
-**properties you never declared**. Detect it, record it, or revert it.
-
 [![npm](https://img.shields.io/npm/v/cdk-real-drift)](https://www.npmjs.com/package/cdk-real-drift)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-> **Day to day you run one command — `cdkrd check`.** It finds drift and offers
-> **Record / Revert / Ignore** right there; the other verbs are just its non-TTY/CI
-> equivalents (`check --fail` in CI). See [Quick start](#quick-start).
+Drift detection for AWS CDK that sees what your template can't — including the
+**properties you never declared**. Detect it, record it, or revert it.
 
 ## Why
 


### PR DESCRIPTION
## What

Two header cleanups for a simpler, more readable top-of-README:

1. **Move the npm + license badges directly under the H1**, above the tagline — the conventional top-of-readme placement.
2. **Remove the day-to-day workflow blockquote** from the header. It hurt the tagline's readability and simplicity, and Quick start already documents the one-command (`cdkrd check`) flow in full.

Result — title → badges → tagline → `## Why`.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_