### PR TITLE
fix(noise): align object arrays when AWS generates an identity field the template omits

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -49,6 +49,7 @@ import {
   resolveGeneratedDefault,
   sortNestedObjectArrays,
   sortUnorderedObjectArray,
+  stripAsymmetricIdentityFields,
   stripAwsTagsDeep,
   UNORDERED_ARRAY_PROPS,
   UNORDERED_NESTED_OBJECT_ARRAY_PATHS,
@@ -179,6 +180,20 @@ const IAM_ATTACHMENT_SUBSET: Record<string, ReadonlySet<string>> = {
 // Pure: the caller decides suppression and finding shape.
 const isNestedObject = (x: unknown): x is Record<string, unknown> =>
   x !== null && typeof x === 'object' && !Array.isArray(x);
+
+// structuredClone rejects the UNRESOLVED Symbol a declared value may carry, so deep-clone
+// the declared model symbol-safe (symbols/primitives pass through by reference/value). Used
+// to clone the declared side before stripAsymmetricIdentityFields mutates it.
+function cloneDeepWithSymbols(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(cloneDeepWithSymbols);
+  if (v !== null && typeof v === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>))
+      out[k] = cloneDeepWithSymbols(val);
+    return out;
+  }
+  return v;
+}
 
 // An IAM policy STATEMENT array (PolicyDocument.Statement, AssumeRolePolicyDocument
 // .Statement, inline Policies[].PolicyDocument.Statement, …). Recognized by the
@@ -357,9 +372,23 @@ export function classifyResource(
   // silently diverge; the pipeline is shared with baseline-file.ts so baseline values
   // normalize identically (see pipeline.ts).
   const oaiMap = opts.oaiCanonicalIds ?? {};
-  const live = normalizeLiveModel(liveRaw, schema, { oaiCanonicalIds: oaiMap, resourceType });
+  // AWS sometimes GENERATES an identity field the template omitted (S3
+  // LifecycleConfiguration.Rules[].Id when `addLifecycleRule` is called without an `id`).
+  // The live element then carries the field while the declared element does not, so the
+  // per-side identity sort would key the LIVE array by the generated id and leave the
+  // DECLARED array in template order — misaligning every element into false drift. Strip
+  // such asymmetric identity fields from a clone of each side BEFORE canonicalization so
+  // neither side is keyed by them (AWS preserves the array order). `declaredIn` can hold
+  // the UNRESOLVED Symbol, which structuredClone rejects — clone it symbol-safe.
+  const liveForCompare = structuredClone(liveRaw);
+  const declaredForCompare = cloneDeepWithSymbols(declaredIn) as Record<string, unknown>;
+  stripAsymmetricIdentityFields(declaredForCompare, liveForCompare);
+  const live = normalizeLiveModel(liveForCompare, schema, {
+    oaiCanonicalIds: oaiMap,
+    resourceType,
+  });
   const declared = canonicalizeForCompare(
-    rewriteOaiPrincipalsDeep(declaredIn, oaiMap),
+    rewriteOaiPrincipalsDeep(declaredForCompare, oaiMap),
     resourceType
   ) as Record<string, unknown>;
   // Drop a parent's reflected child-aggregate property (e.g. SNS Topic.Subscription)

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -781,6 +781,45 @@ export function identityField(arr: unknown[]): string | undefined {
     )
   );
 }
+
+// AWS sometimes GENERATES an identity field the template omitted — most commonly
+// `S3 LifecycleConfiguration.Rules[].Id`: `bucket.addLifecycleRule({...})` without an
+// `id` is the CDK default, so the template carries no `Id`, but S3 assigns a random one
+// and echoes it on read. The live element then has the identity field while the declared
+// element does not, so the per-side identity sort (`canonicalizeTagLists` / `identityField`)
+// sorts the LIVE array by the generated id but leaves the DECLARED array in template order
+// — misaligning every element into a wall of false `declared` drift (observed live: three
+// no-id lifecycle rules reported 8 phantom drifts). AWS preserves the array's declared
+// order (Cloud Control read), so the safe fix is to NOT let an asymmetric identity field
+// drive the sort: walk the declared/live pair in parallel and, at any object array where
+// an IDENTITY_FIELD is present on EVERY element of one side but NOT every element of the
+// other, delete that field from BOTH sides. Neither side is then keyed by it, both stay in
+// positional order, and the compare aligns. A field present on BOTH sides (CloudFront
+// Origins Id, Tags Key, …) is untouched, so the existing identity-keyed canonicalization is
+// unaffected. Mutates the passed (cloned) structures in place; run BEFORE canonicalization.
+export function stripAsymmetricIdentityFields(declared: unknown, live: unknown): void {
+  const isObj = (x: unknown): x is Record<string, unknown> =>
+    !!x && typeof x === 'object' && !Array.isArray(x);
+  if (Array.isArray(declared) && Array.isArray(live)) {
+    if (declared.length > 0 && live.length > 0 && declared.every(isObj) && live.every(isObj)) {
+      for (const f of IDENTITY_FIELDS) {
+        const decAll = declared.every((e) => typeof (e as Record<string, unknown>)[f] === 'string');
+        const liveAll = live.every((e) => typeof (e as Record<string, unknown>)[f] === 'string');
+        if (decAll !== liveAll) {
+          for (const e of declared) delete (e as Record<string, unknown>)[f];
+          for (const e of live) delete (e as Record<string, unknown>)[f];
+        }
+      }
+    }
+    const n = Math.min(declared.length, live.length);
+    for (let i = 0; i < n; i++) stripAsymmetricIdentityFields(declared[i], live[i]);
+    return;
+  }
+  if (isObj(declared) && isObj(live)) {
+    for (const k of Object.keys(declared))
+      if (k in live) stripAsymmetricIdentityFields(declared[k], live[k]);
+  }
+}
 // Identity-keyed OBJECT arrays that carry a per-element `Name` (so `identityField`
 // would otherwise sort them) but whose ARRAY ORDER is SEMANTICALLY SIGNIFICANT.
 // Sorting such an array is doubly wrong: (a) it MASKS a genuine reorder as no-drift

--- a/tests/corpus/AWS__S3__Bucket.LifecycleNoid.json
+++ b/tests/corpus/AWS__S3__Bucket.LifecycleNoid.json
@@ -1,0 +1,267 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Data666C94C7",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+    "constructPath": "CdkRealDriftIntegS3LifecycleNoid/Data",
+    "declared": {
+      "LifecycleConfiguration": {
+        "Rules": [
+          {
+            "ExpirationInDays": 365,
+            "Prefix": "zeta/",
+            "Status": "Enabled",
+            "Transitions": [
+              {
+                "StorageClass": "STANDARD_IA",
+                "TransitionInDays": 30
+              }
+            ]
+          },
+          {
+            "AbortIncompleteMultipartUpload": {
+              "DaysAfterInitiation": 7
+            },
+            "Prefix": "alpha/",
+            "Status": "Enabled"
+          },
+          {
+            "NoncurrentVersionExpiration": {
+              "NoncurrentDays": 180
+            },
+            "NoncurrentVersionTransitions": [
+              {
+                "StorageClass": "GLACIER",
+                "TransitionInDays": 90
+              }
+            ],
+            "Prefix": "mike/",
+            "Status": "Enabled"
+          }
+        ]
+      },
+      "Tags": [
+        {
+          "Key": "aws-cdk:auto-delete-objects",
+          "Value": "true"
+        }
+      ],
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb.s3-website-us-east-1.amazonaws.com",
+    "LifecycleConfiguration": {
+      "TransitionDefaultMinimumObjectSize": "all_storage_classes_128K",
+      "Rules": [
+        {
+          "Status": "Enabled",
+          "Transitions": [
+            {
+              "StorageClass": "STANDARD_IA",
+              "TransitionInDays": 30
+            }
+          ],
+          "ExpirationInDays": 365,
+          "Id": "OWI4YzMxM2UtYTAyOS00MTRjLTllMDAtYWJjMTI1NWI3ODMx",
+          "Prefix": "zeta/"
+        },
+        {
+          "Status": "Enabled",
+          "Id": "NGJmN2I4MjEtOTc3NC00OWM0LTk1OTctM2RmYWIxMjgzNDVl",
+          "Prefix": "alpha/",
+          "AbortIncompleteMultipartUpload": {
+            "DaysAfterInitiation": 7
+          }
+        },
+        {
+          "Status": "Enabled",
+          "NoncurrentVersionExpiration": {
+            "NoncurrentDays": 180
+          },
+          "NoncurrentVersionTransitions": [
+            {
+              "StorageClass": "GLACIER",
+              "TransitionInDays": 90
+            }
+          ],
+          "Id": "ODhjOWQxOTAtOGVkNi00NWE2LTlhY2ItZGVmYjlhNGI1MzEy",
+          "Prefix": "mike/"
+        }
+      ]
+    },
+    "DualStackDomainName": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb.s3.dualstack.us-east-1.amazonaws.com",
+    "VersioningConfiguration": {
+      "Status": "Enabled"
+    },
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+    "RegionalDomainName": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegS3LifecycleNoid",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Data666C94C7",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3LifecycleNoid/710130f0-6fa0-11f1-bd3c-0e9af082d36f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "true",
+        "Key": "aws-cdk:auto-delete-objects"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+      "constructPath": "CdkRealDriftIntegS3LifecycleNoid/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+      "constructPath": "CdkRealDriftIntegS3LifecycleNoid/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "LifecycleConfiguration.TransitionDefaultMinimumObjectSize",
+      "actual": "all_storage_classes_128K",
+      "nested": true,
+      "physicalId": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+      "constructPath": "CdkRealDriftIntegS3LifecycleNoid/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+      "constructPath": "CdkRealDriftIntegS3LifecycleNoid/Data"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Data666C94C7",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegs3lifecyclenoid-data666c94c7-q83g9nhsaasb",
+      "constructPath": "CdkRealDriftIntegS3LifecycleNoid/Data"
+    }
+  ]
+}

--- a/tests/integration/s3-lifecycle-noid/app.ts
+++ b/tests/integration/s3-lifecycle-noid/app.ts
@@ -1,0 +1,43 @@
+// CDK app for the cdk-real-drift S3 lifecycle "no explicit Id" false-positive
+// test. `bucket.addLifecycleRule({...})` WITHOUT an `id` is the most common way
+// CDK users declare lifecycle rules, and the synthesized template omits Rules[].Id.
+// AWS S3 then AUTO-ASSIGNS a (random) Id to every rule and echoes it on read. The
+// risk: the live rules all carry an Id (so cdkrd's identity-keyed canonicalizer
+// sorts the LIVE side by that generated Id) while the declared rules carry none
+// (so the declared side stays in template order) — if the generated Ids sort in a
+// different order than declared, the positional compare MISALIGNS and false-flags
+// every rule. Three distinct no-id rules maximize the chance of a sort mismatch.
+// A freshly deployed + recorded bucket with NO out-of-band change MUST be CLEAN.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Bucket, StorageClass } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3LifecycleNoid");
+
+const bucket = new Bucket(stack, "Data", {
+  versioned: true,
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+// All three rules declared WITHOUT an id (the CDK default). Distinct prefixes so
+// the rules are unambiguous, declared in an order unlikely to match AWS's
+// generated-Id sort order.
+bucket.addLifecycleRule({
+  prefix: "zeta/",
+  transitions: [{ storageClass: StorageClass.INFREQUENT_ACCESS, transitionAfter: Duration.days(30) }],
+  expiration: Duration.days(365),
+});
+bucket.addLifecycleRule({
+  prefix: "alpha/",
+  abortIncompleteMultipartUploadAfter: Duration.days(7),
+});
+bucket.addLifecycleRule({
+  prefix: "mike/",
+  noncurrentVersionTransitions: [
+    { storageClass: StorageClass.GLACIER, transitionAfter: Duration.days(90) },
+  ],
+  noncurrentVersionExpiration: Duration.days(180),
+});
+
+app.synth();

--- a/tests/integration/s3-lifecycle-noid/cdk.json
+++ b/tests/integration/s3-lifecycle-noid/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-lifecycle-noid/package.json
+++ b/tests/integration/s3-lifecycle-noid/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-s3-lifecycle-noid",
+  "private": true, "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-lifecycle-noid false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/s3-lifecycle-noid/verify.sh
+++ b/tests/integration/s3-lifecycle-noid/verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegS3LifecycleNoid; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="; CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" --verbose > /tmp/fresh-$STACK.out 2>&1 || true
+echo "--- lifecycle-related fresh findings ---"; grep -iE "Lifecycle|Not Recorded|declared|At AWS Default" /tmp/fresh-$STACK.out | head -20
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"; rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN, got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -16,6 +16,7 @@ import {
   isTrailingDotEqual,
   TRAILING_DOT_PATHS,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
+  stripAsymmetricIdentityFields,
 } from '../src/normalize/noise.js';
 import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
 import {
@@ -851,5 +852,60 @@ describe('isPhysicalIdSegment (R142 — value echoes a physical-id segment)', ()
   it('non-string value or missing physical id → false', () => {
     expect(isPhysicalIdSegment(123, 'api1|res9|GET')).toBe(false);
     expect(isPhysicalIdSegment('res9', undefined)).toBe(false);
+  });
+});
+
+describe('stripAsymmetricIdentityFields (AWS-generated identity field)', () => {
+  it('strips a live-only identity field so neither side sorts by it (S3 lifecycle no-id)', () => {
+    // declared rules have NO Id (CDK addLifecycleRule default); live rules carry an
+    // AWS-generated Id. Without the strip, the per-side identity sort reorders live by
+    // the generated Id and misaligns every rule.
+    const declared = {
+      LifecycleConfiguration: {
+        Rules: [{ Prefix: 'zeta/' }, { Prefix: 'alpha/' }, { Prefix: 'mike/' }],
+      },
+    };
+    const live = {
+      LifecycleConfiguration: {
+        Rules: [
+          { Id: 'gen-zeta', Prefix: 'zeta/' },
+          { Id: 'gen-alpha', Prefix: 'alpha/' },
+          { Id: 'gen-mike', Prefix: 'mike/' },
+        ],
+      },
+    };
+    stripAsymmetricIdentityFields(declared, live);
+    // Id deleted from every live rule -> identityField no longer keys the array.
+    for (const r of live.LifecycleConfiguration.Rules) expect('Id' in r).toBe(false);
+  });
+
+  it('leaves an identity field present on BOTH sides untouched (CloudFront Origins)', () => {
+    const declared = {
+      Origins: [
+        { Id: 'o1', DomainName: 'a' },
+        { Id: 'o2', DomainName: 'b' },
+      ],
+    };
+    const live = {
+      Origins: [
+        { Id: 'o1', DomainName: 'a' },
+        { Id: 'o2', DomainName: 'b' },
+      ],
+    };
+    stripAsymmetricIdentityFields(declared, live);
+    expect(live.Origins.every((o) => 'Id' in o)).toBe(true);
+    expect(declared.Origins.every((o) => 'Id' in o)).toBe(true);
+  });
+
+  it('strips a declared-only identity field too (reverse asymmetry)', () => {
+    const declared = {
+      Rules: [
+        { Id: 'a', V: 1 },
+        { Id: 'b', V: 2 },
+      ],
+    };
+    const live = { Rules: [{ V: 1 }, { V: 2 }] };
+    stripAsymmetricIdentityFields(declared, live);
+    expect(declared.Rules.every((r) => 'Id' in r)).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug (false positive, CDK default usage)

`bucket.addLifecycleRule({...})` WITHOUT an `id` is the most common way CDK users
declare lifecycle rules — the synthesized template omits `Rules[].Id`. AWS S3 then
auto-assigns a random `Id` to every rule and echoes it on read. The live rules all
carry an `Id` while the declared rules carry none, so cdkrd's per-side identity sort
(`canonicalizeTagLists` / `identityField`) keyed the LIVE array by the generated `Id`
but left the DECLARED array in template order — misaligning every rule.

**Live-proven:** three no-id rules (`zeta/`, `alpha/`, `mike/`) → AWS preserved the
declared order, but the generated Ids sorted to `alpha/mike/zeta` → **8 phantom
`declared` drifts** on a freshly recorded, unchanged bucket.

## The fix (general — closes the class)

`stripAsymmetricIdentityFields(declared, live)` (src/normalize/noise.ts), called in
`classifyResource` BEFORE canonicalization: walk the declared/live pair in parallel
and, at any object array where an `IDENTITY_FIELD` is present on every element of one
side but not the other (the AWS-generated-id signature), delete it from BOTH sides so
neither is keyed by it and the positional compare aligns (AWS preserves array order).
A field present on BOTH sides (CloudFront Origins `Id`, Tags `Key`, …) is untouched,
so existing identity-keyed canonicalization is unchanged.

This is general, not S3-specific: it closes the class for any optional-generated-id
array (S3 `LifecycleConfiguration.Rules`, `ReplicationConfiguration.Rules`, …).
`declaredIn` can hold the `UNRESOLVED` Symbol (structuredClone rejects it), so the
declared side is cloned with a symbol-safe deep clone.

## Tests

- Unit: `stripAsymmetricIdentityFields` (live-only id stripped, both-sides id kept,
  reverse asymmetry) in `noise-and-strip.test.ts`.
- Golden-corpus regression: `AWS__S3__Bucket.LifecycleNoid.json` (the real live read;
  declared findings now empty).
- Integration fixture: `tests/integration/s3-lifecycle-noid`.
- **Live-proven:** re-ran the fixture with the fixed binary → deploy → record →
  `check --fail` CLEAN (was 8 drifts). Stack deleted, sweep clean.
