### PR TITLE
fix(read): close AWS::Logs::LogStream CC read-gap via composite adapter

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -202,6 +202,14 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
     const lg = declared.LogGroupName;
     return typeof lg === 'string' && lg.length > 0 ? `${pid}|${lg}` : undefined;
   },
+  // Logs LogStream primaryIdentifier is [LogGroupName, LogStreamName] — PARENT first
+  // (LogGroupName, then LogStreamName), unlike the child-first SubscriptionFilter. The
+  // CFn physical id (Ref) is the bare LogStreamName; the LogGroupName comes from the
+  // resolved declared Ref. Without this a declared log stream is a CC ValidationException
+  // skip on every check (read-gap, surfaced by the dogfood-data-pipeline Firehose error
+  // log stream). Verified live: `<LogGroupName>|<LogStreamName>` reads, the reverse
+  // ResourceNotFoundExceptions.
+  'AWS::Logs::LogStream': compositeWith('LogGroupName'),
   // TransitGatewayRouteTablePropagation primaryIdentifier is [TransitGatewayRouteTableId,
   // TransitGatewayAttachmentId], but its CFn physical id (Ref) is the AWS console id
   // format `${attachmentId}_${routeTableId}` (underscore, ATTACHMENT first) — NOT the CC

--- a/tests/corpus/AWS__Logs__LogStream.FhLogStream.json
+++ b/tests/corpus/AWS__Logs__LogStream.FhLogStream.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FhLogStream5F86DF95",
+    "resourceType": "AWS::Logs::LogStream",
+    "physicalId": "CdkRealDriftIntegDogfoodDataPipeline-FhLogStream5F86DF95-vHhNtbuB5aIg",
+    "constructPath": "CdkRealDriftIntegDogfoodDataPipeline/FhLogStream",
+    "declared": {
+      "LogGroupName": "CdkRealDriftIntegDogfoodDataPipeline-FhLog1758CD2F-nTwUD3T9mSBs"
+    }
+  },
+  "liveRaw": {
+    "LogStreamName": "CdkRealDriftIntegDogfoodDataPipeline-FhLogStream5F86DF95-vHhNtbuB5aIg",
+    "LogGroupName": "CdkRealDriftIntegDogfoodDataPipeline-FhLog1758CD2F-nTwUD3T9mSBs"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName", "LogStreamName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName", "LogStreamName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [],
+  "description": "Logs LogStream read via the new CC_IDENTIFIER_ADAPTERS LogGroupName|LogStreamName composite (PARENT-first); without the adapter it was a silent CC ValidationException skip. Reads clean (LogStreamName + LogGroupName are both identity/create-only). Harvested from dogfood-data-pipeline."
+}

--- a/tests/integration/dogfood-data-pipeline/app.ts
+++ b/tests/integration/dogfood-data-pipeline/app.ts
@@ -1,0 +1,145 @@
+// CDK app for the cdk-real-drift DOGFOOD #3: a realistic streaming DATA PIPELINE
+// stack (a third interaction surface, after the ALB/ECS web app and the serverless
+// API). A Kinesis data stream feeds a Firehose delivery stream that runs records
+// through a Lambda transform (a ProcessingConfiguration with Parameters — the shape
+// that produced a real reorder+subset FP in #340) and lands GZIP'd objects in S3,
+// with CloudWatch error logging; a Glue database + table provide the data catalog.
+// The point is to surface false positives from the INTERACTION of Kinesis + Firehose
+// (its nested ProcessingConfiguration / S3 destination config) + Glue + S3 + the Lambda
+// transform + the IAM delivery role wiring them. A clean `record` -> `check` MUST be
+// CLEAN; any declared drift is a normalization / default-folding FP.
+import { App, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { CfnDatabase, CfnTable } from 'aws-cdk-lib/aws-glue';
+import { Stream, StreamMode } from 'aws-cdk-lib/aws-kinesis';
+import { CfnDeliveryStream } from 'aws-cdk-lib/aws-kinesisfirehose';
+import { Code, Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { LogGroup, LogStream, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Effect, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import type { Construct } from 'constructs';
+
+class DogfoodDataPipelineStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const source = new Stream(this, 'Source', {
+      streamMode: StreamMode.PROVISIONED,
+      shardCount: 1,
+      retentionPeriod: Duration.hours(24),
+    });
+
+    const bucket = new Bucket(this, 'Lake', {
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    // Glue data catalog over the lake.
+    const db = new CfnDatabase(this, 'Db', {
+      catalogId: this.account,
+      databaseInput: { name: 'cdkrd_pipeline', description: 'cdkrd dogfood catalog' },
+    });
+    new CfnTable(this, 'Events', {
+      catalogId: this.account,
+      databaseName: 'cdkrd_pipeline',
+      tableInput: {
+        name: 'events',
+        tableType: 'EXTERNAL_TABLE',
+        parameters: { classification: 'parquet' },
+        storageDescriptor: {
+          location: `s3://${bucket.bucketName}/events/`,
+          columns: [
+            { name: 'id', type: 'string' },
+            { name: 'ts', type: 'bigint' },
+            { name: 'payload', type: 'string' },
+          ],
+          inputFormat: 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat',
+          outputFormat: 'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat',
+          serdeInfo: {
+            serializationLibrary: 'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe',
+          },
+        },
+      },
+    }).addDependency(db);
+
+    const transform = new LambdaFunction(this, 'Transform', {
+      runtime: Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: Code.fromInline(
+        'exports.handler = async (e) => ({ records: e.records.map(r => ({ recordId: r.recordId, result: "Ok", data: r.data })) });'
+      ),
+      memorySize: 256,
+      timeout: Duration.minutes(1),
+      logRetention: RetentionDays.ONE_WEEK,
+    });
+
+    const logGroup = new LogGroup(this, 'FhLog', {
+      retention: RetentionDays.ONE_DAY,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    const logStream = new LogStream(this, 'FhLogStream', {
+      logGroup,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    // Firehose delivery role with access to the source stream, the lake, the transform.
+    const fhRole = new Role(this, 'FhRole', {
+      assumedBy: new ServicePrincipal('firehose.amazonaws.com'),
+    });
+    bucket.grantReadWrite(fhRole);
+    source.grantRead(fhRole);
+    transform.grantInvoke(fhRole);
+    fhRole.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['logs:PutLogEvents'],
+        resources: [logGroup.logGroupArn],
+      })
+    );
+
+    const firehose = new CfnDeliveryStream(this, 'Firehose', {
+      deliveryStreamType: 'KinesisStreamAsSource',
+      kinesisStreamSourceConfiguration: {
+        kinesisStreamArn: source.streamArn,
+        roleArn: fhRole.roleArn,
+      },
+      extendedS3DestinationConfiguration: {
+        bucketArn: bucket.bucketArn,
+        roleArn: fhRole.roleArn,
+        prefix: 'events/',
+        errorOutputPrefix: 'errors/',
+        compressionFormat: 'GZIP',
+        bufferingHints: { intervalInSeconds: 60, sizeInMBs: 5 },
+        cloudWatchLoggingOptions: {
+          enabled: true,
+          logGroupName: logGroup.logGroupName,
+          logStreamName: logStream.logStreamName,
+        },
+        processingConfiguration: {
+          enabled: true,
+          processors: [
+            {
+              type: 'Lambda',
+              parameters: [
+                { parameterName: 'LambdaArn', parameterValue: transform.functionArn },
+                { parameterName: 'BufferSizeInMBs', parameterValue: '1' },
+                { parameterName: 'BufferIntervalInSeconds', parameterValue: '60' },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    // Firehose validates the role can DescribeStream AT CREATE TIME, so the role's
+    // grant policy must exist first — depend on it explicitly to avoid the IAM race.
+    const fhRolePolicy = fhRole.node.tryFindChild('DefaultPolicy');
+    if (fhRolePolicy) firehose.node.addDependency(fhRolePolicy);
+  }
+}
+
+const app = new App();
+new DogfoodDataPipelineStack(app, 'CdkRealDriftIntegDogfoodDataPipeline', {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-data-pipeline/cdk.json
+++ b/tests/integration/dogfood-data-pipeline/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-data-pipeline/package.json
+++ b/tests/integration/dogfood-data-pipeline/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-data-pipeline",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Realistic streaming data-pipeline dogfood stack for cdk-real-drift false-positive integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-data-pipeline/verify.sh
+++ b/tests/integration/dogfood-data-pipeline/verify.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a realistic streaming DATA
+# PIPELINE — a Kinesis data stream feeding a Firehose delivery stream that runs a
+# Lambda transform (ProcessingConfiguration with Parameters) and lands GZIP'd objects
+# in S3 with CloudWatch error logging, plus a Glue database + table catalog. Unlike
+# the single-type fixtures this exercises the INTERACTION of Kinesis + Firehose (its
+# nested ProcessingConfiguration / S3 destination config) + Glue + S3 + the Lambda
+# transform + the IAM delivery role wiring them. It also exercises the LogStream
+# CC_IDENTIFIER_ADAPTERS composite read (a read-gap this stack surfaced). A clean
+# `record` -> `check` MUST be CLEAN; any declared drift is a default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodDataPipeline
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+export CDK_DEFAULT_ACCOUNT="${CDK_DEFAULT_ACCOUNT:-$(aws sts get-caller-identity --query Account --output text)}"
+export CDK_DEFAULT_REGION="$REGION"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN (no interaction FP; LogStream read via adapter) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+# the LogStream read-gap fix must hold: it must NOT be in the skipped footer
+grep -q "AWS::Logs::LogStream.*ValidationException" "/tmp/cdkrd-$STACK.out" && fail "LogStream still skipped (read-gap regression)"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -377,6 +377,32 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('cdkrd-errors');
   });
 
+  it('Logs LogStream: builds the LogGroupName|LogStreamName composite — PARENT first', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::Logs::LogStream',
+        physicalId: 'my-stream',
+        declared: { LogGroupName: '/aws/my-log-group' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('/aws/my-log-group|my-stream');
+  });
+
+  it('Logs LogStream: an unresolved LogGroupName falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Logs::LogStream', physicalId: 'my-stream', declared: {} }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('my-stream');
+  });
+
   for (const t of [
     'AWS::Cognito::UserPoolDomain',
     'AWS::Cognito::UserPoolResourceServer',


### PR DESCRIPTION
## The read-gap
A declared `AWS::Logs::LogStream` was a **silent Cloud Control `ValidationException` skip** on every check: its primaryIdentifier is the composite `[LogGroupName, LogStreamName]` (**parent first**), but the CFn physical id (Ref) is only the bare `LogStreamName`, so a CC `GetResource` with that bare id is rejected → the resource shows up in the `skipped=` footer as "coverage incomplete".

## The fix
Added a `CC_IDENTIFIER_ADAPTERS` entry — `compositeWith('LogGroupName')` builds `<LogGroupName>|<LogStreamName>` from the resolved declared Ref (verified live: that order reads, the reverse `ResourceNotFoundException`s). Same Logs family as the already-adapted `SubscriptionFilter`, just parent-first.

## How it was found — a third DOGFOOD
A new dogfood integration test, `dogfood-data-pipeline`: a realistic streaming pipeline — **Kinesis → Firehose** (Lambda transform + GZIP to S3 + CloudWatch error logging) **→ S3**, with a **Glue** database + table catalog. Its Firehose error `LogStream` was the skipped resource. Single-type probes never hit LogStream (it has no mutable drift surface), but **real stacks deploy it as a supporting resource** — exactly the kind of "boring" type the dogfood strategy surfaces.

## Verification
- `record` → `check` is **CLEAN** on the whole pipeline (no interaction FP), and the LogStream now **reads instead of skipping** (`verify.sh` INTEG PASS, with a guard asserting LogStream is not in the skipped footer).
- Unit tests for the adapter: parent-first composite build + unresolved-parent fallback to the bare id (honest skip).
- Golden-corpus case `AWS__Logs__LogStream.FhLogStream.json` (reads clean).
- 1731 unit tests + 476 corpus-replay green.

(The fixture also documents a real CDK gotcha: a Firehose with `KinesisStreamAsSource` validates `kinesis:DescribeStream` at create time, so it must `DependsOn` the delivery role's grant policy or the deploy fails — handled in `app.ts`.)
