### PR TITLE
test(integ): add serverless-api dogfood stack + ApiGateway UsagePlanKey corpus

### DIFF
--- a/tests/corpus/AWS__ApiGateway__UsagePlanKey.RestPlanKey.json
+++ b/tests/corpus/AWS__ApiGateway__UsagePlanKey.RestPlanKey.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RestPlanUsagePlanKeyResourceCdkRealDriftIntegDogfoodServerlessApiRestApiKey9A2D24F68AF75E87",
+    "resourceType": "AWS::ApiGateway::UsagePlanKey",
+    "physicalId": "h5k35ksid3:xltzog",
+    "constructPath": "CdkRealDriftIntegDogfoodServerlessApi/Rest/Plan/UsagePlanKeyResource:CdkRealDriftIntegDogfoodServerlessApiRestApiKey9A2D24F6",
+    "declared": {
+      "KeyId": "h5k35ksid3",
+      "KeyType": "API_KEY",
+      "UsagePlanId": "xltzog"
+    }
+  },
+  "liveRaw": {
+    "KeyType": "API_KEY",
+    "UsagePlanId": "xltzog",
+    "KeyId": "h5k35ksid3",
+    "Id": "h5k35ksid3:xltzog"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["KeyId", "KeyType", "UsagePlanId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KeyId", "KeyType", "UsagePlanId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [],
+  "description": "ApiGateway UsagePlanKey (the UsagePlan<->ApiKey link, single Id primaryIdentifier) read clean via Cloud Control, harvested from the dogfood-serverless-api realistic stack."
+}

--- a/tests/integration/dogfood-serverless-api/app.ts
+++ b/tests/integration/dogfood-serverless-api/app.ts
@@ -1,0 +1,103 @@
+// CDK app for the cdk-real-drift DOGFOOD #2: a realistic SERVERLESS API stack (a
+// different interaction surface from the ALB/ECS dogfood-webapp). A REST API Gateway
+// with Lambda-integrated methods behind a Cognito User Pools authorizer, backed by a
+// DynamoDB table, with an SQS dead-letter queue and a usage plan + API key. The point
+// is to surface false positives from the INTERACTION of API Gateway's child resources
+// (RestApi + Resource + Method + Deployment + Stage + Authorizer + UsagePlan), Cognito
+// (UserPool + Client + Domain), Lambda, DynamoDB, and the IAM grants wiring them — the
+// kind of real combination a serverless app actually deploys. A clean `record` ->
+// `check` MUST be CLEAN; any declared drift is a normalization / default-folding FP.
+import { App, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import {
+  AuthorizationType,
+  CognitoUserPoolsAuthorizer,
+  Cors,
+  LambdaIntegration,
+  Period,
+  RestApi,
+} from 'aws-cdk-lib/aws-apigateway';
+import { UserPool, UserPoolClient } from 'aws-cdk-lib/aws-cognito';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Code, Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import type { Construct } from 'constructs';
+
+class DogfoodServerlessApiStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const table = new Table(this, 'Items', {
+      partitionKey: { name: 'id', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.DESTROY,
+      timeToLiveAttribute: 'ttl',
+    });
+
+    const dlq = new Queue(this, 'ApiDlq', { retentionPeriod: Duration.days(14) });
+
+    const handler = new LambdaFunction(this, 'Api', {
+      runtime: Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: Code.fromInline(
+        'exports.handler = async () => ({ statusCode: 200, body: "ok" });'
+      ),
+      memorySize: 256,
+      timeout: Duration.seconds(10),
+      environment: { TABLE: table.tableName },
+      deadLetterQueue: dlq,
+      logRetention: RetentionDays.ONE_WEEK,
+    });
+    table.grantReadWriteData(handler);
+
+    // Cognito user pool + client + an authorizer guarding the API.
+    const userPool = new UserPool(this, 'Users', {
+      selfSignUpEnabled: true,
+      signInAliases: { email: true },
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    const userPoolClient = new UserPoolClient(this, 'UsersClient', {
+      userPool,
+      generateSecret: false,
+      authFlows: { userPassword: true, userSrp: true },
+    });
+    const authorizer = new CognitoUserPoolsAuthorizer(this, 'Authorizer', {
+      cognitoUserPools: [userPool],
+    });
+
+    const api = new RestApi(this, 'Rest', {
+      deployOptions: { stageName: 'prod', throttlingBurstLimit: 100, throttlingRateLimit: 50 },
+      defaultCorsPreflightOptions: { allowOrigins: Cors.ALL_ORIGINS, allowMethods: Cors.ALL_METHODS },
+    });
+    const items = api.root.addResource('items');
+    items.addMethod('GET', new LambdaIntegration(handler), {
+      authorizer,
+      authorizationType: AuthorizationType.COGNITO,
+    });
+    items.addMethod('POST', new LambdaIntegration(handler), {
+      authorizer,
+      authorizationType: AuthorizationType.COGNITO,
+    });
+    const item = items.addResource('{id}');
+    item.addMethod('GET', new LambdaIntegration(handler), {
+      authorizer,
+      authorizationType: AuthorizationType.COGNITO,
+    });
+
+    // a usage plan + API key (a common real serverless add-on)
+    const key = api.addApiKey('ApiKey');
+    const plan = api.addUsagePlan('Plan', {
+      throttle: { burstLimit: 50, rateLimit: 20 },
+      quota: { limit: 10000, period: Period.MONTH },
+    });
+    plan.addApiKey(key);
+    plan.addApiStage({ stage: api.deploymentStage });
+
+    void userPoolClient;
+  }
+}
+
+const app = new App();
+new DogfoodServerlessApiStack(app, 'CdkRealDriftIntegDogfoodServerlessApi', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-serverless-api/cdk.json
+++ b/tests/integration/dogfood-serverless-api/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-serverless-api/package.json
+++ b/tests/integration/dogfood-serverless-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-serverless-api",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Realistic serverless API dogfood stack for cdk-real-drift false-positive integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-serverless-api/verify.sh
+++ b/tests/integration/dogfood-serverless-api/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a realistic SERVERLESS API
+# stack (REST API Gateway with Lambda-integrated methods behind a Cognito User Pools
+# authorizer + a usage plan/API key, backed by DynamoDB + an SQS DLQ). Unlike the
+# single-type fixtures this exercises the INTERACTION of the API Gateway child-resource
+# family (RestApi/Resource/Method/Deployment/Stage/Authorizer/UsagePlan), Cognito,
+# Lambda (incl. the apigw->lambda invoke Permissions), DynamoDB and the IAM grants.
+# A clean `record` -> `check` MUST be CLEAN; any declared drift is a default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodServerlessApi
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN (no interaction FP) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
A second **DOGFOOD** integration test on a different interaction surface from `dogfood-webapp`: a realistic **serverless API** stack (~21 resource types) — a REST **API Gateway** with Lambda-integrated methods behind a **Cognito** User Pools authorizer, plus a usage plan + API key, backed by a **DynamoDB** table and an **SQS** dead-letter queue.

## Why
Exercises the **interaction** of the API Gateway child-resource family (RestApi / Resource / Method / Deployment / Stage / Authorizer / UsagePlan / UsagePlanKey / ApiKey / Account), Cognito (UserPool / Client), Lambda (incl. the six `apigw→lambda` invoke `Permission`s that share Action+Principal — a known cross-match FP source), and the IAM grants wiring them.

## Live result (no bug — a strong positive)
- `record` → `check` is **CLEAN**: zero false positives from the real combination.
- Detection + revert work: Lambda `Timeout` mutated out of band → **detected** → **reverted** → CLEAN.

## New coverage
Promoted one genuinely-new golden-corpus type — `AWS::ApiGateway::UsagePlanKey` (the UsagePlan↔ApiKey link), which reads clean.

Tests-only (no `src/**`) → verify-pr exempt. 1728 unit tests + 475 corpus-replay green.