### PR TITLE
fix(noise): fold AWS-sorted set reorders (ECS Links, Backup ListOfTags, ALB conditions, ASG metrics)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1648,9 +1648,21 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   // keyed by SourceContainer) is reordered the same way — declared [logger, app] reads
   // back [app, logger] — observed on a fresh ecs-taskdef-mounts deploy; MountPoints and
   // SystemControls on the same container were NOT reordered, so they are not listed.
+  // A container's legacy bridge-mode `Links` is a nested SCALAR set (`name:alias`
+  // strings) that ECS echoes SORTED alphabetically, not in template order (declared
+  // [logger:log, init:setup] reads back [init:setup, logger:log]), so a positional
+  // compare false-flags the identical link set on every check of a freshly recorded
+  // task def. The values aren't id/ARN/HTTP/AZ-shaped, so canonicalizeIdArraysDeep
+  // leaves them; sortNestedObjectArrays sorts a scalar array by canonical JSON, so the
+  // same machinery that aligns PortMappings aligns it. A genuine link add/remove still
+  // changes the multiset. Observed live on a fresh ecs-taskdef-sets deploy (DependsOn,
+  // ExtraHosts, DockerSecurityOptions, DnsServers, and task-level PlacementConstraints
+  // were declared non-sorted in the SAME deploy and ECS PRESERVED their order, so they
+  // are deliberately NOT listed — observed-only).
   'AWS::ECS::TaskDefinition': new Set([
     'ContainerDefinitions.PortMappings',
     'ContainerDefinitions.VolumesFrom',
+    'ContainerDefinitions.Links',
   ]),
   // DynamoDB sorts an INCLUDE-projection `NonKeyAttributes` set into its own canonical
   // order: declared ["zeta","alpha","mike","bravo"] reads back reordered, a positional
@@ -1682,7 +1694,56 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   // non-sorted set and ALB PRESERVED its order, so it is NOT listed — observed-only.)
   // `Conditions` is ALSO an UNORDERED_OBJECT_ARRAY_PROPS set; classify composes the
   // two — inner Values sorted first, then the Conditions array sorted by canonical JSON.
-  'AWS::ElasticLoadBalancingV2::ListenerRule': new Set(['Conditions.PathPatternConfig.Values']),
+  // A source-ip condition's `SourceIpConfig.Values` (a CIDR set) and an http-header
+  // condition's `HttpHeaderConfig.Values` (a header-value-string set) are reordered the
+  // same way — observed live on a fresh elbv2-rule-conditions deploy (declared
+  // [10.3/16, 10.1/16, 10.2/16] read back [10.3/16, 10.2/16, 10.1/16]; declared
+  // [zeta, alpha, mike] read back [zeta, mike, alpha]). Both are OR'd value SETS (a
+  // request matches if ANY value matches), so order carries no meaning. CIDRs and
+  // header-value strings aren't id/ARN/HTTP/AZ-shaped, so canonicalizeIdArraysDeep leaves
+  // them. (`QueryStringConfig.Values` was reordered in the SAME deploy too, but its
+  // elements are {Key, Value} pairs — Key IS an IDENTITY_FIELD, so canonicalizeTagListsDeep
+  // already aligns them; `HttpRequestMethodConfig.Values` is a set of HTTP verbs the
+  // generic isHttpMethod sort folds — neither needs a table entry. HostHeaderConfig.Values
+  // was observed order-PRESERVING in the earlier elbv2-rule-values deploy.)
+  'AWS::ElasticLoadBalancingV2::ListenerRule': new Set([
+    'Conditions.PathPatternConfig.Values',
+    'Conditions.SourceIpConfig.Values',
+    'Conditions.HttpHeaderConfig.Values',
+  ]),
+  // A BackupSelection's tag-based membership `BackupSelection.ListOfTags` is a SET of
+  // {ConditionKey, ConditionType, ConditionValue} that AWS Backup echoes SORTED by
+  // ConditionKey, not in template order (declared [zeta, alpha, mike] reads back
+  // [alpha, mike, zeta]), so a positional compare false-flags every shifted condition's
+  // ConditionKey AND ConditionValue as declared drift on a freshly recorded selection.
+  // ConditionKey is NOT an IDENTITY_FIELD (Key/Id/AttributeName/IndexName/Name), so the
+  // keyed canonicalizer can't align it. The set is nested one OBJECT level under the
+  // top-level `BackupSelection` key (not under an array), like Bedrock Guardrail's
+  // ContentPolicyConfig.FiltersConfig — sortNestedObjectArrays sorts the object array by
+  // canonical JSON, aligning equal conditions; a genuine condition add/remove/change
+  // still differs. Observed live on a fresh backup-selection deploy. (The sibling
+  // `BackupSelection.Conditions.StringEquals` — the newer condition shape — was declared
+  // non-sorted in the SAME deploy and AWS PRESERVED its order, so it is deliberately NOT
+  // listed — observed-only.)
+  'AWS::Backup::BackupSelection': new Set(['BackupSelection.ListOfTags']),
+  // An EC2 Auto Scaling group's `MetricsCollection[].Metrics` (the group metrics to
+  // enable) and `NotificationConfigurations[].NotificationTypes` (the lifecycle events to
+  // publish to SNS) are scalar enum SETs nested under their respective arrays that AWS
+  // echoes SORTED alphabetically, not in template order (declared
+  // [GroupTotalInstances, GroupDesiredCapacity, GroupMaxSize, GroupMinSize] reads back
+  // [GroupDesiredCapacity, GroupMaxSize, GroupMinSize, GroupTotalInstances]; declared
+  // [TERMINATE, LAUNCH, LAUNCH_ERROR] reads back [LAUNCH, LAUNCH_ERROR, TERMINATE]), so a
+  // positional compare false-flags the identical set as declared drift on a freshly
+  // recorded ASG. The tokens aren't id/ARN/HTTP/AZ-shaped, so canonicalizeIdArraysDeep
+  // leaves them; the schema marks both insertionOrder:false but the scalar auto-fold skips
+  // array-crossing (`*`) paths, so they need this per-type entry. sortNestedObjectArrays
+  // crosses the MetricsCollection / NotificationConfigurations array and sorts the inner
+  // scalar set; a genuine metric/event add/remove still differs. Observed live on a fresh
+  // asg-notification-metrics deploy.
+  'AWS::AutoScaling::AutoScalingGroup': new Set([
+    'MetricsCollection.Metrics',
+    'NotificationConfigurations.NotificationTypes',
+  ]),
 };
 
 // Return a deep clone of `value` (a declared/live property subtree rooted at one

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2145,6 +2145,173 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('ELBv2 ListenerRule SourceIp/HttpHeader/QueryString condition Values (found by elbv2-rule-conditions)', () => {
+    const T = 'AWS::ElasticLoadBalancingV2::ListenerRule';
+
+    it('a source-ip CIDR Values set returned reordered is NOT drift', () => {
+      const declared = {
+        Conditions: [
+          {
+            Field: 'source-ip',
+            SourceIpConfig: { Values: ['10.3.0.0/16', '10.1.0.0/16', '10.2.0.0/16'] },
+          },
+        ],
+      };
+      const live = {
+        Conditions: [
+          {
+            Field: 'source-ip',
+            SourceIpConfig: { Values: ['10.3.0.0/16', '10.2.0.0/16', '10.1.0.0/16'] },
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('an http-header Values set returned reordered is NOT drift', () => {
+      const declared = {
+        Conditions: [
+          {
+            Field: 'http-header',
+            HttpHeaderConfig: { HttpHeaderName: 'X-Cdkrd', Values: ['zeta', 'alpha', 'mike'] },
+          },
+        ],
+      };
+      const live = {
+        Conditions: [
+          {
+            Field: 'http-header',
+            HttpHeaderConfig: { HttpHeaderName: 'X-Cdkrd', Values: ['zeta', 'mike', 'alpha'] },
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a query-string {Key,Value} set returned reordered is NOT drift (Key is an IDENTITY_FIELD, auto-aligned)', () => {
+      const declared = {
+        Conditions: [
+          {
+            Field: 'query-string',
+            QueryStringConfig: {
+              Values: [
+                { Key: 'zeta', Value: '1' },
+                { Key: 'alpha', Value: '2' },
+                { Key: 'mike', Value: '3' },
+              ],
+            },
+          },
+        ],
+      };
+      const live = {
+        Conditions: [
+          {
+            Field: 'query-string',
+            QueryStringConfig: {
+              Values: [
+                { Key: 'mike', Value: '3' },
+                { Key: 'alpha', Value: '2' },
+                { Key: 'zeta', Value: '1' },
+              ],
+            },
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine source-ip CIDR change still surfaces (no over-fold)', () => {
+      const declared = {
+        Conditions: [
+          { Field: 'source-ip', SourceIpConfig: { Values: ['10.3.0.0/16', '10.1.0.0/16'] } },
+        ],
+      };
+      const live = {
+        Conditions: [
+          { Field: 'source-ip', SourceIpConfig: { Values: ['10.9.0.0/16', '10.1.0.0/16'] } }, // 10.3 -> 10.9
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('AutoScaling group MetricsCollection.Metrics / NotificationConfigurations.NotificationTypes reordered (nested scalar sets, found by asg-notification-metrics)', () => {
+    const T = 'AWS::AutoScaling::AutoScalingGroup';
+
+    it('a MetricsCollection Metrics set returned alphabetically sorted is NOT drift', () => {
+      const declared = {
+        MetricsCollection: [
+          {
+            Granularity: '1Minute',
+            Metrics: [
+              'GroupTotalInstances',
+              'GroupDesiredCapacity',
+              'GroupMaxSize',
+              'GroupMinSize',
+            ],
+          },
+        ],
+      };
+      const live = {
+        MetricsCollection: [
+          {
+            Granularity: '1Minute',
+            Metrics: [
+              'GroupDesiredCapacity',
+              'GroupMaxSize',
+              'GroupMinSize',
+              'GroupTotalInstances',
+            ],
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a NotificationConfigurations NotificationTypes set returned sorted is NOT drift', () => {
+      const declared = {
+        NotificationConfigurations: [
+          {
+            TopicARN: 'arn:aws:sns:us-east-1:111111111111:t',
+            NotificationTypes: [
+              'autoscaling:EC2_INSTANCE_TERMINATE',
+              'autoscaling:EC2_INSTANCE_LAUNCH',
+              'autoscaling:EC2_INSTANCE_LAUNCH_ERROR',
+            ],
+          },
+        ],
+      };
+      const live = {
+        NotificationConfigurations: [
+          {
+            TopicARN: 'arn:aws:sns:us-east-1:111111111111:t',
+            NotificationTypes: [
+              'autoscaling:EC2_INSTANCE_LAUNCH',
+              'autoscaling:EC2_INSTANCE_LAUNCH_ERROR',
+              'autoscaling:EC2_INSTANCE_TERMINATE',
+            ],
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine metric add still surfaces (no over-fold)', () => {
+      const declared = {
+        MetricsCollection: [{ Granularity: '1Minute', Metrics: ['GroupMaxSize', 'GroupMinSize'] }],
+      };
+      const live = {
+        MetricsCollection: [
+          {
+            Granularity: '1Minute',
+            Metrics: ['GroupMinSize', 'GroupMaxSize', 'GroupInServiceInstances'],
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('Bedrock Guardrail nested policy-config arrays (reordered, found by bedrock-guardrail-rich)', () => {
     const T = 'AWS::Bedrock::Guardrail';
     const declared = {
@@ -2289,6 +2456,75 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
             ],
           },
         ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('ECS TaskDefinition Links reordered inside a container (nested scalar set, found by ecs-taskdef-sets)', () => {
+    const T = 'AWS::ECS::TaskDefinition';
+    // `Links` is a SCALAR set (`name:alias` strings) nested under the
+    // ContainerDefinitions ARRAY — like DynamoDB NonKeyAttributes but the values
+    // aren't id/ARN/HTTP/AZ-shaped, so canonicalizeIdArraysDeep leaves them; ECS
+    // echoes them sorted alphabetically.
+    const declared = {
+      ContainerDefinitions: [{ Name: 'app', Links: ['logger:log', 'init:setup'] }],
+    };
+
+    it('AWS returning a container Links set sorted alphabetically is NOT drift', () => {
+      const live = {
+        ContainerDefinitions: [{ Name: 'app', Links: ['init:setup', 'logger:log'] }],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine link add still surfaces (no over-fold)', () => {
+      const live = {
+        ContainerDefinitions: [{ Name: 'app', Links: ['init:setup', 'logger:log', 'cache:redis'] }],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Backup BackupSelection ListOfTags reordered (object set keyed by ConditionKey ∉ IDENTITY_FIELDS, found by backup-selection)', () => {
+    const T = 'AWS::Backup::BackupSelection';
+    // The set is nested one OBJECT level under the top-level `BackupSelection` key — AWS
+    // Backup echoes it sorted by ConditionKey, which is NOT an IDENTITY_FIELD.
+    const declared = {
+      BackupSelection: {
+        SelectionName: 'sel',
+        ListOfTags: [
+          { ConditionType: 'STRINGEQUALS', ConditionKey: 'zeta', ConditionValue: '1' },
+          { ConditionType: 'STRINGEQUALS', ConditionKey: 'alpha', ConditionValue: '2' },
+          { ConditionType: 'STRINGEQUALS', ConditionKey: 'mike', ConditionValue: '3' },
+        ],
+      },
+    };
+
+    it('AWS returning ListOfTags sorted by ConditionKey is NOT drift', () => {
+      const live = {
+        BackupSelection: {
+          SelectionName: 'sel',
+          ListOfTags: [
+            { ConditionType: 'STRINGEQUALS', ConditionKey: 'alpha', ConditionValue: '2' },
+            { ConditionType: 'STRINGEQUALS', ConditionKey: 'mike', ConditionValue: '3' },
+            { ConditionType: 'STRINGEQUALS', ConditionKey: 'zeta', ConditionValue: '1' },
+          ],
+        },
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine ConditionValue change still surfaces (no over-fold)', () => {
+      const live = {
+        BackupSelection: {
+          SelectionName: 'sel',
+          ListOfTags: [
+            { ConditionType: 'STRINGEQUALS', ConditionKey: 'alpha', ConditionValue: '9' }, // 2 -> 9
+            { ConditionType: 'STRINGEQUALS', ConditionKey: 'mike', ConditionValue: '3' },
+            { ConditionType: 'STRINGEQUALS', ConditionKey: 'zeta', ConditionValue: '1' },
+          ],
+        },
       };
       expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
     });

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgNotifMetrics.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgNotifMetrics.json
@@ -1,0 +1,263 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AsgASGD1D7B4E2",
+    "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+    "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+    "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG",
+    "declared": {
+      "DesiredCapacity": "0",
+      "LaunchTemplate": {
+        "LaunchTemplateId": "lt-0b120d1d8aa764306",
+        "Version": "__cdkrd_corpus_unresolved__"
+      },
+      "MaxSize": "4",
+      "MetricsCollection": [
+        {
+          "Granularity": "1Minute",
+          "Metrics": ["GroupTotalInstances", "GroupDesiredCapacity", "GroupMaxSize", "GroupMinSize"]
+        }
+      ],
+      "MinSize": "0",
+      "NotificationConfigurations": [
+        {
+          "NotificationTypes": [
+            "autoscaling:EC2_INSTANCE_TERMINATE",
+            "autoscaling:EC2_INSTANCE_LAUNCH",
+            "autoscaling:EC2_INSTANCE_LAUNCH_ERROR"
+          ],
+          "TopicARN": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegAsgNotificationMetrics-TopicBFC7AF6E-QltHFKATBD6x"
+        }
+      ],
+      "VPCZoneIdentifier": ["subnet-0706a713159293eeb", "subnet-024caa6a688f4b709"]
+    }
+  },
+  "liveRaw": {
+    "LoadBalancerNames": [],
+    "ServiceLinkedRoleARN": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+    "TargetGroupARNs": [],
+    "AvailabilityZoneIds": ["use1-az1", "use1-az2"],
+    "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:111111111111:autoScalingGroup:922c9b12-0541-42f9-8913-8c465092bf9a:autoScalingGroupName/CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+    "Cooldown": "300",
+    "NotificationConfigurations": [
+      {
+        "TopicARN": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegAsgNotificationMetrics-TopicBFC7AF6E-QltHFKATBD6x",
+        "NotificationTypes": [
+          "autoscaling:EC2_INSTANCE_LAUNCH",
+          "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+          "autoscaling:EC2_INSTANCE_TERMINATE"
+        ]
+      }
+    ],
+    "AvailabilityZones": ["us-east-1a", "us-east-1b"],
+    "AvailabilityZoneDistribution": {
+      "CapacityDistributionStrategy": "balanced-best-effort"
+    },
+    "DesiredCapacity": "0",
+    "HealthCheckGracePeriod": 0,
+    "MetricsCollection": [
+      {
+        "Metrics": ["GroupDesiredCapacity", "GroupMaxSize", "GroupMinSize", "GroupTotalInstances"],
+        "Granularity": "1Minute"
+      }
+    ],
+    "InstanceLifecyclePolicy": {
+      "RetentionTriggers": {
+        "TerminateHookAbandon": "terminate"
+      }
+    },
+    "MaxSize": "4",
+    "NewInstancesProtectedFromScaleIn": false,
+    "MinSize": "0",
+    "TerminationPolicies": ["Default"],
+    "LaunchTemplate": {
+      "LaunchTemplateName": "LtFD2A8520_7b9zWcu1KwOs",
+      "Version": "1",
+      "LaunchTemplateId": "lt-0b120d1d8aa764306"
+    },
+    "AutoScalingGroupName": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+    "VPCZoneIdentifier": ["subnet-024caa6a688f4b709", "subnet-0706a713159293eeb"],
+    "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "default"
+    },
+    "Tags": [
+      {
+        "ResourceId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+        "Value": "AsgASGD1D7B4E2",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:logical-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAsgNotificationMetrics/85561180-724b-11f1-bd1d-1213b3172849",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+        "Value": "CdkRealDriftIntegAsgNotificationMetrics",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-name",
+        "PropagateAtLaunch": true
+      }
+    ],
+    "HealthCheckType": "EC2"
+  },
+  "schema": {
+    "readOnly": ["AutoScalingGroupARN"],
+    "writeOnly": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnly": [
+      "AutoScalingGroupName",
+      "InstanceId",
+      "LaunchConfigurationName",
+      "LaunchTemplate",
+      "MixedInstancesPolicy",
+      "VPCZoneIdentifier"
+    ],
+    "readOnlyPaths": ["AutoScalingGroupARN"],
+    "writeOnlyPaths": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnlyPaths": [
+      "AutoScalingGroupName",
+      "InstanceId",
+      "LaunchConfigurationName",
+      "LaunchTemplate",
+      "MixedInstancesPolicy",
+      "VPCZoneIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AvailabilityZoneIds",
+      "AvailabilityZones",
+      "NotificationConfiguration.NotificationTypes",
+      "TargetGroupARNs",
+      "VPCZoneIdentifier"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LaunchTemplate",
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "ServiceLinkedRoleARN",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneIds",
+      "actual": ["use1-az1", "use1-az2"],
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Cooldown",
+      "actual": "300",
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b"],
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneDistribution",
+      "actual": {
+        "CapacityDistributionStrategy": "balanced-best-effort"
+      },
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckGracePeriod",
+      "actual": 0,
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "InstanceLifecyclePolicy",
+      "actual": {
+        "RetentionTriggers": {
+          "TerminateHookAbandon": "terminate"
+        }
+      },
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "TerminationPolicies",
+      "actual": ["Default"],
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "CapacityReservationSpecification",
+      "actual": {
+        "CapacityReservationPreference": "default"
+      },
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckType",
+      "actual": "EC2",
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LaunchTemplate.LaunchTemplateName",
+      "actual": "LtFD2A8520_7b9zWcu1KwOs",
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegAsgNotificationMetrics-AsgASGD1D7B4E2-zZo59QLDGeAt",
+      "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Backup__BackupSelection.SelByConditions.json
+++ b/tests/corpus/AWS__Backup__BackupSelection.SelByConditions.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SelByConditions",
+    "resourceType": "AWS::Backup::BackupSelection",
+    "physicalId": "4deca915-4829-4ec0-99d0-26e6785b9ca8_0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+    "constructPath": "CdkRealDriftIntegBackupSelection/SelByConditions",
+    "declared": {
+      "BackupPlanId": "0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+      "BackupSelection": {
+        "Conditions": {
+          "StringEquals": [
+            {
+              "ConditionKey": "aws:ResourceTag/zebra",
+              "ConditionValue": "x"
+            },
+            {
+              "ConditionKey": "aws:ResourceTag/apple",
+              "ConditionValue": "y"
+            },
+            {
+              "ConditionKey": "aws:ResourceTag/mango",
+              "ConditionValue": "z"
+            }
+          ]
+        },
+        "IamRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegBackupSelection-BackupRoleF43CFD90-Na7hrdoHDO3j",
+        "Resources": ["arn:aws:ec2:*:*:instance/*"],
+        "SelectionName": "cdkrd-by-conditions"
+      }
+    }
+  },
+  "liveRaw": {
+    "BackupSelection": {
+      "ListOfTags": [],
+      "NotResources": [],
+      "SelectionName": "cdkrd-by-conditions",
+      "IamRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegBackupSelection-BackupRoleF43CFD90-Na7hrdoHDO3j",
+      "Resources": ["arn:aws:ec2:*:*:instance/*"],
+      "Conditions": {
+        "StringEquals": [
+          {
+            "ConditionValue": "x",
+            "ConditionKey": "aws:ResourceTag/zebra"
+          },
+          {
+            "ConditionValue": "y",
+            "ConditionKey": "aws:ResourceTag/apple"
+          },
+          {
+            "ConditionValue": "z",
+            "ConditionKey": "aws:ResourceTag/mango"
+          }
+        ],
+        "StringNotLike": [],
+        "StringLike": [],
+        "StringNotEquals": []
+      }
+    },
+    "BackupPlanId": "0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+    "Id": "4deca915-4829-4ec0-99d0-26e6785b9ca8_0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+    "SelectionId": "4deca915-4829-4ec0-99d0-26e6785b9ca8"
+  },
+  "schema": {
+    "readOnly": ["Id", "SelectionId"],
+    "writeOnly": [],
+    "createOnly": ["BackupPlanId", "BackupSelection"],
+    "readOnlyPaths": ["Id", "SelectionId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["BackupPlanId", "BackupSelection"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["BackupSelection.NotResources", "BackupSelection.Resources"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Backup__BackupSelection.SelByTags.json
+++ b/tests/corpus/AWS__Backup__BackupSelection.SelByTags.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SelByTags",
+    "resourceType": "AWS::Backup::BackupSelection",
+    "physicalId": "4c4b5fa7-c723-447e-8c00-875603b6340b_0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+    "constructPath": "CdkRealDriftIntegBackupSelection/SelByTags",
+    "declared": {
+      "BackupPlanId": "0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+      "BackupSelection": {
+        "IamRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegBackupSelection-BackupRoleF43CFD90-Na7hrdoHDO3j",
+        "ListOfTags": [
+          {
+            "ConditionKey": "zeta",
+            "ConditionType": "STRINGEQUALS",
+            "ConditionValue": "1"
+          },
+          {
+            "ConditionKey": "alpha",
+            "ConditionType": "STRINGEQUALS",
+            "ConditionValue": "2"
+          },
+          {
+            "ConditionKey": "mike",
+            "ConditionType": "STRINGEQUALS",
+            "ConditionValue": "3"
+          }
+        ],
+        "SelectionName": "cdkrd-by-tags"
+      }
+    }
+  },
+  "liveRaw": {
+    "BackupSelection": {
+      "ListOfTags": [
+        {
+          "ConditionValue": "2",
+          "ConditionKey": "alpha",
+          "ConditionType": "STRINGEQUALS"
+        },
+        {
+          "ConditionValue": "3",
+          "ConditionKey": "mike",
+          "ConditionType": "STRINGEQUALS"
+        },
+        {
+          "ConditionValue": "1",
+          "ConditionKey": "zeta",
+          "ConditionType": "STRINGEQUALS"
+        }
+      ],
+      "NotResources": [],
+      "SelectionName": "cdkrd-by-tags",
+      "IamRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegBackupSelection-BackupRoleF43CFD90-Na7hrdoHDO3j",
+      "Resources": [],
+      "Conditions": {
+        "StringEquals": [],
+        "StringNotLike": [],
+        "StringLike": [],
+        "StringNotEquals": []
+      }
+    },
+    "BackupPlanId": "0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+    "Id": "4c4b5fa7-c723-447e-8c00-875603b6340b_0f4627f1-a94a-403e-80d2-ffc0be51e51d",
+    "SelectionId": "4c4b5fa7-c723-447e-8c00-875603b6340b"
+  },
+  "schema": {
+    "readOnly": ["Id", "SelectionId"],
+    "writeOnly": [],
+    "createOnly": ["BackupPlanId", "BackupSelection"],
+    "readOnlyPaths": ["Id", "SelectionId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["BackupPlanId", "BackupSelection"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["BackupSelection.NotResources", "BackupSelection.Resources"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ECS__TaskDefinition.TaskDef.sets.json
+++ b/tests/corpus/AWS__ECS__TaskDefinition.TaskDef.sets.json
@@ -1,0 +1,275 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TaskDef",
+    "resourceType": "AWS::ECS::TaskDefinition",
+    "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-ecs-taskdef-sets:1",
+    "constructPath": "CdkRealDriftIntegEcsTaskDefSets/TaskDef",
+    "declared": {
+      "ContainerDefinitions": [
+        {
+          "Essential": false,
+          "Image": "public.ecr.aws/nginx/nginx:latest",
+          "MemoryReservation": 64,
+          "Name": "init"
+        },
+        {
+          "Essential": false,
+          "Image": "public.ecr.aws/nginx/nginx:latest",
+          "MemoryReservation": 64,
+          "Name": "logger"
+        },
+        {
+          "DependsOn": [
+            {
+              "Condition": "START",
+              "ContainerName": "logger"
+            },
+            {
+              "Condition": "START",
+              "ContainerName": "init"
+            }
+          ],
+          "DnsServers": ["10.0.0.3", "10.0.0.2"],
+          "DockerSecurityOptions": ["label:user:nginx", "label:role:webapp"],
+          "Essential": true,
+          "ExtraHosts": [
+            {
+              "Hostname": "zeta.internal",
+              "IpAddress": "10.0.0.9"
+            },
+            {
+              "Hostname": "alpha.internal",
+              "IpAddress": "10.0.0.8"
+            }
+          ],
+          "Image": "public.ecr.aws/nginx/nginx:latest",
+          "Links": ["logger:log", "init:setup"],
+          "MemoryReservation": 256,
+          "Name": "app"
+        }
+      ],
+      "Cpu": "256",
+      "Family": "cdkrd-ecs-taskdef-sets",
+      "Memory": "512",
+      "NetworkMode": "bridge",
+      "PlacementConstraints": [
+        {
+          "Expression": "attribute:ecs.os-type == linux",
+          "Type": "memberOf"
+        },
+        {
+          "Expression": "attribute:ecs.instance-type =~ t3.*",
+          "Type": "memberOf"
+        }
+      ],
+      "RequiresCompatibilities": ["EC2"]
+    }
+  },
+  "liveRaw": {
+    "Volumes": [],
+    "InferenceAccelerators": [],
+    "Memory": "512",
+    "PlacementConstraints": [
+      {
+        "Type": "memberOf",
+        "Expression": "attribute:ecs.os-type == linux"
+      },
+      {
+        "Type": "memberOf",
+        "Expression": "attribute:ecs.instance-type =~ t3.*"
+      }
+    ],
+    "ContainerDefinitions": [
+      {
+        "MemoryReservation": 64,
+        "ExtraHosts": [],
+        "Secrets": [],
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": [],
+        "Image": "public.ecr.aws/nginx/nginx:latest",
+        "Essential": false,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "logger",
+        "MountPoints": [],
+        "DependsOn": [],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": [],
+        "SystemControls": [],
+        "Command": [],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": [],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      },
+      {
+        "MemoryReservation": 64,
+        "ExtraHosts": [],
+        "Secrets": [],
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": [],
+        "Image": "public.ecr.aws/nginx/nginx:latest",
+        "Essential": false,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "init",
+        "MountPoints": [],
+        "DependsOn": [],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": [],
+        "SystemControls": [],
+        "Command": [],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": [],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      },
+      {
+        "MemoryReservation": 256,
+        "ExtraHosts": [
+          {
+            "Hostname": "zeta.internal",
+            "IpAddress": "10.0.0.9"
+          },
+          {
+            "Hostname": "alpha.internal",
+            "IpAddress": "10.0.0.8"
+          }
+        ],
+        "Secrets": [],
+        "VolumesFrom": [],
+        "Cpu": 0,
+        "EntryPoint": [],
+        "DnsServers": ["10.0.0.3", "10.0.0.2"],
+        "Image": "public.ecr.aws/nginx/nginx:latest",
+        "Essential": true,
+        "ResourceRequirements": [],
+        "EnvironmentFiles": [],
+        "Name": "app",
+        "MountPoints": [],
+        "DependsOn": [
+          {
+            "Condition": "START",
+            "ContainerName": "logger"
+          },
+          {
+            "Condition": "START",
+            "ContainerName": "init"
+          }
+        ],
+        "DockerLabels": {},
+        "PortMappings": [],
+        "DockerSecurityOptions": ["label:user:nginx", "label:role:webapp"],
+        "SystemControls": [],
+        "Command": [],
+        "DnsSearchDomains": [],
+        "Environment": [],
+        "Links": ["init:setup", "logger:log"],
+        "CredentialSpecs": [],
+        "Ulimits": []
+      }
+    ],
+    "Family": "cdkrd-ecs-taskdef-sets",
+    "Cpu": "256",
+    "RequiresCompatibilities": ["EC2"],
+    "NetworkMode": "bridge",
+    "Tags": [],
+    "TaskDefinitionArn": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-ecs-taskdef-sets:1"
+  },
+  "schema": {
+    "readOnly": ["TaskDefinitionArn"],
+    "writeOnly": [],
+    "createOnly": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "readOnlyPaths": ["TaskDefinitionArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "ContainerDefinitions",
+      "Cpu",
+      "EnableFaultInjection",
+      "EphemeralStorage",
+      "ExecutionRoleArn",
+      "Family",
+      "InferenceAccelerators",
+      "IpcMode",
+      "Memory",
+      "NetworkMode",
+      "PidMode",
+      "PlacementConstraints",
+      "ProxyConfiguration",
+      "RequiresCompatibilities",
+      "RuntimePlatform",
+      "TaskRoleArn",
+      "Volumes"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ContainerDefinitions.*.VersionConsistency": "enabled"
+    },
+    "unorderedScalarPaths": ["RequiresCompatibilities"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[app].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-ecs-taskdef-sets:1",
+      "constructPath": "CdkRealDriftIntegEcsTaskDefSets/TaskDef"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[init].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-ecs-taskdef-sets:1",
+      "constructPath": "CdkRealDriftIntegEcsTaskDefSets/TaskDef"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TaskDef",
+      "resourceType": "AWS::ECS::TaskDefinition",
+      "path": "ContainerDefinitions[logger].Cpu",
+      "actual": 0,
+      "nested": true,
+      "physicalId": "arn:aws:ecs:us-east-1:111111111111:task-definition/cdkrd-ecs-taskdef-sets:1",
+      "constructPath": "CdkRealDriftIntegEcsTaskDefSets/TaskDef"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleHttpHeader0B4061D9.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleHttpHeader0B4061D9.json
@@ -1,0 +1,86 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RuleHttpHeader0B4061D9",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/c8831c8e7557787f",
+    "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleHttpHeader",
+    "declared": {
+      "Actions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "MessageBody": "ok",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "http-header",
+          "HttpHeaderConfig": {
+            "HttpHeaderName": "X-Cdkrd",
+            "Values": ["zeta", "alpha", "mike"]
+          }
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a",
+      "Priority": 20
+    }
+  },
+  "liveRaw": {
+    "IsDefault": false,
+    "Actions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200",
+          "MessageBody": "ok"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Priority": 20,
+    "RuleArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/c8831c8e7557787f",
+    "Transforms": [],
+    "Conditions": [
+      {
+        "Field": "http-header",
+        "HttpHeaderConfig": {
+          "Values": ["zeta", "mike", "alpha"],
+          "HttpHeaderName": "X-Cdkrd"
+        },
+        "Values": []
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["IsDefault", "RuleArn"],
+    "writeOnly": ["ListenerArn"],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["IsDefault", "RuleArn"],
+    "writeOnlyPaths": ["Actions.*.AuthenticateOidcConfig.ClientSecret", "ListenerArn"],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "RuleHttpHeader0B4061D9",
+      "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "path": "ListenerArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/c8831c8e7557787f",
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleHttpHeader"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleMethodC8F28706.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleMethodC8F28706.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RuleMethodC8F28706",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/83a565631c79e8a9",
+    "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleMethod",
+    "declared": {
+      "Actions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "MessageBody": "ok",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "http-request-method",
+          "HttpRequestMethodConfig": {
+            "Values": ["POST", "GET", "DELETE"]
+          }
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a",
+      "Priority": 40
+    }
+  },
+  "liveRaw": {
+    "IsDefault": false,
+    "Actions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200",
+          "MessageBody": "ok"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Priority": 40,
+    "RuleArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/83a565631c79e8a9",
+    "Transforms": [],
+    "Conditions": [
+      {
+        "Field": "http-request-method",
+        "Values": [],
+        "HttpRequestMethodConfig": {
+          "Values": ["DELETE", "POST", "GET"]
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["IsDefault", "RuleArn"],
+    "writeOnly": ["ListenerArn"],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["IsDefault", "RuleArn"],
+    "writeOnlyPaths": ["Actions.*.AuthenticateOidcConfig.ClientSecret", "ListenerArn"],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "RuleMethodC8F28706",
+      "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "path": "ListenerArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/83a565631c79e8a9",
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleMethod"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleQueryString641E1B2B.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleQueryString641E1B2B.json
@@ -1,0 +1,110 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RuleQueryString641E1B2B",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/540f74d8bbd74bf2",
+    "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleQueryString",
+    "declared": {
+      "Actions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "MessageBody": "ok",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "query-string",
+          "QueryStringConfig": {
+            "Values": [
+              {
+                "Key": "zeta",
+                "Value": "1"
+              },
+              {
+                "Key": "alpha",
+                "Value": "2"
+              },
+              {
+                "Key": "mike",
+                "Value": "3"
+              }
+            ]
+          }
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a",
+      "Priority": 30
+    }
+  },
+  "liveRaw": {
+    "IsDefault": false,
+    "Actions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200",
+          "MessageBody": "ok"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Priority": 30,
+    "RuleArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/540f74d8bbd74bf2",
+    "Transforms": [],
+    "Conditions": [
+      {
+        "Field": "query-string",
+        "Values": [],
+        "QueryStringConfig": {
+          "Values": [
+            {
+              "Value": "3",
+              "Key": "mike"
+            },
+            {
+              "Value": "2",
+              "Key": "alpha"
+            },
+            {
+              "Value": "1",
+              "Key": "zeta"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["IsDefault", "RuleArn"],
+    "writeOnly": ["ListenerArn"],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["IsDefault", "RuleArn"],
+    "writeOnlyPaths": ["Actions.*.AuthenticateOidcConfig.ClientSecret", "ListenerArn"],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "RuleQueryString641E1B2B",
+      "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "path": "ListenerArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/540f74d8bbd74bf2",
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleQueryString"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleSourceIpD7488250.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__ListenerRule.RuleSourceIpD7488250.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RuleSourceIpD7488250",
+    "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/e5d6031394001d04",
+    "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleSourceIp",
+    "declared": {
+      "Actions": [
+        {
+          "FixedResponseConfig": {
+            "ContentType": "text/plain",
+            "MessageBody": "ok",
+            "StatusCode": "200"
+          },
+          "Type": "fixed-response"
+        }
+      ],
+      "Conditions": [
+        {
+          "Field": "source-ip",
+          "SourceIpConfig": {
+            "Values": ["10.3.0.0/16", "10.1.0.0/16", "10.2.0.0/16"]
+          }
+        }
+      ],
+      "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a",
+      "Priority": 10
+    }
+  },
+  "liveRaw": {
+    "IsDefault": false,
+    "Actions": [
+      {
+        "FixedResponseConfig": {
+          "ContentType": "text/plain",
+          "StatusCode": "200",
+          "MessageBody": "ok"
+        },
+        "Type": "fixed-response"
+      }
+    ],
+    "Priority": 10,
+    "RuleArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/e5d6031394001d04",
+    "Transforms": [],
+    "Conditions": [
+      {
+        "Field": "source-ip",
+        "Values": [],
+        "SourceIpConfig": {
+          "Values": ["10.3.0.0/16", "10.2.0.0/16", "10.1.0.0/16"]
+        }
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["IsDefault", "RuleArn"],
+    "writeOnly": ["ListenerArn"],
+    "createOnly": ["ListenerArn"],
+    "readOnlyPaths": ["IsDefault", "RuleArn"],
+    "writeOnlyPaths": ["Actions.*.AuthenticateOidcConfig.ClientSecret", "ListenerArn"],
+    "createOnlyPaths": ["ListenerArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "RuleSourceIpD7488250",
+      "resourceType": "AWS::ElasticLoadBalancingV2::ListenerRule",
+      "path": "ListenerArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener-rule/app/CdkRea-Alb16-NpZ4tSt8qH3R/8078676baac96dbb/9bccb68925af7a9a/e5d6031394001d04",
+      "constructPath": "CdkRealDriftIntegElbv2RuleConditions/RuleSourceIp"
+    }
+  ]
+}

--- a/tests/integration/asg-notification-metrics/app.ts
+++ b/tests/integration/asg-notification-metrics/app.ts
@@ -1,0 +1,74 @@
+// CDK app for the cdk-real-drift EC2 Auto Scaling notification/metrics SET FP test.
+// An ASG's `NotificationConfigurations[].NotificationTypes` (the lifecycle events to
+// publish to SNS) and `MetricsCollection[].Metrics` (the group metrics to enable) are
+// both scalar SETs the CFn schema marks insertionOrder:false, nested under an array —
+// the schema-driven scalar fold skips array-crossing (`*`) paths, so they rely on the
+// per-type table. Neither was ever probed. Each is declared in DELIBERATELY non-sorted
+// order; if EC2 Auto Scaling echoes either reordered, a positional compare false-flags
+// the identical set as declared drift on a freshly recorded ASG. ASGs with SNS
+// notifications + group metrics are a common production pattern. desiredCapacity 0 (no
+// instances launch) so the test is fast and cheap. A clean record -> check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  Vpc,
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  MachineImage,
+  SubnetType,
+  LaunchTemplate,
+} from "aws-cdk-lib/aws-ec2";
+import { AutoScalingGroup, CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAsgNotificationMetrics");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const launchTemplate = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023(),
+});
+
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  launchTemplate,
+  minCapacity: 0,
+  maxCapacity: 4,
+  desiredCapacity: 0,
+});
+
+const topic = new Topic(stack, "Topic");
+
+// Reach the L1 to set the two SET properties in an exact non-sorted order.
+const cfnAsg = asg.node.defaultChild as CfnAutoScalingGroup;
+cfnAsg.notificationConfigurations = [
+  {
+    topicArn: topic.topicArn,
+    // Lifecycle-event SET declared non-alphabetically.
+    notificationTypes: [
+      "autoscaling:EC2_INSTANCE_TERMINATE",
+      "autoscaling:EC2_INSTANCE_LAUNCH",
+      "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+    ],
+  },
+];
+cfnAsg.metricsCollection = [
+  {
+    granularity: "1Minute",
+    // Group-metric SET declared non-alphabetically.
+    metrics: [
+      "GroupTotalInstances",
+      "GroupDesiredCapacity",
+      "GroupMaxSize",
+      "GroupMinSize",
+    ],
+  },
+];
+
+app.synth();

--- a/tests/integration/asg-notification-metrics/cdk.json
+++ b/tests/integration/asg-notification-metrics/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/asg-notification-metrics/package.json
+++ b/tests/integration/asg-notification-metrics/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-asg-notification-metrics",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift asg-notification-metrics false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/asg-notification-metrics/verify.sh
+++ b/tests/integration/asg-notification-metrics/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAsgNotificationMetrics
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-asg-notification-metrics" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/backup-selection/app.ts
+++ b/tests/integration/backup-selection/app.ts
@@ -1,0 +1,87 @@
+// CDK app for the cdk-real-drift AWS Backup *Selection* false-positive test. A
+// BackupSelection's tag-based membership is an insertionOrder:false SET that AWS
+// MAY echo in its own canonical order — the existing backup-rich fixture only
+// covered the Vault + Plan, never a Selection. We probe BOTH membership shapes,
+// each declared in DELIBERATELY non-sorted order, on separate selections:
+//
+//   BackupSelection.ListOfTags            — object set {ConditionType,ConditionKey,ConditionValue}
+//   BackupSelection.Conditions.StringEquals — object set {ConditionKey,ConditionValue}
+//
+// Neither element key (ConditionKey) is one of cdkrd's IDENTITY_FIELDS
+// (Key/Id/AttributeName/IndexName/Name), so a keyed canonicalizer cannot align a
+// reorder — if AWS sorts either set (e.g. by ConditionKey), a positional compare
+// false-flags the identical membership set as declared drift on every check. AWS
+// Backup vault/plan/selection/role are all free (no backups run). A freshly
+// deployed + recorded selection with NO out-of-band change MUST be CLEAN.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { BackupPlan, BackupPlanRule, BackupVault } from "aws-cdk-lib/aws-backup";
+import { CfnBackupSelection } from "aws-cdk-lib/aws-backup";
+import { Schedule } from "aws-cdk-lib/aws-events";
+import { Role, ServicePrincipal, ManagedPolicy } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegBackupSelection");
+
+const vault = new BackupVault(stack, "Vault", {
+  backupVaultName: "cdkrd-backup-selection",
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const plan = new BackupPlan(stack, "Plan", {
+  backupPlanName: "cdkrd-backup-selection",
+  backupVault: vault,
+});
+plan.addRule(
+  new BackupPlanRule({
+    ruleName: "Daily",
+    scheduleExpression: Schedule.cron({ hour: "5", minute: "0" }),
+    startWindow: Duration.hours(1),
+    completionWindow: Duration.hours(2),
+    deleteAfter: Duration.days(35),
+  })
+);
+
+const role = new Role(stack, "BackupRole", {
+  assumedBy: new ServicePrincipal("backup.amazonaws.com"),
+  managedPolicies: [
+    ManagedPolicy.fromAwsManagedPolicyName("service-role/AWSBackupServiceRolePolicyForBackup"),
+  ],
+});
+
+// Selection A — legacy ListOfTags, declared non-sorted by ConditionKey (zeta before alpha).
+new CfnBackupSelection(stack, "SelByTags", {
+  backupPlanId: plan.backupPlanId,
+  backupSelection: {
+    selectionName: "cdkrd-by-tags",
+    iamRoleArn: role.roleArn,
+    listOfTags: [
+      { conditionType: "STRINGEQUALS", conditionKey: "zeta", conditionValue: "1" },
+      { conditionType: "STRINGEQUALS", conditionKey: "alpha", conditionValue: "2" },
+      { conditionType: "STRINGEQUALS", conditionKey: "mike", conditionValue: "3" },
+    ],
+  },
+});
+
+// Selection B — newer Conditions.StringEquals, declared non-sorted by ConditionKey.
+new CfnBackupSelection(stack, "SelByConditions", {
+  backupPlanId: plan.backupPlanId,
+  backupSelection: {
+    selectionName: "cdkrd-by-conditions",
+    iamRoleArn: role.roleArn,
+    // Conditions is a REFINEMENT — AWS rejects a selection that has only Conditions,
+    // so it must accompany a non-empty Resources (or ListOfTags). Resources is a
+    // scalar ARN-pattern set (ARN-shaped → canonicalizeIdArraysDeep would sort it),
+    // declared here so the selection is valid; the probe target is Conditions below.
+    resources: ["arn:aws:ec2:*:*:instance/*"],
+    // `conditions` is a free-form L1 property (not auto-mapped to PascalCase like
+    // listOfTags), so the CFn-shaped keys are written directly.
+    conditions: {
+      StringEquals: [
+        { ConditionKey: "aws:ResourceTag/zebra", ConditionValue: "x" },
+        { ConditionKey: "aws:ResourceTag/apple", ConditionValue: "y" },
+        { ConditionKey: "aws:ResourceTag/mango", ConditionValue: "z" },
+      ],
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/backup-selection/cdk.json
+++ b/tests/integration/backup-selection/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/backup-selection/package.json
+++ b/tests/integration/backup-selection/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-backup-selection",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift backup-selection false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/backup-selection/verify.sh
+++ b/tests/integration/backup-selection/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegBackupSelection
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-backup-selection" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ecs-taskdef-sets/app.ts
+++ b/tests/integration/ecs-taskdef-sets/app.ts
@@ -1,0 +1,82 @@
+// CDK app for the cdk-real-drift ECS (EC2 launch type) TaskDefinition
+// false-positive test — focused on the insertionOrder:false container sub-arrays
+// the existing ecs-taskdef-{rich,caps,mounts} fixtures never exercised. The CFn
+// schema marks all of these `insertionOrder: false` (AWS declares them unordered
+// sets), but that flag is UNRELIABLE — most such sets are actually echoed in
+// template order (caps/ulimits/dnsSearch/systemControls were all proven
+// order-PRESERVING on prior deploys). Only an empirical deploy tells which ones
+// AWS genuinely reorders. Each set below is declared in DELIBERATELY non-sorted
+// order; if ECS echoes any of them reordered, a positional compare false-flags
+// declared drift, and the path is nested under the ContainerDefinitions array so
+// the top-level UNORDERED_* folds can never reach it.
+//
+// Probed (all previously UNTESTED — empty in every corpus case):
+//   ContainerDefinitions[].DependsOn          (object set, keyed by ContainerName ∉ IDENTITY_FIELDS)
+//   ContainerDefinitions[].Links              (scalar set)
+//   ContainerDefinitions[].ExtraHosts         (object set: Hostname/IpAddress)
+//   ContainerDefinitions[].DockerSecurityOptions (scalar set)
+//   ContainerDefinitions[].DnsServers         (scalar set — declared non-sorted this time)
+//   PlacementConstraints                      (object set: Type/Expression)
+//
+// Metadata-only (no cluster/instance/VPC) so it deploys near-instantly. A freshly
+// deployed + recorded task definition with NO out-of-band change MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnTaskDefinition } from "aws-cdk-lib/aws-ecs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEcsTaskDefSets");
+
+new CfnTaskDefinition(stack, "TaskDef", {
+  family: "cdkrd-ecs-taskdef-sets",
+  networkMode: "bridge",
+  requiresCompatibilities: ["EC2"],
+  cpu: "256",
+  memory: "512",
+  // A task-level placement-constraint SET declared non-sorted (instance-type
+  // expression after os-type; alphabetically the reverse).
+  placementConstraints: [
+    { type: "memberOf", expression: "attribute:ecs.os-type == linux" },
+    { type: "memberOf", expression: "attribute:ecs.instance-type =~ t3.*" },
+  ],
+  containerDefinitions: [
+    {
+      name: "init",
+      image: "public.ecr.aws/nginx/nginx:latest",
+      essential: false,
+      memoryReservation: 64,
+    },
+    {
+      name: "logger",
+      image: "public.ecr.aws/nginx/nginx:latest",
+      essential: false,
+      memoryReservation: 64,
+    },
+    {
+      name: "app",
+      image: "public.ecr.aws/nginx/nginx:latest",
+      essential: true,
+      memoryReservation: 256,
+      // Container-startup ordering SET declared non-alphabetically by
+      // ContainerName (logger before init). ContainerName is NOT an
+      // IDENTITY_FIELD, so a keyed canonicalizer cannot align a reorder.
+      dependsOn: [
+        { containerName: "logger", condition: "START" },
+        { containerName: "init", condition: "START" },
+      ],
+      // Legacy bridge-mode container LINKS — a scalar set declared non-sorted.
+      links: ["logger:log", "init:setup"],
+      // /etc/hosts entries — an object set declared non-sorted by Hostname.
+      extraHosts: [
+        { hostname: "zeta.internal", ipAddress: "10.0.0.9" },
+        { hostname: "alpha.internal", ipAddress: "10.0.0.8" },
+      ],
+      // Docker security options — a scalar set declared non-sorted.
+      dockerSecurityOptions: ["label:user:nginx", "label:role:webapp"],
+      // DNS server set declared NON-sorted (the existing corpus only tested a
+      // pre-sorted [10.0.0.2, 10.0.0.3] list — inconclusive for reorder).
+      dnsServers: ["10.0.0.3", "10.0.0.2"],
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/ecs-taskdef-sets/cdk.json
+++ b/tests/integration/ecs-taskdef-sets/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecs-taskdef-sets/package.json
+++ b/tests/integration/ecs-taskdef-sets/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecs-taskdef-sets",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecs-taskdef-sets false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecs-taskdef-sets/verify.sh
+++ b/tests/integration/ecs-taskdef-sets/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsTaskDefSets
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-ecs-taskdef-sets" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elbv2-rule-conditions/app.ts
+++ b/tests/integration/elbv2-rule-conditions/app.ts
@@ -1,0 +1,80 @@
+// CDK app for the cdk-real-drift ALB ListenerRule nested-condition-VALUES FP test.
+// The existing elbv2-rule-values fixture covered PathPatternConfig.Values (folded)
+// and HostHeaderConfig.Values (observed order-PRESERVING). This fixture probes the
+// REMAINING condition-value sets the CFn schema marks insertionOrder:false, each on
+// its own rule, declared in DELIBERATELY non-sorted order:
+//
+//   SourceIpConfig.Values            — scalar CIDR set (not id/ARN-shaped → not auto-folded)
+//   HttpHeaderConfig.Values          — scalar header-value-string set
+//   QueryStringConfig.Values         — object set {Key,Value} (Key ∉ IDENTITY_FIELDS)
+//   HttpRequestMethodConfig.Values   — scalar HTTP-verb set (auto-folded by isHttpMethod → control)
+//
+// If ALB canonicalizes any of these, a positional compare false-flags declared drift
+// on every shifted value of a freshly recorded rule. ListenerRule routing is a very
+// common pattern. The ALB is internal (no public IP) in a NAT-free VPC, so it is
+// cheap and tears down fast. A freshly deployed + recorded stack MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  ApplicationListenerRule,
+  ApplicationLoadBalancer,
+  ListenerAction,
+  ListenerCondition,
+} from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElbv2RuleConditions");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const alb = new ApplicationLoadBalancer(stack, "Alb", { vpc, internetFacing: false });
+const listener = alb.addListener("Listener", {
+  port: 80,
+  defaultAction: ListenerAction.fixedResponse(404, { contentType: "text/plain", messageBody: "nf" }),
+});
+
+const respond = ListenerAction.fixedResponse(200, { contentType: "text/plain", messageBody: "ok" });
+
+// Rule 1 — SourceIp CIDR set declared non-sorted.
+new ApplicationListenerRule(stack, "RuleSourceIp", {
+  listener,
+  priority: 10,
+  conditions: [ListenerCondition.sourceIps(["10.3.0.0/16", "10.1.0.0/16", "10.2.0.0/16"])],
+  action: respond,
+});
+
+// Rule 2 — HttpHeader value set declared non-sorted.
+new ApplicationListenerRule(stack, "RuleHttpHeader", {
+  listener,
+  priority: 20,
+  conditions: [ListenerCondition.httpHeader("X-Cdkrd", ["zeta", "alpha", "mike"])],
+  action: respond,
+});
+
+// Rule 3 — QueryString {Key,Value} object set declared non-sorted by Key.
+new ApplicationListenerRule(stack, "RuleQueryString", {
+  listener,
+  priority: 30,
+  conditions: [
+    ListenerCondition.queryStrings([
+      { key: "zeta", value: "1" },
+      { key: "alpha", value: "2" },
+      { key: "mike", value: "3" },
+    ]),
+  ],
+  action: respond,
+});
+
+// Rule 4 — HttpRequestMethod verb set declared non-sorted (control: auto-folded as HTTP methods).
+new ApplicationListenerRule(stack, "RuleMethod", {
+  listener,
+  priority: 40,
+  conditions: [ListenerCondition.httpRequestMethods(["POST", "GET", "DELETE"])],
+  action: respond,
+});
+
+app.synth();

--- a/tests/integration/elbv2-rule-conditions/cdk.json
+++ b/tests/integration/elbv2-rule-conditions/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elbv2-rule-conditions/package.json
+++ b/tests/integration/elbv2-rule-conditions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elbv2-rule-conditions",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elbv2-rule-conditions false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elbv2-rule-conditions/verify.sh
+++ b/tests/integration/elbv2-rule-conditions/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElbv2RuleConditions
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-elbv2-rule-conditions" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A fresh bug-hunt round driven by an **offline `insertionOrder:false` audit** (fetch raw CFn
schemas, find unordered-set arrays not yet auto-folded, then deploy many candidates non-sorted
in one cheap stack to see which AWS actually reorders). It surfaced **six** false-positive
declared drifts — each an unordered set AWS echoes in its own canonical (usually alphabetical)
order that a positional compare flagged on a freshly recorded stack.

All six are fixed by adding the path to `UNORDERED_NESTED_OBJECT_ARRAY_PATHS` (equality-gated, so
a genuine element change still surfaces — proven by the `no-over-fold` tests). No new mechanism.

| Type | Path | AWS behavior |
| --- | --- | --- |
| `AWS::ECS::TaskDefinition` | `ContainerDefinitions.Links` | scalar `name:alias` set sorted alphabetically |
| `AWS::Backup::BackupSelection` | `BackupSelection.ListOfTags` | object set sorted by `ConditionKey` |
| `AWS::ElasticLoadBalancingV2::ListenerRule` | `Conditions.SourceIpConfig.Values` | CIDR set reordered |
| `AWS::ElasticLoadBalancingV2::ListenerRule` | `Conditions.HttpHeaderConfig.Values` | header-value set reordered |
| `AWS::AutoScaling::AutoScalingGroup` | `MetricsCollection.Metrics` | metric set sorted alphabetically |
| `AWS::AutoScaling::AutoScalingGroup` | `NotificationConfigurations.NotificationTypes` | event set sorted alphabetically |

## Ruled out in the same deploys (AWS preserves order — observed-only, documented in comments)

ECS `DependsOn` / `ExtraHosts` / `DnsServers` / `DockerSecurityOptions` / `PlacementConstraints`;
Backup `Conditions.StringEquals`; ALB `HostHeaderConfig.Values`. ALB `QueryStringConfig.Values`
reorders too, but its `{Key, Value}` elements are already aligned by the existing `Key`
identity-field canonicalizer, so it needs no entry.

## Verification

- Each fix is **live-proven**: deploy → `check` reports the FP → fix → re-deploy → `check` CLEAN
  (`INTEG PASS`) with the integration fixture committed here (`ecs-taskdef-sets`,
  `backup-selection`, `elbv2-rule-conditions`, `asg-notification-metrics`).
- Unit tests (fold + no-over-fold) for each path, plus golden-corpus cases harvested from the
  real live read (account ids sanitized).
- 1694 unit tests pass; typecheck / lint+format / build green.
- Regression set for a `src/normalize/**` change (`noise`, `basic`, `revert` fixtures) all
  `INTEG PASS`.
