### PR TITLE
fix(report): --show-all must not flag first-run live-only values as drift

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -887,8 +887,12 @@ record` step; once a baseline exists, a clean run prompts nothing. `availableAct
 offers `record` when there are undeclared/added findings OR (no baseline AND no drift).
 In `--json` the findings keep `tier: "undeclared"` (the documented enum) plus
 an `"unrecorded": true` field, and `drifted` excludes them. `--show-all`
-bypasses the baseline entirely — no suppression and no unrecorded tagging (a
-raw inventory view).
+ignores the recorded baseline — it lists EVERY current undeclared value with no
+suppression — but still runs `applyBaseline(_, undefined)`, so those live-only
+values are tagged `unrecorded` (Potential Drift), not mislabeled confirmed drift:
+`--show-all --fail` does not exit 1 on a fresh deploy nobody has touched. Only
+`--declared-only` truly bypasses `applyBaseline` (the undeclared tier is filtered
+out first, so its removal pass would misread every recorded entry).
 **Color (R43):** output is colorized via semantic helpers
 ([style.ts](../src/report/style.ts), picocolors) — green/red bold verdicts,
 yellow undeclared tier, dim informational footers — ONLY when stdout is a real

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -9,6 +9,8 @@
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
+  type ApplyBaselineOptions,
+  type BaselineFile,
   checkBaselineAccount,
   constructPathsByLogical,
   declaredKeysByLogical,
@@ -37,6 +39,30 @@ import { resolveInteractively } from './interactive-resolve.js';
 // the same name can recur across regions in one app). Exported (pure) for unit testing.
 export function synthKey(stackName: string, region: string | undefined): string {
   return `${stackName}\0${region ?? ''}`;
+}
+
+// Reconcile classified findings against the baseline for the report. Exported (pure)
+// so the --show-all contract below is unit-tested.
+//
+// `--declared-only` is the ONLY mode that bypasses applyBaseline: it filters the
+// undeclared tier out entirely, so applyBaseline's removal pass would misread EVERY
+// recorded entry as "baseline value removed since record" (latent in R59).
+//
+// `--show-all` (inventory mode) does NOT bypass it. The caller already loaded
+// `baseline = undefined` for show-all (it lists ALL current undeclared state,
+// ignoring whatever is recorded), and applyBaseline(findings, undefined) is exactly
+// the path that tags every undeclared/added value `unrecorded` — i.e. POTENTIAL
+// drift, not confirmed drift. Bypassing it (the pre-#378 behavior) left those values
+// untagged, so the report mislabeled a fresh deploy's live-only inventory as
+// "CFn-Undeclared Drift" / "N drift(s)" and `--show-all --fail` exited 1 on a stack
+// nobody had touched — the first-run false-drift the Potential Drift model removed.
+export function reconcileBaseline(
+  findings: Finding[],
+  baseline: BaselineFile | undefined,
+  opts: { declaredOnly: boolean; applyOpts: ApplyBaselineOptions }
+): Finding[] {
+  if (opts.declaredOnly) return findings;
+  return applyBaseline(findings, baseline, opts.applyOpts);
 }
 
 // `--declared-only` still prints an `At AWS Default (N)` line for values it claims
@@ -308,22 +334,24 @@ export async function runCheck(args: string[]): Promise<number> {
       // otherwise — including the whole no-baseline first run (R60). The report
       // renders unrecorded values as [UNRECORDED: N], excludes them from the
       // verdict/exit, and points at `cdkrd record` on the result line.
-      // --show-all keeps its raw inventory semantics: the baseline is bypassed
-      // entirely (no suppression, no unrecorded tagging). --declared-only also
-      // bypasses it ("undeclared values are not compared"): with the undeclared
-      // tier filtered out, applyBaseline's removal pass would mis-read EVERY
-      // recorded entry as `baseline value removed since record` (latent in R59).
+      // --show-all loaded baseline=undefined above (it lists ALL undeclared state,
+      // ignoring what is recorded) but STILL reconciles: applyBaseline(_, undefined)
+      // tags every undeclared/added value `unrecorded` (potential drift, not confirmed
+      // drift), so a fresh deploy's inventory is not mislabeled as drift and
+      // --show-all --fail does not exit 1 on an untouched stack. Only --declared-only
+      // bypasses applyBaseline (see reconcileBaseline). R59/R86/#378.
       const reconciled = applyIgnores(
-        a.showAll || a.declaredOnly
-          ? findings
-          : applyBaseline(findings, baseline, {
-              declaredByLogical: declaredKeysByLogical(desired.resources),
-              constructPathByLogical: constructPathsByLogical(desired.resources),
-              physicalIdByLogical: physicalIdsByLogical(desired.resources),
-              warn: (s: string) => {
-                if (!a.json) console.error(s);
-              },
-            }),
+        reconcileBaseline(findings, baseline, {
+          declaredOnly: a.declaredOnly,
+          applyOpts: {
+            declaredByLogical: declaredKeysByLogical(desired.resources),
+            constructPathByLogical: constructPathsByLogical(desired.resources),
+            physicalIdByLogical: physicalIdsByLogical(desired.resources),
+            warn: (s: string) => {
+              if (!a.json) console.error(s);
+            },
+          },
+        }),
         stackName,
         region,
         config

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -465,6 +465,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Glue::Crawler': {
     LakeFormationConfiguration: { AccountId: '', UseLakeFormationCredentials: false },
   },
+  // CloudWatch RUM AppMonitor service defaults (observed live on the
+  // rum-appmonitor-rich fixture): a monitor that does not declare Platform reads
+  // back "Web" (the default/only web platform), and one that does not configure
+  // source-map deobfuscation reads back the disabled-state object. Equality-gated:
+  // an Android/iOS platform or an enabled deobfuscation config no longer matches and
+  // surfaces as a real undeclared value.
+  'AWS::RUM::AppMonitor': {
+    Platform: 'Web',
+    DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: 'DISABLED' } },
+  },
 };
 
 // R108: nested service defaults — the NESTED-path twin of KNOWN_DEFAULTS. The

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -5,6 +5,7 @@ import {
   hasCoverageGap,
   nestedStackWarning,
   preDeployFindings,
+  reconcileBaseline,
   strictCoverageExit,
   synthKey,
   undeclaredOnlyFindings,
@@ -46,6 +47,30 @@ describe('preDeployFindings (--pre-deploy scope)', () => {
   it('is a no-op when there are no undeclared findings (regression)', () => {
     const findings = [F('declared'), F('readGap')];
     expect(preDeployFindings(findings)).toEqual(findings);
+  });
+});
+
+describe('reconcileBaseline (--show-all inventory tags live-only as unrecorded, not drift)', () => {
+  // The pre-#378 bug: --show-all bypassed applyBaseline, so a fresh deploy's
+  // undeclared inventory stayed untagged and the report mislabeled it as
+  // "CFn-Undeclared Drift" / "N drift(s)" — and `--show-all --fail` exited 1 on a
+  // stack nobody had touched. --show-all loads baseline=undefined; reconcileBaseline
+  // must still route through applyBaseline so those values are tagged `unrecorded`.
+  it('--show-all (baseline undefined): undeclared + added are tagged unrecorded', () => {
+    const out = reconcileBaseline([F('undeclared'), F('added'), F('declared')], undefined, {
+      declaredOnly: false,
+      applyOpts: {},
+    });
+    const byTier = Object.fromEntries(out.map((f) => [f.tier, f.unrecorded]));
+    expect(byTier.undeclared).toBe(true); // potential drift, not confirmed drift
+    expect(byTier.added).toBe(true);
+    expect(byTier.declared).toBeUndefined(); // a real declared drift still counts
+  });
+
+  it('--declared-only is the ONLY mode that bypasses the baseline (raw passthrough)', () => {
+    const findings = [F('declared'), F('undeclared')];
+    const out = reconcileBaseline(findings, undefined, { declaredOnly: true, applyOpts: {} });
+    expect(out).toBe(findings); // untouched reference: applyBaseline never ran
   });
 });
 

--- a/tests/corpus/AWS__RUM__AppMonitor.Monitor.json
+++ b/tests/corpus/AWS__RUM__AppMonitor.Monitor.json
@@ -1,0 +1,114 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Monitor",
+    "resourceType": "AWS::RUM::AppMonitor",
+    "physicalId": "cdkrd-rum-rich",
+    "constructPath": "CdkRealDriftIntegRumRich/Monitor",
+    "declared": {
+      "AppMonitorConfiguration": {
+        "AllowCookies": true,
+        "EnableXRay": false,
+        "ExcludedPages": [
+          "https://example.com/zeta",
+          "https://example.com/alpha",
+          "https://example.com/mike"
+        ],
+        "FavoritePages": ["/zeta", "/alpha", "/mike"],
+        "IncludedPages": ["https://example.com/include-b", "https://example.com/include-a"],
+        "MetricDestinations": [
+          {
+            "Destination": "CloudWatch"
+          }
+        ],
+        "SessionSampleRate": 1,
+        "Telemetries": ["performance", "errors", "http"]
+      },
+      "CustomEvents": {
+        "Status": "ENABLED"
+      },
+      "CwLogEnabled": false,
+      "Domain": "example.com",
+      "Name": "cdkrd-rum-rich"
+    }
+  },
+  "liveRaw": {
+    "CustomEvents": {
+      "Status": "ENABLED"
+    },
+    "Platform": "Web",
+    "CwLogEnabled": false,
+    "Id": "9a946752-649d-4af5-b9d1-f0cea1723826",
+    "DeobfuscationConfiguration": {
+      "JavaScriptSourceMaps": {
+        "Status": "DISABLED"
+      }
+    },
+    "Domain": "example.com",
+    "AppMonitorConfiguration": {
+      "MetricDestinations": [
+        {
+          "Destination": "CloudWatch"
+        }
+      ],
+      "IncludedPages": ["https://example.com/include-b", "https://example.com/include-a"],
+      "ExcludedPages": [
+        "https://example.com/zeta",
+        "https://example.com/alpha",
+        "https://example.com/mike"
+      ],
+      "FavoritePages": ["/zeta", "/alpha", "/mike"],
+      "SessionSampleRate": 1,
+      "AllowCookies": true,
+      "Telemetries": ["performance", "errors", "http"],
+      "EnableXRay": false
+    },
+    "Name": "cdkrd-rum-rich"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Platform"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Platform"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AppMonitorConfiguration.ExcludedPages",
+      "AppMonitorConfiguration.FavoritePages",
+      "AppMonitorConfiguration.IncludedPages",
+      "AppMonitorConfiguration.Telemetries"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Monitor",
+      "resourceType": "AWS::RUM::AppMonitor",
+      "path": "Platform",
+      "actual": "Web",
+      "physicalId": "cdkrd-rum-rich",
+      "constructPath": "CdkRealDriftIntegRumRich/Monitor"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Monitor",
+      "resourceType": "AWS::RUM::AppMonitor",
+      "path": "DeobfuscationConfiguration",
+      "actual": {
+        "JavaScriptSourceMaps": {
+          "Status": "DISABLED"
+        }
+      },
+      "physicalId": "cdkrd-rum-rich",
+      "constructPath": "CdkRealDriftIntegRumRich/Monitor"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SageMaker__Model.Model.json
+++ b/tests/corpus/AWS__SageMaker__Model.Model.json
@@ -1,0 +1,115 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Model",
+    "resourceType": "AWS::SageMaker::Model",
+    "physicalId": "arn:aws:sagemaker:us-east-1:111111111111:model/cdkrd-sagemaker-model-rich",
+    "constructPath": "CdkRealDriftIntegSageMakerModel/Model",
+    "declared": {
+      "Containers": [
+        {
+          "ContainerHostname": "preprocess",
+          "Environment": {
+            "ZETA": "1",
+            "ALPHA": "2",
+            "MIKE": "3"
+          },
+          "Image": "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1",
+          "Mode": "SingleModel"
+        },
+        {
+          "ContainerHostname": "predict",
+          "Environment": {
+            "GAMMA": "x",
+            "DELTA": "y"
+          },
+          "Image": "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.7-1",
+          "Mode": "SingleModel"
+        }
+      ],
+      "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSageMakerModel-ModelRoleEE661428-QXaa3RQajJlZ",
+      "InferenceExecutionConfig": {
+        "Mode": "Serial"
+      },
+      "ModelName": "cdkrd-sagemaker-model-rich"
+    }
+  },
+  "liveRaw": {
+    "ModelArn": "arn:aws:sagemaker:us-east-1:111111111111:model/cdkrd-sagemaker-model-rich",
+    "EnableNetworkIsolation": false,
+    "ExecutionRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSageMakerModel-ModelRoleEE661428-QXaa3RQajJlZ",
+    "ModelName": "cdkrd-sagemaker-model-rich",
+    "Containers": [
+      {
+        "ContainerHostname": "preprocess",
+        "Mode": "SingleModel",
+        "Environment": {
+          "ZETA": "1",
+          "MIKE": "3",
+          "ALPHA": "2"
+        },
+        "Image": "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1"
+      },
+      {
+        "ContainerHostname": "predict",
+        "Mode": "SingleModel",
+        "Environment": {
+          "GAMMA": "x",
+          "DELTA": "y"
+        },
+        "Image": "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.7-1"
+      }
+    ],
+    "InferenceExecutionConfig": {
+      "Mode": "Serial"
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSageMakerModel/a35ebdb0-723e-11f1-a1a9-1216bdf8392f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSageMakerModel",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Model",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ModelArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "Containers",
+      "EnableNetworkIsolation",
+      "ExecutionRoleArn",
+      "InferenceExecutionConfig",
+      "ModelName",
+      "PrimaryContainer",
+      "VpcConfig"
+    ],
+    "readOnlyPaths": ["ModelArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "Containers",
+      "EnableNetworkIsolation",
+      "ExecutionRoleArn",
+      "InferenceExecutionConfig",
+      "ModelName",
+      "PrimaryContainer",
+      "VpcConfig"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["VpcConfig.SecurityGroupIds", "VpcConfig.Subnets"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/rum-appmonitor-rich/app.ts
+++ b/tests/integration/rum-appmonitor-rich/app.ts
@@ -1,0 +1,43 @@
+// CDK app for the cdk-real-drift CloudWatch RUM AppMonitor false-positive test.
+// RUM (real-user monitoring for web apps) is a common front-end observability
+// resource, and its AppMonitorConfiguration carries several SET-like lists that
+// AWS may echo in its own canonical order (Telemetries, ExcludedPages,
+// IncludedPages, FavoritePages). Those are declared deliberately NON-sorted so a
+// positional compare would false-drift them if RUM reorders. A freshly deployed +
+// recorded monitor with NO out-of-band change MUST report CLEAN.
+//
+// No IdentityPoolId / GuestRoleArn is set (data ingestion is not exercised), so no
+// Cognito identity pool is created — nothing to orphan. CwLogEnabled is left false
+// so RUM does not create a vended CloudWatch log group.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAppMonitor } from "aws-cdk-lib/aws-rum";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRumRich");
+
+new CfnAppMonitor(stack, "Monitor", {
+  name: "cdkrd-rum-rich",
+  domain: "example.com",
+  cwLogEnabled: false,
+  customEvents: { status: "ENABLED" },
+  appMonitorConfiguration: {
+    allowCookies: true,
+    enableXRay: false,
+    sessionSampleRate: 1,
+    // Declared deliberately out of sorted order to expose a set-reorder FP.
+    telemetries: ["performance", "errors", "http"],
+    excludedPages: [
+      "https://example.com/zeta",
+      "https://example.com/alpha",
+      "https://example.com/mike",
+    ],
+    includedPages: [
+      "https://example.com/include-b",
+      "https://example.com/include-a",
+    ],
+    favoritePages: ["/zeta", "/alpha", "/mike"],
+    metricDestinations: [{ destination: "CloudWatch" }],
+  },
+});
+
+app.synth();

--- a/tests/integration/rum-appmonitor-rich/cdk.json
+++ b/tests/integration/rum-appmonitor-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rum-appmonitor-rich/package.json
+++ b/tests/integration/rum-appmonitor-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-rum-appmonitor-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift rum-appmonitor-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/rum-appmonitor-rich/verify-detect.sh
+++ b/tests/integration/rum-appmonitor-rich/verify-detect.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# RUM AppMonitor detect + revert integration test (real AWS): deploy -> record ->
+# change a DECLARED MUTABLE prop (AppMonitorConfiguration.SessionSampleRate) out of
+# band -> check MUST DETECT the declared drift (exit 1) -> revert -> check MUST be
+# CLEAN and the live value MUST be restored. This is the false-negative half a
+# plain record->check->CLEAN fixture (verify.sh) does not exercise.
+set -uo pipefail
+export AWS_CLI_AUTO_PROMPT=off
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRumRich
+NAME=cdkrd-rum-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out /tmp/rum-amc.json
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: SessionSampleRate 1 -> 0.5 (console-edit) ==="
+# update-app-monitor overwrites the whole AppMonitorConfiguration, so resend the
+# full declared config with only SessionSampleRate changed.
+cat > /tmp/rum-amc.json <<'JSON'
+{
+  "AllowCookies": true,
+  "EnableXRay": false,
+  "SessionSampleRate": 0.5,
+  "Telemetries": ["performance", "errors", "http"],
+  "ExcludedPages": ["https://example.com/zeta", "https://example.com/alpha", "https://example.com/mike"],
+  "IncludedPages": ["https://example.com/include-b", "https://example.com/include-a"],
+  "FavoritePages": ["/zeta", "/alpha", "/mike"],
+  "MetricDestinations": [{ "Destination": "CloudWatch" }]
+}
+JSON
+aws rum update-app-monitor --name "$NAME" --region "$REGION" \
+  --app-monitor-configuration file:///tmp/rum-amc.json >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-rum-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "SessionSampleRate" /tmp/cdkrd-rum-detect.out || fail "SessionSampleRate not reported"
+
+echo "=== revert (write declared values back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live value MUST be restored to 1 ==="
+GOT="$(aws rum get-app-monitor --name "$NAME" --region "$REGION" \
+  --query "AppMonitor.AppMonitorConfiguration.SessionSampleRate" --output text)"
+[ "$GOT" = "1.0" ] || [ "$GOT" = "1" ] || fail "live SessionSampleRate not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/rum-appmonitor-rich/verify.sh
+++ b/tests/integration/rum-appmonitor-rich/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A CloudWatch RUM AppMonitor carries several SET-like lists
+# (Telemetries / ExcludedPages / IncludedPages / FavoritePages) declared
+# non-sorted; if RUM echoes them reordered, a positional compare would false-drift
+# them. Any declared drift on a clean recorded stack is a normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRumRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+# Regression for the --show-all first-run false-drift bug: with NO baseline,
+# inventory mode lists every live-only value but they are POTENTIAL drift, not
+# confirmed drift — `check --show-all --fail` MUST exit 0 (not flag the fresh
+# deploy's undeclared inventory as drift and fail CI).
+echo "=== [$STACK] check --show-all --fail (no baseline) MUST be exit 0 ==="
+rm -rf .cdkrd
+$CLI check "$STACK" --region "$REGION" --show-all --fail | tee "/tmp/cdkrd-$STACK-showall.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "--show-all --fail must not flag first-run inventory as drift (got exit $rc)"
+grep -q "Potential Drift" "/tmp/cdkrd-$STACK-showall.out" || fail "--show-all did not label live-only values as Potential Drift"
+grep -q "drift(s)" "/tmp/cdkrd-$STACK-showall.out" && fail "--show-all mislabeled first-run inventory as confirmed drift"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sagemaker-model-rich/app.ts
+++ b/tests/integration/sagemaker-model-rich/app.ts
@@ -1,0 +1,45 @@
+// CDK app for the cdk-real-drift SageMaker Model false-positive / read-gap test.
+// A SageMaker Model is metadata-only (no endpoint, no compute cost) yet common in
+// ML CDK apps. Its CloudFormation physical id is the ModelName while the Cloud
+// Control primaryIdentifier is ModelArn, so this also probes whether cdkrd can
+// read it at all (a bare-name GetResource against an ARN-keyed type is a read-gap
+// class). The container Environment map and the inference-pipeline Containers are
+// exercised. A freshly deployed + recorded model with NO out-of-band change MUST
+// report CLEAN (and MUST NOT come back silently skipped).
+import { App, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnModel } from "aws-cdk-lib/aws-sagemaker";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSageMakerModel");
+
+const role = new Role(stack, "ModelRole", {
+  assumedBy: new ServicePrincipal("sagemaker.amazonaws.com"),
+});
+
+// AWS-provided built-in algorithm images (us-east-1 account). CreateModel does not
+// pull the image, so these only need to be well-formed ECR URIs.
+const XGBOOST = "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.7-1";
+const SKLEARN = "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-scikit-learn:1.2-1";
+
+new CfnModel(stack, "Model", {
+  modelName: "cdkrd-sagemaker-model-rich",
+  executionRoleArn: role.roleArn,
+  inferenceExecutionConfig: { mode: "Serial" },
+  containers: [
+    {
+      containerHostname: "preprocess",
+      image: SKLEARN,
+      mode: "SingleModel",
+      environment: { ZETA: "1", ALPHA: "2", MIKE: "3" },
+    },
+    {
+      containerHostname: "predict",
+      image: XGBOOST,
+      mode: "SingleModel",
+      environment: { GAMMA: "x", DELTA: "y" },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/sagemaker-model-rich/cdk.json
+++ b/tests/integration/sagemaker-model-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sagemaker-model-rich/package.json
+++ b/tests/integration/sagemaker-model-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sagemaker-model-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sagemaker-model-rich false-positive / read-gap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sagemaker-model-rich/verify.sh
+++ b/tests/integration/sagemaker-model-rich/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive / read-gap integration test (real AWS): deploy -> record baseline
+# -> check MUST be CLEAN. A SageMaker Model's CFn physical id is the ModelName but
+# its Cloud Control primaryIdentifier is ModelArn; if cdkrd cannot resolve it the
+# resource comes back silently `skipped=` (a read-gap), and any declared drift on a
+# clean recorded stack is a normalization FP. The check output is asserted to
+# contain the Model resource as read (not skipped).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSageMakerModel
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -524,6 +524,13 @@ describe('noise suppressors', () => {
       AccountId: '',
       UseLakeFormationCredentials: false,
     });
+    // CloudWatch RUM AppMonitor (observed live on rum-appmonitor-rich): an undeclared
+    // Platform reads back "Web", and undeclared source-map deobfuscation reads back the
+    // disabled-state object. Equality-gated, so Android/iOS or an enabled config surfaces.
+    expect(KNOWN_DEFAULTS['AWS::RUM::AppMonitor']).toEqual({
+      Platform: 'Web',
+      DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: 'DISABLED' } },
+    });
   });
 
   it('common stateful/streaming-type constant defaults from the offline corpus sweep', () => {


### PR DESCRIPTION
## What

A bug-hunt round (deploy uncovered common types → catch FP/FN) that found one real **false-positive bug** plus shipped two clean fixtures + corpus and a first-run-noise fold.

### Bug: `--show-all` mislabels first-run live-only values as confirmed drift

`--show-all` (inventory mode) bypassed `applyBaseline` entirely, so a fresh deploy's undeclared inventory was never tagged `unrecorded`. The report then labeled it **CFn-Undeclared Drift / "N drift(s)"** and `check --show-all --fail` exited **1** on a stack nobody had touched — exactly the first-run false-drift the Potential Drift model (#378/#380) removed, just gated behind the flag.

```diff
 # check --show-all --fail on a fresh deploy, no baseline:
-[CFn-Undeclared Drift: 2] (...)   result: 2 drift(s) (undeclared=2)   EXIT 1
+[Potential Drift: 2] (...)        result: no confirmed drift · 2 potential drift   EXIT 0
```

**Fix:** `--show-all` already loads `baseline=undefined` (it lists every undeclared value, ignoring what is recorded); it now still runs `applyBaseline(_, undefined)`, which tags undeclared/added as `unrecorded` (Potential Drift, excluded from the verdict + `--fail`). A genuine **declared** drift still counts. Only `--declared-only` truly bypasses `applyBaseline` (its removal pass would misread recorded entries when the undeclared tier is filtered out). Extracted as the pure, unit-tested `reconcileBaseline`.

### Fixtures + corpus (clean round assets)

- **`rum-appmonitor-rich`** (CloudWatch RUM `AppMonitor`) — common front-end observability. FP-clean (Telemetries / ExcludedPages / IncludedPages / FavoritePages set arrays declared non-sorted do **not** reorder), and detect→revert→restore live-proven (`SessionSampleRate` out-of-band edit). Revertable via Cloud Control.
- **`sagemaker-model-rich`** (`SageMaker::Model`) — metadata-only ML resource. CC-readable despite `ModelArn` primaryIdentifier (no read-gap), fully clean.

### First-run-noise fold (§5.5)

`KNOWN_DEFAULTS['AWS::RUM::AppMonitor']` = `{ Platform: "Web", DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: "DISABLED" } } }` (observed live). Equality-gated, so an Android/iOS platform or an enabled deobfuscation config still surfaces. A fresh RUM deploy now reads CLEAN instead of "2 potential drift".

## Tests

- `reconcileBaseline` unit tests (`--show-all` tags undeclared/added unrecorded; `--declared-only` is the only bypass).
- `noise-and-strip` assertion for the RUM `KNOWN_DEFAULTS` entry.
- Corpus-replay cases for `AWS::RUM::AppMonitor` (folds to atDefault) and `AWS::SageMaker::Model` (clean).
- Integ regression in `rum-appmonitor-rich/verify.sh`: `check --show-all --fail` on a no-baseline deploy MUST exit 0 and label values Potential Drift.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (1675 tests) green.
- Docs: fixed a stale `--show-all` claim in `docs/ARCHITECTURE.md` ("no unrecorded tagging").

## Live verification (us-east-1, real AWS)

- `--show-all --fail` no-baseline → exit 0, Potential Drift (was exit 1).
- RUM record→check CLEAN; SessionSampleRate edit → detect (exit 1) → revert → CLEAN → live restored to 1.0.
- SageMaker record→check CLEAN, Model read by CC.
- Both stacks torn down with `delstack`; `sweep-orphans.sh` SWEEP CLEAN.
