### PR TITLE
test(integ): bug-hunt 3 new common types — ENI/DBProxy/CacheCluster (0 FP) + first-run-noise folds

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -252,6 +252,31 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ActionAfterCompletion: 'NONE',
     ScheduleExpressionTimezone: 'UTC',
   },
+  // R-noise-sweep (found by the eni-rich / dbproxy-rich / elasticache-cachecluster-rich
+  // hunt): constant, documented service defaults a fresh resource reports as undeclared
+  // on every first run. Resource-/AZ-/window-specific values the same read returns
+  // (ENI PrivateIpAddress(es), CacheCluster Snapshot/MaintenanceWindow,
+  // PreferredAvailabilityZones, CacheParameterGroupName which is engine-version-derived)
+  // are deliberately NOT listed — they are genuine undeclared inventory. Equality-gated:
+  // flip any out of band and it no longer matches, so it re-surfaces as real drift.
+  'AWS::EC2::NetworkInterface': {
+    InterfaceType: 'interface',
+    Ipv4PrefixCount: 0,
+    Ipv6PrefixCount: 0,
+    SecondaryPrivateIpAddressCount: 0,
+  },
+  'AWS::ElastiCache::CacheCluster': {
+    NetworkType: 'ipv4',
+    IpDiscovery: 'ipv4',
+    AZMode: 'single-az',
+    AutoMinorVersionUpgrade: true,
+    SnapshotRetentionLimit: 0,
+  },
+  'AWS::RDS::DBProxy': {
+    TargetConnectionNetworkType: 'IPV4',
+    DefaultAuthScheme: 'NONE',
+    EndpointNetworkType: 'IPV4',
+  },
 };
 
 // R108: nested service defaults — the NESTED-path twin of KNOWN_DEFAULTS. The

--- a/tests/corpus/AWS__EC2__NetworkInterface.Eni.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.Eni.json
@@ -1,0 +1,174 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Eni",
+    "resourceType": "AWS::EC2::NetworkInterface",
+    "physicalId": "eni-0876958cf7bca8260",
+    "constructPath": "CdkRealDriftIntegEniRich/Eni",
+    "declared": {
+      "Description": "cdkrd integ network interface",
+      "GroupSet": ["sg-04edb521947dc791b", "sg-053370bc4f29a55b7"],
+      "SourceDestCheck": true,
+      "SubnetId": "subnet-0dc6ca852066400bd",
+      "Tags": [
+        {
+          "Key": "purpose",
+          "Value": "cdkrd-integ"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd integ network interface",
+    "PrivateIpAddress": "10.0.0.221",
+    "PrimaryIpv6Address": "",
+    "PrivateIpAddresses": [
+      {
+        "PrivateIpAddress": "10.0.0.221",
+        "Primary": true
+      }
+    ],
+    "SecondaryPrivateIpAddressCount": 0,
+    "Ipv6PrefixCount": 0,
+    "PrimaryPrivateIpAddress": "10.0.0.221",
+    "Ipv4Prefixes": [],
+    "Ipv4PrefixCount": 0,
+    "GroupSet": ["sg-04edb521947dc791b", "sg-053370bc4f29a55b7"],
+    "Ipv6Prefixes": [],
+    "SubnetId": "subnet-0dc6ca852066400bd",
+    "SourceDestCheck": true,
+    "InterfaceType": "interface",
+    "SecondaryPrivateIpAddresses": [],
+    "VpcId": "vpc-0d6e70aeb7c6b7082",
+    "Id": "eni-0876958cf7bca8260",
+    "Tags": [
+      {
+        "Value": "cdkrd-integ",
+        "Key": "purpose"
+      },
+      {
+        "Value": "Eni",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEniRich/87806a40-6ed7-11f1-9cb2-12e9463d843d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEniRich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "PublicIpDnsNameOptions": {
+      "DnsHostnameType": "",
+      "PublicIpv4DnsName": "",
+      "PublicDualStackDnsName": "",
+      "PublicIpv6DnsName": ""
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnly": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnly": [
+      "ConnectionTrackingSpecification",
+      "EnablePrimaryIpv6",
+      "InterfaceType",
+      "PrivateIpAddress",
+      "PrivateIpAddresses",
+      "SubnetId"
+    ],
+    "readOnlyPaths": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnlyPaths": [
+      "ConnectionTrackingSpecification",
+      "EnablePrimaryIpv6",
+      "InterfaceType",
+      "PrivateIpAddress",
+      "PrivateIpAddresses",
+      "SubnetId"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.221",
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddresses",
+      "actual": [
+        {
+          "PrivateIpAddress": "10.0.0.221",
+          "Primary": true
+        }
+      ],
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SecondaryPrivateIpAddressCount",
+      "actual": 0,
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
@@ -1,0 +1,184 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cache",
+    "resourceType": "AWS::ElastiCache::CacheCluster",
+    "physicalId": "cdk-ca-vpzewz5xmqaf",
+    "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache",
+    "declared": {
+      "CacheNodeType": "cache.t3.micro",
+      "CacheSubnetGroupName": "cdkrealdriftintegelasticachecacheclusterrich-subnetgroup-uwqxjwtvpyts",
+      "Engine": "redis",
+      "EngineVersion": "7.1",
+      "NumCacheNodes": 1,
+      "Port": 6379,
+      "VpcSecurityGroupIds": ["sg-0489652fb7df45d10"]
+    }
+  },
+  "liveRaw": {
+    "EngineVersion": "7.1",
+    "CacheSubnetGroupName": "cdkrealdriftintegelasticachecacheclusterrich-subnetgroup-uwqxjwtvpyts",
+    "Port": 6379,
+    "CacheParameterGroupName": "default.redis7",
+    "PreferredMaintenanceWindow": "sat:03:00-sat:04:00",
+    "AutoMinorVersionUpgrade": true,
+    "NumCacheNodes": 1,
+    "ConfigurationEndpoint": {
+      "Address": "",
+      "Port": ""
+    },
+    "SnapshotWindow": "07:30-08:30",
+    "CacheNodeType": "cache.t3.micro",
+    "SnapshotRetentionLimit": 0,
+    "RedisEndpoint": {
+      "Address": "cdk-ca-vpzewz5xmqaf.jzgy0l.0001.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "TransitEncryptionEnabled": false,
+    "PreferredAvailabilityZones": ["us-east-1a"],
+    "VpcSecurityGroupIds": ["sg-0489652fb7df45d10"],
+    "NetworkType": "ipv4",
+    "IpDiscovery": "ipv4",
+    "ClusterName": "cdk-ca-vpzewz5xmqaf",
+    "LogDeliveryConfigurations": [],
+    "Engine": "redis",
+    "Tags": [],
+    "AZMode": "single-az"
+  },
+  "schema": {
+    "readOnly": ["ConfigurationEndpoint", "RedisEndpoint"],
+    "writeOnly": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZone",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnly": [
+      "CacheSubnetGroupName",
+      "ClusterName",
+      "Engine",
+      "IpDiscovery",
+      "NetworkType",
+      "Port",
+      "PreferredAvailabilityZones",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "readOnlyPaths": [
+      "ConfigurationEndpoint",
+      "ConfigurationEndpoint.Address",
+      "ConfigurationEndpoint.Port",
+      "RedisEndpoint",
+      "RedisEndpoint.Address",
+      "RedisEndpoint.Port"
+    ],
+    "writeOnlyPaths": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZone",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "CacheSubnetGroupName",
+      "ClusterName",
+      "Engine",
+      "IpDiscovery",
+      "NetworkType",
+      "Port",
+      "PreferredAvailabilityZones",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "CacheParameterGroupName",
+      "actual": "default.redis7",
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "sat:03:00-sat:04:00",
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "SnapshotWindow",
+      "actual": "07:30-08:30",
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "SnapshotRetentionLimit",
+      "actual": 0,
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "PreferredAvailabilityZones",
+      "actual": ["us-east-1a"],
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "AZMode",
+      "actual": "single-az",
+      "physicalId": "cdk-ca-vpzewz5xmqaf",
+      "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBProxy.Proxy.json
+++ b/tests/corpus/AWS__RDS__DBProxy.Proxy.json
@@ -1,0 +1,121 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Proxy",
+    "resourceType": "AWS::RDS::DBProxy",
+    "physicalId": "cdkrd-integ-proxy",
+    "constructPath": "CdkRealDriftIntegDbproxyRich/Proxy",
+    "declared": {
+      "Auth": [
+        {
+          "AuthScheme": "SECRETS",
+          "IAMAuth": "DISABLED",
+          "SecretArn": "arn:aws:secretsmanager:us-east-1:111111111111:secret:DbSecret685A0FA5-5MzrpuuXXhEx-6e1Syj"
+        }
+      ],
+      "DBProxyName": "cdkrd-integ-proxy",
+      "DebugLogging": false,
+      "EngineFamily": "POSTGRESQL",
+      "IdleClientTimeout": 1800,
+      "RequireTLS": true,
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegDbproxyRich-ProxyRoleEB89BDF8-n1xVN4CQtcPC",
+      "VpcSecurityGroupIds": ["sg-0fbee10ed0f2fee43"],
+      "VpcSubnetIds": ["subnet-0459bc20c028fa2ba", "subnet-05d9a303dfd4ee2cc"]
+    }
+  },
+  "liveRaw": {
+    "DBProxyArn": "arn:aws:rds:us-east-1:111111111111:db-proxy:prx-06da2a15ab99f91c5",
+    "DBProxyName": "cdkrd-integ-proxy",
+    "DebugLogging": false,
+    "VpcSubnetIds": ["subnet-05d9a303dfd4ee2cc", "subnet-0459bc20c028fa2ba"],
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegDbproxyRich-ProxyRoleEB89BDF8-n1xVN4CQtcPC",
+    "RequireTLS": true,
+    "Endpoint": "cdkrd-integ-proxy.proxy-caxxotukouxo.us-east-1.rds.amazonaws.com",
+    "VpcId": "vpc-02510b0a02ea6d4d2",
+    "IdleClientTimeout": 1800,
+    "TargetConnectionNetworkType": "IPV4",
+    "DefaultAuthScheme": "NONE",
+    "VpcSecurityGroupIds": ["sg-0fbee10ed0f2fee43"],
+    "Auth": [
+      {
+        "SecretArn": "arn:aws:secretsmanager:us-east-1:111111111111:secret:DbSecret685A0FA5-5MzrpuuXXhEx-6e1Syj",
+        "IAMAuth": "DISABLED",
+        "ClientPasswordAuthType": "POSTGRES_SCRAM_SHA_256",
+        "AuthScheme": "SECRETS"
+      }
+    ],
+    "EngineFamily": "POSTGRESQL",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegDbproxyRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Proxy",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegDbproxyRich/88807520-6ed7-11f1-bb8c-0affea89e2cd",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "EndpointNetworkType": "IPV4"
+  },
+  "schema": {
+    "readOnly": ["DBProxyArn", "Endpoint", "VpcId"],
+    "writeOnly": [],
+    "createOnly": [
+      "DBProxyName",
+      "EndpointNetworkType",
+      "EngineFamily",
+      "TargetConnectionNetworkType",
+      "VpcSubnetIds"
+    ],
+    "readOnlyPaths": ["DBProxyArn", "Endpoint", "VpcId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DBProxyName",
+      "EndpointNetworkType",
+      "EngineFamily",
+      "TargetConnectionNetworkType",
+      "VpcSubnetIds"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Proxy",
+      "resourceType": "AWS::RDS::DBProxy",
+      "path": "TargetConnectionNetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrd-integ-proxy",
+      "constructPath": "CdkRealDriftIntegDbproxyRich/Proxy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Proxy",
+      "resourceType": "AWS::RDS::DBProxy",
+      "path": "DefaultAuthScheme",
+      "actual": "NONE",
+      "physicalId": "cdkrd-integ-proxy",
+      "constructPath": "CdkRealDriftIntegDbproxyRich/Proxy"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Proxy",
+      "resourceType": "AWS::RDS::DBProxy",
+      "path": "EndpointNetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrd-integ-proxy",
+      "constructPath": "CdkRealDriftIntegDbproxyRich/Proxy"
+    }
+  ]
+}

--- a/tests/integration/dbproxy-rich/app.ts
+++ b/tests/integration/dbproxy-rich/app.ts
@@ -1,0 +1,54 @@
+// CDK app for the cdk-real-drift dbproxy-rich integration test.
+// AWS::RDS::DBProxy is the standard connection-pooling front door for any
+// serverless-on-RDS / Aurora + Lambda workload, deployed daily, with NO golden-
+// corpus coverage yet (the RDS family covers DBCluster/DBInstance/param groups but
+// not the proxy). It is FULLY_MUTABLE with a single-segment CC primaryIdentifier
+// (DBProxyName), so it reads cleanly. A freshly recorded proxy MUST check CLEAN
+// (the false-positive half — Auth[] is an object array, EngineFamily a case-enum),
+// and `IdleClientTimeout` is a declared MUTABLE scalar (the false-negative target).
+// The proxy needs a secret + an assume-role + >=2 subnets in different AZs; no DB
+// instance/target is required, so the deploy is moderate (no stateful provisioning).
+import { App, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnDBProxy } from "aws-cdk-lib/aws-rds";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegDbproxyRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  natGateways: 0,
+  maxAzs: 2,
+  subnetConfiguration: [{ name: "pub", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc });
+
+const secret = new Secret(stack, "DbSecret", {
+  generateSecretString: {
+    secretStringTemplate: JSON.stringify({ username: "admin" }),
+    generateStringKey: "password",
+    excludePunctuation: true,
+  },
+});
+
+const role = new Role(stack, "ProxyRole", {
+  assumedBy: new ServicePrincipal("rds.amazonaws.com"),
+});
+secret.grantRead(role);
+
+new CfnDBProxy(stack, "Proxy", {
+  dbProxyName: "cdkrd-integ-proxy",
+  engineFamily: "POSTGRESQL",
+  auth: [{ authScheme: "SECRETS", secretArn: secret.secretArn, iamAuth: "DISABLED" }],
+  roleArn: role.roleArn,
+  vpcSubnetIds: vpc.publicSubnets.map((s) => s.subnetId),
+  vpcSecurityGroupIds: [sg.securityGroupId],
+  requireTls: true,
+  // Declared MUTABLE scalar — the false-negative target (change out of band).
+  idleClientTimeout: 1800,
+  debugLogging: false,
+});
+
+app.synth();

--- a/tests/integration/dbproxy-rich/cdk.json
+++ b/tests/integration/dbproxy-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dbproxy-rich/package.json
+++ b/tests/integration/dbproxy-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dbproxy-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift dbproxy-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dbproxy-rich/verify.sh
+++ b/tests/integration/dbproxy-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any declared drift on a clean recorded stack is a normalization
+# false positive (see app.ts for the per-type probe rationale).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDbproxyRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elasticache-cachecluster-rich/app.ts
+++ b/tests/integration/elasticache-cachecluster-rich/app.ts
@@ -1,0 +1,43 @@
+// CDK app for the cdk-real-drift elasticache-cachecluster-rich integration test.
+// AWS::ElastiCache::CacheCluster is the everyday single-node Redis/Memcached cache
+// primitive. The ElastiCache family covers ReplicationGroup / ServerlessCache /
+// ParameterGroup / SubnetGroup but NOT CacheCluster — a direct coverage gap. It is
+// FULLY_MUTABLE with a single-segment CC primaryIdentifier (ClusterName), so it
+// reads cleanly. Its `EngineVersion` is declared as a partial track (`"7.1"`) that
+// the service may resolve to a concrete patch (`"7.1.0"`) — a partial->concrete
+// VERSION_PREFIX false-positive probe (RDS/Aurora/Neptune already fold this; whether
+// ElastiCache needs the same fold is the open question). A freshly recorded cluster
+// MUST check CLEAN. A single cache.t3.micro Redis node on an isolated VPC is cheap.
+import { App, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnCacheCluster, CfnSubnetGroup } from "aws-cdk-lib/aws-elasticache";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElasticacheCacheclusterRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  natGateways: 0,
+  maxAzs: 2,
+  subnetConfiguration: [{ name: "priv", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc });
+
+const subnetGroup = new CfnSubnetGroup(stack, "SubnetGroup", {
+  description: "cdkrd integ cache subnet group",
+  subnetIds: vpc.isolatedSubnets.map((s) => s.subnetId),
+});
+
+const cluster = new CfnCacheCluster(stack, "Cache", {
+  engine: "redis",
+  cacheNodeType: "cache.t3.micro",
+  numCacheNodes: 1,
+  // Partial version track — the VERSION_PREFIX false-positive probe.
+  engineVersion: "7.1",
+  cacheSubnetGroupName: subnetGroup.ref,
+  vpcSecurityGroupIds: [sg.securityGroupId],
+  port: 6379,
+});
+cluster.addDependency(subnetGroup);
+
+app.synth();

--- a/tests/integration/elasticache-cachecluster-rich/cdk.json
+++ b/tests/integration/elasticache-cachecluster-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elasticache-cachecluster-rich/package.json
+++ b/tests/integration/elasticache-cachecluster-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elasticache-cachecluster-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elasticache-cachecluster-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elasticache-cachecluster-rich/verify.sh
+++ b/tests/integration/elasticache-cachecluster-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any declared drift on a clean recorded stack is a normalization
+# false positive (see app.ts for the per-type probe rationale).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElasticacheCacheclusterRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/eni-rich/app.ts
+++ b/tests/integration/eni-rich/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift eni-rich integration test.
+// AWS::EC2::NetworkInterface is a common building block in advanced VPC setups
+// (fixed-IP appliances, multi-NIC instances, PrivateLink endpoints) and has NO
+// golden-corpus coverage yet. It is FULLY_MUTABLE and Cloud Control read/update-
+// capable, so it serves both halves: a freshly recorded ENI MUST check CLEAN (the
+// false-positive half — GroupSet is a sg-id set AWS may reorder, Tags carry
+// aws:* noise), and `SourceDestCheck` is a declared MUTABLE boolean a console edit
+// can flip — the false-negative half (verify-detect.sh). A single ENI on a tiny
+// no-NAT VPC is cheap and fast.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnNetworkInterface, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEniRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  natGateways: 0,
+  maxAzs: 1,
+  subnetConfiguration: [{ name: "pub", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const sg1 = new SecurityGroup(stack, "Sg1", { vpc, allowAllOutbound: true });
+const sg2 = new SecurityGroup(stack, "Sg2", { vpc, allowAllOutbound: true });
+
+new CfnNetworkInterface(stack, "Eni", {
+  subnetId: vpc.publicSubnets[0]!.subnetId,
+  description: "cdkrd integ network interface",
+  // Two security groups (sg-… ids) — a set AWS may echo in its own order; cdkrd
+  // sorts id-shaped scalar arrays generically, so this must not false-drift.
+  groupSet: [sg1.securityGroupId, sg2.securityGroupId],
+  // A declared MUTABLE boolean — the false-negative target (flip out of band).
+  sourceDestCheck: true,
+  tags: [{ key: "purpose", value: "cdkrd-integ" }],
+});
+
+app.synth();

--- a/tests/integration/eni-rich/cdk.json
+++ b/tests/integration/eni-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eni-rich/package.json
+++ b/tests/integration/eni-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eni-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eni-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eni-rich/verify-detect.sh
+++ b/tests/integration/eni-rich/verify-detect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ENI detect + revert integration test (real AWS): the false-NEGATIVE half. Deploy ->
+# record -> flip the DECLARED MUTABLE SourceDestCheck out of band (console-edit
+# scenario via modify-network-interface-attribute) -> check MUST DETECT the declared
+# drift (exit 1) -> revert -> check MUST be CLEAN and the live SourceDestCheck MUST be
+# restored to true.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEniRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ENI="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::EC2::NetworkInterface'].PhysicalResourceId" --output text)"
+[ -n "$ENI" ] || fail "could not resolve network interface id"
+echo "eni=$ENI"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: disable SourceDestCheck (console-edit) ==="
+aws ec2 modify-network-interface-attribute --network-interface-id "$ENI" \
+  --no-source-dest-check --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-eni-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "SourceDestCheck" /tmp/cdkrd-eni-detect.out || fail "SourceDestCheck not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live SourceDestCheck MUST be restored to true ==="
+GOT="$(aws ec2 describe-network-interfaces --network-interface-ids "$ENI" --region "$REGION" \
+  --query "NetworkInterfaces[0].SourceDestCheck" --output text)"
+[ "$GOT" = "True" ] || fail "live SourceDestCheck not restored (got: [$GOT], want: True)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/eni-rich/verify.sh
+++ b/tests/integration/eni-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. An EC2 NetworkInterface carries a sg-id set (GroupSet) AWS may
+# echo reordered and aws:* tags — any declared drift on a clean recorded stack is a
+# normalization false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEniRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -391,6 +391,34 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('ENI / DBProxy / CacheCluster known defaults present (bug-hunt: eni-rich / dbproxy-rich / elasticache-cachecluster-rich)', () => {
+    // Constant, documented service defaults a fresh resource reports as first-run
+    // undeclared inventory; equality-gated, so a value set away from the default still
+    // surfaces. Exercised by the AWS__EC2__NetworkInterface / AWS__RDS__DBProxy /
+    // AWS__ElastiCache__CacheCluster corpus cases. Resource-/AZ-/window-specific live
+    // values (ENI PrivateIpAddress(es), CacheCluster Snapshot/MaintenanceWindow,
+    // PreferredAvailabilityZones, the engine-version-derived CacheParameterGroupName)
+    // are deliberately NOT folded — they are genuine undeclared inventory.
+    expect(KNOWN_DEFAULTS['AWS::EC2::NetworkInterface']).toEqual({
+      InterfaceType: 'interface',
+      Ipv4PrefixCount: 0,
+      Ipv6PrefixCount: 0,
+      SecondaryPrivateIpAddressCount: 0,
+    });
+    expect(KNOWN_DEFAULTS['AWS::ElastiCache::CacheCluster']).toEqual({
+      NetworkType: 'ipv4',
+      IpDiscovery: 'ipv4',
+      AZMode: 'single-az',
+      AutoMinorVersionUpgrade: true,
+      SnapshotRetentionLimit: 0,
+    });
+    expect(KNOWN_DEFAULTS['AWS::RDS::DBProxy']).toEqual({
+      TargetConnectionNetworkType: 'IPV4',
+      DefaultAuthScheme: 'NONE',
+      EndpointNetworkType: 'IPV4',
+    });
+  });
+
   it('first-run-noise folds from the measure-noise sweep (PR follow-up) — common-type constant defaults', () => {
     // Each value was OBSERVED unanimous across the golden corpus and is a genuine
     // constant service default; equality-gated, so a non-default value still surfaces.


### PR DESCRIPTION
## Summary

A clean bug-hunt round on three uncovered, high-frequency, Cloud-Control-readable + FULLY_MUTABLE types — **zero false positives** — plus an offline audit that ruled out two predicted FP classes before any paid deploy.

### New types hunted (all clean record→check)

| Type | Fixture | Result |
| --- | --- | --- |
| `AWS::EC2::NetworkInterface` | `eni-rich` | 0 FP; **FN proven**: out-of-band `SourceDestCheck` flip → detected (exit 1) → revert → CLEAN → live restored |
| `AWS::RDS::DBProxy` | `dbproxy-rich` | 0 FP; `Auth[]` live-adds `ClientPasswordAuthType` default yet stays clean (declared⊆live nested subset) |
| `AWS::ElastiCache::CacheCluster` | `elasticache-cachecluster-rich` | 0 FP; `EngineVersion "7.1"` echoed **verbatim** by CC (not `7.1.0`) → no VERSION_PREFIX fold needed |

### Ruled out offline (no deploy)
- **WAFv2 `GeoMatchStatement.CountryCodes`** — existing `wafv2-webacl-rich` corpus already proves AWS reads it back in exact declared order (`["US","CA","GB"]` verbatim); the set-reorder FP class does not apply.
- **Lambda/ECS VpcConfig subnet/SG sets** — already handled by the generic id/ARN sort (`canonicalizeIdArraysDeep`), not a gap.

### First-run-noise folds
`measure-noise.sh` over the freshly harvested corpus surfaced the genuine **constant** service defaults each fresh resource reports as undeclared inventory. Folded into `KNOWN_DEFAULTS` (equality-gated — a non-default value still surfaces). Shrinks first-run `[Not Recorded]`: ENI 10→6, DBProxy 9→6, CacheCluster 12→7.

### Deliverables
- 3 new golden-corpus cases (the permanent **offline** regression asset).
- 3 committed regression fixtures (`verify.sh` clean-FP; `eni-rich/verify-detect.sh` for detect→revert).
- `KNOWN_DEFAULTS` fold unit test. **1551 unit tests pass.**

### Cleanup
All 3 stacks deleted via `delstack`; `bughunt-track.sh verify` → every stack GONE + `sweep-orphans.sh` SWEEP CLEAN; sentinel cleared.