### PR TITLE
test(integ): 5-round bug-hunt sweep — S3/Lambda/KMS/SNS rich + CloudWatch MetricStream

### DIFF
--- a/tests/corpus/AWS__CloudWatch__MetricStream.Stream.json
+++ b/tests/corpus/AWS__CloudWatch__MetricStream.Stream.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Stream",
+    "resourceType": "AWS::CloudWatch::MetricStream",
+    "physicalId": "CdkRealDriftIntegCloudwatchMetricstream-Stream-sf0BAdBHT2jN",
+    "constructPath": "CdkRealDriftIntegCloudwatchMetricstream/Stream",
+    "declared": {
+      "FirehoseArn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/CdkRealDriftIntegCloudwatchMetricstream-Fh-vKgUW1ELqlFW",
+      "IncludeFilters": [
+        {
+          "MetricNames": ["CPUUtilization", "NetworkIn"],
+          "Namespace": "AWS/EC2"
+        },
+        {
+          "MetricNames": [],
+          "Namespace": "AWS/Lambda"
+        },
+        {
+          "Namespace": "AWS/S3"
+        }
+      ],
+      "OutputFormat": "json",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCloudwatchMetricstr-MsRole2C85F6C4-0QNhw38qXmuL"
+    }
+  },
+  "liveRaw": {
+    "CreationDate": "Tue Jun 23 06:07:47 UTC 2026",
+    "FirehoseArn": "arn:aws:firehose:us-east-1:111111111111:deliverystream/CdkRealDriftIntegCloudwatchMetricstream-Fh-vKgUW1ELqlFW",
+    "IncludeLinkedAccountsMetrics": false,
+    "IncludeFilters": [
+      {
+        "MetricNames": ["CPUUtilization", "NetworkIn"],
+        "Namespace": "AWS/EC2"
+      },
+      {
+        "MetricNames": [],
+        "Namespace": "AWS/Lambda"
+      },
+      {
+        "MetricNames": [],
+        "Namespace": "AWS/S3"
+      }
+    ],
+    "State": "running",
+    "OutputFormat": "json",
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:metric-stream/CdkRealDriftIntegCloudwatchMetricstream-Stream-sf0BAdBHT2jN",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCloudwatchMetricstr-MsRole2C85F6C4-0QNhw38qXmuL",
+    "Tags": [],
+    "LastUpdateDate": "Tue Jun 23 06:07:47 UTC 2026",
+    "Name": "CdkRealDriftIntegCloudwatchMetricstream-Stream-sf0BAdBHT2jN"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreationDate", "LastUpdateDate", "State"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "CreationDate", "LastUpdateDate", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__KMS__Key.RotatedKey753373F0.json
+++ b/tests/corpus/AWS__KMS__Key.RotatedKey753373F0.json
@@ -1,0 +1,154 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RotatedKey753373F0",
+    "resourceType": "AWS::KMS::Key",
+    "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+    "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey",
+    "declared": {
+      "Description": "cdkrd kms-rich rotated multi-region key",
+      "EnableKeyRotation": true,
+      "KeyPolicy": {
+        "Statement": [
+          {
+            "Action": "kms:*",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Resource": "*"
+          },
+          {
+            "Action": ["kms:Describe*", "kms:Get*", "kms:List*"],
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Resource": "*",
+            "Sid": "AllowAccountAdmin"
+          }
+        ],
+        "Version": "2012-10-17"
+      },
+      "MultiRegion": true,
+      "RotationPeriodInDays": 180
+    }
+  },
+  "liveRaw": {
+    "Origin": "AWS_KMS",
+    "MultiRegion": true,
+    "Description": "cdkrd kms-rich rotated multi-region key",
+    "KeyPolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "kms:*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          }
+        },
+        {
+          "Action": ["kms:Describe*", "kms:Get*", "kms:List*"],
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "AllowAccountAdmin"
+        }
+      ]
+    },
+    "KeySpec": "SYMMETRIC_DEFAULT",
+    "Enabled": true,
+    "EnableKeyRotation": true,
+    "KeyUsage": "ENCRYPT_DECRYPT",
+    "KeyId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+    "Arn": "arn:aws:kms:us-east-1:111111111111:key/mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "KeyId"],
+    "writeOnly": ["BypassPolicyLockoutSafetyCheck", "PendingWindowInDays", "RotationPeriodInDays"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "KeyId"],
+    "writeOnlyPaths": [
+      "BypassPolicyLockoutSafetyCheck",
+      "PendingWindowInDays",
+      "RotationPeriodInDays"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    },
+    "defaultPaths": {
+      "KeyPolicy": "{\n    \"Version\": \"2012-10-17\",\n    \"Id\": \"key-default\",\n    \"Statement\": [\n        {\n            \"Sid\": \"Enable IAM User Permissions\",\n            \"Effect\": \"Allow\",\n            \"Principal\": {\n                \"AWS\": \"arn:<partition>:iam::<account-id>:root\"\n            },\n            \"Action\": \"kms:*\",\n            \"Resource\": \"*\"\n        }\n    ]\n}",
+      "KeyUsage": "ENCRYPT_DECRYPT",
+      "Origin": "AWS_KMS",
+      "KeySpec": "SYMMETRIC_DEFAULT",
+      "MultiRegion": false,
+      "BypassPolicyLockoutSafetyCheck": false,
+      "RotationPeriodInDays": 365
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "RotatedKey753373F0",
+      "resourceType": "AWS::KMS::Key",
+      "path": "RotationPeriodInDays",
+      "note": "write-only — cannot be read back",
+      "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RotatedKey753373F0",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Origin",
+      "actual": "AWS_KMS",
+      "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RotatedKey753373F0",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeySpec",
+      "actual": "SYMMETRIC_DEFAULT",
+      "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RotatedKey753373F0",
+      "resourceType": "AWS::KMS::Key",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RotatedKey753373F0",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyUsage",
+      "actual": "ENCRYPT_DECRYPT",
+      "physicalId": "mrk-4f84e44c22a340f1a3f36dc8568e4b2b",
+      "constructPath": "CdkRealDriftIntegKmsRich/RotatedKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.Data666C94C7_s3extras.json
+++ b/tests/corpus/AWS__S3__Bucket.Data666C94C7_s3extras.json
@@ -1,0 +1,356 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Data666C94C7",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+    "constructPath": "CdkRealDriftIntegS3RichExtras/Data",
+    "declared": {
+      "AccelerateConfiguration": {
+        "AccelerationStatus": "Enabled"
+      },
+      "IntelligentTieringConfigurations": [
+        {
+          "Id": "logsTier",
+          "Prefix": "logs/",
+          "Status": "Enabled",
+          "Tierings": [
+            {
+              "AccessTier": "ARCHIVE_ACCESS",
+              "Days": 90
+            }
+          ]
+        },
+        {
+          "Id": "dataTier",
+          "Prefix": "data/",
+          "Status": "Enabled",
+          "Tierings": [
+            {
+              "AccessTier": "ARCHIVE_ACCESS",
+              "Days": 90
+            },
+            {
+              "AccessTier": "DEEP_ARCHIVE_ACCESS",
+              "Days": 180
+            }
+          ]
+        }
+      ],
+      "InventoryConfigurations": [
+        {
+          "Destination": {
+            "BucketArn": "arn:aws:s3:::cdkrealdriftintegs3richextras-destc383b82a-tgyp27tmzfxo",
+            "Format": "CSV",
+            "Prefix": "inv1"
+          },
+          "Enabled": true,
+          "Id": "inv-daily",
+          "IncludedObjectVersions": "All",
+          "ScheduleFrequency": "Weekly"
+        },
+        {
+          "Destination": {
+            "BucketArn": "arn:aws:s3:::cdkrealdriftintegs3richextras-destc383b82a-tgyp27tmzfxo",
+            "Format": "CSV",
+            "Prefix": "inv2"
+          },
+          "Enabled": true,
+          "Id": "inv-weekly",
+          "IncludedObjectVersions": "All",
+          "ScheduleFrequency": "Weekly"
+        }
+      ],
+      "MetricsConfigurations": [
+        {
+          "Id": "EntireBucket"
+        },
+        {
+          "Id": "LogsOnly",
+          "Prefix": "logs/"
+        }
+      ],
+      "OwnershipControls": {
+        "Rules": [
+          {
+            "ObjectOwnership": "ObjectWriter"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "InventoryConfigurations": [
+      {
+        "Destination": {
+          "BucketArn": "arn:aws:s3:::cdkrealdriftintegs3richextras-destc383b82a-tgyp27tmzfxo",
+          "Format": "CSV",
+          "Prefix": "inv1"
+        },
+        "OptionalFields": [],
+        "IncludedObjectVersions": "All",
+        "Enabled": true,
+        "Id": "inv-daily",
+        "ScheduleFrequency": "Weekly"
+      },
+      {
+        "Destination": {
+          "BucketArn": "arn:aws:s3:::cdkrealdriftintegs3richextras-destc383b82a-tgyp27tmzfxo",
+          "Format": "CSV",
+          "Prefix": "inv2"
+        },
+        "OptionalFields": [],
+        "IncludedObjectVersions": "All",
+        "Enabled": true,
+        "Id": "inv-weekly",
+        "ScheduleFrequency": "Weekly"
+      }
+    ],
+    "DomainName": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln.s3-website-us-east-1.amazonaws.com",
+    "NotificationConfiguration": {
+      "TopicConfigurations": [],
+      "QueueConfigurations": [],
+      "LambdaConfigurations": [],
+      "EventBridgeConfiguration": {
+        "EventBridgeEnabled": true
+      }
+    },
+    "DualStackDomainName": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln.s3.dualstack.us-east-1.amazonaws.com",
+    "MetricsConfigurations": [
+      {
+        "Id": "EntireBucket"
+      },
+      {
+        "TagFilters": [null],
+        "Id": "LogsOnly",
+        "Prefix": "logs/"
+      }
+    ],
+    "IntelligentTieringConfigurations": [
+      {
+        "Status": "Enabled",
+        "Tierings": [
+          {
+            "AccessTier": "ARCHIVE_ACCESS",
+            "Days": 90
+          },
+          {
+            "AccessTier": "DEEP_ARCHIVE_ACCESS",
+            "Days": 180
+          }
+        ],
+        "TagFilters": [null],
+        "Id": "dataTier",
+        "Prefix": "data/"
+      },
+      {
+        "Status": "Enabled",
+        "Tierings": [
+          {
+            "AccessTier": "ARCHIVE_ACCESS",
+            "Days": 90
+          }
+        ],
+        "TagFilters": [null],
+        "Id": "logsTier",
+        "Prefix": "logs/"
+      }
+    ],
+    "AbacStatus": "Disabled",
+    "AccelerateConfiguration": {
+      "AccelerationStatus": "Enabled"
+    },
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+    "RegionalDomainName": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "ObjectWriter"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegS3RichExtras",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Data666C94C7",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3RichExtras/4c11cc40-6eca-11f1-9205-0e6c4e574109",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "NotificationConfiguration",
+      "actual": {
+        "TopicConfigurations": [],
+        "QueueConfigurations": [],
+        "LambdaConfigurations": [],
+        "EventBridgeConfiguration": {
+          "EventBridgeEnabled": true
+        }
+      },
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "IntelligentTieringConfigurations[dataTier].TagFilters",
+      "actual": [null],
+      "nested": true,
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "IntelligentTieringConfigurations[logsTier].TagFilters",
+      "actual": [null],
+      "nested": true,
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "MetricsConfigurations[LogsOnly].TagFilters",
+      "actual": [null],
+      "nested": true,
+      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
+      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.EventsD32975C2.json
+++ b/tests/corpus/AWS__SNS__Topic.EventsD32975C2.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EventsD32975C2",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsRichExtras-EventsD32975C2-iHNiTcQGOGLx",
+    "constructPath": "CdkRealDriftIntegSnsRichExtras/Events",
+    "declared": {
+      "DisplayName": "cdkrd events topic",
+      "SignatureVersion": "2",
+      "TracingConfig": "Active"
+    }
+  },
+  "liveRaw": {
+    "SignatureVersion": "2",
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsRichExtras-EventsD32975C2-iHNiTcQGOGLx",
+    "TracingConfig": "Active",
+    "DisplayName": "cdkrd events topic",
+    "FifoTopic": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSnsRichExtras/4bf65500-6eca-11f1-8c6b-12abecc628fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSnsRichExtras",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "EventsD32975C2",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "CdkRealDriftIntegSnsRichExtras-EventsD32975C2-iHNiTcQGOGLx"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "EventsD32975C2",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "TopicName",
+      "actual": "CdkRealDriftIntegSnsRichExtras-EventsD32975C2-iHNiTcQGOGLx",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsRichExtras-EventsD32975C2-iHNiTcQGOGLx",
+      "constructPath": "CdkRealDriftIntegSnsRichExtras/Events"
+    }
+  ]
+}

--- a/tests/integration/cloudwatch-metricstream/app.ts
+++ b/tests/integration/cloudwatch-metricstream/app.ts
@@ -1,0 +1,53 @@
+// CloudWatch MetricStream (to a Firehose -> S3 sink) with multiple IncludeFilters —
+// an object array (keyed by Namespace) AWS may return reordered, a reorder-FP
+// candidate. MetricStream is a common observability export; clean record->check is the
+// FP oracle. Firehose + S3 + roles are cheap (no NAT, no stateful provisioning).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnDeliveryStream } from "aws-cdk-lib/aws-kinesisfirehose";
+import { CfnMetricStream } from "aws-cdk-lib/aws-cloudwatch";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCloudwatchMetricstream");
+
+const sink = new Bucket(stack, "Sink", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const fhRole = new Role(stack, "FhRole", {
+  assumedBy: new ServicePrincipal("firehose.amazonaws.com"),
+});
+sink.grantReadWrite(fhRole);
+
+const fh = new CfnDeliveryStream(stack, "Fh", {
+  deliveryStreamType: "DirectPut",
+  s3DestinationConfiguration: {
+    bucketArn: sink.bucketArn,
+    roleArn: fhRole.roleArn,
+  },
+});
+
+const msRole = new Role(stack, "MsRole", {
+  assumedBy: new ServicePrincipal("streams.metrics.cloudwatch.amazonaws.com"),
+});
+msRole.addToPolicy(
+  new PolicyStatement({
+    actions: ["firehose:PutRecord", "firehose:PutRecordBatch"],
+    resources: [fh.attrArn],
+  }),
+);
+
+new CfnMetricStream(stack, "Stream", {
+  firehoseArn: fh.attrArn,
+  roleArn: msRole.roleArn,
+  outputFormat: "json",
+  includeFilters: [
+    { namespace: "AWS/EC2", metricNames: ["CPUUtilization", "NetworkIn"] },
+    { namespace: "AWS/Lambda", metricNames: [] },
+    { namespace: "AWS/S3" },
+  ],
+});
+
+app.synth();

--- a/tests/integration/cloudwatch-metricstream/cdk.json
+++ b/tests/integration/cloudwatch-metricstream/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudwatch-metricstream/package.json
+++ b/tests/integration/cloudwatch-metricstream/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudwatch-metricstream",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cloudwatch-metricstream integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudwatch-metricstream/verify.sh
+++ b/tests/integration/cloudwatch-metricstream/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCloudwatchMetricstream
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/kms-rich/app.ts
+++ b/tests/integration/kms-rich/app.ts
@@ -1,0 +1,30 @@
+// KMS key exercising rich config the existing KMS corpus (a basic DataKey) does not:
+// automatic key rotation (with an explicit rotation period), a multi-region key, and
+// an explicit key policy (a JSON policy document — a shape-coercion candidate). KMS is
+// a daily-driver type; clean record->check is the FP oracle. (delstack schedules key
+// deletion; the sweep accounts for keys pending deletion.)
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { AccountRootPrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Key } from "aws-cdk-lib/aws-kms";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegKmsRich");
+
+const key = new Key(stack, "RotatedKey", {
+  enableKeyRotation: true,
+  rotationPeriod: Duration.days(180),
+  multiRegion: true,
+  description: "cdkrd kms-rich rotated multi-region key",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+key.addToResourcePolicy(
+  new PolicyStatement({
+    sid: "AllowAccountAdmin",
+    principals: [new AccountRootPrincipal()],
+    actions: ["kms:Describe*", "kms:Get*", "kms:List*"],
+    resources: ["*"],
+  }),
+);
+
+app.synth();

--- a/tests/integration/kms-rich/cdk.json
+++ b/tests/integration/kms-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/kms-rich/package.json
+++ b/tests/integration/kms-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-kms-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift kms-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/kms-rich/verify.sh
+++ b/tests/integration/kms-rich/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegKmsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/lambda-rich-extras/app.ts
+++ b/tests/integration/lambda-rich-extras/app.ts
@@ -1,0 +1,30 @@
+// Lambda function exercising rich config NOT in lambda-rich: a Layer (Layers is an
+// order-significant ARN array — guarded by hasOrderSignificantId, so it must NOT be
+// sorted), a dead-letter SQS queue, multiple env vars, and reserved concurrency.
+// Common production Lambda settings; clean record->check is the FP oracle.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Code, Function as LambdaFn, LayerVersion, Runtime } from "aws-cdk-lib/aws-lambda";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaRichExtras");
+
+const layer = new LayerVersion(stack, "Layer", {
+  code: Code.fromAsset("layer"),
+  compatibleRuntimes: [Runtime.NODEJS_20_X],
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const dlq = new Queue(stack, "Dlq", { retentionPeriod: Duration.days(14) });
+
+new LambdaFn(stack, "Fn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => 'ok';"),
+  layers: [layer],
+  deadLetterQueue: dlq,
+  environment: { STAGE: "prod", REGION_HINT: "us-east-1", FEATURE_X: "on" },
+  reservedConcurrentExecutions: 2,
+});
+
+app.synth();

--- a/tests/integration/lambda-rich-extras/cdk.json
+++ b/tests/integration/lambda-rich-extras/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-rich-extras/layer/nodejs/index.js
+++ b/tests/integration/lambda-rich-extras/layer/nodejs/index.js
@@ -1,0 +1,1 @@
+module.exports.helper = () => "ok";

--- a/tests/integration/lambda-rich-extras/package.json
+++ b/tests/integration/lambda-rich-extras/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-rich-extras",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-rich-extras integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-rich-extras/verify.sh
+++ b/tests/integration/lambda-rich-extras/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaRichExtras
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-rich-extras/app.ts
+++ b/tests/integration/s3-rich-extras/app.ts
@@ -1,0 +1,42 @@
+// S3 bucket exercising rich sub-configs NOT in s3-rich: inventory + metrics
+// configurations (object arrays — reorder-FP candidates), ownership controls,
+// EventBridge notification, transfer acceleration, and intelligent-tiering with
+// multiple tierings. S3 is the #1 daily-driver type; these are common but untested
+// surfaces. Clean record->check is the FP oracle.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Bucket, ObjectOwnership } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3RichExtras");
+
+const dest = new Bucket(stack, "Dest", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+new Bucket(stack, "Data", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+  transferAcceleration: true,
+  eventBridgeEnabled: true,
+  objectOwnership: ObjectOwnership.OBJECT_WRITER,
+  intelligentTieringConfigurations: [
+    { name: "logsTier", prefix: "logs/", archiveAccessTierTime: Duration.days(90) },
+    {
+      name: "dataTier",
+      prefix: "data/",
+      archiveAccessTierTime: Duration.days(90),
+      deepArchiveAccessTierTime: Duration.days(180),
+    },
+  ],
+  metrics: [
+    { id: "EntireBucket" },
+    { id: "LogsOnly", prefix: "logs/" },
+  ],
+  inventories: [
+    { destination: { bucket: dest, prefix: "inv1" }, enabled: true, inventoryId: "inv-daily" },
+    { destination: { bucket: dest, prefix: "inv2" }, enabled: true, inventoryId: "inv-weekly" },
+  ],
+});
+
+app.synth();

--- a/tests/integration/s3-rich-extras/cdk.json
+++ b/tests/integration/s3-rich-extras/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-rich-extras/package.json
+++ b/tests/integration/s3-rich-extras/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-rich-extras",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-rich-extras integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-rich-extras/verify.sh
+++ b/tests/integration/s3-rich-extras/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3RichExtras
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sns-rich-extras/app.ts
+++ b/tests/integration/sns-rich-extras/app.ts
@@ -1,0 +1,35 @@
+// SNS topic exercising rich config not covered by sns-fifo: a standard topic with an
+// explicit signature version, an active tracing config, a display name, and a
+// delivery-policy (a JSON document — a shape-coercion FP candidate). SNS is a
+// daily-driver type; clean record->check is the FP oracle.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnTopic, Topic, TracingConfig } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsRichExtras");
+
+const topic = new Topic(stack, "Events", {
+  displayName: "cdkrd events topic",
+  tracingConfig: TracingConfig.ACTIVE,
+  signatureVersion: "2",
+});
+
+// DeliveryPolicy is a JSON document AWS may echo as a parsed object or a JSON string —
+// a shape-coercion FP candidate. Set on the L1.
+const cfn = topic.node.defaultChild as CfnTopic;
+cfn.deliveryPolicy = {
+  http: {
+    defaultHealthyRetryPolicy: {
+      numRetries: 3,
+      minDelayTarget: 20,
+      maxDelayTarget: 20,
+      numNoDelayRetries: 0,
+      numMinDelayRetries: 0,
+      numMaxDelayRetries: 0,
+      backoffFunction: "linear",
+    },
+    disableSubscriptionOverrides: false,
+  },
+};
+
+app.synth();

--- a/tests/integration/sns-rich-extras/cdk.json
+++ b/tests/integration/sns-rich-extras/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-rich-extras/package.json
+++ b/tests/integration/sns-rich-extras/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sns-rich-extras",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sns-rich-extras integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sns-rich-extras/verify.sh
+++ b/tests/integration/sns-rich-extras/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsRichExtras
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A clean 5-round real-AWS bug hunt over previously-untested **common** configs (per `/hunt-bugs`). **No false positives, no missed detection, no bug** — so the deliverable is the regression coverage: 5 rich integ fixtures + harvested golden corpus, plus one new corpus type.

The FP oracle (`record` → `check` CLEAN) passed on all five; the Lambda `reservedConcurrentExecutions` `detect → revert → restore` FN cycle passed live.

### Rounds
| # | Fixture | Exercised (untested before) | Result |
|---|---|---|---|
| 1 | s3-rich-extras | inventory + metrics + intelligent-tiering + ownership + EventBridge notification + transfer acceleration | CLEAN (no reorder FP on the object-array sub-configs) |
| 2 | lambda-rich-extras | a Layer (order-significant ARN array) + dead-letter SQS + multi env + reserved concurrency | CLEAN + FN target |
| 3 | kms-rich | key rotation + rotation period + multi-region + explicit key policy | CLEAN |
| 4 | sns-rich-extras | tracing config + signature version + JSON DeliveryPolicy (shape-coercion candidate) | CLEAN |
| 5 | cloudwatch-metricstream | MetricStream (**new corpus type**) with multiple IncludeFilters → Firehose→S3 | CLEAN (no reorder FP) |

### Corpus
New `AWS::CloudWatch::MetricStream` type + rich `S3`/`SNS`/`KMS` cases (S3 suffixed to avoid the existing same-logical-id case).

## Tests
1541 unit tests green; typecheck + build + `vp run check` clean.

## Scope
No `src/**` change (clean sweep) → `verify-pr-gate` exempt; `check` + `docs` gates pass.

## Cleanup
All 5 deployed stacks deleted via `delstack`; `bughunt-track.sh verify` → every stack GONE + SWEEP CLEAN (3 orphan custom-resource log groups also swept).
