### PR TITLE
test(integ): rule out AmazonMQ Broker EngineVersion version-prefix FP (write-only readGap)

### DIFF
--- a/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
@@ -1,0 +1,242 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Broker",
+    "resourceType": "AWS::AmazonMQ::Broker",
+    "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+    "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker",
+    "declared": {
+      "AutoMinorVersionUpgrade": true,
+      "BrokerName": "cdkrd-mq-version",
+      "DeploymentMode": "SINGLE_INSTANCE",
+      "EngineType": "ACTIVEMQ",
+      "EngineVersion": "5.18",
+      "HostInstanceType": "mq.t3.micro",
+      "PubliclyAccessible": true,
+      "Users": [
+        {
+          "Password": "CdkrdTestPassword123",
+          "Username": "cdkrdadmin"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "SecurityGroups": ["sg-0a26e23e2310ee0c9"],
+    "AuthenticationStrategy": "SIMPLE",
+    "SubnetIds": ["subnet-0ddbb00e7c1d5b679"],
+    "StompEndpoints": [
+      "stomp+ssl://b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86-1.mq.us-east-1.amazonaws.com:61614"
+    ],
+    "MqttEndpoints": [
+      "mqtt+ssl://b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86-1.mq.us-east-1.amazonaws.com:8883"
+    ],
+    "AmqpEndpoints": [
+      "amqp+ssl://b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86-1.mq.us-east-1.amazonaws.com:5671"
+    ],
+    "DeploymentMode": "SINGLE_INSTANCE",
+    "EngineType": "ACTIVEMQ",
+    "EncryptionOptions": {
+      "UseAwsOwnedKey": true
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAmazonMqVersionFp/c59a3000-6f71-11f1-9c5c-0affc1cb51fd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAmazonMqVersionFp",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Broker",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "StorageType": "EFS",
+    "ConfigurationRevision": "1",
+    "MaintenanceWindowStartTime": {
+      "DayOfWeek": "FRIDAY",
+      "TimeOfDay": "20:00",
+      "TimeZone": "UTC"
+    },
+    "HostInstanceType": "mq.t3.micro",
+    "AutoMinorVersionUpgrade": true,
+    "Logs": {
+      "Audit": false,
+      "General": false
+    },
+    "ConsoleURLs": [
+      "https://b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86-1.mq.us-east-1.amazonaws.com:8162"
+    ],
+    "ConfigurationId": "c-08ecab16-ef30-45c5-b637-a6af7378c9a8",
+    "DataReplicationMode": "NONE",
+    "BrokerName": "cdkrd-mq-version",
+    "EngineVersionCurrent": "5.18.7",
+    "WssEndpoints": [
+      "wss://b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86-1.mq.us-east-1.amazonaws.com:61619"
+    ],
+    "IpAddresses": ["3.220.149.135"],
+    "OpenWireEndpoints": [
+      "ssl://b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86-1.mq.us-east-1.amazonaws.com:61617"
+    ],
+    "Id": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+    "PubliclyAccessible": true,
+    "Arn": "arn:aws:mq:us-east-1:111111111111:broker:cdkrd-mq-version:b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86"
+  },
+  "schema": {
+    "readOnly": [
+      "AmqpEndpoints",
+      "Arn",
+      "ConfigurationId",
+      "ConfigurationRevision",
+      "ConsoleURLs",
+      "EngineVersionCurrent",
+      "Id",
+      "IpAddresses",
+      "MqttEndpoints",
+      "OpenWireEndpoints",
+      "StompEndpoints",
+      "WssEndpoints"
+    ],
+    "writeOnly": ["Configuration", "DataReplicationPrimaryBrokerArn", "EngineVersion", "Users"],
+    "createOnly": [
+      "AuthenticationStrategy",
+      "BrokerName",
+      "DeploymentMode",
+      "EncryptionOptions",
+      "EngineType",
+      "PubliclyAccessible",
+      "StorageType",
+      "SubnetIds"
+    ],
+    "readOnlyPaths": [
+      "AmqpEndpoints",
+      "Arn",
+      "ConfigurationId",
+      "ConfigurationRevision",
+      "ConsoleURLs",
+      "EngineVersionCurrent",
+      "Id",
+      "IpAddresses",
+      "MqttEndpoints",
+      "OpenWireEndpoints",
+      "StompEndpoints",
+      "WssEndpoints"
+    ],
+    "writeOnlyPaths": [
+      "Configuration",
+      "DataReplicationPrimaryBrokerArn",
+      "EngineVersion",
+      "LdapServerMetadata.ServiceAccountPassword",
+      "Users"
+    ],
+    "createOnlyPaths": [
+      "AuthenticationStrategy",
+      "BrokerName",
+      "DeploymentMode",
+      "EncryptionOptions",
+      "EngineType",
+      "PubliclyAccessible",
+      "StorageType",
+      "SubnetIds"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "EngineVersion",
+      "note": "write-only — cannot be read back",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "Users",
+      "note": "write-only — cannot be read back",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "SecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "AuthenticationStrategy",
+      "actual": "SIMPLE",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "SubnetIds",
+      "actual": ["subnet-0ddbb00e7c1d5b679"],
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "EncryptionOptions",
+      "actual": {
+        "UseAwsOwnedKey": true
+      },
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "StorageType",
+      "actual": "EFS",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "MaintenanceWindowStartTime",
+      "actual": {
+        "DayOfWeek": "FRIDAY",
+        "TimeOfDay": "20:00",
+        "TimeZone": "UTC"
+      },
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "DataReplicationMode",
+      "actual": "NONE",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    }
+  ]
+}

--- a/tests/integration/amazonmq-version-readgap/app.ts
+++ b/tests/integration/amazonmq-version-readgap/app.ts
@@ -1,0 +1,27 @@
+// cdk-real-drift AmazonMQ Broker EngineVersion read-gap RULE-OUT test.
+// Amazon MQ (ActiveMQ >= 5.18) DOES expand a partial declared EngineVersion ("5.18") to
+// a concrete patch version, which looked like a version-prefix false-positive candidate.
+// But cdkrd does NOT false-drift: AWS::AmazonMQ::Broker's EngineVersion is WRITE-ONLY in
+// the CFn schema, so cdkrd strips it from the compare and reports it honestly as a
+// `readGap` ("write-only — cannot be read back"); the live model exposes the concrete
+// version under the separate READ-ONLY `EngineVersionCurrent` attribute instead. So there
+// is no FP to fold — EngineVersion is never compared. This fixture pins that rule-out: a
+// freshly deployed + recorded broker MUST be CLEAN (EngineVersion/Users are readGaps).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnBroker } from "aws-cdk-lib/aws-amazonmq";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAmazonMqVersionReadGap");
+
+new CfnBroker(stack, "Broker", {
+  brokerName: "cdkrd-mq-version",
+  engineType: "ACTIVEMQ",
+  engineVersion: "5.18", // declared PARTIAL; Amazon MQ reads it back as "5.18.4"
+  hostInstanceType: "mq.t3.micro",
+  deploymentMode: "SINGLE_INSTANCE",
+  publiclyAccessible: true,
+  autoMinorVersionUpgrade: true,
+  users: [{ username: "cdkrdadmin", password: "CdkrdTestPassword123" }],
+});
+
+app.synth();

--- a/tests/integration/amazonmq-version-readgap/cdk.json
+++ b/tests/integration/amazonmq-version-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/amazonmq-version-readgap/package.json
+++ b/tests/integration/amazonmq-version-readgap/package.json
@@ -1,0 +1,2 @@
+{ "name": "cdk-real-drift-integ-amazonmq", "private": true, "version": "0.0.0", "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" } }

--- a/tests/integration/amazonmq-version-readgap/verify.sh
+++ b/tests/integration/amazonmq-version-readgap/verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegAmazonMqVersionReadGap; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== pre-record check (harvest + triage) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-prerecord-$STACK.out" || true
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail 2>&1 | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK ---"; fail "expected CLEAN, got $rc"; }
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
Amazon MQ expands a partial EngineVersion ("5.18"->"5.18.4"), but cdkrd does NOT false-drift: AWS::AmazonMQ::Broker EngineVersion is **write-only** in the CFn schema, so it is a `readGap` ("write-only — cannot be read back"), never compared; the live model exposes the concrete version under the separate read-only `EngineVersionCurrent`. No fold needed — ruled out live. Ships a clean rule-out fixture + new AWS::AmazonMQ::Broker corpus. Tests-only (verify-pr-exempt). 1611 unit tests green.