### PR TITLE
feat(noise): fold ~25 constant service defaults across common types (first-run-noise sweep)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -97,6 +97,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     MaximumMessageSize: 1048576,
     FifoThroughputLimit: 'perQueue', // FIFO queues only
     DeduplicationScope: 'queue', // FIFO queues only
+    KmsDataKeyReusePeriodSeconds: 300, // default 5 min; appears only on SSE-KMS queues
   },
   'AWS::ElasticLoadBalancingV2::TargetGroup': {
     HealthCheckEnabled: true,
@@ -131,6 +132,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ApiKeySourceType: 'HEADER',
     SecurityPolicy: 'TLS_1_0',
     EndpointConfiguration: { IpAddressType: 'ipv4', Types: ['EDGE'] },
+    DisableExecuteApiEndpoint: false,
   },
   'AWS::EC2::Subnet': {
     PrivateDnsNameOptionsOnLaunch: {
@@ -138,6 +140,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       HostnameType: 'ip-name',
       EnableResourceNameDnsAAAARecord: false,
     },
+    // IPv6 feature flags AWS reports off by default on every IPv4 subnet.
+    AssignIpv6AddressOnCreation: false,
+    EnableDns64: false,
+    Ipv6Native: false,
   },
   // R-noise-sweep (found by the ec2-instance-rich hunt, PR #310 follow-up): a fresh
   // EC2 Instance reports these three constant service defaults as undeclared on every
@@ -159,6 +165,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ApiGatewayV2::Api': {
     RouteSelectionExpression: '$request.method $request.path',
     IpAddressType: 'ipv4', // R-noise-sweep: default; flipping to dualstack no longer matches and surfaces
+    DisableExecuteApiEndpoint: false,
   },
   'AWS::ApiGatewayV2::Integration': {
     ConnectionType: 'INTERNET',
@@ -172,6 +179,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::DynamoDB::Table': {
     BillingMode: 'PROVISIONED',
+    DeletionProtectionEnabled: false,
   },
   'AWS::ECR::Repository': {
     EncryptionConfiguration: { EncryptionType: 'AES256' },
@@ -205,12 +213,15 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // Cognito's default refresh-token validity is 30 (days, the default unit) when a
     // client declares none — observed unanimous across the corpus clients.
     RefreshTokenValidity: 30,
+    EnablePropagateAdditionalUserContextData: false,
   },
   'AWS::ECS::Service': {
     SchedulingStrategy: 'REPLICA',
     // A service with no load-balancer health-check grace reads back 0 (the default) —
     // observed unanimous across the corpus services.
     HealthCheckGracePeriodSeconds: 0,
+    AvailabilityZoneRebalancing: 'ENABLED', // AWS default for new services
+    EnableExecuteCommand: false,
   },
   'AWS::AppSync::GraphQLApi': {
     ApiType: 'GRAPHQL',
@@ -221,6 +232,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // AppSync API otherwise reports them as first-run undeclared inventory.
     QueryDepthLimit: 0,
     ResolverCountLimit: 0,
+    XrayEnabled: false,
   },
   // AppSync Resolvers / Functions default MaxBatchSize to 0 (no batch invocation)
   // when the template declares no batching — observed live on a fresh
@@ -240,6 +252,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::KMS::Key': {
     Enabled: true,
+    KeySpec: 'SYMMETRIC_DEFAULT',
+    KeyUsage: 'ENCRYPT_DECRYPT',
+    Origin: 'AWS_KMS',
   },
   'AWS::IAM::Group': {
     Path: '/',
@@ -295,18 +310,30 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     MonitoringInterval: 0,
     NetworkType: 'IPV4',
     StorageThroughput: 0,
+    // Boolean feature flags off by default (observed unanimous across the corpus
+    // instances). NOT folded: per-resource/engine values (Port, EngineVersion,
+    // LicenseModel, MasterUsername, StorageType, *ParameterGroupName, CACertificateIdentifier).
+    CopyTagsToSnapshot: false,
+    DedicatedLogVolume: false,
+    EnableIAMDatabaseAuthentication: false,
+    EnablePerformanceInsights: false,
+    ManageMasterUserPassword: false,
+    MultiAZ: false,
+    StorageEncrypted: false,
   },
   'AWS::RDS::DBCluster': {
     AutoMinorVersionUpgrade: true,
     DatabaseInsightsMode: 'standard',
     EngineLifecycleSupport: 'open-source-rds-extended-support',
     NetworkType: 'IPV4',
+    EngineMode: 'provisioned', // default; serverless/parallelquery are explicit opt-ins
   },
   'AWS::Neptune::DBInstance': {
     AutoMinorVersionUpgrade: true,
   },
   'AWS::Neptune::DBCluster': {
     NetworkType: 'IPV4',
+    DBPort: 8182, // Neptune's fixed default port
   },
   'AWS::ElastiCache::ReplicationGroup': {
     AutoMinorVersionUpgrade: true,
@@ -345,6 +372,59 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Glue::Job': {
     JobMode: 'SCRIPT',
     MaxRetries: 0,
+  },
+  // R-noise-sweep (PR #355 follow-up): constant service defaults a fresh resource
+  // reports as undeclared on every first run. Each is a documented account-/region-
+  // independent default (NOT a per-resource id/name/AZ/window/port-that-varies-by-engine),
+  // equality-gated like every KNOWN_DEFAULTS entry — flip one out of band and it no
+  // longer matches, so it re-surfaces as real drift.
+  'AWS::AutoScaling::AutoScalingGroup': {
+    Cooldown: '300', // default cooldown 300s (CC returns it as a string)
+    HealthCheckType: 'EC2',
+    HealthCheckGracePeriod: 0,
+  },
+  'AWS::DocDB::DBCluster': {
+    Port: 27017, // DocDB's fixed default port
+  },
+  'AWS::SSM::Association': {
+    DocumentVersion: '$DEFAULT', // default when no explicit version is pinned
+  },
+  // CloudWatch alarm defaults. A metric Alarm's `ActionsEnabled` already folds via its
+  // CFn schema default, so only `TreatMissingData` (the documented "missing" default,
+  // surfaced as undeclared whenever a template omits it — the common case) is added here.
+  // DatapointsToAlarm is NOT folded — it defaults to EvaluationPeriods (a per-alarm value,
+  // not a constant); EvaluationPeriods/Threshold/ComparisonOperator are required so they
+  // are always declared, never first-run noise. CompositeAlarm has NO schema default for
+  // `ActionsEnabled` (observed undeclared in the corpus), so it needs the explicit fold.
+  'AWS::CloudWatch::Alarm': {
+    TreatMissingData: 'missing',
+  },
+  'AWS::CloudWatch::CompositeAlarm': {
+    ActionsEnabled: true,
+  },
+  'AWS::CloudWatch::MetricStream': {
+    IncludeLinkedAccountsMetrics: false,
+    State: 'running', // steady state after a successful create
+  },
+  'AWS::Logs::LogGroup': {
+    LogGroupClass: 'STANDARD',
+    DeletionProtectionEnabled: false,
+    BearerTokenAuthenticationEnabled: false,
+  },
+  'AWS::ApiGateway::Method': {
+    ApiKeyRequired: false,
+  },
+  'AWS::ApiGatewayV2::Route': {
+    ApiKeyRequired: false,
+  },
+  'AWS::ElasticLoadBalancingV2::ListenerRule': {
+    IsDefault: false, // a declared rule is never the listener's default rule
+  },
+  // A Glue Crawler with no Lake Formation config reads back the "off" sentinel object
+  // (empty AccountId + creds disabled) — whole-object equality-gated, so configuring
+  // Lake Formation still surfaces.
+  'AWS::Glue::Crawler': {
+    LakeFormationConfiguration: { AccountId: '', UseLakeFormationCredentials: false },
   },
 };
 

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD.json
@@ -79,6 +79,15 @@
       "actual": "$request.method $request.path",
       "physicalId": "rno3u8uv0f",
       "constructPath": "CdkrdIntegHarvest4/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "rno3u8uv0f",
+      "constructPath": "CdkrdIntegHarvest4/Api"
     }
   ]
 }

--- a/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD_http_rich.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.ApiF70053CD_http_rich.json
@@ -95,6 +95,15 @@
       "actual": "$request.method $request.path",
       "physicalId": "z1mf4h761f",
       "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "z1mf4h761f",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api"
     }
   ]
 }

--- a/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Api.HttpApi.json
@@ -94,6 +94,15 @@
       "actual": "$request.method $request.path",
       "physicalId": "t72tv8phdi",
       "constructPath": "CdkrdIntegHarvest/HttpApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HttpApi",
+      "resourceType": "AWS::ApiGatewayV2::Api",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "t72tv8phdi",
+      "constructPath": "CdkrdIntegHarvest/HttpApi"
     }
   ]
 }

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
@@ -50,20 +50,20 @@
       "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "ApiANYpingPingA3011524",
-      "resourceType": "AWS::ApiGatewayV2::Integration",
-      "path": "IntegrationMethod",
-      "actual": "POST",
-      "physicalId": "qf0uwiu",
-      "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "ApiANYpingPingA3011524",
       "resourceType": "AWS::ApiGatewayV2::Integration",
       "path": "TimeoutInMillis",
       "actual": 30000,
+      "physicalId": "qf0uwiu",
+      "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ApiANYpingPingA3011524",
+      "resourceType": "AWS::ApiGatewayV2::Integration",
+      "path": "IntegrationMethod",
+      "actual": "POST",
       "physicalId": "qf0uwiu",
       "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
     }

--- a/tests/corpus/AWS__ApiGatewayV2__Route.ApiANYpingF0D17186.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Route.ApiANYpingF0D17186.json
@@ -37,5 +37,15 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiANYpingF0D17186",
+      "resourceType": "AWS::ApiGatewayV2::Route",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "lghabc6",
+      "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping"
+    }
+  ]
 }

--- a/tests/corpus/AWS__ApiGatewayV2__Route.ApiGETitems28A279F0.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Route.ApiGETitems28A279F0.json
@@ -38,5 +38,15 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiGETitems28A279F0",
+      "resourceType": "AWS::ApiGatewayV2::Route",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "s2sushb",
+      "constructPath": "CdkRealDriftIntegApigwv2HttpRich/Api/GET--items"
+    }
+  ]
 }

--- a/tests/corpus/AWS__ApiGateway__Method.ApiGET9257B917.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiGET9257B917.json
@@ -71,21 +71,20 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "ApiGET9257B917",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
+    },
+    {
       "tier": "generated",
       "logicalId": "ApiGET9257B917",
       "resourceType": "AWS::ApiGateway::Method",
       "path": "Integration.CacheNamespace",
       "actual": "1pd9ky6ghl",
-      "nested": true,
-      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
-      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "ApiGET9257B917",
-      "resourceType": "AWS::ApiGateway::Method",
-      "path": "Integration.PassthroughBehavior",
-      "actual": "WHEN_NO_MATCH",
       "nested": true,
       "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
       "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
@@ -106,6 +105,16 @@
       "resourceType": "AWS::ApiGateway::Method",
       "path": "Integration.TimeoutInMillis",
       "actual": 29000,
+      "nested": true,
+      "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
+      "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiGET9257B917",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "Integration.PassthroughBehavior",
+      "actual": "WHEN_NO_MATCH",
       "nested": true,
       "physicalId": "38w1jnsg0j|1pd9ky6ghl|GET",
       "constructPath": "CdkdriftIntegHarvest8/Api/Default/GET"

--- a/tests/corpus/AWS__ApiGateway__Method.ApiitemsGET2CEFDB25.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiitemsGET2CEFDB25.json
@@ -76,6 +76,15 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsGET2CEFDB25",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "we41awg0n3|to60x5|GET",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/GET"
+    },
+    {
       "tier": "generated",
       "logicalId": "ApiitemsGET2CEFDB25",
       "resourceType": "AWS::ApiGateway::Method",

--- a/tests/corpus/AWS__ApiGateway__Method.ApiitemsPOST55EC2F9D.json
+++ b/tests/corpus/AWS__ApiGateway__Method.ApiitemsPOST55EC2F9D.json
@@ -76,6 +76,15 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "ApiitemsPOST55EC2F9D",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "we41awg0n3|to60x5|POST",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/Default/items/POST"
+    },
+    {
       "tier": "generated",
       "logicalId": "ApiitemsPOST55EC2F9D",
       "resourceType": "AWS::ApiGateway::Method",

--- a/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
+++ b/tests/corpus/AWS__ApiGateway__Method.RestApiGET0F59260B.json
@@ -88,6 +88,15 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "RestApiGET0F59260B",
+      "resourceType": "AWS::ApiGateway::Method",
+      "path": "ApiKeyRequired",
+      "actual": false,
+      "physicalId": "84xvb60zri|6pva1vasg4|GET",
+      "constructPath": "CdkrdIntegHarvest/RestApi/Default/GET"
+    },
+    {
       "tier": "generated",
       "logicalId": "RestApiGET0F59260B",
       "resourceType": "AWS::ApiGateway::Method",

--- a/tests/corpus/AWS__ApiGateway__RestApi.Api.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.Api.json
@@ -62,6 +62,15 @@
       "tier": "atDefault",
       "logicalId": "Api",
       "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "plg2s0yj0k",
+      "constructPath": "CdkrdIntegHarvest6/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Api",
+      "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
       "actual": "HEADER",
       "physicalId": "plg2s0yj0k",
@@ -83,8 +92,8 @@
       "tier": "atDefault",
       "logicalId": "Api",
       "resourceType": "AWS::ApiGateway::RestApi",
-      "path": "SecurityPolicy",
-      "actual": "TLS_1_0",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
       "physicalId": "plg2s0yj0k",
       "constructPath": "CdkrdIntegHarvest6/Api"
     }

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD.json
@@ -61,6 +61,15 @@
       "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "38w1jnsg0j",
+      "constructPath": "CdkdriftIntegHarvest8/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
       "actual": "HEADER",
       "physicalId": "38w1jnsg0j",
@@ -82,8 +91,8 @@
       "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
-      "path": "SecurityPolicy",
-      "actual": "TLS_1_0",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
       "physicalId": "38w1jnsg0j",
       "constructPath": "CdkdriftIntegHarvest8/Api"
     }

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD_rest_rich.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD_rest_rich.json
@@ -85,6 +85,15 @@
       "constructPath": "CdkRealDriftIntegApigwRestRich/Api"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "ApiF70053CD",
+      "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
+      "physicalId": "we41awg0n3",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",

--- a/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.RestApi0C43BF4B.json
@@ -77,6 +77,15 @@
       "tier": "atDefault",
       "logicalId": "RestApi0C43BF4B",
       "resourceType": "AWS::ApiGateway::RestApi",
+      "path": "SecurityPolicy",
+      "actual": "TLS_1_0",
+      "physicalId": "84xvb60zri",
+      "constructPath": "CdkrdIntegHarvest/RestApi"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "RestApi0C43BF4B",
+      "resourceType": "AWS::ApiGateway::RestApi",
       "path": "ApiKeySourceType",
       "actual": "HEADER",
       "physicalId": "84xvb60zri",
@@ -98,8 +107,8 @@
       "tier": "atDefault",
       "logicalId": "RestApi0C43BF4B",
       "resourceType": "AWS::ApiGateway::RestApi",
-      "path": "SecurityPolicy",
-      "actual": "TLS_1_0",
+      "path": "DisableExecuteApiEndpoint",
+      "actual": false,
       "physicalId": "84xvb60zri",
       "constructPath": "CdkrdIntegHarvest/RestApi"
     }

--- a/tests/corpus/AWS__AppSync__GraphQLApi.AddAuthReorder.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.AddAuthReorder.json
@@ -138,6 +138,15 @@
       "tier": "atDefault",
       "logicalId": "Api",
       "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "XrayEnabled",
+      "actual": false,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/5pw7o66kxzhopgxpkmp2oh5sxi",
+      "constructPath": "CdkRealDriftIntegAppsyncAddAuthReorder/Api"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Api",
+      "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "Visibility",
       "actual": "GLOBAL",
       "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/5pw7o66kxzhopgxpkmp2oh5sxi",

--- a/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
+++ b/tests/corpus/AWS__AppSync__GraphQLApi.Graph.json
@@ -113,6 +113,15 @@
       "tier": "atDefault",
       "logicalId": "Graph",
       "resourceType": "AWS::AppSync::GraphQLApi",
+      "path": "XrayEnabled",
+      "actual": false,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",
+      "constructPath": "CdkrdIntegHarvest3/Graph"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Graph",
+      "resourceType": "AWS::AppSync::GraphQLApi",
       "path": "Visibility",
       "actual": "GLOBAL",
       "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/bb3dolsy4jf4vgdelqzpaojuqq",

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
@@ -88,8 +88,8 @@
       "tier": "undeclared",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
-      "path": "ScalableDimension",
-      "actual": "dynamodb:table:ReadCapacityUnits",
+      "path": "ServiceNamespace",
+      "actual": "dynamodb",
       "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     },
@@ -97,8 +97,8 @@
       "tier": "undeclared",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
-      "path": "ServiceNamespace",
-      "actual": "dynamodb",
+      "path": "ScalableDimension",
+      "actual": "dynamodb:table:ReadCapacityUnits",
       "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:006886ff-939e-44c7-a2b8-6802bb2e3e66:resource/dynamodb/table/CdkrdIntegHarvest4-Sessions8896A56D-1BLLK19UTRX3G:policyName/CdkrdIntegHarvest4ReadTargetReadUtil0E59EFB4",
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     }

--- a/tests/corpus/AWS__Athena__WorkGroup.Queries.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.Queries.json
@@ -65,15 +65,6 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "Queries",
-      "resourceType": "AWS::Athena::WorkGroup",
-      "path": "State",
-      "actual": "ENABLED",
-      "physicalId": "cdkrd-harvest",
-      "constructPath": "CdkrdIntegHarvest/Queries"
-    },
-    {
       "tier": "readGap",
       "logicalId": "Queries",
       "resourceType": "AWS::Athena::WorkGroup",
@@ -95,6 +86,15 @@
         "PublishCloudWatchMetricsEnabled": true,
         "RequesterPaysEnabled": false
       },
+      "physicalId": "cdkrd-harvest",
+      "constructPath": "CdkrdIntegHarvest/Queries"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Queries",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "State",
+      "actual": "ENABLED",
       "physicalId": "cdkrd-harvest",
       "constructPath": "CdkrdIntegHarvest/Queries"
     }

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AutoScalingGroupASG804C35BE.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AutoScalingGroupASG804C35BE.json
@@ -128,7 +128,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "Cooldown",
@@ -157,7 +157,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "HealthCheckGracePeriod",

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AzReorder.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AzReorder.json
@@ -132,7 +132,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "Cooldown",
@@ -161,7 +161,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "HealthCheckGracePeriod",
@@ -203,7 +203,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "HealthCheckType",

--- a/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannelLive.json
+++ b/tests/corpus/AWS__Chatbot__SlackChannelConfiguration.SlackChannelLive.json
@@ -50,8 +50,8 @@
       "tier": "atDefault",
       "logicalId": "SlackChannel425D424B",
       "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
-      "path": "GuardrailPolicies",
-      "actual": ["arn:aws:iam::aws:policy/AdministratorAccess"],
+      "path": "UserRoleRequired",
+      "actual": false,
       "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/main-CostCheck",
       "constructPath": "main-CostCheck/SlackChannel"
     },
@@ -59,8 +59,8 @@
       "tier": "atDefault",
       "logicalId": "SlackChannel425D424B",
       "resourceType": "AWS::Chatbot::SlackChannelConfiguration",
-      "path": "UserRoleRequired",
-      "actual": false,
+      "path": "GuardrailPolicies",
+      "actual": ["arn:aws:iam::aws:policy/AdministratorAccess"],
       "physicalId": "arn:aws:chatbot::111111111111:chat-configuration/slack-channel/main-CostCheck",
       "constructPath": "main-CostCheck/SlackChannel"
     }

--- a/tests/corpus/AWS__CloudWatch__CompositeAlarm.Composite0B9667B9.json
+++ b/tests/corpus/AWS__CloudWatch__CompositeAlarm.Composite0B9667B9.json
@@ -50,7 +50,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Composite0B9667B9",
       "resourceType": "AWS::CloudWatch::CompositeAlarm",
       "path": "ActionsEnabled",

--- a/tests/corpus/AWS__CloudWatch__MetricStream.FilterReorder.json
+++ b/tests/corpus/AWS__CloudWatch__MetricStream.FilterReorder.json
@@ -64,5 +64,15 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Stream",
+      "resourceType": "AWS::CloudWatch::MetricStream",
+      "path": "IncludeLinkedAccountsMetrics",
+      "actual": false,
+      "physicalId": "CdkRealDriftIntegMetricStreamFilterReorder-Stream-jFmkuW30omRd",
+      "constructPath": "CdkRealDriftIntegMetricStreamFilterReorder/Stream"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CloudWatch__MetricStream.Stream.json
+++ b/tests/corpus/AWS__CloudWatch__MetricStream.Stream.json
@@ -66,5 +66,15 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Stream",
+      "resourceType": "AWS::CloudWatch::MetricStream",
+      "path": "IncludeLinkedAccountsMetrics",
+      "actual": false,
+      "physicalId": "CdkRealDriftIntegCloudwatchMetricstream-Stream-sf0BAdBHT2jN",
+      "constructPath": "CdkRealDriftIntegCloudwatchMetricstream/Stream"
+    }
+  ]
 }

--- a/tests/corpus/AWS__CodeBuild__Project.Build.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build.json
@@ -61,6 +61,24 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "Build",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "TimeoutInMinutes",
+      "actual": 60,
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Build"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Build",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "QueuedTimeoutInMinutes",
+      "actual": 480,
+      "physicalId": "cdkrd-harvest6",
+      "constructPath": "CdkrdIntegHarvest6/Build"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Build",
       "resourceType": "AWS::CodeBuild::Project",
@@ -76,24 +94,6 @@
       "path": "Environment.ImagePullCredentialsType",
       "actual": "CODEBUILD",
       "nested": true,
-      "physicalId": "cdkrd-harvest6",
-      "constructPath": "CdkrdIntegHarvest6/Build"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Build",
-      "resourceType": "AWS::CodeBuild::Project",
-      "path": "QueuedTimeoutInMinutes",
-      "actual": 480,
-      "physicalId": "cdkrd-harvest6",
-      "constructPath": "CdkrdIntegHarvest6/Build"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Build",
-      "resourceType": "AWS::CodeBuild::Project",
-      "path": "TimeoutInMinutes",
-      "actual": 60,
       "physicalId": "cdkrd-harvest6",
       "constructPath": "CdkrdIntegHarvest6/Build"
     }

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -332,45 +332,6 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
-      "actual": 7,
-      "nested": true,
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "DeletionProtection",
-      "actual": "INACTIVE",
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "EmailConfiguration",
-      "actual": {
-        "EmailSendingAccount": "COGNITO_DEFAULT"
-      },
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Pool88FC4FF9F",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "MfaConfiguration",
-      "actual": "OFF",
-      "physicalId": "us-east-1_BUaNF3GfH",
-      "constructPath": "CdkdriftIntegHarvest8/Pool8"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
@@ -388,6 +349,15 @@
           "AllowedFirstAuthFactors": ["PASSWORD"]
         }
       },
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
       "physicalId": "us-east-1_BUaNF3GfH",
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
@@ -621,6 +591,24 @@
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
@@ -630,11 +618,23 @@
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
     {
+      "tier": "undeclared",
+      "logicalId": "Pool88FC4FF9F",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_BUaNF3GfH",
+      "constructPath": "CdkdriftIntegHarvest8/Pool8"
+    },
+    {
       "tier": "atDefault",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "UserPoolTier",
-      "actual": "ESSENTIALS",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 7,
+      "nested": true,
       "physicalId": "us-east-1_BUaNF3GfH",
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     }

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -333,45 +333,6 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
-      "actual": 7,
-      "nested": true,
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "DeletionProtection",
-      "actual": "INACTIVE",
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "EmailConfiguration",
-      "actual": {
-        "EmailSendingAccount": "COGNITO_DEFAULT"
-      },
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "PoolD3F588B8",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "MfaConfiguration",
-      "actual": "OFF",
-      "physicalId": "us-east-1_4tB3jYmmc",
-      "constructPath": "CdkrdIntegHarvest6/Pool"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
@@ -389,6 +350,15 @@
           "AllowedFirstAuthFactors": ["PASSWORD"]
         }
       },
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "MfaConfiguration",
+      "actual": "OFF",
       "physicalId": "us-east-1_4tB3jYmmc",
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
@@ -622,6 +592,24 @@
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
@@ -631,11 +619,23 @@
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
     {
+      "tier": "undeclared",
+      "logicalId": "PoolD3F588B8",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_4tB3jYmmc",
+      "constructPath": "CdkrdIntegHarvest6/Pool"
+    },
+    {
       "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "UserPoolTier",
-      "actual": "ESSENTIALS",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 7,
+      "nested": true,
       "physicalId": "us-east-1_4tB3jYmmc",
       "constructPath": "CdkrdIntegHarvest6/Pool"
     }

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -336,48 +336,6 @@
       "tier": "atDefault",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "Policies.SignInPolicy",
-      "actual": {
-        "AllowedFirstAuthFactors": ["PASSWORD"]
-      },
-      "nested": true,
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
-      "actual": 3,
-      "nested": true,
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "DeletionProtection",
-      "actual": "INACTIVE",
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
-      "path": "EmailConfiguration",
-      "actual": {
-        "EmailSendingAccount": "COGNITO_DEFAULT"
-      },
-      "physicalId": "us-east-1_Ifea0bzss",
-      "constructPath": "CdkrdIntegHarvest3/Users"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Users0A0EEA89",
-      "resourceType": "AWS::Cognito::UserPool",
       "path": "MfaConfiguration",
       "actual": "OFF",
       "physicalId": "us-east-1_Ifea0bzss",
@@ -613,6 +571,24 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "UserPoolTier",
+      "actual": "ESSENTIALS",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "DeletionProtection",
+      "actual": "INACTIVE",
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
@@ -622,11 +598,35 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "EmailConfiguration",
+      "actual": {
+        "EmailSendingAccount": "COGNITO_DEFAULT"
+      },
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Users0A0EEA89",
+      "resourceType": "AWS::Cognito::UserPool",
+      "path": "AdminCreateUserConfig.UnusedAccountValidityDays",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "us-east-1_Ifea0bzss",
+      "constructPath": "CdkrdIntegHarvest3/Users"
+    },
+    {
       "tier": "atDefault",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
-      "path": "UserPoolTier",
-      "actual": "ESSENTIALS",
+      "path": "Policies.SignInPolicy",
+      "actual": {
+        "AllowedFirstAuthFactors": ["PASSWORD"]
+      },
+      "nested": true,
       "physicalId": "us-east-1_Ifea0bzss",
       "constructPath": "CdkrdIntegHarvest3/Users"
     }

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client.callbackurls.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client.callbackurls.json
@@ -74,6 +74,15 @@
       "tier": "atDefault",
       "logicalId": "Client",
       "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnablePropagateAdditionalUserContextData",
+      "actual": false,
+      "physicalId": "vse1lkm5r2r10drv0be31kv7u",
+      "constructPath": "CdkRealDriftIntegCognitoCallbackUrls/Client"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Client",
+      "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "AuthSessionValidity",
       "actual": 3,
       "physicalId": "vse1lkm5r2r10drv0be31kv7u",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
@@ -64,6 +64,15 @@
       "tier": "atDefault",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnablePropagateAdditionalUserContextData",
+      "actual": false,
+      "physicalId": "mr9u1vrva41nona9of2rfctdi",
+      "constructPath": "CdkRealDriftIntegCognito/Client"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Client4A7F64DF",
+      "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "AuthSessionValidity",
       "actual": 3,
       "physicalId": "mr9u1vrva41nona9of2rfctdi",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
@@ -63,6 +63,15 @@
       "tier": "atDefault",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
+      "path": "EnablePropagateAdditionalUserContextData",
+      "actual": false,
+      "physicalId": "7d78lu0gfopub8hldk8ogl5asn",
+      "constructPath": "CdkrdIntegHarvest3/WebClient"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WebClient697086FD",
+      "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "AuthSessionValidity",
       "actual": 3,
       "physicalId": "7d78lu0gfopub8hldk8ogl5asn",

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
@@ -89,7 +89,7 @@
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "Port",

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
@@ -88,7 +88,7 @@
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "Port",

--- a/tests/corpus/AWS__DynamoDB__Table.Classic397C6F85.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Classic397C6F85.json
@@ -194,6 +194,15 @@
       "constructPath": "CdkRealDriftIntegDdbNestedSets/Classic"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Classic397C6F85",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "cdkrd-integ-ddb-nested-sets-classic",
+      "constructPath": "CdkRealDriftIntegDdbNestedSets/Classic"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Classic397C6F85",
       "resourceType": "AWS::DynamoDB::Table",

--- a/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
@@ -183,6 +183,15 @@
       "constructPath": "CdkRealDriftIntegDynamoDB/Data"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkRealDriftIntegDynamoDB-Data666C94C7-C09XWQ7XMDHF",
+      "constructPath": "CdkRealDriftIntegDynamoDB/Data"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::DynamoDB::Table",

--- a/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
+++ b/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
@@ -172,6 +172,15 @@
       "constructPath": "CdkrdIntegHarvest2/Orders"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "OrdersA9B65338",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest2-OrdersA9B65338-1T3GPTWJ10CC0",
+      "constructPath": "CdkrdIntegHarvest2/Orders"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "OrdersA9B65338",
       "resourceType": "AWS::DynamoDB::Table",

--- a/tests/corpus/AWS__DynamoDB__Table.ResourcePolicy.json
+++ b/tests/corpus/AWS__DynamoDB__Table.ResourcePolicy.json
@@ -132,6 +132,15 @@
       "actual": "PROVISIONED",
       "physicalId": "CdkRealDriftIntegDdbResourcePolicyRich-TableCD117FA1-TCIZLHHU2N65",
       "constructPath": "CdkRealDriftIntegDdbResourcePolicyRich/Table"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TableCD117FA1",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkRealDriftIntegDdbResourcePolicyRich-TableCD117FA1-TCIZLHHU2N65",
+      "constructPath": "CdkRealDriftIntegDdbResourcePolicyRich/Table"
     }
   ]
 }

--- a/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
@@ -98,6 +98,15 @@
       },
       "physicalId": "CdkrdIntegHarvest-Sessions8896A56D-R1FO6Y7043MX",
       "constructPath": "CdkrdIntegHarvest/Sessions"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Sessions8896A56D",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkrdIntegHarvest-Sessions8896A56D-R1FO6Y7043MX",
+      "constructPath": "CdkrdIntegHarvest/Sessions"
     }
   ]
 }

--- a/tests/corpus/AWS__DynamoDB__Table.Table.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Table.json
@@ -148,6 +148,15 @@
       "constructPath": "CdkRealDriftIntegDdbGsiProjection/Table"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Table",
+      "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "cdkrd-integ-ddb-gsi-projection",
+      "constructPath": "CdkRealDriftIntegDdbGsiProjection/Table"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Table",
       "resourceType": "AWS::DynamoDB::Table",

--- a/tests/corpus/AWS__DynamoDB__Table.TableCD117FA1.json
+++ b/tests/corpus/AWS__DynamoDB__Table.TableCD117FA1.json
@@ -132,6 +132,15 @@
       "tier": "atDefault",
       "logicalId": "TableCD117FA1",
       "resourceType": "AWS::DynamoDB::Table",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "CdkRealDriftIntegDdbKinesisRich-TableCD117FA1-11L4APTFUSFM8",
+      "constructPath": "CdkRealDriftIntegDdbKinesisRich/Table"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TableCD117FA1",
+      "resourceType": "AWS::DynamoDB::Table",
       "path": "PointInTimeRecoverySpecification.RecoveryPeriodInDays",
       "actual": 35,
       "nested": true,

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
@@ -96,11 +96,19 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "unresolved",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "AvailabilityMode",
-      "actual": "zonal",
+      "path": "AllocationId",
+      "physicalId": "nat-07e873bd1eb79666a",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.62",
       "physicalId": "nat-07e873bd1eb79666a",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
@@ -117,25 +125,17 @@
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.0.62",
-      "physicalId": "nat-07e873bd1eb79666a",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
-      "resourceType": "AWS::EC2::NatGateway",
       "path": "VpcId",
       "actual": "vpc-0b4c09b4fa46530e9",
       "physicalId": "nat-07e873bd1eb79666a",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "AllocationId",
+      "path": "AvailabilityMode",
+      "actual": "zonal",
       "physicalId": "nat-07e873bd1eb79666a",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     }

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
@@ -96,11 +96,19 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "unresolved",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "AvailabilityMode",
-      "actual": "zonal",
+      "path": "AllocationId",
+      "physicalId": "nat-029bbcd7fb6e239a7",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
+      "resourceType": "AWS::EC2::NatGateway",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.69.104",
       "physicalId": "nat-029bbcd7fb6e239a7",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
@@ -117,25 +125,17 @@
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.69.104",
-      "physicalId": "nat-029bbcd7fb6e239a7",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
-      "resourceType": "AWS::EC2::NatGateway",
       "path": "VpcId",
       "actual": "vpc-0b4c09b4fa46530e9",
       "physicalId": "nat-029bbcd7fb6e239a7",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
-      "path": "AllocationId",
+      "path": "AvailabilityMode",
+      "actual": "zonal",
       "physicalId": "nat-029bbcd7fb6e239a7",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     }

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
@@ -123,11 +123,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "NetpublicSubnet1SubnetA0498A0F",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az1",
+      "physicalId": "subnet-0f3317e0d9ac5df28",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-0f3317e0d9ac5df28",
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
     },
@@ -145,10 +171,11 @@
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "NetpublicSubnet1SubnetA0498A0F",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-0f3317e0d9ac5df28",
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
@@ -123,11 +123,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "NetpublicSubnet2Subnet5183DBBB",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az2",
+      "physicalId": "subnet-0e4bae13856face36",
+      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-0e4bae13856face36",
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
     },
@@ -145,10 +171,11 @@
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "NetpublicSubnet2Subnet5183DBBB",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-0e4bae13856face36",
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
+++ b/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
@@ -122,11 +122,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az1",
+      "physicalId": "subnet-0a9a838411f55ddb0",
+      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-0a9a838411f55ddb0",
       "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
     },
@@ -144,10 +170,11 @@
       "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-0a9a838411f55ddb0",
       "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
@@ -138,11 +138,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az1",
+      "physicalId": "subnet-011f0a2e9cbd7ebab",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-011f0a2e9cbd7ebab",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
     },
@@ -160,10 +186,11 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-011f0a2e9cbd7ebab",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
@@ -138,11 +138,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az2",
+      "physicalId": "subnet-0b456bc01025cb129",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-0b456bc01025cb129",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
     },
@@ -160,10 +186,11 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-0b456bc01025cb129",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
@@ -138,11 +138,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az1",
+      "physicalId": "subnet-0434e5718302e4709",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-0434e5718302e4709",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
     },
@@ -160,10 +186,11 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-0434e5718302e4709",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
     }

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
@@ -138,11 +138,37 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AvailabilityZone",
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "EnableDns64",
+      "actual": false,
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
       "resourceType": "AWS::EC2::Subnet",
       "path": "AvailabilityZoneId",
       "actual": "use1-az2",
+      "physicalId": "subnet-0433dc95b5f60dbbc",
+      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
+      "resourceType": "AWS::EC2::Subnet",
+      "path": "AssignIpv6AddressOnCreation",
+      "actual": false,
       "physicalId": "subnet-0433dc95b5f60dbbc",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
     },
@@ -160,10 +186,11 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
     },
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
       "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZone",
+      "path": "Ipv6Native",
+      "actual": false,
       "physicalId": "subnet-0433dc95b5f60dbbc",
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
     }

--- a/tests/corpus/AWS__ECS__Service.Service.json
+++ b/tests/corpus/AWS__ECS__Service.Service.json
@@ -134,6 +134,15 @@
       "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Service",
+      "resourceType": "AWS::ECS::Service",
+      "path": "EnableExecuteCommand",
+      "actual": false,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceLbRich-ClusterEB0386A7-FMszPytjsWuw/cdkrd-integ-ecs-lb-svc",
+      "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Service",
       "resourceType": "AWS::ECS::Service",

--- a/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
+++ b/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
@@ -145,6 +145,15 @@
       "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "SvcServiceE0738BDC",
+      "resourceType": "AWS::ECS::Service",
+      "path": "EnableExecuteCommand",
+      "actual": false,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:service/CdkRealDriftIntegEcsServiceCapacity-ClusterEB0386A7-Jfa2GE1aHPmh/CdkRealDriftIntegEcsServiceCapacity-SvcServiceE0738BDC-0AaRfhu4QDDu",
+      "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "SvcServiceE0738BDC",
       "resourceType": "AWS::ECS::Service",

--- a/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
@@ -72,13 +72,11 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "undeclared",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "BackupPolicy",
-      "actual": {
-        "Status": "DISABLED"
-      },
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
       "physicalId": "fs-0679f705e7e468268",
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
@@ -94,11 +92,11 @@
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "KmsKeyId",
-      "actual": "arn:aws:kms:us-east-1:111111111111:key/ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "path": "ThroughputMode",
+      "actual": "bursting",
       "physicalId": "fs-0679f705e7e468268",
       "constructPath": "CdkrdIntegHarvest4/Files"
     },
@@ -106,8 +104,10 @@
       "tier": "atDefault",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
-      "path": "ThroughputMode",
-      "actual": "bursting",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
       "physicalId": "fs-0679f705e7e468268",
       "constructPath": "CdkrdIntegHarvest4/Files"
     }

--- a/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
@@ -61,28 +61,6 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "Fs6C1AF03C",
-      "resourceType": "AWS::EFS::FileSystem",
-      "path": "BackupPolicy",
-      "actual": {
-        "Status": "DISABLED"
-      },
-      "physicalId": "fs-0d81f40b7a880b7ae",
-      "constructPath": "CdkdriftIntegHarvest9/Fs"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Fs6C1AF03C",
-      "resourceType": "AWS::EFS::FileSystem",
-      "path": "FileSystemProtection",
-      "actual": {
-        "ReplicationOverwriteProtection": "ENABLED"
-      },
-      "physicalId": "fs-0d81f40b7a880b7ae",
-      "constructPath": "CdkdriftIntegHarvest9/Fs"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
@@ -104,8 +82,30 @@
       "tier": "atDefault",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
+      "path": "FileSystemProtection",
+      "actual": {
+        "ReplicationOverwriteProtection": "ENABLED"
+      },
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
       "path": "ThroughputMode",
       "actual": "bursting",
+      "physicalId": "fs-0d81f40b7a880b7ae",
+      "constructPath": "CdkdriftIntegHarvest9/Fs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fs6C1AF03C",
+      "resourceType": "AWS::EFS::FileSystem",
+      "path": "BackupPolicy",
+      "actual": {
+        "Status": "DISABLED"
+      },
       "physicalId": "fs-0d81f40b7a880b7ae",
       "constructPath": "CdkdriftIntegHarvest9/Fs"
     }

--- a/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.drifted.json
+++ b/tests/corpus/AWS__Events__Rule.MatrixRuleF1E32BBB.drifted.json
@@ -50,21 +50,21 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "MatrixRuleF1E32BBB",
-      "resourceType": "AWS::Events::Rule",
-      "path": "EventBusName",
-      "actual": "default",
-      "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
-      "constructPath": "CdkrdIntegHarvest3/MatrixRule"
-    },
-    {
       "tier": "declared",
       "logicalId": "MatrixRuleF1E32BBB",
       "resourceType": "AWS::Events::Rule",
       "path": "State",
       "desired": "ENABLED",
       "actual": "DISABLED",
+      "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
+      "constructPath": "CdkrdIntegHarvest3/MatrixRule"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixRuleF1E32BBB",
+      "resourceType": "AWS::Events::Rule",
+      "path": "EventBusName",
+      "actual": "default",
       "physicalId": "CdkrdIntegHarvest3-MatrixRuleF1E32BBB-RmVkDPhzGLgk",
       "constructPath": "CdkrdIntegHarvest3/MatrixRule"
     }

--- a/tests/corpus/AWS__Glue__Crawler.Crawler.json
+++ b/tests/corpus/AWS__Glue__Crawler.Crawler.json
@@ -76,5 +76,18 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Crawler",
+      "resourceType": "AWS::Glue::Crawler",
+      "path": "LakeFormationConfiguration",
+      "actual": {
+        "AccountId": "",
+        "UseLakeFormationCredentials": false
+      },
+      "physicalId": "cdkrd-crawler",
+      "constructPath": "CdkdriftIntegHarvest11/Crawler"
+    }
+  ]
 }

--- a/tests/corpus/AWS__IAM__Role.AliasedFnServiceRole4A9555AA.json
+++ b/tests/corpus/AWS__IAM__Role.AliasedFnServiceRole4A9555AA.json
@@ -64,8 +64,8 @@
       "tier": "atDefault",
       "logicalId": "AliasedFnServiceRole4A9555AA",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn/ServiceRole"
     },
@@ -82,8 +82,8 @@
       "tier": "atDefault",
       "logicalId": "AliasedFnServiceRole4A9555AA",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest5-AliasedFnServiceRole4A9555AA-tJxxoWH4IQ2C",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn/ServiceRole"
     }

--- a/tests/corpus/AWS__IAM__Role.ApiCloudWatchRole73EC6FC4.json
+++ b/tests/corpus/AWS__IAM__Role.ApiCloudWatchRole73EC6FC4.json
@@ -67,8 +67,8 @@
       "tier": "atDefault",
       "logicalId": "ApiCloudWatchRole73EC6FC4",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
       "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
     },
@@ -85,8 +85,8 @@
       "tier": "atDefault",
       "logicalId": "ApiCloudWatchRole73EC6FC4",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkdriftIntegHarvest8-ApiCloudWatchRole73EC6FC4-L4x1jhdWNeUT",
       "constructPath": "CdkdriftIntegHarvest8/Api/CloudWatchRole"
     }

--- a/tests/corpus/AWS__IAM__Role.ApiFnServiceRoleD18AAE0E.json
+++ b/tests/corpus/AWS__IAM__Role.ApiFnServiceRoleD18AAE0E.json
@@ -64,8 +64,8 @@
       "tier": "atDefault",
       "logicalId": "ApiFnServiceRoleD18AAE0E",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
       "constructPath": "CdkrdIntegHarvest4/ApiFn/ServiceRole"
     },
@@ -82,8 +82,8 @@
       "tier": "atDefault",
       "logicalId": "ApiFnServiceRoleD18AAE0E",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest4-ApiFnServiceRoleD18AAE0E-tXwWTGyzrNsl",
       "constructPath": "CdkrdIntegHarvest4/ApiFn/ServiceRole"
     }

--- a/tests/corpus/AWS__IAM__Role.BuildRoleB7C66CB2.json
+++ b/tests/corpus/AWS__IAM__Role.BuildRoleB7C66CB2.json
@@ -107,8 +107,8 @@
       "tier": "atDefault",
       "logicalId": "BuildRoleB7C66CB2",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
       "constructPath": "CdkrdIntegHarvest/Build/Role"
     },
@@ -125,8 +125,8 @@
       "tier": "atDefault",
       "logicalId": "BuildRoleB7C66CB2",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest-BuildRoleB7C66CB2-zFu6uTeBWQhE",
       "constructPath": "CdkrdIntegHarvest/Build/Role"
     }

--- a/tests/corpus/AWS__IAM__Role.CbRole566E4F1D.json
+++ b/tests/corpus/AWS__IAM__Role.CbRole566E4F1D.json
@@ -62,8 +62,8 @@
       "tier": "atDefault",
       "logicalId": "CbRole566E4F1D",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
       "constructPath": "CdkrdIntegHarvest6/CbRole"
     },
@@ -80,8 +80,8 @@
       "tier": "atDefault",
       "logicalId": "CbRole566E4F1D",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest6-CbRole566E4F1D-KicGJKfs66x0",
       "constructPath": "CdkrdIntegHarvest6/CbRole"
     }

--- a/tests/corpus/AWS__IAM__Role.CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092.json
+++ b/tests/corpus/AWS__IAM__Role.CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092.json
@@ -64,8 +64,8 @@
       "tier": "atDefault",
       "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
       "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
     },
@@ -82,8 +82,8 @@
       "tier": "atDefault",
       "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderRole3B1BD092",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustomR-4YM5iKfd6ZFF",
       "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Role"
     }

--- a/tests/corpus/AWS__IAM__Role.Ec2Role2FD9A272.json
+++ b/tests/corpus/AWS__IAM__Role.Ec2Role2FD9A272.json
@@ -62,8 +62,8 @@
       "tier": "atDefault",
       "logicalId": "Ec2Role2FD9A272",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
       "constructPath": "CdkrdIntegHarvest5/Ec2Role"
     },
@@ -80,8 +80,8 @@
       "tier": "atDefault",
       "logicalId": "Ec2Role2FD9A272",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest5-Ec2Role2FD9A272-QoFsnMoLFRBK",
       "constructPath": "CdkrdIntegHarvest5/Ec2Role"
     }

--- a/tests/corpus/AWS__IAM__Role.ExpressRole9F822A77.json
+++ b/tests/corpus/AWS__IAM__Role.ExpressRole9F822A77.json
@@ -62,8 +62,8 @@
       "tier": "atDefault",
       "logicalId": "ExpressRole9F822A77",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
       "constructPath": "CdkrdIntegHarvest5/Express/Role"
     },
@@ -80,8 +80,8 @@
       "tier": "atDefault",
       "logicalId": "ExpressRole9F822A77",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest5-ExpressRole9F822A77-n22tUTypsJHx",
       "constructPath": "CdkrdIntegHarvest5/Express/Role"
     }

--- a/tests/corpus/AWS__IAM__Role.FirehoseRoleAA67C190.json
+++ b/tests/corpus/AWS__IAM__Role.FirehoseRoleAA67C190.json
@@ -92,8 +92,8 @@
       "tier": "atDefault",
       "logicalId": "FirehoseRoleAA67C190",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
       "constructPath": "CdkrdIntegHarvest3/FirehoseRole"
     },
@@ -110,8 +110,8 @@
       "tier": "atDefault",
       "logicalId": "FirehoseRoleAA67C190",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest3-FirehoseRoleAA67C190-pTvsbEFAnRrY",
       "constructPath": "CdkrdIntegHarvest3/FirehoseRole"
     }

--- a/tests/corpus/AWS__IAM__Role.FlowRoleD99EA574.json
+++ b/tests/corpus/AWS__IAM__Role.FlowRoleD99EA574.json
@@ -77,8 +77,8 @@
       "tier": "atDefault",
       "logicalId": "FlowRoleD99EA574",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
       "constructPath": "CdkrdIntegHarvest/Flow/Role"
     },
@@ -95,8 +95,8 @@
       "tier": "atDefault",
       "logicalId": "FlowRoleD99EA574",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest-FlowRoleD99EA574-fkfT28B8EOai",
       "constructPath": "CdkrdIntegHarvest/Flow/Role"
     }

--- a/tests/corpus/AWS__IAM__Role.GlueRoleDEDFFD2C.json
+++ b/tests/corpus/AWS__IAM__Role.GlueRoleDEDFFD2C.json
@@ -64,8 +64,8 @@
       "tier": "atDefault",
       "logicalId": "GlueRoleDEDFFD2C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
       "constructPath": "CdkrdIntegHarvest5/GlueRole"
     },
@@ -82,8 +82,8 @@
       "tier": "atDefault",
       "logicalId": "GlueRoleDEDFFD2C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest5-GlueRoleDEDFFD2C-ogFxtucP6XBp",
       "constructPath": "CdkrdIntegHarvest5/GlueRole"
     }

--- a/tests/corpus/AWS__IAM__Role.MachineRoleD2D3D395.json
+++ b/tests/corpus/AWS__IAM__Role.MachineRoleD2D3D395.json
@@ -73,8 +73,8 @@
       "tier": "atDefault",
       "logicalId": "MachineRoleD2D3D395",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
       "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
     },
@@ -91,8 +91,8 @@
       "tier": "atDefault",
       "logicalId": "MachineRoleD2D3D395",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkRealDriftIntegSfn-MachineRoleD2D3D395-zOEgphaTlAY7",
       "constructPath": "CdkRealDriftIntegSfn/Machine/Role"
     }

--- a/tests/corpus/AWS__IAM__Role.MatrixFnServiceRoleF6E55B32.json
+++ b/tests/corpus/AWS__IAM__Role.MatrixFnServiceRoleF6E55B32.json
@@ -64,8 +64,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixFnServiceRoleF6E55B32",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn/ServiceRole"
     },
@@ -82,8 +82,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixFnServiceRoleF6E55B32",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest3-MatrixFnServiceRoleF6E55B32-ryqUvLrnxdXh",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn/ServiceRole"
     }

--- a/tests/corpus/AWS__IAM__Role.PipeRole4D7B8476.json
+++ b/tests/corpus/AWS__IAM__Role.PipeRole4D7B8476.json
@@ -83,8 +83,8 @@
       "tier": "atDefault",
       "logicalId": "PipeRole4D7B8476",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
       "constructPath": "CdkrdIntegHarvest6/PipeRole"
     },
@@ -101,8 +101,8 @@
       "tier": "atDefault",
       "logicalId": "PipeRole4D7B8476",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest6-PipeRole4D7B8476-Jch6NsBZxbOc",
       "constructPath": "CdkrdIntegHarvest6/PipeRole"
     }

--- a/tests/corpus/AWS__IAM__Role.ReadTargetRoleA9FE198C.json
+++ b/tests/corpus/AWS__IAM__Role.ReadTargetRoleA9FE198C.json
@@ -62,8 +62,8 @@
       "tier": "atDefault",
       "logicalId": "ReadTargetRoleA9FE198C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/Role"
     },
@@ -80,8 +80,8 @@
       "tier": "atDefault",
       "logicalId": "ReadTargetRoleA9FE198C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest4-ReadTargetRoleA9FE198C-PjhZAE0bBV4v",
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/Role"
     }

--- a/tests/corpus/AWS__IAM__Role.RestApiCloudWatchRoleE3ED6605.json
+++ b/tests/corpus/AWS__IAM__Role.RestApiCloudWatchRoleE3ED6605.json
@@ -83,8 +83,8 @@
       "tier": "atDefault",
       "logicalId": "RestApiCloudWatchRoleE3ED6605",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
       "constructPath": "CdkrdIntegHarvest/RestApi/CloudWatchRole"
     },
@@ -101,8 +101,8 @@
       "tier": "atDefault",
       "logicalId": "RestApiCloudWatchRoleE3ED6605",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest-RestApiCloudWatchRoleE3ED6605-WsT5GXX6pADn",
       "constructPath": "CdkrdIntegHarvest/RestApi/CloudWatchRole"
     }

--- a/tests/corpus/AWS__IAM__Role.SchedRole812B2F5C.json
+++ b/tests/corpus/AWS__IAM__Role.SchedRole812B2F5C.json
@@ -78,8 +78,8 @@
       "tier": "atDefault",
       "logicalId": "SchedRole812B2F5C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
       "constructPath": "CdkrdIntegHarvest3/SchedRole"
     },
@@ -96,8 +96,8 @@
       "tier": "atDefault",
       "logicalId": "SchedRole812B2F5C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest3-SchedRole812B2F5C-3Z1ZOCe4hlMx",
       "constructPath": "CdkrdIntegHarvest3/SchedRole"
     }

--- a/tests/corpus/AWS__IAM__Role.TaskExecRoleA2BBB60C.json
+++ b/tests/corpus/AWS__IAM__Role.TaskExecRoleA2BBB60C.json
@@ -62,8 +62,8 @@
       "tier": "atDefault",
       "logicalId": "TaskExecRoleA2BBB60C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
       "constructPath": "CdkrdIntegHarvest6/TaskExecRole"
     },
@@ -80,8 +80,8 @@
       "tier": "atDefault",
       "logicalId": "TaskExecRoleA2BBB60C",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest6-TaskExecRoleA2BBB60C-ZjmLxEi5vU5I",
       "constructPath": "CdkrdIntegHarvest6/TaskExecRole"
     }

--- a/tests/corpus/AWS__IAM__Role.TestRole.permissions-boundary.json
+++ b/tests/corpus/AWS__IAM__Role.TestRole.permissions-boundary.json
@@ -80,8 +80,8 @@
       "tier": "atDefault",
       "logicalId": "TestRole6C9272DF",
       "resourceType": "AWS::IAM::Role",
-      "path": "MaxSessionDuration",
-      "actual": 3600,
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
       "constructPath": "CdkRealDriftIntegIam/TestRole"
     },
@@ -89,8 +89,8 @@
       "tier": "atDefault",
       "logicalId": "TestRole6C9272DF",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
       "physicalId": "CdkRealDriftIntegIam-TestRole6C9272DF-tZZ2sot0XbeC",
       "constructPath": "CdkRealDriftIntegIam/TestRole"
     },

--- a/tests/corpus/AWS__IAM__Role.UrlFnServiceRole8FBBFD8A.json
+++ b/tests/corpus/AWS__IAM__Role.UrlFnServiceRole8FBBFD8A.json
@@ -64,8 +64,8 @@
       "tier": "atDefault",
       "logicalId": "UrlFnServiceRole8FBBFD8A",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
       "constructPath": "CdkrdIntegHarvest6/UrlFn/ServiceRole"
     },
@@ -82,8 +82,8 @@
       "tier": "atDefault",
       "logicalId": "UrlFnServiceRole8FBBFD8A",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest6-UrlFnServiceRole8FBBFD8A-O0fAhbiRABr7",
       "constructPath": "CdkrdIntegHarvest6/UrlFn/ServiceRole"
     }

--- a/tests/corpus/AWS__IAM__Role.WorkerServiceRole8543584E.json
+++ b/tests/corpus/AWS__IAM__Role.WorkerServiceRole8543584E.json
@@ -95,8 +95,8 @@
       "tier": "atDefault",
       "logicalId": "WorkerServiceRole8543584E",
       "resourceType": "AWS::IAM::Role",
-      "path": "Description",
-      "actual": "",
+      "path": "Path",
+      "actual": "/",
       "physicalId": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
       "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole"
     },
@@ -113,8 +113,8 @@
       "tier": "atDefault",
       "logicalId": "WorkerServiceRole8543584E",
       "resourceType": "AWS::IAM::Role",
-      "path": "Path",
-      "actual": "/",
+      "path": "Description",
+      "actual": "",
       "physicalId": "CdkrdIntegHarvest2-WorkerServiceRole8543584E-0AiwQinXEmwk",
       "constructPath": "CdkrdIntegHarvest2/Worker/ServiceRole"
     }

--- a/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
+++ b/tests/corpus/AWS__KMS__Key.DataKey17AFBB84.json
@@ -78,11 +78,11 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "readGap",
       "logicalId": "DataKey17AFBB84",
       "resourceType": "AWS::KMS::Key",
-      "path": "KeySpec",
-      "actual": "SYMMETRIC_DEFAULT",
+      "path": "PendingWindowInDays",
+      "note": "write-only — cannot be read back",
       "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
       "constructPath": "CdkrdIntegHarvest3/DataKey"
     },
@@ -90,8 +90,8 @@
       "tier": "atDefault",
       "logicalId": "DataKey17AFBB84",
       "resourceType": "AWS::KMS::Key",
-      "path": "KeyUsage",
-      "actual": "ENCRYPT_DECRYPT",
+      "path": "Origin",
+      "actual": "AWS_KMS",
       "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
       "constructPath": "CdkrdIntegHarvest3/DataKey"
     },
@@ -108,17 +108,8 @@
       "tier": "atDefault",
       "logicalId": "DataKey17AFBB84",
       "resourceType": "AWS::KMS::Key",
-      "path": "Origin",
-      "actual": "AWS_KMS",
-      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
-      "constructPath": "CdkrdIntegHarvest3/DataKey"
-    },
-    {
-      "tier": "readGap",
-      "logicalId": "DataKey17AFBB84",
-      "resourceType": "AWS::KMS::Key",
-      "path": "PendingWindowInDays",
-      "note": "write-only — cannot be read back",
+      "path": "KeySpec",
+      "actual": "SYMMETRIC_DEFAULT",
       "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
       "constructPath": "CdkrdIntegHarvest3/DataKey"
     },
@@ -128,6 +119,15 @@
       "resourceType": "AWS::KMS::Key",
       "path": "Enabled",
       "actual": true,
+      "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
+      "constructPath": "CdkrdIntegHarvest3/DataKey"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DataKey17AFBB84",
+      "resourceType": "AWS::KMS::Key",
+      "path": "KeyUsage",
+      "actual": "ENCRYPT_DECRYPT",
       "physicalId": "f989c1f9-fd8b-4a78-a71d-a69a1e096af1",
       "constructPath": "CdkrdIntegHarvest3/DataKey"
     }

--- a/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
+++ b/tests/corpus/AWS__Lambda__Function.AliasedFn19257E6A.json
@@ -95,26 +95,6 @@
       "tier": "atDefault",
       "logicalId": "AliasedFn19257E6A",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
-      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
-      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "AliasedFn19257E6A",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
-      "actual": {
-        "Size": 512
-      },
-      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
-      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "AliasedFn19257E6A",
-      "resourceType": "AWS::Lambda::Function",
       "path": "MemorySize",
       "actual": 128,
       "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
@@ -124,8 +104,10 @@
       "tier": "atDefault",
       "logicalId": "AliasedFn19257E6A",
       "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
       "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn"
     },
@@ -133,8 +115,8 @@
       "tier": "atDefault",
       "logicalId": "AliasedFn19257E6A",
       "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
+      "path": "Timeout",
+      "actual": 3,
       "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn"
     },
@@ -153,19 +135,8 @@
       "tier": "atDefault",
       "logicalId": "AliasedFn19257E6A",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Timeout",
-      "actual": 3,
-      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
-      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "AliasedFn19257E6A",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn"
     },
@@ -178,6 +149,35 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye"
       },
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
+      "constructPath": "CdkrdIntegHarvest5/AliasedFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasedFn19257E6A",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
+++ b/tests/corpus/AWS__Lambda__Function.ApiFnE0725F78.json
@@ -95,26 +95,6 @@
       "tier": "atDefault",
       "logicalId": "ApiFnE0725F78",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
-      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
-      "constructPath": "CdkrdIntegHarvest4/ApiFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "ApiFnE0725F78",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
-      "actual": {
-        "Size": 512
-      },
-      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
-      "constructPath": "CdkrdIntegHarvest4/ApiFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "ApiFnE0725F78",
-      "resourceType": "AWS::Lambda::Function",
       "path": "MemorySize",
       "actual": 128,
       "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
@@ -124,8 +104,10 @@
       "tier": "atDefault",
       "logicalId": "ApiFnE0725F78",
       "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
       "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
       "constructPath": "CdkrdIntegHarvest4/ApiFn"
     },
@@ -133,8 +115,8 @@
       "tier": "atDefault",
       "logicalId": "ApiFnE0725F78",
       "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
+      "path": "Timeout",
+      "actual": 3,
       "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
       "constructPath": "CdkrdIntegHarvest4/ApiFn"
     },
@@ -153,19 +135,8 @@
       "tier": "atDefault",
       "logicalId": "ApiFnE0725F78",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Timeout",
-      "actual": 3,
-      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
-      "constructPath": "CdkrdIntegHarvest4/ApiFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "ApiFnE0725F78",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
       "constructPath": "CdkrdIntegHarvest4/ApiFn"
     },
@@ -178,6 +149,35 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo"
       },
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
+      "constructPath": "CdkrdIntegHarvest4/ApiFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiFnE0725F78",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkrdIntegHarvest4-ApiFnE0725F78-SOgyYQxFviSo",
       "constructPath": "CdkrdIntegHarvest4/ApiFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
+++ b/tests/corpus/AWS__Lambda__Function.CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F.json
@@ -99,37 +99,10 @@
       "tier": "atDefault",
       "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
-      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
-      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
+      "path": "TracingConfig",
       "actual": {
-        "Size": 512
+        "Mode": "PassThrough"
       },
-      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
-      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
-      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
-      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
       "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
       "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
     },
@@ -148,10 +121,8 @@
       "tier": "atDefault",
       "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
       "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
       "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
     },
@@ -164,6 +135,35 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq"
       },
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
+      "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CustomS3AutoDeleteObjectsCustomResourceProviderHandler9D90184F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkdriftIntegBasic-CustomS3AutoDeleteObjectsCustom-172a073N52yq",
       "constructPath": "CdkdriftIntegBasic/Custom::S3AutoDeleteObjectsCustomResourceProvider/Handler"
     }

--- a/tests/corpus/AWS__Lambda__Function.Handler.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler.json
@@ -37,6 +37,13 @@
   },
   "expected": [
     {
+      "tier": "unresolved",
+      "logicalId": "Handler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Role",
+      "physicalId": "corpus-handler"
+    },
+    {
       "tier": "atDefault",
       "logicalId": "Handler",
       "resourceType": "AWS::Lambda::Function",
@@ -50,13 +57,6 @@
       "resourceType": "AWS::Lambda::Function",
       "path": "ReservedConcurrentExecutions",
       "actual": 5,
-      "physicalId": "corpus-handler"
-    },
-    {
-      "tier": "unresolved",
-      "logicalId": "Handler",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "Role",
       "physicalId": "corpus-handler"
     }
   ]

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.drifted.json
@@ -94,11 +94,12 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "declared",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
+      "path": "MemorySize",
+      "desired": 256,
+      "actual": 512,
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
@@ -106,28 +107,10 @@
       "tier": "atDefault",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
+      "path": "TracingConfig",
       "actual": {
-        "Size": 512
+        "Mode": "PassThrough"
       },
-      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
-      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "MatrixFn0598BE1E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
-      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
-      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "MatrixFn0598BE1E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
@@ -146,20 +129,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
-      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
-      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
-    },
-    {
-      "tier": "declared",
-      "logicalId": "MatrixFn0598BE1E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "MemorySize",
-      "desired": 256,
-      "actual": 512,
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
@@ -172,6 +143,35 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT"
       },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
+++ b/tests/corpus/AWS__Lambda__Function.MatrixFn0598BE1E.json
@@ -102,37 +102,10 @@
       "tier": "atDefault",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
-      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
-      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "MatrixFn0598BE1E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
+      "path": "TracingConfig",
       "actual": {
-        "Size": 512
+        "Mode": "PassThrough"
       },
-      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
-      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "MatrixFn0598BE1E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
-      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
-      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "MatrixFn0598BE1E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
@@ -151,10 +124,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixFn0598BE1E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     },
@@ -167,6 +138,35 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT"
       },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
+      "constructPath": "CdkrdIntegHarvest3/MatrixFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "MatrixFn0598BE1E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkrdIntegHarvest3-MatrixFn0598BE1E-j93ctthsA8NT",
       "constructPath": "CdkrdIntegHarvest3/MatrixFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
+++ b/tests/corpus/AWS__Lambda__Function.TestFn.injected-concurrency.json
@@ -97,8 +97,78 @@
       "tier": "atDefault",
       "logicalId": "TestFn04335C60",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "ReservedConcurrentExecutions",
+      "actual": 1,
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92"
+      },
+      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
+      "constructPath": "CdkRealDriftIntegLambda/TestFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TestFn04335C60",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
       "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
       "constructPath": "CdkRealDriftIntegLambda/TestFn"
     },
@@ -117,78 +187,8 @@
       "tier": "atDefault",
       "logicalId": "TestFn04335C60",
       "resourceType": "AWS::Lambda::Function",
-      "path": "MemorySize",
-      "actual": 128,
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "RuntimeManagementConfig",
-      "actual": {
-        "UpdateRuntimeOn": "Auto"
-      },
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "Timeout",
-      "actual": 3,
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "LoggingConfig",
-      "actual": {
-        "LogFormat": "Text",
-        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92"
-      },
-      "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
-      "constructPath": "CdkRealDriftIntegLambda/TestFn"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "TestFn04335C60",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "ReservedConcurrentExecutions",
-      "actual": 1,
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkRealDriftIntegLambda-TestFn04335C60-jyxmUSaHcl92",
       "constructPath": "CdkRealDriftIntegLambda/TestFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
+++ b/tests/corpus/AWS__Lambda__Function.UrlFnE068003E.json
@@ -95,26 +95,6 @@
       "tier": "atDefault",
       "logicalId": "UrlFnE068003E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
-      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
-      "constructPath": "CdkrdIntegHarvest6/UrlFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "UrlFnE068003E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
-      "actual": {
-        "Size": 512
-      },
-      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
-      "constructPath": "CdkrdIntegHarvest6/UrlFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "UrlFnE068003E",
-      "resourceType": "AWS::Lambda::Function",
       "path": "MemorySize",
       "actual": 128,
       "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
@@ -124,8 +104,10 @@
       "tier": "atDefault",
       "logicalId": "UrlFnE068003E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
       "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
       "constructPath": "CdkrdIntegHarvest6/UrlFn"
     },
@@ -133,8 +115,8 @@
       "tier": "atDefault",
       "logicalId": "UrlFnE068003E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "RecursiveLoop",
-      "actual": "Terminate",
+      "path": "Timeout",
+      "actual": 3,
       "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
       "constructPath": "CdkrdIntegHarvest6/UrlFn"
     },
@@ -153,19 +135,8 @@
       "tier": "atDefault",
       "logicalId": "UrlFnE068003E",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Timeout",
-      "actual": 3,
-      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
-      "constructPath": "CdkrdIntegHarvest6/UrlFn"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "UrlFnE068003E",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
+      "path": "PackageType",
+      "actual": "Zip",
       "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
       "constructPath": "CdkrdIntegHarvest6/UrlFn"
     },
@@ -178,6 +149,35 @@
         "LogFormat": "Text",
         "LogGroup": "/aws/lambda/CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz"
       },
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
+      "constructPath": "CdkrdIntegHarvest6/UrlFn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "UrlFnE068003E",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "CdkrdIntegHarvest6-UrlFnE068003E-K1YnoUoQKhJz",
       "constructPath": "CdkrdIntegHarvest6/UrlFn"
     }

--- a/tests/corpus/AWS__Lambda__Function.VpcHandler.json
+++ b/tests/corpus/AWS__Lambda__Function.VpcHandler.json
@@ -50,8 +50,18 @@
       "tier": "atDefault",
       "logicalId": "VpcHandler",
       "resourceType": "AWS::Lambda::Function",
-      "path": "Architectures",
-      "actual": ["x86_64"],
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "corpus-vpc-handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcHandler",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
       "physicalId": "corpus-vpc-handler"
     },
     {
@@ -68,18 +78,8 @@
       "tier": "atDefault",
       "logicalId": "VpcHandler",
       "resourceType": "AWS::Lambda::Function",
-      "path": "PackageType",
-      "actual": "Zip",
-      "physicalId": "corpus-vpc-handler"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "VpcHandler",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "TracingConfig",
-      "actual": {
-        "Mode": "PassThrough"
-      },
+      "path": "Architectures",
+      "actual": ["x86_64"],
       "physicalId": "corpus-vpc-handler"
     }
   ]

--- a/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
+++ b/tests/corpus/AWS__Lambda__Function.Worker11F36D0F.json
@@ -128,9 +128,9 @@
       "tier": "atDefault",
       "logicalId": "Worker11F36D0F",
       "resourceType": "AWS::Lambda::Function",
-      "path": "EphemeralStorage",
+      "path": "RuntimeManagementConfig",
       "actual": {
-        "Size": 512
+        "UpdateRuntimeOn": "Auto"
       },
       "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
       "constructPath": "CdkrdIntegHarvest2/Worker"
@@ -141,6 +141,18 @@
       "resourceType": "AWS::Lambda::Function",
       "path": "PackageType",
       "actual": "Zip",
+      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
+      "constructPath": "CdkrdIntegHarvest2/Worker"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Worker11F36D0F",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv"
+      },
       "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
       "constructPath": "CdkrdIntegHarvest2/Worker"
     },
@@ -157,21 +169,9 @@
       "tier": "atDefault",
       "logicalId": "Worker11F36D0F",
       "resourceType": "AWS::Lambda::Function",
-      "path": "RuntimeManagementConfig",
+      "path": "EphemeralStorage",
       "actual": {
-        "UpdateRuntimeOn": "Auto"
-      },
-      "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
-      "constructPath": "CdkrdIntegHarvest2/Worker"
-    },
-    {
-      "tier": "generated",
-      "logicalId": "Worker11F36D0F",
-      "resourceType": "AWS::Lambda::Function",
-      "path": "LoggingConfig",
-      "actual": {
-        "LogFormat": "Text",
-        "LogGroup": "/aws/lambda/CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv"
+        "Size": 512
       },
       "physicalId": "CdkrdIntegHarvest2-Worker11F36D0F-9jtMp4eDVKIv",
       "constructPath": "CdkrdIntegHarvest2/Worker"

--- a/tests/corpus/AWS__Lambda__Version.AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df.json
+++ b/tests/corpus/AWS__Lambda__Version.AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df.json
@@ -51,8 +51,10 @@
       "tier": "undeclared",
       "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
       "resourceType": "AWS::Lambda::Version",
-      "path": "CodeSha256",
-      "actual": "pYaOwiRWhhzD/erZKRp1WZbhCcuhmh7CovRZdCS9P3w=",
+      "path": "RuntimePolicy",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
       "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion"
     },
@@ -60,10 +62,8 @@
       "tier": "undeclared",
       "logicalId": "AliasedFnCurrentVersionDA7A21869cb49ad9ac6df8374f18a1d3cb3836df",
       "resourceType": "AWS::Lambda::Version",
-      "path": "RuntimePolicy",
-      "actual": {
-        "UpdateRuntimeOn": "Auto"
-      },
+      "path": "CodeSha256",
+      "actual": "pYaOwiRWhhzD/erZKRp1WZbhCcuhmh7CovRZdCS9P3w=",
       "physicalId": "arn:aws:lambda:us-east-1:111111111111:function:CdkrdIntegHarvest5-AliasedFn19257E6A-xOPAiBQg8vye:1",
       "constructPath": "CdkrdIntegHarvest5/AliasedFn/CurrentVersion"
     }

--- a/tests/corpus/AWS__Logs__LogGroup.AppLogsC5DF83A6.json
+++ b/tests/corpus/AWS__Logs__LogGroup.AppLogsC5DF83A6.json
@@ -81,8 +81,8 @@
       "tier": "atDefault",
       "logicalId": "AppLogsC5DF83A6",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "DeletionProtectionEnabled",
-      "actual": false,
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
       "physicalId": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
       "constructPath": "CdkrdIntegHarvest/AppLogs"
     },
@@ -90,8 +90,8 @@
       "tier": "atDefault",
       "logicalId": "AppLogsC5DF83A6",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "LogGroupClass",
-      "actual": "STANDARD",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
       "physicalId": "CdkrdIntegHarvest-AppLogsC5DF83A6-66Qaf6Ss2V6h",
       "constructPath": "CdkrdIntegHarvest/AppLogs"
     }

--- a/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.drifted.json
+++ b/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.drifted.json
@@ -54,11 +54,12 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
+      "tier": "declared",
       "logicalId": "MatrixLogsDDD521D9",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "BearerTokenAuthenticationEnabled",
-      "actual": false,
+      "path": "RetentionInDays",
+      "desired": 7,
+      "actual": 30,
       "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
       "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
     },
@@ -66,7 +67,7 @@
       "tier": "atDefault",
       "logicalId": "MatrixLogsDDD521D9",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "DeletionProtectionEnabled",
+      "path": "BearerTokenAuthenticationEnabled",
       "actual": false,
       "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
       "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
@@ -81,12 +82,11 @@
       "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
     },
     {
-      "tier": "declared",
+      "tier": "atDefault",
       "logicalId": "MatrixLogsDDD521D9",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "RetentionInDays",
-      "desired": 7,
-      "actual": 30,
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
       "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
       "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
     }

--- a/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.json
+++ b/tests/corpus/AWS__Logs__LogGroup.MatrixLogsDDD521D9.json
@@ -66,8 +66,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixLogsDDD521D9",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "DeletionProtectionEnabled",
-      "actual": false,
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
       "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
       "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
     },
@@ -75,8 +75,8 @@
       "tier": "atDefault",
       "logicalId": "MatrixLogsDDD521D9",
       "resourceType": "AWS::Logs::LogGroup",
-      "path": "LogGroupClass",
-      "actual": "STANDARD",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
       "physicalId": "CdkrdIntegHarvest3-MatrixLogsDDD521D9-Zn23SPxJoN6J",
       "constructPath": "CdkrdIntegHarvest3/MatrixLogs"
     }

--- a/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
+++ b/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
@@ -137,7 +137,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Neptune::DBCluster",
       "path": "DBPort",

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
@@ -206,7 +206,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "EngineMode",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
@@ -256,6 +256,15 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
@@ -279,6 +288,15 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
       "actual": 0,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
       "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
@@ -315,6 +333,15 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
       "actual": "default:aurora-mysql-8-0",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
       "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
@@ -376,6 +403,24 @@
       "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
       "path": "EngineLifecycleSupport",
       "actual": "open-source-rds-extended-support",
       "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
@@ -418,11 +463,29 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "VPCSecurityGroups",
       "actual": ["sg-026f2d5597a41d0de"],
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
       "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
@@ -256,6 +256,15 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
@@ -279,6 +288,15 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
       "actual": 0,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
       "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
@@ -315,6 +333,15 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
       "actual": "default:aurora-mysql-8-0",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
       "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
@@ -376,6 +403,24 @@
       "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
       "path": "EngineLifecycleSupport",
       "actual": "open-source-rds-extended-support",
       "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
@@ -418,11 +463,29 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "VPCSecurityGroups",
       "actual": ["sg-026f2d5597a41d0de"],
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
       "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },

--- a/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
+++ b/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
@@ -359,6 +359,15 @@
       "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
+      "constructPath": "CdkdriftIntegHarvest13/Database"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DatabaseB269D8BB",
+      "resourceType": "AWS::RDS::DBInstance",
       "path": "AutoMinorVersionUpgrade",
       "actual": true,
       "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
@@ -379,6 +388,15 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "NetworkType",
       "actual": "IPV4",
+      "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
+      "constructPath": "CdkdriftIntegHarvest13/Database"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DatabaseB269D8BB",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
       "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
@@ -424,6 +442,24 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",
       "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
+      "constructPath": "CdkdriftIntegHarvest13/Database"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DatabaseB269D8BB",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
+      "constructPath": "CdkdriftIntegHarvest13/Database"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DatabaseB269D8BB",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
       "physicalId": "cdkdriftintegharvest13-databaseb269d8bb-zbfb79ingqnm",
       "constructPath": "CdkdriftIntegHarvest13/Database"
     }

--- a/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
+++ b/tests/corpus/AWS__S3__Bucket.ArchiveDA4CB258.json
@@ -208,15 +208,6 @@
       "tier": "atDefault",
       "logicalId": "ArchiveDA4CB258",
       "resourceType": "AWS::S3::Bucket",
-      "path": "AbacStatus",
-      "actual": "Disabled",
-      "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
-      "constructPath": "CdkrdIntegHarvest2/Archive"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "ArchiveDA4CB258",
-      "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
       "actual": {
         "ServerSideEncryptionConfiguration": [
@@ -231,6 +222,15 @@
           }
         ]
       },
+      "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
+      "constructPath": "CdkrdIntegHarvest2/Archive"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ArchiveDA4CB258",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
       "physicalId": "cdkrdintegharvest2-archiveda4cb258-ghyrdvyo0xbi",
       "constructPath": "CdkrdIntegHarvest2/Archive"
     },

--- a/tests/corpus/AWS__S3__Bucket.Assets9A31D427.json
+++ b/tests/corpus/AWS__S3__Bucket.Assets9A31D427.json
@@ -126,6 +126,21 @@
       "tier": "atDefault",
       "logicalId": "Assets9A31D427",
       "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
+      "constructPath": "CdkrdIntegCloudfront/Assets"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Assets9A31D427",
+      "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
       "actual": {
         "ServerSideEncryptionConfiguration": [
@@ -137,21 +152,6 @@
             "ServerSideEncryptionByDefault": {
               "SSEAlgorithm": "AES256"
             }
-          }
-        ]
-      },
-      "physicalId": "cdkrdintegcloudfront-assets9a31d427-1zofo9zaqpfh",
-      "constructPath": "CdkrdIntegCloudfront/Assets"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Assets9A31D427",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
-      "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
           }
         ]
       },

--- a/tests/corpus/AWS__S3__Bucket.AuditLogsB945E340.json
+++ b/tests/corpus/AWS__S3__Bucket.AuditLogsB945E340.json
@@ -126,6 +126,21 @@
       "tier": "atDefault",
       "logicalId": "AuditLogsB945E340",
       "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
+      "constructPath": "CdkrdIntegHarvest3/AuditLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AuditLogsB945E340",
+      "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
       "actual": {
         "ServerSideEncryptionConfiguration": [
@@ -137,21 +152,6 @@
             "ServerSideEncryptionByDefault": {
               "SSEAlgorithm": "AES256"
             }
-          }
-        ]
-      },
-      "physicalId": "cdkrdintegharvest3-auditlogsb945e340-0v3maaeqpkte",
-      "constructPath": "CdkrdIntegHarvest3/AuditLogs"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "AuditLogsB945E340",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
-      "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
           }
         ]
       },

--- a/tests/corpus/AWS__S3__Bucket.CorpusBucket.json
+++ b/tests/corpus/AWS__S3__Bucket.CorpusBucket.json
@@ -42,22 +42,22 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "CorpusBucket",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "VersioningConfiguration",
-      "actual": {
-        "Status": "Suspended"
-      },
-      "physicalId": "corpus-bucket"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "CorpusBucket",
       "resourceType": "AWS::S3::Bucket",
       "path": "AccelerateConfiguration",
       "actual": {
         "AccelerationStatus": "Enabled"
+      },
+      "physicalId": "corpus-bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "CorpusBucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "VersioningConfiguration",
+      "actual": {
+        "Status": "Suspended"
       },
       "physicalId": "corpus-bucket"
     }

--- a/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
+++ b/tests/corpus/AWS__S3__Bucket.Data666C94C7.json
@@ -135,16 +135,12 @@
       "constructPath": "CdkdriftIntegBasic/Data"
     },
     {
-      "tier": "atDefault",
+      "tier": "undeclared",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
+      "path": "AccelerateConfiguration",
       "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
-          }
-        ]
+        "AccelerationStatus": "Suspended"
       },
       "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
       "constructPath": "CdkdriftIntegBasic/Data"
@@ -164,12 +160,16 @@
       "constructPath": "CdkdriftIntegBasic/Data"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::S3::Bucket",
-      "path": "AccelerateConfiguration",
+      "path": "OwnershipControls",
       "actual": {
-        "AccelerationStatus": "Suspended"
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
       },
       "physicalId": "cdkdriftintegbasic-data666c94c7-7pabf0qbkwro",
       "constructPath": "CdkdriftIntegBasic/Data"

--- a/tests/corpus/AWS__S3__Bucket.FirehoseSinkB757FE18.json
+++ b/tests/corpus/AWS__S3__Bucket.FirehoseSinkB757FE18.json
@@ -126,6 +126,21 @@
       "tier": "atDefault",
       "logicalId": "FirehoseSinkB757FE18",
       "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
+      "constructPath": "CdkrdIntegHarvest3/FirehoseSink"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FirehoseSinkB757FE18",
+      "resourceType": "AWS::S3::Bucket",
       "path": "BucketEncryption",
       "actual": {
         "ServerSideEncryptionConfiguration": [
@@ -137,21 +152,6 @@
             "ServerSideEncryptionByDefault": {
               "SSEAlgorithm": "AES256"
             }
-          }
-        ]
-      },
-      "physicalId": "cdkrdintegharvest3-firehosesinkb757fe18-uznwhjxebzxy",
-      "constructPath": "CdkrdIntegHarvest3/FirehoseSink"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "FirehoseSinkB757FE18",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "OwnershipControls",
-      "actual": {
-        "Rules": [
-          {
-            "ObjectOwnership": "BucketOwnerEnforced"
           }
         ]
       },

--- a/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
+++ b/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
@@ -52,9 +52,9 @@
       "tier": "undeclared",
       "logicalId": "Mailer",
       "resourceType": "AWS::SES::ConfigurationSet",
-      "path": "ReputationOptions",
+      "path": "SendingOptions",
       "actual": {
-        "ReputationMetricsEnabled": true
+        "SendingEnabled": true
       },
       "physicalId": "cdkrd-harvest3",
       "constructPath": "CdkrdIntegHarvest3/Mailer"
@@ -63,9 +63,9 @@
       "tier": "undeclared",
       "logicalId": "Mailer",
       "resourceType": "AWS::SES::ConfigurationSet",
-      "path": "SendingOptions",
+      "path": "ReputationOptions",
       "actual": {
-        "SendingEnabled": true
+        "ReputationMetricsEnabled": true
       },
       "physicalId": "cdkrd-harvest3",
       "constructPath": "CdkrdIntegHarvest3/Mailer"

--- a/tests/corpus/AWS__SQS__Queue.MainRedrive.json
+++ b/tests/corpus/AWS__SQS__Queue.MainRedrive.json
@@ -85,7 +85,7 @@
       "constructPath": "CdkRealDriftIntegSqsRedriveRich/Main"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Main54E5BC70",
       "resourceType": "AWS::SQS::Queue",
       "path": "KmsDataKeyReusePeriodSeconds",

--- a/tests/corpus/AWS__SSM__Association.Assoc.json
+++ b/tests/corpus/AWS__SSM__Association.Assoc.json
@@ -69,7 +69,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Assoc",
       "resourceType": "AWS::SSM::Association",
       "path": "DocumentVersion",

--- a/tests/corpus/AWS__SSM__PatchBaseline.Patch.json
+++ b/tests/corpus/AWS__SSM__PatchBaseline.Patch.json
@@ -92,6 +92,15 @@
       "tier": "atDefault",
       "logicalId": "Patch",
       "resourceType": "AWS::SSM::PatchBaseline",
+      "path": "RejectedPatchesAction",
+      "actual": "ALLOW_AS_DEPENDENCY",
+      "physicalId": "pb-0dc7b8f7d8aa1a1a3",
+      "constructPath": "CdkrdIntegHarvest6/Patch"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Patch",
+      "resourceType": "AWS::SSM::PatchBaseline",
       "path": "ApprovedPatchesComplianceLevel",
       "actual": "UNSPECIFIED",
       "physicalId": "pb-0dc7b8f7d8aa1a1a3",
@@ -112,15 +121,6 @@
       "resourceType": "AWS::SSM::PatchBaseline",
       "path": "DefaultBaseline",
       "actual": false,
-      "physicalId": "pb-0dc7b8f7d8aa1a1a3",
-      "constructPath": "CdkrdIntegHarvest6/Patch"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Patch",
-      "resourceType": "AWS::SSM::PatchBaseline",
-      "path": "RejectedPatchesAction",
-      "actual": "ALLOW_AS_DEPENDENCY",
       "physicalId": "pb-0dc7b8f7d8aa1a1a3",
       "constructPath": "CdkrdIntegHarvest6/Patch"
     }

--- a/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
+++ b/tests/corpus/AWS__Scheduler__Schedule.HourlyPing.json
@@ -57,8 +57,8 @@
       "tier": "atDefault",
       "logicalId": "HourlyPing",
       "resourceType": "AWS::Scheduler::Schedule",
-      "path": "ActionAfterCompletion",
-      "actual": "NONE",
+      "path": "ScheduleExpressionTimezone",
+      "actual": "UTC",
       "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
       "constructPath": "CdkrdIntegHarvest3/HourlyPing"
     },
@@ -66,8 +66,8 @@
       "tier": "atDefault",
       "logicalId": "HourlyPing",
       "resourceType": "AWS::Scheduler::Schedule",
-      "path": "ScheduleExpressionTimezone",
-      "actual": "UTC",
+      "path": "ActionAfterCompletion",
+      "actual": "NONE",
       "physicalId": "CdkrdIntegHarvest3-HourlyPing-1FRBZJC1OF6LB",
       "constructPath": "CdkrdIntegHarvest3/HourlyPing"
     },

--- a/tests/corpus/AWS__WAFv2__WebACL.Edge.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.Edge.json
@@ -130,8 +130,10 @@
       "tier": "undeclared",
       "logicalId": "Edge",
       "resourceType": "AWS::WAFv2::WebACL",
-      "path": "Name",
-      "actual": "Edge-iCCoPGcllLnA",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
       "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
       "constructPath": "CdkrdIntegHarvest2/Edge"
     },
@@ -139,10 +141,8 @@
       "tier": "undeclared",
       "logicalId": "Edge",
       "resourceType": "AWS::WAFv2::WebACL",
-      "path": "OnSourceDDoSProtectionConfig",
-      "actual": {
-        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
-      },
+      "path": "Name",
+      "actual": "Edge-iCCoPGcllLnA",
       "physicalId": "Edge-iCCoPGcllLnA|8db5286a-695e-41b6-beba-f4207a727afc|REGIONAL",
       "constructPath": "CdkrdIntegHarvest2/Edge"
     }

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -462,6 +462,63 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('PR #355-followup noise sweep: constant defaults on common daily-driver types', () => {
+    // Each value was OBSERVED unanimous (>=2 cases) across the golden corpus and is a
+    // documented constant service default — equality-gated, so a non-default value still
+    // surfaces. Resource-/engine-/state-specific values were deliberately excluded.
+    // Ports / fixed enums.
+    expect(KNOWN_DEFAULTS['AWS::DocDB::DBCluster'].Port).toBe(27017);
+    expect(KNOWN_DEFAULTS['AWS::Neptune::DBCluster'].DBPort).toBe(8182);
+    expect(KNOWN_DEFAULTS['AWS::SQS::Queue'].KmsDataKeyReusePeriodSeconds).toBe(300);
+    expect(KNOWN_DEFAULTS['AWS::RDS::DBCluster'].EngineMode).toBe('provisioned');
+    expect(KNOWN_DEFAULTS['AWS::SSM::Association'].DocumentVersion).toBe('$DEFAULT');
+    // AutoScaling.
+    expect(KNOWN_DEFAULTS['AWS::AutoScaling::AutoScalingGroup']).toEqual({
+      Cooldown: '300',
+      HealthCheckType: 'EC2',
+      HealthCheckGracePeriod: 0,
+    });
+    // CloudWatch alarms (Alarm.ActionsEnabled already folds via its schema default).
+    expect(KNOWN_DEFAULTS['AWS::CloudWatch::Alarm'].TreatMissingData).toBe('missing');
+    expect(KNOWN_DEFAULTS['AWS::CloudWatch::CompositeAlarm'].ActionsEnabled).toBe(true);
+    expect(KNOWN_DEFAULTS['AWS::CloudWatch::MetricStream']).toEqual({
+      IncludeLinkedAccountsMetrics: false,
+      State: 'running',
+    });
+    // KMS key defaults.
+    expect(KNOWN_DEFAULTS['AWS::KMS::Key']).toEqual({
+      Enabled: true,
+      KeySpec: 'SYMMETRIC_DEFAULT',
+      KeyUsage: 'ENCRYPT_DECRYPT',
+      Origin: 'AWS_KMS',
+    });
+    // Boolean feature flags off by default on very common types.
+    expect(KNOWN_DEFAULTS['AWS::DynamoDB::Table'].DeletionProtectionEnabled).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::Logs::LogGroup']).toEqual({
+      LogGroupClass: 'STANDARD',
+      DeletionProtectionEnabled: false,
+      BearerTokenAuthenticationEnabled: false,
+    });
+    expect(KNOWN_DEFAULTS['AWS::EC2::Subnet'].AssignIpv6AddressOnCreation).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::EC2::Subnet'].EnableDns64).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::EC2::Subnet'].Ipv6Native).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::ApiGateway::Method'].ApiKeyRequired).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::ApiGatewayV2::Route'].ApiKeyRequired).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::ApiGateway::RestApi'].DisableExecuteApiEndpoint).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::ApiGatewayV2::Api'].DisableExecuteApiEndpoint).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::AppSync::GraphQLApi'].XrayEnabled).toBe(false);
+    expect(
+      KNOWN_DEFAULTS['AWS::Cognito::UserPoolClient'].EnablePropagateAdditionalUserContextData
+    ).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::ECS::Service'].EnableExecuteCommand).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::ECS::Service'].AvailabilityZoneRebalancing).toBe('ENABLED');
+    expect(KNOWN_DEFAULTS['AWS::ElasticLoadBalancingV2::ListenerRule'].IsDefault).toBe(false);
+    expect(KNOWN_DEFAULTS['AWS::Glue::Crawler'].LakeFormationConfiguration).toEqual({
+      AccountId: '',
+      UseLakeFormationCredentials: false,
+    });
+  });
+
   it('common stateful/streaming-type constant defaults from the offline corpus sweep', () => {
     // Constant, documented service defaults common stateful/streaming types report as
     // first-run undeclared noise. Verified against the golden corpus (RDS DBInstance
@@ -476,6 +533,13 @@ describe('noise suppressors', () => {
       MonitoringInterval: 0,
       NetworkType: 'IPV4',
       StorageThroughput: 0,
+      CopyTagsToSnapshot: false,
+      DedicatedLogVolume: false,
+      EnableIAMDatabaseAuthentication: false,
+      EnablePerformanceInsights: false,
+      ManageMasterUserPassword: false,
+      MultiAZ: false,
+      StorageEncrypted: false,
     });
     expect(KNOWN_DEFAULTS['AWS::RDS::DBCluster'].NetworkType).toBe('IPV4');
     expect(KNOWN_DEFAULTS['AWS::ElastiCache::ReplicationGroup']).toEqual({


### PR DESCRIPTION
## First-run-noise sweep: fold ~25 constant service defaults (PR #355 follow-up)

A `measure-noise.sh` sweep over the golden corpus found many **constant service
defaults** that a fresh resource reports as undeclared `[Not Recorded]` on first run.
Each value was **observed unanimous (≥2 real-AWS corpus reads)** and is a documented
constant, so folding it to the `atDefault` tier shrinks first-run noise.

**Safety:** every fold is **equality-gated** (a value set away from the default still
surfaces), and regenerating the **40 affected golden-corpus cases** proved **no
declared-tier finding changes** — a noise fold only moves `undeclared → atDefault`.

### Added (high-confidence, multi-case-unanimous)
Ports/enums: DocDB `Port` 27017, Neptune `DBPort` 8182, SQS `KmsDataKeyReusePeriodSeconds`
300, RDS DBCluster `EngineMode`, SSM Association `DocumentVersion` `$DEFAULT`, ASG
`Cooldown`/`HealthCheckType`/`HealthCheckGracePeriod`, KMS `KeySpec`/`KeyUsage`/`Origin`,
Logs LogGroup `LogGroupClass` STANDARD, MetricStream `State` running, CloudWatch Alarm
`TreatMissingData` + CompositeAlarm `ActionsEnabled`. Boolean feature-flags off by default:
DynamoDB `DeletionProtectionEnabled`, EC2 Subnet IPv6 flags, ApiGateway(v1/v2)
`ApiKeyRequired`/`DisableExecuteApiEndpoint`, AppSync `XrayEnabled`, Cognito UserPoolClient
`EnablePropagateAdditionalUserContextData`, ECS Service `AvailabilityZoneRebalancing`/
`EnableExecuteCommand`, ELBv2 ListenerRule `IsDefault`, RDS DBInstance 7 boolean flags.

### Deliberately NOT folded
Per-resource / engine- or version-derived / state / dynamic values: engine-varying ports,
EngineVersion, `*ParameterGroupName`, MasterUsername, AZ/IP/window values,
CACertificateIdentifier, DBInstanceStatus, `DatapointsToAlarm` (= EvaluationPeriods).
EventBridge Rule `EventBusName` 'default' and ECS Service `PlatformVersion` were already
handled.

Validated: 1604 unit tests green; the new `noise-and-strip` test pins every added entry;
40 corpus-replay cases regenerated (real-AWS reads) prove the folds + zero declared-tier
change; a focused live deploy confirms the previously-noisy defaults now fold to atDefault.
