### PR TITLE
docs: explain Record/Revert/Ignore before the first-run notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,18 @@ ApiStack: unrecorded values found — what do you want to do?
     Decide per finding — assign a different action to each
 ```
 
+What each choice does here:
+
+- **Record** — accept the live-only values as the norm; cdkrd watches them and
+  re-flags any later out-of-band change. The usual first-run choice, and the switch
+  that arms undeclared / added detection.
+- **Revert** — write the desired value back to AWS: *removes* an undeclared
+  live-only value (rarely what you want for a legitimate default), or restores a
+  declared one.
+- **Ignore** — stop reporting it, for good (watching off).
+
 A few things to know about that first run:
 
-- **Record is the move.** It accepts today's live-only values as the norm and
-  *keeps watching*, so a later out-of-band change to them shows up as drift — the
-  undeclared detection nothing else gives. (Revert is offered too, but it *removes*
-  these legitimate values; Ignore stops watching them.)
 - **`Not Recorded` is expected, not a false positive.** The list is the full
   inventory, standouts only (`--show-all` expands), printed *before* the prompt — so
   you never record blind.


### PR DESCRIPTION
## What

Two related catches on the first-run section:

1. After the prompt, the bullets jumped straight to "things to know" — assuming the reader already knew what **Record / Revert / Ignore** do. Added a short **"What each choice does here"** list (one line each, in the first-run context) right after the menu.
2. The lead bullet **"Record is the move"** was opaque. Dropped it; its content is now the `Record` line of the action list.

"A few things to know about that first run" stays, now a **facts-only** block (Not Recorded is expected; declared drift caught from run one).

So the flow is: menu → what each action does → first-run facts → revert example → CI.

Docs-only change (no `src/**`); CI re-runs typecheck/lint/build/test on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdrPfpBSJVfNdUDTPMMFL6)_