### PR TITLE
test: rule out ECS Service LoadBalancers reorder FP (multi-target-group)

### DIFF
--- a/tests/corpus/AWS__ECS__Service.Service.json
+++ b/tests/corpus/AWS__ECS__Service.Service.json
@@ -1,0 +1,193 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Service",
+    "resourceType": "AWS::ECS::Service",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+    "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service",
+    "declared": {
+      "Cluster": "arn:aws:ecs:us-east-1:111111111111:cluster/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw",
+      "DesiredCount": 0,
+      "LaunchType": "FARGATE",
+      "LoadBalancers": [
+        {
+          "ContainerName": "web",
+          "ContainerPort": 8080,
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-ecs-lb-tg8080/03a4fa548e647ddf"
+        },
+        {
+          "ContainerName": "web",
+          "ContainerPort": 80,
+          "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-ecs-lb-tg80/9e463b788a7bec81"
+        }
+      ],
+      "NetworkConfiguration": {
+        "AwsvpcConfiguration": {
+          "AssignPublicIp": "DISABLED",
+          "SecurityGroups": ["sg-0acc90954e221e57f"],
+          "Subnets": ["subnet-0555c0b9a4a9fec91", "subnet-0f0b2c36e6a7e22ec"]
+        }
+      },
+      "ServiceName": "cdkrd-integ-ecs-lb-svc",
+      "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkRealDriftIntegEcsServiceLbRichTaskDef9F02A589:1"
+    }
+  },
+  "liveRaw": {
+    "PlatformVersion": "LATEST",
+    "HealthCheckGracePeriodSeconds": 0,
+    "EnableECSManagedTags": false,
+    "EnableExecuteCommand": false,
+    "PlacementConstraints": [],
+    "Cluster": "arn:aws:ecs:us-east-1:111111111111:cluster/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw",
+    "LoadBalancers": [
+      {
+        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-ecs-lb-tg8080/03a4fa548e647ddf",
+        "ContainerName": "web",
+        "ContainerPort": 8080
+      },
+      {
+        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-ecs-lb-tg80/9e463b788a7bec81",
+        "ContainerName": "web",
+        "ContainerPort": 80
+      }
+    ],
+    "ServiceArn": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+    "DesiredCount": 0,
+    "PlacementStrategies": [],
+    "DeploymentController": {
+      "Type": "ECS"
+    },
+    "LaunchType": "FARGATE",
+    "Name": "cdkrd-integ-ecs-lb-svc",
+    "AvailabilityZoneRebalancing": "ENABLED",
+    "Role": "arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+    "SchedulingStrategy": "REPLICA",
+    "TaskDefinition": "arn:aws:ecs:us-east-1:111111111111:task-definition/CdkRealDriftIntegEcsServiceLbRichTaskDef9F02A589:1",
+    "ServiceName": "cdkrd-integ-ecs-lb-svc",
+    "NetworkConfiguration": {
+      "AwsvpcConfiguration": {
+        "SecurityGroups": ["sg-0acc90954e221e57f"],
+        "Subnets": ["subnet-0555c0b9a4a9fec91", "subnet-0f0b2c36e6a7e22ec"],
+        "AssignPublicIp": "DISABLED"
+      }
+    },
+    "DeploymentConfiguration": {
+      "BakeTimeInMinutes": 0,
+      "Strategy": "ROLLING",
+      "DeploymentCircuitBreaker": {
+        "Enable": false,
+        "Rollback": false
+      },
+      "MaximumPercent": 200,
+      "MinimumHealthyPercent": 100
+    }
+  },
+  "schema": {
+    "readOnly": ["Name", "ServiceArn"],
+    "writeOnly": [
+      "ForceNewDeployment",
+      "Monitoring",
+      "ServiceConnectConfiguration",
+      "VolumeConfigurations"
+    ],
+    "createOnly": ["Cluster", "LaunchType", "Role", "SchedulingStrategy", "ServiceName"],
+    "readOnlyPaths": ["Name", "ServiceArn"],
+    "writeOnlyPaths": [
+      "ForceNewDeployment",
+      "Monitoring",
+      "ServiceConnectConfiguration",
+      "VolumeConfigurations"
+    ],
+    "createOnlyPaths": ["Cluster", "LaunchType", "Role", "SchedulingStrategy", "ServiceName"],
+    "defaults": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    },
+    "defaultPaths": {
+      "PlatformVersion": "LATEST",
+      "AvailabilityZoneRebalancing": "ENABLED"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "PlatformVersion",
+      "actual": "LATEST",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "HealthCheckGracePeriodSeconds",
+      "actual": 0,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentController",
+      "actual": {
+        "Type": "ECS"
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "AvailabilityZoneRebalancing",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "Role",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "SchedulingStrategy",
+      "actual": "REPLICA",
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "DeploymentConfiguration",
+      "actual": {
+        "BakeTimeInMinutes": 0,
+        "Strategy": "ROLLING",
+        "DeploymentCircuitBreaker": {
+          "Enable": false,
+          "Rollback": false
+        },
+        "MaximumPercent": 200,
+        "MinimumHealthyPercent": 100
+      },
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    }
+  ]
+}

--- a/tests/integration/ecs-service-lb-rich/app.ts
+++ b/tests/integration/ecs-service-lb-rich/app.ts
@@ -1,0 +1,104 @@
+// CDK app for the cdk-real-drift ECS Service multi-target-group false-positive
+// test. AWS::ECS::Service.LoadBalancers is an identity-LESS object array
+// ({ContainerName, ContainerPort, TargetGroupArn, ...}) that a service behind an
+// ALB can hold MULTIPLE of (one container exposing two ports, each registered to
+// its own target group — a common multi-listener / blue-green shape). It is NOT
+// in any noise.ts fold table, so if ECS returns the set in its own canonical
+// order a positional diff would false-flag every shifted entry as declared drift
+// — the same set-reorder FP class as EC2 SecurityGroup rules / ELBv2 ListenerRule
+// Conditions. This fixture declares the two LoadBalancers entries in DELIBERATELY
+// NON-canonical order (port 8080 first) so a reorder, if ECS performs one, is
+// revealed: a freshly deployed + recorded service MUST classify CLEAN.
+//
+// NAT-free + fast: internal ALB in PRIVATE_ISOLATED subnets, desiredCount 0 so no
+// task is scheduled (no image pull) — the LoadBalancers config is stored on the
+// service regardless of running tasks.
+import { App, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  CfnService,
+  Cluster,
+  ContainerImage,
+  FargateTaskDefinition,
+} from "aws-cdk-lib/aws-ecs";
+import {
+  ApplicationLoadBalancer,
+  ApplicationProtocol,
+  ApplicationTargetGroup,
+  TargetType,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEcsServiceLbRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const cluster = new Cluster(stack, "Cluster", { vpc });
+
+const taskDef = new FargateTaskDefinition(stack, "TaskDef", { cpu: 256, memoryLimitMiB: 512 });
+taskDef.addContainer("web", {
+  image: ContainerImage.fromRegistry("public.ecr.aws/nginx/nginx:latest"),
+  portMappings: [{ containerPort: 80 }, { containerPort: 8080 }],
+});
+
+const alb = new ApplicationLoadBalancer(stack, "Alb", {
+  vpc,
+  internetFacing: false,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  loadBalancerName: "cdkrd-ecs-lb-rich",
+});
+
+const tg80 = new ApplicationTargetGroup(stack, "Tg80", {
+  vpc,
+  targetGroupName: "cdkrd-ecs-lb-tg80",
+  port: 80,
+  protocol: ApplicationProtocol.HTTP,
+  targetType: TargetType.IP,
+});
+const tg8080 = new ApplicationTargetGroup(stack, "Tg8080", {
+  vpc,
+  targetGroupName: "cdkrd-ecs-lb-tg8080",
+  port: 8080,
+  protocol: ApplicationProtocol.HTTP,
+  targetType: TargetType.IP,
+});
+
+const l80 = alb.addListener("L80", { port: 80, protocol: ApplicationProtocol.HTTP, defaultTargetGroups: [tg80] });
+const l8080 = alb.addListener("L8080", {
+  port: 8080,
+  protocol: ApplicationProtocol.HTTP,
+  defaultTargetGroups: [tg8080],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc, allowAllOutbound: true });
+
+const service = new CfnService(stack, "Service", {
+  cluster: cluster.clusterArn,
+  serviceName: "cdkrd-integ-ecs-lb-svc",
+  taskDefinition: taskDef.taskDefinitionArn,
+  desiredCount: 0,
+  launchType: "FARGATE",
+  // Declared NON-canonical (port 8080 entry first): if ECS canonicalizes the
+  // LoadBalancers set into a different order, a positional compare surfaces it.
+  loadBalancers: [
+    { containerName: "web", containerPort: 8080, targetGroupArn: tg8080.targetGroupArn },
+    { containerName: "web", containerPort: 80, targetGroupArn: tg80.targetGroupArn },
+  ],
+  networkConfiguration: {
+    awsvpcConfiguration: {
+      subnets: vpc.isolatedSubnets.map((s) => s.subnetId),
+      securityGroups: [sg.securityGroupId],
+      assignPublicIp: "DISABLED",
+    },
+  },
+});
+// The service can only be created once each target group is associated with a
+// listener on the ALB.
+service.node.addDependency(l80);
+service.node.addDependency(l8080);
+
+app.synth();

--- a/tests/integration/ecs-service-lb-rich/cdk.json
+++ b/tests/integration/ecs-service-lb-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecs-service-lb-rich/package.json
+++ b/tests/integration/ecs-service-lb-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecs-service-lb-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecs-service-lb-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecs-service-lb-rich/verify.sh
+++ b/tests/integration/ecs-service-lb-rich/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy an ECS Service with TWO
+# LoadBalancers entries (one container, ports 80 + 8080, each to its own ALB
+# target group), declared in NON-canonical order -> record baseline -> check MUST
+# be CLEAN. AWS::ECS::Service.LoadBalancers is an identity-less object array not in
+# any noise.ts fold table; if ECS returns the set reordered, a positional diff
+# false-flags declared drift. NAT-free (internal ALB in isolated subnets,
+# desiredCount 0).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsServiceLbRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (raw classification + corpus harvest) ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-/tmp/corpus-ecs-service-lb-rich}" \
+  $CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug hunt: ECS Service multi-target-group LoadBalancers

A `/hunt-bugs` round targeting a genuinely-uncovered, common shape surfaced by offline audit: `AWS::ECS::Service.LoadBalancers`.

### The hypothesis
`LoadBalancers` is an **identity-less object array** (`{ContainerName, ContainerPort, TargetGroupArn, ...}`) that a service behind an ALB can hold **multiple** of — one container exposing two ports, each registered to its own target group (a common multi-listener / blue-green shape). It appears in **no `noise.ts` fold table**, so if ECS returned the set in its own canonical order, a positional diff would false-flag every shifted entry as declared drift — the same set-reorder FP class as `EC2::SecurityGroup` rules and `ELBv2::ListenerRule` `Conditions`.

### The result: ruled out (no FP)
Deployed a NAT-free fixture (internal ALB + 2 target groups + Fargate `desiredCount 0`) declaring the two entries in **non-canonical order `[8080, 80]`** (a reorder is only revealed when the declaration is non-sorted). ECS **preserves** the declared order:

- `liveRaw.LoadBalancers` reads back `[8080, 80]` — identical order; only intra-element key order differs, which the normalizer already handles.
- `record` → `check` is **CLEAN**.

So this is a **ruled-out gap, not a fold-table addition** — entries are added only on an *observed* reorder. `ServiceRegistries` is excluded too: AWS permits at most one per service, so it cannot reorder.

### Ships
- `tests/integration/ecs-service-lb-rich/` — fixture + `verify.sh` (asserts CLEAN). Permanent regression integ.
- `tests/corpus/AWS__ECS__Service.Service.json` — the **first ECS Service corpus case with a populated `LoadBalancers` array**, so `corpus-replay` pins the preserved-order classification offline forever.

### Verification
- `vp run typecheck` / `vp check` / `vp run build` / `vp test run` (1501 tests) all green.
- Live deploy on a real account; stack force-deleted via `delstack`, sweep CLEAN, no orphans.

No `src/**` change (test-only).