### PR TITLE
docs(skills): invoke vp pack / vp test run directly to dodge stale-cache replay

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -21,14 +21,19 @@ Run these sequentially and report results:
    `vp run lint:fix`**: CI runs `vp check` (which includes formatting), and
    `lint:fix` does NOT touch formatting — so a `lint:fix`-only run can pass
    locally while CI fails with formatting issues on the same branch.
-3. `vp run build` — `vp pack` (tsdown ESM bundle to `dist/`).
-4. `vp run test` — `vp test run` (Vitest unit tests; `tests/integration/**` is
-   excluded by `vite.config.ts`).
+3. `vp pack` (tsdown ESM bundle to `dist/`). **Invoke `vp pack` DIRECTLY, not
+   `vp run build`**: the `run`-task wrapper caches and can REPLAY a stale `dist/`
+   that does not reflect the current `src/` — a fresh `vp pack` always rebuilds.
+   A stale `dist/` has caused a false-negative live-test (a `cdkrd check` ran an
+   old binary that lacked the change under test).
+4. `vp test run` (Vitest unit tests; `tests/integration/**` is excluded by
+   `vite.config.ts`). **Invoke `vp test run` DIRECTLY, not `vp run test`** — same
+   cache-replay foot-gun: `vp run test` can replay a stale pass.
 
 When piping any of the above to `tail` / `head` / `grep`, **check the actual
 output content** for `Error` / `Command failed` markers — `$?` after a pipeline
 reflects the LAST stage (usually 0), NOT the build tool's exit. When in doubt,
-capture without piping: `vp run X > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
+capture without piping: `vp <cmd> > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
 
 ## Output
 
@@ -38,7 +43,7 @@ Report as a table:
 | -------------------------------- | --------- |
 | typecheck (`vp run typecheck`)   | pass/fail |
 | lint + format (`vp check --fix`) | pass/fail |
-| build (`vp run build`)           | pass/fail |
+| build (`vp pack`)                | pass/fail |
 | tests (N files, M tests)         | pass/fail |
 
 If all pass, confirm "All checks passed."

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -29,13 +29,16 @@ Run each check and report pass/fail:
    - `vp run typecheck` passes
    - `vp check --fix` passes (lint + format; use this, not `lint:fix` — see
      `/check`)
-   - `vp run build` succeeds
+   - `vp pack` succeeds. **Invoke `vp pack` DIRECTLY, not `vp run build`** — the
+     `run`-task wrapper caches and can REPLAY a stale `dist/`, which has caused a
+     false-negative live-test (step 6 ran an old binary lacking the change).
    - When piping to `tail` / `head` / `grep`, check the actual output for
      `Error` / `Command failed` — `$?` after a pipeline reflects the last stage,
-     not the build tool. When in doubt: `vp run X > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
+     not the build tool. When in doubt: `vp <cmd> > /tmp/out 2>&1; rc=$?; tail -3 /tmp/out; echo "[rc=$rc]"`.
 
 2. **Tests**
-   - `vp run test` — all unit tests pass; report file + test counts.
+   - `vp test run` — all unit tests pass; report file + test counts. **Invoke
+     `vp test run` DIRECTLY, not `vp run test`** (same cache-replay foot-gun).
    - **Coverage of changes**: compare `git diff HEAD~5 --name-only` for `src/`
      vs `tests/`. If logic was added/changed in `src/` with no corresponding test
      added/updated, flag as **fail** and add the missing tests before proceeding.
@@ -60,7 +63,9 @@ Run each check and report pass/fail:
 6. **Live-test changed behavior**
    - Unit tests verify code correctness; this verifies _feature_ correctness
      against the runtime the user actually sees.
-   - Build the latest source: `vp run build`.
+   - Build the latest source: `vp pack` (DIRECTLY — not `vp run build`, whose
+     cache can replay a stale `dist/` and make this live-test exercise an old
+     binary).
    - For each user-visible change (CLI command, output format, flag, error
      message), run the actual command path and confirm the output matches the
      spec:


### PR DESCRIPTION
## What

`/check` and `/verify-pr` instructed `vp run build` / `vp run test`. The `run`-task
wrapper caches and can REPLAY a stale `dist/` (or a stale test pass) that does not
reflect the current `src/`. During the 2026-06-24 bug-hunt this produced a
**false-negative live-test**: a `cdkrd check` ran an old binary that lacked the
change under test, briefly masking whether the AmazonMQ fold worked.

Switch both skills to invoke `vp pack` / `vp test run` **directly** (no cache
replay), with an inline note explaining the foot-gun so the guidance is
self-documenting.

docs/tooling-only (no `src/**`) -> verify-pr-gate exempt.
