### PR TITLE
fix(noise): fold ALB ListenerRule nested PathPatternConfig.Values reorder

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -600,8 +600,18 @@ export function classifyResource(
       declaredVal = declaredSorted;
       liveVal = liveAligned;
     } else if (unorderedObjArray) {
-      declaredVal = sortUnorderedObjectArray(v);
-      liveVal = sortUnorderedObjectArray(live[k]);
+      // A key in BOTH UNORDERED_OBJECT_ARRAY_PROPS and UNORDERED_NESTED_OBJECT_ARRAY_PATHS
+      // (ELBv2 ListenerRule `Conditions`) needs both folds: sort each element's nested
+      // unordered set FIRST (so its canonical JSON is normalized), THEN sort the object
+      // array itself. Without the inner sort, the outer canonical-JSON sort sees a
+      // reordered-but-equal nested set as a different element and the positional diff
+      // still false-flags it.
+      declaredVal = sortUnorderedObjectArray(
+        nestedSubPaths.length > 0 ? sortNestedObjectArrays(v, nestedSubPaths) : v
+      );
+      liveVal = sortUnorderedObjectArray(
+        nestedSubPaths.length > 0 ? sortNestedObjectArrays(live[k], nestedSubPaths) : live[k]
+      );
     } else if (nestedSubPaths.length > 0) {
       declaredVal = sortNestedObjectArrays(v, nestedSubPaths);
       liveVal = sortNestedObjectArrays(live[k], nestedSubPaths);

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1002,6 +1002,18 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
     'GlobalSecondaryIndexes.Projection.NonKeyAttributes',
     'LocalSecondaryIndexes.Projection.NonKeyAttributes',
   ]),
+  // An ALB ListenerRule path-pattern condition's `Values` is a SET of patterns OR'd
+  // together (order carries no meaning — a request matches if ANY value matches), and
+  // ALB returns them in its OWN canonical order: declared ["/zebra/*","/alpha/*",
+  // "/mango/*"] reads back ["/alpha/*","/zebra/*","/mango/*"], so a positional compare
+  // false-flags the whole set. The set is nested one object level (PathPatternConfig)
+  // under the `Conditions` ARRAY, so sortNestedObjectArrays recurses element-wise and
+  // sorts the scalar Values array. Observed live on a fresh elbv2-rule-values deploy.
+  // (HostHeaderConfig.Values was tested in the SAME deploy with a deliberately
+  // non-sorted set and ALB PRESERVED its order, so it is NOT listed — observed-only.)
+  // `Conditions` is ALSO an UNORDERED_OBJECT_ARRAY_PROPS set; classify composes the
+  // two — inner Values sorted first, then the Conditions array sorted by canonical JSON.
+  'AWS::ElasticLoadBalancingV2::ListenerRule': new Set(['Conditions.PathPatternConfig.Values']),
 };
 
 // Return a deep clone of `value` (a declared/live property subtree rooted at one

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1447,6 +1447,63 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  // A path-pattern condition's `Values` is a SET ALB reorders into its own canonical
+  // order (found by elbv2-rule-values: declared ["/zebra/*","/alpha/*","/mango/*"] read
+  // back ["/alpha/*","/zebra/*","/mango/*"]). The set is nested under the Conditions
+  // ARRAY, which is ITSELF an unordered object set — so this exercises the compose path
+  // (inner Values sorted first, then the Conditions array sorted by canonical JSON).
+  describe('ELBv2 ListenerRule nested PathPatternConfig.Values set (found by elbv2-rule-values)', () => {
+    const T = 'AWS::ElasticLoadBalancingV2::ListenerRule';
+    const declared = {
+      Conditions: [
+        {
+          Field: 'path-pattern',
+          PathPatternConfig: { Values: ['/zebra/*', '/alpha/*', '/mango/*'] },
+        },
+        { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+      ],
+    };
+
+    it('ALB reordering the nested Values set is NOT drift', () => {
+      const live = {
+        Conditions: [
+          {
+            Field: 'path-pattern',
+            PathPatternConfig: { Values: ['/alpha/*', '/zebra/*', '/mango/*'] },
+          },
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('Values reorder AND Conditions reorder together is NOT drift (compose)', () => {
+      const live = {
+        Conditions: [
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+          {
+            Field: 'path-pattern',
+            PathPatternConfig: { Values: ['/mango/*', '/alpha/*', '/zebra/*'] },
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine Values change still surfaces (no over-fold)', () => {
+      const live = {
+        Conditions: [
+          {
+            Field: 'path-pattern',
+            PathPatternConfig: { Values: ['/alpha/*', '/zebra/*', '/CHANGED/*'] },
+          },
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('Bedrock Guardrail nested policy-config arrays (reordered, found by bedrock-guardrail-rich)', () => {
     const T = 'AWS::Bedrock::Guardrail';
     const declared = {

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.values.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.Rule4C995B7F.values.json
@@ -1,0 +1,113 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule4C995B7F",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-Gjv9j13vSOgr/5e8f46be04d0d5a6/160b3a942ed8a17a/90945430e6a97c3a",
+    "constructPath": "CdkRealDriftIntegElbv2RuleValues/Rule",
+    "declared": {
+      "Actions": [
+        {
+          "ForwardConfig": {
+            "TargetGroups": [
+              {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkRea-TgBE8-MAXLUPEBVX4E/a3cc689fffb5423f",
+                "Weight": 20
+              },
+              {
+                "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkRea-TgA40-HVAG8LLXGCIQ/f356184c27741057",
+                "Weight": 10
+              }
+            ]
+          },
+          "Type": "forward"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "path-pattern",
+          "PathPatternConfig": {
+            "Values": ["/zebra/*", "/alpha/*", "/mango/*"]
+          }
+        },
+        {
+          "Field": "host-header",
+          "HostHeaderConfig": {
+            "Values": ["zzz.example.com", "aaa.example.com"]
+          }
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkRea-Alb16-Gjv9j13vSOgr/5e8f46be04d0d5a6/160b3a942ed8a17a",
+      "Priority": 10
+    }
+  },
+  "liveRaw": {
+    "IsDefault": false,
+    "Actions": [
+      {
+        "Type": "forward",
+        "ForwardConfig": {
+          "TargetGroupStickinessConfig": {
+            "Enabled": false
+          },
+          "TargetGroups": [
+            {
+              "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkRea-TgBE8-MAXLUPEBVX4E/a3cc689fffb5423f",
+              "Weight": 20
+            },
+            {
+              "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkRea-TgA40-HVAG8LLXGCIQ/f356184c27741057",
+              "Weight": 10
+            }
+          ]
+        }
+      }
+    ],
+    "Priority": 10,
+    "RuleArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-Gjv9j13vSOgr/5e8f46be04d0d5a6/160b3a942ed8a17a/90945430e6a97c3a",
+    "Transforms": [],
+    "Conditions": [
+      {
+        "Field": "path-pattern",
+        "Values": ["/alpha/*", "/zebra/*", "/mango/*"],
+        "PathPatternConfig": {
+          "Values": ["/alpha/*", "/zebra/*", "/mango/*"]
+        }
+      },
+      {
+        "Field": "host-header",
+        "Values": ["zzz.example.com", "aaa.example.com"],
+        "HostHeaderConfig": {
+          "Values": ["zzz.example.com", "aaa.example.com"]
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["IsDefault", "RuleArn"],
+    "writeOnly": ["ListenerArn"],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["IsDefault", "RuleArn"],
+    "writeOnlyPaths": ["Actions.*.AuthenticateOidcConfig.ClientSecret", "ListenerArn"],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Rule4C995B7F",
+      "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "path": "ListenerArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-Gjv9j13vSOgr/5e8f46be04d0d5a6/160b3a942ed8a17a/90945430e6a97c3a",
+      "constructPath": "CdkRealDriftIntegElbv2RuleValues/Rule"
+    }
+  ]
+}

--- a/tests/integration/elbv2-rule-values/app.ts
+++ b/tests/integration/elbv2-rule-values/app.ts
@@ -1,0 +1,74 @@
+// CDK app for the cdk-real-drift ALB ListenerRule nested-VALUES-set FP test. The
+// existing elbv2-listenerrule-rich fixture proved the top-level Conditions array is
+// folded (UNORDERED_OBJECT_ARRAY_PROPS), but it declared each condition's `Values`
+// already in sorted order ("/api/*" < "/v2/*", "example.com" < "www.example.com"),
+// so it could NOT reveal whether ALB reorders the SCALAR string set nested INSIDE
+// each condition's *Config. This fixture declares those Values in DELIBERATELY
+// non-sorted order — within the 5-values-per-rule cap — so if ALB canonicalizes the
+// set, a positional compare false-flags declared drift on every shifted value of a
+// freshly deployed + recorded rule. ListenerRule routing (path/host conditions) is a
+// very common pattern. Within one condition, multiple values are OR'd, so order is
+// NOT semantic — a genuine set.
+//
+// Secondary probe (shared ALB infra): the rule's action is a weighted-forward to two
+// target groups declared in non-canonical order, to check whether ALB reorders the
+// identity-less {TargetGroupArn,Weight} set nested under Actions[].ForwardConfig.
+// A freshly deployed + recorded stack MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  ApplicationListenerRule,
+  ApplicationLoadBalancer,
+  ApplicationTargetGroup,
+  ListenerAction,
+  ListenerCondition,
+  TargetType,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElbv2RuleValues");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const alb = new ApplicationLoadBalancer(stack, "Alb", { vpc, internetFacing: false });
+
+const listener = alb.addListener("Listener", {
+  port: 80,
+  defaultAction: ListenerAction.fixedResponse(404, {
+    contentType: "text/plain",
+    messageBody: "nf",
+  }),
+});
+
+// Two empty (no-target) target groups for the weighted-forward probe.
+const tgA = new ApplicationTargetGroup(stack, "TgA", {
+  vpc,
+  port: 80,
+  targetType: TargetType.IP,
+});
+const tgB = new ApplicationTargetGroup(stack, "TgB", {
+  vpc,
+  port: 80,
+  targetType: TargetType.IP,
+});
+
+new ApplicationListenerRule(stack, "Rule", {
+  listener,
+  priority: 10,
+  // Values declared NON-alphabetically; 3 + 2 = 5 (the per-rule cap).
+  conditions: [
+    ListenerCondition.pathPatterns(["/zebra/*", "/alpha/*", "/mango/*"]),
+    ListenerCondition.hostHeaders(["zzz.example.com", "aaa.example.com"]),
+  ],
+  // Weighted-forward to two target groups, declared B-before-A.
+  action: ListenerAction.weightedForward([
+    { targetGroup: tgB, weight: 20 },
+    { targetGroup: tgA, weight: 10 },
+  ]),
+});
+
+app.synth();

--- a/tests/integration/elbv2-rule-values/cdk.json
+++ b/tests/integration/elbv2-rule-values/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elbv2-rule-values/package.json
+++ b/tests/integration/elbv2-rule-values/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elbv2-rule-values",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elbv2-rule-values false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elbv2-rule-values/verify.sh
+++ b/tests/integration/elbv2-rule-values/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. An ALB ListenerRule declares each condition's Values set, and a
+# weighted-forward action's target groups, in NON-sorted order. Any declared drift
+# here is a nested-set reorder normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElbv2RuleValues
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-elbv2-rule-values" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

An ALB `ListenerRule` path-pattern condition's `Values` is a SET of patterns OR'd together (a request matches if ANY value matches — order is never semantic), and ALB returns them in its **own canonical order**:

```
desired=["/zebra/*","/alpha/*","/mango/*"]
actual =["/alpha/*","/zebra/*","/mango/*"]
```

So a positional compare false-flags the whole set as **declared drift** on a freshly deployed + recorded rule. ListenerRule path/host routing is a very common pattern. Added `Conditions.PathPatternConfig.Values` to `UNORDERED_NESTED_OBJECT_ARRAY_PATHS`.

## Latent compose bug exposed

`Conditions` is ALSO in `UNORDERED_OBJECT_ARRAY_PROPS` — making `ListenerRule` the **first type in BOTH tables for the same key**. classify's exclusive `else-if` chain took the unordered-object-array branch and **skipped the nested-set sort entirely**. Fixed by composing: sort each element's nested unordered set FIRST (normalizing its canonical JSON), THEN sort the object array. No prior type had table overlap, so this was latent; `SecurityGroup` (unordered-only) and `Bedrock`/`ECS`/`DynamoDB` (nested-only) paths are unchanged (covered by existing corpus + unit tests).

## How it was found

Bug-hunt (`/hunt-bugs`), continuing the nested-under-array-set vein. The existing `elbv2-listenerrule-rich` fixture declared each condition's `Values` already in sorted order, so it could not reveal the reorder. The new `elbv2-rule-values` fixture declares them **non-sorted** → FP reproduced live → fixed → re-deploy CLEAN (live-verified).

## Observed-only scope

`HostHeaderConfig.Values` was tested in the **same** deploy with a deliberately non-sorted set and ALB **preserved** its order (negative evidence) → NOT folded. The weighted-forward `Actions[].ForwardConfig.TargetGroups` probe also showed no reorder → not folded. Only the live-observed path-pattern set is added.

## Safety

The fold is equality-gated (multiset-only) — a genuine `Values` add/remove/change still surfaces.

## Tests

- `tests/classify.test.ts`: reorder-not-drift, **compose** (Values reorder AND Conditions reorder together), and genuine-change-surfaces.
- `tests/corpus/`: harvested golden-corpus ListenerRule case (suffixed filename — logical id collides with the existing rich case).
- `tests/integration/elbv2-rule-values/`: committed regression fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
