### PR TITLE
fix(revert): add SDK PutPermission writer for EventBusPolicy (CC RFC6902 patch fails)

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -81,6 +81,11 @@ import {
   DescribeConfigRulesCommand,
   PutConfigRuleCommand,
 } from '@aws-sdk/client-config-service';
+import {
+  DescribeEventBusCommand,
+  EventBridgeClient,
+  PutPermissionCommand,
+} from '@aws-sdk/client-eventbridge';
 import { ChangeResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { DeleteBucketPolicyCommand, PutBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
 import {
@@ -168,6 +173,63 @@ const writeSqsQueuePolicy: SdkWriter = async (ctx, ops) => {
       new SetQueueAttributesCommand({ QueueUrl: queue, Attributes: { Policy: desired } })
     );
   }
+};
+
+// AWS::Events::EventBusPolicy is a resource-policy STATEMENT on an event bus — the
+// same class as SNS TopicPolicy / SQS QueuePolicy / S3 BucketPolicy, all of which
+// revert via their native SDK because a Cloud Control RFC6902 patch is wrong for a
+// policy here: the live `Statement` comes back as a SINGULAR object while classify
+// canonicalizes it to a one-element array, so an indexed op (`/Statement/0/Action`)
+// targets a path the raw model lacks (`noSuchPath`) and the CC revert FAILS. We write
+// the desired statement directly via PutPermission, MERGING by StatementId into the
+// bus's current aggregate policy so a sibling statement (another EventBusPolicy
+// resource, or one added out of band) is preserved rather than wiped.
+const writeEventBusPolicy: SdkWriter = async (ctx) => {
+  const eventBusName = str(ctx.declared['EventBusName']) ?? 'default';
+  const statementId = str(ctx.declared['StatementId']);
+  if (!statementId) throw new Error('cannot resolve StatementId for EventBusPolicy revert');
+  const c = new EventBridgeClient({ region: ctx.region });
+
+  // Desired statement = the declared (template) intent. Modern templates declare a full
+  // `Statement` object; the legacy CfnEventBusPolicy form declares Action+Principal.
+  const declaredStmt = ctx.declared['Statement'];
+  let desiredStatement: Record<string, unknown>;
+  if (declaredStmt && typeof declaredStmt === 'object' && !Array.isArray(declaredStmt)) {
+    desiredStatement = { Sid: statementId, ...(declaredStmt as Record<string, unknown>) };
+  } else {
+    const action = ctx.declared['Action'];
+    const principal = str(ctx.declared['Principal']);
+    if (action === undefined || principal === undefined)
+      throw new Error('EventBusPolicy revert needs a Statement (or Action + Principal)');
+    desiredStatement = {
+      Sid: statementId,
+      Effect: 'Allow',
+      Principal: principal === '*' ? '*' : { AWS: `arn:aws:iam::${principal}:root` },
+      Action: action,
+      Resource: `arn:aws:events:${ctx.region}:${ctx.accountId}:event-bus/${eventBusName}`,
+      ...(ctx.declared['Condition'] !== undefined ? { Condition: ctx.declared['Condition'] } : {}),
+    };
+  }
+
+  const bus = await c.send(new DescribeEventBusCommand({ Name: eventBusName }));
+  const policy =
+    bus.Policy && bus.Policy.length > 0
+      ? (JSON.parse(bus.Policy) as { Version?: string; Statement?: unknown })
+      : { Version: '2012-10-17', Statement: [] as unknown };
+  const statements: Record<string, unknown>[] = Array.isArray(policy.Statement)
+    ? (policy.Statement as Record<string, unknown>[])
+    : policy.Statement
+      ? [policy.Statement as Record<string, unknown>]
+      : [];
+  const idx = statements.findIndex((s) => s?.['Sid'] === statementId);
+  if (idx >= 0) statements[idx] = desiredStatement;
+  else statements.push(desiredStatement);
+  await c.send(
+    new PutPermissionCommand({
+      EventBusName: eventBusName,
+      Policy: JSON.stringify({ Version: policy.Version ?? '2012-10-17', Statement: statements }),
+    })
+  );
 };
 
 const writeIamPolicy: SdkWriter = async (ctx, ops) => {
@@ -909,6 +971,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::S3::BucketPolicy': writeS3BucketPolicy,
   'AWS::SNS::TopicPolicy': writeSnsTopicPolicy,
   'AWS::SQS::QueuePolicy': writeSqsQueuePolicy,
+  'AWS::Events::EventBusPolicy': writeEventBusPolicy,
   'AWS::IAM::Policy': writeIamPolicy,
   'AWS::IAM::ManagedPolicy': writeIamManagedPolicy,
 };

--- a/tests/corpus/AWS__Events__EventBusPolicy.BusPolicy.json
+++ b/tests/corpus/AWS__Events__EventBusPolicy.BusPolicy.json
@@ -1,0 +1,54 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "BusPolicy",
+    "resourceType": "AWS::Events::EventBusPolicy",
+    "physicalId": "CdkRealDriftIntegEventBusPolicyReadgap-bus|AllowSelfPutEvents",
+    "constructPath": "CdkRealDriftIntegEventBusPolicyReadgap/BusPolicy",
+    "declared": {
+      "EventBusName": "CdkRealDriftIntegEventBusPolicyReadgap-bus",
+      "Statement": {
+        "Sid": "AllowSelfPutEvents",
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::111111111111:root"
+        },
+        "Action": "events:PutEvents",
+        "Resource": "arn:aws:events:us-east-1:111111111111:event-bus/CdkRealDriftIntegEventBusPolicyReadgap-bus"
+      },
+      "StatementId": "AllowSelfPutEvents"
+    }
+  },
+  "liveRaw": {
+    "EventBusName": "CdkRealDriftIntegEventBusPolicyReadgap-bus",
+    "StatementId": "AllowSelfPutEvents",
+    "Statement": {
+      "Action": "events:PutEvents",
+      "Resource": "arn:aws:events:us-east-1:111111111111:event-bus/CdkRealDriftIntegEventBusPolicyReadgap-bus",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::111111111111:root"
+      },
+      "Sid": "AllowSelfPutEvents"
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["Action", "Condition", "Principal"],
+    "createOnly": ["EventBusName", "StatementId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["Action", "Condition", "Principal"],
+    "createOnlyPaths": ["EventBusName", "StatementId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [],
+  "description": "AWS::Events::EventBusPolicy reads cleanly via Cloud Control (the CFn physical id IS the EventBusName|StatementId composite). Its live Statement is a SINGULAR object; classify canonicalizes it to a one-element array. Detection works; revert routes to the SDK PutPermission writer (a CC RFC6902 patch would build an indexed op the raw model lacks)."
+}

--- a/tests/integration/eventbus-policy-readgap/app.ts
+++ b/tests/integration/eventbus-policy-readgap/app.ts
@@ -1,0 +1,34 @@
+// CDK app for the cdk-real-drift Events EventBusPolicy read-gap (false-negative)
+// integration test. AWS::Events::EventBusPolicy has a COMPOSITE primaryIdentifier
+// [EventBusName, StatementId] but the CFn physical id (Ref) is only the child
+// StatementId, so a bare Cloud Control GetResource is rejected and the policy is
+// silently `skipped` — an out-of-band change to who may PutEvents is then INVISIBLE
+// (a missed detection). This fixture confirms the gap and pins the fix.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import { CfnEventBus, CfnEventBusPolicy } from 'aws-cdk-lib/aws-events';
+import type { Construct } from 'constructs';
+
+class EventBusPolicyStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const bus = new CfnEventBus(this, 'Bus', { name: `${id}-bus` });
+
+    new CfnEventBusPolicy(this, 'BusPolicy', {
+      eventBusName: bus.name,
+      statementId: 'AllowSelfPutEvents',
+      statement: {
+        Sid: 'AllowSelfPutEvents',
+        Effect: 'Allow',
+        Principal: { AWS: `arn:aws:iam::${Stack.of(this).account}:root` },
+        Action: 'events:PutEvents',
+        Resource: bus.attrArn,
+      },
+    });
+  }
+}
+
+const app = new App();
+new EventBusPolicyStack(app, 'CdkRealDriftIntegEventBusPolicyReadgap', {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/eventbus-policy-readgap/cdk.json
+++ b/tests/integration/eventbus-policy-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eventbus-policy-readgap/package.json
+++ b/tests/integration/eventbus-policy-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eventbus-policy-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eventbus-policy-readgap false-negative integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eventbus-policy-readgap/verify-detect.sh
+++ b/tests/integration/eventbus-policy-readgap/verify-detect.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# EventBusPolicy detect + revert integration test (real AWS). AWS::Events::EventBusPolicy
+# is read fine by Cloud Control (the CFn physical id IS the EventBusName|StatementId
+# composite), so detection works — but its live `Statement` comes back as a SINGULAR
+# object while classify canonicalizes it to a one-element array, so a Cloud Control
+# RFC6902 revert builds an indexed op (`/Statement/0/Action`) the raw model lacks and
+# FAILS. This pins the SDK PutPermission writer: deploy -> record -> change the
+# statement's Action out of band -> check MUST DETECT -> revert MUST succeed (no
+# RFC6902 noSuchPath) -> check MUST be CLEAN and the live Action restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEventBusPolicyReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+BUS="$STACK-bus"
+ID="$BUS|AllowSelfPutEvents"
+export CDK_DEFAULT_ACCOUNT="${CDK_DEFAULT_ACCOUNT:-$(aws sts get-caller-identity --query Account --output text)}"
+export CDK_DEFAULT_REGION="$REGION"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+# poll Cloud Control until the live statement Action equals $1 (the update is async)
+wait_action() {
+  for _ in $(seq 1 30); do
+    cur="$(aws cloudcontrol get-resource --type-name AWS::Events::EventBusPolicy \
+      --identifier "$ID" --region "$REGION" --query 'ResourceDescription.Properties' \
+      --output text 2>/dev/null)"
+    case "$cur" in *"$1"*) return 0 ;; esac
+    sleep 3
+  done
+  return 1
+}
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: Statement Action events:PutEvents -> events:PutRule ==="
+aws cloudcontrol update-resource --type-name AWS::Events::EventBusPolicy --identifier "$ID" \
+  --region "$REGION" \
+  --patch-document '[{"op":"replace","path":"/Statement/Action","value":"events:PutRule"}]' \
+  >/dev/null || fail "inject drift"
+wait_action "PutRule" || fail "mutation did not apply"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-ebp-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "Statement.0.Action" /tmp/cdkrd-ebp-detect.out || fail "Statement.0.Action not reported"
+
+echo "=== revert (write declared statement back via PutPermission) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-ebp-revert.out || fail "revert"
+grep -q "FAILED" /tmp/cdkrd-ebp-revert.out && fail "revert reported FAILED (RFC6902 noSuchPath regression)"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live Action MUST be restored to events:PutEvents ==="
+wait_action "PutEvents" || fail "live Action not restored to PutEvents"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -82,6 +82,11 @@ import {
   DescribeConfigRulesCommand,
   PutConfigRuleCommand,
 } from '@aws-sdk/client-config-service';
+import {
+  DescribeEventBusCommand,
+  EventBridgeClient,
+  PutPermissionCommand,
+} from '@aws-sdk/client-eventbridge';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
@@ -101,6 +106,7 @@ const glue = mockClient(GlueClient);
 const logs = mockClient(CloudWatchLogsClient);
 const route53 = mockClient(Route53Client);
 const configService = mockClient(ConfigServiceClient);
+const eventbridge = mockClient(EventBridgeClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -143,6 +149,77 @@ beforeEach(() => {
   logs.reset();
   route53.reset();
   configService.reset();
+  eventbridge.reset();
+});
+
+describe('EventBusPolicy writer (CC RFC6902 patch fails on a singular-object Statement)', () => {
+  const desiredStmt = {
+    Sid: 'AllowSelfPutEvents',
+    Effect: 'Allow',
+    Principal: { AWS: 'arn:aws:iam::123456789012:root' },
+    Action: 'events:PutEvents',
+    Resource: 'arn:aws:events:us-east-1:123456789012:event-bus/mybus',
+  };
+  const ebpCtx = (over: Partial<OverrideCtx> = {}): OverrideCtx =>
+    ctx({
+      physicalId: 'mybus|AllowSelfPutEvents',
+      declared: {
+        EventBusName: 'mybus',
+        StatementId: 'AllowSelfPutEvents',
+        Statement: desiredStmt,
+      },
+      ...over,
+    });
+
+  it('reverts via PutPermission, restoring the declared statement by StatementId and PRESERVING a sibling', async () => {
+    // live bus policy has the drifted target (Action changed to PutRule) + an unrelated sibling.
+    eventbridge.on(DescribeEventBusCommand).resolves({
+      Policy: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [
+          { ...desiredStmt, Action: 'events:PutRule' },
+          {
+            Sid: 'SiblingFromAnotherResource',
+            Effect: 'Allow',
+            Principal: '*',
+            Action: 'events:PutEvents',
+          },
+        ],
+      }),
+    });
+    await SDK_WRITERS['AWS::Events::EventBusPolicy'](ebpCtx(), []);
+    const calls = eventbridge.commandCalls(PutPermissionCommand);
+    expect(calls).toHaveLength(1);
+    const policy = JSON.parse(calls[0].args[0].input.Policy as string);
+    const target = policy.Statement.find((s: { Sid: string }) => s.Sid === 'AllowSelfPutEvents');
+    expect(target.Action).toBe('events:PutEvents'); // restored
+    // the sibling statement is untouched (not wiped by the revert)
+    expect(
+      policy.Statement.some((s: { Sid: string }) => s.Sid === 'SiblingFromAnotherResource')
+    ).toBe(true);
+    expect(calls[0].args[0].input.EventBusName).toBe('mybus');
+  });
+
+  it('re-adds the declared statement when it was removed out of band (no Sid match in live)', async () => {
+    eventbridge.on(DescribeEventBusCommand).resolves({
+      Policy: JSON.stringify({ Version: '2012-10-17', Statement: [] }),
+    });
+    await SDK_WRITERS['AWS::Events::EventBusPolicy'](ebpCtx(), []);
+    const policy = JSON.parse(
+      eventbridge.commandCalls(PutPermissionCommand)[0].args[0].input.Policy as string
+    );
+    expect(policy.Statement).toHaveLength(1);
+    expect(policy.Statement[0].Sid).toBe('AllowSelfPutEvents');
+  });
+
+  it('throws when the StatementId is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::Events::EventBusPolicy'](
+        ebpCtx({ declared: { EventBusName: 'mybus' } }),
+        []
+      )
+    ).rejects.toThrow(/StatementId/);
+  });
 });
 
 describe('OpenSearch Domain writer (CC UpdateResource rejects on override_main_response_version)', () => {


### PR DESCRIPTION
## The bug
`AWS::Events::EventBusPolicy` is read fine by Cloud Control — the CFn physical id (Ref) **is** the `EventBusName|StatementId` composite, so `check` reads and **detects** an out-of-band statement change correctly. But its **`revert` was broken**: CC returns the live `Statement` as a **singular object**, while classify canonicalizes a policy `Statement` to a one-element array. The revert therefore built an RFC6902 op `/Statement/0/Action` (array index) that the raw object model doesn't have, and Cloud Control rejected it:

```
FAILED: .../BusPolicy — [ADD Operation] noSuchPath in source, path provided: //Statement/0/Action
```

The failure was **masked**: the EventBus's live model reflects its resource policy as an undeclared `EventBus.Policy`, and reverting *that* restored the underlying state — so the stack converged `CLEAN after revert` even though the EventBusPolicy resource's own revert printed `FAILED`. (Found incidentally while hunting read-gap FNs — detection was never the problem.)

## The fix
Policy-statement resources need a **native-SDK writer**, not a CC RFC6902 patch — `S3::BucketPolicy` / `SNS::TopicPolicy` / `SQS::QueuePolicy` / `IAM::Policy` were all already in `SDK_WRITERS`; **EventBusPolicy was the one missing**. The new `writeEventBusPolicy`:
- reads the bus's current aggregate policy (`DescribeEventBus`),
- **merges the desired declared statement by `StatementId`** so a sibling statement (another EventBusPolicy resource, or one added out of band) is **preserved, not wiped**,
- writes the whole policy back via `PutPermission`.

Handles both the modern `Statement`-object form and the legacy `Action`/`Principal` form; throws clearly when the StatementId is unresolvable.

## Verification
- **Live-proven** detect → revert → clean (`tests/integration/eventbus-policy-readgap/verify-detect.sh`, **INTEG PASS**): mutate `Statement.Action` out of band → `check` detects (exit 1) → `revert` succeeds with **no** RFC6902 `noSuchPath` → `check` CLEAN → live Action restored.
- 3 writer unit tests (mock `EventBridgeClient`): restore-by-Sid **+ preserve sibling**, re-add when removed out of band, throw on missing StatementId.
- Golden-corpus case `AWS__Events__EventBusPolicy.BusPolicy.json` (reads clean via the composite Ref).
- Full suite: 1725 tests green. `@aws-sdk/client-eventbridge` was already a dependency.
