### PR TITLE
test(integ): bug-hunt 2 modern-config types — Lambda SnapStart/RuntimeMgmt/DLQ + SNS FIFO ArchivePolicy (0 FP)

### DIFF
--- a/tests/corpus/AWS__Lambda__Function.Handler886CB40B_config_rich.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler886CB40B_config_rich.json
@@ -1,0 +1,183 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Handler886CB40B",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+    "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler",
+    "declared": {
+      "Code": {
+        "ZipFile": "def handler(event, context):\n    return {'ok': True}\n"
+      },
+      "DeadLetterConfig": {
+        "TargetArn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegLambdaConfigRich-DlqD1FAA4AD-HIEDs1Z4x7X9"
+      },
+      "Description": "cdkrd lambda-config-rich test handler",
+      "Environment": {
+        "Variables": {
+          "STAGE": "test",
+          "FEATURE_FLAG": "on"
+        }
+      },
+      "Handler": "index.handler",
+      "LoggingConfig": {
+        "ApplicationLogLevel": "INFO",
+        "LogFormat": "JSON",
+        "LogGroup": "CdkRealDriftIntegLambdaConfigRich-Logs6819BB44-QAP7lFiD0Okm",
+        "SystemLogLevel": "WARN"
+      },
+      "MemorySize": 256,
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaCo-HandlerServiceRoleFCDC14A-zJlg5Dv3Ox7f",
+      "Runtime": "python3.12",
+      "RuntimeManagementConfig": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "SnapStart": {
+        "ApplyOn": "PublishedVersions"
+      },
+      "Timeout": 15,
+      "TracingConfig": {
+        "Mode": "Active"
+      }
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 256,
+    "Description": "cdkrd lambda-config-rich test handler",
+    "TracingConfig": {
+      "Mode": "Active"
+    },
+    "DeadLetterConfig": {
+      "TargetArn": "arn:aws:sqs:us-east-1:111111111111:CdkRealDriftIntegLambdaConfigRich-DlqD1FAA4AD-HIEDs1Z4x7X9"
+    },
+    "Timeout": 15,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "PublishedVersions"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaCo-HandlerServiceRoleFCDC14A-zJlg5Dv3Ox7f",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+    "Runtime": "python3.12",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "JSON",
+      "ApplicationLogLevel": "INFO",
+      "LogGroup": "CdkRealDriftIntegLambdaConfigRich-Logs6819BB44-QAP7lFiD0Okm",
+      "SystemLogLevel": "WARN"
+    },
+    "RecursiveLoop": "Terminate",
+    "Environment": {
+      "Variables": {
+        "STAGE": "test",
+        "FEATURE_FLAG": "on"
+      }
+    },
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegLambdaConfigRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Handler886CB40B",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambdaConfigRich/bc590b20-6eee-11f1-993d-0e2943754679",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "SnapStart",
+      "note": "write-only — cannot be read back",
+      "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkRealDriftIntegLambdaConfigRich-Handler886CB40B-ngKYSKhJ4Uyj",
+      "constructPath": "CdkRealDriftIntegLambdaConfigRich/Handler"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.TopicBFC7AF6E.json
+++ b/tests/corpus/AWS__SNS__Topic.TopicBFC7AF6E.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TopicBFC7AF6E",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsArchiveRich-Topic-CB408FAC.fifo",
+    "constructPath": "CdkRealDriftIntegSnsArchiveRich/Topic",
+    "declared": {
+      "ArchivePolicy": {
+        "MessageRetentionPeriod": 30
+      },
+      "ContentBasedDeduplication": true,
+      "DisplayName": "cdkrd sns archive rich",
+      "FifoTopic": true,
+      "SignatureVersion": "2",
+      "TopicName": "CdkRealDriftIntegSnsArchiveRich-Topic-CB408FAC.fifo",
+      "TracingConfig": "Active"
+    }
+  },
+  "liveRaw": {
+    "SignatureVersion": "2",
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsArchiveRich-Topic-CB408FAC.fifo",
+    "TracingConfig": "Active",
+    "DisplayName": "cdkrd sns archive rich",
+    "FifoTopic": true,
+    "ContentBasedDeduplication": true,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSnsArchiveRich/bc5cdbb0-6eee-11f1-8770-0affd52f7795",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSnsArchiveRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TopicBFC7AF6E",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {
+      "MessageRetentionPeriod": "30"
+    },
+    "TopicName": "CdkRealDriftIntegSnsArchiveRich-Topic-CB408FAC.fifo"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/lambda-config-rich/app.ts
+++ b/tests/integration/lambda-config-rich/app.ts
@@ -1,0 +1,61 @@
+// CDK app for the cdk-real-drift Lambda "modern config knobs" false-positive test.
+// Lambda is the single most commonly deployed CDK resource, and these newer
+// production knobs are NOT yet exercised by lambda-rich: SnapStart (Python 3.12),
+// the structured LoggingConfig (JSON format + per-stream log levels + an explicit
+// log group), RuntimeManagementConfig, and a dead-letter queue. Each of these is
+// an enum- or nested-object-shaped property — exactly the shape that historically
+// hides a normalization false positive (an enum echoed in a different case, a
+// nested config the service default-fills). A freshly deployed + recorded function
+// with NO out-of-band change MUST report CLEAN.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  ApplicationLogLevel,
+  Code,
+  Function as LambdaFunction,
+  LoggingFormat,
+  Runtime,
+  RuntimeManagementMode,
+  SnapStartConf,
+  SystemLogLevel,
+  Tracing,
+} from "aws-cdk-lib/aws-lambda";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaConfigRich");
+
+const logGroup = new LogGroup(stack, "Logs", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const dlq = new Queue(stack, "Dlq", {
+  retentionPeriod: Duration.days(7),
+});
+
+new LambdaFunction(stack, "Handler", {
+  // SnapStart supports Java 11+, Python 3.12+, .NET 8+ — pin Python 3.12.
+  runtime: Runtime.PYTHON_3_12,
+  handler: "index.handler",
+  code: Code.fromInline("def handler(event, context):\n    return {'ok': True}\n"),
+  memorySize: 256,
+  timeout: Duration.seconds(15),
+  description: "cdkrd lambda-config-rich test handler",
+  environment: {
+    STAGE: "test",
+    FEATURE_FLAG: "on",
+  },
+  // Structured JSON logging with per-stream levels + an explicit log group.
+  loggingFormat: LoggingFormat.JSON,
+  applicationLogLevelV2: ApplicationLogLevel.INFO,
+  systemLogLevelV2: SystemLogLevel.WARN,
+  logGroup,
+  // Newer config props not covered elsewhere.
+  snapStart: SnapStartConf.ON_PUBLISHED_VERSIONS,
+  runtimeManagementMode: RuntimeManagementMode.AUTO,
+  deadLetterQueue: dlq,
+  tracing: Tracing.ACTIVE,
+});
+
+app.synth();

--- a/tests/integration/lambda-config-rich/cdk.json
+++ b/tests/integration/lambda-config-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-config-rich/package.json
+++ b/tests/integration/lambda-config-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-config-rich/verify-detect.sh
+++ b/tests/integration/lambda-config-rich/verify-detect.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Lambda config-rich: harvest the live read into the golden corpus (fresh deploy,
+# pre-record) THEN run the detect + revert false-negative test. Deploy -> harvest
+# corpus -> record -> change a DECLARED MUTABLE prop (MemorySize) out of band ->
+# check MUST DETECT (exit 1) -> revert -> check MUST be CLEAN -> live restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaConfigRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CORPUS_DIR="${CORPUS_DIR:-/tmp/corpus-lambda-config}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN" ] || fail "could not resolve function physical id"
+
+echo "=== harvest corpus (fresh, pre-record) -> $CORPUS_DIR ==="
+rm -rf "$CORPUS_DIR"
+CDKRD_CORPUS_DIR="$CORPUS_DIR" $CLI check "$STACK" --region "$REGION" || true
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: MemorySize 256->512 (console-edit) ==="
+aws lambda update-function-configuration --function-name "$FN" --region "$REGION" \
+  --memory-size 512 >/dev/null || fail "inject drift"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-lambda-config-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "MemorySize" /tmp/cdkrd-lambda-config-detect.out || fail "MemorySize not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+GOT="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" \
+  --query "MemorySize" --output text)"
+[ "$GOT" = "256" ] || fail "live MemorySize not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/lambda-config-rich/verify.sh
+++ b/tests/integration/lambda-config-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded stack with NO out-of-band change
+# must report no drift; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaConfigRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sns-archive-rich/app.ts
+++ b/tests/integration/sns-archive-rich/app.ts
@@ -1,0 +1,26 @@
+// CDK app for the cdk-real-drift SNS FIFO archive false-positive test. SNS is a
+// very common CDK resource, but the FIFO archive knobs are not yet exercised: a
+// FIFO topic with content-based dedup, a message-archive retention policy
+// (ArchivePolicy), an explicit signature version, and active tracing. ArchivePolicy
+// is the interesting one — CloudFormation declares it as a nested OBJECT
+// (`{ MessageRetentionPeriod: 30 }`) while the SNS API stores topic attributes as
+// strings, so the live read can come back JSON-STRING-shaped: a classic
+// object<->string normalization false-positive surface. A freshly deployed +
+// recorded topic with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { Topic, TracingConfig } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsArchiveRich");
+
+new Topic(stack, "Topic", {
+  fifo: true,
+  contentBasedDeduplication: true,
+  // FIFO message archive — emits ArchivePolicy: { MessageRetentionPeriod: 30 }.
+  messageRetentionPeriodInDays: 30,
+  signatureVersion: "2",
+  tracingConfig: TracingConfig.ACTIVE,
+  displayName: "cdkrd sns archive rich",
+});
+
+app.synth();

--- a/tests/integration/sns-archive-rich/cdk.json
+++ b/tests/integration/sns-archive-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-archive-rich/package.json
+++ b/tests/integration/sns-archive-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sns-archive-rich/verify-detect.sh
+++ b/tests/integration/sns-archive-rich/verify-detect.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# SNS archive-rich: harvest the live read into the golden corpus (fresh deploy,
+# pre-record) THEN run the detect (+ revert if supported) false-negative test.
+# Deploy -> harvest corpus -> record -> change a DECLARED MUTABLE prop (DisplayName)
+# out of band -> check MUST DETECT (exit 1) -> revert -> check CLEAN -> restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsArchiveRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CORPUS_DIR="${CORPUS_DIR:-/tmp/corpus-sns-archive}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  # An SNS FIFO topic with an ArchivePolicy cannot be deleted until the policy is
+  # cleared (AWS: "Cannot delete a topic with an ArchivePolicy"), which would
+  # otherwise leave the stack DELETE_FAILED even under delstack. Clear it first.
+  for arn in $(aws sns list-topics --region "$REGION" \
+      --query "Topics[?contains(TopicArn,'$STACK')].TopicArn" --output text 2>/dev/null); do
+    aws sns set-topic-attributes --topic-arn "$arn" --region "$REGION" \
+      --attribute-name ArchivePolicy --attribute-value '{}' >/dev/null 2>&1 || true
+  done
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SNS::Topic'].PhysicalResourceId" --output text)"
+[ -n "$ARN" ] || fail "could not resolve topic ARN"
+
+echo "=== harvest corpus (fresh, pre-record) -> $CORPUS_DIR ==="
+rm -rf "$CORPUS_DIR"
+CDKRD_CORPUS_DIR="$CORPUS_DIR" $CLI check "$STACK" --region "$REGION" || true
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: DisplayName -> 'drifted out of band' (console-edit) ==="
+aws sns set-topic-attributes --topic-arn "$ARN" --region "$REGION" \
+  --attribute-name DisplayName --attribute-value "drifted out of band" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sns-archive-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "DisplayName" /tmp/cdkrd-sns-archive-detect.out || fail "DisplayName not reported"
+
+echo "=== revert (write declared value back; SNS Topic via Cloud Control) ==="
+if $CLI revert "$STACK" --region "$REGION" --yes; then
+  echo "=== check MUST be CLEAN after revert ==="
+  $CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN (exit 0) after revert"
+  GOT="$(aws sns get-topic-attributes --topic-arn "$ARN" --region "$REGION" \
+    --query "Attributes.DisplayName" --output text)"
+  [ "$GOT" = "cdkrd sns archive rich" ] || fail "live DisplayName not restored (got: $GOT)"
+  echo "INTEG PASS ($STACK detect+revert)"
+else
+  echo "NOTE: SNS Topic revert not supported (SDK_WRITERS gap) — detection confirmed, restoring manually"
+  aws sns set-topic-attributes --topic-arn "$ARN" --region "$REGION" \
+    --attribute-name DisplayName --attribute-value "cdkrd sns archive rich" >/dev/null || true
+  echo "INTEG PASS ($STACK detect-only; revert is a future SDK_WRITERS candidate)"
+fi

--- a/tests/integration/sns-archive-rich/verify.sh
+++ b/tests/integration/sns-archive-rich/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded stack with NO out-of-band change
+# must report no drift; any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsArchiveRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  # An SNS FIFO topic with an ArchivePolicy cannot be deleted until the policy is
+  # cleared (AWS: "Cannot delete a topic with an ArchivePolicy"), which would
+  # otherwise leave the stack DELETE_FAILED even under delstack. Clear it first.
+  for arn in $(aws sns list-topics --region "$REGION" \
+      --query "Topics[?contains(TopicArn,'$STACK')].TopicArn" --output text 2>/dev/null); do
+    aws sns set-topic-attributes --topic-arn "$arn" --region "$REGION" \
+      --attribute-name ArchivePolicy --attribute-value '{}' >/dev/null 2>&1 || true
+  done
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug hunt — clean round (0 FP / 0 FN), 2 new fixtures + corpus

Deployed two high-frequency types in configurations not yet exercised, ran the FP test (record→check CLEAN) and FN test (mutate declared mutable prop → check detects → revert → CLEAN), then harvested the live reads into the golden corpus. No cdkrd bug found; no `src/**` change.

### lambda-config-rich
Lambda Function with newer production knobs not covered by `lambda-rich` / `lambda-loggingconfig-rich`: **SnapStart** (Python 3.12), **RuntimeManagementConfig**, a **dead-letter queue**, plus the structured **LoggingConfig**.
- FP: **CLEAN** (`atDefault=15, generated=1, readGap=1`).
- SnapStart classifies as `readGap` when no version is published (Cloud Control returns no SnapStart on the `$LATEST` config) — correct, not a false negative.
- RuntimeManagementConfig / DeadLetterConfig / LoggingConfig all matched.
- FN: detect + revert verified on `MemorySize`.

### sns-archive-rich
SNS **FIFO** topic with content-based dedup, an **ArchivePolicy** (message archive), an explicit `SignatureVersion`, and active tracing.
- FP: **CLEAN**. ArchivePolicy is declared as a nested object `{ MessageRetentionPeriod: 30 }` (number) but read back `{ MessageRetentionPeriod: "30" }` (string); the number↔string coercion folds it with no false positive — the interesting bit this fixture pins.
- FN: detect + revert verified on `DisplayName` (SNS Topic reverts via Cloud Control).

### Teardown note (encoded in both `verify.sh` cleanups)
An SNS FIFO topic with an ArchivePolicy **cannot be deleted** until the policy is cleared (`AWS: "Cannot delete a topic with an ArchivePolicy"`), which otherwise leaves the stack `DELETE_FAILED` even under `delstack`. Cleanup now clears `ArchivePolicy` first.

### Corpus
Promotes the Lambda Function (suffixed to avoid the `Handler886CB40B` logical-id collision with `lambda-loggingconfig-rich`) and SNS Topic live reads into `tests/corpus` as permanent offline regressions. 400 corpus-replay cases pass; full suite 1557 tests green.

Tests-only PR (no `src/**`) → `verify-pr-gate` exempt.