### PR TITLE
style: apply oxc formatting to README + classify.test (CI parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ What each choice does here:
 - **Record** — accept the live-only values as the norm; cdkrd watches them and
   re-flags any later out-of-band change. The usual first-run choice, and the switch
   that arms undeclared / added detection.
-- **Revert** — write the desired value back to AWS: *removes* an undeclared
+- **Revert** — write the desired value back to AWS: _removes_ an undeclared
   live-only value (rarely what you want for a legitimate default), or restores a
   declared one.
 - **Ignore** — stop reporting it, for good (watching off).

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1140,7 +1140,10 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
               {
                 Type: 'Lambda',
                 Parameters: [
-                  { ParameterName: 'LambdaArn', ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f' },
+                  {
+                    ParameterName: 'LambdaArn',
+                    ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f',
+                  },
                   { ParameterName: 'RoleArn', ParameterValue: 'arn:aws:iam::1:role/r' },
                 ],
               },
@@ -1160,7 +1163,10 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
                   Parameters: [
                     { ParameterName: 'RoleArn', ParameterValue: 'arn:aws:iam::1:role/r' },
                     { ParameterName: 'NumberOfRetries', ParameterValue: '3' },
-                    { ParameterName: 'LambdaArn', ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f' },
+                    {
+                      ParameterName: 'LambdaArn',
+                      ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f',
+                    },
                   ],
                 },
               ],


### PR DESCRIPTION
Pure formatting fix (no logic change) to bring main into oxc/prettier compliance — pre-existing drift surfaced during the #344 bug hunt while CI is paused for billing.

- README.md: emphasis `*removes*` → `_removes_`.
- tests/classify.test.ts: wrap long object literals introduced in #340.

`mise exec -- vp run check` now passes clean (was flagging these 2 files). typecheck/build/1534 tests all green. No src/** touched.