### PR TITLE
fix(read): read AppConfig HostedConfigurationVersion + Deployment via 3-segment composite id

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -91,6 +91,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     MessageRetentionPeriod: 345600,
     ReceiveMessageWaitTimeSeconds: 0,
     SqsManagedSseEnabled: true,
+    // AWS now provisions a 1 MiB max message size by default (observed unanimous
+    // across 10 corpus queues that declare none); a queue that pins a smaller value
+    // still surfaces (equality-gated).
+    MaximumMessageSize: 1048576,
     FifoThroughputLimit: 'perQueue', // FIFO queues only
     DeduplicationScope: 'queue', // FIFO queues only
   },
@@ -198,9 +202,15 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Cognito::UserPoolClient': {
     EnableTokenRevocation: true,
     AuthSessionValidity: 3,
+    // Cognito's default refresh-token validity is 30 (days, the default unit) when a
+    // client declares none — observed unanimous across the corpus clients.
+    RefreshTokenValidity: 30,
   },
   'AWS::ECS::Service': {
     SchedulingStrategy: 'REPLICA',
+    // A service with no load-balancer health-check grace reads back 0 (the default) —
+    // observed unanimous across the corpus services.
+    HealthCheckGracePeriodSeconds: 0,
   },
   'AWS::AppSync::GraphQLApi': {
     ApiType: 'GRAPHQL',
@@ -348,6 +358,22 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   },
   'AWS::Scheduler::Schedule': {
     'Target.RetryPolicy': { MaximumEventAgeInSeconds: 86400, MaximumRetryAttempts: 185 },
+  },
+  'AWS::ECS::Service': {
+    // A service declaring no deployment configuration reads back AWS's defaults — the
+    // ROLLING strategy with a 0-minute bake time. Observed unanimous across the corpus.
+    'DeploymentConfiguration.Strategy': 'ROLLING',
+    'DeploymentConfiguration.BakeTimeInMinutes': 0,
+  },
+  'AWS::OpenSearchService::Domain': {
+    // A gp3 EBS volume reads back the gp3 baseline 3000 IOPS / 125 MiB/s throughput
+    // when the template leaves them unset — server defaults, not user intent.
+    'EBSOptions.Iops': 3000,
+    'EBSOptions.Throughput': 125,
+  },
+  'AWS::KinesisFirehose::DeliveryStream': {
+    // S3 backup is Disabled by default when a destination declares no backup mode.
+    'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',
   },
 };
 

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -65,6 +65,36 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   },
   'AWS::AppConfig::Environment': compositeWith('ApplicationId'),
   'AWS::AppConfig::ConfigurationProfile': compositeWith('ApplicationId'),
+  // AppConfig HostedConfigurationVersion + Deployment are 3-SEGMENT composites whose
+  // CFn physical id is only the LAST segment (the VersionNumber / DeploymentNumber), so
+  // the bare id is a CC ValidationException skip (read-gap) until paired with both
+  // parents from the resolved declared Refs — in primaryIdentifier order. Verified live
+  // (appconfig-deployment-readgap): HostedConfigurationVersion reads as
+  // `ApplicationId|ConfigurationProfileId|VersionNumber`; Deployment reads as
+  // `ApplicationId|EnvironmentId|DeploymentNumber`. An unresolved parent → fall back to
+  // the bare physical id (honest skip).
+  'AWS::AppConfig::HostedConfigurationVersion': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const appId = declared.ApplicationId;
+    const profileId = declared.ConfigurationProfileId;
+    return typeof appId === 'string' &&
+      appId.length > 0 &&
+      typeof profileId === 'string' &&
+      profileId.length > 0
+      ? `${appId}|${profileId}|${pid}`
+      : undefined;
+  },
+  'AWS::AppConfig::Deployment': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const appId = declared.ApplicationId;
+    const envId = declared.EnvironmentId;
+    return typeof appId === 'string' &&
+      appId.length > 0 &&
+      typeof envId === 'string' &&
+      envId.length > 0
+      ? `${appId}|${envId}|${pid}`
+      : undefined;
+  },
   // ApiGateway v1 (REST) parent-first composites `[RestApiId, <child>]` and Cognito
   // `[UserPoolId, <child>]` — same parent-first `|` shape as above. The CFn physical
   // id is only the child (Model→Name, RequestValidator→RequestValidatorId,

--- a/tests/corpus/AWS__AppConfig__Deployment.CfgDeployment.json
+++ b/tests/corpus/AWS__AppConfig__Deployment.CfgDeployment.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CfgDeployment",
+    "resourceType": "AWS::AppConfig::Deployment",
+    "physicalId": "1",
+    "constructPath": "CdkRealDriftIntegAppconfigDeploymentReadgap/CfgDeployment",
+    "declared": {
+      "ApplicationId": "op3xb7a",
+      "ConfigurationProfileId": "7wzsy97",
+      "ConfigurationVersion": "1",
+      "DeploymentStrategyId": "t27xew3",
+      "EnvironmentId": "vl7a755"
+    }
+  },
+  "liveRaw": {
+    "DeploymentStrategyId": "t27xew3",
+    "ConfigurationProfileId": "7wzsy97",
+    "EnvironmentId": "vl7a755",
+    "ConfigurationVersion": "1",
+    "State": "COMPLETE",
+    "DeploymentNumber": "1",
+    "ApplicationId": "op3xb7a",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAppconfigDeploymentReadgap/2be95c10-6ed1-11f1-b056-0ee26e63283b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAppconfigDeploymentReadgap",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CfgDeployment",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["DeploymentNumber", "State"],
+    "writeOnly": ["DynamicExtensionParameters"],
+    "createOnly": [
+      "ApplicationId",
+      "ConfigurationProfileId",
+      "ConfigurationVersion",
+      "DeploymentStrategyId",
+      "Description",
+      "DynamicExtensionParameters",
+      "EnvironmentId",
+      "KmsKeyIdentifier",
+      "Tags"
+    ],
+    "readOnlyPaths": ["DeploymentNumber", "State"],
+    "writeOnlyPaths": ["DynamicExtensionParameters"],
+    "createOnlyPaths": [
+      "ApplicationId",
+      "ConfigurationProfileId",
+      "ConfigurationVersion",
+      "DeploymentStrategyId",
+      "Description",
+      "DynamicExtensionParameters",
+      "EnvironmentId",
+      "KmsKeyIdentifier",
+      "Tags"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppConfig__HostedConfigurationVersion.CfgVersion.json
+++ b/tests/corpus/AWS__AppConfig__HostedConfigurationVersion.CfgVersion.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CfgVersion",
+    "resourceType": "AWS::AppConfig::HostedConfigurationVersion",
+    "physicalId": "1",
+    "constructPath": "CdkRealDriftIntegAppconfigDeploymentReadgap/CfgVersion",
+    "declared": {
+      "ApplicationId": "op3xb7a",
+      "ConfigurationProfileId": "7wzsy97",
+      "Content": "{\"feature\":{\"enabled\":true}}",
+      "ContentType": "application/json"
+    }
+  },
+  "liveRaw": {
+    "ConfigurationProfileId": "7wzsy97",
+    "ContentType": "application/json",
+    "Content": "{\"feature\":{\"enabled\":true}}",
+    "ApplicationId": "op3xb7a",
+    "VersionNumber": "1"
+  },
+  "schema": {
+    "readOnly": ["VersionNumber"],
+    "writeOnly": ["LatestVersionNumber"],
+    "createOnly": [
+      "ApplicationId",
+      "ConfigurationProfileId",
+      "Content",
+      "ContentType",
+      "Description",
+      "LatestVersionNumber",
+      "VersionLabel"
+    ],
+    "readOnlyPaths": ["VersionNumber"],
+    "writeOnlyPaths": ["LatestVersionNumber"],
+    "createOnlyPaths": [
+      "ApplicationId",
+      "ConfigurationProfileId",
+      "Content",
+      "ContentType",
+      "Description",
+      "LatestVersionNumber",
+      "VersionLabel"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client.callbackurls.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client.callbackurls.json
@@ -80,7 +80,7 @@
       "constructPath": "CdkRealDriftIntegCognitoCallbackUrls/Client"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Client",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "RefreshTokenValidity",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
@@ -82,17 +82,17 @@
       "tier": "atDefault",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "EnableTokenRevocation",
-      "actual": true,
+      "path": "RefreshTokenValidity",
+      "actual": 30,
       "physicalId": "mr9u1vrva41nona9of2rfctdi",
       "constructPath": "CdkRealDriftIntegCognito/Client"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "RefreshTokenValidity",
-      "actual": 30,
+      "path": "EnableTokenRevocation",
+      "actual": true,
       "physicalId": "mr9u1vrva41nona9of2rfctdi",
       "constructPath": "CdkRealDriftIntegCognito/Client"
     }

--- a/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
@@ -81,17 +81,17 @@
       "tier": "atDefault",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "EnableTokenRevocation",
-      "actual": true,
+      "path": "RefreshTokenValidity",
+      "actual": 30,
       "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
       "constructPath": "CdkrdIntegHarvest3/WebClient"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
-      "path": "RefreshTokenValidity",
-      "actual": 30,
+      "path": "EnableTokenRevocation",
+      "actual": true,
       "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
       "constructPath": "CdkrdIntegHarvest3/WebClient"
     }

--- a/tests/corpus/AWS__ECS__Service.Service.json
+++ b/tests/corpus/AWS__ECS__Service.Service.json
@@ -125,7 +125,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Service",
       "resourceType": "AWS::ECS::Service",
       "path": "HealthCheckGracePeriodSeconds",

--- a/tests/corpus/AWS__ECS__Service.ServiceD69D759B.json
+++ b/tests/corpus/AWS__ECS__Service.ServiceD69D759B.json
@@ -129,7 +129,7 @@
       "constructPath": "CdkdriftIntegHarvest10/Service/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ServiceD69D759B",
       "resourceType": "AWS::ECS::Service",
       "path": "HealthCheckGracePeriodSeconds",
@@ -165,7 +165,7 @@
       "constructPath": "CdkdriftIntegHarvest10/Service/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ServiceD69D759B",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentConfiguration.BakeTimeInMinutes",
@@ -175,7 +175,7 @@
       "constructPath": "CdkdriftIntegHarvest10/Service/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ServiceD69D759B",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentConfiguration.Strategy",

--- a/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
+++ b/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
@@ -136,7 +136,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SvcServiceE0738BDC",
       "resourceType": "AWS::ECS::Service",
       "path": "HealthCheckGracePeriodSeconds",
@@ -192,7 +192,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SvcServiceE0738BDC",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentConfiguration.BakeTimeInMinutes",
@@ -202,7 +202,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SvcServiceE0738BDC",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentConfiguration.Strategy",

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.json
@@ -134,7 +134,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Stream",
       "resourceType": "AWS::KinesisFirehose::DeliveryStream",
       "path": "ExtendedS3DestinationConfiguration.S3BackupMode",

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.processors.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.processors.json
@@ -205,7 +205,7 @@
       "constructPath": "CdkRealDriftIntegFirehoseProcessorsRich/Stream"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Stream",
       "resourceType": "AWS::KinesisFirehose::DeliveryStream",
       "path": "ExtendedS3DestinationConfiguration.S3BackupMode",

--- a/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
@@ -230,7 +230,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "EBSOptions.Throughput",
@@ -240,7 +240,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "EBSOptions.Iops",

--- a/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
@@ -233,7 +233,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "EBSOptions.Throughput",
@@ -243,7 +243,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "EBSOptions.Iops",

--- a/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
+++ b/tests/corpus/AWS__SQS__Queue.DlqD1FAA4AD.json
@@ -39,26 +39,8 @@
       "tier": "atDefault",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
-      "constructPath": "CdkRealDriftIntegSqs/Dlq"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "DlqD1FAA4AD",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
-      "constructPath": "CdkRealDriftIntegSqs/Dlq"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "DlqD1FAA4AD",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     },
@@ -75,8 +57,17 @@
       "tier": "atDefault",
       "logicalId": "DlqD1FAA4AD",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     },
@@ -86,6 +77,15 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",
       "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
+      "constructPath": "CdkRealDriftIntegSqs/Dlq"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "DlqD1FAA4AD",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-DlqD1FAA4AD-JVro9NWZxliC",
       "constructPath": "CdkRealDriftIntegSqs/Dlq"
     }

--- a/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
+++ b/tests/corpus/AWS__SQS__Queue.InboxA8E05DC3.json
@@ -53,35 +53,8 @@
       "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
-      "constructPath": "CdkrdIntegHarvest2/Inbox"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "InboxA8E05DC3",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
-      "constructPath": "CdkrdIntegHarvest2/Inbox"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "InboxA8E05DC3",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
-      "constructPath": "CdkrdIntegHarvest2/Inbox"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "InboxA8E05DC3",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
@@ -98,8 +71,26 @@
       "tier": "atDefault",
       "logicalId": "InboxA8E05DC3",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     },
@@ -109,6 +100,15 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",
       "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
+      "constructPath": "CdkrdIntegHarvest2/Inbox"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "InboxA8E05DC3",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-InboxA8E05DC3-hBjRn2Y5QXx2",
       "constructPath": "CdkrdIntegHarvest2/Inbox"
     }

--- a/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDF1CC2D4.json
@@ -70,7 +70,7 @@
       "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
+      "path": "ReceiveMessageWaitTimeSeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
       "constructPath": "CdkrdIntegHarvest2/Jobs"
@@ -85,11 +85,29 @@
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDF1CC2D4",
       "resourceType": "AWS::SQS::Queue",
       "path": "MaximumMessageSize",
       "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
+      "constructPath": "CdkrdIntegHarvest2/Jobs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "JobsDF1CC2D4",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DelaySeconds",
+      "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     },
@@ -108,24 +126,6 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "QueueName",
       "actual": "CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
-      "constructPath": "CdkrdIntegHarvest2/Jobs"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "JobsDF1CC2D4",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
-      "constructPath": "CdkrdIntegHarvest2/Jobs"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "JobsDF1CC2D4",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDF1CC2D4-55t0xhloKlDd.fifo",
       "constructPath": "CdkrdIntegHarvest2/Jobs"
     }

--- a/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
+++ b/tests/corpus/AWS__SQS__Queue.JobsDlqB53173A1.json
@@ -59,16 +59,7 @@
       "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DeduplicationScope",
-      "actual": "queue",
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "JobsDlqB53173A1",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
+      "path": "ReceiveMessageWaitTimeSeconds",
       "actual": 0,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
@@ -83,7 +74,7 @@
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
       "path": "MaximumMessageSize",
@@ -95,26 +86,8 @@
       "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "JobsDlqB53173A1",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
-      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "JobsDlqB53173A1",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "ReceiveMessageWaitTimeSeconds",
-      "actual": 0,
+      "path": "VisibilityTimeout",
+      "actual": 30,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     },
@@ -131,8 +104,35 @@
       "tier": "atDefault",
       "logicalId": "JobsDlqB53173A1",
       "resourceType": "AWS::SQS::Queue",
-      "path": "VisibilityTimeout",
-      "actual": 30,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "DeduplicationScope",
+      "actual": "queue",
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
+      "constructPath": "CdkrdIntegHarvest2/JobsDlq"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "JobsDlqB53173A1",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest2-JobsDlqB53173A1-BEgYQfzn3hUc.fifo",
       "constructPath": "CdkrdIntegHarvest2/JobsDlq"
     }

--- a/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
+++ b/tests/corpus/AWS__SQS__Queue.Main54E5BC70.json
@@ -68,26 +68,8 @@
       "tier": "atDefault",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
-      "constructPath": "CdkRealDriftIntegSqs/Main"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Main54E5BC70",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
-      "constructPath": "CdkRealDriftIntegSqs/Main"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "Main54E5BC70",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
       "constructPath": "CdkRealDriftIntegSqs/Main"
     },
@@ -104,8 +86,26 @@
       "tier": "atDefault",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
+      "constructPath": "CdkRealDriftIntegSqs/Main"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Main54E5BC70",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegSqs-Main54E5BC70-YkLGtyHzwGys",
       "constructPath": "CdkRealDriftIntegSqs/Main"
     }

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.drifted.json
@@ -51,26 +51,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
@@ -87,8 +69,26 @@
       "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     }

--- a/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
+++ b/tests/corpus/AWS__SQS__Queue.MatrixQueueEEAE6F08.json
@@ -41,26 +41,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
-      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "MatrixQueueEEAE6F08",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     },
@@ -77,8 +59,26 @@
       "tier": "atDefault",
       "logicalId": "MatrixQueueEEAE6F08",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
+      "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "MatrixQueueEEAE6F08",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest3-MatrixQueueEEAE6F08-Df0ZjowYewgM",
       "constructPath": "CdkrdIntegHarvest3/MatrixQueue"
     }

--- a/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeDstD49C8EAB.json
@@ -38,35 +38,8 @@
       "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
-      "constructPath": "CdkrdIntegHarvest6/PipeDst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeDstD49C8EAB",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
-      "constructPath": "CdkrdIntegHarvest6/PipeDst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "PipeDstD49C8EAB",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
-      "constructPath": "CdkrdIntegHarvest6/PipeDst"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "PipeDstD49C8EAB",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
@@ -83,8 +56,26 @@
       "tier": "atDefault",
       "logicalId": "PipeDstD49C8EAB",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     },
@@ -94,6 +85,15 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",
       "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
+      "constructPath": "CdkrdIntegHarvest6/PipeDst"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "PipeDstD49C8EAB",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeDstD49C8EAB-UUESETBv6IoT",
       "constructPath": "CdkrdIntegHarvest6/PipeDst"
     }

--- a/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
+++ b/tests/corpus/AWS__SQS__Queue.PipeSrc0E082391.json
@@ -38,35 +38,8 @@
       "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
-      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PipeSrc0E082391",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
-      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "PipeSrc0E082391",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
-      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "PipeSrc0E082391",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
@@ -83,8 +56,26 @@
       "tier": "atDefault",
       "logicalId": "PipeSrc0E082391",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     },
@@ -94,6 +85,15 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",
       "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
+      "constructPath": "CdkrdIntegHarvest6/PipeSrc"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "PipeSrc0E082391",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkrdIntegHarvest6-PipeSrc0E082391-2hmrNLVPmm0V",
       "constructPath": "CdkrdIntegHarvest6/PipeSrc"
     }

--- a/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
+++ b/tests/corpus/AWS__SQS__Queue.Target3191CF44.json
@@ -37,35 +37,8 @@
       "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
-      "path": "DelaySeconds",
-      "actual": 0,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
-      "constructPath": "CdkRealDriftIntegEvents/Target"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Target3191CF44",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MaximumMessageSize",
-      "actual": 1048576,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
-      "constructPath": "CdkRealDriftIntegEvents/Target"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Target3191CF44",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "MessageRetentionPeriod",
-      "actual": 345600,
-      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
-      "constructPath": "CdkRealDriftIntegEvents/Target"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "Target3191CF44",
-      "resourceType": "AWS::SQS::Queue",
-      "path": "QueueName",
-      "actual": "CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "path": "SqsManagedSseEnabled",
+      "actual": true,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
@@ -82,8 +55,26 @@
       "tier": "atDefault",
       "logicalId": "Target3191CF44",
       "resourceType": "AWS::SQS::Queue",
-      "path": "SqsManagedSseEnabled",
-      "actual": true,
+      "path": "DelaySeconds",
+      "actual": 0,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MessageRetentionPeriod",
+      "actual": 345600,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "MaximumMessageSize",
+      "actual": 1048576,
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "constructPath": "CdkRealDriftIntegEvents/Target"
     },
@@ -93,6 +84,15 @@
       "resourceType": "AWS::SQS::Queue",
       "path": "VisibilityTimeout",
       "actual": 30,
+      "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
+      "constructPath": "CdkRealDriftIntegEvents/Target"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Target3191CF44",
+      "resourceType": "AWS::SQS::Queue",
+      "path": "QueueName",
+      "actual": "CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "physicalId": "https://sqs.us-east-1.amazonaws.com/111111111111/CdkRealDriftIntegEvents-Target3191CF44-1f6RO2SlTsMe",
       "constructPath": "CdkRealDriftIntegEvents/Target"
     }

--- a/tests/integration/appconfig-deployment-readgap/app.ts
+++ b/tests/integration/appconfig-deployment-readgap/app.ts
@@ -1,0 +1,52 @@
+// AppConfig stack exercising the 3-segment COMPOSITE-identifier types not yet covered:
+// AWS::AppConfig::HostedConfigurationVersion ([ApplicationId, ConfigurationProfileId,
+// VersionNumber]) and AWS::AppConfig::Deployment ([ApplicationId, EnvironmentId,
+// DeploymentNumber]). Like the PR #346 probe, this confirms whether their declared CC
+// read works with the bare CFn physical id or is a ValidationException read-gap needing
+// a CC_IDENTIFIER_ADAPTERS entry. AppConfig has no infra (cheap). A clean record->check
+// is also the FP oracle.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnConfigurationProfile,
+  CfnDeployment,
+  CfnDeploymentStrategy,
+  CfnEnvironment,
+  CfnHostedConfigurationVersion,
+} from "aws-cdk-lib/aws-appconfig";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAppconfigDeploymentReadgap");
+
+const application = new CfnApplication(stack, "Cfg", { name: "cdkrd-readgap-app" });
+const env = new CfnEnvironment(stack, "CfgEnv", {
+  applicationId: application.ref,
+  name: "prod",
+});
+const profile = new CfnConfigurationProfile(stack, "CfgProfile", {
+  applicationId: application.ref,
+  name: "flags",
+  locationUri: "hosted",
+});
+const version = new CfnHostedConfigurationVersion(stack, "CfgVersion", {
+  applicationId: application.ref,
+  configurationProfileId: profile.ref,
+  contentType: "application/json",
+  content: JSON.stringify({ feature: { enabled: true } }),
+});
+const strategy = new CfnDeploymentStrategy(stack, "CfgStrategy", {
+  name: "cdkrd-fast",
+  deploymentDurationInMinutes: 0,
+  growthFactor: 100,
+  replicateTo: "NONE",
+  finalBakeTimeInMinutes: 0,
+});
+new CfnDeployment(stack, "CfgDeployment", {
+  applicationId: application.ref,
+  environmentId: env.ref,
+  configurationProfileId: profile.ref,
+  configurationVersion: version.ref,
+  deploymentStrategyId: strategy.ref,
+});
+
+app.synth();

--- a/tests/integration/appconfig-deployment-readgap/cdk.json
+++ b/tests/integration/appconfig-deployment-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/appconfig-deployment-readgap/package.json
+++ b/tests/integration/appconfig-deployment-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-appconfig-deployment-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift appconfig-deployment-readgap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/appconfig-deployment-readgap/verify.sh
+++ b/tests/integration/appconfig-deployment-readgap/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# FP oracle + read-gap regression: deploy -> record -> check MUST be CLEAN, and the
+# 3-segment composite-id types (HostedConfigurationVersion, Deployment) must be READ
+# (not CC-skipped).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAppconfigDeploymentReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "=== composite types MUST be READ (not skipped) ==="
+$CLI check "$STACK" --region "$REGION" --verbose 2>&1 | grep -qE "Skipped.*(HostedConfigurationVersion|Deployment)" \
+  && fail "a 3-segment composite type is still skipped (read-gap)" || echo "(no composite skip — read-gap closed)"
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -10,6 +10,7 @@ import {
   isTrivialEmpty,
   isVersionPrefixMatch,
   KNOWN_DEFAULTS,
+  KNOWN_DEFAULT_PATHS,
   stripAwsTagsDeep,
   VERSION_PREFIX_PATHS,
   isTrailingDotEqual,
@@ -387,6 +388,25 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULTS['AWS::AppSync::GraphQLApi'].ResolverCountLimit).toBe(0);
     expect(KNOWN_DEFAULTS['AWS::Logs::SubscriptionFilter']).toEqual({
       Distribution: 'ByLogStream',
+    });
+  });
+
+  it('first-run-noise folds from the measure-noise sweep (PR follow-up) — common-type constant defaults', () => {
+    // Each value was OBSERVED unanimous across the golden corpus and is a genuine
+    // constant service default; equality-gated, so a non-default value still surfaces.
+    expect(KNOWN_DEFAULTS['AWS::SQS::Queue'].MaximumMessageSize).toBe(1048576);
+    expect(KNOWN_DEFAULTS['AWS::Cognito::UserPoolClient'].RefreshTokenValidity).toBe(30);
+    expect(KNOWN_DEFAULTS['AWS::ECS::Service'].HealthCheckGracePeriodSeconds).toBe(0);
+    expect(KNOWN_DEFAULT_PATHS['AWS::ECS::Service']).toEqual({
+      'DeploymentConfiguration.Strategy': 'ROLLING',
+      'DeploymentConfiguration.BakeTimeInMinutes': 0,
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::OpenSearchService::Domain']).toEqual({
+      'EBSOptions.Iops': 3000,
+      'EBSOptions.Throughput': 125,
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::KinesisFirehose::DeliveryStream']).toEqual({
+      'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',
     });
   });
 

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -429,6 +429,51 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('env1');
   });
 
+  it('AppConfig HostedConfigurationVersion: builds the ApplicationId|ConfigurationProfileId|VersionNumber 3-seg composite', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::AppConfig::HostedConfigurationVersion',
+        physicalId: '1',
+        declared: { ApplicationId: 'app99', ConfigurationProfileId: 'prof7' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('app99|prof7|1');
+  });
+
+  it('AppConfig Deployment: builds the ApplicationId|EnvironmentId|DeploymentNumber 3-seg composite', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::AppConfig::Deployment',
+        physicalId: '1',
+        declared: { ApplicationId: 'app99', EnvironmentId: 'env5' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('app99|env5|1');
+  });
+
+  it('AppConfig 3-seg composites: an unresolved parent falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    for (const t of ['AWS::AppConfig::HostedConfigurationVersion', 'AWS::AppConfig::Deployment']) {
+      cc.reset();
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({ resourceType: t, physicalId: '1', declared: { ApplicationId: 'app99' } }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('1');
+    }
+  });
+
   // R79: ApplicationAutoScaling ScalingPolicy [Arn, ScalableDimension] — the
   // dimension is parsed from the resolved ScalingTargetId (the ScalableTarget
   // physical id `resourceId|scalableDimension|serviceNamespace`).


### PR DESCRIPTION
## What

Two follow-ups from the bug-hunt session, in one PR.

### 1. Read-gap fix (bug)
`AWS::AppConfig::HostedConfigurationVersion` `[ApplicationId, ConfigurationProfileId, VersionNumber]` and `AWS::AppConfig::Deployment` `[ApplicationId, EnvironmentId, DeploymentNumber]` have **3-segment composite** Cloud Control primaryIdentifiers, but their CFn physical id is only the last segment. So a declared version/deployment was a CC `ValidationException` skip on every `check` (read-gap) — undeclared drift on it invisible.

Fix: `CC_IDENTIFIER_ADAPTERS` entries that prepend both parents from the resolved declared Refs, in primaryIdentifier order. **Verified live** (`appconfig-deployment-readgap` fixture): the bare id skips; `ApplicationId|ConfigurationProfileId|VersionNumber` and `ApplicationId|EnvironmentId|DeploymentNumber` read. (This extends the Logs SubscriptionFilter composite-id class from PR #344 to 3 segments — found via the `primaryIdentifier`-arity probe added to the hunt-bugs skill in #346.)

### 2. First-run noise (feat)
Fold constant service defaults the `measure-noise` sweep surfaced (unanimous across the golden corpus, equality-gated) to `atDefault`:
- `KNOWN_DEFAULTS`: SQS `MaximumMessageSize=1048576`, Cognito UserPoolClient `RefreshTokenValidity=30`, ECS Service `HealthCheckGracePeriodSeconds=0`
- `KNOWN_DEFAULT_PATHS`: ECS Service `DeploymentConfiguration.Strategy=ROLLING` / `BakeTimeInMinutes=0`, OpenSearch `EBSOptions.Iops=3000` / `Throughput=125`, Firehose `ExtendedS3DestinationConfiguration.S3BackupMode=Disabled`

(measure-noise also flagged engine-dependent RDS values and a *declared* Lambda `ReservedConcurrentExecutions` — deliberately NOT folded; only universal constants on common types.)

## Tests
- `router.test.ts`: 2 AppConfig 3-seg composite cases + unresolved-parent fallback.
- 2 new corpus types (HostedConfigurationVersion, Deployment); 20 existing corpus cases' `expected` updated for the new folds.
- `noise-and-strip.test.ts`: the new defaults.
- 1547 unit tests green; typecheck + build + `vp run check` clean.
- **verify-pr**: all 7 core integration fixtures + the appconfig fixture `INTEG PASS`; sweep CLEAN.

## Cleanup
The appconfig stack + all integ stacks deleted via `delstack`; `bughunt-track.sh verify` + sweep → GONE + SWEEP CLEAN.
