### PR TITLE
docs(readme): move demo GIF below the cdkrd check console block

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ $ npx cdk drift
 `cdkrd` reads the **full** live resource model and subtracts everything
 explainable, so the same change shows up:
 
-![cdkrd finds an out-of-band inline policy that `cdk drift` reports as zero](demo/demo.gif)
-
 ```console
 $ npx cdkrd check
 === cdkrd check: ApiStack (us-east-1) ===
@@ -30,6 +28,8 @@ $ npx cdkrd check
 
 result: 1 drift(s) (undeclared=1)
 ```
+
+![cdkrd finds an out-of-band inline policy that `cdk drift` reports as zero](demo/demo.gif)
 
 | Capability                                                     | `cdkrd` | `cdk drift` / CFn drift detection |
 | -------------------------------------------------------------- | :-----: | :-------------------------------: |


### PR DESCRIPTION
## What

Reorder the "Why" section: the side-by-side demo GIF now sits **after** the `cdkrd check` console block instead of before it.

## Why

Line 21 ends with a colon — "so the same change shows up:" — which sets up its payoff. The most natural follow-on is the text **console block** that literally shows the drift, not an interrupting GIF. The GIF (a side-by-side that subsumes both `cdkrd` and `cdk drift`) now reads as the animated capstone after the reader has seen both static blocks (`cdk drift` = 0, `cdkrd` = 1 drift).

New flow:
1. `cdk drift` = 0 (static block)
2. "shows up:" → `cdkrd check` console block (text payoff)
3. demo GIF (animated side-by-side summary)

Docs-only; no source touched.