### PR TITLE
fix(report): count only standout live-only values as potential drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ No baseline yet — these live-only values can't be confirmed as drift. Record t
   ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
 
-result: no confirmed drift · 42 potential drift (2 shown, 40 folded — Record to set a baseline)
+result: no confirmed drift · 2 potential drift (+ 40 nested live-only to record)
 
 ApiStack: potential drift found (live-only, no baseline yet) — what do you want to do?
   ❯ Nothing (decide later)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -859,17 +859,21 @@ user did not pick. They render as their own `[Potential Drift: N]` section (note
 `live-only and not yet in your .cdkrd baseline, so cdkrd can't tell whether it's
 intended or an out-of-band change — Record to accept it, or Revert to
 remove it`) alongside any real `[CFn-Undeclared Drift]` section, are excluded from the verdict and the
-`--fail` exit, and the `result:` line carries the count + the way out
-(`· N potential drift (X shown, Y folded — Record to set a baseline)`
-when some fold; R112). A "No baseline yet — … Record them right from this `cdkrd
-check` prompt, or run `cdkrd record`." line prints under the header whenever any
-unrecorded value is present, naming the ambiguity (cannot confirm as drift) and
-BOTH record paths. When BOTH a drift section and a standout `[Potential Drift]`
-section print, a lone `N drift(s)` verdict reads as a mismatch against the 2+
-visible blocks, so the line switches to a combined findings count counting only
-what is SHOWN — `result: 3 findings — 1 drift (declared=1) + 2 potential drift
-(23 folded — Record to set a baseline)` — keeping the red drift verdict intact
-(R114); single-category runs keep their plain `CLEAN` / `no confirmed drift` / `N drift(s)` verdict.
+`--fail` exit. The `result:` "potential drift" count is the SHOWN standout
+(top-level) values ONLY — `· N potential drift (+ M nested live-only to record)`,
+the tail only when nested values fold. FOLDED nested values (undeclared-subkey,
+R96) are AWS-populated noise present on any fresh deploy, so when ONLY nested
+values exist (no standout — the untouched-deploy case) the verdict is the neutral
+`· N live-only value(s) to record as baseline (run cdkrd record)`, NOT potential
+drift, and the "No baseline yet — … Record them right from this `cdkrd check`
+prompt, or run `cdkrd record`." preamble is SUPPRESSED (it prints only when a
+standout value is present, since only those are values cdkrd cannot confirm).
+When BOTH a drift section and a standout `[Potential Drift]` section print, a lone
+`N drift(s)` verdict reads as a mismatch against the 2+ visible blocks, so the
+line switches to a combined findings count counting only what is SHOWN —
+`result: 3 findings — 1 drift (declared=1) + 2 potential drift (+ 23 nested
+live-only to record)` — keeping the red drift verdict intact (R114);
+single-category runs keep their plain `CLEAN` / `no confirmed drift` / `N drift(s)` verdict.
 Declared and deleted drift still report and fail normally. The interactive after-report
 prompt still fires for unrecorded values (`potential drift found (live-only, no
 baseline yet) — what do you want to do?`) so "show them first" keeps its promise of a selective record.

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -231,11 +231,14 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
     section(byTier(tier), TIER_NAMES[tier], TIER_NOTES[tier], tierStyle(tier), leadingBlank);
 
   log(style.header(`=== cdkrd check: ${header} ===`));
-  // When live-only values have no baseline yet, say so up front: with nothing to
-  // compare against, cdkrd genuinely CANNOT tell whether they are intentional or an
+  // When STANDOUT live-only values have no baseline yet, say so up front: with nothing
+  // to compare against, cdkrd genuinely CANNOT tell whether they are intentional or an
   // out-of-band change — that ambiguity (not "all clear") is why they are POTENTIAL
-  // drift. No count here — the [Potential Drift: N] section and the result line carry it.
-  if (unrecordedItems.length > 0) {
+  // drift. Gated on the SHOWN (standout) count, NOT the total: a fresh deploy carries
+  // many FOLDED nested AWS-populated values (undeclared-subkey, R96) that exist whether
+  // or not anyone touched the console — those are inventory to record, not potential
+  // drift, so they must not trigger this "can't be confirmed as drift" preamble.
+  if (unrecordedShown.length > 0) {
     log(
       style.undeclaredTier(
         "No baseline yet — these live-only values can't be confirmed as drift. Record them right from this `cdkrd check` prompt, or run `cdkrd record`."
@@ -276,45 +279,44 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // counting only what is SHOWN (folded values are not findings, just a parenthetical).
   // The combined framing fires ONLY in this mixed case; single-category runs keep their
   // natural verdict (CLEAN / N drift / inventory note) — the mismatch can't arise there.
-  const mixed = drifted > 0 && unrecordedShown.length > 0;
+  // "potential drift" counts ONLY the SHOWN standout (top-level) live-only values — the
+  // ones cdkrd surfaces as worth a look. FOLDED nested values (undeclared-subkey, R96)
+  // are AWS-populated noise present on ANY fresh deploy regardless of console action, so
+  // they are inventory to RECORD, not potential drift: an untouched stack must read
+  // "no confirmed drift", never "N potential drift". A `(+ N nested live-only to record)`
+  // tail keeps the folded count visible without inflating the headline.
+  const shown = unrecordedShown.length;
+  const folded = unrecordedFoldedCount;
+  const nestedTail = folded > 0 ? ` (+ ${folded} nested live-only to record)` : '';
+  const mixed = drifted > 0 && shown > 0;
   let resultBody: string;
   if (mixed) {
-    const foldedHint =
-      unrecordedFoldedCount > 0
-        ? `${unrecordedFoldedCount} folded — Record to set a baseline`
-        : 'Record to set a baseline';
+    // R114: DRIFT + standout potential both visible -> one combined findings count so the
+    // verdict matches the printed blocks (was a lone "1 drift(s)" beside 2 sections).
     resultBody =
-      `${drifted + unrecordedShown.length} findings — ${style.drift(`${drifted} drift`)} (${driftCounts})` +
-      // "potential drift" (not "undeclared drift"): the [Potential Drift] set is
-      // undeclared PROPERTIES plus out-of-band `added` RESOURCES (PR4) that have no
-      // baseline yet — unconfirmed, never counted as confirmed drift; both await a record.
-      ` + ${style.undeclaredTier(`${unrecordedShown.length} potential drift`)}` +
-      style.infoTier(` (${foldedHint})`);
+      `${drifted + shown} findings — ${style.drift(`${drifted} drift`)} (${driftCounts})` +
+      ` + ${style.undeclaredTier(`${shown} potential drift`)}` +
+      style.infoTier(nestedTail);
   } else {
     // the verdict is the one line that must stand out: green CLEAN / red drift count.
-    // "CLEAN" is reserved for a truly clean stack (nothing unrecorded); when live-only
-    // values await a baseline there IS no confirmed drift but the stack is NOT clean —
-    // those values are POTENTIAL drift (we can't yet tell intent from out-of-band), so
-    // say "no confirmed drift" instead of the green all-clear.
+    // "CLEAN" is reserved for a truly clean stack (nothing unrecorded). With only FOLDED
+    // nested live-only values it is "no confirmed drift" + a neutral "to record" count
+    // (NOT potential drift). With SHOWN standout values it is "no confirmed drift · N
+    // potential drift" — those are what cdkrd genuinely cannot yet judge.
     const verdict =
       drifted > 0
         ? `${style.drift(`${drifted} drift(s)`)} (${driftCounts})`
-        : unrecordedItems.length > 0
+        : shown > 0 || folded > 0
           ? 'no confirmed drift'
           : style.clean('CLEAN');
-    // unrecorded values are stated NEXT TO the verdict as POTENTIAL drift (not confirmed
-    // drift): the count and the way out, in one place (R60). The total counts ALL
-    // unrecorded values but the [Potential Drift] section lists only the standout
-    // (non-folded) ones, so name the split (R112) — otherwise "25 potential" reads as a
-    // mismatch against a visible "[Potential Drift: 2]".
     const unrecordedNote =
-      unrecordedItems.length > 0
-        ? style.undeclaredTier(
-            unrecordedFoldedCount > 0
-              ? ` · ${unrecordedItems.length} potential drift (${unrecordedShown.length} shown, ${unrecordedFoldedCount} folded — Record to set a baseline)`
-              : ` · ${unrecordedItems.length} potential drift (Record to set a baseline)`
-          )
-        : '';
+      shown > 0
+        ? style.undeclaredTier(` · ${shown} potential drift`) + style.infoTier(nestedTail)
+        : folded > 0
+          ? style.infoTier(
+              ` · ${folded} live-only value(s) to record as baseline (run cdkrd record)`
+            )
+          : '';
     resultBody = `${verdict}${unrecordedNote}`;
   }
   // A blank line before the verdict ONLY when drift sections were printed — it must

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -25,9 +25,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(text).toContain('[Potential Drift: 2]');
     expect(text).toContain('Record to accept it'); // the section explains the way out
     expect(text).not.toContain('Undeclared Drift');
-    expect(text).toContain(
-      'result: no confirmed drift · 2 potential drift (Record to set a baseline)'
-    );
+    expect(text).toContain('result: no confirmed drift · 2 potential drift');
     // R-Potential: the no-baseline header explains WHY these are potential, not clean,
     // and that you can record straight from this check (or via `cdkrd record`).
     expect(text).toContain("No baseline yet — these live-only values can't be confirmed as drift");
@@ -36,13 +34,28 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     );
   });
 
-  it('result note names the shown/folded split so the section count and total reconcile (R112)', () => {
-    // 2 standout (shown in [Potential Drift: 2]) + 3 nested (folded) = 5 total
+  it('potential-drift count is the SHOWN standout only; folded nested are a "to record" tail (R112)', () => {
+    // 2 standout (shown in [Potential Drift: 2]) + 3 nested (folded). Only the 2 standout
+    // count as potential drift — the 3 nested AWS-populated values are inventory.
     const nested = (p: string): Finding => ({ ...U(p), nested: true });
     const { text } = run([U(), U('Q'), nested('a'), nested('b'), nested('c')]);
     expect(text).toContain('[Potential Drift: 2]'); // only the standout are listed
     expect(text).toContain(
-      'result: no confirmed drift · 5 potential drift (2 shown, 3 folded — Record to set a baseline)'
+      'result: no confirmed drift · 2 potential drift (+ 3 nested live-only to record)'
+    );
+  });
+
+  it('FOLDED-only (untouched fresh deploy): no potential drift, just "to record" inventory', () => {
+    // No standout values, only nested AWS-populated ones — must NOT read as potential
+    // drift, and must NOT print the "can't be confirmed as drift" preamble.
+    const nested = (p: string): Finding => ({ ...U(p), nested: true });
+    const { code, text } = run([nested('a'), nested('b')]);
+    expect(code).toBe(0);
+    expect(text).not.toContain('[Potential Drift'); // section lists standout only -> none
+    expect(text).not.toContain('No baseline yet'); // no standout -> no alarming preamble
+    expect(text).not.toContain('potential drift'); // the count phrase must not appear
+    expect(text).toContain(
+      'result: no confirmed drift · 2 live-only value(s) to record as baseline (run cdkrd record)'
     );
   });
 
@@ -69,7 +82,7 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     const { code, text } = run([F('declared'), U('Q'), nested('a'), nested('b')]);
     expect(code).toBe(1);
     expect(text).toContain(
-      'result: 2 findings — 1 drift (declared=1) + 1 potential drift (2 folded — Record to set a baseline)'
+      'result: 2 findings — 1 drift (declared=1) + 1 potential drift (+ 2 nested live-only to record)'
     );
   });
 


### PR DESCRIPTION
## What

Fix a regression from #378: an **untouched fresh deploy** reported `N potential drift` (e.g. `23 potential drift`) even though nobody changed anything.

#378 counted the **total** unrecorded set (shown standout + folded nested) as "potential drift". But a fresh deploy always carries many **folded nested AWS-populated values** (`undeclared-subkey`, R96) — they exist regardless of console action and are inventory to record, not candidate drift. Counting them as "potential drift" is a false alarm.

## Fix

Count only the **SHOWN standout (top-level)** live-only values as potential drift; present folded nested values as neutral "to record" inventory.

### Untouched deploy (folded-only) — before → after

```diff
-result: no confirmed drift · 23 potential drift (0 shown, 23 folded — Record to set a baseline)
+result: no confirmed drift · 23 live-only value(s) to record as baseline (run cdkrd record)
```

Also suppresses the `No baseline yet — … can't be confirmed as drift` preamble and the `[Potential Drift]` section when there are no standout values (nothing cdkrd genuinely can't judge).

### Standout present (e.g. a console-set `DisplayName="test"`)

```console
No baseline yet — these live-only values can't be confirmed as drift. Record them right from this `cdkrd check` prompt, or run `cdkrd record`.

[Potential Drift: 1] (...)
  ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"

result: no confirmed drift · 1 potential drift (+ 1 nested live-only to record)
```

So a value changed before first use shows `1 potential drift`; an untouched stack shows `0` (just inventory). This also aligns the no-declared-drift branch with the mixed branch, which already counted shown-only.

## Verification

- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (1655 tests, +1 new folded-only test) green.
- Live test (deploy → no-baseline `check` with folded-only nested values → neutral "to record", no "potential drift") via `/verify-pr` before merge.
