### PR TITLE
test(read): composite-identifier read-gap regression fixtures + hunt-bugs skill note

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -61,14 +61,38 @@ non-negotiable", which is enforced by a gate, not by trust.
    Such a type yields **zero FP/FN bugs** and has **no regression value as a fixture**
    — it is an `SDK_OVERRIDES` reader candidate (a separate feature task), not a hunt
    target. So do NOT burn a paid deploy on it. Confirm support first:
+
    ```bash
    aws cloudformation describe-type --type RESOURCE --type-name AWS::Foo::Bar \
      --query 'ProvisioningType'   # FULLY_MUTABLE/IMMUTABLE = provisionable; then probe READ:
    # if you have a live instance, `cloudcontrol get-resource` — UnsupportedActionException = CC-gap
    ```
+
    (Confirmed CC-gap this way: ServiceDiscovery HttpNamespace+Service, DocumentDB
    DBCluster/DBInstance, AppSync ApiKey/GraphQLSchema — all `SDK_OVERRIDES` candidates,
    not hunt targets.)
+
+   **A `read` handler being present is NOT enough — also check the
+   `primaryIdentifier` ARITY.** A type can have a CC `read` handler yet still be
+   silently `skipped` with a `ValidationException` (a DIFFERENT read-gap class than
+   `UnsupportedActionException`) when its `primaryIdentifier` is COMPOSITE (more than
+   one segment) but its CFn physical id is only the CHILD segment — Cloud Control
+   `GetResource` then rejects the bare id. This is a `CC_IDENTIFIER_ADAPTERS` fix
+   (derive the `parent|child` / `child|parent` composite from the resolved declared
+   Ref), NOT an `SDK_OVERRIDES` one. Probe it offline before deploying:
+
+   ```bash
+   aws cloudformation describe-type --type RESOURCE --type-name AWS::Foo::Bar \
+     --query 'Schema' --output text | python3 -c "import json,sys; s=json.load(sys.stdin); print(s['primaryIdentifier'])"
+   ```
+
+   `primaryIdentifier` length > 1, the type is CC-`read`-able, it is NOT already in
+   `CC_IDENTIFIER_ADAPTERS` / `SDK_OVERRIDES`, and the CFn `Ref` returns only the
+   child segment → a likely declared-read gap worth a (cheap) deploy to confirm the
+   exact composite order (the order is unreliable to guess — verify live, e.g. with
+   `aws cloudcontrol get-resource`). Confirmed this way: Logs SubscriptionFilter
+   (`FilterName|LogGroupName`, PR #344).
+
 5. **Predict FP classes from the fold allowlists, then audit them OFFLINE before any
    paid deploy.** The per-type fold tables in `src/normalize/noise.ts` ARE the inventory
    of FP classes already found — and most are CURATED, KNOWN-INCOMPLETE allowlists

--- a/tests/corpus/AWS__IAM__RolePolicy.RolePol.json
+++ b/tests/corpus/AWS__IAM__RolePolicy.RolePol.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RolePol",
+    "resourceType": "AWS::IAM::RolePolicy",
+    "physicalId": "cdkrd-inline-role|CdkRealDriftIntegIamInlinepolicyReadga-Role1ABCC5F0-mKcXhktffN8N",
+    "constructPath": "CdkRealDriftIntegIamInlinepolicyReadgap/RolePol",
+    "declared": {
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["logs:CreateLogGroup"],
+            "Resource": "*"
+          }
+        ]
+      },
+      "PolicyName": "cdkrd-inline-role",
+      "RoleName": "CdkRealDriftIntegIamInlinepolicyReadga-Role1ABCC5F0-mKcXhktffN8N"
+    }
+  },
+  "liveRaw": {
+    "RoleName": "CdkRealDriftIntegIamInlinepolicyReadga-Role1ABCC5F0-mKcXhktffN8N",
+    "PolicyName": "cdkrd-inline-role",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["logs:CreateLogGroup"],
+          "Resource": "*",
+          "Effect": "Allow"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["PolicyName", "RoleName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PolicyName", "RoleName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IAM__UserPolicy.UserPol.json
+++ b/tests/corpus/AWS__IAM__UserPolicy.UserPol.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "UserPol",
+    "resourceType": "AWS::IAM::UserPolicy",
+    "physicalId": "cdkrd-inline-user|CdkRealDriftIntegIamInlinepolicyReadga-User00B015A1-XkZobepSw9Lq",
+    "constructPath": "CdkRealDriftIntegIamInlinepolicyReadgap/UserPol",
+    "declared": {
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject"],
+            "Resource": "*"
+          }
+        ]
+      },
+      "PolicyName": "cdkrd-inline-user",
+      "UserName": "CdkRealDriftIntegIamInlinepolicyReadga-User00B015A1-XkZobepSw9Lq"
+    }
+  },
+  "liveRaw": {
+    "UserName": "CdkRealDriftIntegIamInlinepolicyReadga-User00B015A1-XkZobepSw9Lq",
+    "PolicyName": "cdkrd-inline-user",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["s3:GetObject"],
+          "Resource": "*",
+          "Effect": "Allow"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["PolicyName", "UserName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PolicyName", "UserName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__WebACLAssociation.Assoc.json
+++ b/tests/corpus/AWS__WAFv2__WebACLAssociation.Assoc.json
@@ -1,0 +1,34 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Assoc",
+    "resourceType": "AWS::WAFv2::WebACLAssociation",
+    "physicalId": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_suMiTfZwE|arn:aws:wafv2:us-east-1:111111111111:regional/webacl/Acl-iJvYQv2pC84g/f0755f63-6d44-4116-a4a8-9d306885e51d",
+    "constructPath": "CdkRealDriftIntegWafv2WebaclassociationReadgap/Assoc",
+    "declared": {
+      "ResourceArn": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_suMiTfZwE",
+      "WebACLArn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/Acl-iJvYQv2pC84g/f0755f63-6d44-4116-a4a8-9d306885e51d"
+    }
+  },
+  "liveRaw": {
+    "ResourceArn": "arn:aws:cognito-idp:us-east-1:111111111111:userpool/us-east-1_suMiTfZwE",
+    "WebACLArn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/Acl-iJvYQv2pC84g/f0755f63-6d44-4116-a4a8-9d306885e51d"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ResourceArn", "WebACLArn"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResourceArn", "WebACLArn"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/iam-inlinepolicy-readgap/app.ts
+++ b/tests/integration/iam-inlinepolicy-readgap/app.ts
@@ -1,0 +1,47 @@
+// CDK app for the cdk-real-drift iam-inlinepolicy-readgap integration test.
+// AWS::IAM::RolePolicy and AWS::IAM::UserPolicy (the standalone L1 inline-policy
+// resources) have COMPOSITE Cloud Control primaryIdentifiers — [PolicyName, RoleName]
+// and [PolicyName, UserName] — but their CFn physical id is only the bare PolicyName.
+// So like Logs SubscriptionFilter (PR #344), a declared inline policy is a CC
+// ValidationException skip on every check (a read-gap) until a CC_IDENTIFIER_ADAPTERS
+// entry pairs the PolicyName with its resolved parent. Zero-infra (just IAM), so this
+// is the cheapest composite-identifier read-gap probe.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnRolePolicy,
+  CfnUserPolicy,
+  Role,
+  ServicePrincipal,
+  User,
+} from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegIamInlinepolicyReadgap");
+
+const role = new Role(stack, "Role", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+});
+new CfnRolePolicy(stack, "RolePol", {
+  policyName: "cdkrd-inline-role",
+  roleName: role.roleName,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Action: ["logs:CreateLogGroup"], Resource: "*" },
+    ],
+  },
+});
+
+const user = new User(stack, "User");
+new CfnUserPolicy(stack, "UserPol", {
+  policyName: "cdkrd-inline-user",
+  userName: user.userName,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Action: ["s3:GetObject"], Resource: "*" },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/iam-inlinepolicy-readgap/cdk.json
+++ b/tests/integration/iam-inlinepolicy-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/iam-inlinepolicy-readgap/package.json
+++ b/tests/integration/iam-inlinepolicy-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-iam-inlinepolicy-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift iam-inlinepolicy-readgap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/iam-inlinepolicy-readgap/verify.sh
+++ b/tests/integration/iam-inlinepolicy-readgap/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. AWS::IAM::RolePolicy / UserPolicy are composite-identifier resources
+# that must be read via the CC_IDENTIFIER_ADAPTERS PolicyName|parent pairing; this
+# fixture is also the regression that proves they are no longer a CC ValidationException
+# read-gap. Any declared drift on a clean recorded stack is a false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamInlinepolicyReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "=== [$STACK] the inline policies MUST be READ (not CC-skipped) ==="
+$CLI check "$STACK" --region "$REGION" --verbose 2>&1 | grep -qE "Skipped.*(RolePolicy|UserPolicy)" \
+  && fail "an inline policy is still skipped (read-gap not closed)" || echo "(no inline-policy skip — read-gap closed)"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/wafv2-webaclassociation-readgap/app.ts
+++ b/tests/integration/wafv2-webaclassociation-readgap/app.ts
@@ -1,0 +1,34 @@
+// CDK app for the cdk-real-drift wafv2-webaclassociation-readgap integration test.
+// AWS::WAFv2::WebACLAssociation has a COMPOSITE Cloud Control primaryIdentifier
+// [ResourceArn, WebACLArn]. A regional WebACL associated with a protected resource
+// (here a Cognito user pool — the cheapest associatable target, no ALB/NAT) is a
+// common WAF setup. This probes whether a declared association is a CC read-gap
+// (ValidationException skip) like the other composite-identifier types, and the live
+// read confirms the exact composite order for any needed CC_IDENTIFIER_ADAPTERS entry.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { UserPool } from "aws-cdk-lib/aws-cognito";
+import { CfnWebACL, CfnWebACLAssociation } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2WebaclassociationReadgap");
+
+const acl = new CfnWebACL(stack, "Acl", {
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdReadgapAcl",
+    sampledRequestsEnabled: true,
+  },
+});
+
+const pool = new UserPool(stack, "Pool", {
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new CfnWebACLAssociation(stack, "Assoc", {
+  resourceArn: pool.userPoolArn,
+  webAclArn: acl.attrArn,
+});
+
+app.synth();

--- a/tests/integration/wafv2-webaclassociation-readgap/cdk.json
+++ b/tests/integration/wafv2-webaclassociation-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-webaclassociation-readgap/package.json
+++ b/tests/integration/wafv2-webaclassociation-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-webaclassociation-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-webaclassociation-readgap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-webaclassociation-readgap/verify.sh
+++ b/tests/integration/wafv2-webaclassociation-readgap/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. AWS::WAFv2::WebACLAssociation is a composite-identifier resource
+# that must be read via the CC_IDENTIFIER_ADAPTERS PolicyName|parent pairing; this
+# fixture is also the regression that proves they are no longer a CC ValidationException
+# read-gap. Any declared drift on a clean recorded stack is a false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2WebaclassociationReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "=== [$STACK] the WebACL association MUST be READ (not CC-skipped) ==="
+$CLI check "$STACK" --region "$REGION" --verbose 2>&1 | grep -qE "Skipped.*(WebACLAssociation)" \
+  && fail "the WebACL association is still skipped (read-gap not closed)" || echo "(no association skip — read-gap closed)"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

Follow-up to #344 (the Logs SubscriptionFilter composite-identifier read-gap). Two parts:

### 1. hunt-bugs skill hardening
`SKILL.md` principle 4 now warns that a CC `read` handler being present does **not** mean `GetResource` works with the bare CFn physical id: a **composite `primaryIdentifier`** whose physical id is only the child segment is a `ValidationException` read-gap (a different class than `UnsupportedActionException`). This is a `CC_IDENTIFIER_ADAPTERS` fix, not `SDK_OVERRIDES`. Added the offline `primaryIdentifier`-arity probe so future hunts catch this class before deploying.

### 2. Audited the composite-identifier vein (live)
Deployed and checked three previously-uncovered common composite-identifier types. **All three read cleanly with their bare CFn physical id — NOT read-gaps** (hypothesis ruled out live):

| Type | identifier |
|---|---|
| AWS::IAM::RolePolicy | `[PolicyName, RoleName]` |
| AWS::IAM::UserPolicy | `[PolicyName, UserName]` |
| AWS::WAFv2::WebACLAssociation | `[ResourceArn, WebACLArn]` |

Shipped as rich integ fixtures + clean golden-corpus cases (`expected: []`) so a future regression that broke their read/classify would fail offline `corpus-replay`. A clean round whose deliverable is the regression coverage + the sharpened hunt heuristic.

## Tests
- 3 new `corpus-replay` cases; 1537 unit tests green; typecheck + build + `vp run check` clean.

## Scope
No `src/**` change (no gap to fix) → `verify-pr-gate` exempt; `check` + `docs` gates pass.

## Cleanup
Both deployed stacks deleted via `delstack`; `bughunt-track.sh verify` → GONE + SWEEP CLEAN.
