### PR TITLE
fix(read,noise): CodeDeploy DeploymentGroup read-gap + AutoRollback Events reorder FP

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -129,6 +129,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ConnectivityType: 'public',
     AvailabilityMode: 'zonal',
   },
+  'AWS::CodeDeploy::DeploymentGroup': {
+    // The schema carries no explicit `default`, but its description states the value
+    // applied when the property is "unspecified" is UPDATE — CodeDeploy always echoes
+    // it back on a group that never declared it (live-observed,
+    // codedeploy-deploymentgroup-readgap). Equality-gated, so a switch to IGNORE
+    // still surfaces.
+    OutdatedInstancesStrategy: 'UPDATE',
+  },
   'AWS::EFS::FileSystem': {
     ThroughputMode: 'bursting',
     BackupPolicy: { Status: 'DISABLED' },
@@ -1329,6 +1337,16 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   // add/remove still changes the multiset. (Weighted/latency routing uses separate
   // RecordSets with SetIdentifier, not ordered ResourceRecords, so this is FP-safe.)
   'AWS::Route53::RecordSet': new Set(['ResourceRecords']),
+  // Live-observed on a fresh codedeploy-deploymentgroup-readgap deploy: a deployment
+  // group's AutoRollbackConfiguration.Events is a SET of rollback-trigger enums that
+  // CodeDeploy echoes SORTED alphabetically, not in template order (declared
+  // [DEPLOYMENT_STOP_ON_ALARM, DEPLOYMENT_FAILURE] read back [DEPLOYMENT_FAILURE,
+  // DEPLOYMENT_STOP_ON_ALARM]) — a positional compare false-drifts the identical event
+  // set. A genuine event add/remove still changes the multiset. (The sibling
+  // TriggerConfigurations[].TriggerEvents set was observed to PRESERVE template order on
+  // the same deploy, so it is deliberately NOT folded.) The path is nested but the
+  // declared-loop suppression keys on the full dotted `d.path`, so the dotted key works.
+  'AWS::CodeDeploy::DeploymentGroup': new Set(['AutoRollbackConfiguration.Events']),
 };
 
 // True when both values are scalar arrays containing the same multiset of

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -127,6 +127,15 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // a declared hook ValidationException-skips (read-gap). Verified live
   // (autoscaling-lifecyclehook-rich).
   'AWS::AutoScaling::LifecycleHook': compositeWith('AutoScalingGroupName'),
+  // CodeDeploy DeploymentGroup primaryIdentifier is [ApplicationName,
+  // DeploymentGroupName] — parent-first. The CFn physical id (Ref) is the bare
+  // DeploymentGroupName; the ApplicationName comes from the resolved declared Ref.
+  // Without this a declared deployment group is a CC ValidationException skip on every
+  // check (read-gap), so both undeclared drift on it AND an out-of-band change to a
+  // declared property (DeploymentConfigName, AlarmConfiguration, …) are invisible.
+  // Verified live (codedeploy-deploymentgroup-readgap): `ApplicationName|DeploymentGroupName`
+  // reads; the reverse order returns NotFound ("No application found for name").
+  'AWS::CodeDeploy::DeploymentGroup': compositeWith('ApplicationName'),
   // AutoScaling ScheduledAction primaryIdentifier is [ScheduledActionName,
   // AutoScalingGroupName] — CHILD-first, the REVERSE of its sibling LifecycleHook
   // (parent-first). The CFn physical id is the bare ScheduledActionName; the ASG name

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -811,6 +811,80 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['ResourceRecords']);
     });
 
+    // Live-observed FP (codedeploy-deploymentgroup-readgap fixture): a deployment
+    // group's AutoRollbackConfiguration.Events is a SET of rollback-trigger enums that
+    // CodeDeploy echoes SORTED alphabetically. The path is NESTED, so this also pins
+    // that the declared-loop fold keys on the full dotted `d.path`.
+    it('UNORDERED_ARRAY_PROPS: CodeDeploy DeploymentGroup nested AutoRollbackConfiguration.Events reorder is NOT drift', () => {
+      const dg = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Group',
+        resourceType: 'AWS::CodeDeploy::DeploymentGroup',
+        physicalId: 'cdkrd-readgap-dg',
+        declared,
+      });
+      // same event set, reordered (AWS sorts) -> no drift
+      expect(
+        classifyResource(
+          dg({
+            AutoRollbackConfiguration: {
+              Enabled: true,
+              Events: ['DEPLOYMENT_STOP_ON_ALARM', 'DEPLOYMENT_FAILURE'],
+            },
+          }),
+          {
+            AutoRollbackConfiguration: {
+              Enabled: true,
+              Events: ['DEPLOYMENT_FAILURE', 'DEPLOYMENT_STOP_ON_ALARM'],
+            },
+          },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine event change still reports the nested path
+      expect(
+        tiers(
+          classifyResource(
+            dg({
+              AutoRollbackConfiguration: {
+                Enabled: true,
+                Events: ['DEPLOYMENT_STOP_ON_ALARM', 'DEPLOYMENT_FAILURE'],
+              },
+            }),
+            {
+              AutoRollbackConfiguration: {
+                Enabled: true,
+                Events: ['DEPLOYMENT_FAILURE', 'DEPLOYMENT_STOP_ON_REQUEST'],
+              },
+            },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['AutoRollbackConfiguration.Events']);
+    });
+
+    // Live-observed (same fixture): CodeDeploy always echoes OutdatedInstancesStrategy
+    // = "UPDATE" on a group that never declared it (documented unspecified behavior).
+    it('KNOWN_DEFAULTS: undeclared CodeDeploy OutdatedInstancesStrategy=UPDATE folds to atDefault; IGNORE surfaces', () => {
+      const res = (live: Record<string, unknown>) =>
+        classifyResource(
+          {
+            logicalId: 'Group',
+            resourceType: 'AWS::CodeDeploy::DeploymentGroup',
+            physicalId: 'cdkrd-readgap-dg',
+            declared: {},
+          },
+          live,
+          emptySchema
+        );
+      expect(tiers(res({ OutdatedInstancesStrategy: 'UPDATE' })).atDefault).toEqual([
+        'OutdatedInstancesStrategy',
+      ]);
+      // an out-of-band switch to IGNORE is no longer the default -> surfaces as undeclared
+      expect(tiers(res({ OutdatedInstancesStrategy: 'IGNORE' })).undeclared).toEqual([
+        'OutdatedInstancesStrategy',
+      ]);
+    });
+
     it('undeclared EventSelectors equal to the default folds to atDefault; a changed one surfaces', () => {
       expect(
         tiers(

--- a/tests/corpus/AWS__CodeDeploy__DeploymentGroup.Group.json
+++ b/tests/corpus/AWS__CodeDeploy__DeploymentGroup.Group.json
@@ -1,0 +1,144 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Group",
+    "resourceType": "AWS::CodeDeploy::DeploymentGroup",
+    "physicalId": "cdkrd-readgap-dg",
+    "constructPath": "CdkRealDriftIntegCodeDeployDeploymentGroupReadgap/Group",
+    "declared": {
+      "AlarmConfiguration": {
+        "Alarms": [
+          {
+            "Name": "zeta-CdkRealDriftIntegCodeDeployDeploymentGroupReadgap"
+          },
+          {
+            "Name": "alpha-CdkRealDriftIntegCodeDeployDeploymentGroupReadgap"
+          }
+        ],
+        "Enabled": true
+      },
+      "ApplicationName": "CdkRealDriftIntegCodeDeployDeploymentGroupReadgap-App-XzN9elTm5vrt",
+      "AutoRollbackConfiguration": {
+        "Enabled": true,
+        "Events": ["DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_FAILURE"]
+      },
+      "DeploymentConfigName": "CodeDeployDefault.OneAtATime",
+      "DeploymentGroupName": "cdkrd-readgap-dg",
+      "DeploymentStyle": {
+        "DeploymentOption": "WITHOUT_TRAFFIC_CONTROL",
+        "DeploymentType": "IN_PLACE"
+      },
+      "Ec2TagSet": {
+        "Ec2TagSetList": [
+          {
+            "Ec2TagGroup": [
+              {
+                "Key": "App",
+                "Type": "KEY_AND_VALUE",
+                "Value": "cdkrd"
+              },
+              {
+                "Key": "Tier",
+                "Type": "KEY_AND_VALUE",
+                "Value": "web"
+              }
+            ]
+          }
+        ]
+      },
+      "ServiceRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodeDeployDepl-ServiceRole4288B192-cliuKmJod31M",
+      "TriggerConfigurations": [
+        {
+          "TriggerEvents": ["DeploymentFailure", "DeploymentSuccess", "DeploymentStart"],
+          "TriggerName": "deploy-events",
+          "TriggerTargetArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegCodeDeployDeploymentGroupReadgap-TriggerTopic92976BC4-JWKRrjz7yAe6"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "CdkRealDriftIntegCodeDeployDeploymentGroupReadgap-App-XzN9elTm5vrt",
+    "DeploymentStyle": {
+      "DeploymentType": "IN_PLACE",
+      "DeploymentOption": "WITHOUT_TRAFFIC_CONTROL"
+    },
+    "ServiceRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodeDeployDepl-ServiceRole4288B192-cliuKmJod31M",
+    "AutoScalingGroups": [],
+    "Ec2TagSet": {
+      "Ec2TagSetList": [
+        {
+          "Ec2TagGroup": [
+            {
+              "Type": "KEY_AND_VALUE",
+              "Value": "cdkrd",
+              "Key": "App"
+            },
+            {
+              "Type": "KEY_AND_VALUE",
+              "Value": "web",
+              "Key": "Tier"
+            }
+          ]
+        }
+      ]
+    },
+    "OutdatedInstancesStrategy": "UPDATE",
+    "TriggerConfigurations": [
+      {
+        "TriggerName": "deploy-events",
+        "TriggerEvents": ["DeploymentFailure", "DeploymentSuccess", "DeploymentStart"],
+        "TriggerTargetArn": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegCodeDeployDeploymentGroupReadgap-TriggerTopic92976BC4-JWKRrjz7yAe6"
+      }
+    ],
+    "DeploymentConfigName": "CodeDeployDefault.OneAtATime",
+    "AlarmConfiguration": {
+      "IgnorePollAlarmFailure": false,
+      "Alarms": [
+        {
+          "Name": "zeta-CdkRealDriftIntegCodeDeployDeploymentGroupReadgap"
+        },
+        {
+          "Name": "alpha-CdkRealDriftIntegCodeDeployDeploymentGroupReadgap"
+        }
+      ],
+      "Enabled": true
+    },
+    "Ec2TagFilters": [],
+    "TerminationHookEnabled": false,
+    "ECSServices": [],
+    "AutoRollbackConfiguration": {
+      "Events": ["DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_FAILURE"],
+      "Enabled": true
+    },
+    "DeploymentGroupName": "cdkrd-readgap-dg",
+    "Tags": [],
+    "OnPremisesInstanceTagFilters": []
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApplicationName", "DeploymentGroupName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApplicationName", "DeploymentGroupName"],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Group",
+      "resourceType": "AWS::CodeDeploy::DeploymentGroup",
+      "path": "OutdatedInstancesStrategy",
+      "actual": "UPDATE",
+      "physicalId": "cdkrd-readgap-dg",
+      "constructPath": "CdkRealDriftIntegCodeDeployDeploymentGroupReadgap/Group"
+    }
+  ]
+}

--- a/tests/integration/codedeploy-deploymentgroup-readgap/app.ts
+++ b/tests/integration/codedeploy-deploymentgroup-readgap/app.ts
@@ -1,0 +1,114 @@
+// CDK app for the cdk-real-drift codedeploy-deploymentgroup-readgap integration test.
+//
+// AWS::CodeDeploy::DeploymentGroup is a daily-driver CI/CD type with NO golden-corpus
+// coverage. Its CloudFormation `Ref` returns only the bare DeploymentGroupName, but
+// Cloud Control's primaryIdentifier is the COMPOSITE [ApplicationName,
+// DeploymentGroupName] (parent-first) — so without a CC_IDENTIFIER_ADAPTERS entry CC
+// GetResource ValidationException-skips the group on every check (a silent read-gap:
+// undeclared drift on it is invisible). This fixture proves the gap is closed
+// (parent-first `ApplicationName|DeploymentGroupName`, the SubscriptionFilter /
+// LifecycleHook pattern).
+//
+// It also doubles as a set-like-reorder false-positive probe: TriggerEvents and
+// AutoRollbackConfiguration.Events are scalar enum SETS declared NON-sorted, and the
+// AlarmConfiguration.Alarms object array is declared out of Name order — AWS may
+// re-emit any of them in a different order.
+//
+// Cheap: an EC2/on-prem (Server) deployment group needs no instances, no NAT, no
+// stateful provisioning — just the application, a service role, an SNS trigger
+// target, and two CloudWatch alarms.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnDeploymentGroup,
+} from "aws-cdk-lib/aws-codedeploy";
+import { Alarm, Metric } from "aws-cdk-lib/aws-cloudwatch";
+import {
+  ManagedPolicy,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCodeDeployDeploymentGroupReadgap");
+
+const application = new CfnApplication(stack, "App", {
+  computePlatform: "Server",
+});
+
+const serviceRole = new Role(stack, "ServiceRole", {
+  assumedBy: new ServicePrincipal("codedeploy.amazonaws.com"),
+  managedPolicies: [
+    ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSCodeDeployRole"),
+  ],
+});
+
+const triggerTopic = new Topic(stack, "TriggerTopic");
+
+const makeAlarm = (id: string, label: string) =>
+  new Alarm(stack, id, {
+    alarmName: `${label}-${stack.stackName}`,
+    metric: new Metric({
+      namespace: "CdkRealDrift/CodeDeploy",
+      metricName: `${label}Metric`,
+      period: Duration.minutes(5),
+    }),
+    threshold: 1,
+    evaluationPeriods: 1,
+  });
+
+// declared out of Name order on purpose (zeta before alpha) — a reorder probe for
+// the Alarms object array
+const zetaAlarm = makeAlarm("ZetaAlarm", "zeta");
+const alphaAlarm = makeAlarm("AlphaAlarm", "alpha");
+
+new CfnDeploymentGroup(stack, "Group", {
+  applicationName: application.ref,
+  serviceRoleArn: serviceRole.roleArn,
+  deploymentGroupName: "cdkrd-readgap-dg",
+  // a MUTABLE declared property — the false-negative (out-of-band-change) probe
+  deploymentConfigName: "CodeDeployDefault.OneAtATime",
+  deploymentStyle: {
+    deploymentType: "IN_PLACE",
+    deploymentOption: "WITHOUT_TRAFFIC_CONTROL",
+  },
+  // scalar enum SET, declared NON-sorted (Failure, Success, Start) — reorder probe
+  triggerConfigurations: [
+    {
+      triggerName: "deploy-events",
+      triggerTargetArn: triggerTopic.topicArn,
+      triggerEvents: [
+        "DeploymentFailure",
+        "DeploymentSuccess",
+        "DeploymentStart",
+      ],
+    },
+  ],
+  // scalar enum SET, declared NON-sorted — reorder probe
+  autoRollbackConfiguration: {
+    enabled: true,
+    events: ["DEPLOYMENT_STOP_ON_ALARM", "DEPLOYMENT_FAILURE"],
+  },
+  alarmConfiguration: {
+    enabled: true,
+    alarms: [
+      { name: zetaAlarm.alarmName },
+      { name: alphaAlarm.alarmName },
+    ],
+  },
+  // an EC2 tag set (no live instances required for the group to exist) — also a
+  // set-like nested array
+  ec2TagSet: {
+    ec2TagSetList: [
+      {
+        ec2TagGroup: [
+          { key: "App", value: "cdkrd", type: "KEY_AND_VALUE" },
+          { key: "Tier", value: "web", type: "KEY_AND_VALUE" },
+        ],
+      },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/codedeploy-deploymentgroup-readgap/cdk.json
+++ b/tests/integration/codedeploy-deploymentgroup-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codedeploy-deploymentgroup-readgap/package.json
+++ b/tests/integration/codedeploy-deploymentgroup-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-codedeploy-deploymentgroup-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift codedeploy-deploymentgroup-readgap integration test. Run via verify.sh / verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/codedeploy-deploymentgroup-readgap/verify-detect.sh
+++ b/tests/integration/codedeploy-deploymentgroup-readgap/verify-detect.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# DeploymentGroup detect + revert integration test (real AWS): the false-NEGATIVE
+# half. Deploy -> record -> change the DECLARED MUTABLE DeploymentConfigName out of
+# band (console-edit scenario via update-deployment-group) -> check MUST DETECT the
+# declared drift (exit 1) -> revert (Cloud Control UpdateResource) -> check MUST be
+# CLEAN and the live DeploymentConfigName MUST be restored. This also exercises that
+# the read-gap fix actually reads the group (a `skipped` group could never detect).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodeDeployDeploymentGroupReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+APP="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::CodeDeploy::Application'].PhysicalResourceId" --output text)"
+DG=cdkrd-readgap-dg
+[ -n "$APP" ] || fail "could not resolve application name"
+
+ORIG="$(aws deploy get-deployment-group --application-name "$APP" --deployment-group-name "$DG" \
+  --region "$REGION" --query "deploymentGroupInfo.deploymentConfigName" --output text)"
+echo "app=$APP dg=$DG origConfig=[$ORIG]"
+[ "$ORIG" = "CodeDeployDefault.OneAtATime" ] || fail "unexpected original config: $ORIG"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: change DeploymentConfigName (console-edit) ==="
+aws deploy update-deployment-group --application-name "$APP" \
+  --current-deployment-group-name "$DG" \
+  --deployment-config-name "CodeDeployDefault.AllAtOnce" \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-codedeploy-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "DeploymentConfigName" /tmp/cdkrd-codedeploy-detect.out || fail "DeploymentConfigName not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live DeploymentConfigName MUST be restored ==="
+GOT="$(aws deploy get-deployment-group --application-name "$APP" --deployment-group-name "$DG" \
+  --region "$REGION" --query "deploymentGroupInfo.deploymentConfigName" --output text)"
+[ "$GOT" = "$ORIG" ] || fail "live DeploymentConfigName not restored (got: [$GOT], want: [$ORIG])"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/codedeploy-deploymentgroup-readgap/verify.sh
+++ b/tests/integration/codedeploy-deploymentgroup-readgap/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive + read-gap integration test (real AWS): deploy -> record baseline ->
+# check MUST be CLEAN. AWS::CodeDeploy::DeploymentGroup's CFn Ref is the bare
+# DeploymentGroupName, but Cloud Control's primaryIdentifier is the composite
+# [ApplicationName, DeploymentGroupName]; the CC_IDENTIFIER_ADAPTERS entry must pair
+# them (parent-first) or the group is silently `skipped` (read-gap). A surviving
+# declared drift on a clean recorded stack is a set-like-reorder normalization FP
+# (TriggerEvents / AutoRollbackConfiguration.Events / Alarms).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodeDeployDeploymentGroupReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (read-gap probe — group must NOT be skipped) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK.pre"
+grep -qi "skipped" "/tmp/cdkrd-$STACK.pre" && echo "WARN: a resource was skipped (possible read-gap) — inspect above"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -287,6 +287,36 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('my-asg|my-hook');
   });
 
+  it('CodeDeploy DeploymentGroup: builds the ApplicationName|DeploymentGroupName composite — parent first', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::CodeDeploy::DeploymentGroup',
+        physicalId: 'cdkrd-readgap-dg',
+        declared: { ApplicationName: 'my-app' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('my-app|cdkrd-readgap-dg');
+  });
+
+  it('CodeDeploy DeploymentGroup: an unresolved ApplicationName falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::CodeDeploy::DeploymentGroup',
+        physicalId: 'cdkrd-readgap-dg',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('cdkrd-readgap-dg');
+  });
+
   it('AutoScaling ScheduledAction: builds the ScheduledActionName|AutoScalingGroupName composite — CHILD first (reverse of LifecycleHook)', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(


### PR DESCRIPTION
## Bug-hunt round (real AWS) — AWS::CodeDeploy::DeploymentGroup

A daily-driver CI/CD type with no golden-corpus coverage. One deploy surfaced **three** findings:

### 1. FN — silent read-gap (the primary bug)
`AWS::CodeDeploy::DeploymentGroup`'s CFn `Ref` is the bare `DeploymentGroupName`, but Cloud Control's `primaryIdentifier` is the composite `[ApplicationName, DeploymentGroupName]` (parent-first). Without an adapter, CC `GetResource` `ValidationException`-skips the group on **every** check — so undeclared drift on it AND out-of-band changes to declared props (DeploymentConfigName, AlarmConfiguration, …) are invisible.

Fixed with `CC_IDENTIFIER_ADAPTERS['AWS::CodeDeploy::DeploymentGroup'] = compositeWith('ApplicationName')`. Same class as SubscriptionFilter (#344) / LifecycleHook. Verified live: `ApplicationName|DeploymentGroupName` reads; the reverse 404s (`No application found for name`).

### 2. FP — set-like reorder (exposed by the fix)
`AutoRollbackConfiguration.Events` is a SET of rollback-trigger enums CodeDeploy echoes **sorted alphabetically**, not in template order (declared `[STOP_ON_ALARM, FAILURE]` → live `[FAILURE, STOP_ON_ALARM]`). A positional compare false-drifts the identical set. Folded via `UNORDERED_ARRAY_PROPS` (nested dotted path — the declared-loop suppression keys on `d.path`).

The sibling `TriggerConfigurations[].TriggerEvents` was observed to **preserve** template order on the same deploy → deliberately **not** folded.

### 3. Noise — service default
`OutdatedInstancesStrategy="UPDATE"` is the documented "unspecified" default AWS always echoes → `KNOWN_DEFAULTS` fold (equality-gated; a switch to `IGNORE` still surfaces).

## Tests / coverage
- New `codedeploy-deploymentgroup-readgap` fixture (+ `verify.sh` / `verify-detect.sh`).
- Golden-corpus case `AWS__CodeDeploy__DeploymentGroup.Group.json`.
- Unit tests: the parent-first adapter (+ unresolved fallback), the nested `AutoRollbackConfiguration.Events` reorder fold, the `OutdatedInstancesStrategy` default fold.

## Live-proven (acct 531991745243, us-east-1)
- `record` → `check` **CLEAN** (no skip, no declared drift).
- detect: out-of-band `DeploymentConfigName` change → `check` exit 1 reports it.
- `revert` (CC `UpdateResource`) → `check` **CLEAN** → live value restored.
- Stack deleted (`delstack`), SWEEP CLEAN.

All 1629 unit tests pass; `basic` integ regression PASS.