### PR TITLE
test(classify): cover Firehose Processors fold on non-ExtendedS3 destinations

### DIFF
--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1080,6 +1080,54 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       ).filter((f) => f.tier === 'declared');
       expect(declaredF).toHaveLength(1);
     });
+
+    it('the fold is destination-agnostic: a Redshift (non-ExtendedS3) Processors path also folds', () => {
+      // PARAMETER_NAME_SUBSET_PATHS matches the dotted-path SUFFIX `Processors.<n>.Parameters`,
+      // so the same reorder + default-fill on any destination config that carries a
+      // ProcessingConfiguration (RedshiftDestinationConfiguration, AmazonopensearchserviceDestinationConfiguration,
+      // SplunkDestinationConfiguration, …) is suppressed too — not just ExtendedS3.
+      const redshiftDeclared = {
+        RedshiftDestinationConfiguration: {
+          ProcessingConfiguration: {
+            Enabled: true,
+            Processors: [
+              {
+                Type: 'Lambda',
+                Parameters: [
+                  { ParameterName: 'LambdaArn', ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f' },
+                  { ParameterName: 'RoleArn', ParameterValue: 'arn:aws:iam::1:role/r' },
+                ],
+              },
+            ],
+          },
+        },
+      };
+      const findings = classifyResource(
+        res(T, redshiftDeclared),
+        {
+          RedshiftDestinationConfiguration: {
+            ProcessingConfiguration: {
+              Enabled: true,
+              Processors: [
+                {
+                  Type: 'Lambda',
+                  Parameters: [
+                    { ParameterName: 'RoleArn', ParameterValue: 'arn:aws:iam::1:role/r' },
+                    { ParameterName: 'NumberOfRetries', ParameterValue: '3' },
+                    { ParameterName: 'LambdaArn', ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f' },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+        emptySchema
+      );
+      expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+      expect(findings.filter((f) => f.tier === 'undeclared').map((f) => f.path)).toEqual([
+        'RedshiftDestinationConfiguration.ProcessingConfiguration.Processors.0.Parameters[NumberOfRetries]',
+      ]);
+    });
   });
 
   describe('JSON-string vs declared object (SSM Document.Content)', () => {


### PR DESCRIPTION
Offline follow-up to #340. `PARAMETER_NAME_SUBSET_PATHS` matches the dotted-path suffix `Processors.<n>.Parameters`, so the reorder + default-fill fold applies to **any** Firehose destination config with a `ProcessingConfiguration` (Redshift / OpenSearch / Splunk / …), not just ExtendedS3. Adds a regression asserting a `RedshiftDestinationConfiguration` Lambda-processor path also folds (declared ⊆ live by ParameterName → no declared FP; the injected `NumberOfRetries` surfaces as nested `undeclared`). Test-only; 1519 tests green.