### PR TITLE
docs: point to --pre-deploy from the CFn-declared vocabulary note

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,10 @@ Three sources, named so "declared" is never ambiguous:
 | **recorded / unrecorded**      | your `.cdkrd` baseline file (a separate axis) | whether you have snapshotted that live-only value yet   |
 
 So `CFn-declared` ≠ "declared in my CDK code" and ≠ "in my `.cdkrd` baseline" — it
-means the deployed **CloudFormation** template. `CFn-undeclared` and `unrecorded`
-are different axes (template vs baseline file), not synonyms.
+means the deployed **CloudFormation** template. (Want to compare against your
+**local** CDK code instead of the deployed template? That's
+[`--pre-deploy`](#--pre-deploy).) `CFn-undeclared` and `unrecorded` are different
+axes (template vs baseline file), not synonyms.
 
 ### How each kind of drift is judged
 


### PR DESCRIPTION
## What

The vocabulary note states `CFn-declared` means the **deployed** CloudFormation template, not your local CDK code. A reader who wants the local-code comparison has that question right at this sentence — so answer it inline with a pointer:

> … it means the deployed **CloudFormation** template. (Want to compare against your **local** CDK code instead of the deployed template? That's [`--pre-deploy`](#--pre-deploy).)

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_