### PR TITLE
docs: make first-run revert/ignore explicit in the Quick start intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ npx cdkrd check                 # checks every stack your app defines
 ```
 
 `check` is the only command you run by hand. It prints what it found, then offers
-the applicable actions inline — **Record / Revert / Ignore** — on every run, the
-first included ([what each verb does](#the-model-one-verb-you-run-three-it-offers)).
+the applicable actions inline — **Record / Revert / Ignore** — from run one, not
+only once you've recorded a baseline: even on the very first run you can revert or
+ignore, not just record ([what each verb does](#the-model-one-verb-you-run-three-it-offers)).
 Day one usually looks like this — a clean stack with live-only values to record, no
 drift:
 


### PR DESCRIPTION
## What

In the Quick start intro, "on every run, the first included" attached to the actions in general and left first-run **revert** too implicit. State it directly:

> … offers the applicable actions inline — **Record / Revert / Ignore** — from run one, not only once you've recorded a baseline: even on the very first run you can revert or ignore, not just record.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_