### PR TITLE
test(integ): rule out 3 set-reorder FP classes — ENI multi-IP / EventBridge EventPattern / SNS FilterPolicy

### DIFF
--- a/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
@@ -1,0 +1,196 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Eni",
+    "resourceType": "AWS::EC2::NetworkInterface",
+    "physicalId": "eni-01ce38782d866c24f",
+    "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni",
+    "declared": {
+      "Description": "cdkrd integ multi-ip network interface",
+      "PrivateIpAddresses": [
+        {
+          "Primary": true,
+          "PrivateIpAddress": "10.0.0.10"
+        },
+        {
+          "Primary": false,
+          "PrivateIpAddress": "10.0.0.200"
+        },
+        {
+          "Primary": false,
+          "PrivateIpAddress": "10.0.0.50"
+        },
+        {
+          "Primary": false,
+          "PrivateIpAddress": "10.0.0.150"
+        }
+      ],
+      "SubnetId": "subnet-08cb471bab414eb4c"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd integ multi-ip network interface",
+    "PrivateIpAddress": "10.0.0.10",
+    "PrimaryIpv6Address": "",
+    "PrivateIpAddresses": [
+      {
+        "PrivateIpAddress": "10.0.0.10",
+        "Primary": true
+      },
+      {
+        "PrivateIpAddress": "10.0.0.200",
+        "Primary": false
+      },
+      {
+        "PrivateIpAddress": "10.0.0.50",
+        "Primary": false
+      },
+      {
+        "PrivateIpAddress": "10.0.0.150",
+        "Primary": false
+      }
+    ],
+    "SecondaryPrivateIpAddressCount": 3,
+    "Ipv6PrefixCount": 0,
+    "PrimaryPrivateIpAddress": "10.0.0.10",
+    "Ipv4Prefixes": [],
+    "Ipv4PrefixCount": 0,
+    "GroupSet": ["sg-0dd629030dbd15c82"],
+    "Ipv6Prefixes": [],
+    "SubnetId": "subnet-08cb471bab414eb4c",
+    "SourceDestCheck": true,
+    "InterfaceType": "interface",
+    "SecondaryPrivateIpAddresses": ["10.0.0.200", "10.0.0.50", "10.0.0.150"],
+    "VpcId": "vpc-0fcf6cf7ef21b2203",
+    "Id": "eni-01ce38782d866c24f",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegEniMultiipRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Eni",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEniMultiipRich/4d2cec50-6ee2-11f1-936a-12e3eb1881c1",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "PublicIpDnsNameOptions": {
+      "DnsHostnameType": "",
+      "PublicIpv4DnsName": "",
+      "PublicDualStackDnsName": "",
+      "PublicIpv6DnsName": ""
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnly": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnly": [
+      "ConnectionTrackingSpecification",
+      "EnablePrimaryIpv6",
+      "InterfaceType",
+      "PrivateIpAddress",
+      "PrivateIpAddresses",
+      "SubnetId"
+    ],
+    "readOnlyPaths": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnlyPaths": [
+      "ConnectionTrackingSpecification",
+      "EnablePrimaryIpv6",
+      "InterfaceType",
+      "PrivateIpAddress",
+      "PrivateIpAddresses",
+      "SubnetId"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.10",
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SecondaryPrivateIpAddressCount",
+      "actual": 3,
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "GroupSet",
+      "actual": ["sg-0dd629030dbd15c82"],
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Events__Rule.EventPatternRule.json
+++ b/tests/corpus/AWS__Events__Rule.EventPatternRule.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MatrixRuleF1E32BBB",
+    "resourceType": "AWS::Events::Rule",
+    "physicalId": "cdkrd-integ-pattern-rule",
+    "constructPath": "CdkRealDriftIntegEventbridgePatternRich/MatrixRule",
+    "declared": {
+      "EventPattern": {
+        "source": ["aws.ecs", "aws.ec2", "aws.batch"],
+        "detail-type": ["zeta-event", "alpha-event", "mike-event"],
+        "detail": {
+          "state": ["terminated", "running", "pending"]
+        }
+      },
+      "Name": "cdkrd-integ-pattern-rule",
+      "State": "ENABLED"
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "default",
+    "EventPattern": {
+      "detail-type": ["zeta-event", "alpha-event", "mike-event"],
+      "source": ["aws.ecs", "aws.ec2", "aws.batch"],
+      "detail": {
+        "state": ["terminated", "running", "pending"]
+      }
+    },
+    "State": "ENABLED",
+    "Targets": [],
+    "Id": "cdkrd-integ-pattern-rule",
+    "Arn": "arn:aws:events:us-east-1:111111111111:rule/cdkrd-integ-pattern-rule",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEventbridgePatternRich/4de259a0-6ee2-11f1-81b5-124122232bd7",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEventbridgePatternRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MatrixRuleF1E32BBB",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-pattern-rule"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["EventBusName", "Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EventBusName", "Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixRuleF1E32BBB",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
+      "physicalId": "cdkrd-integ-pattern-rule",
+      "constructPath": "CdkRealDriftIntegEventbridgePatternRich/MatrixRule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Subscription.FilterPolicySub.json
+++ b/tests/corpus/AWS__SNS__Subscription.FilterPolicySub.json
@@ -1,0 +1,58 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "QueueCdkRealDriftIntegSnsFilterpolicyRichTopicDB62B9A22D250F41",
+    "resourceType": "AWS::SNS::Subscription",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-TopicBFC7AF6E-K1qULk3vOzd3:ea92533b-72e4-41bd-9d99-ce9f1ddfb9fb",
+    "constructPath": "CdkRealDriftIntegSnsFilterpolicyRich/Queue/CdkRealDriftIntegSnsFilterpolicyRichTopicDB62B9A2",
+    "declared": {
+      "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-Queue4A7E3555-1LrWUZAyQsJp",
+      "FilterPolicy": {
+        "tier": ["gold", "bronze", "silver"],
+        "region": ["us-west-2", "eu-west-1", "ap-south-1"]
+      },
+      "Protocol": "sqs",
+      "RawMessageDelivery": true,
+      "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-TopicBFC7AF6E-K1qULk3vOzd3"
+    }
+  },
+  "liveRaw": {
+    "RawMessageDelivery": true,
+    "Endpoint": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-Queue4A7E3555-1LrWUZAyQsJp",
+    "FilterPolicy": {
+      "tier": ["gold", "bronze", "silver"],
+      "region": ["us-west-2", "eu-west-1", "ap-south-1"]
+    },
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-TopicBFC7AF6E-K1qULk3vOzd3",
+    "FilterPolicyScope": "MessageAttributes",
+    "Arn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-TopicBFC7AF6E-K1qULk3vOzd3:ea92533b-72e4-41bd-9d99-ce9f1ddfb9fb",
+    "Protocol": "sqs"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["Region"],
+    "createOnly": ["Endpoint", "Protocol", "Region", "TopicArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["Region"],
+    "createOnlyPaths": ["Endpoint", "Protocol", "Region", "TopicArn"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "QueueCdkRealDriftIntegSnsFilterpolicyRichTopicDB62B9A22D250F41",
+      "resourceType": "AWS::SNS::Subscription",
+      "path": "FilterPolicyScope",
+      "actual": "MessageAttributes",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsFilterpolicyRich-TopicBFC7AF6E-K1qULk3vOzd3:ea92533b-72e4-41bd-9d99-ce9f1ddfb9fb",
+      "constructPath": "CdkRealDriftIntegSnsFilterpolicyRich/Queue/CdkRealDriftIntegSnsFilterpolicyRichTopicDB62B9A2"
+    }
+  ]
+}

--- a/tests/integration/eni-multiip-rich/app.ts
+++ b/tests/integration/eni-multiip-rich/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift eni-multiip-rich integration test.
+// Follow-up to the eni-rich hunt (#349): that fixture had a SINGLE private IP, so
+// the `PrivateIpAddresses` object-array was length 1 and the set-reorder path was
+// never exercised. An ENI with MULTIPLE secondary IPs declares
+// `PrivateIpAddresses` as a multi-element object array keyed by `PrivateIpAddress`
+// (NOT an IDENTITY_FIELD, NOT id-shaped scalars) — an UNGUARDED object-array-set:
+// AWS may echo the set in its own (sorted) order, so a positional diff false-flags
+// every shifted element on a freshly recorded ENI. We declare the secondaries in a
+// deliberately NON-sorted order to provoke it; a clean record→check must be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnNetworkInterface, IpAddresses, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEniMultiipRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  ipAddresses: IpAddresses.cidr("10.0.0.0/16"),
+  natGateways: 0,
+  maxAzs: 1,
+  subnetConfiguration: [{ name: "pub", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+// The first subnet is 10.0.0.0/24 (AWS reserves .1-.3 and .255). Declare a primary
+// plus three secondaries in a NON-sorted order so an AWS canonical re-sort surfaces.
+new CfnNetworkInterface(stack, "Eni", {
+  subnetId: vpc.publicSubnets[0]!.subnetId,
+  description: "cdkrd integ multi-ip network interface",
+  privateIpAddresses: [
+    { privateIpAddress: "10.0.0.10", primary: true },
+    { privateIpAddress: "10.0.0.200", primary: false },
+    { privateIpAddress: "10.0.0.50", primary: false },
+    { privateIpAddress: "10.0.0.150", primary: false },
+  ],
+});
+
+app.synth();

--- a/tests/integration/eni-multiip-rich/cdk.json
+++ b/tests/integration/eni-multiip-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eni-multiip-rich/package.json
+++ b/tests/integration/eni-multiip-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eni-multiip-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eni-multiip-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eni-multiip-rich/verify.sh
+++ b/tests/integration/eni-multiip-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. The probed property is a semantically-unordered SET that AWS may
+# echo reordered; any declared drift on a clean recorded stack is a normalization
+# (set-reorder) false positive. See app.ts for the per-type rationale.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEniMultiipRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/eventbridge-pattern-rich/app.ts
+++ b/tests/integration/eventbridge-pattern-rich/app.ts
@@ -1,0 +1,29 @@
+// CDK app for the cdk-real-drift eventbridge-pattern-rich integration test.
+// AWS::Events::Rule is a daily-driver type, but every existing Events::Rule fixture
+// uses ScheduleExpression only — the EventPattern path is untested. Cloud Control
+// returns EventPattern as a PARSED OBJECT (confirmed live), and its value-arrays
+// (`source`, `detail-type`, `detail.*`) are OR-match SETS (a request matches if ANY
+// value matches — order carries no meaning). None of these nested scalar value-lists
+// is id/ARN-shaped, so the generic id-array sort skips them, and no per-type fold
+// lists Events::Rule — an UNGUARDED set-reorder gap. We declare each array NON-sorted
+// to provoke an AWS canonical re-sort; a clean record→check must be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { Rule } from "aws-cdk-lib/aws-events";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEventbridgePatternRich");
+
+new Rule(stack, "MatrixRule", {
+  ruleName: "cdkrd-integ-pattern-rule",
+  eventPattern: {
+    // top-level OR-set value-lists, declared deliberately NON-alphabetical
+    source: ["aws.ecs", "aws.ec2", "aws.batch"],
+    detailType: ["zeta-event", "alpha-event", "mike-event"],
+    // nested-under-object value-list (detail.<key>), also NON-sorted
+    detail: {
+      state: ["terminated", "running", "pending"],
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/eventbridge-pattern-rich/cdk.json
+++ b/tests/integration/eventbridge-pattern-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eventbridge-pattern-rich/package.json
+++ b/tests/integration/eventbridge-pattern-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eventbridge-pattern-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eventbridge-pattern-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eventbridge-pattern-rich/verify.sh
+++ b/tests/integration/eventbridge-pattern-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. The probed property is a semantically-unordered SET that AWS may
+# echo reordered; any declared drift on a clean recorded stack is a normalization
+# (set-reorder) false positive. See app.ts for the per-type rationale.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEventbridgePatternRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sns-filterpolicy-rich/app.ts
+++ b/tests/integration/sns-filterpolicy-rich/app.ts
@@ -1,0 +1,35 @@
+// CDK app for the cdk-real-drift sns-filterpolicy-rich integration test.
+// An SNS Subscription FilterPolicy is a JSON document whose attribute values are
+// OR-match value-LISTS (a message matches if ANY listed value matches — order is
+// meaningless). The value-lists sit under user-chosen attribute keys (not a fixed
+// path, not id-shaped), so no existing fold reaches them and the positional deep
+// compare would false-flag an AWS re-serialization that reorders them. The single
+// existing FilterPolicy corpus case declared its list already-sorted, so a reorder
+// was never exercised. We declare the lists NON-sorted to probe whether SNS reorders
+// on store; a clean record→check must be CLEAN. An SQS-subscribed topic is fully
+// in-account (no external endpoint, no confirmation needed).
+import { App, Stack } from "aws-cdk-lib";
+import { SubscriptionFilter, Topic } from "aws-cdk-lib/aws-sns";
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsFilterpolicyRich");
+
+const topic = new Topic(stack, "Topic");
+const queue = new Queue(stack, "Queue");
+
+topic.addSubscription(
+  new SqsSubscription(queue, {
+    rawMessageDelivery: true,
+    filterPolicy: {
+      // OR-set value-lists declared deliberately NON-sorted
+      tier: SubscriptionFilter.stringFilter({ allowlist: ["gold", "bronze", "silver"] }),
+      region: SubscriptionFilter.stringFilter({
+        allowlist: ["us-west-2", "eu-west-1", "ap-south-1"],
+      }),
+    },
+  }),
+);
+
+app.synth();

--- a/tests/integration/sns-filterpolicy-rich/cdk.json
+++ b/tests/integration/sns-filterpolicy-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-filterpolicy-rich/package.json
+++ b/tests/integration/sns-filterpolicy-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sns-filterpolicy-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sns-filterpolicy-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sns-filterpolicy-rich/verify.sh
+++ b/tests/integration/sns-filterpolicy-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. The probed property is a semantically-unordered SET that AWS may
+# echo reordered; any declared drift on a clean recorded stack is a normalization
+# (set-reorder) false positive. See app.ts for the per-type rationale.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsFilterpolicyRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Summary

Three **predicted** set-reorder false-positive classes, confirmed by live deploy to be **NON-bugs** — AWS preserves the array-value order in every case, so a positional diff stays clean and no fold is warranted (observed-only discipline: do not fold a divergence AWS does not actually produce). Each ships a permanent offline corpus case pinning the order-preservation.

| Probe | Declared (non-sorted) | Live | Verdict |
| --- | --- | --- | --- |
| `EC2::NetworkInterface` `PrivateIpAddresses` | `.10/.200/.50/.150` | identical order | preserved → no fold |
| `Events::Rule` `EventPattern` (`source`/`detail-type`/`detail.state`) | non-sorted lists | value arrays verbatim (object-keys reorder is compared by key) | preserved → no fold |
| `SNS::Subscription` `FilterPolicy` (`tier`/`region`) | non-sorted lists | identical order | preserved → no fold |

These extend coverage the prior hunts could not reach: the #349 `eni-rich` ENI had a **single** IP (multi-element set never exercised); every existing `Events::Rule` fixture is `ScheduleExpression`-only (EventPattern untested); the one existing `FilterPolicy` corpus case declared a **sorted** list.

## Why it matters

The offline audit flagged all three as **structurally unguarded** (no fold, keys not in `IDENTITY_FIELDS`, not id-shaped scalars). Only a live deploy could tell "unguarded but AWS-preserves-order" (no action) from "unguarded and AWS-reorders" (FP needing a fold). All three are the former — so the deliverable is the **proof**, captured as 3 corpus cases (suffixed filenames to avoid logical-id collisions).

## Scope

**Tests-only — no `src/` touched.** 3 fixtures + 3 golden-corpus cases. 1554 unit tests pass. All 3 stacks deleted via `delstack`, SWEEP CLEAN, sentinel cleared.
