### PR TITLE
feat(noise): fold ECS container Cpu=0 default to atDefault

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -293,6 +293,14 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::DynamoDB::Table': {
     'PointInTimeRecoverySpecification.RecoveryPeriodInDays': 35,
   },
+  'AWS::ECS::TaskDefinition': {
+    // A container that does not reserve CPU reads back Cpu: 0 (the documented "no
+    // reservation" default) for EVERY container, so a multi-container task def floods
+    // the first run with `ContainerDefinitions[*].Cpu = 0` not-recorded noise. Fold the
+    // constant default to atDefault; a container that actually reserves CPU (Cpu != 0)
+    // no longer matches and surfaces. Observed live on the ecs-taskdef-caps deploy.
+    'ContainerDefinitions.*.Cpu': 0,
+  },
   'AWS::Glue::Database': {
     'DatabaseInput.CreateTableDefaultPermissions': [
       {

--- a/tests/corpus/AWS__ECS__TaskDefinition.Task.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.Task.json
@@ -115,7 +115,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Task",
       "resourceType": "AWS::ECS::TaskDefinition",
       "path": "ContainerDefinitions[app].Cpu",

--- a/tests/corpus/AWS__ECS__TaskDefinition.TaskDef.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.TaskDef.json
@@ -234,7 +234,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "TaskDef",
       "resourceType": "AWS::ECS::TaskDefinition",
       "path": "ContainerDefinitions[app].Cpu",
@@ -244,7 +244,7 @@
       "constructPath": "CdkRealDriftIntegEcsTaskDefCaps/TaskDef"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "TaskDef",
       "resourceType": "AWS::ECS::TaskDefinition",
       "path": "ContainerDefinitions[sidecar].Cpu",


### PR DESCRIPTION
## What

Follow-up noise-reduction from the ECS PortMappings hunt (#318). A container that does not reserve CPU reads back `Cpu: 0` (the documented "no reservation" default) for EVERY container, so a multi-container task definition floods a first run with `ContainerDefinitions[*].Cpu = 0` not-recorded noise.

## Change

Add `AWS::ECS::TaskDefinition` -> `ContainerDefinitions.*.Cpu: 0` to `KNOWN_DEFAULT_PATHS`, folding the constant default to the `atDefault` tier. Equality-gated: a container that actually reserves CPU (`Cpu != 0`) no longer matches and still surfaces.

## Verification

- Data-driven from `measure-noise.sh` over the real ECS corpus (only ECS::TaskDefinition candidate).
- Covered by the existing data-driven KNOWN_DEFAULT_PATHS invariant test.
- Both ECS TaskDefinition corpus cases re-recorded (Cpu now `atDefault`) and replayed offline by `corpus-replay` from real live data.
- typecheck / lint+format / build / 1491 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)