### PR TITLE
test(corpus): add GlobalTable Replicas + NLB SubnetMappings reorder rule-outs

### DIFF
--- a/tests/corpus/AWS__DynamoDB__GlobalTable.GT.replicas.json
+++ b/tests/corpus/AWS__DynamoDB__GlobalTable.GT.replicas.json
@@ -1,0 +1,124 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GT",
+    "resourceType": "AWS::DynamoDB::GlobalTable",
+    "physicalId": "CdkRealDriftIntegDdbGlobalTableReplicas-GT-AISY8USF2SYC",
+    "constructPath": "CdkRealDriftIntegDdbGlobalTableReplicas/GT",
+    "declared": {
+      "AttributeDefinitions": [
+        {
+          "AttributeName": "pk",
+          "AttributeType": "S"
+        }
+      ],
+      "BillingMode": "PAY_PER_REQUEST",
+      "KeySchema": [
+        {
+          "AttributeName": "pk",
+          "KeyType": "HASH"
+        }
+      ],
+      "Replicas": [
+        {
+          "Region": "us-west-2"
+        },
+        {
+          "Region": "us-east-1"
+        }
+      ],
+      "StreamSpecification": {
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      }
+    }
+  },
+  "liveRaw": {
+    "TableId": "655af2d2-c615-4bc5-9f1e-12a343ada757",
+    "TableName": "CdkRealDriftIntegDdbGlobalTableReplicas-GT-AISY8USF2SYC",
+    "AttributeDefinitions": [
+      {
+        "AttributeType": "S",
+        "AttributeName": "pk"
+      }
+    ],
+    "StreamSpecification": {
+      "StreamViewType": "NEW_AND_OLD_IMAGES"
+    },
+    "BillingMode": "PAY_PER_REQUEST",
+    "KeySchema": [
+      {
+        "KeyType": "HASH",
+        "AttributeName": "pk"
+      }
+    ],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "Arn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkRealDriftIntegDdbGlobalTableReplicas-GT-AISY8USF2SYC",
+    "StreamArn": "arn:aws:dynamodb:us-east-1:111111111111:table/CdkRealDriftIntegDdbGlobalTableReplicas-GT-AISY8USF2SYC/stream/2026-06-27T19:10:02.367",
+    "Replicas": [
+      {
+        "ContributorInsightsSpecification": {
+          "Enabled": false
+        },
+        "GlobalSecondaryIndexes": [],
+        "Region": "us-west-2",
+        "GlobalTableSettingsReplicationMode": "ENABLED_WITH_OVERRIDES",
+        "TableClass": "STANDARD",
+        "DeletionProtectionEnabled": false
+      },
+      {
+        "ContributorInsightsSpecification": {
+          "Enabled": false
+        },
+        "GlobalSecondaryIndexes": [],
+        "Region": "us-east-1",
+        "GlobalTableSettingsReplicationMode": "ENABLED_WITH_OVERRIDES",
+        "TableClass": "STANDARD",
+        "DeletionProtectionEnabled": false
+      }
+    ],
+    "TimeToLiveSpecification": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "StreamArn", "TableId"],
+    "writeOnly": ["GlobalTableSourceArn"],
+    "createOnly": ["GlobalTableSourceArn", "KeySchema", "LocalSecondaryIndexes", "TableName"],
+    "readOnlyPaths": ["Arn", "StreamArn", "TableId"],
+    "writeOnlyPaths": [
+      "GlobalSecondaryIndexes.*.WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings.SeedCapacity",
+      "GlobalTableSourceArn",
+      "Replicas.*.GlobalSecondaryIndexes.*.ReadProvisionedThroughputSettings.ReadCapacityAutoScalingSettings.SeedCapacity",
+      "Replicas.*.ReadProvisionedThroughputSettings.ReadCapacityAutoScalingSettings.SeedCapacity",
+      "WriteProvisionedThroughputSettings.WriteCapacityAutoScalingSettings.SeedCapacity"
+    ],
+    "createOnlyPaths": ["GlobalTableSourceArn", "KeySchema", "LocalSecondaryIndexes", "TableName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "GT",
+      "resourceType": "AWS::DynamoDB::GlobalTable",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "CdkRealDriftIntegDdbGlobalTableReplicas-GT-AISY8USF2SYC",
+      "constructPath": "CdkRealDriftIntegDdbGlobalTableReplicas/GT"
+    }
+  ],
+  "description": "Multi-region GlobalTable Replicas RULE-OUT: declared non-sorted by Region [us-west-2, us-east-1]; Cloud Control PRESERVES the declared order (not sorted), so Replicas is NOT a reorder FP and needs no fold. New multi-region coverage (existing GlobalTable corpus is single-region)."
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
@@ -1,0 +1,205 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Nlb",
+    "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+    "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb",
+    "declared": {
+      "Scheme": "internal",
+      "SubnetMappings": [
+        {
+          "SubnetId": "subnet-09675102dd2b4e7d1"
+        },
+        {
+          "SubnetId": "subnet-06375aa74c4098557"
+        }
+      ],
+      "Type": "network"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "SecurityGroups": [],
+    "LoadBalancerAttributes": [
+      {
+        "Value": "",
+        "Key": "access_logs.s3.prefix"
+      },
+      {
+        "Value": "false",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "access_logs.s3.enabled"
+      },
+      {
+        "Value": "false",
+        "Key": "zonal_shift.config.enabled"
+      },
+      {
+        "Value": "",
+        "Key": "access_logs.s3.bucket"
+      },
+      {
+        "Value": "false",
+        "Key": "deletion_protection.enabled"
+      },
+      {
+        "Value": "0",
+        "Key": "secondary_ips.auto_assigned.per_subnet"
+      },
+      {
+        "Value": "any_availability_zone",
+        "Key": "dns_record.client_routing_policy"
+      }
+    ],
+    "Scheme": "internal",
+    "DNSName": "CdkRealD-Nlb-NB5U8c26yJm1-dba9c61ba1aa1fcb.elb.us-east-1.amazonaws.com",
+    "Name": "CdkRealD-Nlb-NB5U8c26yJm1",
+    "LoadBalancerName": "CdkRealD-Nlb-NB5U8c26yJm1",
+    "Subnets": ["subnet-09675102dd2b4e7d1", "subnet-06375aa74c4098557"],
+    "Type": "network",
+    "CanonicalHostedZoneID": "Z26RNL4JYFTOTI",
+    "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+    "EnablePrefixForIpv6SourceNat": "off",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegNlbSubnetMappings/c87e8040-725b-11f1-b19e-0e3526a02887",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegNlbSubnetMappings",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Nlb",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "LoadBalancerFullName": "net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+    "SubnetMappings": [
+      {
+        "SubnetId": "subnet-09675102dd2b4e7d1"
+      },
+      {
+        "SubnetId": "subnet-06375aa74c4098557"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnly": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnly": ["Name", "Scheme", "Type"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneID",
+      "DNSName",
+      "LoadBalancerArn",
+      "LoadBalancerFullName",
+      "LoadBalancerName"
+    ],
+    "writeOnlyPaths": ["EnableCapacityReservationProvisionStabilize"],
+    "createOnlyPaths": ["Name", "Scheme", "Type"],
+    "defaults": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "defaultPaths": {
+      "EnableCapacityReservationProvisionStabilize": false
+    },
+    "unorderedScalarPaths": ["SecurityGroups", "Subnets"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes",
+      "actual": [
+        {
+          "Value": "",
+          "Key": "access_logs.s3.bucket"
+        },
+        {
+          "Value": "false",
+          "Key": "access_logs.s3.enabled"
+        },
+        {
+          "Value": "",
+          "Key": "access_logs.s3.prefix"
+        },
+        {
+          "Value": "false",
+          "Key": "deletion_protection.enabled"
+        },
+        {
+          "Value": "any_availability_zone",
+          "Key": "dns_record.client_routing_policy"
+        },
+        {
+          "Value": "false",
+          "Key": "load_balancing.cross_zone.enabled"
+        },
+        {
+          "Value": "0",
+          "Key": "secondary_ips.auto_assigned.per_subnet"
+        },
+        {
+          "Value": "false",
+          "Key": "zonal_shift.config.enabled"
+        }
+      ],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "Name",
+      "actual": "CdkRealD-Nlb-NB5U8c26yJm1",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "Subnets",
+      "actual": ["subnet-06375aa74c4098557", "subnet-09675102dd2b4e7d1"],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "EnablePrefixForIpv6SourceNat",
+      "actual": "off",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    }
+  ],
+  "description": "NLB SubnetMappings RULE-OUT: declared non-sorted by SubnetId; Cloud Control PRESERVES the declared order, so SubnetMappings is NOT a reorder FP and needs no fold. (The live model also echoes a Subnets scalar mirror as undeclared inventory.)"
+}

--- a/tests/integration/ddb-globaltable-replicas/app.ts
+++ b/tests/integration/ddb-globaltable-replicas/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift DynamoDB GlobalTable Replicas set-reorder
+// false-positive integration test. A multi-region global table declares its
+// `Replicas` (an `insertionOrder:false` object array keyed by Region — not in
+// IDENTITY_FIELDS) NON-sorted (us-west-2 before the us-east-1 home region); if
+// Cloud Control echoes the set sorted by Region, a freshly recorded clean stack
+// false-positives as declared drift.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import { CfnGlobalTable } from 'aws-cdk-lib/aws-dynamodb';
+import type { Construct } from 'constructs';
+
+class DdbGlobalTableReplicasStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    new CfnGlobalTable(this, 'GT', {
+      attributeDefinitions: [{ attributeName: 'pk', attributeType: 'S' }],
+      keySchema: [{ attributeName: 'pk', keyType: 'HASH' }],
+      billingMode: 'PAY_PER_REQUEST',
+      streamSpecification: { streamViewType: 'NEW_AND_OLD_IMAGES' },
+      // Replicas declared us-west-2 before us-east-1 (non-sorted by Region). The
+      // home region (us-east-1) MUST be present in the list.
+      replicas: [{ region: 'us-west-2' }, { region: 'us-east-1' }],
+    });
+  }
+}
+
+const app = new App();
+new DdbGlobalTableReplicasStack(app, 'CdkRealDriftIntegDdbGlobalTableReplicas', {
+  env: { region: 'us-east-1' },
+});

--- a/tests/integration/ddb-globaltable-replicas/cdk.json
+++ b/tests/integration/ddb-globaltable-replicas/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ddb-globaltable-replicas/package.json
+++ b/tests/integration/ddb-globaltable-replicas/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ddb-globaltable-replicas",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ddb-globaltable-replicas false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ddb-globaltable-replicas/verify.sh
+++ b/tests/integration/ddb-globaltable-replicas/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Probes the AWS::DynamoDB::GlobalTable Replicas set (declared
+# non-sorted by Region); a reorder by AWS surfaces as a declared-tier FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDdbGlobalTableReplicas
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-ddb-globaltable-replicas" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/nlb-subnetmappings/app.ts
+++ b/tests/integration/nlb-subnetmappings/app.ts
@@ -1,0 +1,35 @@
+// CDK app for the cdk-real-drift ELBv2 LoadBalancer SubnetMappings set-reorder
+// false-positive integration test. An internal NLB declares its `SubnetMappings`
+// (an `insertionOrder:false` object array keyed by SubnetId — not in
+// IDENTITY_FIELDS) NON-sorted (the second AZ's subnet first); if Cloud Control
+// echoes the set reordered (e.g. by AZ/SubnetId), a freshly recorded clean stack
+// false-positives as declared drift.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import { SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { CfnLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import type { Construct } from 'constructs';
+
+class NlbSubnetMappingsStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const vpc = new Vpc(this, 'Vpc', {
+      maxAzs: 2,
+      natGateways: 0,
+      subnetConfiguration: [{ name: 'isolated', subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+    });
+    const [s1, s2] = vpc.isolatedSubnets;
+
+    new CfnLoadBalancer(this, 'Nlb', {
+      type: 'network',
+      scheme: 'internal',
+      // SubnetMappings declared with the second subnet first (non-sorted by SubnetId).
+      subnetMappings: [{ subnetId: s2.subnetId }, { subnetId: s1.subnetId }],
+    });
+  }
+}
+
+const app = new App();
+new NlbSubnetMappingsStack(app, 'CdkRealDriftIntegNlbSubnetMappings', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/nlb-subnetmappings/cdk.json
+++ b/tests/integration/nlb-subnetmappings/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/nlb-subnetmappings/package.json
+++ b/tests/integration/nlb-subnetmappings/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-nlb-subnetmappings",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift nlb-subnetmappings false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/nlb-subnetmappings/verify.sh
+++ b/tests/integration/nlb-subnetmappings/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Probes the AWS::ElasticLoadBalancingV2::LoadBalancer SubnetMappings
+# set (declared non-sorted by SubnetId); a reorder by AWS surfaces as a declared-tier FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNlbSubnetMappings
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus + pre-record classification (no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-nlb-subnetmappings" $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
Round-2 of the `insertionOrder:false` set-reorder hunt — both candidates **RULED OUT** (AWS preserves the declared order; neither is a false positive, neither needs a fold). Shipped as clean-FP regression fixtures + golden-corpus cases.

## Rule-outs
- **`AWS::DynamoDB::GlobalTable` `Replicas`**: a multi-region table declared the set non-sorted by Region `[us-west-2, us-east-1]`; Cloud Control echoed it in the **same declared order** (not sorted). New **multi-region** coverage — the existing GlobalTable corpus is single-region only.
- **`AWS::ElasticLoadBalancingV2::LoadBalancer` `SubnetMappings`**: an internal NLB declared the set non-sorted by SubnetId; Cloud Control **preserved** the order (and also echoes a `Subnets` scalar mirror as undeclared inventory).

Confirms the `insertionOrder:false` flag over-predicts reorders (~half of such sets preserve order). Both fixtures **INTEG PASS** (record → check CLEAN). Tests-only (no `src/**`) → verify-pr exempt.

Corpus replay: 471 cases green; full suite 1721 tests.