### PR TITLE
docs: clarify that only standout live-only values are Potential Drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ properties you **declared**, plus anything deleted out-of-band: those compare
 against your template, so they need no baseline. Values that live only on the
 real resource (never in your template) can't be judged yet on this first run:
 with no baseline, `check` can't tell an intentional setting from an out-of-band
-change, so it lists them as _Potential Drift_. They become confirmed (and
-watched) the moment you **Record** them; from then on, any out-of-band change to
-a recorded value is real drift.
+change. It folds away the ones it can explain (AWS defaults, generated names,
+nested sub-keys) and flags only the rest as _Potential Drift_; record those, and
+any later out-of-band change to them is real drift.
 
 So a typical first run reports no _confirmed_ drift, just live-only values
 (potential drift) you can record:


### PR DESCRIPTION
## Summary

Fixes an inaccuracy in the Quick start (README-only).

The previous sentence read: "with no baseline, `check` can't tell an intentional setting from an out-of-band change, so it lists **them** as _Potential Drift_" where "them" was "values that live only on the real resource". That implies every unrecorded live-only value becomes Potential Drift.

It doesn't. `check` first folds away the live-only values it can explain (AWS defaults into `atDefault`, generated names into `generated`, untouched nested sub-keys into `nested`, all in the `info:` footer) and flags **only the rest** as Potential Drift. The example output in the same section already shows this: `2 potential drift (+ 40 nested live-only to record)`.

New wording:

> ... with no baseline, `check` can't tell an intentional setting from an out-of-band change. It folds away the ones it can explain (AWS defaults, generated names, nested sub-keys) and flags only the rest as _Potential Drift_; record those, and any later out-of-band change to them is real drift.

## Verification

- Confirmed against `src/diff/classify.ts`: live-only undeclared values split into `atDefault` / `generated` / `nested` (folded) vs standout `undeclared` (Potential Drift).
- No em-dashes, no tables touched, prose-wrap preserved.
- `check` and `docs` markgate markers fresh; docs-only diff, so `verify-pr-gate` is exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9qvGpF3WG6V6ezbBymYZi)_