### PR TITLE
test(ecs): add ecs-service-capacity FP fixture (CapacityProviderStrategy order-preserved)

### DIFF
--- a/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
+++ b/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
@@ -1,0 +1,215 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SvcServiceE0738BDC",
+    "resourceType": "AWS::ECS::Service",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+    "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service",
+    "declared": {
+      "CapacityProviderStrategy": [
+        {
+          "CapacityProvider": "FARGATE_SPOT",
+          "Weight": 2
+        },
+        {
+          "Base": 1,
+          "CapacityProvider": "FARGATE",
+          "Weight": 1
+        }
+      ],
+      "Cluster": "CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh",
+      "DeploymentConfiguration": {
+        "Alarms": {
+          "AlarmNames": [],
+          "Enable": false,
+          "Rollback": false
+        },
+        "MaximumPercent": 200,
+        "MinimumHealthyPercent": 50
+      },
+      "DesiredCount": 0,
+      "EnableECSManagedTags": false,
+      "NetworkConfiguration": {
+        "AwsvpcConfiguration": {
+          "AssignPublicIp": "ENABLED",
+          "SecurityGroups": ["sg-0d4e870f719c58849"],
+          "Subnets": ["subnet-047c2ed308739d019"]
+        }
+      },
+      "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkRealDriftIntegEcsServiceCapacityTask73FED16D:1"
+    }
+  },
+  "liveRaw": {
+    "PlatformVersion": "LATEST",
+    "HealthCheckGracePeriodSeconds": 0,
+    "EnableECSManagedTags": false,
+    "EnableExecuteCommand": false,
+    "PlacementConstraints": [],
+    "Cluster": "CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh",
+    "ServiceArn": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+    "DesiredCount": 0,
+    "PlacementStrategies": [],
+    "DeploymentController": {
+      "Type": "ECS"
+    },
+    "CapacityProviderStrategy": [
+      {
+        "CapacityProvider": "FARGATE_SPOT",
+        "Base": 0,
+        "Weight": 2
+      },
+      {
+        "CapacityProvider": "FARGATE",
+        "Base": 1,
+        "Weight": 1
+      }
+    ],
+    "Name": "CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+    "AvailabilityZoneRebalancing": "ENABLED",
+    "Role": "arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+    "SchedulingStrategy": "REPLICA",
+    "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkRealDriftIntegEcsServiceCapacityTask73FED16D:1",
+    "ServiceName": "CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+    "NetworkConfiguration": {
+      "AwsvpcConfiguration": {
+        "SecurityGroups": ["sg-0d4e870f719c58849"],
+        "Subnets": ["subnet-047c2ed308739d019"],
+        "AssignPublicIp": "ENABLED"
+      }
+    },
+    "DeploymentConfiguration": {
+      "BakeTimeInMinutes": 0,
+      "Alarms": {
+        "AlarmNames": [],
+        "Enable": false,
+        "Rollback": false
+      },
+      "Strategy": "ROLLING",
+      "DeploymentCircuitBreaker": {
+        "Enable": false,
+        "Rollback": false
+      },
+      "MaximumPercent": 200,
+      "MinimumHealthyPercent": 50
+    }
+  },
+  "schema": {
+    "readOnly": ["Name", "ServiceArn"],
+    "writeOnly": [
+      "ForceNewDeployment",
+      "Monitoring",
+      "ServiceConnectConfiguration",
+      "VolumeConfigurations"
+    ],
+    "createOnly": ["Cluster", "LaunchType", "Role", "SchedulingStrategy", "ServiceName"],
+    "readOnlyPaths": ["Name", "ServiceArn"],
+    "writeOnlyPaths": [
+      "ForceNewDeployment",
+      "Monitoring",
+      "ServiceConnectConfiguration",
+      "VolumeConfigurations"
+    ],
+    "createOnlyPaths": ["Cluster", "LaunchType", "Role", "SchedulingStrategy", "ServiceName"],
+    "defaults": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "defaultPaths": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "PlatformVersion",
+      "actual": "LATEST",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "HealthCheckGracePeriodSeconds",
+      "actual": 0,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentController",
+      "actual": {
+        "Type": "ECS"
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "AvailabilityZoneRebalancing",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "Role",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "SchedulingStrategy",
+      "actual": "REPLICA",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "ServiceName",
+      "actual": "CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentConfiguration.BakeTimeInMinutes",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentConfiguration.Strategy",
+      "actual": "ROLLING",
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    }
+  ]
+}

--- a/tests/integration/ecs-service-capacity/app.ts
+++ b/tests/integration/ecs-service-capacity/app.ts
@@ -1,0 +1,52 @@
+// CDK app for the cdk-real-drift ECS Service CapacityProviderStrategy reorder FP test.
+// An ECS Service's `CapacityProviderStrategy` is a SET of {CapacityProvider,Weight,Base}
+// with NO identity field (CapacityProvider is not Key/Id/Name), so neither
+// canonicalizeTagListsDeep (identity-keyed) nor canonicalizeIdArraysDeep (id/method
+// scalars) touches it — and it is in no UNORDERED_* allowlist. The FARGATE +
+// FARGATE_SPOT weighted split is a STANDARD cost-optimization pattern. If ECS echoes the
+// strategy in its own canonical order (on-demand before spot), a positional compare
+// false-flags declared drift on a freshly deployed + recorded service. Declared
+// SPOT-before-ON-DEMAND so a reorder is visible. A minimal VPC (one AZ) + cluster + task
+// def + a desiredCount-0 service (no tasks scheduled — fast deploy/delete, no image pull).
+// A clean recorded service MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  Cluster,
+  ContainerImage,
+  FargateService,
+  FargateTaskDefinition,
+} from "aws-cdk-lib/aws-ecs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEcsServiceCapacity");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "p", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+const cluster = new Cluster(stack, "Cluster", {
+  vpc,
+  enableFargateCapacityProviders: true,
+});
+const taskDef = new FargateTaskDefinition(stack, "Task", { cpu: 256, memoryLimitMiB: 512 });
+taskDef.addContainer("c", {
+  image: ContainerImage.fromRegistry("public.ecr.aws/amazonlinux/amazonlinux:latest"),
+  command: ["sleep", "3600"],
+});
+
+new FargateService(stack, "Svc", {
+  cluster,
+  taskDefinition: taskDef,
+  desiredCount: 0,
+  assignPublicIp: true,
+  vpcSubnets: { subnetType: SubnetType.PUBLIC },
+  // Declared SPOT-before-ON-DEMAND, in non-canonical order, to surface any reorder.
+  capacityProviderStrategies: [
+    { capacityProvider: "FARGATE_SPOT", weight: 2 },
+    { capacityProvider: "FARGATE", weight: 1, base: 1 },
+  ],
+});
+
+app.synth();

--- a/tests/integration/ecs-service-capacity/cdk.json
+++ b/tests/integration/ecs-service-capacity/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecs-service-capacity/package.json
+++ b/tests/integration/ecs-service-capacity/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecs-service-capacity",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecs-service-capacity false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecs-service-capacity/verify.sh
+++ b/tests/integration/ecs-service-capacity/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. An ECS Fargate Service declares a FARGATE_SPOT + FARGATE
+# CapacityProviderStrategy in non-canonical order; any declared drift here is a
+# set-reorder normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsServiceCapacity
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-ecs-service-capacity" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A bug-hunt round (`/hunt-bugs`) continuing the nested / identity-less-set false-positive vein. **Outcome: CLEAN — no bug.** Ships a new rich ECS Service fixture + golden-corpus case as the round's asset.

## Candidate audited

An ECS Service's `CapacityProviderStrategy` is a SET of `{CapacityProvider,Weight,Base}` with **no identity field** (`CapacityProvider` is not `Key`/`Id`/`Name`), so `canonicalizeTagListsDeep` (identity-keyed) and `canonicalizeIdArraysDeep` (id/method scalars) both skip it, and it is in no `UNORDERED_*` allowlist. The `FARGATE` + `FARGATE_SPOT` weighted split is a standard cost-optimization pattern — a plausible reorder FP.

## Live result — ruled out

Deployed a Fargate service declaring the strategy **SPOT-before-on-demand** (non-canonical order). ECS **preserved** the declared order on read:

```
declared: [{FARGATE_SPOT, Weight 2}, {FARGATE, Weight 1, Base 1}]
live    : [{FARGATE_SPOT, Base 0, Weight 2}, {FARGATE, Base 1, Weight 1}]   # same order
```

ECS only enriches the spot entry with `Base: 0` (which folds), so `record` → `check` is **CLEAN** (live-verified). No reorder, no fold needed → candidate ruled out. **No source change.**

## Asset shipped (a clean round still grows coverage)

- `tests/integration/ecs-service-capacity/` — the first **rich** ECS Service fixture (prior coverage was only `ecs-service-added`), exercising `enableFargateCapacityProviders` + a multi-provider weighted strategy + a desiredCount-0 service.
- `tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json` — harvested golden-corpus case pinning the order-preservation + `Base:0` enrichment as FP-free offline regression (the existing ECS Service corpus case declared no `CapacityProviderStrategy`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
