### PR TITLE
feat(noise): fold VPC/MemoryDB/Config first-run defaults + 4 common-type fixtures

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,7 +13,12 @@ the full design.
   can't safely target a deep sub-field — fix in IaC or re-record); create-only
   properties (changing them needs replacement); toggle-style properties with no
   "absent" state (e.g. S3 transfer acceleration); `AWS::Lambda::Permission` and
-  `AWS::Budgets::Budget` (their write APIs can't reconstruct the desired state).
+  `AWS::Budgets::Budget` (their write APIs can't reconstruct the desired state);
+  and a declared change INSIDE a JSON-string-typed property (e.g.
+  `AWS::Config::ConfigRule` `InputParameters` — cdkrd descends into the parsed
+  JSON for a precise finding, but an RFC6902 sub-path patch can't apply to a
+  string value, so revert reports non-convergence rather than silently failing;
+  whole-property revert for such props is a follow-up). Detection still works.
   Not-revertable findings fold into a one-line-per-reason summary (`--verbose` for
   the full list). When findings exist but nothing is revertable, `revert` prints
   `nothing revertable` and exits 1.
@@ -53,6 +58,14 @@ the full design.
 - **Unsupported / unreadable types.** A type Cloud Control can't read (no CC
   support, or a CC handler error with no SDK override) is `skipped`, surfaced in the
   `skipped=N` line and never silently CLEAN; `--strict` makes such a gap CI-failing.
+  Known CC-unreadable common types with no SDK override yet (all surface as
+  `skipped`, never false drift): ACM `Certificate` and ELBv2
+  `ListenerCertificate` (also impractical to live-test — ACM validation blocks
+  the create); CloudWatch `AnomalyDetector` and `InsightRule` (SDK-override
+  candidates); and `AWS::EC2::VPCCidrBlock` (composite `[Id, VpcId]` id whose
+  CFn physical id is only the child segment — an adapter candidate, though it is
+  an immutable association, so nothing can drift). Coverage gaps, not false
+  negatives.
 - **Non-ASCII template literals.** CloudFormation's `GetTemplate` (cdkrd's
   declared source) returns every non-ASCII character in a stored string literal
   as a literal `?` — so a declared value like an `AWS::SSM::Parameter`

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -168,6 +168,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ApiGateway::DomainName': {
     SecurityPolicy: 'TLS_1_2',
   },
+  // A VPC is in nearly every CDK stack. AWS reports these two constant defaults on
+  // every first run when the template does not declare them (raw CfnVPC, or an L2 Vpc
+  // that sets only DNS hostnames): InstanceTenancy "default" (vs dedicated/host) and
+  // EnableDnsSupport on (the VPC default). Observed live on the vpcpeering-rich /
+  // egressonly-rich fixtures. Equality-gated: a dedicated-tenancy VPC or DNS-support
+  // disabled out of band no longer matches and surfaces as real undeclared drift.
+  'AWS::EC2::VPC': {
+    InstanceTenancy: 'default',
+    EnableDnsSupport: true,
+  },
   'AWS::EC2::Subnet': {
     PrivateDnsNameOptionsOnLaunch: {
       EnableResourceNameDnsARecord: false,
@@ -326,6 +336,19 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     AutoMinorVersionUpgrade: true,
     SnapshotRetentionLimit: 0,
   },
+  // MemoryDB (managed Redis/Valkey) constant service defaults, observed live on the
+  // memorydb-rich fixture: the Redis default Port, auto minor-version upgrade on,
+  // data tiering off (returned as the string "false"), and the ipv4 network/discovery
+  // defaults. Equality-gated. Per-resource/random values the same read returns
+  // (ParameterGroupName is engine-version-derived, Snapshot/MaintenanceWindow are
+  // AWS-assigned) are deliberately NOT listed — they are genuine undeclared inventory.
+  'AWS::MemoryDB::Cluster': {
+    Port: 6379,
+    AutoMinorVersionUpgrade: true,
+    DataTiering: 'false',
+    NetworkType: 'ipv4',
+    IpDiscovery: 'ipv4',
+  },
   'AWS::RDS::DBProxy': {
     TargetConnectionNetworkType: 'IPV4',
     DefaultAuthScheme: 'NONE',
@@ -464,6 +487,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // Lake Formation still surfaces.
   'AWS::Glue::Crawler': {
     LakeFormationConfiguration: { AccountId: '', UseLakeFormationCredentials: false },
+  },
+  // A config-change-triggered ConfigRule reads back EvaluationModes [{Mode:"DETECTIVE"}]
+  // (the default) when the template does not declare it. Observed live on the
+  // config-rule-rich fixture. Equality-gated: a PROACTIVE mode no longer matches.
+  'AWS::Config::ConfigRule': {
+    EvaluationModes: [{ Mode: 'DETECTIVE' }],
   },
   // CloudWatch RUM AppMonitor service defaults (observed live on the
   // rum-appmonitor-rich fixture): a monitor that does not declare Platform reads

--- a/tests/corpus/AWS__Config__ConfigRule.Rule4C995B7F.json
+++ b/tests/corpus/AWS__Config__ConfigRule.Rule4C995B7F.json
@@ -1,0 +1,73 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule4C995B7F",
+    "resourceType": "AWS::Config::ConfigRule",
+    "physicalId": "cdkrd-access-keys-rotated",
+    "constructPath": "CdkRealDriftIntegConfigRule/Rule",
+    "declared": {
+      "ConfigRuleName": "cdkrd-access-keys-rotated",
+      "InputParameters": {
+        "maxAccessKeyAge": 90
+      },
+      "MaximumExecutionFrequency": "TwentyFour_Hours",
+      "Source": {
+        "Owner": "AWS",
+        "SourceIdentifier": "ACCESS_KEYS_ROTATED"
+      }
+    }
+  },
+  "liveRaw": {
+    "ConfigRuleId": "config-rule-elg2df",
+    "EvaluationModes": [
+      {
+        "Mode": "DETECTIVE"
+      }
+    ],
+    "Compliance": {
+      "Type": "NON_COMPLIANT"
+    },
+    "ConfigRuleName": "cdkrd-access-keys-rotated",
+    "Arn": "arn:aws:config:us-east-1:111111111111:config-rule/config-rule-elg2df",
+    "MaximumExecutionFrequency": "TwentyFour_Hours",
+    "Source": {
+      "Owner": "AWS",
+      "SourceIdentifier": "ACCESS_KEYS_ROTATED"
+    },
+    "InputParameters": {
+      "maxAccessKeyAge": "90"
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "ConfigRuleId"],
+    "writeOnly": [],
+    "createOnly": ["ConfigRuleName"],
+    "readOnlyPaths": ["Arn", "Compliance.Type", "ConfigRuleId"],
+    "writeOnlyPaths": ["Source.CustomPolicyDetails.PolicyText"],
+    "createOnlyPaths": ["ConfigRuleName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Rule4C995B7F",
+      "resourceType": "AWS::Config::ConfigRule",
+      "path": "EvaluationModes",
+      "actual": [
+        {
+          "Mode": "DETECTIVE"
+        }
+      ],
+      "physicalId": "cdkrd-access-keys-rotated",
+      "constructPath": "CdkRealDriftIntegConfigRule/Rule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EgressOnlyInternetGateway.Eoigw.json
+++ b/tests/corpus/AWS__EC2__EgressOnlyInternetGateway.Eoigw.json
@@ -1,0 +1,35 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Eoigw",
+    "resourceType": "AWS::EC2::EgressOnlyInternetGateway",
+    "physicalId": "eigw-0403c7bee7356b8d4",
+    "constructPath": "CdkRealDriftIntegEgressOnly/Eoigw",
+    "declared": {
+      "VpcId": "vpc-037e48f9acc9cbeb5"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-037e48f9acc9cbeb5",
+    "Id": "eigw-0403c7bee7356b8d4",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["VpcId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["VpcId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPC.VpcA.json
+++ b/tests/corpus/AWS__EC2__VPC.VpcA.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "VpcA",
+    "resourceType": "AWS::EC2::VPC",
+    "physicalId": "vpc-0373cc22511ff1925",
+    "constructPath": "CdkRealDriftIntegVpcPeering/VpcA",
+    "declared": {
+      "CidrBlock": "10.71.0.0/16"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-0373cc22511ff1925",
+    "InstanceTenancy": "default",
+    "CidrBlockAssociations": ["vpc-cidr-assoc-0287e333301bce071"],
+    "CidrBlock": "10.71.0.0/16",
+    "DefaultNetworkAcl": "acl-092f7925c5122d1bd",
+    "EnableDnsSupport": true,
+    "Ipv6CidrBlocks": [],
+    "DefaultSecurityGroup": "sg-0ee8db580b00e58f2",
+    "EnableDnsHostnames": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcPeering/a5ea9f10-7246-11f1-80f8-12a714253e55",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegVpcPeering",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "VpcA",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnly": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnly": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "readOnlyPaths": [
+      "CidrBlockAssociations",
+      "DefaultNetworkAcl",
+      "DefaultSecurityGroup",
+      "Ipv6CidrBlocks",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "createOnlyPaths": ["CidrBlock", "InstanceTenancy", "Ipv4IpamPoolId", "Ipv4NetmaskLength"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["CidrBlockAssociations", "Ipv6CidrBlocks"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcA",
+      "resourceType": "AWS::EC2::VPC",
+      "path": "InstanceTenancy",
+      "actual": "default",
+      "physicalId": "vpc-0373cc22511ff1925",
+      "constructPath": "CdkRealDriftIntegVpcPeering/VpcA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "VpcA",
+      "resourceType": "AWS::EC2::VPC",
+      "path": "EnableDnsSupport",
+      "actual": true,
+      "physicalId": "vpc-0373cc22511ff1925",
+      "constructPath": "CdkRealDriftIntegVpcPeering/VpcA"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__VPCPeeringConnection.Peering.json
+++ b/tests/corpus/AWS__EC2__VPCPeeringConnection.Peering.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Peering",
+    "resourceType": "AWS::EC2::VPCPeeringConnection",
+    "physicalId": "pcx-0cafcb2456cd624fd",
+    "constructPath": "CdkRealDriftIntegVpcPeering/Peering",
+    "declared": {
+      "PeerVpcId": "vpc-01d0100fcc5453481",
+      "VpcId": "vpc-0373cc22511ff1925"
+    }
+  },
+  "liveRaw": {
+    "VpcId": "vpc-0373cc22511ff1925",
+    "PeerVpcId": "vpc-01d0100fcc5453481",
+    "Id": "pcx-0cafcb2456cd624fd",
+    "PeerRegion": "us-east-1",
+    "PeerOwnerId": "111111111111",
+    "Tags": [
+      {
+        "Value": "Peering",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcPeering/a5ea9f10-7246-11f1-80f8-12a714253e55",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegVpcPeering",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["AssumeRoleRegion", "PeerRoleArn"],
+    "createOnly": [
+      "AssumeRoleRegion",
+      "PeerOwnerId",
+      "PeerRegion",
+      "PeerRoleArn",
+      "PeerVpcId",
+      "VpcId"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["AssumeRoleRegion", "PeerRoleArn"],
+    "createOnlyPaths": [
+      "AssumeRoleRegion",
+      "PeerOwnerId",
+      "PeerRegion",
+      "PeerRoleArn",
+      "PeerVpcId",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Peering",
+      "resourceType": "AWS::EC2::VPCPeeringConnection",
+      "path": "PeerRegion",
+      "actual": "us-east-1",
+      "physicalId": "pcx-0cafcb2456cd624fd",
+      "constructPath": "CdkRealDriftIntegVpcPeering/Peering"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Peering",
+      "resourceType": "AWS::EC2::VPCPeeringConnection",
+      "path": "PeerOwnerId",
+      "actual": "111111111111",
+      "physicalId": "pcx-0cafcb2456cd624fd",
+      "constructPath": "CdkRealDriftIntegVpcPeering/Peering"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MemoryDB__Cluster.Cluster.json
+++ b/tests/corpus/AWS__MemoryDB__Cluster.Cluster.json
@@ -1,0 +1,174 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cluster",
+    "resourceType": "AWS::MemoryDB::Cluster",
+    "physicalId": "cdkrd-memorydb-rich",
+    "constructPath": "CdkRealDriftIntegMemoryDb/Cluster",
+    "declared": {
+      "ACLName": "open-access",
+      "ClusterName": "cdkrd-memorydb-rich",
+      "Engine": "redis",
+      "EngineVersion": "7.1",
+      "NodeType": "db.t4g.small",
+      "NumReplicasPerShard": 0,
+      "NumShards": 1,
+      "SecurityGroupIds": ["sg-05b7d3252962eba68", "sg-054642cb654614915"],
+      "SnapshotRetentionLimit": 1,
+      "SubnetGroupName": "cdkrd-memorydb-sng",
+      "TLSEnabled": true
+    }
+  },
+  "liveRaw": {
+    "Status": "available",
+    "NumReplicasPerShard": 0,
+    "EngineVersion": "7.1",
+    "ParameterGroupName": "default.memorydb-redis7",
+    "SubnetGroupName": "cdkrd-memorydb-sng",
+    "Port": 6379,
+    "ACLName": "open-access",
+    "AutoMinorVersionUpgrade": true,
+    "SecurityGroupIds": ["sg-054642cb654614915", "sg-05b7d3252962eba68"],
+    "ClusterEndpoint": {
+      "Address": "clustercfg.cdkrd-memorydb-rich.jzgy0l.memorydb.us-east-1.amazonaws.com",
+      "Port": 6379
+    },
+    "NumShards": 1,
+    "SnapshotWindow": "09:30-10:30",
+    "SnapshotRetentionLimit": 1,
+    "DataTiering": "false",
+    "TLSEnabled": true,
+    "NetworkType": "ipv4",
+    "NodeType": "db.t4g.small",
+    "IpDiscovery": "ipv4",
+    "ClusterName": "cdkrd-memorydb-rich",
+    "MaintenanceWindow": "fri:07:00-fri:08:00",
+    "ParameterGroupStatus": "in-sync",
+    "ARN": "arn:aws:memorydb:us-east-1:111111111111:cluster/cdkrd-memorydb-rich",
+    "Engine": "redis"
+  },
+  "schema": {
+    "readOnly": ["ARN", "ParameterGroupStatus", "Status"],
+    "writeOnly": ["FinalSnapshotName", "MultiRegionClusterName", "SnapshotArns", "SnapshotName"],
+    "createOnly": [
+      "ClusterName",
+      "DataTiering",
+      "KmsKeyId",
+      "MultiRegionClusterName",
+      "NetworkType",
+      "Port",
+      "SnapshotArns",
+      "SnapshotName",
+      "SubnetGroupName",
+      "TLSEnabled"
+    ],
+    "readOnlyPaths": [
+      "ARN",
+      "ClusterEndpoint.Address",
+      "ClusterEndpoint.Port",
+      "ParameterGroupStatus",
+      "Status"
+    ],
+    "writeOnlyPaths": [
+      "FinalSnapshotName",
+      "MultiRegionClusterName",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "ClusterName",
+      "DataTiering",
+      "KmsKeyId",
+      "MultiRegionClusterName",
+      "NetworkType",
+      "Port",
+      "SnapshotArns",
+      "SnapshotName",
+      "SubnetGroupName",
+      "TLSEnabled"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds", "SnapshotArns"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "ParameterGroupName",
+      "actual": "default.memorydb-redis7",
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "Port",
+      "actual": 6379,
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "SnapshotWindow",
+      "actual": "09:30-10:30",
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "DataTiering",
+      "actual": "false",
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::MemoryDB::Cluster",
+      "path": "MaintenanceWindow",
+      "actual": "fri:07:00-fri:08:00",
+      "physicalId": "cdkrd-memorydb-rich",
+      "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
+    }
+  ]
+}

--- a/tests/corpus/AWS__MemoryDB__SubnetGroup.SubnetGroup.json
+++ b/tests/corpus/AWS__MemoryDB__SubnetGroup.SubnetGroup.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SubnetGroup",
+    "resourceType": "AWS::MemoryDB::SubnetGroup",
+    "physicalId": "cdkrd-memorydb-sng",
+    "constructPath": "CdkRealDriftIntegMemoryDb/SubnetGroup",
+    "declared": {
+      "SubnetGroupName": "cdkrd-memorydb-sng",
+      "SubnetIds": ["subnet-021c456d21966a289", "subnet-0b5e0dd9d989e48f2"]
+    }
+  },
+  "liveRaw": {
+    "SupportedNetworkTypes": ["ipv4"],
+    "SubnetGroupName": "cdkrd-memorydb-sng",
+    "SubnetIds": ["subnet-0b5e0dd9d989e48f2", "subnet-021c456d21966a289"],
+    "ARN": "arn:aws:memorydb:us-east-1:111111111111:subnetgroup/cdkrd-memorydb-sng"
+  },
+  "schema": {
+    "readOnly": ["ARN", "SupportedNetworkTypes"],
+    "writeOnly": [],
+    "createOnly": ["SubnetGroupName"],
+    "readOnlyPaths": ["ARN", "SupportedNetworkTypes"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["SubnetGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SubnetIds", "SupportedNetworkTypes"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/config-rule-rich/app.ts
+++ b/tests/integration/config-rule-rich/app.ts
@@ -1,0 +1,26 @@
+// CDK app for the cdk-real-drift AWS Config ConfigRule governance test. A ConfigRule
+// is a governance control — an out-of-band weakening (a looser rotation age) is
+// exactly the drift cdkrd should catch. AWS rejects any ConfigRule unless a
+// ConfigurationRecorder is active, and the CFn-native recorder hits a well-known
+// create-stabilization deadlock (it waits to be "recording", which needs a delivery
+// channel ordered after it). So verify.sh provisions the recorder + delivery channel
+// via the SDK (no deadlock) and this stack carries ONLY the rule, giving cdkrd a
+// declared side to compare. A freshly deployed + recorded rule MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  ManagedRule,
+  ManagedRuleIdentifiers,
+  MaximumExecutionFrequency,
+} from "aws-cdk-lib/aws-config";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegConfigRule");
+
+new ManagedRule(stack, "Rule", {
+  configRuleName: "cdkrd-access-keys-rotated",
+  identifier: ManagedRuleIdentifiers.ACCESS_KEYS_ROTATED,
+  inputParameters: { maxAccessKeyAge: 90 },
+  maximumExecutionFrequency: MaximumExecutionFrequency.TWENTY_FOUR_HOURS,
+});
+
+app.synth();

--- a/tests/integration/config-rule-rich/cdk.json
+++ b/tests/integration/config-rule-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/config-rule-rich/package.json
+++ b/tests/integration/config-rule-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-config-rule-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift config-rule-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/config-rule-rich/recorder-setup.sh
+++ b/tests/integration/config-rule-rich/recorder-setup.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Shared AWS Config recorder/delivery-channel bootstrap for the config-rule-rich
+# fixture. The CFn-native AWS::Config::ConfigurationRecorder hits a create-time
+# stabilization deadlock (it waits to be "recording", which needs a delivery channel
+# ordered after it), so the recorder + channel are provisioned here via the SDK
+# instead. A ConfigRule cannot exist without an active recorder. Account-singleton:
+# these are torn down by teardown_recorder so the account is left as found.
+export AWS_CLI_AUTO_PROMPT=off
+
+CONF_ROLE=cdkrd-config-recorder-role
+CONF_REC=cdkrd-config-recorder
+CONF_CHAN=cdkrd-config-channel
+
+setup_recorder() {
+  local region="$1"
+  local account bucket
+  account="$(aws sts get-caller-identity --query Account --output text)"
+  bucket="cdkrd-config-${account}-${region}"
+
+  aws iam create-role --role-name "$CONF_ROLE" \
+    --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"config.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+    >/dev/null 2>&1 || true
+  aws iam attach-role-policy --role-name "$CONF_ROLE" \
+    --policy-arn arn:aws:iam::aws:policy/service-role/AWS_ConfigRole >/dev/null 2>&1 || true
+
+  aws s3api create-bucket --bucket "$bucket" --region "$region" >/dev/null 2>&1 || true
+  cat > /tmp/cdkrd-config-bucket-policy.json <<JSON
+{ "Version": "2012-10-17", "Statement": [
+  { "Sid": "AWSConfigBucketPermissionsCheck", "Effect": "Allow",
+    "Principal": { "Service": "config.amazonaws.com" },
+    "Action": ["s3:GetBucketAcl","s3:ListBucket"], "Resource": "arn:aws:s3:::${bucket}" },
+  { "Sid": "AWSConfigBucketDelivery", "Effect": "Allow",
+    "Principal": { "Service": "config.amazonaws.com" },
+    "Action": "s3:PutObject", "Resource": "arn:aws:s3:::${bucket}/AWSLogs/${account}/Config/*",
+    "Condition": { "StringEquals": { "s3:x-amz-acl": "bucket-owner-full-control" } } } ] }
+JSON
+  aws s3api put-bucket-policy --bucket "$bucket" --policy file:///tmp/cdkrd-config-bucket-policy.json >/dev/null
+  # IAM eventual consistency before Config assumes the role
+  sleep 10
+  # JSON (not CLI shorthand): the shorthand coerces recordingGroup.allSupported to the
+  # string "false", which fails parameter validation.
+  cat > /tmp/cdkrd-config-recorder.json <<JSON
+{ "name": "${CONF_REC}", "roleARN": "arn:aws:iam::${account}:role/${CONF_ROLE}",
+  "recordingGroup": { "allSupported": false, "includeGlobalResourceTypes": false, "resourceTypes": ["AWS::IAM::User"] } }
+JSON
+  aws configservice put-configuration-recorder --region "$region" \
+    --configuration-recorder "file:///tmp/cdkrd-config-recorder.json" >/dev/null
+  aws configservice put-delivery-channel --region "$region" \
+    --delivery-channel "name=${CONF_CHAN},s3BucketName=${bucket}" >/dev/null
+  aws configservice start-configuration-recorder --region "$region" \
+    --configuration-recorder-name "$CONF_REC" >/dev/null
+}
+
+teardown_recorder() {
+  local region="$1"
+  local account bucket
+  account="$(aws sts get-caller-identity --query Account --output text)"
+  bucket="cdkrd-config-${account}-${region}"
+  aws configservice stop-configuration-recorder --region "$region" --configuration-recorder-name "$CONF_REC" >/dev/null 2>&1 || true
+  aws configservice delete-delivery-channel --region "$region" --delivery-channel-name "$CONF_CHAN" >/dev/null 2>&1 || true
+  aws configservice delete-configuration-recorder --region "$region" --configuration-recorder-name "$CONF_REC" >/dev/null 2>&1 || true
+  aws s3 rm "s3://${bucket}" --recursive >/dev/null 2>&1 || true
+  aws s3api delete-bucket --bucket "$bucket" --region "$region" >/dev/null 2>&1 || true
+  aws iam detach-role-policy --role-name "$CONF_ROLE" --policy-arn arn:aws:iam::aws:policy/service-role/AWS_ConfigRole >/dev/null 2>&1 || true
+  aws iam delete-role --role-name "$CONF_ROLE" >/dev/null 2>&1 || true
+}

--- a/tests/integration/config-rule-rich/verify-detect.sh
+++ b/tests/integration/config-rule-rich/verify-detect.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# ConfigRule detect integration test (real AWS): the governance-weakening scenario.
+# Provision a recorder (SDK) -> deploy rule -> record -> weaken maxAccessKeyAge
+# 90 -> 365 out of band (someone loosens a rotation rule) -> check MUST DETECT
+# (exit 1, reporting InputParameters.maxAccessKeyAge) -> restore the rule manually.
+#
+# This is DETECT-ONLY: revert is NOT exercised. AWS::Config::ConfigRule stores
+# InputParameters as a JSON STRING, so cdkrd descends into it for a precise nested
+# finding, but the revert's RFC6902 sub-path patch (/InputParameters/maxAccessKeyAge)
+# cannot apply to a string value — revert honestly reports non-convergence rather than
+# silently failing. Reverting into a JSON-string property is a known limitation (a
+# follow-up SDK_WRITERS / whole-property-revert task), like Route53 RecordSet's revert
+# gap. Detection — catching the unauthorized weakening — is the point and works.
+set -uo pipefail
+export AWS_CLI_AUTO_PROMPT=off
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+# shellcheck source=/dev/null
+source "$HERE/recorder-setup.sh"
+STACK=CdkRealDriftIntegConfigRule
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  teardown_recorder "$REGION"
+  rm -rf .cdkrd cdk.out /tmp/config-rule-*.json
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== provision Config recorder (SDK) ==="
+setup_recorder "$REGION" || fail "recorder setup"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: maxAccessKeyAge 90 -> 365 (governance weakening) ==="
+cat > /tmp/config-rule-365.json <<'JSON'
+{ "ConfigRuleName": "cdkrd-access-keys-rotated", "Source": { "Owner": "AWS", "SourceIdentifier": "ACCESS_KEYS_ROTATED" },
+  "InputParameters": "{\"maxAccessKeyAge\":\"365\"}", "MaximumExecutionFrequency": "TwentyFour_Hours" }
+JSON
+aws configservice put-config-rule --region "$REGION" --config-rule file:///tmp/config-rule-365.json || fail "inject drift"
+
+echo "=== check MUST DETECT the weakening ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-config-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "maxAccessKeyAge" /tmp/cdkrd-config-detect.out || fail "weakened parameter not reported"
+
+echo "=== restore the rule to 90 (manual; revert-into-JSON-string is a known gap) ==="
+cat > /tmp/config-rule-90.json <<'JSON'
+{ "ConfigRuleName": "cdkrd-access-keys-rotated", "Source": { "Owner": "AWS", "SourceIdentifier": "ACCESS_KEYS_ROTATED" },
+  "InputParameters": "{\"maxAccessKeyAge\":\"90\"}", "MaximumExecutionFrequency": "TwentyFour_Hours" }
+JSON
+aws configservice put-config-rule --region "$REGION" --config-rule file:///tmp/config-rule-90.json || fail "restore"
+
+echo "=== check MUST be CLEAN after restore ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after restore"
+
+echo "INTEG PASS ($STACK detect)"

--- a/tests/integration/config-rule-rich/verify.sh
+++ b/tests/integration/config-rule-rich/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): provision a Config recorder via SDK,
+# deploy the ConfigRule stack, record baseline, check MUST be CLEAN. A managed
+# ConfigRule's InputParameters round-trips as a JSON string; any declared drift on a
+# clean recorded stack is a normalization FP. The recorder is torn down too.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+# shellcheck source=/dev/null
+source "$HERE/recorder-setup.sh"
+STACK=CdkRealDriftIntegConfigRule
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  teardown_recorder "$REGION"
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] provision Config recorder (SDK) ==="
+setup_recorder "$REGION" || fail "recorder setup"
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/egressonly-rich/app.ts
+++ b/tests/integration/egressonly-rich/app.ts
@@ -1,0 +1,16 @@
+// CDK app for the cdk-real-drift egress-only internet gateway false-positive test.
+// An EgressOnlyInternetGateway is the IPv6 equivalent of a NAT gateway, common on
+// dual-stack VPCs. Cheap. A freshly deployed + recorded EOIGW with NO out-of-band
+// change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnEgressOnlyInternetGateway, CfnVPC, CfnVPCCidrBlock } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEgressOnly");
+
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.73.0.0/16" });
+new CfnVPCCidrBlock(stack, "Ipv6", { vpcId: vpc.ref, amazonProvidedIpv6CidrBlock: true });
+
+new CfnEgressOnlyInternetGateway(stack, "Eoigw", { vpcId: vpc.ref });
+
+app.synth();

--- a/tests/integration/egressonly-rich/cdk.json
+++ b/tests/integration/egressonly-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/egressonly-rich/package.json
+++ b/tests/integration/egressonly-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-egressonly-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift egressonly-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/egressonly-rich/verify.sh
+++ b/tests/integration/egressonly-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any declared drift on a clean recorded stack is a normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEgressOnly
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/memorydb-rich/app.ts
+++ b/tests/integration/memorydb-rich/app.ts
@@ -1,0 +1,45 @@
+// CDK app for the cdk-real-drift MemoryDB false-positive test. MemoryDB (managed
+// Redis/Valkey) is a common cache backend. This exercises a single-node cluster in
+// an isolated VPC with TWO security groups declared in a deliberately non-sorted
+// order (SecurityGroupIds is a set AWS may echo reordered) and a partial
+// EngineVersion (a version-prefix FP probe: does CC echo "7.1" verbatim like
+// ElastiCache, or expand it?). A freshly deployed + recorded cluster with NO
+// out-of-band change MUST report CLEAN.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnSubnetGroup } from "aws-cdk-lib/aws-memorydb";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMemoryDb");
+
+const vpc = new Vpc(stack, "Vpc", {
+  natGateways: 0,
+  maxAzs: 2,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED }],
+});
+
+const sgA = new SecurityGroup(stack, "SgA", { vpc, allowAllOutbound: true });
+const sgB = new SecurityGroup(stack, "SgB", { vpc, allowAllOutbound: true });
+
+const subnetGroup = new CfnSubnetGroup(stack, "SubnetGroup", {
+  subnetGroupName: "cdkrd-memorydb-sng",
+  subnetIds: vpc.selectSubnets({ subnetType: SubnetType.PRIVATE_ISOLATED }).subnetIds,
+});
+
+const cluster = new CfnCluster(stack, "Cluster", {
+  clusterName: "cdkrd-memorydb-rich",
+  nodeType: "db.t4g.small",
+  aclName: "open-access",
+  engine: "redis",
+  engineVersion: "7.1",
+  numShards: 1,
+  numReplicasPerShard: 0,
+  tlsEnabled: true,
+  subnetGroupName: subnetGroup.ref,
+  // declared deliberately non-sorted to expose a SecurityGroupIds set-reorder FP
+  securityGroupIds: [sgB.securityGroupId, sgA.securityGroupId],
+  snapshotRetentionLimit: 1,
+});
+cluster.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/memorydb-rich/cdk.json
+++ b/tests/integration/memorydb-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/memorydb-rich/package.json
+++ b/tests/integration/memorydb-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-memorydb-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift memorydb-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/memorydb-rich/verify-detect.sh
+++ b/tests/integration/memorydb-rich/verify-detect.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# MemoryDB detect + revert integration test (real AWS): deploy -> record -> change a
+# DECLARED MUTABLE prop (SnapshotRetentionLimit) out of band -> check MUST DETECT
+# (exit 1) -> revert -> check CLEAN -> live value restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMemoryDb
+CLUSTER=cdkrd-memorydb-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: SnapshotRetentionLimit 1 -> 5 (console-edit) ==="
+aws memorydb update-cluster --cluster-name "$CLUSTER" --region "$REGION" \
+  --snapshot-retention-limit 5 >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-memorydb-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "SnapshotRetentionLimit" /tmp/cdkrd-memorydb-detect.out || fail "SnapshotRetentionLimit not reported"
+
+echo "=== revert (write declared values back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live SnapshotRetentionLimit MUST be restored to 1 ==="
+GOT="$(aws memorydb describe-clusters --cluster-name "$CLUSTER" --region "$REGION" \
+  --query "Clusters[0].SnapshotRetentionLimit" --output text)"
+[ "$GOT" = "1" ] || fail "live value not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/memorydb-rich/verify.sh
+++ b/tests/integration/memorydb-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A MemoryDB cluster carries a SecurityGroupIds set (declared
+# non-sorted) AWS may echo reordered and a partial EngineVersion; any declared
+# drift on a clean recorded stack is a normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMemoryDb
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/vpcpeering-rich/app.ts
+++ b/tests/integration/vpcpeering-rich/app.ts
@@ -1,0 +1,19 @@
+// CDK app for the cdk-real-drift VPC peering false-positive test. A
+// VPCPeeringConnection between two same-account same-region VPCs is a common
+// multi-VPC primitive. Cheap (no NAT/IGW). A freshly deployed + recorded peering
+// with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnVPC, CfnVPCPeeringConnection } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegVpcPeering");
+
+const vpcA = new CfnVPC(stack, "VpcA", { cidrBlock: "10.71.0.0/16" });
+const vpcB = new CfnVPC(stack, "VpcB", { cidrBlock: "10.72.0.0/16" });
+
+new CfnVPCPeeringConnection(stack, "Peering", {
+  vpcId: vpcA.ref,
+  peerVpcId: vpcB.ref,
+});
+
+app.synth();

--- a/tests/integration/vpcpeering-rich/cdk.json
+++ b/tests/integration/vpcpeering-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/vpcpeering-rich/package.json
+++ b/tests/integration/vpcpeering-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-vpcpeering-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift vpcpeering-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/vpcpeering-rich/verify.sh
+++ b/tests/integration/vpcpeering-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any declared drift on a clean recorded stack is a normalization FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegVpcPeering
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -438,6 +438,16 @@ describe('noise suppressors', () => {
       AutoMinorVersionUpgrade: true,
       SnapshotRetentionLimit: 0,
     });
+    expect(KNOWN_DEFAULTS['AWS::MemoryDB::Cluster']).toEqual({
+      Port: 6379,
+      AutoMinorVersionUpgrade: true,
+      DataTiering: 'false',
+      NetworkType: 'ipv4',
+      IpDiscovery: 'ipv4',
+    });
+    expect(KNOWN_DEFAULTS['AWS::Config::ConfigRule']).toEqual({
+      EvaluationModes: [{ Mode: 'DETECTIVE' }],
+    });
     expect(KNOWN_DEFAULTS['AWS::RDS::DBProxy']).toEqual({
       TargetConnectionNetworkType: 'IPV4',
       DefaultAuthScheme: 'NONE',
@@ -505,6 +515,10 @@ describe('noise suppressors', () => {
       LogGroupClass: 'STANDARD',
       DeletionProtectionEnabled: false,
       BearerTokenAuthenticationEnabled: false,
+    });
+    expect(KNOWN_DEFAULTS['AWS::EC2::VPC']).toEqual({
+      InstanceTenancy: 'default',
+      EnableDnsSupport: true,
     });
     expect(KNOWN_DEFAULTS['AWS::EC2::Subnet'].AssignIpv6AddressOnCreation).toBe(false);
     expect(KNOWN_DEFAULTS['AWS::EC2::Subnet'].EnableDns64).toBe(false);


### PR DESCRIPTION
## What

A pre-release coverage round (deploy uncovered common types → catch FP/FN, fold first-run noise). No tool bug this time — the value is a ubiquitous-type noise fold, four new common-type fixtures with FP/FN proven live, and six golden-corpus cases.

## Noise folds (KNOWN_DEFAULTS — shrink first-run `[Potential Drift]`)

- **`AWS::EC2::VPC`** (ubiquitous — in nearly every stack): `InstanceTenancy="default"`, `EnableDnsSupport=true`. Observed live; equality-gated.
- **`AWS::MemoryDB::Cluster`**: `Port=6379`, `AutoMinorVersionUpgrade=true`, `DataTiering="false"`, `NetworkType="ipv4"`, `IpDiscovery="ipv4"`.
- **`AWS::Config::ConfigRule`**: `EvaluationModes=[{Mode:"DETECTIVE"}]`.

Each shrank a real fresh-deploy inventory (e.g. MemoryDB 12→7 potential drift; VPC peering 6→2).

## Fixtures + corpus (live-proven on us-east-1)

- **`memorydb-rich`** (managed Redis, common cache): FP-clean (EngineVersion `"7.1"` does NOT FP — Cloud Control echoes the partial verbatim, as predicted from the ElastiCache lesson; SecurityGroupIds does not reorder), and **detect→revert→restore** proven (SnapshotRetentionLimit out-of-band edit; revertable via Cloud Control).
- **`config-rule-rich`** (AWS Config governance): FP-clean, and the **governance-weakening detect** proven (out-of-band `maxAccessKeyAge` 90→365 → `check` exits 1). Self-contained recorder is provisioned via SDK in `verify.sh` (the CFn-native `ConfigurationRecorder` hits a create-stabilization deadlock); detect-only because reverting INTO a JSON-string property (`InputParameters`) isn't supported yet — revert honestly reports non-convergence (documented).
- **`vpcpeering-rich`**, **`egressonly-rich`** (common networking): FP-clean (the VPC fold covers their noise).
- Six corpus cases: MemoryDB Cluster/SubnetGroup, VPCPeeringConnection, EgressOnlyInternetGateway, ConfigRule, and a raw-VPC case pinning the new fold.

## Docs

`docs/limitations.md`: documented the known CC-unreadable common types that surface as `skipped` (ACM Certificate, ELBv2 ListenerCertificate, CloudWatch AnomalyDetector/InsightRule, EC2 VPCCidrBlock) and the ConfigRule revert-into-JSON-string limitation.

## Deliberately deferred (with reasoning)

- **CloudWatch AnomalyDetector / InsightRule SDK overrides** — confirmed CC read-gaps + read shapes harvested, but closing them needs a new `@aws-sdk/client-cloudwatch` dependency for niche observability types (AnomalyDetector also has a fragile multi-shape model). Documented as SDK-override candidates.
- **EC2 VPCCidrBlock** — composite-id read-gap, but an immutable association (nothing can drift); documented.
- **Config / MemoryDB version FP, SG reorder** — ruled out (offline prediction confirmed live).

## Tests

- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (1681 tests, +6 corpus-replay + 4 fold assertions) green.
- All deployed stacks torn down with `delstack`; the SDK-provisioned Config recorder/channel/bucket/role removed; `sweep-orphans.sh` SWEEP CLEAN.
