### PR TITLE
feat(noise): fold AmazonMQ Broker service defaults into KNOWN_DEFAULTS

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -58,6 +58,18 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Lambda::Url': { InvokeMode: 'BUFFERED' },
   'AWS::Events::Rule': { EventBusName: 'default' },
   'AWS::Athena::WorkGroup': { State: 'ENABLED' },
+  // AmazonMQ Broker service defaults (observed live on the amazonmq-version-readgap
+  // fixture): a broker created without these knobs reports all three as undeclared
+  // first-run noise. AuthenticationStrategy is SIMPLE unless LDAP is configured;
+  // EncryptionOptions falls back to the AWS-owned key when no KMS key is declared;
+  // DataReplicationMode is NONE unless cross-region data replication (CRDR) is
+  // enabled. Equality-gated like every KNOWN_DEFAULTS entry — a broker that sets a
+  // KMS key / LDAP / CRDR reads back a non-matching value and stays undeclared.
+  'AWS::AmazonMQ::Broker': {
+    AuthenticationStrategy: 'SIMPLE',
+    EncryptionOptions: { UseAwsOwnedKey: true },
+    DataReplicationMode: 'NONE',
+  },
   // Chatbot applies the AdministratorAccess guardrail when none is declared
   // (verified live on a default-config SlackChannelConfiguration).
   'AWS::Chatbot::SlackChannelConfiguration': {

--- a/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
@@ -152,6 +152,35 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "AuthenticationStrategy",
+      "actual": "SIMPLE",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "DataReplicationMode",
+      "actual": "NONE",
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "EncryptionOptions",
+      "actual": {
+        "UseAwsOwnedKey": true
+      },
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
       "tier": "readGap",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
@@ -173,37 +202,21 @@
       "tier": "undeclared",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "MaintenanceWindowStartTime",
+      "actual": {
+        "DayOfWeek": "FRIDAY",
+        "TimeOfDay": "20:00",
+        "TimeZone": "UTC"
+      },
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
       "path": "SecurityGroups",
       "actual": ["sg-0a26e23e2310ee0c9"],
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "AuthenticationStrategy",
-      "actual": "SIMPLE",
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "SubnetIds",
-      "actual": ["subnet-0ddbb00e7c1d5b679"],
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "EncryptionOptions",
-      "actual": {
-        "UseAwsOwnedKey": true
-      },
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
@@ -220,21 +233,8 @@
       "tier": "undeclared",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "MaintenanceWindowStartTime",
-      "actual": {
-        "DayOfWeek": "FRIDAY",
-        "TimeOfDay": "20:00",
-        "TimeZone": "UTC"
-      },
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "DataReplicationMode",
-      "actual": "NONE",
+      "path": "SubnetIds",
+      "actual": ["subnet-0ddbb00e7c1d5b679"],
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     }

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -441,6 +441,11 @@ describe('noise suppressors', () => {
       DefaultAuthScheme: 'NONE',
       EndpointNetworkType: 'IPV4',
     });
+    expect(KNOWN_DEFAULTS['AWS::AmazonMQ::Broker']).toEqual({
+      AuthenticationStrategy: 'SIMPLE',
+      EncryptionOptions: { UseAwsOwnedKey: true },
+      DataReplicationMode: 'NONE',
+    });
   });
 
   it('first-run-noise folds from the measure-noise sweep (PR follow-up) — common-type constant defaults', () => {


### PR DESCRIPTION
## What

Surfaced during the 2026-06-24 bug-hunt: a default-config `AWS::AmazonMQ::Broker`
reports three constant service defaults as first-run **undeclared** noise:

- `AuthenticationStrategy` = `SIMPLE` (unless LDAP is configured)
- `EncryptionOptions` = `{ UseAwsOwnedKey: true }` (no customer KMS key declared)
- `DataReplicationMode` = `NONE` (no cross-region data replication)

Fold them into `KNOWN_DEFAULTS` so a fresh `check` classifies them `atDefault`
(informational) instead of `[Not Recorded]`. Equality-gated like every
`KNOWN_DEFAULTS` entry — a broker that sets a KMS key / LDAP / CRDR reads back a
non-matching value and stays `undeclared`, so a real out-of-band change never hides.

Deliberately NOT folded (per-resource / non-constant): `StorageType` (EBS single
vs EFS multi-az), `MaintenanceWindowStartTime`, `SecurityGroups`, `SubnetIds`.

## Verification

- Unit test: `KNOWN_DEFAULTS['AWS::AmazonMQ::Broker']` assertion in `noise-and-strip.test.ts`.
- Corpus replay: `AWS__AmazonMQ__Broker.Broker.json` `expected` regenerated — the 3 props move `undeclared`→`atDefault` (9→9 findings, nothing else changed).
- **Live-verified** on a real AmazonMQ broker deploy: a fresh `check --verbose` shows `[At AWS Default: 3]` (the 3 folded props) + `[Not Recorded: 4]` (the genuine per-resource values), and record→check is CLEAN. Stack deleted, sweep clean.

src change → verify-pr gate satisfied (check + docs + verify-pr markers set; live-test done).