### PR TITLE
docs: convey why record (not revert/ignore) on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,13 @@ Then act on what `check` prints, from its own interactive prompt:
 1. **Whenever `check` finds drift** — act on it inline from the prompt:
    **Record / Revert / Ignore**. This works from the very first run, not just
    later.
-2. **First run** — usually no drift yet, just live-only values to **record** as
-   your baseline (one prompt; writes a git file, nothing to AWS — the switch that
-   arms undeclared / added detection). If real drift *is* present, you revert or
-   ignore it inline too, same as #1.
+2. **First run** — usually no drift yet, just live-only values (AWS defaults,
+   generated names) to **record** as your baseline. Recording is the payoff move:
+   it accepts today's undeclared state as the norm and *keeps watching*, so any
+   later out-of-band change to it shows up as drift — the undeclared detection
+   nothing else gives you. (You wouldn't revert these — they're legitimate — nor
+   ignore them and stop watching.) One prompt; writes a git file, nothing to AWS.
+   Genuine drift, if present, you revert or ignore inline (#1).
 3. **In CI** — `npx cdkrd check --fail` (read-only, never prompts, exits 1 on
    drift).
 


### PR DESCRIPTION
## What

In the Quick start, the first-run live-only values were framed as just "record as your baseline" with no payoff — so a reader could reasonably wonder *why not just revert or ignore instead?*

Spelled out record's value in step 2: recording **accepts today's undeclared state as the norm and keeps watching**, so any later out-of-band change to it surfaces as drift — the undeclared-drift detection nothing else gives you. And the contrast: you wouldn't revert these (they're legitimate AWS defaults / generated names) nor ignore them (that stops watching). So on the first run, record is the move.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_