### PR TITLE
docs: shorten the Quick start baseline paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,10 @@ It prints what it found, then offers the actions that apply right in the prompt:
 **Record**, **Revert**, or **Ignore**
 ([what each verb does](#the-model-one-verb-you-run-three-it-offers)).
 
-On a fresh project, `check` already flags drift on the properties your template
-declares (plus any resource deleted out of band). Live-only values, the ones on
-the real resource but not in your template, show as informational, not drift.
-**Record** them to start watching: that writes the `.cdkrd` baseline snapshot, and
-any later out-of-band change then surfaces as drift. You create the baseline
-whenever you're ready, not up front.
+On a fresh project, `check` already flags drift on your declared properties (and
+any out-of-band deletes). Live-only values, on the real resource but not your
+template, stay informational until you **Record** them; after that, any
+out-of-band change to them is drift.
 
 So a typical first run is a clean stack with live-only values you can record:
 


### PR DESCRIPTION
## Summary

Shortens the second paragraph of the Quick start from four sentences to two (README-only).

- Dropped the explicit ".cdkrd baseline snapshot" mention — the first-run example and the Record bullet right below already show it.
- Dropped "you create the baseline whenever you're ready, not up front" — the first paragraph already says there's nothing to set up first.

No information lost: declared drift is still flagged from the first run, and live-only values are still informational until recorded.

## Verification

- `check` and `docs` markgate markers fresh.
- Docs-only diff, so `verify-pr-gate` is exempt per `.markgate.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9qvGpF3WG6V6ezbBymYZi)_