### PR TITLE
fix(noise): fold ECS RequiresCompatibilities + Route53 HealthCheck Regions reorder FPs

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1347,6 +1347,21 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   // the same deploy, so it is deliberately NOT folded.) The path is nested but the
   // declared-loop suppression keys on the full dotted `d.path`, so the dotted key works.
   'AWS::CodeDeploy::DeploymentGroup': new Set(['AutoRollbackConfiguration.Events']),
+  // Live-observed on a fresh enumset-reorder deploy: ECS echoes a task definition's
+  // RequiresCompatibilities (a SET of launch-type enums — FARGATE/EC2/EXTERNAL) SORTED
+  // alphabetically, not in template order (declared [FARGATE, EC2] read back
+  // [EC2, FARGATE]). A positional compare false-drifts the identical launch-type set on
+  // every check. A genuine compatibility add/remove still changes the multiset. Hits
+  // every multi-launch-type ECS user. (The verbs aren't ids/ARNs/HTTP/AZ, so the generic
+  // canonicalizeIdArraysDeep leaves them untouched — hence this per-type entry.)
+  'AWS::ECS::TaskDefinition': new Set(['RequiresCompatibilities']),
+  // Live-observed on the same deploy: Route53 echoes a health check's
+  // HealthCheckConfig.Regions (the SET of regions where the Route53 health checkers run)
+  // SORTED alphabetically, not in template order (declared [us-west-2, us-east-1,
+  // eu-west-1] read back [eu-west-1, us-east-1, us-west-2]). Region NAMES lack the hex/AZ
+  // suffix so the generic id/AZ fold does not match them; the set carries no order
+  // meaning. Nested dotted path — the declared-loop suppression keys on the full d.path.
+  'AWS::Route53::HealthCheck': new Set(['HealthCheckConfig.Regions']),
 };
 
 // True when both values are scalar arrays containing the same multiset of

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -862,6 +862,74 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['AutoRollbackConfiguration.Events']);
     });
 
+    // Live-observed FP (enumset-reorder fixture): ECS echoes a task definition's
+    // RequiresCompatibilities launch-type set SORTED alphabetically (declared
+    // [FARGATE, EC2] read back [EC2, FARGATE]).
+    it('UNORDERED_ARRAY_PROPS: ECS TaskDefinition RequiresCompatibilities reorder is NOT drift', () => {
+      const td = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'TaskDef',
+        resourceType: 'AWS::ECS::TaskDefinition',
+        physicalId: 'cdkrd-enumset:1',
+        declared,
+      });
+      expect(
+        classifyResource(
+          td({ RequiresCompatibilities: ['FARGATE', 'EC2'] }),
+          { RequiresCompatibilities: ['EC2', 'FARGATE'] },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine launch-type change still reports
+      expect(
+        tiers(
+          classifyResource(
+            td({ RequiresCompatibilities: ['FARGATE', 'EC2'] }),
+            { RequiresCompatibilities: ['EC2', 'EXTERNAL'] },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['RequiresCompatibilities']);
+    });
+
+    // Live-observed FP (same fixture): Route53 echoes a health check's
+    // HealthCheckConfig.Regions set SORTED alphabetically (declared
+    // [us-west-2, us-east-1, eu-west-1] read back [eu-west-1, us-east-1, us-west-2]).
+    // Region names lack the hex/AZ suffix so the generic id/AZ fold does not catch them.
+    it('UNORDERED_ARRAY_PROPS: Route53 HealthCheck nested HealthCheckConfig.Regions reorder is NOT drift', () => {
+      const hc = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'HealthCheck',
+        resourceType: 'AWS::Route53::HealthCheck',
+        physicalId: 'hc-1',
+        declared,
+      });
+      expect(
+        classifyResource(
+          hc({
+            HealthCheckConfig: { Type: 'HTTP', Regions: ['us-west-2', 'us-east-1', 'eu-west-1'] },
+          }),
+          { HealthCheckConfig: { Type: 'HTTP', Regions: ['eu-west-1', 'us-east-1', 'us-west-2'] } },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine region change still reports the nested path
+      expect(
+        tiers(
+          classifyResource(
+            hc({
+              HealthCheckConfig: { Type: 'HTTP', Regions: ['us-west-2', 'us-east-1', 'eu-west-1'] },
+            }),
+            {
+              HealthCheckConfig: {
+                Type: 'HTTP',
+                Regions: ['eu-west-1', 'us-east-1', 'ap-southeast-1'],
+              },
+            },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['HealthCheckConfig.Regions']);
+    });
+
     // Live-observed (same fixture): CodeDeploy always echoes OutdatedInstancesStrategy
     // = "UPDATE" on a group that never declared it (documented unspecified behavior).
     it('KNOWN_DEFAULTS: undeclared CodeDeploy OutdatedInstancesStrategy=UPDATE folds to atDefault; IGNORE surfaces', () => {

--- a/tests/corpus/AWS__ECS__TaskDefinition.TaskDef.enumset.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.TaskDef.enumset.json
@@ -1,0 +1,128 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TaskDef",
+    "resourceType": "AWS::ECS::TaskDefinition",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-enumset:2",
+    "constructPath": "CdkRealDriftIntegEnumsetReorder/TaskDef",
+    "declared": {
+      "ContainerDefinitions": [
+        {
+          "Essential": true,
+          "Image": "public.ecr.aws/amazonlinux/amazonlinux:latest",
+          "Name": "app"
+        }
+      ],
+      "Cpu": "256",
+      "Family": "cdkrd-enumset",
+      "Memory": "512",
+      "NetworkMode": "awsvpc",
+      "RequiresCompatibilities": ["FARGATE", "EC2"]
+    }
+  },
+  "liveRaw": {
+    "Volumes": [],
+    "InferenceAccelerators": [],
+    "Memory": "512",
+    "PlacementConstraints": [],
+    "ContainerDefinitions": [
+      {
+        "ExtraHosts": [],
+        "Secrets": [],
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": [],
+        "Image": "public.ecr.aws/amazonlinux/amazonlinux:latest",
+        "Essential": true,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "app",
+        "MountPoints": [],
+        "DependsOn": [],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": [],
+        "SystemControls": [],
+        "Command": [],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": [],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      }
+    ],
+    "Family": "cdkrd-enumset",
+    "Cpu": "256",
+    "RequiresCompatibilities": ["EC2", "FARGATE"],
+    "NetworkMode": "awsvpc",
+    "Tags": [],
+    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-enumset:2"
+  },
+  "schema": {
+    "readOnly": ["TaskDefinitionArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "readOnlyPaths": ["TaskDefinitionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ContainerDefinitions.*.VersionConsistency": "enabled"
+    }
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-enumset:2",
+      "constructPath": "CdkRealDriftIntegEnumsetReorder/TaskDef"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Route53__HealthCheck.HealthCheck.json
+++ b/tests/corpus/AWS__Route53__HealthCheck.HealthCheck.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HealthCheck",
+    "resourceType": "AWS::Route53::HealthCheck",
+    "physicalId": "7e085731-5f57-4b64-84bd-bc211308dc23",
+    "constructPath": "CdkRealDriftIntegEnumsetReorder/HealthCheck",
+    "declared": {
+      "HealthCheckConfig": {
+        "FailureThreshold": 3,
+        "FullyQualifiedDomainName": "example.com",
+        "Port": 80,
+        "Regions": ["us-west-2", "us-east-1", "eu-west-1"],
+        "RequestInterval": 30,
+        "ResourcePath": "/",
+        "Type": "HTTP"
+      }
+    }
+  },
+  "liveRaw": {
+    "HealthCheckId": "7e085731-5f57-4b64-84bd-bc211308dc23",
+    "HealthCheckConfig": {
+      "EnableSNI": false,
+      "Type": "HTTP",
+      "ResourcePath": "/",
+      "FullyQualifiedDomainName": "example.com",
+      "MeasureLatency": false,
+      "Inverted": false,
+      "Port": 80,
+      "RequestInterval": 30,
+      "Regions": ["eu-west-1", "us-east-1", "us-west-2"],
+      "FailureThreshold": 3
+    }
+  },
+  "schema": {
+    "readOnly": ["HealthCheckId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["HealthCheckId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "HealthCheckConfig.MeasureLatency",
+      "HealthCheckConfig.RequestInterval",
+      "HealthCheckConfig.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {}
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/enumset-reorder/app.ts
+++ b/tests/integration/enumset-reorder/app.ts
@@ -1,0 +1,67 @@
+// CDK app for the cdk-real-drift enumset-reorder integration test.
+//
+// The set-reorder false-positive vein, scalar-ENUM edition. cdkrd's generic
+// canonicalizeIdArraysDeep folds id/ARN, AZ-name, and HTTP-method scalar sets, but a
+// plain enum/string set (a list of fixed keyword values AWS treats as unordered yet
+// echoes in ITS canonical order) is only covered by the per-type UNORDERED_ARRAY_PROPS
+// allowlist — so any common type with such a set that no fixture has exercised is an
+// unguarded gap. The CodeDeploy AutoRollbackConfiguration.Events FP (#364) was exactly
+// this class.
+//
+// Each resource below declares a multi-element scalar enum SET in a deliberately
+// NON-sorted order (a sorted declaration would hide a reorder). All are cheap/instant
+// — no NAT, no running task, no stateful provisioning:
+//   - ECS TaskDefinition.RequiresCompatibilities  ['FARGATE','EC2']  (every ECS user)
+//   - Cognito UserPool.UsernameAttributes (sign-in alias set; declared non-sorted —
+//     'phone_number' before 'email'). AutoVerifiedAttributes is avoided because
+//     verifying phone_number demands an SMS config; UsernameAttributes does not.
+//   - Route53 HealthCheck.HealthCheckConfig.Regions (a region-name set the AZ regex
+//     does NOT match, so the generic fold leaves it untouched)
+import { App, Stack } from "aws-cdk-lib";
+import { CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+import { CfnUserPool } from "aws-cdk-lib/aws-cognito";
+import { CfnHealthCheck } from "aws-cdk-lib/aws-route53";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEnumsetReorder");
+
+// ECS TaskDefinition — RequiresCompatibilities is a scalar enum set; declared
+// FARGATE-before-EC2 (non-sorted: 'E' < 'F').
+new CfnTaskDefinition(stack, "TaskDef", {
+  family: "cdkrd-enumset",
+  requiresCompatibilities: ["FARGATE", "EC2"],
+  networkMode: "awsvpc",
+  cpu: "256",
+  memory: "512",
+  containerDefinitions: [
+    {
+      name: "app",
+      image: "public.ecr.aws/amazonlinux/amazonlinux:latest",
+      essential: true,
+    },
+  ],
+});
+
+// Cognito UserPool — UsernameAttributes is a scalar enum set (allowed sign-in
+// aliases); declared non-sorted ('phone_number' before 'email').
+new CfnUserPool(stack, "UserPool", {
+  userPoolName: "cdkrd-enumset",
+  usernameAttributes: ["phone_number", "email"],
+});
+
+// Route53 HealthCheck — Regions is a set of region-name enums (where the Route53
+// health checkers run); declared non-sorted. Region names lack the hex/AZ suffix so
+// the generic id/AZ fold leaves them untouched.
+new CfnHealthCheck(stack, "HealthCheck", {
+  healthCheckConfig: {
+    type: "HTTP",
+    fullyQualifiedDomainName: "example.com",
+    port: 80,
+    resourcePath: "/",
+    requestInterval: 30,
+    failureThreshold: 3,
+    regions: ["us-west-2", "us-east-1", "eu-west-1"],
+  },
+});
+
+app.synth();

--- a/tests/integration/enumset-reorder/cdk.json
+++ b/tests/integration/enumset-reorder/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/enumset-reorder/package.json
+++ b/tests/integration/enumset-reorder/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-enumset-reorder",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift enumset-reorder integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/enumset-reorder/verify.sh
+++ b/tests/integration/enumset-reorder/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Scalar-enum set-reorder false-positive probe (real AWS): deploy -> record baseline
+# -> check MUST be CLEAN. Each resource declares a multi-element enum SET in a
+# non-sorted order; a surviving declared drift on a clean recorded stack is a
+# set-reorder normalization false positive (AWS echoes the set in its own canonical
+# order) for an enum class the generic id/AZ/HTTP fold does not cover.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEnumsetReorder
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (full classification) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK.pre"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug-hunt round (real AWS) — scalar-enum set-reorder vein

cdkrd's generic `canonicalizeIdArraysDeep` folds id/ARN, AZ-name, and HTTP-method scalar sets, but a plain **enum/string set** (a list of fixed keyword values AWS treats as unordered yet echoes in ITS canonical order) is only covered by the per-type `UNORDERED_ARRAY_PROPS` allowlist — so any common type with such a set no fixture has exercised is an unguarded FP. (Same class as the CodeDeploy `AutoRollbackConfiguration.Events` FP in #364.)

One `enumset-reorder` deploy surfaced **two real FPs** (both AWS-sorted alphabetically):

| Type | Path | declared → live |
|---|---|---|
| **ECS::TaskDefinition** | `RequiresCompatibilities` | `[FARGATE, EC2]` → `[EC2, FARGATE]` |
| **Route53::HealthCheck** | `HealthCheckConfig.Regions` | `[us-west-2, us-east-1, eu-west-1]` → `[eu-west-1, us-east-1, us-west-2]` |

ECS hits **every multi-launch-type user**. Route53 region names lack the hex/AZ suffix so the generic id/AZ fold leaves them untouched (nested dotted path).

Both folded via `UNORDERED_ARRAY_PROPS` (equality-gated on the multiset, so a genuine add/remove still surfaces).

### Rule-out
`Cognito::UserPool.UsernameAttributes` was probed on the same deploy and observed to **preserve** template order → deliberately **not** folded.

## Tests / coverage
- New `enumset-reorder` fixture (+ `verify.sh`).
- Golden-corpus cases: `AWS__ECS__TaskDefinition.TaskDef.enumset.json` (suffixed to avoid a logical-id collision) + `AWS__Route53__HealthCheck.HealthCheck.json`.
- Unit tests for both folds (reorder suppressed; a genuine change still reports the path).

## Live-proven (acct 531991745243, us-east-1)
- Pre-record `check` showed **both** as declared drift.
- After the fold: `record` → `check` **CLEAN**.
- Stack deleted (`delstack`), SWEEP CLEAN.

All 1633 unit tests pass; `basic` integ regression PASS.
