### PR TITLE
test(integ): add realistic dogfood-webapp stack + standalone SG-rule corpus

### DIFF
--- a/tests/corpus/AWS__EC2__SecurityGroupEgress.WebSgEgress.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupEgress.WebSgEgress.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebLBSecurityGrouptoCdkRealDriftIntegDogfoodWebappWebServiceSecurityGroup13E7969080C3E6727D",
+    "resourceType": "AWS::EC2::SecurityGroupEgress",
+    "physicalId": "sgr-0413be8e50008338f",
+    "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/LB/SecurityGroup/to CdkRealDriftIntegDogfoodWebappWebServiceSecurityGroup13E79690:80",
+    "declared": {
+      "Description": "Load balancer to target",
+      "DestinationSecurityGroupId": "sg-0e1d238d8265ebe4b",
+      "FromPort": 80,
+      "GroupId": "sg-0b5e58abecfacf5a7",
+      "IpProtocol": "tcp",
+      "ToPort": 80
+    }
+  },
+  "liveRaw": {
+    "Description": "Load balancer to target",
+    "FromPort": 80,
+    "ToPort": 80,
+    "IpProtocol": "tcp",
+    "DestinationSecurityGroupId": "sg-0e1d238d8265ebe4b",
+    "Id": "sgr-0413be8e50008338f",
+    "GroupId": "sg-0b5e58abecfacf5a7"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "CidrIp",
+      "CidrIpv6",
+      "DestinationPrefixListId",
+      "DestinationSecurityGroupId",
+      "FromPort",
+      "GroupId",
+      "IpProtocol",
+      "ToPort"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "CidrIp",
+      "CidrIpv6",
+      "DestinationPrefixListId",
+      "DestinationSecurityGroupId",
+      "FromPort",
+      "GroupId",
+      "IpProtocol",
+      "ToPort"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [],
+  "description": "Standalone EC2 SG rule resource emitted when two security groups cross-reference each other (ALB SG <-> ECS service SG), harvested from the dogfood-webapp realistic stack. Reads clean (no FP)."
+}

--- a/tests/corpus/AWS__EC2__SecurityGroupIngress.WebSgIngress.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupIngress.WebSgIngress.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebServiceSecurityGroupfromCdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F408013CF9C8D",
+    "resourceType": "AWS::EC2::SecurityGroupIngress",
+    "physicalId": "sgr-0f22ac16d7a19bd95",
+    "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/Service/SecurityGroup/from CdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F40:80",
+    "declared": {
+      "Description": "Load balancer to target",
+      "FromPort": 80,
+      "GroupId": "sg-0e1d238d8265ebe4b",
+      "IpProtocol": "tcp",
+      "SourceSecurityGroupId": "sg-0b5e58abecfacf5a7",
+      "ToPort": 80
+    }
+  },
+  "liveRaw": {
+    "GroupName": "CdkRealDriftIntegDogfoodWebapp-WebServiceSecurityGroupBAF50CC8-Uhwf3Gj3nM2K",
+    "Description": "Load balancer to target",
+    "FromPort": 80,
+    "SourceSecurityGroupName": "CdkRealDriftIntegDogfoodWebapp-WebLBSecurityGroupAD942A36-s0hAAOAkGDag",
+    "ToPort": 80,
+    "SourceSecurityGroupOwnerId": "111111111111",
+    "IpProtocol": "tcp",
+    "Id": "sgr-0f22ac16d7a19bd95",
+    "SourceSecurityGroupId": "sg-0b5e58abecfacf5a7",
+    "GroupId": "sg-0e1d238d8265ebe4b"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "CidrIp",
+      "CidrIpv6",
+      "FromPort",
+      "GroupId",
+      "GroupName",
+      "IpProtocol",
+      "SourcePrefixListId",
+      "SourceSecurityGroupId",
+      "SourceSecurityGroupName",
+      "SourceSecurityGroupOwnerId",
+      "ToPort"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "CidrIp",
+      "CidrIpv6",
+      "FromPort",
+      "GroupId",
+      "GroupName",
+      "IpProtocol",
+      "SourcePrefixListId",
+      "SourceSecurityGroupId",
+      "SourceSecurityGroupName",
+      "SourceSecurityGroupOwnerId",
+      "ToPort"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "WebServiceSecurityGroupfromCdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F408013CF9C8D",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "GroupName",
+      "actual": "CdkRealDriftIntegDogfoodWebapp-WebServiceSecurityGroupBAF50CC8-Uhwf3Gj3nM2K",
+      "physicalId": "sgr-0f22ac16d7a19bd95",
+      "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/Service/SecurityGroup/from CdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F40:80"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WebServiceSecurityGroupfromCdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F408013CF9C8D",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "SourceSecurityGroupName",
+      "actual": "CdkRealDriftIntegDogfoodWebapp-WebLBSecurityGroupAD942A36-s0hAAOAkGDag",
+      "physicalId": "sgr-0f22ac16d7a19bd95",
+      "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/Service/SecurityGroup/from CdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F40:80"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WebServiceSecurityGroupfromCdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F408013CF9C8D",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "SourceSecurityGroupOwnerId",
+      "actual": "111111111111",
+      "physicalId": "sgr-0f22ac16d7a19bd95",
+      "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/Service/SecurityGroup/from CdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F40:80"
+    }
+  ],
+  "description": "Standalone EC2 SG rule resource emitted when two security groups cross-reference each other (ALB SG <-> ECS service SG), harvested from the dogfood-webapp realistic stack. Reads clean (no FP)."
+}

--- a/tests/integration/dogfood-webapp/app.ts
+++ b/tests/integration/dogfood-webapp/app.ts
@@ -1,0 +1,107 @@
+// CDK app for the cdk-real-drift DOGFOOD integration test: a realistic
+// multi-resource web-app + async-worker stack (NOT a single-type probe). The point
+// is to surface false positives that only arise from the INTERACTION of many real
+// resources with their real defaults — ALB + ECS Fargate service + task definition +
+// CloudWatch logs + IAM roles/policies + security groups + DynamoDB + SQS + a Lambda
+// consumer + S3 + a Secret, all wired with grants the way a real CDK user writes them.
+// A clean `record` -> `check` MUST be CLEAN; any declared drift is a normalization /
+// default-folding FP from a real property combination the single-type fixtures miss.
+// No NAT gateway (Fargate runs in public subnets with a public IP) to bound cost.
+import { App, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Cluster, ContainerImage } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService } from 'aws-cdk-lib/aws-ecs-patterns';
+import { Code, Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import type { Construct } from 'constructs';
+
+class DogfoodWebappStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const vpc = new Vpc(this, 'Vpc', {
+      maxAzs: 2,
+      natGateways: 0,
+      subnetConfiguration: [{ name: 'public', subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+    });
+
+    // --- data + messaging layer ---
+    const table = new Table(this, 'Table', {
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      sortKey: { name: 'sk', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.DESTROY,
+      pointInTimeRecovery: true,
+    });
+    table.addGlobalSecondaryIndex({
+      indexName: 'by-status',
+      partitionKey: { name: 'status', type: AttributeType.STRING },
+    });
+
+    const bucket = new Bucket(this, 'Assets', {
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    const secret = new Secret(this, 'ApiKey', {
+      generateSecretString: { passwordLength: 24, excludePunctuation: true },
+    });
+
+    const dlq = new Queue(this, 'Dlq', { retentionPeriod: Duration.days(14) });
+    const queue = new Queue(this, 'Jobs', {
+      visibilityTimeout: Duration.seconds(60),
+      deadLetterQueue: { queue: dlq, maxReceiveCount: 5 },
+    });
+
+    // --- async worker: Lambda consuming the queue, reading the table/bucket/secret ---
+    const worker = new LambdaFunction(this, 'Worker', {
+      runtime: Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: Code.fromInline(
+        'exports.handler = async (e) => { console.log(JSON.stringify(e)); return {}; };'
+      ),
+      memorySize: 256,
+      timeout: Duration.seconds(30),
+      environment: { TABLE: table.tableName, BUCKET: bucket.bucketName, SECRET: secret.secretArn },
+      logRetention: RetentionDays.ONE_WEEK,
+    });
+    worker.addEventSource(new SqsEventSource(queue, { batchSize: 10 }));
+    table.grantReadWriteData(worker);
+    bucket.grantRead(worker);
+    secret.grantRead(worker);
+
+    // --- web tier: an internet-facing ALB in front of a Fargate service ---
+    const cluster = new Cluster(this, 'Cluster', { vpc, containerInsights: true });
+    const web = new ApplicationLoadBalancedFargateService(this, 'Web', {
+      cluster,
+      cpu: 256,
+      memoryLimitMiB: 512,
+      desiredCount: 1,
+      assignPublicIp: true,
+      taskSubnets: { subnetType: SubnetType.PUBLIC },
+      publicLoadBalancer: true,
+      taskImageOptions: {
+        image: ContainerImage.fromRegistry('public.ecr.aws/docker/library/httpd:2.4'),
+        containerPort: 80,
+        environment: { QUEUE_URL: queue.queueUrl, TABLE: table.tableName },
+      },
+    });
+    web.targetGroup.configureHealthCheck({ path: '/', healthyHttpCodes: '200-399' });
+    // the web task may enqueue jobs + read its data
+    queue.grantSendMessages(web.taskDefinition.taskRole);
+    table.grantReadData(web.taskDefinition.taskRole);
+  }
+}
+
+const app = new App();
+new DogfoodWebappStack(app, 'CdkRealDriftIntegDogfoodWebapp', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-webapp/cdk.json
+++ b/tests/integration/dogfood-webapp/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-webapp/package.json
+++ b/tests/integration/dogfood-webapp/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-webapp",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Realistic multi-resource dogfood stack for cdk-real-drift false-positive integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-webapp/verify.sh
+++ b/tests/integration/dogfood-webapp/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a realistic multi-resource
+# web-app + async-worker stack (ALB + ECS Fargate service/task + CloudWatch logs +
+# IAM roles/policies + security groups + DynamoDB + SQS + a Lambda consumer + S3 +
+# a Secret), wired with grants the way a real CDK user writes them. Unlike the
+# single-type fixtures this exercises the INTERACTION of ~28 resource types with
+# their real defaults. A clean `record` -> `check` MUST be CLEAN; any declared drift
+# is a normalization / default-folding FP from a real property combination.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodWebapp
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN (no interaction FP) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
A multi-resource **DOGFOOD** integration test — the first that exercises the **interaction** of ~28 resource types rather than a single type. A realistic web-app + async-worker stack: an internet-facing **ALB** in front of an **ECS Fargate** service/task (CloudWatch logs + IAM roles/policies + security groups), plus a **DynamoDB** table, an **SQS** queue + DLQ, a **Lambda** consumer, an **S3** bucket, and a **Secret** — all wired with grants the way a real CDK user writes them (no NAT; Fargate in public subnets to bound cost).

## Why
The single-type fixtures (237 types / 240 fixtures) are saturated; this guards against FPs that only arise from **real property combinations** across interacting resources.

## Live result (no bug — a strong positive)
- `record` → `check` is **CLEAN**: zero false positives from the real combination.
- Detection + revert work on the realistic stack: Lambda `MemorySize` mutated out of band → **detected** → **reverted** → CLEAN, live restored.

## New coverage
Promoted two genuinely-new golden-corpus types harvested from the stack — the standalone `AWS::EC2::SecurityGroupEgress` / `SecurityGroupIngress` rule resources CDK emits when two SGs cross-reference each other (the ALB SG ↔ the ECS service SG); both read clean.

Tests-only (no `src/**`) → verify-pr exempt. 1727 unit tests + 474 corpus-replay green.