### PR TITLE
fix(noise): fold EC2 Instance Volumes subset + ElastiCache LogDeliveryConfigurations reorder

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -109,7 +109,22 @@ const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpe
   // each live-only mapping as nested undeclared inventory. A genuinely removed declared
   // mapping (no live DeviceName match) still surfaces as declared drift. Observed live on a
   // fresh ec2-instance-rich deploy (a gp3 root volume + an attached data volume).
-  'AWS::EC2::Instance': { BlockDeviceMappings: { idField: 'DeviceName' } },
+  // An EC2 Instance's `Volumes` (EBS volumes ATTACHED at launch, each {Device, VolumeId})
+  // is the same superset shape as BlockDeviceMappings: the live model adds the AMI's ROOT
+  // volume (e.g. `/dev/xvda`) — which the template never declares as an attachment — as an
+  // EXTRA element, and AWS may interleave it among the declared attachments. A positional/
+  // whole-array compare then false-flags the entire `Volumes` as declared drift on every
+  // fresh deploy of an instance that attaches volumes. Aligning declared volumes to live BY
+  // Device lets each declared attachment subset-compare against its live twin and emits the
+  // live-only root volume as nested undeclared inventory (recordable). A genuinely detached
+  // declared volume (no live Device match) still surfaces as declared drift. Observed live
+  // on a fresh ec2-instance-sets deploy (two attached gp3 volumes + the AMI root). (The
+  // sibling `NetworkInterfaces` set was tested in the SAME deploy declared non-sorted by
+  // DeviceIndex and AWS PRESERVED its order — subset-clean, so it is NOT folded.)
+  'AWS::EC2::Instance': {
+    BlockDeviceMappings: { idField: 'DeviceName' },
+    Volumes: { idField: 'Device' },
+  },
   // A Cognito UserPoolUser's UserAttributes is a SET keyed by Name where the live model
   // is a SUPERSET of the template's: AWS ALWAYS injects the server-generated immutable
   // `sub` (the user id), plus `email_verified`/`phone_number_verified` once those

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1661,6 +1661,21 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
   // a genuine region add/remove still differs. Observed live on a fresh
   // secret-replica-regions deploy.
   'AWS::SecretsManager::Secret': new Set(['ReplicaRegions']),
+  // An ElastiCache CacheCluster's `LogDeliveryConfigurations` is a SET of {LogType,
+  // LogFormat, DestinationType, DestinationDetails} that AWS echoes SORTED by LogType,
+  // not in template order (declared [slow-log, engine-log] reads back [engine-log,
+  // slow-log] alphabetically), so a positional compare false-flags every field of every
+  // shifted config — LogType AND the resolved destination LogGroup — as declared drift on
+  // a freshly recorded cluster. The element key `LogType` is NOT one of
+  // canonicalizeTagListsDeep's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name), so
+  // that keyed canonicalizer can't align it — hence the per-type opt-in. Sorting both
+  // sides by canonical JSON aligns equal configs; a genuine destination/format change
+  // still differs. Observed live on a fresh elasticache-logdelivery deploy (slow-log +
+  // engine-log to CloudWatch Logs). The same shape exists on AWS::ElastiCache::
+  // ReplicationGroup (`LogDeliveryConfigurations` of identical {LogType, …} elements) —
+  // folded by the same set-semantics reasoning.
+  'AWS::ElastiCache::CacheCluster': new Set(['LogDeliveryConfigurations']),
+  'AWS::ElastiCache::ReplicationGroup': new Set(['LogDeliveryConfigurations']),
 };
 
 // Per-type NESTED array paths AWS returns reordered (dotted from the resource

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2306,6 +2306,38 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('ElastiCache CacheCluster LogDeliveryConfigurations reordered (object set keyed by LogType ∉ IDENTITY_FIELDS, found by elasticache-logdelivery)', () => {
+    const T = 'AWS::ElastiCache::CacheCluster';
+    const cfg = (logType: string, logGroup: string) => ({
+      LogType: logType,
+      LogFormat: 'json',
+      DestinationType: 'cloudwatch-logs',
+      DestinationDetails: { CloudWatchLogsDetails: { LogGroup: logGroup } },
+    });
+    const declared = {
+      LogDeliveryConfigurations: [cfg('slow-log', 'slow-grp'), cfg('engine-log', 'engine-grp')],
+    };
+
+    it('Cloud Control returning the set reordered by LogType is NOT drift', () => {
+      // Cloud Control echoes the configs alphabetically by LogType (engine-log first),
+      // and the order is non-deterministic between reads — sorting both sides aligns them.
+      const live = {
+        LogDeliveryConfigurations: [cfg('engine-log', 'engine-grp'), cfg('slow-log', 'slow-grp')],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine destination change still surfaces (no over-fold)', () => {
+      const live = {
+        LogDeliveryConfigurations: [
+          cfg('engine-log', 'engine-grp'),
+          cfg('slow-log', 'CHANGED-grp'),
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('AutoScaling group MetricsCollection.Metrics / NotificationConfigurations.NotificationTypes reordered (nested scalar sets, found by asg-notification-metrics)', () => {
     const T = 'AWS::AutoScaling::AutoScalingGroup';
 
@@ -4140,6 +4172,76 @@ describe('EC2 Instance BlockDeviceMappings identity-keyed subset (found by ec2-i
       bare
     ).filter((f) => f.tier === 'declared');
     expect(declaredDrift).toHaveLength(1);
+  });
+});
+
+describe('EC2 Instance Volumes identity-keyed subset (found by ec2-instance-sets)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const inst = (declared: Record<string, unknown>) => ({
+    logicalId: 'Inst',
+    resourceType: 'AWS::EC2::Instance',
+    physicalId: 'i-0abc',
+    declared,
+  });
+  // The template attaches two volumes, declared NON-sorted by Device (/dev/sdg first).
+  const declaredVols = [
+    { Device: '/dev/sdg', VolumeId: 'vol-aaaa' },
+    { Device: '/dev/sdf', VolumeId: 'vol-bbbb' },
+  ];
+  // The live model adds the AMI ROOT volume (/dev/xvda) the template never declared and
+  // interleaves it among the declared attachments (keys also reordered VolumeId-first).
+  const liveVols = [
+    { VolumeId: 'vol-aaaa', Device: '/dev/sdg' },
+    { VolumeId: 'vol-root', Device: '/dev/xvda' },
+    { VolumeId: 'vol-bbbb', Device: '/dev/sdf' },
+  ];
+
+  it('the extra live root volume does NOT false-drift the whole Volumes array', () => {
+    const findings = classifyResource(inst({ Volumes: declaredVols }), { Volumes: liveVols }, bare);
+    expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+    // the live-only root volume surfaces as nested undeclared inventory, keyed by Device
+    const undeclared = findings.filter(
+      (f) => f.tier === 'undeclared' && f.path === 'Volumes[/dev/xvda]'
+    );
+    expect(undeclared).toHaveLength(1);
+  });
+
+  it('a declared attachment detached out of band (Device removed from live) is declared drift', () => {
+    const declaredDrift = classifyResource(
+      inst({ Volumes: declaredVols }),
+      {
+        Volumes: [
+          { VolumeId: 'vol-aaaa', Device: '/dev/sdg' },
+          { VolumeId: 'vol-root', Device: '/dev/xvda' },
+        ],
+      }, // /dev/sdf gone
+      bare
+    ).filter((f) => f.tier === 'declared');
+    expect(declaredDrift).toHaveLength(1);
+  });
+
+  it('a different volume attached at a declared Device is declared drift', () => {
+    const declaredDrift = classifyResource(
+      inst({ Volumes: declaredVols }),
+      {
+        Volumes: [
+          { VolumeId: 'vol-aaaa', Device: '/dev/sdg' },
+          { VolumeId: 'vol-CHANGED', Device: '/dev/sdf' },
+        ],
+      },
+      bare
+    ).filter((f) => f.tier === 'declared');
+    expect(declaredDrift).toHaveLength(1);
+    expect(declaredDrift[0]).toMatchObject({ desired: 'vol-bbbb', actual: 'vol-CHANGED' });
   });
 });
 

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -1,0 +1,482 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Inst",
+    "resourceType": "AWS::EC2::Instance",
+    "physicalId": "i-06fd4581f0d168d8a",
+    "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "ImageId": "ami-00948338a4aeec604",
+      "InstanceType": "t3.micro",
+      "NetworkInterfaces": [
+        {
+          "DeviceIndex": "1",
+          "SubnetId": "subnet-0f3c7a3910f1a4f50"
+        },
+        {
+          "DeviceIndex": "0",
+          "SubnetId": "subnet-0f3c7a3910f1a4f50"
+        }
+      ],
+      "Volumes": [
+        {
+          "Device": "/dev/sdg",
+          "VolumeId": "vol-0fe744e96a13d5738"
+        },
+        {
+          "Device": "/dev/sdf",
+          "VolumeId": "vol-02faa902bddcdb9ee"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Tenancy": "default",
+    "SecurityGroups": ["default"],
+    "PrivateDnsName": "ip-10-0-0-226.ec2.internal",
+    "PrivateIpAddress": "10.0.0.226",
+    "BlockDeviceMappings": [
+      {
+        "Ebs": {
+          "SnapshotId": "",
+          "VolumeType": "gp3",
+          "Encrypted": false,
+          "Iops": 3000,
+          "VolumeSize": 1,
+          "DeleteOnTermination": false
+        },
+        "DeviceName": "/dev/sdg"
+      },
+      {
+        "Ebs": {
+          "SnapshotId": "snap-0ddddd66776eccb06",
+          "VolumeType": "gp3",
+          "Encrypted": false,
+          "Iops": 3000,
+          "VolumeSize": 8,
+          "DeleteOnTermination": true
+        },
+        "DeviceName": "/dev/xvda"
+      },
+      {
+        "Ebs": {
+          "SnapshotId": "",
+          "VolumeType": "gp3",
+          "Encrypted": false,
+          "Iops": 3000,
+          "VolumeSize": 1,
+          "DeleteOnTermination": false
+        },
+        "DeviceName": "/dev/sdf"
+      }
+    ],
+    "SubnetId": "subnet-0f3c7a3910f1a4f50",
+    "EbsOptimized": false,
+    "Volumes": [
+      {
+        "VolumeId": "vol-0fe744e96a13d5738",
+        "Device": "/dev/sdg"
+      },
+      {
+        "VolumeId": "vol-0aac921ab46964337",
+        "Device": "/dev/xvda"
+      },
+      {
+        "VolumeId": "vol-02faa902bddcdb9ee",
+        "Device": "/dev/sdf"
+      }
+    ],
+    "PrivateIp": "10.0.0.226",
+    "EnclaveOptions": {
+      "Enabled": false
+    },
+    "NetworkInterfaces": [
+      {
+        "AssociateCarrierIpAddress": false,
+        "PrivateIpAddress": "10.0.0.95",
+        "PrivateIpAddresses": [
+          {
+            "PrivateIpAddress": "10.0.0.95",
+            "Primary": true
+          }
+        ],
+        "SecondaryPrivateIpAddressCount": 0,
+        "DeviceIndex": "1",
+        "Ipv6AddressCount": 0,
+        "GroupSet": ["sg-0e3c1d897fce18437"],
+        "Ipv6Addresses": [],
+        "SubnetId": "subnet-0f3c7a3910f1a4f50",
+        "AssociatePublicIpAddress": false,
+        "NetworkInterfaceId": "eni-0374ce66ce479bc37",
+        "DeleteOnTermination": true
+      },
+      {
+        "AssociateCarrierIpAddress": false,
+        "PrivateIpAddress": "10.0.0.226",
+        "PrivateIpAddresses": [
+          {
+            "PrivateIpAddress": "10.0.0.226",
+            "Primary": true
+          }
+        ],
+        "SecondaryPrivateIpAddressCount": 0,
+        "DeviceIndex": "0",
+        "Ipv6AddressCount": 0,
+        "GroupSet": ["sg-0e3c1d897fce18437"],
+        "Ipv6Addresses": [],
+        "SubnetId": "subnet-0f3c7a3910f1a4f50",
+        "AssociatePublicIpAddress": false,
+        "NetworkInterfaceId": "eni-05633fa73067fdffc",
+        "DeleteOnTermination": true
+      }
+    ],
+    "ImageId": "ami-00948338a4aeec604",
+    "InstanceType": "t3.micro",
+    "Monitoring": false,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEc2InstanceSets/af9cc6f0-7255-11f1-be68-0affea89e2cd",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEc2InstanceSets",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Inst",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "HibernationOptions": {
+      "Configured": false
+    },
+    "MetadataOptions": {
+      "HttpPutResponseHopLimit": 2,
+      "HttpProtocolIpv6": "disabled",
+      "HttpTokens": "required",
+      "InstanceMetadataTags": "disabled",
+      "HttpEndpoint": "enabled"
+    },
+    "InstanceId": "i-06fd4581f0d168d8a",
+    "InstanceInitiatedShutdownBehavior": "stop",
+    "CpuOptions": {
+      "ThreadsPerCore": 2,
+      "CoreCount": 1
+    },
+    "AvailabilityZone": "us-east-1a",
+    "PrivateDnsNameOptions": {
+      "EnableResourceNameDnsARecord": false,
+      "HostnameType": "ip-name",
+      "EnableResourceNameDnsAAAARecord": false
+    },
+    "PublicDnsName": "",
+    "SecurityGroupIds": ["sg-0e3c1d897fce18437"],
+    "DisableApiTermination": false,
+    "SourceDestCheck": true,
+    "PlacementGroupName": "",
+    "VpcId": "vpc-03d7155e6f0cf2b47",
+    "State": {
+      "Code": "16",
+      "Name": "running"
+    },
+    "CreditSpecification": {
+      "CPUCredits": "unlimited"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "InstanceId",
+      "PrivateDnsName",
+      "PrivateIp",
+      "PublicDnsName",
+      "PublicIp",
+      "State",
+      "VpcId"
+    ],
+    "writeOnly": [
+      "AdditionalInfo",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "LaunchTemplate",
+      "LicenseSpecification",
+      "PropagateTagsToVolumeOnCreation"
+    ],
+    "createOnly": [
+      "AdditionalInfo",
+      "Affinity",
+      "AvailabilityZone",
+      "BlockDeviceMappings",
+      "CpuOptions",
+      "EbsOptimized",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "EnclaveOptions",
+      "HibernationOptions",
+      "HostId",
+      "HostResourceGroupArn",
+      "ImageId",
+      "InstanceType",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "KernelId",
+      "KeyName",
+      "LaunchTemplate",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "PlacementGroupName",
+      "PrivateDnsNameOptions",
+      "PrivateIpAddress",
+      "RamdiskId",
+      "SecurityGroupIds",
+      "SecurityGroups",
+      "SubnetId",
+      "Tenancy",
+      "UserData"
+    ],
+    "readOnlyPaths": [
+      "InstanceId",
+      "PrivateDnsName",
+      "PrivateIp",
+      "PublicDnsName",
+      "PublicIp",
+      "State",
+      "VpcId"
+    ],
+    "writeOnlyPaths": [
+      "AdditionalInfo",
+      "BlockDeviceMappings.*.NoDevice",
+      "BlockDeviceMappings.*.VirtualName",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "LaunchTemplate",
+      "LicenseSpecification",
+      "PropagateTagsToVolumeOnCreation"
+    ],
+    "createOnlyPaths": [
+      "AdditionalInfo",
+      "Affinity",
+      "AvailabilityZone",
+      "BlockDeviceMappings",
+      "CpuOptions",
+      "EbsOptimized",
+      "ElasticGpuSpecifications",
+      "ElasticInferenceAccelerators",
+      "EnclaveOptions",
+      "HibernationOptions",
+      "HostId",
+      "HostResourceGroupArn",
+      "ImageId",
+      "InstanceType",
+      "Ipv6AddressCount",
+      "Ipv6Addresses",
+      "KernelId",
+      "KeyName",
+      "LaunchTemplate",
+      "LicenseSpecifications",
+      "NetworkInterfaces",
+      "PlacementGroupName",
+      "PrivateDnsNameOptions",
+      "PrivateIpAddress",
+      "RamdiskId",
+      "SecurityGroupIds",
+      "SecurityGroups",
+      "SubnetId",
+      "Tenancy",
+      "UserData"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "HibernationOptions.Configured": false,
+      "MetadataOptions.HttpPutResponseHopLimit": 1
+    },
+    "unorderedScalarPaths": ["SecurityGroupIds", "SecurityGroups"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "AvailabilityZone",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Volumes[/dev/xvda]",
+      "actual": {
+        "VolumeId": "vol-0aac921ab46964337",
+        "Device": "/dev/xvda"
+      },
+      "nested": true,
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Tenancy",
+      "actual": "default",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SecurityGroups",
+      "actual": ["default"],
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.226",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "BlockDeviceMappings",
+      "actual": [
+        {
+          "Ebs": {
+            "SnapshotId": "",
+            "VolumeType": "gp3",
+            "Encrypted": false,
+            "Iops": 3000,
+            "VolumeSize": 1,
+            "DeleteOnTermination": false
+          },
+          "DeviceName": "/dev/sdg"
+        },
+        {
+          "Ebs": {
+            "SnapshotId": "snap-0ddddd66776eccb06",
+            "VolumeType": "gp3",
+            "Encrypted": false,
+            "Iops": 3000,
+            "VolumeSize": 8,
+            "DeleteOnTermination": true
+          },
+          "DeviceName": "/dev/xvda"
+        },
+        {
+          "Ebs": {
+            "SnapshotId": "",
+            "VolumeType": "gp3",
+            "Encrypted": false,
+            "Iops": 3000,
+            "VolumeSize": 1,
+            "DeleteOnTermination": false
+          },
+          "DeviceName": "/dev/sdf"
+        }
+      ],
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SubnetId",
+      "actual": "subnet-0f3c7a3910f1a4f50",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "CpuOptions",
+      "actual": {
+        "ThreadsPerCore": 2,
+        "CoreCount": 1
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SecurityGroupIds",
+      "actual": ["sg-0e3c1d897fce18437"],
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "CreditSpecification",
+      "actual": {
+        "CPUCredits": "unlimited"
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    }
+  ],
+  "description": "EC2 Instance Volumes subset fold: live includes the AMI root /dev/xvda volume the template never declared (declared subset by Device); NetworkInterfaces declared non-sorted by DeviceIndex were preserved by AWS (subset-clean)."
+}

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
@@ -1,0 +1,242 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cache",
+    "resourceType": "AWS::ElastiCache::CacheCluster",
+    "physicalId": "cdk-ca-10pi2rh9u51yw",
+    "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache",
+    "declared": {
+      "CacheNodeType": "cache.t3.micro",
+      "CacheSubnetGroupName": "cdkrealdriftintegelasticachelogdelivery-subnetgroup-mjvu5qdc3pnk",
+      "Engine": "redis",
+      "EngineVersion": "7.1",
+      "LogDeliveryConfigurations": [
+        {
+          "DestinationDetails": {
+            "CloudWatchLogsDetails": {
+              "LogGroup": "CdkRealDriftIntegElastiCacheLogDelivery-SlowLogFAB80CD3-EsS916Y5oSx2"
+            }
+          },
+          "DestinationType": "cloudwatch-logs",
+          "LogFormat": "json",
+          "LogType": "slow-log"
+        },
+        {
+          "DestinationDetails": {
+            "CloudWatchLogsDetails": {
+              "LogGroup": "CdkRealDriftIntegElastiCacheLogDelivery-EngineLog07487AD2-B8JPCy7JEXyO"
+            }
+          },
+          "DestinationType": "cloudwatch-logs",
+          "LogFormat": "json",
+          "LogType": "engine-log"
+        }
+      ],
+      "NumCacheNodes": 1,
+      "VpcSecurityGroupIds": ["sg-050bf811dcecb9d9b"]
+    }
+  },
+  "liveRaw": {
+    "EngineVersion": "7.1",
+    "CacheSubnetGroupName": "cdkrealdriftintegelasticachelogdelivery-subnetgroup-mjvu5qdc3pnk",
+    "Port": 6379,
+    "CacheParameterGroupName": "default.redis7",
+    "PreferredMaintenanceWindow": "mon:05:00-mon:06:00",
+    "AutoMinorVersionUpgrade": true,
+    "NumCacheNodes": 1,
+    "ConfigurationEndpoint": {
+      "Address": "",
+      "Port": ""
+    },
+    "SnapshotWindow": "03:00-04:00",
+    "CacheNodeType": "cache.t3.micro",
+    "SnapshotRetentionLimit": 0,
+    "RedisEndpoint": {
+      "Address": "cdk-ca-10pi2rh9u51yw.jzgy0l.0001.use1.cache.amazonaws.com",
+      "Port": "6379"
+    },
+    "TransitEncryptionEnabled": false,
+    "PreferredAvailabilityZones": ["us-east-1b"],
+    "VpcSecurityGroupIds": ["sg-050bf811dcecb9d9b"],
+    "NetworkType": "ipv4",
+    "IpDiscovery": "ipv4",
+    "ClusterName": "cdk-ca-10pi2rh9u51yw",
+    "LogDeliveryConfigurations": [
+      {
+        "LogFormat": "json",
+        "LogType": "engine-log",
+        "DestinationType": "cloudwatch-logs",
+        "DestinationDetails": {
+          "CloudWatchLogsDetails": {
+            "LogGroup": "CdkRealDriftIntegElastiCacheLogDelivery-EngineLog07487AD2-B8JPCy7JEXyO"
+          }
+        }
+      },
+      {
+        "LogFormat": "json",
+        "LogType": "slow-log",
+        "DestinationType": "cloudwatch-logs",
+        "DestinationDetails": {
+          "CloudWatchLogsDetails": {
+            "LogGroup": "CdkRealDriftIntegElastiCacheLogDelivery-SlowLogFAB80CD3-EsS916Y5oSx2"
+          }
+        }
+      }
+    ],
+    "Engine": "redis",
+    "Tags": [],
+    "AZMode": "single-az"
+  },
+  "schema": {
+    "readOnly": ["ConfigurationEndpoint", "RedisEndpoint"],
+    "writeOnly": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZone",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnly": [
+      "CacheSubnetGroupName",
+      "ClusterName",
+      "Engine",
+      "IpDiscovery",
+      "NetworkType",
+      "Port",
+      "PreferredAvailabilityZones",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "readOnlyPaths": [
+      "ConfigurationEndpoint",
+      "ConfigurationEndpoint.Address",
+      "ConfigurationEndpoint.Port",
+      "RedisEndpoint",
+      "RedisEndpoint.Address",
+      "RedisEndpoint.Port"
+    ],
+    "writeOnlyPaths": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZone",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "createOnlyPaths": [
+      "CacheSubnetGroupName",
+      "ClusterName",
+      "Engine",
+      "IpDiscovery",
+      "NetworkType",
+      "Port",
+      "PreferredAvailabilityZones",
+      "SnapshotArns",
+      "SnapshotName"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "CacheSecurityGroupNames",
+      "PreferredAvailabilityZones",
+      "SnapshotArns",
+      "VpcSecurityGroupIds"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "Port",
+      "actual": 6379,
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "CacheParameterGroupName",
+      "actual": "default.redis7",
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "mon:05:00-mon:06:00",
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "SnapshotWindow",
+      "actual": "03:00-04:00",
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "SnapshotRetentionLimit",
+      "actual": 0,
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "PreferredAvailabilityZones",
+      "actual": ["us-east-1b"],
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "NetworkType",
+      "actual": "ipv4",
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "IpDiscovery",
+      "actual": "ipv4",
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cache",
+      "resourceType": "AWS::ElastiCache::CacheCluster",
+      "path": "AZMode",
+      "actual": "single-az",
+      "physicalId": "cdk-ca-10pi2rh9u51yw",
+      "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
+    }
+  ],
+  "description": "ElastiCache CacheCluster LogDeliveryConfigurations set reordered by AWS (Cloud Control echoes engine-log before the declared slow-log, non-deterministically) — UNORDERED_OBJECT_ARRAY_PROPS aligns both sides so the reorder is not a declared FP."
+}

--- a/tests/integration/ec2-instance-sets/app.ts
+++ b/tests/integration/ec2-instance-sets/app.ts
@@ -1,0 +1,63 @@
+// CDK app for the cdk-real-drift EC2 Instance set-reorder false-positive
+// integration test. It probes whether AWS reorders two `insertionOrder:false`
+// object-array properties on AWS::EC2::Instance when Cloud Control reads them
+// back:
+//   - `Volumes` (attached EBS, keyed by Device/VolumeId — neither in
+//     IDENTITY_FIELDS), declared NON-sorted by Device (/dev/sdg before /dev/sdf).
+//   - `NetworkInterfaces` (keyed by DeviceIndex — not in IDENTITY_FIELDS),
+//     declared NON-sorted by DeviceIndex (1 before 0).
+// Both are declared out of order on purpose: if AWS canonicalizes (sorts) either
+// set, a freshly recorded clean stack false-positives as declared drift.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import {
+  AmazonLinuxCpuType,
+  CfnInstance,
+  CfnVolume,
+  MachineImage,
+  SubnetType,
+  Vpc,
+} from 'aws-cdk-lib/aws-ec2';
+import type { Construct } from 'constructs';
+
+class Ec2InstanceSetsStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const vpc = new Vpc(this, 'Vpc', {
+      maxAzs: 1,
+      natGateways: 0,
+      subnetConfiguration: [{ name: 'public', subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+    });
+    const subnet = vpc.publicSubnets[0];
+    const az = subnet.availabilityZone;
+
+    const imageId = MachineImage.latestAmazonLinux2023({
+      cpuType: AmazonLinuxCpuType.X86_64,
+    }).getImage(this).imageId;
+
+    // Two EBS volumes in the instance's AZ, attached in a non-sorted Device order.
+    const vol1 = new CfnVolume(this, 'Vol1', { availabilityZone: az, size: 1, volumeType: 'gp3' });
+    const vol2 = new CfnVolume(this, 'Vol2', { availabilityZone: az, size: 1, volumeType: 'gp3' });
+
+    new CfnInstance(this, 'Inst', {
+      imageId,
+      instanceType: 't3.micro',
+      availabilityZone: az,
+      // NetworkInterfaces declared DeviceIndex 1 before 0 (non-sorted).
+      networkInterfaces: [
+        { deviceIndex: '1', subnetId: subnet.subnetId },
+        { deviceIndex: '0', subnetId: subnet.subnetId },
+      ],
+      // Volumes declared /dev/sdg before /dev/sdf (non-sorted by Device).
+      volumes: [
+        { device: '/dev/sdg', volumeId: vol2.ref },
+        { device: '/dev/sdf', volumeId: vol1.ref },
+      ],
+    });
+  }
+}
+
+const app = new App();
+new Ec2InstanceSetsStack(app, 'CdkRealDriftIntegEc2InstanceSets', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/ec2-instance-sets/cdk.json
+++ b/tests/integration/ec2-instance-sets/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ec2-instance-sets/package.json
+++ b/tests/integration/ec2-instance-sets/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ec2-instance-sets",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ec2-instance-sets false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ec2-instance-sets/verify.sh
+++ b/tests/integration/ec2-instance-sets/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Probes the AWS::EC2::Instance Volumes + NetworkInterfaces sets
+# (both declared non-sorted); a reorder by AWS surfaces as a declared-tier FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEc2InstanceSets
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-ec2-instance-sets" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/elasticache-logdelivery/app.ts
+++ b/tests/integration/elasticache-logdelivery/app.ts
@@ -1,0 +1,78 @@
+// CDK app for the cdk-real-drift ElastiCache CacheCluster set-reorder
+// false-positive integration test. It probes whether AWS reorders the
+// `LogDeliveryConfigurations` set (an `insertionOrder:false` object array keyed
+// by LogType — not in IDENTITY_FIELDS) when Cloud Control reads it back. The two
+// configs are declared NON-sorted by LogType (slow-log before engine-log); if
+// AWS canonicalizes (sorts) the set, a freshly recorded clean stack
+// false-positives as declared drift.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import { CfnCacheCluster, CfnSubnetGroup } from 'aws-cdk-lib/aws-elasticache';
+import { SecurityGroup, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import type { Construct } from 'constructs';
+
+class ElastiCacheLogDeliveryStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const vpc = new Vpc(this, 'Vpc', {
+      maxAzs: 2,
+      natGateways: 0,
+      subnetConfiguration: [{ name: 'isolated', subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+    });
+
+    const subnetGroup = new CfnSubnetGroup(this, 'SubnetGroup', {
+      description: 'cdkrd integ subnet group',
+      subnetIds: vpc.isolatedSubnets.map((s) => s.subnetId),
+    });
+
+    const sg = new SecurityGroup(this, 'Sg', {
+      vpc,
+      description: 'cdkrd integ cache sg',
+    });
+
+    const slowLog = new LogGroup(this, 'SlowLog', {
+      retention: RetentionDays.ONE_DAY,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    const engineLog = new LogGroup(this, 'EngineLog', {
+      retention: RetentionDays.ONE_DAY,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    new CfnCacheCluster(this, 'Cache', {
+      engine: 'redis',
+      cacheNodeType: 'cache.t3.micro',
+      numCacheNodes: 1,
+      engineVersion: '7.1',
+      cacheSubnetGroupName: subnetGroup.ref,
+      vpcSecurityGroupIds: [sg.securityGroupId],
+      // LogDeliveryConfigurations declared slow-log before engine-log (non-sorted
+      // by LogType; alphabetical would be engine-log first).
+      logDeliveryConfigurations: [
+        {
+          logType: 'slow-log',
+          logFormat: 'json',
+          destinationType: 'cloudwatch-logs',
+          destinationDetails: {
+            cloudWatchLogsDetails: { logGroup: slowLog.logGroupName },
+          },
+        },
+        {
+          logType: 'engine-log',
+          logFormat: 'json',
+          destinationType: 'cloudwatch-logs',
+          destinationDetails: {
+            cloudWatchLogsDetails: { logGroup: engineLog.logGroupName },
+          },
+        },
+      ],
+    });
+  }
+}
+
+const app = new App();
+new ElastiCacheLogDeliveryStack(app, 'CdkRealDriftIntegElastiCacheLogDelivery', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/elasticache-logdelivery/cdk.json
+++ b/tests/integration/elasticache-logdelivery/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elasticache-logdelivery/package.json
+++ b/tests/integration/elasticache-logdelivery/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elasticache-logdelivery",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elasticache-logdelivery false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elasticache-logdelivery/verify.sh
+++ b/tests/integration/elasticache-logdelivery/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Probes the AWS::ElastiCache::CacheCluster LogDeliveryConfigurations
+# set (declared non-sorted by LogType); a reorder by AWS surfaces as a declared-tier FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegElastiCacheLogDelivery
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-elasticache-logdelivery" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
Two false-positive drift classes found by the `insertionOrder:false` audit (hunt-w5), both **live-proven** (FP on a freshly recorded clean stack → fix → re-check CLEAN, INTEG PASS):

## 1. `AWS::EC2::Instance` `Volumes` — a SUBSET FP, not a reorder
The live model injects the AMI **root** volume (`/dev/xvda`) — which the template never declares as an attachment — as an extra element and interleaves it among the declared volumes, so a positional/whole-array compare false-flags the entire `Volumes` as declared drift on every fresh deploy of an instance that attaches volumes.

Fix: aligned declared attachments to live **by `Device`** via `IDENTITY_KEYED_SUBSET_ARRAYS` (the same mechanism + same resource type as the existing `BlockDeviceMappings`/`DeviceName` entry — just a sibling key). The live-only root volume becomes nested undeclared inventory (recordable); a detached or changed declared attachment still surfaces as declared drift.

Ruled out in the same deploy: `NetworkInterfaces`, declared non-sorted by `DeviceIndex` `[1,0]`, was **preserved** by AWS (subset-clean) → not folded. `SsmAssociations` is a read-gap (absent from the live model) → skipped.

## 2. `AWS::ElastiCache::CacheCluster` `LogDeliveryConfigurations` — reorder
Cloud Control echoes the set sorted by `LogType` (`engine-log` before the declared `slow-log`) and **non-deterministically between reads** (it flip-flopped across reads minutes apart; native `describe-cache-clusters` keeps template order — only CC reorders). A positional compare false-flags every shifted config's `LogType` and resolved destination `LogGroup`.

Fix: added to `UNORDERED_OBJECT_ARRAY_PROPS` (`LogType` is not an `IDENTITY_FIELD`); sorting both sides aligns equal configs, a genuine destination/format change still differs. Folded the sibling `AWS::ElastiCache::ReplicationGroup` (identical shape) by the same equality-gated reasoning.

## Tests
- Unit tests in `tests/classify.test.ts` (fold + no-over-fold for each).
- Sanitized golden-corpus cases: `AWS__EC2__Instance.Inst.sets.json`, `AWS__ElastiCache__CacheCluster.Cache.logdelivery.json` (the ElastiCache `liveRaw` is set to the proven-reordered CC order so the replay genuinely exercises the fold).
- Committed regression integ fixtures `tests/integration/ec2-instance-sets`, `tests/integration/elasticache-logdelivery` (both INTEG PASS).
- Full suite: 42 files / 1714 tests green; 469 corpus-replay cases green.
