### PR TITLE
feat(desired): recover GetTemplate ?-masked non-ASCII literals from local synth

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -201,7 +201,9 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
 1. resolve stacks        resolve-stacks.ts: synth-discover the app → all | exact names | globs
 2. desired (declared)    template-adapter.ts: GetTemplate + DescribeStackResources
                          (phys-id map) + DescribeStacks (params) → intrinsic resolution
-                         (--pre-deploy: LOCAL synth template replaces GetTemplate)
+                         (--pre-deploy: LOCAL synth template replaces GetTemplate;
+                         otherwise the synth template recovers GetTemplate's `?`-masked
+                         non-ASCII literals — recover-nonascii.ts, mask-gated per leaf)
 3. live full state       read/router.ts: Custom:: → skip (no API call); SDK override
                          (gap types) FIRST, else CC API GetResource; not-found →
                          deleted; unreadable → skipped

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -53,12 +53,20 @@ the full design.
 - **Unsupported / unreadable types.** A type Cloud Control can't read (no CC
   support, or a CC handler error with no SDK override) is `skipped`, surfaced in the
   `skipped=N` line and never silently CLEAN; `--strict` makes such a gap CI-failing.
-- **Non-ASCII template literals.** CloudFormation's `GetTemplate` (cdkrd's declared
-  source) returns every non-ASCII character in a stored string literal as a literal
-  `?` — so a declared value like an `AWS::SSM::Parameter` `Value: áéíóúABC`
-  comes back `?????ABC` while the live value is intact. cdkrd detects the mask (the
-  live value with its non-ASCII chars replaced by `?` equals the declared value) and
-  reports the property as `readGap` (declared but unverifiable) rather than a false
-  declared drift. The trade-off: a same-length edit that changes ONLY non-ASCII
-  characters is invisible through `GetTemplate` and not detected (any ASCII or length
-  change still is).
+- **Non-ASCII template literals.** CloudFormation's `GetTemplate` (cdkrd's
+  declared source) returns every non-ASCII character in a stored string literal
+  as a literal `?` — so a declared value like an `AWS::SSM::Parameter`
+  `Value: áéíóúABC` comes back `?????ABC` while the live value is intact
+  (CloudFormation compares the intact value server-side, so its own drift
+  detection reports such a property IN_SYNC). cdkrd **recovers** the real value
+  from the LOCAL synth template (the `cdk.out` assembly it already produces for
+  stack discovery): when the synth value at the same path masks to the deployed
+  `?`-value (same ASCII skeleton + length), it is the deployed declared value
+  with its non-ASCII restored, so the compare runs on real text. When recovery
+  is impossible (no synth template, or the synth value's skeleton diverged), the
+  property degrades to `readGap` (declared but unverifiable) rather than a false
+  declared drift. Two consequences: (1) for these specific values the "intent" is
+  the local synth rather than the deployed template, so a same-length
+  non-ASCII-only edit made in code but **not yet deployed** surfaces as drift
+  (code-vs-reality); (2) a pure-ASCII template is never affected (GetTemplate
+  does not mask ASCII).

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -190,7 +190,7 @@ export async function runCheck(args: string[]): Promise<number> {
   // R37: one blank line between consecutive stack reports (text mode only) — done
   // here at the call site so a single-stack run never gets a stray leading blank.
   const separate = stackSeparator();
-  for (const { stackName, region } of stacks) {
+  for (const { stackName, region, template } of stacks) {
     if (!region) {
       console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
       worst = Math.max(worst, 2);
@@ -202,7 +202,10 @@ export async function runCheck(args: string[]): Promise<number> {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
         continue;
       }
-      const gathered = await gatherFindings(stackName, region, synthTemplates?.get(sKey));
+      // The stack's synth template (always carried by resolveStacks) is the non-ASCII
+      // RECOVERY source for the deployed-template path — loadDesired ignores it under
+      // --pre-deploy (where synthTemplates is already the declared override).
+      const gathered = await gatherFindings(stackName, region, synthTemplates?.get(sKey), template);
       const { desired, schemas, liveByLogical } = gathered;
       let findings = gathered.findings;
 

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -214,12 +214,16 @@ export async function gatherFindings(
   // --pre-deploy: use the LOCAL synth template as the declared source instead of
   // the deployed template, so check reports the declared drift the next deploy
   // would overwrite. physIds + live reads still come from the deployed stack.
-  templateOverride?: Record<string, unknown>
+  templateOverride?: Record<string, unknown>,
+  // the LOCAL synth template, passed through to loadDesired to recover GetTemplate's
+  // `?`-masked non-ASCII literals (mask-gated). Distinct from templateOverride: it does
+  // not replace the declared source, only patches corrupted leaves.
+  recoveryTemplate?: Record<string, unknown>
 ): Promise<GatherResult> {
   const cfn = new CloudFormationClient({ region, ...READ_RETRY });
   const cc = new CloudControlClient({ region, ...READ_RETRY });
 
-  const desired = await loadDesired(cfn, stackName, region, templateOverride);
+  const desired = await loadDesired(cfn, stackName, region, templateOverride, recoveryTemplate);
   const findings: Finding[] = [];
   const schemas = new Map<string, SchemaInfo>();
 

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -43,14 +43,14 @@ export async function runIgnore(args: string[]): Promise<number> {
 
   let worst = 0;
   let wroteAny = false;
-  for (const { stackName, region } of stacks) {
+  for (const { stackName, region, template } of stacks) {
     if (!region) {
       console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
       worst = Math.max(worst, 2);
       continue;
     }
     try {
-      const { desired, findings } = await gatherFindings(stackName, region);
+      const { desired, findings } = await gatherFindings(stackName, region, undefined, template);
       // Reconcile exactly as check does so the offered drift matches what the user saw:
       // suppress already-recorded baseline entries, then re-tag config-ignored findings
       // out (they are already `ignored`, so ignoreStack never re-offers them).

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -34,7 +34,7 @@ export async function runRecord(args: string[]): Promise<number> {
   }
 
   let worst = 0;
-  for (const { stackName, region } of stacks) {
+  for (const { stackName, region, template } of stacks) {
     if (!region) {
       console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
       worst = Math.max(worst, 2);
@@ -43,7 +43,8 @@ export async function runRecord(args: string[]): Promise<number> {
     try {
       // gather FIRST: the baseline filename embeds the accountId, which only the
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
-      const { desired, findings } = await gatherFindings(stackName, region);
+      // `template` (synth) recovers GetTemplate's `?`-masked non-ASCII literals.
+      const { desired, findings } = await gatherFindings(stackName, region, undefined, template);
       // ignore rules re-tag matching undeclared findings out of the record set, so an
       // externally-managed property is never recorded (and never re-detected).
       const result = await recordStack({

--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -18,6 +18,9 @@ import { isGlob, matchesGlob } from './glob-match.js';
 export interface ResolvedStack {
   stackName: string;
   region: string | undefined; // region to query this stack in (may be undefined → caller errors)
+  // the synthesized template for this stack — used by check to recover GetTemplate's
+  // `?`-masked non-ASCII literals. Carried from the same synth that discovered the stack.
+  template: Record<string, unknown>;
 }
 
 export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
@@ -36,29 +39,37 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
   // --all, or no names → every stack the app defines. --all is the explicit form of the
   // no-argument default; it also overrides any positional names (target everything).
   if (a.all || a.stackNames.length === 0) {
-    return discovered.map((s) => ({ stackName: s.stackName, region: s.region ?? a.region }));
+    return discovered.map((s) => ({
+      stackName: s.stackName,
+      region: s.region ?? a.region,
+      template: s.template,
+    }));
   }
 
   // names (exact and/or glob) matched against the app's stacks
   const seen = new Set<string>();
   const out: ResolvedStack[] = [];
-  const add = (stackName: string, region: string | undefined): void => {
+  const add = (
+    stackName: string,
+    region: string | undefined,
+    template: Record<string, unknown>
+  ): void => {
     const key = `${stackName}\0${region ?? ''}`;
     if (seen.has(key)) return;
     seen.add(key);
-    out.push({ stackName, region });
+    out.push({ stackName, region, template });
   };
   const known = (): string => discovered.map((s) => s.stackName).join(', ') || 'none';
   for (const name of a.stackNames) {
     if (isGlob(name)) {
       for (const s of discovered) {
-        if (matchesGlob(name, s.stackName)) add(s.stackName, s.region ?? a.region);
+        if (matchesGlob(name, s.stackName)) add(s.stackName, s.region ?? a.region, s.template);
       }
     } else {
       const hit = discovered.find((s) => s.stackName === name);
       if (!hit)
         throw new Error(`stack "${name}" is not defined by the CDK app (found: ${known()})`);
-      add(hit.stackName, hit.region ?? a.region);
+      add(hit.stackName, hit.region ?? a.region, hit.template);
     }
   }
   if (out.length === 0) {

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -43,7 +43,7 @@ export async function runRevert(args: string[]): Promise<number> {
   }
 
   let worst = 0;
-  for (const { stackName, region } of stacks) {
+  for (const { stackName, region, template } of stacks) {
     if (!region) {
       console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
       worst = Math.max(worst, 2);
@@ -52,7 +52,9 @@ export async function runRevert(args: string[]): Promise<number> {
     try {
       // gather FIRST: the baseline filename embeds the accountId, which only the
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
-      const gathered = await gatherFindings(stackName, region);
+      // `template` (synth) recovers GetTemplate's `?`-masked non-ASCII literals so a
+      // revert writes the REAL declared value, never a `?????` mask.
+      const gathered = await gatherFindings(stackName, region, undefined, template);
       const baseline: BaselineFile | undefined = await loadBaseline(
         stackName,
         gathered.desired.accountId,

--- a/src/desired/recover-nonascii.ts
+++ b/src/desired/recover-nonascii.ts
@@ -1,0 +1,51 @@
+// Recover non-ASCII string literals that CloudFormation's GetTemplate masked as `?`.
+//
+// GetTemplate (cdkrd's declared source) replaces every non-ASCII character in a stored
+// string literal with a literal `?` — see `isCfnTemplateNonAsciiMask`. CloudFormation
+// compares against the INTACT value server-side (its own drift detection reports such a
+// property IN_SYNC), but the value it exposes through GetTemplate is lossy, so a
+// client-side compare against the live value would false-flag every check. Without a
+// recovery source the property degrades to a `readGap` (declared-but-unverifiable):
+// honest, but cdkrd then detects LESS than `cdk drift` on that property.
+//
+// The LOCAL synth template (the cdk.out assembly cdkrd already produces for stack
+// discovery) carries the intact UTF-8. When the synth value at the SAME template path
+// masks to the deployed `?`-value (same ASCII skeleton, same length, ≥1 non-ASCII char),
+// it IS the deployed declared value with its non-ASCII recovered — substitute it so the
+// comparison runs on real text and a genuine out-of-band non-ASCII change is detectable.
+//
+// Gated per-value by the mask: a synth value whose ASCII skeleton or length does NOT
+// match the deployed mask (the local code diverged structurally from what is deployed)
+// is NEVER substituted — that property stays a `readGap`. So this only ever fires on the
+// exact values GetTemplate corrupted; a pure-ASCII template is untouched (GetTemplate
+// never masks ASCII, so no `?`-leaf ever matches a non-ASCII synth value).
+import { isCfnTemplateNonAsciiMask } from '../normalize/noise.js';
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+// Walk the parsed DEPLOYED template and the LOCAL synth template in parallel by
+// key/index; replace any deployed string leaf that is a non-ASCII GetTemplate mask of the
+// synth value with the (intact) synth value. Returns the recovered template; mutates
+// nested objects/arrays of `deployed` in place (callers pass the freshly parsed template).
+export function recoverNonAsciiMasks(deployed: unknown, recovery: unknown): unknown {
+  if (typeof deployed === 'string') {
+    return typeof recovery === 'string' && isCfnTemplateNonAsciiMask(deployed, recovery)
+      ? recovery
+      : deployed;
+  }
+  if (Array.isArray(deployed) && Array.isArray(recovery)) {
+    for (let i = 0; i < deployed.length; i++) {
+      deployed[i] = recoverNonAsciiMasks(deployed[i], recovery[i]);
+    }
+    return deployed;
+  }
+  if (isObject(deployed) && isObject(recovery)) {
+    for (const k of Object.keys(deployed)) {
+      deployed[k] = recoverNonAsciiMasks(deployed[k], recovery[k]);
+    }
+    return deployed;
+  }
+  return deployed;
+}

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -12,6 +12,7 @@ import {
 import { classifyStackStatus, StackNotCheckableError } from '../aws-errors.js';
 import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import type { DesiredResource, ResolverContext } from '../types.js';
+import { recoverNonAsciiMasks } from './recover-nonascii.js';
 import { parseCfnTemplate } from './yaml-cfn.js';
 
 export interface Desired {
@@ -131,7 +132,11 @@ export async function loadDesired(
   region: string,
   // when provided (--pre-deploy), this LOCAL synth template is the declared source
   // instead of the deployed GetTemplate; physIds + params still come from the live stack
-  templateOverride?: Record<string, unknown>
+  templateOverride?: Record<string, unknown>,
+  // the LOCAL synth template, used ONLY to recover non-ASCII string literals that
+  // GetTemplate masked as `?` (see recoverNonAsciiMasks). Unlike templateOverride it does
+  // NOT replace the declared source — it patches only the mask-matching corrupted leaves.
+  recoveryTemplate?: Record<string, unknown>
 ): Promise<Desired> {
   // GetTemplate + DescribeStacks are single calls (kept in Promise.all); ListStackResources
   // is paginated separately (DescribeStackResources caps at 100, CDK stacks reach ~500).
@@ -159,6 +164,10 @@ export async function loadDesired(
     string,
     any
   >;
+  // Recover GetTemplate's `?`-masked non-ASCII literals from the local synth template
+  // (mask-gated, per leaf). Skipped under --pre-deploy: there the declared source already
+  // IS the intact synth template, so there is nothing to recover.
+  if (!templateOverride && recoveryTemplate) recoverNonAsciiMasks(template, recoveryTemplate);
   const rawTemplate = templateOverride
     ? JSON.stringify(templateOverride)
     : (tmplRes.TemplateBody ?? '{}');

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -79,12 +79,19 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 export interface DiscoveredStack {
   stackName: string;
   region: string | undefined; // the stack's own env.region, when concrete
+  // the synthesized template — carried through so the check path can recover GetTemplate's
+  // `?`-masked non-ASCII literals from it without re-synthesizing (synthApp already built it).
+  template: Record<string, unknown>;
 }
 
-/** Synth and return each stack's name + its own (concrete) region, for auto-discovery. */
+/** Synth and return each stack's name + its own (concrete) region + template, for discovery. */
 export async function discoverStacks(
   app: string,
   opts: SynthOptions = {}
 ): Promise<DiscoveredStack[]> {
-  return (await synthApp(app, opts)).map((s) => ({ stackName: s.stackName, region: s.region }));
+  return (await synthApp(app, opts)).map((s) => ({
+    stackName: s.stackName,
+    region: s.region,
+    template: s.template,
+  }));
 }

--- a/tests/recover-nonascii.test.ts
+++ b/tests/recover-nonascii.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { recoverNonAsciiMasks } from '../src/desired/recover-nonascii.js';
+
+describe('recoverNonAsciiMasks (GetTemplate `?`-mask recovery from local synth)', () => {
+  it('recovers a masked scalar when the synth value masks to it', () => {
+    const deployed = { Resources: { P: { Properties: { Value: '?????ABC' } } } };
+    const synth = { Resources: { P: { Properties: { Value: 'áéíóúABC' } } } };
+    recoverNonAsciiMasks(deployed, synth);
+    expect(deployed.Resources.P.Properties.Value).toBe('áéíóúABC');
+  });
+
+  it('does NOT recover when the synth value masks DIFFERENTLY (structural divergence)', () => {
+    // synth value has a different length/skeleton → its mask != the deployed mask, so the
+    // deployed declared value stays the `?`-mask (and downstream stays a readGap).
+    const deployed = { V: '?????ABC' };
+    recoverNonAsciiMasks(deployed, { V: 'áéíóúXYZ' }); // mask `?????XYZ` != `?????ABC`
+    expect(deployed.V).toBe('?????ABC');
+    const deployed2 = { V: '?????ABC' };
+    recoverNonAsciiMasks(deployed2, { V: 'áéíóúàABC' }); // 6 non-ASCII → `??????ABC`
+    expect(deployed2.V).toBe('?????ABC');
+  });
+
+  it('leaves a pure-ASCII template completely untouched (mask never matches)', () => {
+    // GetTemplate never masks ASCII, so no deployed leaf is a `?`-mask of a non-ASCII
+    // synth value — even a literal `?` in an ASCII value is left as-is.
+    const deployed = { A: 'plain', B: 'a?c', N: 5, L: ['x', 'y'] };
+    const synth = { A: 'plain', B: 'a?c', N: 5, L: ['x', 'y'] };
+    recoverNonAsciiMasks(deployed, synth);
+    expect(deployed).toEqual({ A: 'plain', B: 'a?c', N: 5, L: ['x', 'y'] });
+  });
+
+  it('walks arrays and nested objects', () => {
+    const deployed = { Tags: [{ Value: '???' }, { Value: 'keep' }] };
+    const synth = { Tags: [{ Value: 'áéí' }, { Value: 'keep' }] };
+    recoverNonAsciiMasks(deployed, synth);
+    expect(deployed.Tags[0].Value).toBe('áéí');
+    expect(deployed.Tags[1].Value).toBe('keep');
+  });
+
+  it('is robust to a missing / mismatched-shape synth side (no throw, no change)', () => {
+    const deployed = { V: '?????ABC', Nested: { X: '???' } };
+    recoverNonAsciiMasks(deployed, undefined);
+    recoverNonAsciiMasks(deployed, { V: 42, Nested: 'not-an-object' });
+    expect(deployed).toEqual({ V: '?????ABC', Nested: { X: '???' } });
+  });
+});

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -241,6 +241,64 @@ describe('loadDesired ListStackResources pagination', () => {
   });
 });
 
+describe('loadDesired non-ASCII recovery (GetTemplate `?`-mask from local synth)', () => {
+  function ssmStack(cfn: ReturnType<typeof mockClient>, maskedValue: string) {
+    // GetTemplate returns the deployed body with the non-ASCII Value masked as `?`.
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: { P: { Type: 'AWS::SSM::Parameter', Properties: { Value: maskedValue } } },
+      }),
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/S/x',
+          StackName: 'S',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'P',
+          PhysicalResourceId: '/p',
+          ResourceType: 'AWS::SSM::Parameter',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+  }
+  const valueOf = (d: Awaited<ReturnType<typeof loadDesired>>) =>
+    (d.resources.find((r) => r.logicalId === 'P')?.declared as { Value?: unknown }).Value;
+
+  it('recovers the masked declared value from the synth template when the mask matches', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    ssmStack(cfn, '?????ABC');
+    const synth = {
+      Resources: { P: { Type: 'AWS::SSM::Parameter', Properties: { Value: 'áéíóúABC' } } },
+    };
+    const desired = await loadDesired(
+      cfn as unknown as CloudFormationClient,
+      'S',
+      'us-east-1',
+      undefined,
+      synth
+    );
+    expect(valueOf(desired)).toBe('áéíóúABC'); // recovered, ready for a real compare
+  });
+
+  it('leaves the mask in place (→ readGap downstream) when no synth recovery is given', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    ssmStack(cfn, '?????ABC');
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'S', 'us-east-1');
+    expect(valueOf(desired)).toBe('?????ABC'); // unchanged → classify emits readGap
+  });
+});
+
 describe('loadDesired Fn::ImportValue exports prefetch', () => {
   function stackMocks(cfn: ReturnType<typeof mockClient>, templateBody: string) {
     cfn.on(GetTemplateCommand).resolves({ TemplateBody: templateBody });


### PR DESCRIPTION
## Why

Stacked on #382. After #382 a clean check on a real stack was CLEAN but the Japanese `AWS::SSM::Parameter` values showed as `readGap` (declared-but-unverifiable). Investigating further: CloudFormation's `GetTemplate` (cdkrd's declared source) masks every non-ASCII char in a stored string literal as a literal `?` — `Value: こんにちはABC` → `?????ABC` — while CloudFormation compares the **intact** value server-side (its own drift detection reports these IN_SYNC). So `readGap` left cdkrd detecting **less** than `cdk drift` on those properties.

| | declared source | non-ASCII SSM verdict |
|---|---|---|
| `cdk drift` / CFn drift | CFn internal store (intact) | ✅ IN_SYNC |
| cdkrd (#382) | GetTemplate (masked) | ⚠️ readGap (unverifiable) |
| cdkrd (this PR) | GetTemplate + **synth recovery** | ✅ compared (CLEAN, or detects a real change) |

## What

The local synth template (the `cdk.out` assembly cdkrd already produces for stack discovery) carries the intact UTF-8. `recover-nonascii.ts` walks the deployed template and the synth template in parallel; when the synth value at the same path **masks to** the deployed `?`-value (same ASCII skeleton + length, ≥1 non-ASCII char) it IS the deployed declared value with its non-ASCII restored — substitute it so the compare runs on real text.

- **Mask-gated per leaf**: a synth value whose skeleton/length diverged is never substituted → the property stays a `readGap`.
- **Pure-ASCII templates are untouched**: GetTemplate never masks ASCII, so no `?`-leaf ever matches a non-ASCII synth value — zero behavior change for ASCII-only users.
- **No extra synth**: `discoverStacks`/`resolveStacks` already synth for discovery; each stack's template is now carried through `ResolvedStack` → `gatherFindings` → `loadDesired` as a recovery source (distinct from the `--pre-deploy` override; recovery is skipped under `--pre-deploy`). `record`/`ignore`/`revert` pass it too, so a **revert writes the real declared value, never a `?????` mask**.

## Trade-off

For these specific values "intent" becomes the local synth rather than the deployed template (the deployed value is unreadable). So a same-length non-ASCII-only edit made in code but **not yet deployed** surfaces as drift (code-vs-reality). Documented in `docs/limitations.md`.

## Verification

Live-verified against the reporting stack: the 4 Japanese SSM values went from `readGap` to recovered + **CLEAN** (readGap 14 → 10 write-only), matching `cdk drift`'s IN_SYNC. Unit tests: `recover-nonascii` (mask match / structural-divergence no-op / ASCII untouched / arrays+nesting / robustness) + `loadDesired` recovery wiring. Full suite green (42 files, 1671 tests); typecheck/lint/build clean.

> Note: live **detection** (mutating a real param) was not run to avoid changing the user's real stack; the detect path is unit-covered (recovered value ≠ live → declared drift).
