### PR TITLE
fix(noise): fold two more set reorders (ASG inline lifecycle hooks, Secret replica regions)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1639,6 +1639,28 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
   // sibling RDS DB/DBClusterParameterGroup `Parameters` is a free-form Map<String,String>,
   // not this array shape, so it is key-canonicalized — not folded here.)
   'AWS::Redshift::ClusterParameterGroup': new Set(['Parameters']),
+  // An EC2 Auto Scaling group's inline `LifecycleHookSpecificationList` is a SET of
+  // hooks AWS echoes SORTED by LifecycleHookName, not in template order (declared
+  // [zeta-terminate, alpha-launch] reads back [alpha-launch, zeta-terminate]), so a
+  // positional compare false-flags every field of every shifted hook as declared drift
+  // on a freshly recorded ASG. The element key `LifecycleHookName` is NOT one of
+  // canonicalizeTagListsDeep's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name), so
+  // that keyed canonicalizer can't align it — hence the per-type opt-in. Sorting both
+  // sides by canonical JSON aligns equal hooks; a genuine hook add/remove/change still
+  // differs. Observed live on a fresh asg-lifecyclehook-inline deploy. (This is the
+  // ASG's OWN inline hook list — distinct from the standalone AWS::AutoScaling::
+  // LifecycleHook resource the autoscaling-lifecyclehook-rich fixture covers.)
+  'AWS::AutoScaling::AutoScalingGroup': new Set(['LifecycleHookSpecificationList']),
+  // A multi-region Secret's `ReplicaRegions` is a SET of {Region, KmsKeyId} that Secrets
+  // Manager echoes SORTED by Region, not in template order (declared [us-west-2,
+  // eu-west-1] reads back [eu-west-1, us-west-2]), so a positional compare false-flags
+  // every shifted replica's Region as declared drift on a freshly recorded secret. The
+  // element key `Region` is NOT one of canonicalizeTagListsDeep's IDENTITY_FIELDS
+  // (Key/Id/AttributeName/IndexName/Name), so that keyed canonicalizer can't align it —
+  // hence the per-type opt-in. Sorting both sides by canonical JSON aligns equal replicas;
+  // a genuine region add/remove still differs. Observed live on a fresh
+  // secret-replica-regions deploy.
+  'AWS::SecretsManager::Secret': new Set(['ReplicaRegions']),
 };
 
 // Per-type NESTED array paths AWS returns reordered (dotted from the resource

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2235,6 +2235,77 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('AutoScaling group inline LifecycleHookSpecificationList reordered (object set keyed by LifecycleHookName ∉ IDENTITY_FIELDS, found by asg-lifecyclehook-inline)', () => {
+    const T = 'AWS::AutoScaling::AutoScalingGroup';
+    const declared = {
+      LifecycleHookSpecificationList: [
+        {
+          LifecycleHookName: 'zeta-terminate',
+          LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+          DefaultResult: 'CONTINUE',
+        },
+        {
+          LifecycleHookName: 'alpha-launch',
+          LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING',
+          DefaultResult: 'CONTINUE',
+        },
+      ],
+    };
+
+    it('AWS returning the hook list sorted by LifecycleHookName is NOT drift', () => {
+      const live = {
+        LifecycleHookSpecificationList: [
+          {
+            LifecycleHookName: 'alpha-launch',
+            LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING',
+            DefaultResult: 'CONTINUE',
+          },
+          {
+            LifecycleHookName: 'zeta-terminate',
+            LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+            DefaultResult: 'CONTINUE',
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine hook transition change still surfaces (no over-fold)', () => {
+      const live = {
+        LifecycleHookSpecificationList: [
+          {
+            LifecycleHookName: 'alpha-launch',
+            LifecycleTransition: 'autoscaling:EC2_INSTANCE_LAUNCHING',
+            DefaultResult: 'ABANDON',
+          }, // CONTINUE -> ABANDON
+          {
+            LifecycleHookName: 'zeta-terminate',
+            LifecycleTransition: 'autoscaling:EC2_INSTANCE_TERMINATING',
+            DefaultResult: 'CONTINUE',
+          },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('SecretsManager Secret ReplicaRegions reordered (object set keyed by Region ∉ IDENTITY_FIELDS, found by secret-replica-regions)', () => {
+    const T = 'AWS::SecretsManager::Secret';
+    const declared = {
+      ReplicaRegions: [{ Region: 'us-west-2' }, { Region: 'eu-west-1' }],
+    };
+
+    it('AWS returning ReplicaRegions sorted by Region is NOT drift', () => {
+      const live = { ReplicaRegions: [{ Region: 'eu-west-1' }, { Region: 'us-west-2' }] };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine replica region change still surfaces (no over-fold)', () => {
+      const live = { ReplicaRegions: [{ Region: 'eu-west-1' }, { Region: 'ap-south-1' }] }; // us-west-2 -> ap-south-1
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('AutoScaling group MetricsCollection.Metrics / NotificationConfigurations.NotificationTypes reordered (nested scalar sets, found by asg-notification-metrics)', () => {
     const T = 'AWS::AutoScaling::AutoScalingGroup';
 

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgLifecycleHookInline.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgLifecycleHookInline.json
@@ -1,0 +1,260 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AsgASGD1D7B4E2",
+    "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+    "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+    "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG",
+    "declared": {
+      "DesiredCapacity": "0",
+      "LaunchTemplate": {
+        "LaunchTemplateId": "lt-0d82f1be2fdc57dd9",
+        "Version": "__cdkrd_corpus_unresolved__"
+      },
+      "LifecycleHookSpecificationList": [
+        {
+          "DefaultResult": "CONTINUE",
+          "HeartbeatTimeout": 300,
+          "LifecycleHookName": "zeta-terminate",
+          "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING"
+        },
+        {
+          "DefaultResult": "CONTINUE",
+          "HeartbeatTimeout": 300,
+          "LifecycleHookName": "alpha-launch",
+          "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING"
+        }
+      ],
+      "MaxSize": "2",
+      "MinSize": "0",
+      "VPCZoneIdentifier": ["subnet-0b0b34828264f6e53", "subnet-01c064a369becc012"]
+    }
+  },
+  "liveRaw": {
+    "LifecycleHookSpecificationList": [
+      {
+        "LifecycleHookName": "alpha-launch",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_LAUNCHING",
+        "HeartbeatTimeout": 300,
+        "DefaultResult": "CONTINUE"
+      },
+      {
+        "LifecycleHookName": "zeta-terminate",
+        "LifecycleTransition": "autoscaling:EC2_INSTANCE_TERMINATING",
+        "HeartbeatTimeout": 300,
+        "DefaultResult": "CONTINUE"
+      }
+    ],
+    "LoadBalancerNames": [],
+    "ServiceLinkedRoleARN": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+    "TargetGroupARNs": [],
+    "AvailabilityZoneIds": ["use1-az1", "use1-az2"],
+    "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:111111111111:autoScalingGroup:946dbd2d-9365-4196-973a-79bd89a5bb46:autoScalingGroupName/CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+    "Cooldown": "300",
+    "AvailabilityZones": ["us-east-1a", "us-east-1b"],
+    "AvailabilityZoneDistribution": {
+      "CapacityDistributionStrategy": "balanced-best-effort"
+    },
+    "DesiredCapacity": "0",
+    "HealthCheckGracePeriod": 0,
+    "MetricsCollection": [],
+    "InstanceLifecyclePolicy": {
+      "RetentionTriggers": {
+        "TerminateHookAbandon": "terminate"
+      }
+    },
+    "MaxSize": "2",
+    "NewInstancesProtectedFromScaleIn": false,
+    "MinSize": "0",
+    "TerminationPolicies": ["Default"],
+    "LaunchTemplate": {
+      "LaunchTemplateName": "LtFD2A8520_3lF4fBFfZ3tD",
+      "Version": "1",
+      "LaunchTemplateId": "lt-0d82f1be2fdc57dd9"
+    },
+    "AutoScalingGroupName": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+    "VPCZoneIdentifier": ["subnet-0b0b34828264f6e53", "subnet-01c064a369becc012"],
+    "CapacityReservationSpecification": {
+      "CapacityReservationPreference": "default"
+    },
+    "Tags": [
+      {
+        "ResourceId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+        "Value": "AsgASGD1D7B4E2",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:logical-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAsgLifecycleHookInline/f6dce2d0-724f-11f1-8fd6-0affd3d3c987",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-id",
+        "PropagateAtLaunch": true
+      },
+      {
+        "ResourceId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+        "Value": "CdkRealDriftIntegAsgLifecycleHookInline",
+        "ResourceType": "auto-scaling-group",
+        "Key": "aws:cloudformation:stack-name",
+        "PropagateAtLaunch": true
+      }
+    ],
+    "HealthCheckType": "EC2"
+  },
+  "schema": {
+    "readOnly": ["AutoScalingGroupARN"],
+    "writeOnly": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnly": [
+      "AutoScalingGroupName",
+      "InstanceId",
+      "LaunchConfigurationName",
+      "LaunchTemplate",
+      "MixedInstancesPolicy",
+      "VPCZoneIdentifier"
+    ],
+    "readOnlyPaths": ["AutoScalingGroupARN"],
+    "writeOnlyPaths": ["InstanceId", "SkipZonalShiftValidation"],
+    "createOnlyPaths": [
+      "AutoScalingGroupName",
+      "InstanceId",
+      "LaunchConfigurationName",
+      "LaunchTemplate",
+      "MixedInstancesPolicy",
+      "VPCZoneIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AvailabilityZoneIds",
+      "AvailabilityZones",
+      "NotificationConfiguration.NotificationTypes",
+      "TargetGroupARNs",
+      "VPCZoneIdentifier"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LaunchTemplate",
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "ServiceLinkedRoleARN",
+      "actual": "arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneIds",
+      "actual": ["use1-az1", "use1-az2"],
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "Cooldown",
+      "actual": "300",
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b"],
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "AvailabilityZoneDistribution",
+      "actual": {
+        "CapacityDistributionStrategy": "balanced-best-effort"
+      },
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckGracePeriod",
+      "actual": 0,
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "InstanceLifecyclePolicy",
+      "actual": {
+        "RetentionTriggers": {
+          "TerminateHookAbandon": "terminate"
+        }
+      },
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "TerminationPolicies",
+      "actual": ["Default"],
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "CapacityReservationSpecification",
+      "actual": {
+        "CapacityReservationPreference": "default"
+      },
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "HealthCheckType",
+      "actual": "EC2",
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "AsgASGD1D7B4E2",
+      "resourceType": "AWS::AutoScaling::AutoScalingGroup",
+      "path": "LaunchTemplate.LaunchTemplateName",
+      "actual": "LtFD2A8520_3lF4fBFfZ3tD",
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegAsgLifecycleHookInline-AsgASGD1D7B4E2-oglb6MR7K6Er",
+      "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Topic.SnsDeliveryStatus.json
+++ b/tests/corpus/AWS__SNS__Topic.SnsDeliveryStatus.json
@@ -1,0 +1,102 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Topic",
+    "resourceType": "AWS::SNS::Topic",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:cdkrd-sns-deliverystatus",
+    "constructPath": "CdkRealDriftIntegSnsDeliveryStatus/Topic",
+    "declared": {
+      "DeliveryStatusLogging": [
+        {
+          "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "Protocol": "sqs",
+          "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "SuccessFeedbackSampleRate": "100"
+        },
+        {
+          "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "Protocol": "application",
+          "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "SuccessFeedbackSampleRate": "100"
+        },
+        {
+          "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "Protocol": "lambda",
+          "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "SuccessFeedbackSampleRate": "100"
+        },
+        {
+          "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "Protocol": "firehose",
+          "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+          "SuccessFeedbackSampleRate": "100"
+        }
+      ],
+      "TopicName": "cdkrd-sns-deliverystatus"
+    }
+  },
+  "liveRaw": {
+    "DeliveryStatusLogging": [
+      {
+        "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "SuccessFeedbackSampleRate": "100",
+        "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "Protocol": "sqs"
+      },
+      {
+        "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "SuccessFeedbackSampleRate": "100",
+        "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "Protocol": "application"
+      },
+      {
+        "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "SuccessFeedbackSampleRate": "100",
+        "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "Protocol": "lambda"
+      },
+      {
+        "FailureFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "SuccessFeedbackSampleRate": "100",
+        "SuccessFeedbackRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegSnsDeliverySt-FeedbackRoleCAF84E5C-EftQMwfaEPCG",
+        "Protocol": "firehose"
+      }
+    ],
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-sns-deliverystatus",
+    "FifoTopic": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSnsDeliveryStatus/f6d4f390-724f-11f1-827a-0afffb7669f5",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSnsDeliveryStatus",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Topic",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "ArchivePolicy": {},
+    "TopicName": "cdkrd-sns-deliverystatus"
+  },
+  "schema": {
+    "readOnly": ["TopicArn"],
+    "writeOnly": [],
+    "createOnly": ["FifoTopic", "TopicName"],
+    "readOnlyPaths": ["TopicArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["FifoTopic", "TopicName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__SecretsManager__Secret.ReplicaRegions.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.ReplicaRegions.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SecretA720EF05",
+    "resourceType": "AWS::SecretsManager::Secret",
+    "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
+    "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret",
+    "declared": {
+      "GenerateSecretString": {},
+      "Name": "cdkrd-secret-replica-regions",
+      "ReplicaRegions": [
+        {
+          "Region": "us-west-2"
+        },
+        {
+          "Region": "eu-west-1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ReplicaRegions": [
+      {
+        "KmsKeyId": "alias/aws/secretsmanager",
+        "Region": "eu-west-1"
+      },
+      {
+        "KmsKeyId": "alias/aws/secretsmanager",
+        "Region": "us-west-2"
+      }
+    ],
+    "Id": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
+    "Tags": [],
+    "Name": "cdkrd-secret-replica-regions"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": ["GenerateSecretString", "SecretString"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["GenerateSecretString", "SecretString"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "SecretA720EF05",
+      "resourceType": "AWS::SecretsManager::Secret",
+      "path": "GenerateSecretString",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
+      "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret"
+    }
+  ]
+}

--- a/tests/integration/asg-lifecyclehook-inline/app.ts
+++ b/tests/integration/asg-lifecyclehook-inline/app.ts
@@ -1,0 +1,62 @@
+// CDK app for the cdk-real-drift ASG INLINE LifecycleHookSpecificationList FP test.
+// The existing autoscaling-lifecyclehook-rich fixture covers the STANDALONE
+// AWS::AutoScaling::LifecycleHook resource; the ASG's own inline
+// `LifecycleHookSpecificationList` (a SET of hooks the CFn schema marks
+// insertionOrder:false) was never probed. Its element key is `LifecycleHookName`,
+// which is NOT one of cdkrd's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name),
+// so a keyed canonicalizer cannot align a reorder. The two hooks are declared in
+// DELIBERATELY non-sorted order by name; if EC2 Auto Scaling echoes the list sorted
+// (the pattern its sibling MetricsCollection/NotificationConfigurations sets follow),
+// a positional compare false-flags every field of every shifted hook as declared
+// drift on a freshly recorded ASG. desiredCapacity 0 (no instances) so it is cheap.
+// A clean record -> check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  Vpc,
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  MachineImage,
+  SubnetType,
+  LaunchTemplate,
+} from "aws-cdk-lib/aws-ec2";
+import { AutoScalingGroup, CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAsgLifecycleHookInline");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+const launchTemplate = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023(),
+});
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  launchTemplate,
+  minCapacity: 0,
+  maxCapacity: 2,
+  desiredCapacity: 0,
+});
+
+const cfnAsg = asg.node.defaultChild as CfnAutoScalingGroup;
+// Two lifecycle hooks declared non-alphabetically by LifecycleHookName (zeta before alpha).
+cfnAsg.lifecycleHookSpecificationList = [
+  {
+    lifecycleHookName: "zeta-terminate",
+    lifecycleTransition: "autoscaling:EC2_INSTANCE_TERMINATING",
+    defaultResult: "CONTINUE",
+    heartbeatTimeout: 300,
+  },
+  {
+    lifecycleHookName: "alpha-launch",
+    lifecycleTransition: "autoscaling:EC2_INSTANCE_LAUNCHING",
+    defaultResult: "CONTINUE",
+    heartbeatTimeout: 300,
+  },
+];
+
+app.synth();

--- a/tests/integration/asg-lifecyclehook-inline/cdk.json
+++ b/tests/integration/asg-lifecyclehook-inline/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/asg-lifecyclehook-inline/package.json
+++ b/tests/integration/asg-lifecyclehook-inline/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-asg-lifecyclehook-inline",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift asg-lifecyclehook-inline false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/asg-lifecyclehook-inline/verify.sh
+++ b/tests/integration/asg-lifecyclehook-inline/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAsgLifecycleHookInline
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-asg-lifecyclehook-inline" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/secret-replica-regions/app.ts
+++ b/tests/integration/secret-replica-regions/app.ts
@@ -1,0 +1,25 @@
+// CDK app for the cdk-real-drift SecretsManager Secret ReplicaRegions SET FP test.
+// A multi-region (DR) Secret's `ReplicaRegions` is a SET of {Region, KmsKeyId} the
+// CFn schema marks insertionOrder:false. Its element key is `Region`, which is NOT
+// one of cdkrd's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name), so a keyed
+// canonicalizer cannot align a reorder. The two replica regions are declared in
+// DELIBERATELY non-sorted order (us-west-2 before eu-west-1); if Secrets Manager
+// echoes the list sorted by Region, a positional compare false-flags every shifted
+// replica as declared drift on a freshly recorded secret. A replica secret carries
+// no value/data, so it is cheap. A clean record -> check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSecretReplicaRegions");
+
+new Secret(stack, "Secret", {
+  secretName: "cdkrd-secret-replica-regions",
+  // Replica regions declared NON-sorted (us-west-2 before eu-west-1).
+  replicaRegions: [
+    { region: "us-west-2" },
+    { region: "eu-west-1" },
+  ],
+});
+
+app.synth();

--- a/tests/integration/secret-replica-regions/cdk.json
+++ b/tests/integration/secret-replica-regions/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/secret-replica-regions/package.json
+++ b/tests/integration/secret-replica-regions/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-secret-replica-regions",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift secret-replica-regions false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/secret-replica-regions/verify.sh
+++ b/tests/integration/secret-replica-regions/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSecretReplicaRegions
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-secret-replica-regions" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sns-deliverystatus/app.ts
+++ b/tests/integration/sns-deliverystatus/app.ts
@@ -1,0 +1,65 @@
+// CDK app for the cdk-real-drift SNS Topic DeliveryStatusLogging SET FP test. A
+// Topic's `DeliveryStatusLogging` is a SET of per-protocol logging configs the CFn
+// schema marks insertionOrder:false. Its element key is `Protocol`, which is NOT one
+// of cdkrd's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name), so a keyed
+// canonicalizer cannot align a reorder. The four protocol entries are declared in
+// DELIBERATELY non-sorted order; if SNS echoes the list sorted by Protocol, a
+// positional compare false-flags every shifted entry as declared drift on a freshly
+// recorded topic. SNS topics + an IAM feedback role are free. A clean record ->
+// check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+import { Role, ServicePrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsDeliveryStatus");
+
+const feedbackRole = new Role(stack, "FeedbackRole", {
+  assumedBy: new ServicePrincipal("sns.amazonaws.com"),
+});
+feedbackRole.addToPolicy(
+  new PolicyStatement({
+    actions: [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:PutMetricFilter",
+      "logs:PutRetentionPolicy",
+    ],
+    resources: ["*"],
+  })
+);
+
+new CfnTopic(stack, "Topic", {
+  topicName: "cdkrd-sns-deliverystatus",
+  // Per-protocol delivery-status logging declared NON-sorted by Protocol
+  // (sqs before application before lambda before firehose).
+  deliveryStatusLogging: [
+    {
+      protocol: "sqs",
+      successFeedbackRoleArn: feedbackRole.roleArn,
+      failureFeedbackRoleArn: feedbackRole.roleArn,
+      successFeedbackSampleRate: "100",
+    },
+    {
+      protocol: "application",
+      successFeedbackRoleArn: feedbackRole.roleArn,
+      failureFeedbackRoleArn: feedbackRole.roleArn,
+      successFeedbackSampleRate: "100",
+    },
+    {
+      protocol: "lambda",
+      successFeedbackRoleArn: feedbackRole.roleArn,
+      failureFeedbackRoleArn: feedbackRole.roleArn,
+      successFeedbackSampleRate: "100",
+    },
+    {
+      protocol: "firehose",
+      successFeedbackRoleArn: feedbackRole.roleArn,
+      failureFeedbackRoleArn: feedbackRole.roleArn,
+      successFeedbackSampleRate: "100",
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/sns-deliverystatus/cdk.json
+++ b/tests/integration/sns-deliverystatus/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-deliverystatus/package.json
+++ b/tests/integration/sns-deliverystatus/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-sns-deliverystatus",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sns-deliverystatus false-positive integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/sns-deliverystatus/verify.sh
+++ b/tests/integration/sns-deliverystatus/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. ECS heavily default-fills the ContainerDefinitions JSON; any
+# drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsDeliveryStatus
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-sns-deliverystatus" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A continued `insertionOrder:false` hunt (follow-on to #387) surfaced two more
false-positive declared drifts — both top-level object sets AWS echoes sorted by a
non-identity key — fixed by adding the path to `UNORDERED_OBJECT_ARRAY_PROPS`
(equality-gated, so a genuine element change still surfaces).

| Type | Path | AWS behavior |
| --- | --- | --- |
| `AWS::AutoScaling::AutoScalingGroup` | `LifecycleHookSpecificationList` | sorted by `LifecycleHookName` |
| `AWS::SecretsManager::Secret` | `ReplicaRegions` | sorted by `Region` |

The ASG entry is the group's **own inline** hook list — distinct from the standalone
`AWS::AutoScaling::LifecycleHook` resource already covered by `autoscaling-lifecyclehook-rich`.

## Rule-out (documented, not folded)

`AWS::SNS::Topic` `DeliveryStatusLogging` was declared non-sorted by `Protocol` in the
same hunt and SNS **preserved** order — kept as a clean corpus case (`sns-deliverystatus`).

## Verification

- Each fix is live-proven: deploy → `check` reports the FP → fix → re-deploy → CLEAN
  (`INTEG PASS`) with the integration fixtures committed here.
- Unit tests (fold + no-over-fold) + golden-corpus cases from the real live read
  (account ids sanitized). Cross-region replica cleanup verified for the Secret fixture.
- 1707 unit tests pass; typecheck / lint+format / build green; `noise` regression
  fixture `INTEG PASS`.
