### PR TITLE
fix(noise): fold DynamoDB LSI + GlobalTable NonKeyAttributes reorder

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -983,16 +983,25 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
     'ContainerDefinitions.PortMappings',
     'ContainerDefinitions.VolumesFrom',
   ]),
-  // DynamoDB sorts a GSI's INCLUDE-projection `NonKeyAttributes` alphabetically:
-  // declared ["zeta","alpha","mike","bravo"] reads back ["alpha","bravo","mike","zeta"],
-  // a positional compare false-flags the whole set. This is a nested SCALAR set (plain
-  // attribute names — not id/ARN-shaped, so canonicalizeIdArraysDeep leaves it) nested
-  // under the GlobalSecondaryIndexes ARRAY; sortNestedObjectArrays sorts scalar arrays by
+  // DynamoDB sorts an INCLUDE-projection `NonKeyAttributes` set into its own canonical
+  // order: declared ["zeta","alpha","mike","bravo"] reads back reordered, a positional
+  // compare false-flags the whole set. This is a nested SCALAR set (plain attribute names
+  // — not id/ARN-shaped, so canonicalizeIdArraysDeep leaves it) nested under the
+  // (Global|Local)SecondaryIndexes ARRAY; sortNestedObjectArrays sorts scalar arrays by
   // canonical JSON too, so the same machinery aligns it. A genuine attribute add/remove
-  // still changes the multiset. Observed live on a fresh ddb-gsi-projection deploy.
-  // (AWS::DynamoDB::GlobalTable has the identical GSI projection shape — a likely sibling,
-  // left unlisted until observed.)
-  'AWS::DynamoDB::Table': new Set(['GlobalSecondaryIndexes.Projection.NonKeyAttributes']),
+  // still changes the multiset. The GSI path was observed live on a fresh
+  // ddb-gsi-projection deploy; the LSI path and the AWS::DynamoDB::GlobalTable (TableV2)
+  // GSI *and* LSI paths — the identical projection shape on a Table's LSI and on the
+  // GlobalTable type — were observed live on a fresh ddb-nested-sets deploy (declared
+  // ["yankee","bravo","oscar","delta"] read back ["oscar","delta","yankee","bravo"], etc.).
+  'AWS::DynamoDB::Table': new Set([
+    'GlobalSecondaryIndexes.Projection.NonKeyAttributes',
+    'LocalSecondaryIndexes.Projection.NonKeyAttributes',
+  ]),
+  'AWS::DynamoDB::GlobalTable': new Set([
+    'GlobalSecondaryIndexes.Projection.NonKeyAttributes',
+    'LocalSecondaryIndexes.Projection.NonKeyAttributes',
+  ]),
 };
 
 // Return a deep clone of `value` (a declared/live property subtree rooted at one

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1643,6 +1643,36 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
       expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
     });
   });
+
+  // The siblings of the GSI fold above, found by ddb-nested-sets: the SAME nested
+  // INCLUDE-projection NonKeyAttributes set lives on a Table's LocalSecondaryIndexes
+  // and on the AWS::DynamoDB::GlobalTable (TableV2) type's GSI *and* LSI, all of which
+  // AWS reorders into its own canonical order (declared ["yankee","bravo","oscar",
+  // "delta"] read back ["oscar","delta","yankee","bravo"], etc.). Each must fold the
+  // reorder yet still surface a genuine element change.
+  describe('DynamoDB nested NonKeyAttributes sibling sets reordered (found by ddb-nested-sets)', () => {
+    const idx = (arrKey: string, attrs: string[]) => ({
+      [arrKey]: [
+        { IndexName: 'idx1', Projection: { ProjectionType: 'INCLUDE', NonKeyAttributes: attrs } },
+      ],
+    });
+    const cases = [
+      { T: 'AWS::DynamoDB::Table', arrKey: 'LocalSecondaryIndexes' },
+      { T: 'AWS::DynamoDB::GlobalTable', arrKey: 'GlobalSecondaryIndexes' },
+      { T: 'AWS::DynamoDB::GlobalTable', arrKey: 'LocalSecondaryIndexes' },
+    ];
+    for (const { T, arrKey } of cases) {
+      const declared = idx(arrKey, ['yankee', 'bravo', 'oscar', 'delta']);
+      it(`${T} ${arrKey}: reordered NonKeyAttributes set is NOT drift`, () => {
+        const live = idx(arrKey, ['oscar', 'delta', 'yankee', 'bravo']);
+        expect(declaredTiers(T, declared, live)).toEqual([]);
+      });
+      it(`${T} ${arrKey}: a genuine NonKeyAttributes change still surfaces`, () => {
+        const live = idx(arrKey, ['oscar', 'delta', 'yankee', 'omega']); // bravo -> omega
+        expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+      });
+    }
+  });
 });
 
 describe('LATEST sentinel declared false positives (Fargate PlatformVersion, found by ecs-taskset-rich)', () => {

--- a/tests/corpus/AWS__DynamoDB__GlobalTable.Global7C59AC82.json
+++ b/tests/corpus/AWS__DynamoDB__GlobalTable.Global7C59AC82.json
@@ -1,0 +1,232 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Global7C59AC82",
+    "resourceType": "AWS::DynamoDB::GlobalTable",
+    "physicalId": "cdkrd-integ-ddb-nested-sets-global",
+    "constructPath": "CdkRealDriftIntegDdbNestedSets/Global",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "sk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "gsi1pk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "lsi1sk",
+          "AttributeType": "N"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "GlobalSecondaryIndexes": [
+        {
+          "IndexName": "gsi1",
+          "KeySchema": [
+            {
+              "AttributeName": "gsi1pk",
+              "KeyType": "HASH"
+            }
+          ],
+          "Projection": {
+            "NonKeyAttributes": ["quebec", "foxtrot", "tango", "golf"],
+            "ProjectionType": "INCLUDE"
+          }
+        }
+      ],
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "LocalSecondaryIndexes": [
+        {
+          "IndexName": "lsi1",
+          "KeySchema": [
+            {
+              "AttributeName": "pk",
+              "KeyType": "HASH"
+            },
+            {
+              "AttributeName": "lsi1sk",
+              "KeyType": "RANGE"
+            }
+          ],
+          "Projection": {
+            "NonKeyAttributes": ["sierra", "echo", "november", "alpha"],
+            "ProjectionType": "INCLUDE"
+          }
+        }
+      ],
+      "Replicas": [
+        {
+          "GlobalSecondaryIndexes": [
+            {
+              "IndexName": "gsi1"
+            }
+          ],
+          "Region": "us-east-1"
+        }
+      ],
+      "TableName": "cdkrd-integ-ddb-nested-sets-global"
+    }
+  },
+  "liveRaw": {
+    "TableId": "1e6f34f7-6919-4262-8e4d-971c3939d6a5",
+    "TableName": "cdkrd-integ-ddb-nested-sets-global",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "gsi1pk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "sk"
+      },
+      {
+        "AttributeType": "N",
+        "AttributeName": "lsi1sk"
+      }
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+    "GlobalSecondaryIndexes": [
+      {
+        "IndexName": "gsi1",
+        "Projection": {
+          "NonKeyAttributes": ["golf", "foxtrot", "tango", "quebec"],
+          "ProjectionType": "INCLUDE"
+        },
+        "KeySchema": [
+          {
+            "KeyType": "HASH",
+            "AttributeName": "gsi1pk"
+          }
+        ],
+        "WarmThroughput": {
+          "ReadUnitsPerSecond": 12000,
+          "WriteUnitsPerSecond": 4000
+        }
+      }
+    ],
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      },
+      {
+        "KeyType": "RANGE",
+        "AttributeName": "sk"
+      }
+    ],
+    "LocalSecondaryIndexes": [
+      {
+        "IndexName": "lsi1",
+        "Projection": {
+          "NonKeyAttributes": ["november", "sierra", "alpha", "echo"],
+          "ProjectionType": "INCLUDE"
+        },
+        "KeySchema": [
+          {
+            "KeyType": "HASH",
+            "AttributeName": "pk"
+          },
+          {
+            "KeyType": "RANGE",
+            "AttributeName": "lsi1sk"
+          }
+        ]
+      }
+    ],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/cdkrd-integ-ddb-nested-sets-global",
+    "Replicas": [
+      {
+        "ContributorInsightsSpecification": {
+          "Enabled": false
+        },
+        "GlobalSecondaryIndexes": [
+          {
+            "IndexName": "gsi1",
+            "ContributorInsightsSpecification": {
+              "Enabled": false
+            }
+          }
+        ],
+        "Region": "us-east-1",
+        "GlobalTableSettingsReplicationMode": "DISABLED",
+        "TableClass": "STANDARD",
+        "DeletionProtectionEnabled": false
+      }
+    ],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn", "TableId"],
+    "writeOnly": ["GlobalTableSourceArn"],
+    "createOnly": ["GlobalTableSourceArn", "KeySchema", "LocalSecondaryIndexes", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn", "TableId"],
+    "writeOnlyPaths": [
+      "GlobalSecondaryIndexes.*.WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings.SeedCapacity",
+      "GlobalTableSourceArn",
+      "Replicas.*.GlobalSecondaryIndexes.*.ReadProvisionedThroughputSettings.ReadCapacityAutoScalingSettings.SeedCapacity",
+      "Replicas.*.ReadProvisionedThroughputSettings.ReadCapacityAutoScalingSettings.SeedCapacity",
+      "WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings.SeedCapacity"
+    ],
+    "createOnlyPaths": ["GlobalTableSourceArn", "KeySchema", "LocalSecondaryIndexes", "TableName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Global7C59AC82",
+      "resourceType": "AWS::DynamoDB::GlobalTable",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "cdkrd-integ-ddb-nested-sets-global",
+      "constructPath": "CdkRealDriftIntegDdbNestedSets/Global"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Global7C59AC82",
+      "resourceType": "AWS::DynamoDB::GlobalTable",
+      "path": "GlobalSecondaryIndexes[gsi1].WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "nested": true,
+      "physicalId": "cdkrd-integ-ddb-nested-sets-global",
+      "constructPath": "CdkRealDriftIntegDdbNestedSets/Global"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DynamoDB__Table.Classic397C6F85.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Classic397C6F85.json
@@ -1,0 +1,210 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Classic397C6F85",
+    "resourceType": "AWS::DynamoDB::Table",
+    "physicalId": "cdkrd-integ-ddb-nested-sets-classic",
+    "constructPath": "CdkRealDriftIntegDdbNestedSets/Classic",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "sk",
+          "AttributeType": "S"
+        },
+        {
+          "AttributeName": "lsi1sk",
+          "AttributeType": "N"
+        },
+        {
+          "AttributeName": "gsi1pk",
+          "AttributeType": "S"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "GlobalSecondaryIndexes": [
+        {
+          "IndexName": "gsi1",
+          "KeySchema": [
+            {
+              "AttributeName": "gsi1pk",
+              "KeyType": "HASH"
+            }
+          ],
+          "Projection": {
+            "NonKeyAttributes": ["zeta", "alpha", "mike", "bravo"],
+            "ProjectionType": "INCLUDE"
+          }
+        }
+      ],
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        },
+        {
+          "AttributeName": "sk",
+          "KeyType": "RANGE"
+        }
+      ],
+      "LocalSecondaryIndexes": [
+        {
+          "IndexName": "lsi1",
+          "KeySchema": [
+            {
+              "AttributeName": "pk",
+              "KeyType": "HASH"
+            },
+            {
+              "AttributeName": "lsi1sk",
+              "KeyType": "RANGE"
+            }
+          ],
+          "Projection": {
+            "NonKeyAttributes": ["yankee", "bravo", "oscar", "delta"],
+            "ProjectionType": "INCLUDE"
+          }
+        }
+      ],
+      "TableName": "cdkrd-integ-ddb-nested-sets-classic"
+    }
+  },
+  "liveRaw": {
+    "SSESpecification": {
+      "SSEEnabled": false
+    },
+    "ContributorInsightsSpecification": {
+      "Enabled": false
+    },
+    "PointInTimeRecoverySpecification": {
+      "PointInTimeRecoveryEnabled": false
+    },
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "TableName": "cdkrd-integ-ddb-nested-sets-classic",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "gsi1pk"
+      },
+      {
+        "AttributeType": "N",
+        "AttributeName": "lsi1sk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      },
+      {
+        "AttributeType": "S",
+        "AttributeName": "sk"
+      }
+    ],
+    "BillingMode": "PAY_PER_REQUEST",
+    "GlobalSecondaryIndexes": [
+      {
+        "IndexName": "gsi1",
+        "ContributorInsightsSpecification": {
+          "Enabled": false
+        },
+        "Projection": {
+          "NonKeyAttributes": ["alpha", "bravo", "zeta", "mike"],
+          "ProjectionType": "INCLUDE"
+        },
+        "KeySchema": [
+          {
+            "KeyType": "HASH",
+            "AttributeName": "gsi1pk"
+          }
+        ],
+        "WarmThroughput": {
+          "ReadUnitsPerSecond": 12000,
+          "WriteUnitsPerSecond": 4000
+        }
+      }
+    ],
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      },
+      {
+        "KeyType": "RANGE",
+        "AttributeName": "sk"
+      }
+    ],
+    "LocalSecondaryIndexes": [
+      {
+        "IndexName": "lsi1",
+        "Projection": {
+          "NonKeyAttributes": ["oscar", "delta", "yankee", "bravo"],
+          "ProjectionType": "INCLUDE"
+        },
+        "KeySchema": [
+          {
+            "KeyType": "HASH",
+            "AttributeName": "pk"
+          },
+          {
+            "KeyType": "RANGE",
+            "AttributeName": "lsi1sk"
+          }
+        ]
+      }
+    ],
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/cdkrd-integ-ddb-nested-sets-classic",
+    "DeletionProtectionEnabled": false,
+    "Tags": [],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn"],
+    "writeOnly": ["ImportSourceSpecification"],
+    "createOnly": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn"],
+    "writeOnlyPaths": ["ImportSourceSpecification"],
+    "createOnlyPaths": ["ImportSourceSpecification", "KeySchema", "TableName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Classic397C6F85",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "cdkrd-integ-ddb-nested-sets-classic",
+      "constructPath": "CdkRealDriftIntegDdbNestedSets/Classic"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Classic397C6F85",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "GlobalSecondaryIndexes[gsi1].WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "nested": true,
+      "physicalId": "cdkrd-integ-ddb-nested-sets-classic",
+      "constructPath": "CdkRealDriftIntegDdbNestedSets/Classic"
+    }
+  ]
+}

--- a/tests/integration/ddb-nested-sets/app.ts
+++ b/tests/integration/ddb-nested-sets/app.ts
@@ -1,0 +1,77 @@
+// CDK app for the cdk-real-drift DynamoDB nested-set FP test — the SIBLINGS of the
+// already-guarded `AWS::DynamoDB::Table` GSI `NonKeyAttributes` reorder (R-class
+// UNORDERED_NESTED_OBJECT_ARRAY_PATHS). An INCLUDE projection carries
+// `NonKeyAttributes` — a SET of plain attribute names nested INSIDE the
+// (Global|Local)SecondaryIndexes array — that DynamoDB echoes ALPHABETICALLY
+// sorted, regardless of declaration order. The existing allowlist only covers
+// `AWS::DynamoDB::Table` `GlobalSecondaryIndexes.Projection.NonKeyAttributes`; the
+// identical shape on a Table's LSI, and on `AWS::DynamoDB::GlobalTable` (TableV2)
+// GSI *and* LSI, were unguarded. This fixture declares each in DELIBERATELY
+// non-alphabetical order so a positional compare false-flags declared drift on a
+// freshly deployed + recorded table unless the fold reaches every path. DynamoDB
+// is ubiquitous and PAY_PER_REQUEST tables deploy in seconds. A clean recorded
+// stack MUST be CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  AttributeType,
+  Billing,
+  BillingMode,
+  ProjectionType,
+  Table,
+  TableV2,
+} from "aws-cdk-lib/aws-dynamodb";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegDdbNestedSets");
+
+// Classic AWS::DynamoDB::Table — exercises the Table LSI gap (and re-covers the
+// already-guarded GSI path as a regression). The L2 `Table` takes indexes via
+// add*SecondaryIndex methods, NOT constructor props.
+const classic = new Table(stack, "Classic", {
+  tableName: "cdkrd-integ-ddb-nested-sets-classic",
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  sortKey: { name: "sk", type: AttributeType.STRING },
+  billingMode: BillingMode.PAY_PER_REQUEST,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+classic.addLocalSecondaryIndex({
+  indexName: "lsi1",
+  sortKey: { name: "lsi1sk", type: AttributeType.NUMBER },
+  projectionType: ProjectionType.INCLUDE,
+  // A set of non-key attribute names, declared NON-alphabetically.
+  nonKeyAttributes: ["yankee", "bravo", "oscar", "delta"],
+});
+classic.addGlobalSecondaryIndex({
+  indexName: "gsi1",
+  partitionKey: { name: "gsi1pk", type: AttributeType.STRING },
+  projectionType: ProjectionType.INCLUDE,
+  nonKeyAttributes: ["zeta", "alpha", "mike", "bravo"],
+});
+
+// Modern AWS::DynamoDB::GlobalTable (TableV2), single region — exercises the
+// GlobalTable GSI *and* LSI gaps.
+new TableV2(stack, "Global", {
+  tableName: "cdkrd-integ-ddb-nested-sets-global",
+  partitionKey: { name: "pk", type: AttributeType.STRING },
+  sortKey: { name: "sk", type: AttributeType.STRING },
+  billing: Billing.onDemand(),
+  removalPolicy: RemovalPolicy.DESTROY,
+  localSecondaryIndexes: [
+    {
+      indexName: "lsi1",
+      sortKey: { name: "lsi1sk", type: AttributeType.NUMBER },
+      projectionType: ProjectionType.INCLUDE,
+      nonKeyAttributes: ["sierra", "echo", "november", "alpha"],
+    },
+  ],
+  globalSecondaryIndexes: [
+    {
+      indexName: "gsi1",
+      partitionKey: { name: "gsi1pk", type: AttributeType.STRING },
+      projectionType: ProjectionType.INCLUDE,
+      nonKeyAttributes: ["quebec", "foxtrot", "tango", "golf"],
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/ddb-nested-sets/cdk.json
+++ b/tests/integration/ddb-nested-sets/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ddb-nested-sets/package.json
+++ b/tests/integration/ddb-nested-sets/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ddb-nested-sets",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ddb-nested-sets false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ddb-nested-sets/verify.sh
+++ b/tests/integration/ddb-nested-sets/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A classic AWS::DynamoDB::Table (LSI + GSI INCLUDE projections) and
+# a modern AWS::DynamoDB::GlobalTable (TableV2, GSI + LSI INCLUDE projections) each
+# carry a NonKeyAttributes set declared NON-alphabetically; DynamoDB echoes them
+# sorted. Any declared drift here is a nested-set reorder normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDdbNestedSets
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-ddb-nested-sets" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

DynamoDB echoes an INCLUDE-projection `NonKeyAttributes` set in its **own canonical order**, so a positional compare false-flags **declared drift** on a freshly deployed + recorded table. `UNORDERED_NESTED_OBJECT_ARRAY_PATHS` already folded this for an `AWS::DynamoDB::Table` **GSI**; this extends the fold to the identical projection shape on:

- `AWS::DynamoDB::Table` → `LocalSecondaryIndexes.Projection.NonKeyAttributes`
- `AWS::DynamoDB::GlobalTable` (TableV2) → `GlobalSecondaryIndexes.Projection.NonKeyAttributes`
- `AWS::DynamoDB::GlobalTable` (TableV2) → `LocalSecondaryIndexes.Projection.NonKeyAttributes`

The GlobalTable GSI path was the `// likely sibling, left unlisted until observed` note in the code — now observed and closed.

## How it was found

Bug-hunt (`/hunt-bugs`): offline-predicted the gap from the fold allowlist, then deployed the new `ddb-nested-sets` fixture. All three surfaced live as FPs on a fresh deploy:

```
desired=["yankee","bravo","oscar","delta"]   (Table LSI)
actual =["oscar","delta","yankee","bravo"]
desired=["quebec","foxtrot","tango","golf"]  (GlobalTable GSI)
actual =["golf","foxtrot","tango","quebec"]
desired=["sierra","echo","november","alpha"] (GlobalTable LSI)
actual =["november","sierra","alpha","echo"]
```

With the fix, a fresh deploy → record → check is **CLEAN** (live-verified).

## Safety

The fold is equality-gated (multiset-only) — a genuine attribute add/remove still surfaces. Unit tests assert both directions for each sibling path.

## Tests

- `tests/classify.test.ts`: new describe block — reorder-not-drift + genuine-change-surfaces for each of the 3 sibling paths.
- `tests/corpus/`: golden-corpus cases harvested live for both `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable` (replayed offline by `corpus-replay`).
- `tests/integration/ddb-nested-sets/`: committed regression fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)