### PR TITLE
test(integ): FP-hunt fixtures + golden-corpus cases (S3 AccessPoint, ASG StepScaling, WAFv2 reorder, ResourceGroups, CodeSigning)

### DIFF
--- a/tests/corpus/AWS__AutoScaling__ScalingPolicy.StepPolicy.json
+++ b/tests/corpus/AWS__AutoScaling__ScalingPolicy.StepPolicy.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "StepPolicy",
+    "resourceType": "AWS::AutoScaling::ScalingPolicy",
+    "physicalId": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:8eddc60b-5ccd-4f3e-8bda-df27793339ad:autoScalingGroupName/CdkRealDriftIntegAsgStepScaling-AsgASGD1D7B4E2-4W3CZtGVhJj4:policyName/CdkRealDriftIntegAsgStepScaling-StepPolicy-4XENIrI4an4f",
+    "constructPath": "CdkRealDriftIntegAsgStepScaling/StepPolicy",
+    "declared": {
+      "AdjustmentType": "ChangeInCapacity",
+      "AutoScalingGroupName": "CdkRealDriftIntegAsgStepScaling-AsgASGD1D7B4E2-4W3CZtGVhJj4",
+      "MetricAggregationType": "Average",
+      "PolicyType": "StepScaling",
+      "StepAdjustments": [
+        {
+          "MetricIntervalLowerBound": 50,
+          "ScalingAdjustment": 3
+        },
+        {
+          "MetricIntervalLowerBound": 10,
+          "MetricIntervalUpperBound": 50,
+          "ScalingAdjustment": 1
+        },
+        {
+          "MetricIntervalUpperBound": 10,
+          "ScalingAdjustment": -1
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "MetricAggregationType": "Average",
+    "PolicyType": "StepScaling",
+    "StepAdjustments": [
+      {
+        "MetricIntervalLowerBound": 50,
+        "ScalingAdjustment": 3
+      },
+      {
+        "MetricIntervalUpperBound": 50,
+        "MetricIntervalLowerBound": 10,
+        "ScalingAdjustment": 1
+      },
+      {
+        "MetricIntervalUpperBound": 10,
+        "ScalingAdjustment": -1
+      }
+    ],
+    "PolicyName": "CdkRealDriftIntegAsgStepScaling-StepPolicy-4XENIrI4an4f",
+    "AutoScalingGroupName": "CdkRealDriftIntegAsgStepScaling-AsgASGD1D7B4E2-4W3CZtGVhJj4",
+    "Arn": "arn:aws:autoscaling:us-east-1:111111111111:scalingPolicy:8eddc60b-5ccd-4f3e-8bda-df27793339ad:autoScalingGroupName/CdkRealDriftIntegAsgStepScaling-AsgASGD1D7B4E2-4W3CZtGVhJj4:policyName/CdkRealDriftIntegAsgStepScaling-StepPolicy-4XENIrI4an4f",
+    "AdjustmentType": "ChangeInCapacity"
+  },
+  "schema": {
+    "readOnly": ["Arn", "PolicyName"],
+    "writeOnly": [],
+    "createOnly": ["AutoScalingGroupName"],
+    "readOnlyPaths": ["Arn", "PolicyName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AutoScalingGroupName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Lambda__CodeSigningConfig.Csc.json
+++ b/tests/corpus/AWS__Lambda__CodeSigningConfig.Csc.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Csc",
+    "resourceType": "AWS::Lambda::CodeSigningConfig",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:code-signing-config:csc-0896f236f13827be3",
+    "constructPath": "CdkRealDriftIntegCodeSigningRich/Csc",
+    "declared": {
+      "AllowedPublishers": {
+        "SigningProfileVersionArns": [
+          "arn:aws:signer:us-east-1:111111111111:/signing-profiles/Profile_jPH7bQdF9rEK/bHVsx7KGoB"
+        ]
+      },
+      "Description": "cdkrd code signing probe"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd code signing probe",
+    "AllowedPublishers": {
+      "SigningProfileVersionArns": [
+        "arn:aws:signer:us-east-1:111111111111:/signing-profiles/Profile_jPH7bQdF9rEK/bHVsx7KGoB"
+      ]
+    },
+    "CodeSigningPolicies": {
+      "UntrustedArtifactOnDeployment": "Warn"
+    },
+    "CodeSigningConfigId": "csc-0896f236f13827be3",
+    "CodeSigningConfigArn": "arn:aws:lambda:us-east-1:111111111111:code-signing-config:csc-0896f236f13827be3",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegCodeSigningRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Csc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCodeSigningRich/967dc910-6f87-11f1-9e8c-12dbef2039ab",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CodeSigningConfigArn", "CodeSigningConfigId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["CodeSigningConfigArn", "CodeSigningConfigId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "CodeSigningPolicies.UntrustedArtifactOnDeployment": "Warn"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Csc",
+      "resourceType": "AWS::Lambda::CodeSigningConfig",
+      "path": "CodeSigningPolicies",
+      "actual": {
+        "UntrustedArtifactOnDeployment": "Warn"
+      },
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:code-signing-config:csc-0896f236f13827be3",
+      "constructPath": "CdkRealDriftIntegCodeSigningRich/Csc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ResourceGroups__Group.Group.json
+++ b/tests/corpus/AWS__ResourceGroups__Group.Group.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Group",
+    "resourceType": "AWS::ResourceGroups::Group",
+    "physicalId": "cdkrd-integ-group",
+    "constructPath": "CdkRealDriftIntegResourceGroupsRich/Group",
+    "declared": {
+      "Description": "cdkrd resource group probe",
+      "Name": "cdkrd-integ-group",
+      "ResourceQuery": {
+        "Query": {
+          "ResourceTypeFilters": ["AWS::AllSupported"],
+          "TagFilters": [
+            {
+              "Key": "env",
+              "Values": ["prod", "staging"]
+            },
+            {
+              "Key": "team",
+              "Values": ["platform"]
+            }
+          ]
+        },
+        "Type": "TAG_FILTERS_1_0"
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd resource group probe",
+    "ResourceQuery": {
+      "Type": "TAG_FILTERS_1_0",
+      "Query": {
+        "TagFilters": [
+          {
+            "Values": ["prod", "staging"],
+            "Key": "env"
+          },
+          {
+            "Values": ["platform"],
+            "Key": "team"
+          }
+        ],
+        "ResourceTypeFilters": ["AWS::AllSupported"]
+      }
+    },
+    "Arn": "arn:aws:resource-groups:us-east-1:111111111111:group/cdkrd-integ-group",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegResourceGroupsRich/956fb470-6f87-11f1-b1ed-0affc5fa2c75",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegResourceGroupsRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Group",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-group"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__AccessPoint.Ap.json
+++ b/tests/corpus/AWS__S3__AccessPoint.Ap.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Ap",
+    "resourceType": "AWS::S3::AccessPoint",
+    "physicalId": "cdkrd-ap",
+    "constructPath": "CdkRealDriftIntegS3AccessPoint/Ap",
+    "declared": {
+      "Bucket": "cdkrealdriftintegs3accesspoint-data666c94c7-mekpxz72dqw5",
+      "Name": "cdkrd-ap",
+      "Policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "111111111111"
+            },
+            "Action": ["s3:GetObject"],
+            "Resource": "arn:aws:s3:us-east-1:111111111111:accesspoint/cdkrd-ap/object/*"
+          }
+        ]
+      },
+      "PublicAccessBlockConfiguration": {
+        "BlockPublicAcls": true,
+        "BlockPublicPolicy": true,
+        "IgnorePublicAcls": true,
+        "RestrictPublicBuckets": true
+      }
+    }
+  },
+  "liveRaw": {
+    "Policy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:us-east-1:111111111111:accesspoint/cdkrd-ap/object/*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          }
+        }
+      ]
+    },
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "Bucket": "cdkrealdriftintegs3accesspoint-data666c94c7-mekpxz72dqw5",
+    "Alias": "cdkrd-ap-gdorjbegei6f8zc78ra57j8e3yru1use1a-s3alias",
+    "BucketAccountId": "111111111111",
+    "Arn": "arn:aws:s3:us-east-1:111111111111:accesspoint/cdkrd-ap",
+    "NetworkOrigin": "Internet",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3AccessPoint/b7706a40-6f84-11f1-ad00-0affe791820b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegS3AccessPoint",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Ap",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-ap"
+  },
+  "schema": {
+    "readOnly": ["Alias", "Arn", "NetworkOrigin"],
+    "writeOnly": [],
+    "createOnly": ["Bucket", "BucketAccountId", "Name", "VpcConfiguration"],
+    "readOnlyPaths": ["Alias", "Arn", "NetworkOrigin"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket", "BucketAccountId", "Name", "VpcConfiguration"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Ap",
+      "resourceType": "AWS::S3::AccessPoint",
+      "path": "BucketAccountId",
+      "actual": "111111111111",
+      "physicalId": "cdkrd-ap",
+      "constructPath": "CdkRealDriftIntegS3AccessPoint/Ap"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Signer__SigningProfile.Profile.json
+++ b/tests/corpus/AWS__Signer__SigningProfile.Profile.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Profile",
+    "resourceType": "AWS::Signer::SigningProfile",
+    "physicalId": "arn:aws:signer:us-east-1:111111111111:/signing-profiles/Profile_jPH7bQdF9rEK",
+    "constructPath": "CdkRealDriftIntegCodeSigningRich/Profile",
+    "declared": {
+      "PlatformId": "AWSLambda-SHA384-ECDSA"
+    }
+  },
+  "liveRaw": {
+    "ProfileVersionArn": "arn:aws:signer:us-east-1:111111111111:/signing-profiles/Profile_jPH7bQdF9rEK/bHVsx7KGoB",
+    "SignatureValidityPeriod": {
+      "Type": "MONTHS",
+      "Value": 135
+    },
+    "PlatformId": "AWSLambda-SHA384-ECDSA",
+    "ProfileName": "Profile_jPH7bQdF9rEK",
+    "Arn": "arn:aws:signer:us-east-1:111111111111:/signing-profiles/Profile_jPH7bQdF9rEK",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCodeSigningRich/967dc910-6f87-11f1-9e8c-12dbef2039ab",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegCodeSigningRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Profile",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ProfileVersion": "bHVsx7KGoB"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ProfileName", "ProfileVersion", "ProfileVersionArn"],
+    "writeOnly": [],
+    "createOnly": ["PlatformId", "ProfileName", "SignatureValidityPeriod"],
+    "readOnlyPaths": ["Arn", "ProfileName", "ProfileVersion", "ProfileVersionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PlatformId", "ProfileName", "SignatureValidityPeriod"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Profile",
+      "resourceType": "AWS::Signer::SigningProfile",
+      "path": "SignatureValidityPeriod",
+      "actual": {
+        "Type": "MONTHS",
+        "Value": 135
+      },
+      "physicalId": "arn:aws:signer:us-east-1:111111111111:/signing-profiles/Profile_jPH7bQdF9rEK",
+      "constructPath": "CdkRealDriftIntegCodeSigningRich/Profile"
+    }
+  ]
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl_reorder.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl_reorder.json
@@ -1,0 +1,211 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebAcl",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "cdkrd-integ-rule-reorder|33a5f090-df72-4b99-b2ee-653b2ca3a71f|REGIONAL",
+    "constructPath": "CdkRealDriftIntegWafv2RuleReorder/WebAcl",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Name": "cdkrd-integ-rule-reorder",
+      "Rules": [
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "rate-rule",
+          "Priority": 3,
+          "Statement": {
+            "RateBasedStatement": {
+              "AggregateKeyType": "IP",
+              "Limit": 2000
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "rateRule",
+            "SampledRequestsEnabled": true
+          }
+        },
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "geo-rule",
+          "Priority": 1,
+          "Statement": {
+            "GeoMatchStatement": {
+              "CountryCodes": ["US", "CA", "GB"]
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "geoRule",
+            "SampledRequestsEnabled": true
+          }
+        },
+        {
+          "Name": "managed-rule",
+          "OverrideAction": {
+            "None": {}
+          },
+          "Priority": 2,
+          "Statement": {
+            "ManagedRuleGroupStatement": {
+              "Name": "AWSManagedRulesCommonRuleSet",
+              "VendorName": "AWS"
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "managedRule",
+            "SampledRequestsEnabled": true
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "cdkrdRuleReorder",
+        "SampledRequestsEnabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "REGIONAL",
+    "Capacity": 703,
+    "Id": "33a5f090-df72-4b99-b2ee-653b2ca3a71f",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-integ-rule-reorder/33a5f090-df72-4b99-b2ee-653b2ca3a71f",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 1,
+        "Statement": {
+          "GeoMatchStatement": {
+            "CountryCodes": ["US", "CA", "GB"]
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "geoRule",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "geo-rule"
+      },
+      {
+        "Priority": 2,
+        "Statement": {
+          "ManagedRuleGroupStatement": {
+            "VendorName": "AWS",
+            "RuleActionOverrides": [],
+            "ManagedRuleGroupConfigs": [],
+            "ExcludedRules": [],
+            "Name": "AWSManagedRulesCommonRuleSet"
+          }
+        },
+        "OverrideAction": {
+          "None": {}
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "managedRule",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "managed-rule"
+      },
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 3,
+        "Statement": {
+          "RateBasedStatement": {
+            "AggregateKeyType": "IP",
+            "Limit": 2000,
+            "EvaluationWindowSec": 300
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "rateRule",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "rate-rule"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdRuleReorder",
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:cdkrd-integ-rule-reorder:",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegWafv2RuleReorder/5fcd7570-6f85-11f1-b994-0ef93e3e6391",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegWafv2RuleReorder",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WebAcl",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-rule-reorder"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "cdkrd-integ-rule-reorder|33a5f090-df72-4b99-b2ee-653b2ca3a71f|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2RuleReorder/WebAcl"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "Rules[rate-rule].Statement.RateBasedStatement.EvaluationWindowSec",
+      "actual": 300,
+      "nested": true,
+      "physicalId": "cdkrd-integ-rule-reorder|33a5f090-df72-4b99-b2ee-653b2ca3a71f|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2RuleReorder/WebAcl"
+    }
+  ]
+}

--- a/tests/integration/asg-stepscaling/app.ts
+++ b/tests/integration/asg-stepscaling/app.ts
@@ -1,0 +1,53 @@
+// CDK app for the cdk-real-drift EC2 Auto Scaling step-scaling false-positive
+// test. An EC2 ASG with a StepScaling policy is a common production pattern. Its
+// StepScalingPolicyConfiguration.StepAdjustments is an OBJECT array whose
+// elements carry NO standard identity field (Key/Id/Name) — so the global
+// identity-keyed sort does NOT cover it. EC2 Auto Scaling returns StepAdjustments
+// in its own canonical order (by interval bound); here they are declared OUT of
+// order (upper band first). If AWS reorders them and the path is not folded, a
+// positional diff false-flags StepAdjustments on a freshly deployed + recorded
+// stack. A clean record -> check MUST be CLEAN. The ASG keeps desiredCapacity 0
+// (no instances launch) so the test is fast and cheap.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Vpc, InstanceType, InstanceClass, InstanceSize, MachineImage, SubnetType, LaunchTemplate } from "aws-cdk-lib/aws-ec2";
+import { AutoScalingGroup, CfnScalingPolicy } from "aws-cdk-lib/aws-autoscaling";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAsgStepScaling");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+// LaunchConfigurations are blocked for new accounts; use a LaunchTemplate.
+const launchTemplate = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023(),
+});
+
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  launchTemplate,
+  minCapacity: 0,
+  maxCapacity: 4,
+  desiredCapacity: 0,
+});
+
+// L1 ScalingPolicy so we control the exact StepAdjustments array order (the L2
+// scaleOnMetric sorts the steps, hiding any AWS-side reorder). Declared OUT of
+// ascending-bound order on purpose (upper band first).
+new CfnScalingPolicy(stack, "StepPolicy", {
+  autoScalingGroupName: asg.autoScalingGroupName,
+  policyType: "StepScaling",
+  adjustmentType: "ChangeInCapacity",
+  metricAggregationType: "Average",
+  stepAdjustments: [
+    { metricIntervalLowerBound: 50, scalingAdjustment: 3 },
+    { metricIntervalLowerBound: 10, metricIntervalUpperBound: 50, scalingAdjustment: 1 },
+    { metricIntervalUpperBound: 10, scalingAdjustment: -1 },
+  ],
+});
+
+app.synth();

--- a/tests/integration/asg-stepscaling/cdk.json
+++ b/tests/integration/asg-stepscaling/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/asg-stepscaling/package.json
+++ b/tests/integration/asg-stepscaling/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-asg-stepscaling",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift asg-stepscaling false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/asg-stepscaling/verify.sh
+++ b/tests/integration/asg-stepscaling/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAsgStepScaling
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/codesigning-rich/app.ts
+++ b/tests/integration/codesigning-rich/app.ts
@@ -1,0 +1,27 @@
+// CDK app for the cdk-real-drift Lambda CodeSigningConfig false-positive test.
+// AWS::Lambda::CodeSigningConfig is the common way to enforce signed Lambda code.
+// It carries an AllowedPublishers.SigningProfileVersionArns array plus a
+// CodeSigningPolicies block whose UntrustedArtifactOnDeployment defaults to "Warn"
+// when omitted — exactly the kind of service default cdkrd must fold without a
+// false positive. A freshly deployed + recorded config with NO out-of-band change
+// MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnSigningProfile } from "aws-cdk-lib/aws-signer";
+import { CfnCodeSigningConfig } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCodeSigningRich");
+
+const profile = new CfnSigningProfile(stack, "Profile", {
+  platformId: "AWSLambda-SHA384-ECDSA",
+});
+
+new CfnCodeSigningConfig(stack, "Csc", {
+  description: "cdkrd code signing probe",
+  allowedPublishers: {
+    signingProfileVersionArns: [profile.attrProfileVersionArn],
+  },
+  // CodeSigningPolicies omitted on purpose so AWS fills the "Warn" default.
+});
+
+app.synth();

--- a/tests/integration/codesigning-rich/cdk.json
+++ b/tests/integration/codesigning-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codesigning-rich/package.json
+++ b/tests/integration/codesigning-rich/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-codesigning-rich",
+  "private": true, "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift codesigning-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/codesigning-rich/verify.sh
+++ b/tests/integration/codesigning-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodeSigningRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/resourcegroups-rich/app.ts
+++ b/tests/integration/resourcegroups-rich/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift ResourceGroups::Group false-positive test.
+// AWS::ResourceGroups::Group is a common way to group resources by tag/stack. Its
+// ResourceQuery.Query is a STRUCTURED OBJECT in the CloudFormation template, but
+// services frequently store such query/definition blobs as a JSON STRING and echo
+// them back stringified — the object<->JSON-string divergence class. If Cloud
+// Control returns Query as a string (or with reordered TagFilters/Values), a naive
+// diff false-flags it. A freshly deployed + recorded group with NO out-of-band
+// change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnGroup } from "aws-cdk-lib/aws-resourcegroups";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegResourceGroupsRich");
+
+new CfnGroup(stack, "Group", {
+  name: "cdkrd-integ-group",
+  description: "cdkrd resource group probe",
+  resourceQuery: {
+    type: "TAG_FILTERS_1_0",
+    query: {
+      resourceTypeFilters: ["AWS::AllSupported"],
+      tagFilters: [
+        { key: "env", values: ["prod", "staging"] },
+        { key: "team", values: ["platform"] },
+      ],
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/resourcegroups-rich/cdk.json
+++ b/tests/integration/resourcegroups-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/resourcegroups-rich/package.json
+++ b/tests/integration/resourcegroups-rich/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-resourcegroups-rich",
+  "private": true, "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift resourcegroups-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/resourcegroups-rich/verify.sh
+++ b/tests/integration/resourcegroups-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegResourceGroupsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-accesspoint/app.ts
+++ b/tests/integration/s3-accesspoint/app.ts
@@ -1,0 +1,41 @@
+// CDK app for the cdk-real-drift S3 Access Point false-positive test.
+// AWS::S3::AccessPoint is a common way to expose a bucket with a scoped policy +
+// hardened public-access block, and is not yet covered by any fixture. A fresh
+// access point ships a full default PublicAccessBlockConfiguration and a
+// NetworkOrigin the template may not declare; a freshly deployed + recorded
+// stack with NO out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { CfnAccessPoint } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3AccessPoint");
+
+const bucket = new Bucket(stack, "Data", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+new CfnAccessPoint(stack, "Ap", {
+  bucket: bucket.bucketName,
+  name: "cdkrd-ap",
+  publicAccessBlockConfiguration: {
+    blockPublicAcls: true,
+    ignorePublicAcls: true,
+    blockPublicPolicy: true,
+    restrictPublicBuckets: true,
+  },
+  policy: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { AWS: stack.account },
+        Action: ["s3:GetObject"],
+        Resource: `arn:aws:s3:${stack.region}:${stack.account}:accesspoint/cdkrd-ap/object/*`,
+      },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/s3-accesspoint/cdk.json
+++ b/tests/integration/s3-accesspoint/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-accesspoint/package.json
+++ b/tests/integration/s3-accesspoint/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-accesspoint",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-accesspoint false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-accesspoint/verify.sh
+++ b/tests/integration/s3-accesspoint/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3AccessPoint
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/wafv2-rule-reorder/app.ts
+++ b/tests/integration/wafv2-rule-reorder/app.ts
@@ -1,0 +1,62 @@
+// CDK app for the cdk-real-drift WAFv2 WebACL Rules-reorder false-positive test.
+// The existing wafv2-webacl-rich fixture always declares its Rules in ascending
+// Priority order, so it never exercises a TOP-LEVEL Rules array whose declared
+// order differs from what WAFv2 echoes back. WAFv2 returns Rules ordered by
+// Priority; here we declare them OUT of priority order. If WAFv2 reorders the
+// array and `Rules` is not folded as an unordered (identity-keyed) object array,
+// a positional diff false-flags `Rules` on a freshly deployed + recorded WebACL.
+// A clean record -> check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2RuleReorder");
+
+const vis = (name: string) => ({
+  sampledRequestsEnabled: true,
+  cloudWatchMetricsEnabled: true,
+  metricName: name,
+});
+
+new CfnWebACL(stack, "WebAcl", {
+  name: "cdkrd-integ-rule-reorder",
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: vis("cdkrdRuleReorder"),
+  // Declared OUT of priority order on purpose (3, 1, 2) to expose any
+  // WAFv2-side reordering of the top-level Rules array.
+  rules: [
+    {
+      name: "rate-rule",
+      priority: 3,
+      action: { block: {} },
+      visibilityConfig: vis("rateRule"),
+      statement: {
+        rateBasedStatement: { limit: 2000, aggregateKeyType: "IP" },
+      },
+    },
+    {
+      name: "geo-rule",
+      priority: 1,
+      action: { block: {} },
+      visibilityConfig: vis("geoRule"),
+      statement: {
+        geoMatchStatement: { countryCodes: ["US", "CA", "GB"] },
+      },
+    },
+    {
+      name: "managed-rule",
+      priority: 2,
+      overrideAction: { none: {} },
+      visibilityConfig: vis("managedRule"),
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: "AWS",
+          name: "AWSManagedRulesCommonRuleSet",
+        },
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/wafv2-rule-reorder/cdk.json
+++ b/tests/integration/wafv2-rule-reorder/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-rule-reorder/package.json
+++ b/tests/integration/wafv2-rule-reorder/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-rule-reorder",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-rule-reorder false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-rule-reorder/verify.sh
+++ b/tests/integration/wafv2-rule-reorder/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2RuleReorder
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A real-AWS bug-hunt round (`/hunt-bugs`) across 5 previously-uncovered, common
resource configs. **All were clean — no FP/FN found** — so this PR is the
clean-round deliverable: the live reads captured as permanent offline
golden-corpus regression cases, plus the fixtures that produced them.

## Fixtures (5)

- **s3-accesspoint** — `AWS::S3::AccessPoint` (uncovered common type; PublicAccessBlock + scoped policy).
- **wafv2-rule-reorder** — `AWS::WAFv2::WebACL` Rules declared OUT of priority order + a managed rule group (probes top-level Rules reordering; absorbed by the global `Name`-identity sort → clean).
- **asg-stepscaling** — `AWS::AutoScaling::ScalingPolicy` StepScaling with `StepAdjustments` declared out of bound-order. Notable: the native `describe-policies` API reorders StepAdjustments, but **Cloud Control preserves declared order**, so cdkrd (CC read path) is clean.
- **resourcegroups-rich** — `AWS::ResourceGroups::Group` with a tag-filter `ResourceQuery` (probes object↔JSON-string; CC returns a structured object → clean).
- **codesigning-rich** — `AWS::Lambda::CodeSigningConfig` + `AWS::Signer::SigningProfile` (default-fill probe).

## Corpus (6 new types)

`AWS__S3__AccessPoint`, `AWS__AutoScaling__ScalingPolicy` (EC2 step-scaling, distinct from the existing App-Auto-Scaling target-tracking case), `AWS__WAFv2__WebACL.WebAcl_reorder`, `AWS__ResourceGroups__Group`, `AWS__Lambda__CodeSigningConfig`, `AWS__Signer__SigningProfile`.

All replay green in `corpus-replay.test.ts`. Every tracked stack was deleted and `sweep-orphans.sh` reports SWEEP CLEAN.

tests-only (no `src/**`) → verify-pr-gate exempt.