### PR TITLE
fix(read,noise): ApiGateway DocumentationPart read-gap + Cognito UserPoolResourceServer Scopes reorder FP

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,8 +93,10 @@ fields, canonicalization) rather than by maintaining a hand-curated allow-list o
    — the inverse of `compositeWith`'s parent-first order); plus the ApiGateway v1
    parent-first `[RestApiId, <child>]` (Model/RequestValidator/Resource/Stage) and
    Cognito `[UserPoolId, <child>]` (UserPoolDomain/UserPoolResourceServer) composites,
-   and ApiGateway::Deployment which is CHILD-first `[DeploymentId, RestApiId]`
-   (`${physicalId}|${RestApiId}`) — all R129, verified live (skipped 7→0); note
+   and the CHILD-first `[<child>, RestApiId]` (`${physicalId}|${RestApiId}`) cases
+   ApiGateway::Deployment (R129) and ApiGateway::DocumentationPart — all verified
+   live (skipped 7→0; DocumentationPart found by the cognito/apigw-rest-subres hunt);
+   note
    ApiGateway::Method needs NO adapter, its CFn physical id is already the full
    `RestApiId|ResourceId|HttpMethod` — `CC_IDENTIFIER_ADAPTERS`
    in router.ts maps those without leaving the CC read path, which is strictly

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1204,6 +1204,19 @@ export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
 // canonical JSON before the positional diff — a genuine rule change still differs.
 export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   'AWS::EC2::SecurityGroup': new Set(['SecurityGroupIngress', 'SecurityGroupEgress']),
+  // Cognito UserPoolResourceServer `Scopes` is a SET of {ScopeName, ScopeDescription}
+  // OAuth scopes that AWS echoes SORTED by ScopeName, not in template order (declared
+  // [zeta.write, alpha.read, mike.admin] reads back [alpha.read, mike.admin, zeta.write]),
+  // so a positional compare false-flags every shifted scope's ScopeName AND
+  // ScopeDescription as declared drift on a freshly recorded resource server. The
+  // element key `ScopeName` is NOT one of canonicalizeTagListsDeep's IDENTITY_FIELDS
+  // (Key/Id/AttributeName/IndexName/Name), so that keyed canonicalizer can't align it —
+  // hence the per-type opt-in. Sorting both sides by canonical JSON aligns equal scopes;
+  // a genuine scope add/remove/change still differs. Observed live on a fresh
+  // cognito-userpool-sets deploy. (The sibling UserPool `AliasAttributes` set was tested
+  // in the SAME deploy with a deliberately non-sorted list and Cognito PRESERVED its
+  // order, so it is NOT folded — observed-only.)
+  'AWS::Cognito::UserPoolResourceServer': new Set(['Scopes']),
   // ListenerRule `Conditions` is a SET keyed by Field (path-pattern / host-header /
   // http-header / …) that AWS returns REORDERED relative to the template, so a
   // positional compare false-flags every condition. Sorting both sides by canonical

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -142,6 +142,20 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
       ? `${pid}|${restApiId}`
       : undefined;
   },
+  // ApiGateway::DocumentationPart is child-first like Deployment: its primaryIdentifier
+  // is `[DocumentationPartId, RestApiId]` (verified live — `RestApiId|DocumentationPartId`
+  // returns NotFound; only `DocumentationPartId|RestApiId` reads). The CFn physical id is
+  // the bare DocumentationPartId; RestApiId comes from the resolved declared Ref. Without
+  // this a declared documentation part is a CC ValidationException skip on every check
+  // (read-gap), so undeclared drift on it is invisible. (RequestValidator/Model are
+  // parent-first and already adapted above.)
+  'AWS::ApiGateway::DocumentationPart': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const restApiId = declared.RestApiId;
+    return typeof restApiId === 'string' && restApiId.length > 0
+      ? `${pid}|${restApiId}`
+      : undefined;
+  },
   // ApplicationAutoScaling ScalingPolicy: primaryIdentifier is [Arn,
   // ScalableDimension]. The CFn physical id IS the PolicyARN, but ScalableDimension
   // is not a direct ScalingPolicy property — it rides on the resolved

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1617,6 +1617,41 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('Cognito UserPoolResourceServer Scopes (ScopeName-keyed reordered set, cognito-userpool-sets)', () => {
+    const T = 'AWS::Cognito::UserPoolResourceServer';
+    // declared in scrambled (non-alphabetical) order; AWS echoes the set SORTED by
+    // ScopeName. ScopeName is NOT an IDENTITY_FIELD, so only the per-type fold aligns it.
+    const declared = {
+      Scopes: [
+        { ScopeName: 'zeta.write', ScopeDescription: 'zeta scope' },
+        { ScopeName: 'alpha.read', ScopeDescription: 'alpha scope' },
+        { ScopeName: 'mike.admin', ScopeDescription: 'mike scope' },
+      ],
+    };
+
+    it('AWS returning the Scopes sorted by ScopeName is NOT drift', () => {
+      const live = {
+        Scopes: [
+          { ScopeName: 'alpha.read', ScopeDescription: 'alpha scope' },
+          { ScopeName: 'mike.admin', ScopeDescription: 'mike scope' },
+          { ScopeName: 'zeta.write', ScopeDescription: 'zeta scope' },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine scope change (a renamed ScopeName) still surfaces', () => {
+      const live = {
+        Scopes: [
+          { ScopeName: 'alpha.read', ScopeDescription: 'alpha scope' },
+          { ScopeName: 'mike.admin', ScopeDescription: 'mike scope' },
+          { ScopeName: 'zeta.delete', ScopeDescription: 'zeta scope' }, // write -> delete
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('ELBv2 ListenerRule Conditions (reordered set, found by elbv2-listenerrule-rich)', () => {
     const T = 'AWS::ElasticLoadBalancingV2::ListenerRule';
     const declared = {

--- a/tests/corpus/AWS__ApiGateway__DocumentationPart.DocPart.json
+++ b/tests/corpus/AWS__ApiGateway__DocumentationPart.DocPart.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DocPart",
+    "resourceType": "AWS::ApiGateway::DocumentationPart",
+    "physicalId": "9dgubo",
+    "constructPath": "CdkRealDriftIntegApigwRestSubres/DocPart",
+    "declared": {
+      "Location": {
+        "Type": "API"
+      },
+      "Properties": "{\"description\":\"cdkrd doc part\"}",
+      "RestApiId": "zllyn0eobd"
+    }
+  },
+  "liveRaw": {
+    "RestApiId": "zllyn0eobd",
+    "Properties": "{\"description\":\"cdkrd doc part\"}",
+    "DocumentationPartId": "9dgubo",
+    "Location": {
+      "Type": "API"
+    }
+  },
+  "schema": {
+    "readOnly": ["DocumentationPartId"],
+    "writeOnly": [],
+    "createOnly": ["Location", "RestApiId"],
+    "readOnlyPaths": ["DocumentationPartId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Location", "RestApiId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPoolResourceServer.ResourceServer.json
+++ b/tests/corpus/AWS__Cognito__UserPoolResourceServer.ResourceServer.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ResourceServer",
+    "resourceType": "AWS::Cognito::UserPoolResourceServer",
+    "physicalId": "cdkrd-api",
+    "constructPath": "CdkRealDriftIntegCognitoUserPoolSets/ResourceServer",
+    "declared": {
+      "Identifier": "cdkrd-api",
+      "Name": "cdkrd-resource-server",
+      "Scopes": [
+        {
+          "ScopeDescription": "zeta scope",
+          "ScopeName": "zeta.write"
+        },
+        {
+          "ScopeDescription": "alpha scope",
+          "ScopeName": "alpha.read"
+        },
+        {
+          "ScopeDescription": "mike scope",
+          "ScopeName": "mike.admin"
+        }
+      ],
+      "UserPoolId": "us-east-1_1CWC05xF7"
+    }
+  },
+  "liveRaw": {
+    "UserPoolId": "us-east-1_1CWC05xF7",
+    "Identifier": "cdkrd-api",
+    "Scopes": [
+      {
+        "ScopeName": "alpha.read",
+        "ScopeDescription": "alpha scope"
+      },
+      {
+        "ScopeName": "mike.admin",
+        "ScopeDescription": "mike scope"
+      },
+      {
+        "ScopeName": "zeta.write",
+        "ScopeDescription": "zeta scope"
+      }
+    ],
+    "Name": "cdkrd-resource-server"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Identifier", "UserPoolId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Identifier", "UserPoolId"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/apigw-rest-subres/app.ts
+++ b/tests/integration/apigw-rest-subres/app.ts
@@ -1,0 +1,65 @@
+// CDK app for the cdk-real-drift apigw-rest-subres read-gap integration test.
+// API Gateway REST sub-resources (RequestValidator, Model, DocumentationPart) all
+// carry a COMPOSITE Cloud Control primaryIdentifier (e.g. RequestValidator is
+// [RestApiId, RequestValidatorId], Model is [RestApiId, Name], DocumentationPart is
+// [DocumentationPartId, RestApiId]) while their CFn Ref returns only the CHILD
+// segment. If cdkrd does not derive the composite id, Cloud Control GetResource
+// rejects the bare child id with ValidationException and the resource is silently
+// `skipped` — a read-gap false negative (the Logs SubscriptionFilter class, PR #344).
+// This fixture deploys all three so a `check` reveals whether they are read or skipped.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  CfnDocumentationPart,
+  JsonSchemaType,
+  JsonSchemaVersion,
+  MockIntegration,
+  PassthroughBehavior,
+  RestApi,
+} from "aws-cdk-lib/aws-apigateway";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegApigwRestSubres");
+
+const api = new RestApi(stack, "Api", {
+  restApiName: "cdkrd-rest-subres",
+});
+api.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+// A method is required for the RestApi to deploy a usable stage.
+api.root.addMethod(
+  "GET",
+  new MockIntegration({
+    integrationResponses: [{ statusCode: "200" }],
+    passthroughBehavior: PassthroughBehavior.NEVER,
+    requestTemplates: { "application/json": '{"statusCode": 200}' },
+  }),
+  { methodResponses: [{ statusCode: "200" }] },
+);
+
+// Composite-id sub-resource #1: RequestValidator [RestApiId, RequestValidatorId].
+api.addRequestValidator("Validator", {
+  requestValidatorName: "cdkrd-validator",
+  validateRequestBody: true,
+  validateRequestParameters: true,
+});
+
+// Composite-id sub-resource #2: Model [RestApiId, Name].
+api.addModel("Model", {
+  modelName: "cdkrdModel",
+  contentType: "application/json",
+  schema: {
+    schema: JsonSchemaVersion.DRAFT4,
+    title: "cdkrdModel",
+    type: JsonSchemaType.OBJECT,
+    properties: { id: { type: JsonSchemaType.STRING } },
+  },
+});
+
+// Composite-id sub-resource #3: DocumentationPart [DocumentationPartId, RestApiId].
+new CfnDocumentationPart(stack, "DocPart", {
+  restApiId: api.restApiId,
+  location: { type: "API" },
+  properties: JSON.stringify({ description: "cdkrd doc part" }),
+});
+
+app.synth();

--- a/tests/integration/apigw-rest-subres/cdk.json
+++ b/tests/integration/apigw-rest-subres/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/apigw-rest-subres/package.json
+++ b/tests/integration/apigw-rest-subres/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-apigw-rest-subres",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift apigw-rest-subres integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/apigw-rest-subres/verify.sh
+++ b/tests/integration/apigw-rest-subres/verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Read-gap integration test (real AWS): API Gateway REST sub-resources
+# (RequestValidator, Model, DocumentationPart) each carry a COMPOSITE Cloud Control
+# primaryIdentifier while their CFn Ref returns only the child segment. If cdkrd does
+# not derive the composite id, Cloud Control GetResource rejects the bare id and the
+# resource is silently classified `skipped` (a read-gap false negative). This test
+# deploys all three and asserts NONE of them are skipped (they must be read), then runs
+# the standard record -> check CLEAN false-positive oracle.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApigwRestSubres
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check --json (fresh, pre-record) — inspect for skipped sub-resources ==="
+$CLI check "$STACK" --region "$REGION" --json | tee "/tmp/cdkrd-$STACK.json" >/dev/null || true
+python3 - "$STACK" <<'PY' || fail "read-gap: a composite-id sub-resource was skipped"
+import json, sys
+stack = sys.argv[1]
+data = json.load(open(f"/tmp/cdkrd-{stack}.json"))
+findings = data.get("findings", [])
+gap_types = {
+    "AWS::ApiGateway::RequestValidator",
+    "AWS::ApiGateway::Model",
+    "AWS::ApiGateway::DocumentationPart",
+}
+skipped = [f for f in findings if f.get("tier") == "skipped" and f.get("resourceType") in gap_types]
+if skipped:
+    print("READ-GAP DETECTED — composite-id sub-resources skipped (not read):")
+    for f in skipped:
+        print(f"  {f['resourceType']} {f.get('logicalId')} — {f.get('note')}")
+    sys.exit(1)
+print("OK — no composite-id sub-resource was skipped; all three were read.")
+PY
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cognito-userpool-sets/app.ts
+++ b/tests/integration/cognito-userpool-sets/app.ts
@@ -1,0 +1,39 @@
+// CDK app for the cdk-real-drift cognito-userpool-sets reorder false-positive test.
+// Two set-like arrays declared in deliberately NON-canonical (scrambled) order:
+//   1. UserPool `AliasAttributes` — a set of sign-in aliases; Cognito is the service
+//      whose UserPoolClient OAuth/URL sets were proven to reorder (folded as
+//      UNORDERED_ARRAY_PROPS), so its sibling pool-level sets are prime suspects.
+//   2. UserPoolResourceServer `Scopes` — an OBJECT array keyed by ScopeName, which is
+//      NOT one of cdkrd's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name), so if
+//      Cognito reorders it the canonicalizer cannot align it (the EC2
+//      BlockDeviceMappings DeviceName / Cognito Schema class).
+// If AWS echoes either set in its own canonical order, a freshly recorded `check`
+// false-flags the reordered-but-identical set as declared drift. UserPoolResourceServer
+// is also a brand-new corpus type (only `added`-tier child coverage existed before).
+// Declared with L1 constructs so the array element ORDER is controlled exactly.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnUserPool, CfnUserPoolResourceServer } from "aws-cdk-lib/aws-cognito";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCognitoUserPoolSets");
+
+const pool = new CfnUserPool(stack, "Pool", {
+  userPoolName: "cdkrd-userpool-sets",
+  // scrambled (non-alphabetical) 3-element sign-in alias set.
+  aliasAttributes: ["preferred_username", "phone_number", "email"],
+  adminCreateUserConfig: { allowAdminCreateUserOnly: true },
+});
+
+new CfnUserPoolResourceServer(stack, "ResourceServer", {
+  userPoolId: pool.ref,
+  identifier: "cdkrd-api",
+  name: "cdkrd-resource-server",
+  // scrambled (non-alphabetical) object-array set, keyed by ScopeName.
+  scopes: [
+    { scopeName: "zeta.write", scopeDescription: "zeta scope" },
+    { scopeName: "alpha.read", scopeDescription: "alpha scope" },
+    { scopeName: "mike.admin", scopeDescription: "mike scope" },
+  ],
+});
+
+app.synth();

--- a/tests/integration/cognito-userpool-sets/cdk.json
+++ b/tests/integration/cognito-userpool-sets/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cognito-userpool-sets/package.json
+++ b/tests/integration/cognito-userpool-sets/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cognito-userpool-sets",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cognito-userpool-sets integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cognito-userpool-sets/verify.sh
+++ b/tests/integration/cognito-userpool-sets/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Cognito UserPool AliasAttributes + UserPoolResourceServer Scopes are set-like arrays declared in scrambled order; if AWS canonicalizes either, a positional diff false-flags the reordered-but-identical set as declared drift.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCognitoUserPoolSets
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/wafv2-regexset/app.ts
+++ b/tests/integration/wafv2-regexset/app.ts
@@ -1,0 +1,23 @@
+// CDK app for the cdk-real-drift wafv2-regexset reorder false-positive test.
+// WAFv2 RegexPatternSet `RegularExpressionList` is the sibling of WAFv2 IPSet
+// `Addresses`, which AWS is proven to echo in its own canonical order (folded as
+// UNORDERED_ARRAY_PROPS). The existing RegexPatternSet corpus declared its list
+// already in ASCII order, so the reorder is UNTESTED. Declared here in deliberately
+// scrambled (non-canonical) order with 3 elements: if AWS returns them sorted, a
+// freshly recorded `check` false-flags the reordered-but-identical set as declared
+// drift. Cloud Control reads RegularExpressionList back (it is NOT write-only), so the
+// reorder, if any, is observable. Serverless, ~30s deploy, no NAT.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnRegexPatternSet } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2Regexset");
+
+new CfnRegexPatternSet(stack, "RegexSet", {
+  name: "cdkrd-regexset",
+  scope: "REGIONAL",
+  // scrambled: sorted ASCII order would be alpha, mango, zebra.
+  regularExpressionList: ["^/zebra/.*$", "^/alpha/.*$", "^/mango/.*$"],
+});
+
+app.synth();

--- a/tests/integration/wafv2-regexset/cdk.json
+++ b/tests/integration/wafv2-regexset/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-regexset/package.json
+++ b/tests/integration/wafv2-regexset/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-regexset",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-regexset integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-regexset/verify.sh
+++ b/tests/integration/wafv2-regexset/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. WAFv2 RegexPatternSet RegularExpressionList is a set declared in scrambled order; if AWS echoes it sorted (like the sibling IPSet Addresses), a positional diff false-flags it as declared drift.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2Regexset
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -404,6 +404,40 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('dep123');
   });
 
+  // ApiGateway::DocumentationPart is CHILD-first [DocumentationPartId, RestApiId] —
+  // verified live (cognito/apigw-rest-subres hunt) that `RestApiId|DocumentationPartId`
+  // returns NotFound; only `DocumentationPartId|RestApiId` reads. Without the adapter the
+  // bare DocumentationPartId is a CC ValidationException skip (read-gap).
+  it('ApiGateway DocumentationPart: builds the DocumentationPartId|RestApiId composite — child FIRST', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGateway::DocumentationPart',
+        physicalId: '9dgubo',
+        declared: { RestApiId: 'api456' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('9dgubo|api456');
+  });
+
+  it('ApiGateway DocumentationPart: an unresolved RestApiId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGateway::DocumentationPart',
+        physicalId: '9dgubo',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('9dgubo');
+  });
+
   // R77: AppConfig Environment/ConfigurationProfile composite [ApplicationId, <child id>].
   for (const t of ['AWS::AppConfig::Environment', 'AWS::AppConfig::ConfigurationProfile']) {
     it(`${t}: builds the ApplicationId|<child> composite identifier`, async () => {


### PR DESCRIPTION
## Summary

Bug-hunt round — 3 cheap probe stacks (apigw-rest-subres / cognito-userpool-sets / wafv2-regexset), **2 real bugs found live + fixed**, 2 offline-predicted classes ruled out.

### 🐛 FN — `AWS::ApiGateway::DocumentationPart` silent read-gap
It was `skipped` on every check (CC `GetResource` ValidationException). Its `primaryIdentifier` is the **child-first** composite `[DocumentationPartId, RestApiId]`, but the CFn Ref returns only the bare `DocumentationPartId`, so all drift on it was invisible. Added a `CC_IDENTIFIER_ADAPTERS` entry building `DocumentationPartId|RestApiId` (verified live — the reverse order returns `NotFound`). Sibling `RequestValidator`/`Model` are parent-first and already adapted (read fine in the same deploy).

### 🐛 FP — `AWS::Cognito::UserPoolResourceServer` `Scopes` reorder
`Scopes` (a set of `{ScopeName, ScopeDescription}`) is echoed by AWS **sorted by ScopeName**, not in template order, so a freshly recorded `check` false-flagged every shifted scope — **6 declared-drift findings on a clean stack**. `ScopeName` is not an `IDENTITY_FIELD`, so the keyed canonicalizer can't align it → added a per-type `UNORDERED_OBJECT_ARRAY_PROPS` entry. Live-proven full cycle: a genuine scope change still detects (exit 1) and **reverts via Cloud Control UpdateResource**.

### ✅ Rule-outs (observed-only, declared NON-sorted, AWS PRESERVED order)
- Cognito UserPool `AliasAttributes`
- WAFv2 RegexPatternSet `RegularExpressionList` (unlike its sibling IPSet `Addresses`)

## Tests
- `router.test.ts` — DocumentationPart composite + unresolved-parent fallback
- `classify.test.ts` — Scopes reorder-is-not-drift + genuine-change-still-surfaces
- 2 new golden-corpus cases (replayed offline forever)
- 3 regression integ fixtures
- **1564 unit tests green**, typecheck / lint+format / build all pass

## Cleanup
All 3 stacks deleted via `delstack`, `bughunt-track.sh verify` → GONE + SWEEP CLEAN, sentinel cleared.
