### PR TITLE
feat(noise): extend ELB_ATTRIBUTE_DEFAULTS with ALB idle_timeout + NLB keys

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -593,9 +593,19 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     'client_keep_alive.seconds': '3600',
     'connection_logs.s3.enabled': 'false',
     'health_check_logs.s3.enabled': 'false',
+    // ALB idle_timeout default (observed live on a bare ALB that declared no
+    // idleTimeout). NLB has no idle_timeout attribute, so no cross-type conflict.
+    'idle_timeout.timeout_seconds': '60',
     // ALB cross-zone load balancing is always on and not configurable -> AWS always
-    // returns "true"; an NLB's default "false" never matches, so it stays undeclared.
+    // returns "true". NB: an NLB's cross_zone default is "false" — the OPPOSITE — and
+    // this table is keyed only by resourceType (shared ALB/NLB), so the two cannot both
+    // fold; the ALB value wins and an NLB's cross_zone stays `undeclared` (a known minor
+    // residual; the equality gate keeps it correct, never mis-folding).
     'load_balancing.cross_zone.enabled': 'true',
+    // NLB-only attribute keys (an ALB never returns them, so no conflict) — observed live
+    // on a bare internal NLB.
+    'dns_record.client_routing_policy': 'any_availability_zone',
+    'secondary_ips.auto_assigned.per_subnet': '0',
     'routing.http.desync_mitigation_mode': 'defensive',
     'routing.http.drop_invalid_header_fields.enabled': 'false',
     'routing.http.preserve_host_header.enabled': 'false',

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -920,6 +920,52 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       expect(undeclared[0]).toMatchObject({ actual: 'true', nested: true });
     });
 
+    it('a bare ALB idle_timeout default (60) and NLB-only keys fold to atDefault', () => {
+      // A bare ALB declares no idleTimeout -> idle_timeout.timeout_seconds reads back the
+      // live default "60"; a fresh NLB returns dns_record.client_routing_policy and
+      // secondary_ips.auto_assigned.per_subnet. All are curated defaults -> atDefault.
+      const atDefault = classifyResource(
+        res(T, {
+          LoadBalancerAttributes: [{ Key: 'deletion_protection.enabled', Value: 'false' }],
+        }),
+        {
+          LoadBalancerAttributes: [
+            { Key: 'deletion_protection.enabled', Value: 'false' },
+            { Key: 'idle_timeout.timeout_seconds', Value: '60' },
+            { Key: 'dns_record.client_routing_policy', Value: 'any_availability_zone' },
+            { Key: 'secondary_ips.auto_assigned.per_subnet', Value: '0' },
+          ],
+        },
+        emptySchema
+      ).filter((f) => f.tier === 'atDefault');
+      expect(atDefault.map((f) => f.path).sort()).toEqual([
+        'LoadBalancerAttributes[dns_record.client_routing_policy]',
+        'LoadBalancerAttributes[idle_timeout.timeout_seconds]',
+        'LoadBalancerAttributes[secondary_ips.auto_assigned.per_subnet]',
+      ]);
+    });
+
+    it("an NLB's cross_zone default (false) does NOT fold (the ALB-keyed table holds true) and stays undeclared", () => {
+      // The table is keyed only by resourceType, and ALB cross_zone default "true" wins;
+      // an NLB's "false" must NOT mis-fold against "true" — the equality gate keeps it
+      // `undeclared` (recorded, fail-closed), a known minor residual noise on NLBs.
+      const undeclared = classifyResource(
+        res(T, {
+          LoadBalancerAttributes: [{ Key: 'deletion_protection.enabled', Value: 'false' }],
+        }),
+        {
+          LoadBalancerAttributes: [
+            { Key: 'deletion_protection.enabled', Value: 'false' },
+            { Key: 'load_balancing.cross_zone.enabled', Value: 'false' },
+          ],
+        },
+        emptySchema
+      ).filter((f) => f.tier === 'undeclared');
+      expect(undeclared.map((f) => f.path)).toEqual([
+        'LoadBalancerAttributes[load_balancing.cross_zone.enabled]',
+      ]);
+    });
+
     it('a genuine change to a DECLARED attribute still surfaces, named by Key (R78)', () => {
       const drifted = liveAll.map((a) =>
         a.Key === 'idle_timeout.timeout_seconds' ? { ...a, Value: '300' } : a

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.bare.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.bare.json
@@ -1,0 +1,366 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Alb16C2F182",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+    "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb",
+    "declared": {
+      "LoadBalancerAttributes": [
+        {
+          "Key": "deletion_protection.enabled",
+          "Value": "false"
+        }
+      ],
+      "Name": "cdkrd-elbnlb-alb",
+      "Scheme": "internal",
+      "SecurityGroups": ["sg-011d5b2f6d22ce57a"],
+      "Subnets": ["subnet-09efd9a39c9be842b", "subnet-0a584bb91c190387c"],
+      "Type": "application"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "SecurityGroups": ["sg-011d5b2f6d22ce57a"],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "append",
+        "Key": "routing.http.xff_header_processing.mode"
+      },
+      {
+        "Value": "true",
+        "Key": "routing.http2.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "waf.fail_open.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "defensive",
+        "Key": "routing.http.desync_mitigation_mode"
+      },
+      {
+        "Value": "",
+        "Key": "connection_logs.s3.prefix"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.preserve_host_header.enabled"
+      },
+      {
+        "Value": "true",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "health_check_logs.s3.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "health_check_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.xff_client_port.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "3600",
+        "Key": "client_keep_alive.seconds"
+      },
+      {
+        "Value": "false",
+        "Key": "routing.http.drop_invalid_header_fields.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "connection_logs.s3.enabled"
+      },
+      {
+        "Value": "60",
+        "Key": "idle_timeout.timeout_seconds"
+      }
+    ],
+    "Scheme": "internal",
+    "DNSName": "internal-cdkrd-elbnlb-alb-1544776433.us-east-1.elb.amazonaws.com",
+    "Name": "cdkrd-elbnlb-alb",
+    "LoadBalancerName": "cdkrd-elbnlb-alb",
+    "Subnets": ["subnet-09efd9a39c9be842b", "subnet-0a584bb91c190387c"],
+    "Type": "application",
+    "CanonicalHostedZoneID": "Z35SXDOTRQ7X7K",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegElbNlbNoise/fdbeff70-6ea8-11f1-9948-0e83e86a7399",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegElbNlbNoise",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Alb16C2F182",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "LoadBalancerFullName": "app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-09efd9a39c9be842b"
+      },
+      {
+        "SubnetId": "subnet-0a584bb91c190387c"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "defaultPaths": {
+      "EnableCapacityReservationProvisionStabilize": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[access_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[client_keep_alive.seconds]",
+      "actual": "3600",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[connection_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[health_check_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[idle_timeout.timeout_seconds]",
+      "actual": "60",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.desync_mitigation_mode]",
+      "actual": "defensive",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.drop_invalid_header_fields.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.preserve_host_header.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.x_amzn_tls_version_and_cipher_suite.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.xff_client_port.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http.xff_header_processing.mode]",
+      "actual": "append",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[routing.http2.enabled]",
+      "actual": "true",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[waf.fail_open.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[zonal_shift.config.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Alb16C2F182",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "SubnetMappings",
+      "actual": [
+        {
+          "SubnetId": "subnet-09efd9a39c9be842b"
+        },
+        {
+          "SubnetId": "subnet-0a584bb91c190387c"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.NlbBCDB97FE.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.NlbBCDB97FE.json
@@ -1,0 +1,209 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NlbBCDB97FE",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+    "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb",
+    "declared": {
+      "LoadBalancerAttributes": [
+        {
+          "Key": "deletion_protection.enabled",
+          "Value": "false"
+        }
+      ],
+      "Name": "cdkrd-elbnlb-nlb",
+      "Scheme": "internal",
+      "Subnets": ["subnet-09efd9a39c9be842b", "subnet-0a584bb91c190387c"],
+      "Type": "network"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "SecurityGroups": [],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "0",
+        "Key": "secondary_ips.auto_assigned.per_subnet"
+      },
+      {
+        "Value": "any_availability_zone",
+        "Key": "dns_record.client_routing_policy"
+      }
+    ],
+    "Scheme": "internal",
+    "DNSName": "cdkrd-elbnlb-nlb-eb9dd5a0db2c9d98.elb.us-east-1.amazonaws.com",
+    "Name": "cdkrd-elbnlb-nlb",
+    "LoadBalancerName": "cdkrd-elbnlb-nlb",
+    "Subnets": ["subnet-09efd9a39c9be842b", "subnet-0a584bb91c190387c"],
+    "Type": "network",
+    "CanonicalHostedZoneID": "Z26RNL4JYFTOTI",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegElbNlbNoise/fdbeff70-6ea8-11f1-9948-0e83e86a7399",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegElbNlbNoise",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "NlbBCDB97FE",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "LoadBalancerFullName": "net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-09efd9a39c9be842b"
+      },
+      {
+        "SubnetId": "subnet-0a584bb91c190387c"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "defaultPaths": {
+      "EnableCapacityReservationProvisionStabilize": false
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[access_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[dns_record.client_routing_policy]",
+      "actual": "any_availability_zone",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[secondary_ips.auto_assigned.per_subnet]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[zonal_shift.config.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "NlbBCDB97FE",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "SubnetMappings",
+      "actual": [
+        {
+          "SubnetId": "subnet-09efd9a39c9be842b"
+        },
+        {
+          "SubnetId": "subnet-0a584bb91c190387c"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
+      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
+    }
+  ]
+}

--- a/tests/integration/elb-nlb-noise/app.ts
+++ b/tests/integration/elb-nlb-noise/app.ts
@@ -1,0 +1,44 @@
+// CDK app for the cdk-real-drift ELB first-run-noise harvest. Two bare internal
+// load balancers in isolated subnets (NAT-free):
+//   - a Network Load Balancer (NLB) — its server-default attribute bag uses keys
+//     (and defaults) DIFFERENT from an ALB's, none of which the ALB-only
+//     ELB_ATTRIBUTE_DEFAULTS entries cover, so a fresh NLB lists them all under
+//     [Not Recorded]. Harvest the live values to curate the NLB defaults.
+//   - an Application Load Balancer (ALB) with NO idleTimeout declared — so
+//     `idle_timeout.timeout_seconds` reads back the live default "60" UNDECLARED
+//     (every other ELB fixture declares idleTimeout, hiding it from the corpus).
+// A freshly deployed + recorded stack MUST be CLEAN; the value is the harvested
+// live attribute bags that grow ELB_ATTRIBUTE_DEFAULTS.
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  ApplicationLoadBalancer,
+  NetworkLoadBalancer,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElbNlbNoise");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+// Bare ALB: no idleTimeout -> idle_timeout.timeout_seconds=60 reads back undeclared.
+new ApplicationLoadBalancer(stack, "Alb", {
+  vpc,
+  internetFacing: false,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  loadBalancerName: "cdkrd-elbnlb-alb",
+});
+
+// Internal NLB: harvest its server-default attribute bag.
+new NetworkLoadBalancer(stack, "Nlb", {
+  vpc,
+  internetFacing: false,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  loadBalancerName: "cdkrd-elbnlb-nlb",
+});
+
+app.synth();

--- a/tests/integration/elb-nlb-noise/cdk.json
+++ b/tests/integration/elb-nlb-noise/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elb-nlb-noise/package.json
+++ b/tests/integration/elb-nlb-noise/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elb-nlb-noise",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elb-nlb-noise first-run-noise harvest. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elb-nlb-noise/verify.sh
+++ b/tests/integration/elb-nlb-noise/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# First-run-noise harvest (real AWS): deploy a bare internal ALB + NLB -> check
+# (corpus harvest, pre-record) -> record -> check MUST be CLEAN. NAT-free.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElbNlbNoise
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (harvest) ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-/tmp/corpus-elb-nlb-noise}" \
+  $CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN, got $rc"; }
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
feat(noise): extend ELB_ATTRIBUTE_DEFAULTS with ALB idle_timeout + NLB keys

Follow-up to the #339 ELB attribute-bag at-default fold, closing two gaps a fresh
bug-hunt harvest (elb-nlb-noise: a bare internal ALB + an internal NLB) surfaced:

- ALB idle_timeout.timeout_seconds=60: every prior ELB fixture DECLARED idleTimeout,
  so its live default never appeared undeclared in the corpus and was left out of the
  table. A bare ALB (no idleTimeout) reads it back as undeclared "60" -> now folds to
  atDefault. NLB has no idle_timeout attribute, so no cross-type conflict.
- NLB-only keys dns_record.client_routing_policy=any_availability_zone and
  secondary_ips.auto_assigned.per_subnet=0: an ALB never returns them, so they are
  safe per-type additions (live-observed on a fresh NLB). The NLB's shared keys
  (access_logs.s3.enabled, zonal_shift.config.enabled) already fold via the existing
  =false entries.

KNOWN LIMITATION (documented in code + test): load_balancing.cross_zone.enabled
defaults "true" on an ALB but "false" on an NLB, and ELB_ATTRIBUTE_DEFAULTS is keyed
only by resourceType (shared ALB/NLB) -> the ALB value wins and an NLB's cross_zone
stays `undeclared`. The equality gate keeps this CORRECT (never mis-folds), just a
minor residual first-run noise line on NLBs.

Ships the elb-nlb-noise fixture (verify.sh asserts CLEAN) + the first NLB golden
corpus case (4 attrs fold to atDefault, cross_zone stays undeclared) + a bare-ALB
corpus case (idle_timeout=60 -> atDefault). New unit tests cover the idle_timeout +
NLB-key folds and the cross_zone non-fold (fail-closed).
