### PR TITLE
docs: correct misleading "writes: nothing" and "does not read CDK code" claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # cdk-real-drift (`cdkrd`)
 
-Drift detection for AWS CDK that sees what your template can't — including the
-**properties you never declared**. Detect it, record it, or revert it.
-
 [![npm](https://img.shields.io/npm/v/cdk-real-drift)](https://www.npmjs.com/package/cdk-real-drift)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-> **Day to day you run one command — `cdkrd check`.** It finds drift and offers
-> **Record / Revert / Ignore** right there; the other verbs are just its non-TTY/CI
-> equivalents (`check --fail` in CI). See [Quick start](#quick-start).
+Drift detection for AWS CDK that sees what your template can't — including the
+**properties you never declared**. Detect it, record it, or revert it.
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ ApiStack: CLEAN after revert.
 offers from the prompt** — and the same actions as standalone commands for
 non-TTY use:
 
-| verb           | meaning                                                               | writes                     |
-| -------------- | --------------------------------------------------------------------- | -------------------------- |
-| `cdkrd check`  | find drift (the one you run)                                          | nothing                    |
-| `cdkrd record` | "this undeclared / added state is the norm — tell me if it _changes_" | a git file (baseline)      |
-| `cdkrd ignore` | "stop reporting this property, ever"                                  | a git file (`config.json`) |
-| `cdkrd revert` | "this state is WRONG" — write the desired value back                  | AWS (plan + confirm)       |
+| verb           | meaning                                                               | writes                               |
+| -------------- | --------------------------------------------------------------------- | ------------------------------------ |
+| `cdkrd check`  | find drift (the one you run)                                          | nothing — the 3 below do the writing |
+| `cdkrd record` | "this undeclared / added state is the norm — tell me if it _changes_" | a git file (baseline)                |
+| `cdkrd ignore` | "stop reporting this property, ever"                                  | a git file (`config.json`)           |
+| `cdkrd revert` | "this state is WRONG" — write the desired value back                  | AWS (plan + confirm)                 |
 
 The one distinction to keep straight:
 
@@ -177,11 +177,13 @@ writes one.
 
 ## How it works
 
-cdkrd compares the **live AWS resource** against your **CloudFormation template**
-(the one you DEPLOYED by default; the local synth with `--pre-deploy`). It does
-**not** read your CDK code — it's reality vs intent, not `cdk diff`, so undeployed
-code changes never show up as drift (see [`--pre-deploy`](#--pre-deploy) for the
-opt-in inversion).
+cdkrd compares the **live AWS resource** against your **CloudFormation template** —
+the one you DEPLOYED by default, or the local CDK synth with `--pre-deploy`. The
+yardstick is always that template (deployed or synthesized), **not** a line-by-line
+diff of your CDK source the way `cdk diff` works — it's reality vs intent. So by
+default, undeployed code changes never show up as drift; `--pre-deploy` inverts
+that, checking live state against the freshly synthesized template (see
+[`--pre-deploy`](#--pre-deploy)).
 
 ### The vocabulary
 


### PR DESCRIPTION
## What

Two accuracy corrections to the README, both flagged as misleading:

1. **Verb table `writes` column.** `cdkrd check` listed `writes: nothing`, which reads as false — `check` is the interactive launchpad that runs record / revert / ignore. Reframed TTY-independently: **`nothing — the 3 below do the writing`** (the interactive "offering" is already explained in the prose above the table).

2. **"It does not read your CDK code".** Too absolute — `--pre-deploy` compares against the local CDK **synth**, and the app is synthesized for stack discovery regardless. Reframed around the real point: the yardstick is the CloudFormation **template** (deployed or synthesized), **not** a line-by-line diff of your CDK source the way `cdk diff` works — consistent with the "reality vs intent, not code vs template" framing in DESIGN.md / ARCHITECTURE.md.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_