### PR TITLE
docs: note revert/ignore on first run in the Quick start step too

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # cdk-real-drift (`cdkrd`)
 
-Drift detection for AWS CDK that sees what your template can't — including the
-**properties you never declared**. Detect it, record it, or revert it.
-
 [![npm](https://img.shields.io/npm/v/cdk-real-drift)](https://www.npmjs.com/package/cdk-real-drift)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
-> **Day to day you run one command — `cdkrd check`.** It finds drift and offers
-> **Record / Revert / Ignore** right there; the other verbs are just its non-TTY/CI
-> equivalents (`check --fail` in CI). See [Quick start](#quick-start).
+Drift detection for AWS CDK that sees what your template can't — including the
+**properties you never declared**. Detect it, record it, or revert it.
 
 ## Why
 

--- a/README.md
+++ b/README.md
@@ -155,12 +155,12 @@ ApiStack: CLEAN after revert.
 offers from the prompt** — and the same actions as standalone commands for
 non-TTY use:
 
-| verb           | meaning                                                               | writes                     |
-| -------------- | --------------------------------------------------------------------- | -------------------------- |
-| `cdkrd check`  | find drift (the one you run)                                          | nothing                    |
-| `cdkrd record` | "this undeclared / added state is the norm — tell me if it _changes_" | a git file (baseline)      |
-| `cdkrd ignore` | "stop reporting this property, ever"                                  | a git file (`config.json`) |
-| `cdkrd revert` | "this state is WRONG" — write the desired value back                  | AWS (plan + confirm)       |
+| verb           | meaning                                                               | writes                               |
+| -------------- | --------------------------------------------------------------------- | ------------------------------------ |
+| `cdkrd check`  | find drift (the one you run)                                          | nothing — the 3 below do the writing |
+| `cdkrd record` | "this undeclared / added state is the norm — tell me if it _changes_" | a git file (baseline)                |
+| `cdkrd ignore` | "stop reporting this property, ever"                                  | a git file (`config.json`)           |
+| `cdkrd revert` | "this state is WRONG" — write the desired value back                  | AWS (plan + confirm)                 |
 
 The one distinction to keep straight:
 
@@ -177,11 +177,13 @@ writes one.
 
 ## How it works
 
-cdkrd compares the **live AWS resource** against your **CloudFormation template**
-(the one you DEPLOYED by default; the local synth with `--pre-deploy`). It does
-**not** read your CDK code — it's reality vs intent, not `cdk diff`, so undeployed
-code changes never show up as drift (see [`--pre-deploy`](#--pre-deploy) for the
-opt-in inversion).
+cdkrd compares the **live AWS resource** against your **CloudFormation template** —
+the one you DEPLOYED by default, or the local CDK synth with `--pre-deploy`. The
+yardstick is always that template (deployed or synthesized), **not** a line-by-line
+diff of your CDK source the way `cdk diff` works — it's reality vs intent. So by
+default, undeployed code changes never show up as drift; `--pre-deploy` inverts
+that, checking live state against the freshly synthesized template (see
+[`--pre-deploy`](#--pre-deploy)).
 
 ### The vocabulary
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,9 @@ ApiStack: CLEAN after revert.
 
 ## The model: one verb you run, three it offers
 
-`cdkrd check` is the entry point. The other three verbs are the **actions it
-offers from the prompt** — and the same actions as standalone commands for
-non-TTY use:
+`cdkrd check` is the entry point. On a TTY it finds drift and offers the other
+three as inline actions; all four are standalone commands too, for non-TTY use
+(scripting / CI). Here's what each command does, run on its own:
 
 | verb           | meaning                                                               | writes                               |
 | -------------- | --------------------------------------------------------------------- | ------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,17 @@ A few things to know about that first run:
   blind.
 - **Recording writes only a git file** — `.cdkrd/ApiStack.<account>.<region>.json`,
   nothing to AWS. Commit it; from then on `check` is CLEAN until reality changes.
-- **Declared drift needs no baseline** — it's detected from the very first run.
+- **Record vs Ignore — both silence the value, differently.** Record **snapshots**
+  it and **keeps watching** (a later change re-surfaces as drift); Ignore writes a
+  `config.json` rule and **stops watching** for good. On first run you'll almost
+  always Record; Ignore is for a live-only value you never want reported. (Full
+  breakdown under [Day to day](#day-to-day-act-on-drift).)
+- **Already drifting on day 1? You can revert right away.** Undeclared / added
+  detection only arms once you record, but **declared** drift is caught from the
+  very first `check`. When it's present, the prompt also offers **Revert** (write
+  the template value back) and **Ignore** — so you fix or accept it immediately,
+  with no need to record first. (`record` covers undeclared / added values only,
+  never declared drift.)
 
 Even a fully clean fresh deploy still prompts to record, so the day-1 baseline is
 always established through `check` itself:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ npx cdkrd check                 # checks every stack your app defines
 Then act on what `check` prints, from its own interactive prompt:
 
 1. **First run** — record a baseline (one prompt; writes a git file, nothing to
-   AWS). This is the switch that arms undeclared / added detection.
+   AWS). This is the switch that arms undeclared / added detection. (Already
+   drifting? A **declared** drift on that first run can be reverted or ignored
+   right there too — record isn't the only choice.)
 2. **Day to day** — when `check` finds drift, pick **Record / Revert / Ignore**
    inline.
 3. **In CI** — `npx cdkrd check --fail` (read-only, never prompts, exits 1 on


### PR DESCRIPTION
## What

Follow-up to #319. The Quick start **First run** step still mentioned only recording a baseline, so it read as if record were the only first-run action. Added a light parenthetical mirroring the First run section: a **declared** drift on the first `check` can be reverted or ignored right there too — record isn't the only choice.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_