### PR TITLE
test(integ): prove SNS Topic attributes revert via Cloud Control — no SDK_WRITERS gap

### DIFF
--- a/tests/corpus/AWS__SNS__Topic.TopicBFC7AF6E_revert_attrs.json
+++ b/tests/corpus/AWS__SNS__Topic.TopicBFC7AF6E_revert_attrs.json
@@ -1,0 +1,66 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TopicBFC7AF6E",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsRevertAttrs-TopicBFC7AF6E-jDErcwWfkqYj",
+    "constructPath": "CdkRealDriftIntegSnsRevertAttrs/Topic",
+    "declared": {
+      "DisplayName": "cdkrd revert original",
+      "KmsMasterKeyId": "arn:aws:kms:us-east-1:111111111111:key/7a756e13-ae9b-462e-a37e-742eb0cd3050",
+      "SignatureVersion": "2",
+      "TracingConfig": "Active"
+    }
+  },
+  "liveRaw": {
+    "SignatureVersion": "2",
+    "KmsMasterKeyId": "arn:aws:kms:us-east-1:111111111111:key/7a756e13-ae9b-462e-a37e-742eb0cd3050",
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsRevertAttrs-TopicBFC7AF6E-jDErcwWfkqYj",
+    "TracingConfig": "Active",
+    "DisplayName": "cdkrd revert original",
+    "FifoTopic": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSnsRevertAttrs/d29ce810-6ef4-11f1-be47-0ef1e7bc3c2f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSnsRevertAttrs",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TopicBFC7AF6E",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "CdkRealDriftIntegSnsRevertAttrs-TopicBFC7AF6E-jDErcwWfkqYj"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "TopicBFC7AF6E",
+      "resourceType": "AWS::SNS::Topic",
+      "path": "TopicName",
+      "actual": "CdkRealDriftIntegSnsRevertAttrs-TopicBFC7AF6E-jDErcwWfkqYj",
+      "physicalId": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSnsRevertAttrs-TopicBFC7AF6E-jDErcwWfkqYj",
+      "constructPath": "CdkRealDriftIntegSnsRevertAttrs/Topic"
+    }
+  ]
+}

--- a/tests/integration/sns-revert-attrs/app.ts
+++ b/tests/integration/sns-revert-attrs/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift SNS Topic revert-gap probe. SNS topic
+// configuration is an "attribute bag": the API stores DisplayName / SignatureVersion
+// / TracingConfig / KmsMasterKeyId as individual topic attributes set one key at a
+// time (SetTopicAttributes), and cdkrd reverts a Topic via Cloud Control
+// UpdateResource. This fixture deploys a standard (non-FIFO) topic declaring four
+// mutable attributes so the companion verify-revert.sh can mutate each out of band
+// and confirm `cdkrd revert` (Cloud Control) actually writes each one back — i.e.
+// whether any SNS Topic attribute is a "CC-readable but CC-revert-rejects" gap that
+// would need a type-specific SDK writer. A freshly deployed + recorded topic with NO
+// out-of-band change must also report CLEAN (false-positive guard).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Key } from "aws-cdk-lib/aws-kms";
+import { Topic, TracingConfig } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsRevertAttrs");
+
+const key = new Key(stack, "TopicKey", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  pendingWindow: undefined, // default 30-day window; swept on teardown
+});
+
+new Topic(stack, "Topic", {
+  displayName: "cdkrd revert original",
+  signatureVersion: "2",
+  tracingConfig: TracingConfig.ACTIVE,
+  masterKey: key,
+});
+
+app.synth();

--- a/tests/integration/sns-revert-attrs/cdk.json
+++ b/tests/integration/sns-revert-attrs/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-revert-attrs/package.json
+++ b/tests/integration/sns-revert-attrs/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sns-revert-attrs/verify-revert.sh
+++ b/tests/integration/sns-revert-attrs/verify-revert.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SNS Topic revert-gap probe (real AWS): deploy -> harvest corpus (fresh, pre-record)
+# -> record -> mutate FOUR mutable topic attributes out of band -> check MUST DETECT
+# (exit 1) -> revert (Cloud Control UpdateResource) -> check MUST be CLEAN -> assert
+# each live attribute restored. A post-revert drift names any attribute Cloud Control
+# could not write back (a "CC-readable but CC-revert-rejects" gap needing an SDK writer).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsRevertAttrs
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CORPUS_DIR="${CORPUS_DIR:-/tmp/corpus-sns-revert}"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ARN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SNS::Topic'].PhysicalResourceId" --output text)"
+[ -n "$ARN" ] || fail "could not resolve topic ARN"
+echo "topic: $ARN"
+
+echo "=== harvest corpus (fresh, pre-record) -> $CORPUS_DIR ==="
+rm -rf "$CORPUS_DIR"
+CDKRD_CORPUS_DIR="$CORPUS_DIR" $CLI check "$STACK" --region "$REGION" || true
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+ORIG_KMS="$(aws sns get-topic-attributes --topic-arn "$ARN" --region "$REGION" \
+  --query "Attributes.KmsMasterKeyId" --output text)"
+echo "original KmsMasterKeyId: $ORIG_KMS"
+
+echo "=== out-of-band: mutate DisplayName / SignatureVersion / TracingConfig / KmsMasterKeyId ==="
+aws sns set-topic-attributes --topic-arn "$ARN" --region "$REGION" --attribute-name DisplayName     --attribute-value "drifted out of band" >/dev/null || fail "mutate DisplayName"
+aws sns set-topic-attributes --topic-arn "$ARN" --region "$REGION" --attribute-name SignatureVersion --attribute-value "1"                   >/dev/null || fail "mutate SignatureVersion"
+aws sns set-topic-attributes --topic-arn "$ARN" --region "$REGION" --attribute-name TracingConfig    --attribute-value "PassThrough"         >/dev/null || fail "mutate TracingConfig"
+aws sns set-topic-attributes --topic-arn "$ARN" --region "$REGION" --attribute-name KmsMasterKeyId   --attribute-value "alias/aws/sns"       >/dev/null || fail "mutate KmsMasterKeyId"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sns-revert-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+for p in DisplayName SignatureVersion TracingConfig KmsMasterKeyId; do
+  grep -q "$p" /tmp/cdkrd-sns-revert-detect.out || echo "  NOTE: $p not in detect output (read gap?)"
+done
+
+echo "=== revert (Cloud Control UpdateResource) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert command errored"
+
+echo "=== check after revert (names any CC-revert gap) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sns-revert-after.out
+rc=${PIPESTATUS[0]}
+
+echo "=== live attribute values after revert ==="
+GOT_DN="$(aws sns get-topic-attributes --topic-arn "$ARN" --region "$REGION" --query "Attributes.DisplayName" --output text)"
+GOT_SV="$(aws sns get-topic-attributes --topic-arn "$ARN" --region "$REGION" --query "Attributes.SignatureVersion" --output text)"
+GOT_TC="$(aws sns get-topic-attributes --topic-arn "$ARN" --region "$REGION" --query "Attributes.TracingConfig" --output text)"
+GOT_KMS="$(aws sns get-topic-attributes --topic-arn "$ARN" --region "$REGION" --query "Attributes.KmsMasterKeyId" --output text)"
+echo "  DisplayName     = $GOT_DN   (want: cdkrd revert original)"
+echo "  SignatureVersion= $GOT_SV   (want: 2)"
+echo "  TracingConfig   = $GOT_TC   (want: Active)"
+echo "  KmsMasterKeyId  = $GOT_KMS  (want: NOT alias/aws/sns)"
+
+[ "$rc" -eq 0 ] || fail "post-revert check still reports drift — see /tmp/cdkrd-sns-revert-after.out for the CC-revert gap"
+[ "$GOT_DN" = "cdkrd revert original" ] || fail "DisplayName not restored: $GOT_DN"
+[ "$GOT_SV" = "2" ] || fail "SignatureVersion not restored: $GOT_SV"
+[ "$GOT_TC" = "Active" ] || fail "TracingConfig not restored: $GOT_TC"
+[ "$GOT_KMS" != "alias/aws/sns" ] || fail "KmsMasterKeyId not restored: still $GOT_KMS"
+
+echo "INTEG PASS ($STACK — all 4 SNS Topic attributes revert via Cloud Control)"


### PR DESCRIPTION
## Follow-up to #352 — close the SNS Topic revert-gap question

#352 left an open question raised in review: is any mutable SNS Topic attribute a *"CC-readable but CC-revert-rejects"* case (the bug class that needs a type-specific SDK writer, like the ELB attribute writer)? SNS topic config is an **attribute bag** set one key at a time via `SetTopicAttributes`, so it was a plausible gap.

### Probe
`sns-revert-attrs` deploys a standard (non-FIFO) topic declaring four mutable attributes — **DisplayName, SignatureVersion, TracingConfig, KmsMasterKeyId** (a customer KMS key) — then:
1. mutates all four out of band,
2. asserts `check` detects all four (`declared=4`),
3. reverts via **Cloud Control `UpdateResource`**,
4. asserts the post-revert `check` is **CLEAN** with every live attribute restored (`KmsMasterKeyId` back to the customer key ARN, not `alias/aws/sns`).

### Result
**All four attributes revert cleanly through Cloud Control.** There is **no SNS Topic revert gap** and **no SDK writer is warranted** — `AWS::SNS::Topic` correctly stays out of `SDK_WRITERS`. The fixture is kept as a permanent regression that pins this conclusion (so a future Cloud Control regression on SNS revert fails a test).

Fresh-deploy read also CLEAN (`KmsMasterKeyId` ARN / `SignatureVersion` / `TracingConfig` all FP-safe), harvested into `tests/corpus` (SNS Topic suffixed to avoid the `TopicBFC7AF6E` logical-id collision with the `sns-archive-rich` corpus). Full suite **1558 tests** green. No `src/**` change → `verify-pr-gate` exempt.