### PR TITLE
docs: remove prose em-dashes reintroduced in the Quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,16 @@ It prints what it found, then offers three actions right in the prompt:
   live-only value, or restores a declared one).
 - **Ignore**: stop reporting it, for good.
 
-On a fresh project — with no baseline yet — `check` still reports drift on the
+On a fresh project (with no baseline yet), `check` still reports drift on the
 properties you **declared**, plus anything deleted out-of-band: those compare
 against your template, so they need no baseline. Values that live only on the
-real resource (never in your template) can't be judged yet on this first run —
+real resource (never in your template) can't be judged yet on this first run:
 with no baseline, `check` can't tell an intentional setting from an out-of-band
 change, so it lists them as _Potential Drift_. They become confirmed (and
 watched) the moment you **Record** them; from then on, any out-of-band change to
 a recorded value is real drift.
 
-So a typical first run reports no _confirmed_ drift — just live-only values
+So a typical first run reports no _confirmed_ drift, just live-only values
 (potential drift) you can record:
 
 ```console
@@ -398,7 +398,7 @@ info:
 
 - **Drift tiers** (`deleted` / `declared` / `undeclared`) are always listed in
   full and drive the `--fail` exit. They are the point.
-- **`[Potential Drift: N]`**: undeclared values with no baseline yet — cdkrd
+- **`[Potential Drift: N]`**: undeclared values with no baseline yet; cdkrd
   can't tell an intentional setting from an out-of-band change, so they're listed
   in full as _potential_ (unconfirmed) drift and don't drive the `--fail` exit;
   `result:` points you at `cdkrd record` to accept them (or `revert` to remove).


### PR DESCRIPTION
## Summary

Removes the prose em-dashes that came back into the Quick start with the Potential Drift rewrite (README-only).

Four prose occurrences replaced:
- `On a fresh project — with no baseline yet —` becomes `On a fresh project (with no baseline yet),`
- `... this first run —` becomes `... this first run:`
- `no _confirmed_ drift — just live-only values` becomes `no _confirmed_ drift, just live-only values`
- `no baseline yet — cdkrd` becomes `no baseline yet; cdkrd`

After this, prose contains zero em-dashes. The remaining `—` in the file are all inside `console` blocks, because they mirror the actual CLI output strings (e.g. those in `src/aws-errors.ts`); changing those would desync the docs from the tool.

## Verification

- Verified by scanning the file: every remaining `—` is inside a fenced `console` block; prose has none.
- No tables touched, prose-wrap preserved, so no formatter impact.
- `check` and `docs` markgate markers fresh; docs-only diff, so `verify-pr-gate` is exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9qvGpF3WG6V6ezbBymYZi)_