### PR TITLE
feat(noise): fold constant service defaults for 17 common types (first-run-noise sweep)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -277,6 +277,75 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     DefaultAuthScheme: 'NONE',
     EndpointNetworkType: 'IPV4',
   },
+  // R-noise-sweep (offline audit of the golden corpus via scripts/measure-noise.sh):
+  // constant, documented service defaults common stateful/streaming types report as
+  // first-run undeclared inventory. Same exclusions as every entry above — NO
+  // names/ids/ARNs, no AZ (us-east-1x / use1-azN), no randomized window
+  // (Snapshot/Maintenance/Backup), no engine-/version-derived value (EngineVersion,
+  // OptionGroupName, *ParameterGroupName, port), no per-resource IP. Equality-gated:
+  // flip any out of band and it no longer matches, so it re-surfaces as real drift.
+  // The RDS DBInstance values were observed UNANIMOUS across 3 corpus instances
+  // spanning different engines (aurora-mysql + mysql8.0), confirming they are
+  // constant service defaults, not engine-derived.
+  'AWS::RDS::DBInstance': {
+    AutoMinorVersionUpgrade: true,
+    BackupTarget: 'region',
+    DatabaseInsightsMode: 'standard',
+    EngineLifecycleSupport: 'open-source-rds-extended-support',
+    MonitoringInterval: 0,
+    NetworkType: 'IPV4',
+    StorageThroughput: 0,
+  },
+  'AWS::RDS::DBCluster': {
+    AutoMinorVersionUpgrade: true,
+    DatabaseInsightsMode: 'standard',
+    EngineLifecycleSupport: 'open-source-rds-extended-support',
+    NetworkType: 'IPV4',
+  },
+  'AWS::Neptune::DBInstance': {
+    AutoMinorVersionUpgrade: true,
+  },
+  'AWS::Neptune::DBCluster': {
+    NetworkType: 'IPV4',
+  },
+  'AWS::ElastiCache::ReplicationGroup': {
+    AutoMinorVersionUpgrade: true,
+    ClusterMode: 'disabled',
+    IpDiscovery: 'ipv4',
+    NetworkType: 'ipv4',
+    ReplicasPerNodeGroup: 0,
+  },
+  'AWS::ElastiCache::ServerlessCache': {
+    SnapshotRetentionLimit: 0,
+  },
+  'AWS::OpenSearchService::Domain': {
+    IPAddressType: 'ipv4',
+  },
+  'AWS::EC2::VPCEndpoint': {
+    IpAddressType: 'ipv4',
+  },
+  'AWS::EC2::TransitGateway': {
+    SecurityGroupReferencingSupport: 'disable',
+  },
+  'AWS::EC2::FlowLog': {
+    MaxAggregationInterval: 600,
+  },
+  'AWS::Pipes::Pipe': {
+    DesiredState: 'RUNNING',
+  },
+  'AWS::Synthetics::Canary': {
+    FailureRetentionPeriod: 31,
+    SuccessRetentionPeriod: 31,
+    ProvisionedResourceCleanup: 'AUTOMATIC',
+  },
+  'AWS::MSK::Cluster': {
+    EnhancedMonitoring: 'DEFAULT',
+    StorageMode: 'LOCAL',
+  },
+  'AWS::Glue::Job': {
+    JobMode: 'SCRIPT',
+    MaxRetries: 0,
+  },
 };
 
 // R108: nested service defaults — the NESTED-path twin of KNOWN_DEFAULTS. The
@@ -341,6 +410,9 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   },
   'AWS::CodeBuild::Project': {
     'Environment.ImagePullCredentialsType': 'CODEBUILD',
+    // A project with no explicit artifacts (NO_ARTIFACTS source) reads back the
+    // Packaging default NONE — R-noise-sweep, observed live.
+    'Artifacts.Packaging': 'NONE',
   },
   'AWS::Cognito::UserPool': {
     'AdminCreateUserConfig.UnusedAccountValidityDays': 7,
@@ -399,6 +471,27 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::KinesisFirehose::DeliveryStream': {
     // S3 backup is Disabled by default when a destination declares no backup mode.
     'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',
+  },
+  // R-noise-sweep (offline corpus audit): nested constant defaults the schema does
+  // not annotate. Equality-gated; a non-default value still surfaces.
+  'AWS::WAFv2::WebACL': {
+    // A rate-based rule with no explicit window reads back the 5-minute (300s) default.
+    'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,
+  },
+  'AWS::SES::EmailIdentity': {
+    // A custom MAIL FROM domain reads back the documented default fallback behavior.
+    'MailFromAttributes.BehaviorOnMxFailure': 'USE_DEFAULT_VALUE',
+  },
+  'AWS::MSK::Cluster': {
+    // Brokers spread across AZs read back the DEFAULT distribution when unspecified.
+    'BrokerNodeGroupInfo.BrokerAZDistribution': 'DEFAULT',
+  },
+  'AWS::Batch::JobDefinition': {
+    // A Fargate job definition reads back the documented runtime-platform defaults
+    // (x86_64 / Linux) and the LATEST Fargate platform version when none is declared.
+    'ContainerProperties.RuntimePlatform.CpuArchitecture': 'X86_64',
+    'ContainerProperties.RuntimePlatform.OperatingSystemFamily': 'LINUX',
+    'ContainerProperties.FargatePlatformConfiguration.PlatformVersion': 'LATEST',
   },
 };
 

--- a/tests/corpus/AWS__Batch__JobDefinition.JobDef97B0969F.json
+++ b/tests/corpus/AWS__Batch__JobDefinition.JobDef97B0969F.json
@@ -120,7 +120,7 @@
       "constructPath": "CdkRealDriftIntegBatchRich/JobDef"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobDef97B0969F",
       "resourceType": "AWS::Batch::JobDefinition",
       "path": "ContainerProperties.FargatePlatformConfiguration.PlatformVersion",
@@ -130,7 +130,7 @@
       "constructPath": "CdkRealDriftIntegBatchRich/JobDef"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobDef97B0969F",
       "resourceType": "AWS::Batch::JobDefinition",
       "path": "ContainerProperties.RuntimePlatform.OperatingSystemFamily",
@@ -140,7 +140,7 @@
       "constructPath": "CdkRealDriftIntegBatchRich/JobDef"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "JobDef97B0969F",
       "resourceType": "AWS::Batch::JobDefinition",
       "path": "ContainerProperties.RuntimePlatform.CpuArchitecture",

--- a/tests/corpus/AWS__CodeBuild__Project.Build45A36621.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build45A36621.json
@@ -129,7 +129,7 @@
       "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Build45A36621",
       "resourceType": "AWS::CodeBuild::Project",
       "path": "Artifacts.Packaging",

--- a/tests/corpus/AWS__EC2__FlowLog.FlowLog3CB084E9.json
+++ b/tests/corpus/AWS__EC2__FlowLog.FlowLog3CB084E9.json
@@ -102,7 +102,7 @@
       "constructPath": "CdkdriftIntegHarvest11/FlowLog/FlowLog"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FlowLog3CB084E9",
       "resourceType": "AWS::EC2::FlowLog",
       "path": "MaxAggregationInterval",

--- a/tests/corpus/AWS__EC2__TransitGateway.Tgw.json
+++ b/tests/corpus/AWS__EC2__TransitGateway.Tgw.json
@@ -93,7 +93,7 @@
       "constructPath": "CdkRealDriftIntegTransitGatewayRich/Tgw"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Tgw",
       "resourceType": "AWS::EC2::TransitGateway",
       "path": "SecurityGroupReferencingSupport",

--- a/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
@@ -102,6 +102,24 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "VpcS3Endpoint4A3DE4B5",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "ServiceRegion",
+      "actual": "us-east-1",
+      "physicalId": "vpce-010c0956e4433b47b",
+      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "VpcS3Endpoint4A3DE4B5",
       "resourceType": "AWS::EC2::VPCEndpoint",
@@ -119,17 +137,9 @@
       "tier": "undeclared",
       "logicalId": "VpcS3Endpoint4A3DE4B5",
       "resourceType": "AWS::EC2::VPCEndpoint",
-      "path": "IpAddressType",
-      "actual": "ipv4",
-      "physicalId": "vpce-010c0956e4433b47b",
-      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "VpcS3Endpoint4A3DE4B5",
-      "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "PolicyDocument",
       "actual": {
+        "Version": "2008-10-17",
         "Statement": [
           {
             "Action": ["*"],
@@ -137,18 +147,8 @@
             "Principal": "*",
             "Resource": ["*"]
           }
-        ],
-        "Version": "2008-10-17"
+        ]
       },
-      "physicalId": "vpce-010c0956e4433b47b",
-      "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "VpcS3Endpoint4A3DE4B5",
-      "resourceType": "AWS::EC2::VPCEndpoint",
-      "path": "ServiceRegion",
-      "actual": "us-east-1",
       "physicalId": "vpce-010c0956e4433b47b",
       "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
     }

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
@@ -190,7 +190,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "ClusterMode",
@@ -199,7 +199,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "ReplicasPerNodeGroup",
@@ -208,7 +208,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "NetworkType",
@@ -217,7 +217,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "AutoMinorVersionUpgrade",
@@ -253,7 +253,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "IpDiscovery",

--- a/tests/corpus/AWS__ElastiCache__ServerlessCache.ServerlessCache.json
+++ b/tests/corpus/AWS__ElastiCache__ServerlessCache.ServerlessCache.json
@@ -73,7 +73,7 @@
       "constructPath": "CdkdriftIntegHarvest13/ServerlessCache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ServerlessCache",
       "resourceType": "AWS::ElastiCache::ServerlessCache",
       "path": "SnapshotRetentionLimit",

--- a/tests/corpus/AWS__Glue__Job.GlueJob.json
+++ b/tests/corpus/AWS__Glue__Job.GlueJob.json
@@ -53,6 +53,33 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "MaxRetries",
+      "actual": 0,
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "JobMode",
+      "actual": "SCRIPT",
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "GlueJob",
+      "resourceType": "AWS::Glue::Job",
+      "path": "Timeout",
+      "actual": 2880,
+      "physicalId": "cdkrd-harvest5",
+      "constructPath": "CdkrdIntegHarvest5/GlueJob"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
@@ -69,33 +96,6 @@
       "actual": {
         "MaxConcurrentRuns": 1
       },
-      "physicalId": "cdkrd-harvest5",
-      "constructPath": "CdkrdIntegHarvest5/GlueJob"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "GlueJob",
-      "resourceType": "AWS::Glue::Job",
-      "path": "JobMode",
-      "actual": "SCRIPT",
-      "physicalId": "cdkrd-harvest5",
-      "constructPath": "CdkrdIntegHarvest5/GlueJob"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "GlueJob",
-      "resourceType": "AWS::Glue::Job",
-      "path": "MaxRetries",
-      "actual": 0,
-      "physicalId": "cdkrd-harvest5",
-      "constructPath": "CdkrdIntegHarvest5/GlueJob"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "GlueJob",
-      "resourceType": "AWS::Glue::Job",
-      "path": "Timeout",
-      "actual": 2880,
       "physicalId": "cdkrd-harvest5",
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
     }

--- a/tests/corpus/AWS__MSK__Cluster.Cluster.json
+++ b/tests/corpus/AWS__MSK__Cluster.Cluster.json
@@ -119,7 +119,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MSK::Cluster",
       "path": "EnhancedMonitoring",
@@ -145,7 +145,7 @@
       "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MSK::Cluster",
       "path": "StorageMode",
@@ -194,7 +194,7 @@
       "constructPath": "CdkRealDriftIntegMskCluster/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MSK::Cluster",
       "path": "BrokerNodeGroupInfo.BrokerAZDistribution",

--- a/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
+++ b/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
@@ -155,7 +155,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Neptune::DBCluster",
       "path": "NetworkType",

--- a/tests/corpus/AWS__Neptune__DBInstance.Instance.json
+++ b/tests/corpus/AWS__Neptune__DBInstance.Instance.json
@@ -100,7 +100,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Instance"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Instance",
       "resourceType": "AWS::Neptune::DBInstance",
       "path": "AutoMinorVersionUpgrade",

--- a/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
@@ -193,7 +193,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "IPAddressType",

--- a/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
@@ -196,7 +196,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "IPAddressType",

--- a/tests/corpus/AWS__Pipes__Pipe.Pipe.json
+++ b/tests/corpus/AWS__Pipes__Pipe.Pipe.json
@@ -72,7 +72,7 @@
       "constructPath": "CdkrdIntegHarvest6/Pipe"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Pipe",
       "resourceType": "AWS::Pipes::Pipe",
       "path": "DesiredState",

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
@@ -197,7 +197,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "DatabaseInsightsMode",
@@ -233,7 +233,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "NetworkType",
@@ -242,7 +242,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "EngineLifecycleSupport",
@@ -278,7 +278,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "AutoMinorVersionUpgrade",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
@@ -247,7 +247,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DatabaseInsightsMode",
@@ -265,7 +265,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageThroughput",
@@ -274,7 +274,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
@@ -319,7 +319,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AutoMinorVersionUpgrade",
@@ -364,7 +364,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "NetworkType",
@@ -373,7 +373,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "EngineLifecycleSupport",
@@ -400,7 +400,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "BackupTarget",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
@@ -247,7 +247,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DatabaseInsightsMode",
@@ -265,7 +265,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageThroughput",
@@ -274,7 +274,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
@@ -319,7 +319,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AutoMinorVersionUpgrade",
@@ -364,7 +364,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "NetworkType",
@@ -373,7 +373,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "EngineLifecycleSupport",
@@ -400,7 +400,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "BackupTarget",

--- a/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
+++ b/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
@@ -284,7 +284,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DatabaseInsightsMode",
@@ -302,7 +302,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageThroughput",
@@ -311,7 +311,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
@@ -356,7 +356,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AutoMinorVersionUpgrade",
@@ -374,7 +374,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "NetworkType",
@@ -383,7 +383,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "EngineLifecycleSupport",
@@ -410,7 +410,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "BackupTarget",

--- a/tests/corpus/AWS__SES__EmailIdentity.EmailIdentity7187767D.json
+++ b/tests/corpus/AWS__SES__EmailIdentity.EmailIdentity7187767D.json
@@ -116,7 +116,7 @@
       "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EmailIdentity7187767D",
       "resourceType": "AWS::SES::EmailIdentity",
       "path": "MailFromAttributes.BehaviorOnMxFailure",

--- a/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
+++ b/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
@@ -95,7 +95,7 @@
       "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Canary11957FE2",
       "resourceType": "AWS::Synthetics::Canary",
       "path": "SuccessRetentionPeriod",
@@ -118,7 +118,7 @@
       "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Canary11957FE2",
       "resourceType": "AWS::Synthetics::Canary",
       "path": "FailureRetentionPeriod",
@@ -127,7 +127,7 @@
       "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Canary11957FE2",
       "resourceType": "AWS::Synthetics::Canary",
       "path": "ProvisionedResourceCleanup",

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl.json
@@ -163,7 +163,7 @@
       "constructPath": "CdkRealDriftIntegWafv2Rich/WebAcl"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebAcl",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "Rules[RateLimit].Statement.RateBasedStatement.EvaluationWindowSec",

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl_rich.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl_rich.json
@@ -369,7 +369,7 @@
       "constructPath": "CdkRealDriftIntegWafv2WebAclRich/WebAcl"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebAcl",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "Rules[rate-rule].Statement.RateBasedStatement.EvaluationWindowSec",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -438,6 +438,62 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('common stateful/streaming-type constant defaults from the offline corpus sweep', () => {
+    // Constant, documented service defaults common stateful/streaming types report as
+    // first-run undeclared noise. Verified against the golden corpus (RDS DBInstance
+    // values unanimous across 3 instances spanning aurora-mysql + mysql8.0) and
+    // exercised by the corpus-replay cases. Equality-gated: a non-default value still
+    // surfaces. Resource-/AZ-/window-/engine-derived values are deliberately excluded.
+    expect(KNOWN_DEFAULTS['AWS::RDS::DBInstance']).toEqual({
+      AutoMinorVersionUpgrade: true,
+      BackupTarget: 'region',
+      DatabaseInsightsMode: 'standard',
+      EngineLifecycleSupport: 'open-source-rds-extended-support',
+      MonitoringInterval: 0,
+      NetworkType: 'IPV4',
+      StorageThroughput: 0,
+    });
+    expect(KNOWN_DEFAULTS['AWS::RDS::DBCluster'].NetworkType).toBe('IPV4');
+    expect(KNOWN_DEFAULTS['AWS::ElastiCache::ReplicationGroup']).toEqual({
+      AutoMinorVersionUpgrade: true,
+      ClusterMode: 'disabled',
+      IpDiscovery: 'ipv4',
+      NetworkType: 'ipv4',
+      ReplicasPerNodeGroup: 0,
+    });
+    expect(KNOWN_DEFAULTS['AWS::Neptune::DBInstance'].AutoMinorVersionUpgrade).toBe(true);
+    expect(KNOWN_DEFAULTS['AWS::EC2::VPCEndpoint'].IpAddressType).toBe('ipv4');
+    expect(KNOWN_DEFAULTS['AWS::EC2::TransitGateway'].SecurityGroupReferencingSupport).toBe(
+      'disable'
+    );
+    expect(KNOWN_DEFAULTS['AWS::EC2::FlowLog'].MaxAggregationInterval).toBe(600);
+    expect(KNOWN_DEFAULTS['AWS::Pipes::Pipe'].DesiredState).toBe('RUNNING');
+    expect(KNOWN_DEFAULTS['AWS::Synthetics::Canary']).toEqual({
+      FailureRetentionPeriod: 31,
+      SuccessRetentionPeriod: 31,
+      ProvisionedResourceCleanup: 'AUTOMATIC',
+    });
+    expect(KNOWN_DEFAULTS['AWS::MSK::Cluster']).toEqual({
+      EnhancedMonitoring: 'DEFAULT',
+      StorageMode: 'LOCAL',
+    });
+    expect(KNOWN_DEFAULTS['AWS::OpenSearchService::Domain'].IPAddressType).toBe('ipv4');
+    expect(KNOWN_DEFAULTS['AWS::Glue::Job']).toEqual({ JobMode: 'SCRIPT', MaxRetries: 0 });
+    // nested
+    expect(KNOWN_DEFAULT_PATHS['AWS::WAFv2::WebACL']).toEqual({
+      'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::SES::EmailIdentity']).toEqual({
+      'MailFromAttributes.BehaviorOnMxFailure': 'USE_DEFAULT_VALUE',
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::Batch::JobDefinition']).toEqual({
+      'ContainerProperties.RuntimePlatform.CpuArchitecture': 'X86_64',
+      'ContainerProperties.RuntimePlatform.OperatingSystemFamily': 'LINUX',
+      'ContainerProperties.FargatePlatformConfiguration.PlatformVersion': 'LATEST',
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::CodeBuild::Project']['Artifacts.Packaging']).toBe('NONE');
+  });
+
   it('S3 suspended versioning is a known default — the off state a revert lands on (R46)', () => {
     expect(KNOWN_DEFAULTS['AWS::S3::Bucket'].VersioningConfiguration).toEqual({
       Status: 'Suspended',


### PR DESCRIPTION
## Summary

Offline `measure-noise.sh` audit of the golden corpus surfaced constant, documented **service defaults** that common stateful/streaming types report as first-run `undeclared` inventory. Fold them to `atDefault` so a first run is quieter — **equality-gated**, so a value set away from the default still surfaces as real drift, and `atDefault` is still shown (footer / `--show-all`), never recorded.

### Folds added

**Top-level (`KNOWN_DEFAULTS`):** RDS `DBInstance` (7 props), RDS `DBCluster`, Neptune `DBInstance`/`DBCluster`, ElastiCache `ReplicationGroup`/`ServerlessCache`, OpenSearch `Domain` `IPAddressType`, EC2 `VPCEndpoint`/`TransitGateway`/`FlowLog`, `Pipes::Pipe`, `Synthetics::Canary`, `MSK::Cluster`, `Glue::Job`.

**Nested (`KNOWN_DEFAULT_PATHS`):** WAFv2 `WebACL` rate-rule `EvaluationWindowSec`=300, SES `EmailIdentity` `BehaviorOnMxFailure`, MSK `BrokerAZDistribution`, Batch `JobDefinition` Fargate `RuntimePlatform`/`PlatformVersion`, CodeBuild `Artifacts.Packaging`.

The RDS DBInstance values were observed **unanimous across 3 corpus instances** spanning aurora-mysql + mysql8.0 — confirming they are constant service defaults, not engine-derived.

### Excluded (per the standing rule)

names/ids/ARNs, AZs, randomized windows (`Snapshot`/`Maintenance`/`Backup`), ports, and engine-/version-derived values (`EngineVersion`, `OptionGroupName`, `*ParameterGroupName`) — genuine inventory, not defaults.

### Corpus impact (reviewability)

22 golden-corpus cases regenerated. **Exactly 54 findings flip `undeclared`→`atDefault`; no finding added, removed, or otherwise changed** — verified by a per-file path/count parity check across all 22 files. `corpus-replay` reproduces the new `expected`.

### Scope

Offline-only — **no new fixtures, no deploys.** `src/normalize/noise.ts` (+93), unit test (+56), 22 corpus regens. New `KNOWN_DEFAULTS`/`KNOWN_DEFAULT_PATHS` test; **1555 unit tests pass.**
