### PR TITLE
test(integ): fix stale drift-tier label greps in integration scripts

### DIFF
--- a/tests/integration/ccadapters/verify-ccadapters.sh
+++ b/tests/integration/ccadapters/verify-ccadapters.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: ZERO declared drift AND no ValidationException
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 # the whole point: the composite-id types must now READ, not skip as ValidationException
 grep -q "ValidationException" "$OUT" && fail "a CC ValidationException skip remains — an adapter is missing/wrong"

--- a/tests/integration/cloudfront/verify-cloudfront.sh
+++ b/tests/integration/cloudfront/verify-cloudfront.sh
@@ -48,7 +48,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN ==="

--- a/tests/integration/cloudwatch-alarm/verify.sh
+++ b/tests/integration/cloudwatch-alarm/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cloudwatch-alarm-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-cloudwatch-alarm-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-cloudwatch-alarm-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/cognito/verify.sh
+++ b/tests/integration/cognito/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cognito-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-cognito-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-cognito-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/dynamodb/verify-nested.sh
+++ b/tests/integration/dynamodb/verify-nested.sh
@@ -58,7 +58,7 @@ echo "=== 1. baseline-free check: nested values FOLD into the info footer ==="
 $CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-nested-1.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (inventory only), got $rc"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-nested-1.out && fail "fresh deploy reported DECLARED drift"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-nested-1.out && fail "fresh deploy reported DECLARED drift"
 grep -qE "undeclared-subkey=[1-9]" /tmp/cdkrd-nested-1.out || fail "expected an 'undeclared-subkey=N' fold in the info footer"
 
 echo "=== 2. --show-all expands BOTH the R98 array-element and R96 object-nested paths ==="

--- a/tests/integration/dynamodb/verify.sh
+++ b/tests/integration/dynamodb/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-dynamodb-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-dynamodb-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-dynamodb-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/ec2-instance-rich/verify.sh
+++ b/tests/integration/ec2-instance-rich/verify.sh
@@ -38,7 +38,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ec2-rich-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-ec2-rich-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-ec2-rich-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/eventbridge/verify.sh
+++ b/tests/integration/eventbridge/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-eventbridge-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-eventbridge-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-eventbridge-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/harvest/verify-harvest.sh
+++ b/tests/integration/harvest/verify-harvest.sh
@@ -42,7 +42,7 @@ echo "=== baseline-free check: fresh deploy must have ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --verbose | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest10/verify-harvest10.sh
+++ b/tests/integration/harvest10/verify-harvest10.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest11/verify-harvest11.sh
+++ b/tests/integration/harvest11/verify-harvest11.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest12/verify-harvest12.sh
+++ b/tests/integration/harvest12/verify-harvest12.sh
@@ -47,7 +47,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest13/verify-harvest13.sh
+++ b/tests/integration/harvest13/verify-harvest13.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest2/verify-harvest2.sh
+++ b/tests/integration/harvest2/verify-harvest2.sh
@@ -42,7 +42,7 @@ echo "=== baseline-free check: fresh deploy must have ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --verbose | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest3/verify-harvest3.sh
+++ b/tests/integration/harvest3/verify-harvest3.sh
@@ -63,7 +63,7 @@ echo "=== A1. baseline-free check: fresh deploy must have ZERO declared drift ==
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== A2. record + check --fail must be CLEAN across every type ==="
@@ -92,7 +92,7 @@ sleep 10
 echo "=== B3. one check must report ALL FIVE as DECLARED drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
-grep -q "DECLARED DRIFT: 5" "$OUT" || fail "expected exactly 5 declared drifts"
+grep -q "CFn-Declared Drift: 5" "$OUT" || fail "expected exactly 5 declared drifts"
 for needle in MemorySize VisibilityTimeout RetentionInDays DisplayName MatrixRule; do
   grep -q "$needle" "$OUT" || fail "missing declared drift: $needle"
 done

--- a/tests/integration/harvest4/verify-harvest4.sh
+++ b/tests/integration/harvest4/verify-harvest4.sh
@@ -52,7 +52,7 @@ echo "=== A1. baseline-free check: fresh deploy must have ZERO declared drift ==
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== A2. record + check --fail must be CLEAN across every type ==="
@@ -77,7 +77,7 @@ sleep 10
 echo "=== B2. check must name ONLY the mutated attribute by Key ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
 [ "${PIPESTATUS[0]}" -eq 1 ] || fail "expected drift exit 1"
-grep -q "DECLARED DRIFT: 1" "$OUT" || fail "expected exactly 1 declared drift (Key-scoped compare failed)"
+grep -q "CFn-Declared Drift: 1" "$OUT" || fail "expected exactly 1 declared drift (Key-scoped compare failed)"
 grep -q "idle_timeout" "$OUT" || fail "missing idle_timeout drift"
 
 if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then

--- a/tests/integration/harvest5/verify-harvest5.sh
+++ b/tests/integration/harvest5/verify-harvest5.sh
@@ -45,7 +45,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest6/verify-harvest6.sh
+++ b/tests/integration/harvest6/verify-harvest6.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest7/verify-harvest7.sh
+++ b/tests/integration/harvest7/verify-harvest7.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest8/verify-harvest8.sh
+++ b/tests/integration/harvest8/verify-harvest8.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/harvest9/verify-harvest9.sh
+++ b/tests/integration/harvest9/verify-harvest9.sh
@@ -46,7 +46,7 @@ echo "=== 1. baseline-free check: fresh deploy must have ZERO declared drift ===
 $CLI check "$STACK" --region "$REGION" | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "expected exit 0 (unrecorded inventory only), got $rc"
-grep -q "DECLARED DRIFT" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
+grep -q "CFn-Declared Drift" "$OUT" && fail "fresh deploy reported DECLARED drift — false positive"
 grep -q "deleted" "$OUT" && fail "fresh deploy reported a deleted resource"
 
 echo "=== 2. record + check --fail must be CLEAN across every type ==="

--- a/tests/integration/iam/verify-sibling-policy-doc.sh
+++ b/tests/integration/iam/verify-sibling-policy-doc.sh
@@ -68,11 +68,11 @@ echo "=== check must DETECT it as DECLARED drift on the AWS::IAM::Policy resourc
 $CLI check "$STACK" --region "$REGION" --fail | tee "$OUT"
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "FALSE NEGATIVE — sibling document change not detected (exit $rc, expected 1)"
-grep -q "DECLARED DRIFT" "$OUT" || fail "not reported in the DECLARED tier — the sibling's own check did not fire"
+grep -q "CFn-Declared Drift" "$OUT" || fail "not reported in the DECLARED tier — the sibling's own check did not fire"
 grep -q "DefaultPolicy" "$OUT" || fail "the sibling AWS::IAM::Policy resource is not named in the finding"
 grep -q "s3:GetObject" "$OUT" || fail "the out-of-band action is not shown as the live value"
 # the role itself must NOT double-report this as undeclared (the by-name filter holds)
-grep -q "UNDECLARED DRIFT" "$OUT" && fail "the role leaked the sibling change as undeclared drift (filter broke)"
+grep -q "CFn-Undeclared Drift" "$OUT" && fail "the role leaked the sibling change as undeclared drift (filter broke)"
 echo "OK: sibling document change caught as DECLARED drift, not swallowed, not double-reported"
 
 echo "=== revert should restore the declared document ==="

--- a/tests/integration/noise/verify.sh
+++ b/tests/integration/noise/verify.sh
@@ -48,7 +48,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-noise-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-noise-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-noise-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/securitygroup/verify.sh
+++ b/tests/integration/securitygroup/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-securitygroup-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-securitygroup-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-securitygroup-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/sqs/verify.sh
+++ b/tests/integration/sqs/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sqs-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-sqs-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-sqs-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/ssm/verify.sh
+++ b/tests/integration/ssm/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ssm-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-ssm-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-ssm-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="

--- a/tests/integration/stepfunctions/verify.sh
+++ b/tests/integration/stepfunctions/verify.sh
@@ -36,7 +36,7 @@ echo "=== check --fail (no baseline) must find ZERO declared drift ==="
 $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-stepfunctions-pre.out
 rc=${PIPESTATUS[0]}
 [ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
-grep -q "DECLARED DRIFT" /tmp/cdkrd-stepfunctions-pre.out \
+grep -q "CFn-Declared Drift" /tmp/cdkrd-stepfunctions-pre.out \
   && fail "a declared property was wrongly reported as drift (false positive)"
 
 echo "=== record then check must stay CLEAN ==="


### PR DESCRIPTION
## What

A report-label change renamed the drift-tier section headers to `CFn-Declared Drift` / `CFn-Undeclared Drift` (Title Case + `CFn-` prefix, R130), but **27 integration verify scripts** still grep the old all-caps `DECLARED DRIFT` / `UNDECLARED DRIFT`. grep is case-sensitive, so they no longer match — and these scripts are excluded from the unit run, so the staleness was silent.

Surfaced as a follow-up from #389 (the live verify-pr run hit it on `iam/verify-sibling-policy-doc.sh`).

## Impact of the staleness

- **Negative checks** (`grep "DECLARED DRIFT" && fail "false positive"`) became **toothless** — the pattern never matches, so a real declared-drift false positive on a fresh deploy would slip past the assertion.
- **Positive checks** (`grep ... || fail`) genuinely **FAIL**: `iam/verify-sibling-policy-doc.sh:71`, `harvest3/verify-harvest3.sh:95` (`: 5`), `harvest4/verify-harvest4.sh:80` (`: 1`).

## Fix

Replace the old labels with the current ones across all 27 scripts:
- `UNDECLARED DRIFT` -> `CFn-Undeclared Drift` (done **first**, so the `DECLARED DRIFT` pass cannot corrupt the substring)
- `DECLARED DRIFT` -> `CFn-Declared Drift` (carries the count variants `: 5` / `: 1`)
- The capital `D` in the new label matches only the declared header, not `CFn-Undeclared Drift` — slightly *more* precise than the old all-caps substring.
- The lowercase fail **messages** (`reported DECLARED drift`) are prose and left untouched.

## Verification

- Proven against the **real cdkrd output captured during the #389 verify-pr run**: the fixed `grep "CFn-Declared Drift"` matches `[CFn-Declared Drift: 1]`, and there is no `CFn-Undeclared Drift` leak.
- `bash -n` syntax check passes on all 27 edited scripts.
- typecheck / lint+format / build / unit (1712) all green (no src change).
- Tests-only diff (verify-pr-exempt).

Note: two stale `[DECLARED DRIFT: N]` examples remain in `src/report/report.ts` **comments** (illustrative bracket-format, not labels) — left out to keep this PR tests-only; can be swept in a future src-touching PR.
