### PR TITLE
feat(revert): revert declared drift inside JSON-string properties (ConfigRule InputParameters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,8 @@ permissions), plus, for the SDK-written types: `s3:PutBucketPolicy` /
 `iam:CreatePolicyVersion` / `DeletePolicyVersion` / `ListPolicyVersions`,
 `elasticloadbalancing:ModifyLoadBalancerAttributes` / `ModifyTargetGroupAttributes`,
 `glue:UpdateTable`, `logs:PutMetricFilter`, `route53:ChangeResourceRecordSets`,
-`docdb:ModifyDBCluster` / `ModifyDBInstance`.
+`docdb:ModifyDBCluster` / `ModifyDBInstance`,
+`config:DescribeConfigRules` / `config:PutConfigRule`.
 
 </details>
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -658,7 +658,14 @@ only when non-zero — unrecorded values are named as such, never folded into
     boolean — its LogGroup update handler's downstream call errors with "The
     security token included in the request is invalid" (proven live) — so the
     writer toggles it directly (a `remove` reverts to the schema default DISABLED;
-    an `add` carries the desired boolean). Scoped to the EXACT top-level path: deeper
+    an `add` carries the desired boolean). An `AWS::Config::ConfigRule`'s
+    `InputParameters` (a `JSON_STRING_PROPS` property — Config stores it as one JSON
+    string) reverts via `PutConfigRule`, writing a COMPACT JSON string with
+    string-coerced param values: a CC `UpdateResource` re-serializes the JSON into
+    Config's string field with spaces / a numeric value, which the provider rejects
+    ("Blank spaces are not acceptable for input parameter" — proven live). classify
+    reports such a property WHOLE at its top-level path (never a fragile sub-path
+    finding). Scoped to the EXACT top-level path: deeper
     `Policies.*` declared drift still patches via CC. A resource with both kinds
     of findings splits into one `cc` item and one `sdk` item.
 - **Not revertable (reported honestly, never silently skipped)**:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -13,13 +13,13 @@ the full design.
   can't safely target a deep sub-field — fix in IaC or re-record); create-only
   properties (changing them needs replacement); toggle-style properties with no
   "absent" state (e.g. S3 transfer acceleration); `AWS::Lambda::Permission` and
-  `AWS::Budgets::Budget` (their write APIs can't reconstruct the desired state);
-  and a declared change INSIDE a JSON-string-typed property (e.g.
-  `AWS::Config::ConfigRule` `InputParameters` — cdkrd descends into the parsed
-  JSON for a precise finding, but an RFC6902 sub-path patch can't apply to a
-  string value, so revert reports non-convergence rather than silently failing;
-  whole-property revert for such props is a follow-up). Detection still works.
-  Not-revertable findings fold into a one-line-per-reason summary (`--verbose` for
+  `AWS::Budgets::Budget` (their write APIs can't reconstruct the desired state).
+  (A declared change inside a JSON-string-typed property such as
+  `AWS::Config::ConfigRule` `InputParameters` — stored by the provider as one JSON
+  string — IS revertable: it is compared and reverted as a whole property via the
+  type's SDK writer, since a Cloud Control patch re-serializes the JSON in a shape
+  the provider rejects.) Not-revertable findings fold into a one-line-per-reason
+  summary (`--verbose` for
   the full list). When findings exist but nothing is revertable, `revert` prints
   `nothing revertable` and exits 1.
 - **Revert writes the canonical form** of the desired value — semantically equal to

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@aws-sdk/client-cloudwatch-logs": "^3.1066.0",
     "@aws-sdk/client-codebuild": "^3.1068.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1069.0",
+    "@aws-sdk/client-config-service": "^3.1075.0",
     "@aws-sdk/client-docdb": "^3.1073.0",
     "@aws-sdk/client-ec2": "^3.1066.0",
     "@aws-sdk/client-ecs": "^3.1066.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1069.0
         version: 3.1069.0
+      '@aws-sdk/client-config-service':
+        specifier: ^3.1075.0
+        version: 3.1075.0
       '@aws-sdk/client-docdb':
         specifier: ^3.1073.0
         version: 3.1073.0
@@ -310,6 +313,10 @@ packages:
     resolution: {integrity: sha512-mTlm1+wHWlZl91jRUUii4hN+ZFcEkNyMDkVM2/qJBZLAzRvXnSrLEykqxowTC3aeK7YzXenwGgEyoBE21zdxQw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-config-service@3.1075.0':
+    resolution: {integrity: sha512-Yd7VPZIorkDbG6742YOnqYeTOKyawuVK6DB9crKghYj0Ve1SpYgWNnhX8WCuNKBIQIZ0Hqr1Znr53MtcQ1cvqw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-docdb@3.1073.0':
     resolution: {integrity: sha512-sdJBAJyNRkNFophs/7zBEk9xCK1B7yHmBwwnHssRx4b3pEDbddsXNu/7BmXS3bzV4AYdwrYrvKhns/dlj00i6w==}
     engines: {node: '>=20.0.0'}
@@ -418,6 +425,10 @@ packages:
     resolution: {integrity: sha512-YofH63shc6YRdXjz80BJkpJW+Bkn0Cuu2dn4Rv7s9G2Idt58tgtzQEWxrR2xVljlVfIBeUjPuULnSVYLke3sUQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.23':
+    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     resolution: {integrity: sha512-4L/REssieLON1hVsTzZucP1p2u5jmPNejyh/9BCGZXr93IalBbhRPCrtKIKwMTu9yRGr/bcKzhrQocByKLSzLQ==}
     engines: {node: '>=20.0.0'}
@@ -434,6 +445,10 @@ packages:
     resolution: {integrity: sha512-h6FEC95fbexUd6zxm4PdgS82bTcI2PRtUb2ZwMipb/Xr8bPwtf0G8rBo2jp7NA24Mbx2JA8/WingiYpA9RCCyw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.49':
+    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.48':
     resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
@@ -444,6 +459,10 @@ packages:
 
   '@aws-sdk/credential-provider-http@3.972.50':
     resolution: {integrity: sha512-lJO3OLpjvz5m/RSBQmsG/CEUGsvCy5ruxKwPQaOCqxqCMuyYT2BZwQUTDZVVwqQ9LrZKuK24JSa6r31hL/tvkg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.51':
+    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.53':
@@ -458,6 +477,10 @@ packages:
     resolution: {integrity: sha512-TBoF4buBGYhXjdZAryayY2TrkQj2B2KfE/msG4V53XCt+w0EhEwM2JRjx8p2grJ2C6gtH5++SAwEvGMRdi0yyw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.52':
     resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
@@ -468,6 +491,10 @@ packages:
 
   '@aws-sdk/credential-provider-login@3.972.54':
     resolution: {integrity: sha512-hBWI3wZTdTGiuMfmPts6AWbAjFfRniOQnqx68tc2cQvRKWawFbN9wkLOVPWM1FAOyowZU73mC6Fi+rHSHNyLFw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.55':
@@ -482,6 +509,10 @@ packages:
     resolution: {integrity: sha512-u6dClpzNdWf1HGWz4wwhdXi1wiOofCLniM9S4BQQGlLAN9TW7VB+ld5V533GdKrYMaFeBGFqKnj0JCYvynLqwQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.58':
+    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.46':
     resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
     engines: {node: '>=20.0.0'}
@@ -492,6 +523,10 @@ packages:
 
   '@aws-sdk/credential-provider-process@3.972.48':
     resolution: {integrity: sha512-w6VZwojPt12WnEkAUy6Nu4K6sWCbBmR7QX390b0nE6vRvkXbrYr9Lq9VySGkfjiMjpUA87op+J4EgvRmtWIDoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.49':
+    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.52':
@@ -506,6 +541,10 @@ packages:
     resolution: {integrity: sha512-23uZpIpF2SIFDCa1fcWa202tK4gGeyvX6GIIAjiB8WBsvsVRBMnJ/7dCxHzxf7eZT7GToJg837LDIBnZsl/VUg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
@@ -516,6 +555,10 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.54':
     resolution: {integrity: sha512-0Iv5QttS6wcATlodYKgvQj6B9Db51rx7NU9fqu0PoLeS4BIgdYMc/QK4smwLwpm5RFrs02V/eLyEFp3FklvlNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.1066.0':
@@ -576,6 +619,10 @@ packages:
     resolution: {integrity: sha512-4IwtcYSxEIVw5hcp8ogq0CMbFNZFw7jJUetpfFUhFFeqsa1K8j2Ihg2hnxLyOp3stMZnXda6VzOmPi1AFZQXcg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.23':
+    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
@@ -596,6 +643,10 @@ packages:
     resolution: {integrity: sha512-4LDW2Qob6LoLFuqYSYZq2AyTE9koSE9+i+n5UZcm10GpmQOK0zRD9L4uYlzItiTKksIWgC/qMFChAi3RvKYtMg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1074.0':
+    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.12':
     resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
     engines: {node: '>=20.0.0'}
@@ -614,6 +665,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.30':
     resolution: {integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.31':
+    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -3592,13 +3647,13 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
@@ -3632,7 +3687,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -3641,8 +3696,8 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@aws-crypto/crc32c': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
@@ -3808,9 +3863,22 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/credential-provider-node': 3.972.57
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/client-config-service@3.1075.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-node': 3.972.58
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
@@ -4173,25 +4241,36 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.23':
+    dependencies:
+      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/xml-builder': 3.972.31
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     dependencies:
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.46':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.47':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4205,10 +4284,18 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.48':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
@@ -4217,7 +4304,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-http@3.972.49':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
@@ -4235,9 +4322,19 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-http@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-ini@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/credential-provider-env': 3.972.46
       '@aws-sdk/credential-provider-http': 3.972.48
       '@aws-sdk/credential-provider-login': 3.972.52
@@ -4245,7 +4342,7 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.972.52
       '@aws-sdk/credential-provider-web-identity': 3.972.52
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/credential-provider-imds': 4.3.8
       '@smithy/types': 4.14.3
@@ -4253,7 +4350,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-ini@3.972.54':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/credential-provider-env': 3.972.47
       '@aws-sdk/credential-provider-http': 3.972.49
       '@aws-sdk/credential-provider-login': 3.972.53
@@ -4283,18 +4380,34 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-login': 3.972.55
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
@@ -4305,6 +4418,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4352,17 +4474,31 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.58':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.49
+      '@aws-sdk/credential-provider-http': 3.972.51
+      '@aws-sdk/credential-provider-ini': 3.972.56
+      '@aws-sdk/credential-provider-process': 3.972.49
+      '@aws-sdk/credential-provider-sso': 3.972.55
+      '@aws-sdk/credential-provider-web-identity': 3.972.55
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.46':
     dependencies:
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.974.22
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.47':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4376,19 +4512,27 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-process@3.972.49':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-sso@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.20
       '@aws-sdk/token-providers': 3.1066.0
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/token-providers': 3.1069.0
       '@aws-sdk/types': 3.973.13
@@ -4406,18 +4550,28 @@ snapshots:
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
+      '@aws-sdk/token-providers': 3.1074.0
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-web-identity@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
@@ -4428,6 +4582,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4536,9 +4699,9 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/signature-v4-multi-region': 3.996.34
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
@@ -4549,7 +4712,7 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/signature-v4-multi-region': 3.996.35
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
@@ -4563,6 +4726,19 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.974.22
+      '@aws-sdk/signature-v4-multi-region': 3.996.35
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.23':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.23
       '@aws-sdk/signature-v4-multi-region': 3.996.35
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
@@ -4587,16 +4763,16 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1066.0':
     dependencies:
-      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1069.0':
     dependencies:
-      '@aws-sdk/core': 3.974.21
+      '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.21
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
@@ -4607,6 +4783,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.22
       '@aws-sdk/nested-clients': 3.997.22
+      '@aws-sdk/types': 3.973.13
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1074.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/nested-clients': 3.997.23
       '@aws-sdk/types': 3.973.13
       '@smithy/core': 3.24.6
       '@smithy/types': 4.14.3
@@ -4636,6 +4821,11 @@ snapshots:
     dependencies:
       '@smithy/types': 4.14.3
       fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.31':
+    dependencies:
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -25,6 +25,7 @@ import {
   isEqualUnorderedScalarSet,
   isEquivalentRateExpression,
   isJsonStringStructEqual,
+  JSON_STRING_PROPS,
   isPemEqual,
   isStringlyEqualScalar,
   isStringlyEqualScalarArray,
@@ -476,6 +477,41 @@ export function classifyResource(
         path: k,
         note: 'declared but not returned by live read',
       });
+      continue;
+    }
+    // A CloudFormation JSON-STRING property (AWS::Config::ConfigRule InputParameters):
+    // the schema types it as a string holding JSON, but CDK declares it as an object and
+    // the live read returns it parsed. Compare and emit it as a WHOLE UNIT at the
+    // top-level path — never descend — so the revert rewrites the whole property as a
+    // compact JSON string (a sub-path RFC6902 patch makes Cloud Control re-serialize the
+    // JSON in a shape the provider rejects; see JSON_STRING_PROPS). Fold a stringly-equal
+    // value (declared `90` vs live `"90"`, the param-values-are-strings coercion) so a
+    // clean deploy is not drift; a genuine value change is one declared finding at `k`.
+    if (JSON_STRING_PROPS[resourceType]?.has(k)) {
+      // Parse a side that arrives as a raw JSON string (some providers return the
+      // property unparsed) so both forms compare structurally; then fold a stringly-equal
+      // value (declared `90` vs live `"90"`). A genuine value change is one declared
+      // finding at the whole property path.
+      const parseJson = (x: unknown): unknown => {
+        if (typeof x !== 'string') return x;
+        try {
+          return JSON.parse(x) as unknown;
+        } catch {
+          return x;
+        }
+      };
+      const dv = parseJson(v);
+      const lv = parseJson(live[k]);
+      if (!deepEqual(dv, lv) && !isStringlyEqualDeep(dv, lv)) {
+        findings.push({
+          tier: 'declared',
+          logicalId,
+          resourceType,
+          path: k,
+          desired: v,
+          actual: live[k],
+        });
+      }
       continue;
     }
     // ManagedPolicy attachment lists (Roles/Users/Groups): tier each member by WHO
@@ -933,6 +969,10 @@ export function classifyResource(
     // `hasUnresolved(dv)` guard, which hid that whole class (FP-safe: unresolved subtrees
     // simply aren't descended).
     if (dv === UNRESOLVED || !(k in live)) continue;
+    // A JSON-string property (ConfigRule InputParameters) is compared and reported as a
+    // WHOLE UNIT in the declared loop above — never descend into it for nested undeclared
+    // sub-keys, which would emit a fragile dotted finding the revert can't target.
+    if (JSON_STRING_PROPS[resourceType]?.has(k)) continue;
     collectNestedUndeclared(dv, live[k], k, (path, value) => {
       if (isAllAwsTags(value) || isTrivialEmpty(value)) return;
       const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1154,6 +1154,23 @@ export function isJsonStringStructEqual(a: unknown, b: unknown): boolean {
   return false;
 }
 
+// Per-type TOP-LEVEL properties the CloudFormation schema types as a JSON STRING
+// but which CDK declares (and the live read often returns) as a parsed OBJECT —
+// e.g. AWS::Config::ConfigRule `InputParameters`. The provider stores the whole
+// property as a single JSON string; Cloud Control surfaces it parsed for reads but
+// re-serializes the model to that string on UpdateResource. A sub-path RFC6902
+// patch (`/InputParameters/maxAccessKeyAge`) therefore makes Cloud Control rebuild
+// the JSON string in a shape the provider rejects (Config: "Blank spaces are not
+// acceptable for input parameter") — the revert never converges. So such a property
+// must be compared and reverted as a WHOLE UNIT: classify emits one finding at the
+// top-level path (folded stringly so a clean `90` vs `"90"` is not drift), and the
+// revert writes the whole property as a COMPACT JSON STRING (`JSON.stringify` of the
+// declared object), which the provider accepts verbatim. Curated, like the sibling
+// per-type tables — add a property here once its sub-path revert is observed to fail.
+export const JSON_STRING_PROPS: Record<string, ReadonlySet<string>> = {
+  'AWS::Config::ConfigRule': new Set(['InputParameters']),
+};
+
 // Per-type property paths AWS compares CASE-INSENSITIVELY (R75: Route53
 // RecordSet AliasTarget.DNSName — an ALB's generated DNS name is mixed-case in
 // the template's GetAtt and all-lowercase in the live record; DNS hostnames are

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -11,7 +11,7 @@
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
-import { awsManagedTags, KNOWN_DEFAULTS } from '../normalize/noise.js';
+import { awsManagedTags, JSON_STRING_PROPS, KNOWN_DEFAULTS } from '../normalize/noise.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { SDK_PROP_WRITERS, SDK_WRITERS } from './writers.js';
@@ -347,6 +347,25 @@ export function buildRevertPlan(
     // by kind (+ path when prop-scoped) so each item resolves to ONE writer.
     const propScoped =
       !SDK_WRITERS[f.resourceType] && SDK_PROP_WRITERS[f.resourceType]?.[f.path] !== undefined;
+    // A JSON-string property (JSON_STRING_PROPS) can NEVER be reverted via Cloud Control:
+    // CC re-serializes the JSON it stores into the provider's string field with spaces,
+    // which the provider rejects (Config: "Blank spaces are not acceptable") — proven live.
+    // So it MUST route to an SDK writer that writes the compact JSON string directly; if no
+    // writer covers it, refuse rather than emit a CC patch that always fails at apply.
+    if (
+      JSON_STRING_PROPS[f.resourceType]?.has(f.path) &&
+      !propScoped &&
+      !SDK_WRITERS[f.resourceType]
+    ) {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason:
+          'JSON-string property — revert needs a type-specific SDK writer (not available yet)',
+      });
+      continue;
+    }
     const kind: RevertItem['kind'] = SDK_WRITERS[f.resourceType] || propScoped ? 'sdk' : 'cc';
 
     const op = revertOp(f, recorded);

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -76,6 +76,11 @@ import {
   PutRolePolicyCommand,
   PutUserPolicyCommand,
 } from '@aws-sdk/client-iam';
+import {
+  ConfigServiceClient,
+  DescribeConfigRulesCommand,
+  PutConfigRuleCommand,
+} from '@aws-sdk/client-config-service';
 import { ChangeResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { DeleteBucketPolicyCommand, PutBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
 import {
@@ -734,6 +739,75 @@ const writeRoute53RecordSet: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// AWS::Config::ConfigRule `InputParameters` — Config stores it as a single JSON STRING.
+// Cloud Control CAN read it (returned parsed as an object) but CANNOT revert it: a CC
+// UpdateResource re-serializes the JSON into Config's string field WITH SPACES, which the
+// PutConfigRule provider rejects ("Blank spaces are not acceptable for input parameter")
+// — proven live, the same CC-revalidation class as OpenSearch/CloudFront. So revert this
+// property via PutConfigRule directly, writing the declared value as a COMPACT JSON string
+// (no spaces). PutConfigRule is a whole-rule UPSERT, so re-read the current rule and
+// overwrite only InputParameters, preserving Source/Scope/MaximumExecutionFrequency/etc.
+// Config stores InputParameters as a JSON string whose param VALUES are themselves
+// strings (a managed rule's `maxAccessKeyAge` is `"90"`, not `90`). CDK declares them
+// typed (`90`), and CloudFormation coerces them to strings on deploy — cdkrd treats
+// `90` and `"90"` as equal (stringly). The revert must write the SAME string-valued form
+// CloudFormation produced, or PutConfigRule rejects the numeric value with the misleading
+// "Blank spaces are not acceptable for input parameter" error (proven live). So serialize
+// the declared object with each scalar param value coerced to a string; objects/arrays
+// (a rare structured param) are left as-is for JSON to render.
+const configInputParametersString = (v: unknown): string => {
+  let model: unknown = v;
+  if (typeof v === 'string') {
+    try {
+      model = JSON.parse(v);
+    } catch {
+      return v; // already a string we can't parse — pass through verbatim
+    }
+  }
+  if (model !== null && typeof model === 'object' && !Array.isArray(model)) {
+    const coerced: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(model as Record<string, unknown>)) {
+      coerced[k] = typeof val === 'number' || typeof val === 'boolean' ? String(val) : val;
+    }
+    return JSON.stringify(coerced);
+  }
+  return JSON.stringify(model);
+};
+const writeConfigRuleInputParameters: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['ConfigRuleName']);
+  if (!name) throw new Error('cannot resolve Config rule name for revert');
+  const op = ops.find((o) => o.path === '/InputParameters');
+  if (op?.op !== 'add') throw new Error('Config rule InputParameters revert: unexpected op');
+  const client = new ConfigServiceClient({ region: ctx.region });
+  const got = await client.send(new DescribeConfigRulesCommand({ ConfigRuleNames: [name] }));
+  const rule = got.ConfigRules?.[0];
+  if (!rule) throw new Error(`Config rule not found for revert: ${name}`);
+  // Re-PUT the rule with only InputParameters overwritten. Drop the server-populated
+  // fields PutConfigRule rejects (ConfigRuleArn/Id/State, CreatedBy, and a newer
+  // RuleEvaluationVisibility — proven live: "AWS Config populates the
+  // RuleEvaluationVisibility field ... Try again without populating [it]"); keep the rest
+  // (Source/Scope/Description/MaximumExecutionFrequency/EvaluationModes). The rule is
+  // matched by the preserved ConfigRuleName.
+  const {
+    ConfigRuleArn,
+    ConfigRuleId,
+    ConfigRuleState,
+    CreatedBy,
+    RuleEvaluationVisibility,
+    ...rest
+  } = rule;
+  void ConfigRuleArn;
+  void ConfigRuleId;
+  void ConfigRuleState;
+  void CreatedBy;
+  void RuleEvaluationVisibility;
+  await client.send(
+    new PutConfigRuleCommand({
+      ConfigRule: { ...rest, InputParameters: configInputParametersString(op.value) },
+    })
+  );
+};
+
 // AWS::OpenSearchService::Domain — Cloud Control CAN read this type, but its
 // UpdateResource REJECTS a property patch: it re-submits the full model and AWS's own
 // legacy `override_main_response_version` AdvancedOption (returned on read) is rejected
@@ -844,6 +918,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
 // resource type -> EXACT top-level finding path. Deeper paths (e.g. a declared
 // drift at Policies.0...) still go through Cloud Control as before.
 export const SDK_PROP_WRITERS: Record<string, Record<string, SdkWriter>> = {
+  'AWS::Config::ConfigRule': { InputParameters: writeConfigRuleInputParameters },
   'AWS::IAM::Role': { Policies: writeIamRoleInlinePolicies },
   'AWS::Logs::LogGroup': { BearerTokenAuthenticationEnabled: writeLogGroupBearerTokenAuth },
   'AWS::ElasticLoadBalancingV2::LoadBalancer': {

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -154,6 +154,54 @@ describe('classifyResource (the heart)', () => {
     expect(drifted.declared).toEqual(['Value']);
   });
 
+  // A CloudFormation JSON-STRING property (AWS::Config::ConfigRule InputParameters):
+  // CDK declares it as an object, Cloud Control returns it parsed. It must be compared
+  // and reported as a WHOLE UNIT at the top-level path — never descended — so the revert
+  // can rewrite it as a compact JSON string instead of a sub-path patch the provider
+  // rejects. A stringly-equal value (declared `90` vs live `"90"`, the param-values-are-
+  // strings coercion) is folded; a real value change is one declared finding at the
+  // top-level path (NOT the nested `InputParameters.maxAccessKeyAge`).
+  it('JSON-string property (ConfigRule InputParameters): clean folds, change is one top-level finding', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const res: DesiredResource = {
+      logicalId: 'Rule',
+      resourceType: 'AWS::Config::ConfigRule',
+      physicalId: 'cdkrd-access-keys-rotated',
+      declared: { InputParameters: { maxAccessKeyAge: 90 } }, // CDK declares a number
+    };
+    // Clean: live param values are strings (`"90"`) — stringly-equal, not drift.
+    const clean = tiers(
+      classifyResource(res, { InputParameters: { maxAccessKeyAge: '90' } }, emptySchema)
+    );
+    expect(clean.declared).toEqual([]);
+    expect(clean.undeclared).toEqual([]); // never descended into a fragile nested finding
+    // Weakened out of band (90 -> 365): ONE declared finding at the WHOLE property path.
+    const drifted = classifyResource(
+      res,
+      { InputParameters: { maxAccessKeyAge: '365' } },
+      emptySchema
+    );
+    const declared = drifted.filter((f) => f.tier === 'declared');
+    expect(declared).toHaveLength(1);
+    expect(declared[0].path).toBe('InputParameters'); // top-level, NOT InputParameters.maxAccessKeyAge
+    expect(declared[0].desired).toEqual({ maxAccessKeyAge: 90 });
+    expect(declared[0].actual).toEqual({ maxAccessKeyAge: '365' });
+    // also returned as a raw JSON string by some providers — still folded/compared whole.
+    const asString = tiers(
+      classifyResource(res, { InputParameters: '{"maxAccessKeyAge":"90"}' }, emptySchema)
+    );
+    expect(asString.declared).toEqual([]);
+  });
+
   // First-run noise folds for a clean deploy: a Cognito user pool
   // ALWAYS returns the immutable OIDC standard attributes in Schema (fold to atDefault via
   // IDENTITY_KEYED_DEFAULT_ELEMENTS) and a Lambda Version's CodeSha256 is a per-deploy

--- a/tests/integration/config-rule-rich/verify-detect.sh
+++ b/tests/integration/config-rule-rich/verify-detect.sh
@@ -1,16 +1,14 @@
 #!/usr/bin/env bash
-# ConfigRule detect integration test (real AWS): the governance-weakening scenario.
-# Provision a recorder (SDK) -> deploy rule -> record -> weaken maxAccessKeyAge
-# 90 -> 365 out of band (someone loosens a rotation rule) -> check MUST DETECT
-# (exit 1, reporting InputParameters.maxAccessKeyAge) -> restore the rule manually.
+# ConfigRule detect+revert integration test (real AWS): the governance-weakening
+# scenario, end to end. Provision a recorder (SDK) -> deploy rule -> record -> weaken
+# maxAccessKeyAge 90 -> 365 out of band (someone loosens a rotation rule) -> check MUST
+# DETECT (exit 1) -> revert MUST restore it -> check MUST be CLEAN.
 #
-# This is DETECT-ONLY: revert is NOT exercised. AWS::Config::ConfigRule stores
-# InputParameters as a JSON STRING, so cdkrd descends into it for a precise nested
-# finding, but the revert's RFC6902 sub-path patch (/InputParameters/maxAccessKeyAge)
-# cannot apply to a string value — revert honestly reports non-convergence rather than
-# silently failing. Reverting into a JSON-string property is a known limitation (a
-# follow-up SDK_WRITERS / whole-property-revert task), like Route53 RecordSet's revert
-# gap. Detection — catching the unauthorized weakening — is the point and works.
+# AWS::Config::ConfigRule stores InputParameters as a JSON STRING; cdkrd compares and
+# reverts it as a WHOLE property (JSON_STRING_PROPS) via the PutConfigRule SDK writer —
+# Cloud Control cannot revert it (its read-modify-write re-serializes the JSON into
+# Config's string field with spaces / numeric values, which the provider rejects). The
+# writer writes a COMPACT JSON string with string-coerced param values. Live-proven.
 set -uo pipefail
 export AWS_CLI_AUTO_PROMPT=off
 HERE="$(cd "$(dirname "$0")" && pwd)"
@@ -54,15 +52,12 @@ rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
 grep -q "maxAccessKeyAge" /tmp/cdkrd-config-detect.out || fail "weakened parameter not reported"
 
-echo "=== restore the rule to 90 (manual; revert-into-JSON-string is a known gap) ==="
-cat > /tmp/config-rule-90.json <<'JSON'
-{ "ConfigRuleName": "cdkrd-access-keys-rotated", "Source": { "Owner": "AWS", "SourceIdentifier": "ACCESS_KEYS_ROTATED" },
-  "InputParameters": "{\"maxAccessKeyAge\":\"90\"}", "MaximumExecutionFrequency": "TwentyFour_Hours" }
-JSON
-aws configservice put-config-rule --region "$REGION" --config-rule file:///tmp/config-rule-90.json || fail "restore"
+echo "=== revert MUST restore the rule to 90 (PutConfigRule SDK writer) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-config-revert.out
+grep -q "reverted:" /tmp/cdkrd-config-revert.out || fail "revert did not report success"
 
-echo "=== check MUST be CLEAN after restore ==="
+echo "=== check MUST be CLEAN after revert ==="
 $CLI check "$STACK" --region "$REGION" --fail
-[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after restore"
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
 
-echo "INTEG PASS ($STACK detect)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -75,6 +75,30 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('JSON-string property (ConfigRule InputParameters) -> SDK writer (CC re-serializes with spaces; provider rejects)', () => {
+    // classify reports the whole property at the top-level path. Cloud Control cannot
+    // revert it (its read-modify-write re-serializes the JSON into Config's string field
+    // with spaces -> "Blank spaces are not acceptable"), so it must route to the
+    // type's SDK writer (PutConfigRule, compact JSON string). The op carries the whole
+    // declared value; the writer compacts it.
+    const f = F({
+      tier: 'declared',
+      resourceType: 'AWS::Config::ConfigRule',
+      physicalId: 'cdkrd-access-keys-rotated',
+      path: 'InputParameters',
+      desired: { maxAccessKeyAge: 90 },
+      actual: { maxAccessKeyAge: '365' },
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk'); // NOT cc — the CC patch always fails for this prop
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/InputParameters',
+      value: { maxAccessKeyAge: 90 },
+    });
+  });
+
   it('declared drift carries the live value as `prior` (per-entry SDK writers need it)', () => {
     // A declared /Policies drift on an IAM Role (a rogue inline policy added out of
     // band → whole-array drift) must carry the live array as `prior` so

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -77,6 +77,11 @@ import {
   SetQueueAttributesCommand,
   SQSClient,
 } from '@aws-sdk/client-sqs';
+import {
+  ConfigServiceClient,
+  DescribeConfigRulesCommand,
+  PutConfigRuleCommand,
+} from '@aws-sdk/client-config-service';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
@@ -95,6 +100,7 @@ const opensearch = mockClient(OpenSearchClient);
 const glue = mockClient(GlueClient);
 const logs = mockClient(CloudWatchLogsClient);
 const route53 = mockClient(Route53Client);
+const configService = mockClient(ConfigServiceClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -136,6 +142,7 @@ beforeEach(() => {
   glue.reset();
   logs.reset();
   route53.reset();
+  configService.reset();
 });
 
 describe('OpenSearch Domain writer (CC UpdateResource rejects on override_main_response_version)', () => {
@@ -1270,5 +1277,68 @@ describe('Logs LogGroup BearerTokenAuthenticationEnabled prop-scoped writer (CC 
     expect(
       logs.commandCalls(PutBearerTokenAuthenticationCommand)[0].args[0].input.logGroupIdentifier
     ).toBe(LG);
+  });
+});
+
+describe('writeConfigRuleInputParameters (AWS::Config::ConfigRule, JSON-string property)', () => {
+  const inputParamsOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/InputParameters',
+    value,
+    human: 'InputParameters -> deployed-template value',
+  });
+
+  it('re-PUTs the rule with a COMPACT InputParameters JSON string (no spaces), preserving other fields', async () => {
+    configService.on(DescribeConfigRulesCommand).resolves({
+      ConfigRules: [
+        {
+          ConfigRuleName: 'cdkrd-access-keys-rotated',
+          ConfigRuleArn: 'arn:aws:config:us-east-1:111122223333:config-rule/config-rule-x',
+          ConfigRuleId: 'config-rule-x',
+          ConfigRuleState: 'ACTIVE',
+          Source: { Owner: 'AWS', SourceIdentifier: 'ACCESS_KEYS_ROTATED' },
+          MaximumExecutionFrequency: 'TwentyFour_Hours',
+          InputParameters: '{"maxAccessKeyAge":"365"}',
+        },
+      ],
+    });
+    configService.on(PutConfigRuleCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::Config::ConfigRule', [
+      inputParamsOp({ maxAccessKeyAge: 90 }),
+    ])!;
+    await writer(ctx({ physicalId: 'cdkrd-access-keys-rotated' }), [
+      inputParamsOp({ maxAccessKeyAge: 90 }),
+    ]);
+    const put = configService.commandCalls(PutConfigRuleCommand)[0].args[0].input.ConfigRule!;
+    // compact JSON string with STRING-coerced param values — Config rejects both spaces
+    // and a numeric value ("Blank spaces are not acceptable for input parameter")
+    expect(put.InputParameters).toBe('{"maxAccessKeyAge":"90"}');
+    expect(put.InputParameters).not.toContain(' ');
+    // other rule fields preserved; read-only server fields dropped
+    expect(put.Source).toEqual({ Owner: 'AWS', SourceIdentifier: 'ACCESS_KEYS_ROTATED' });
+    expect(put.MaximumExecutionFrequency).toBe('TwentyFour_Hours');
+    expect(put.ConfigRuleArn).toBeUndefined();
+    expect(put.ConfigRuleId).toBeUndefined();
+    expect(put.ConfigRuleState).toBeUndefined();
+  });
+
+  it('compacts a value that arrives as a whitespace-laden JSON string', async () => {
+    configService.on(DescribeConfigRulesCommand).resolves({
+      ConfigRules: [{ ConfigRuleName: 'r', Source: { Owner: 'AWS', SourceIdentifier: 'X' } }],
+    });
+    configService.on(PutConfigRuleCommand).resolves({});
+    const writer = resolveSdkWriter('AWS::Config::ConfigRule', [inputParamsOp('{ "a": "1" }')])!;
+    await writer(ctx({ physicalId: 'r' }), [inputParamsOp('{ "a": "1" }')]);
+    expect(
+      configService.commandCalls(PutConfigRuleCommand)[0].args[0].input.ConfigRule!.InputParameters
+    ).toBe('{"a":"1"}');
+  });
+
+  it('throws when the rule cannot be found (no silent no-op)', async () => {
+    configService.on(DescribeConfigRulesCommand).resolves({ ConfigRules: [] });
+    const writer = resolveSdkWriter('AWS::Config::ConfigRule', [inputParamsOp({ a: 1 })])!;
+    await expect(writer(ctx({ physicalId: 'missing' }), [inputParamsOp({ a: 1 })])).rejects.toThrow(
+      /Config rule not found/
+    );
   });
 });


### PR DESCRIPTION
## What

Makes a declared change **inside a JSON-string-typed property** revertable — closing the one gap shipped in PR #386 (where `AWS::Config::ConfigRule` `InputParameters` was detect-only).

A CloudFormation "JSON-string" property is a `String`-typed property that actually holds JSON. CDK declares it as an **object**, and Cloud Control reads it back **parsed** — so a console edit to a parameter (e.g. weakening `maxAccessKeyAge` `90` → `365` on the `ACCESS_KEYS_ROTATED` managed rule, a real governance-weakening scenario) was **detected** but could not be **reverted**.

## The bug (ground-truthed live, not from the schema)

A live probe showed the failure is **not** "can't patch a string" (my earlier note was wrong). Cloud Control returns `InputParameters` as a parsed object at both check and revert time, so revert built a sub-path patch `add /InputParameters/maxAccessKeyAge`. Cloud Control's read-modify-write then **re-serializes** the object into Config's JSON-string field — with spaces and a numeric value — which `PutConfigRule` rejects:

> `Blank spaces are not acceptable for input parameter: maxAccessKeyAge`

A compact-string CC patch **also** fails the same way (CC reformats regardless), and a numeric value triggers the same misleading error — Config wants string-valued params. So the property cannot be reverted via Cloud Control at all; it needs the resource's own SDK.

## Fix (live-proven detect → revert → CLEAN)

- **`JSON_STRING_PROPS`** (`normalize/noise.ts`): curated per-type table of `String`-typed JSON properties (`AWS::Config::ConfigRule` → `InputParameters`).
- **classify** compares and reports such a property as **one whole finding at its top-level path** (never a fragile `InputParameters.maxAccessKeyAge` sub-path), folding stringly-equal values (`90` vs `"90"`) so a clean deploy is not drift.
- **revert** routes it to a prop-scoped SDK writer (`PutConfigRule`) that writes a **compact JSON string with string-coerced param values**, and drops the server-only fields `PutConfigRule` rejects (`ConfigRuleArn`/`Id`/`State`, `CreatedBy`, `RuleEvaluationVisibility`). A `JSON_STRING_PROPS` finding with **no** SDK writer is refused (not-revertable) rather than emitting a CC patch that always fails.
- New dependency: `@aws-sdk/client-config-service`.

## Tests

- **Unit (1705 green)**: classify whole-property fold + drift; revert-plan SDK routing; writers mock (compact output, string-coercion, server-field drop, rule-not-found throw).
- **Integration (real AWS, us-east-1)**: `tests/integration/config-rule-rich/verify-detect.sh` upgraded from detect-only to a full **detect → revert → restore → CLEAN** cycle — **INTEG PASS**.
- Core verify-pr suite (basic / iam / lambda / revert / policies) re-run on real AWS.

## Docs

`docs/limitations.md` (the JSON-string revert gap is now revertable, not a limitation), README "Additional write permissions" (`config:DescribeConfigRules` / `config:PutConfigRule`), `docs/ARCHITECTURE.md` (SDK_PROP_WRITERS section).
