### PR TITLE
test(integ): add event-driven orchestration dogfood stack

### DIFF
--- a/tests/integration/dogfood-event-driven/app.ts
+++ b/tests/integration/dogfood-event-driven/app.ts
@@ -1,0 +1,102 @@
+// CDK app for the cdk-real-drift DOGFOOD #4: a realistic EVENT-DRIVEN orchestration
+// stack (a fourth interaction surface, after the web app, the serverless API, and the
+// data pipeline). A Step Functions state machine (a Lambda task -> SNS publish, with
+// CloudWatch logging + X-Ray tracing) is triggered by an EventBridge rule (a custom
+// event pattern, with a dead-letter queue + retry policy on the target), backed by a
+// DynamoDB table and an SNS topic with an SQS subscriber. The point is to surface
+// false positives from the INTERACTION of Step Functions (its DefinitionString /
+// LoggingConfiguration / TracingConfiguration), EventBridge (the rule's Targets array
+// with RoleArn / DeadLetterConfig / RetryPolicy), Lambda, SNS, SQS, DynamoDB and the
+// IAM grants wiring them. A clean `record` -> `check` MUST be CLEAN; any declared
+// drift is a normalization / default-folding FP.
+import { App, Duration, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { AttributeType, BillingMode, Table } from 'aws-cdk-lib/aws-dynamodb';
+import { Rule } from 'aws-cdk-lib/aws-events';
+import { SfnStateMachine } from 'aws-cdk-lib/aws-events-targets';
+import { Code, Function as LambdaFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Topic } from 'aws-cdk-lib/aws-sns';
+import { SqsSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
+import { Queue } from 'aws-cdk-lib/aws-sqs';
+import {
+  Choice,
+  Condition,
+  DefinitionBody,
+  LogLevel,
+  Pass,
+  StateMachine,
+  Succeed,
+  TaskInput,
+} from 'aws-cdk-lib/aws-stepfunctions';
+import { LambdaInvoke, SnsPublish } from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import type { Construct } from 'constructs';
+
+class DogfoodEventDrivenStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const table = new Table(this, 'State', {
+      partitionKey: { name: 'pk', type: AttributeType.STRING },
+      billingMode: BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    const topic = new Topic(this, 'Notify');
+    const subscriberDlq = new Queue(this, 'SubDlq');
+    const subscriberQueue = new Queue(this, 'SubQueue', { visibilityTimeout: Duration.seconds(60) });
+    topic.addSubscription(new SqsSubscription(subscriberQueue, { deadLetterQueue: subscriberDlq }));
+
+    const worker = new LambdaFunction(this, 'Worker', {
+      runtime: Runtime.NODEJS_20_X,
+      handler: 'index.handler',
+      code: Code.fromInline('exports.handler = async (e) => ({ ok: true, n: (e.n || 0) + 1 });'),
+      memorySize: 256,
+      timeout: Duration.seconds(15),
+      environment: { TABLE: table.tableName },
+      logRetention: RetentionDays.ONE_WEEK,
+    });
+    table.grantReadWriteData(worker);
+
+    // Step Functions workflow: invoke the worker, branch, publish to SNS.
+    const invoke = new LambdaInvoke(this, 'Invoke', { lambdaFunction: worker, outputPath: '$.Payload' });
+    const publish = new SnsPublish(this, 'Publish', {
+      topic,
+      message: TaskInput.fromJsonPathAt('$'),
+      subject: 'workflow-done',
+    });
+    const definition = invoke.next(
+      new Choice(this, 'Ok?')
+        .when(Condition.booleanEquals('$.ok', true), publish.next(new Succeed(this, 'Done')))
+        .otherwise(new Pass(this, 'Skip'))
+    );
+
+    const smLog = new LogGroup(this, 'SmLog', {
+      retention: RetentionDays.ONE_WEEK,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+    const machine = new StateMachine(this, 'Machine', {
+      definitionBody: DefinitionBody.fromChainable(definition),
+      tracingEnabled: true,
+      logs: { destination: smLog, level: LogLevel.ALL, includeExecutionData: true },
+      timeout: Duration.minutes(5),
+    });
+
+    // EventBridge rule (custom event pattern) -> the state machine, with a DLQ + retry.
+    const ruleDlq = new Queue(this, 'RuleDlq');
+    new Rule(this, 'OnOrder', {
+      eventPattern: { source: ['cdkrd.orders'], detailType: ['OrderPlaced'] },
+      targets: [
+        new SfnStateMachine(machine, {
+          deadLetterQueue: ruleDlq,
+          retryAttempts: 3,
+          maxEventAge: Duration.hours(1),
+        }),
+      ],
+    });
+  }
+}
+
+const app = new App();
+new DogfoodEventDrivenStack(app, 'CdkRealDriftIntegDogfoodEventDriven', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-event-driven/cdk.json
+++ b/tests/integration/dogfood-event-driven/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-event-driven/package.json
+++ b/tests/integration/dogfood-event-driven/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-event-driven",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Realistic event-driven orchestration dogfood stack for cdk-real-drift false-positive integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-event-driven/verify.sh
+++ b/tests/integration/dogfood-event-driven/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a realistic EVENT-DRIVEN
+# orchestration stack. A Step Functions state machine (a Lambda task -> SNS publish,
+# with CloudWatch logging + X-Ray tracing) is triggered by an EventBridge rule (a
+# custom event pattern with a DLQ + retry policy on the target), backed by a DynamoDB
+# table and an SNS topic with an SQS subscriber. Unlike the single-type fixtures this
+# exercises the INTERACTION of Step Functions (DefinitionString / LoggingConfiguration
+# / TracingConfiguration), EventBridge (the rule Targets array with RoleArn / DLQ /
+# RetryPolicy), Lambda, SNS, SQS, DynamoDB and the IAM grants. A clean `record` ->
+# `check` MUST be CLEAN; any declared drift is a default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodEventDriven
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN (no interaction FP) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
A fourth **DOGFOOD** integration test on a new interaction surface (after the web app, the serverless API, and the data pipeline): a realistic **event-driven orchestration** stack. A **Step Functions** state machine (a Lambda task → SNS publish, with CloudWatch logging + X-Ray tracing) is triggered by an **EventBridge** rule (a custom event pattern with a DLQ + retry policy on the target), backed by a **DynamoDB** table and an **SNS** topic with an **SQS** subscriber.

## Why
Exercises the **interaction** of Step Functions (`DefinitionString` / `LoggingConfiguration` / `TracingConfiguration`), EventBridge (the rule `Targets` array with `RoleArn` / `DeadLetterConfig` / `RetryPolicy`), Lambda, SNS, SQS (incl. the SNS→SQS subscription redrive + the `QueuePolicy`s), DynamoDB and the IAM grants.

## Live result (no bug — a strong positive)
- `record` → `check` is **CLEAN**: zero false positives from the real combination.
- Detection + revert work: SQS `VisibilityTimeout` mutated out of band → **detected** → **reverted** → CLEAN.
- No read-gap (the only skip is the LogRetention custom resource, correctly skipped), and every resource type was already covered.

A fully clean run that adds a realistic event-driven regression guard the single-type fixtures can't give. Tests-only (no `src/**`) → verify-pr exempt. 1731 unit tests green.
