### PR TITLE
test(integ): dogfood four new domains (EKS, SageMaker, CI/CD, analytics)

### DIFF
--- a/tests/corpus/AWS__Athena__NamedQuery.TopErrors.json
+++ b/tests/corpus/AWS__Athena__NamedQuery.TopErrors.json
@@ -1,0 +1,41 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TopErrors",
+    "resourceType": "AWS::Athena::NamedQuery",
+    "physicalId": "8e13bc0b-0d42-49a2-a187-422e2d4bb432",
+    "constructPath": "CdkRealDriftIntegDogfoodAnalytics/TopErrors",
+    "declared": {
+      "Database": "cdkrd_analytics",
+      "Name": "top-errors",
+      "QueryString": "SELECT msg, count(*) c FROM logs WHERE level = 'ERROR' GROUP BY msg ORDER BY c DESC",
+      "WorkGroup": "cdkrd-analytics"
+    }
+  },
+  "liveRaw": {
+    "WorkGroup": "cdkrd-analytics",
+    "QueryString": "SELECT msg, count(*) c FROM logs WHERE level = 'ERROR' GROUP BY msg ORDER BY c DESC",
+    "Database": "cdkrd_analytics",
+    "NamedQueryId": "8e13bc0b-0d42-49a2-a187-422e2d4bb432",
+    "Name": "top-errors"
+  },
+  "schema": {
+    "readOnly": ["NamedQueryId"],
+    "writeOnly": [],
+    "createOnly": ["Database", "Description", "Name", "QueryString", "WorkGroup"],
+    "readOnlyPaths": ["NamedQueryId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Database", "Description", "Name", "QueryString", "WorkGroup"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [],
+  "description": "Athena NamedQuery read clean via Cloud Control, harvested from the dogfood-analytics stack (Athena WorkGroup + NamedQuery over a Glue catalog)."
+}

--- a/tests/corpus/AWS__EKS__Cluster.Cluster.json
+++ b/tests/corpus/AWS__EKS__Cluster.Cluster.json
@@ -1,0 +1,208 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cluster",
+    "resourceType": "AWS::EKS::Cluster",
+    "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+    "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster",
+    "declared": {
+      "Name": "CdkRealDriftIntegDogfoodEks-cluster",
+      "ResourcesVpcConfig": {
+        "EndpointPrivateAccess": false,
+        "EndpointPublicAccess": true,
+        "SubnetIds": ["subnet-06744a7a2f1a5e2f5", "subnet-0ff27dcd243b93afb"]
+      },
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegDogfoodEks-ClusterRoleD9CA7471-qi1VCYEIJU2H",
+      "Version": "1.31"
+    }
+  },
+  "liveRaw": {
+    "Logging": {
+      "ClusterLogging": {
+        "EnabledTypes": []
+      }
+    },
+    "DeletionProtection": false,
+    "AccessConfig": {
+      "AuthenticationMode": "CONFIG_MAP"
+    },
+    "CertificateAuthorityData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lJZlM2TWlmcS9pOWN3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TmpBMk1qZ3dOalEzTURoYUZ3MHpOakEyTWpVd05qVXlNRGhhTUJVeApFekFSQmdOVkJBTVRDbXQxWW1WeWJtVjBaWE13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURyQ2pQTGROWUo0S0oxdVR6cmYwRHhZSUs3WmRNR2FzVnNObGh6ZkJyMzFsQnhIMzNwR2ZUZEZ6OHYKVUdUd2E5Vk1INUFNSDM0Q1l2MVhKRlFENGZQRlk0K2hvaWxaZFlndnM2UU9EWkIxZkdSVE9NS01TbE84MTZRMQowai8ybGRHaWs1aVNMM3QzaytBVTN4cjZTRXBGVllvYmRJS253T0NObHJGWnNTV3FhbGZ0Mi90dHRHMWJqaWJUCkUwTlh4UHZLcFNrSEtHNk13emM0N2VNcEl5dUYzcE42dTVZbmMyeTRWL0xyL3RGYXF5N1h0NGk3bS8vNERRL1AKOU50UGVpMy9jUWRJd1EzQjEyd0svdG50WDZsVGJiL3pwdjNqdXNTUHhQOU5ldmNGVnZNOUdKTUhwMWF4UGkzMwpnNFdxMDBaNW11b3IwV1greDJueWdPRStQRDJyQWdNQkFBR2pXVEJYTUE0R0ExVWREd0VCL3dRRUF3SUNwREFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJSeisvZi9HbFdmWml1VGJ0UXNqbmdSUGZiQTV6QVYKQmdOVkhSRUVEakFNZ2dwcmRXSmxjbTVsZEdWek1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQUtaeHJwRWNITwpJTHRlZEwxRmRTNFJWcUo2RWFleUJ5QlVJREk4cXRSSFV3VmVWZnc5cWxIUW1DQ3dGQmN6ZFFmT0ZPYWNIeVVDCkxuUEtBYTE5RUMxRStlSUt6MGR2cWdseXpNQU9GUXYwSWxSZHRvT1dVUlhqdk9sZHhVSTFyV0k5NVlwbkx2ejUKMXl2Um81ZXA0OEg5a3hlMkh0aVVzcTllbzdYY3dtdjRkTGtTOUxIbkZ0c1RiZk9QT2VhcSszakpZZDJwZTlzZQphUHlMdTdZZ1F5bWl2S1pGWFZkUWdnSEdKWEo2YzdJTkZLRlhwZjRPUzBSWlIyL3lBWnRJZ0trZmlnS1NFK25nCllhVHBmU1pTelNjbGhxSXA1NThMWXc3dU5rdzJXK2JobUczdXpjZURtemNKMUhDamo1VjExd1hqOENUdFE4WjgKNDNqSHRWWW5hTzYrCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+    "EncryptionConfig": [],
+    "KubernetesNetworkConfig": {
+      "ServiceIpv4Cidr": "172.20.0.0/16",
+      "IpFamily": "ipv4",
+      "ElasticLoadBalancing": {
+        "Enabled": false
+      }
+    },
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegDogfoodEks-ClusterRoleD9CA7471-qi1VCYEIJU2H",
+    "Name": "CdkRealDriftIntegDogfoodEks-cluster",
+    "UpgradePolicy": {
+      "SupportType": "EXTENDED"
+    },
+    "Endpoint": "https://A0FCCA78DC1BF23F87B884594F0E8906.gr7.us-east-1.eks.amazonaws.com",
+    "Version": "1.31",
+    "ControlPlaneScalingConfig": {
+      "Tier": "standard"
+    },
+    "ClusterSecurityGroupId": "sg-05b8869d1ba59c2ad",
+    "Arn": "arn:aws:eks:us-east-1:111111111111:cluster/CdkRealDriftIntegDogfoodEks-cluster",
+    "ResourcesVpcConfig": {
+      "EndpointPublicAccess": true,
+      "ControlPlaneEgressMode": "AWS_MANAGED",
+      "PublicAccessCidrs": ["0.0.0.0/0"],
+      "EndpointPrivateAccess": false,
+      "SecurityGroupIds": [],
+      "SubnetIds": ["subnet-06744a7a2f1a5e2f5", "subnet-0ff27dcd243b93afb"]
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegDogfoodEks/f4514160-72bc-11f1-9f2a-0affd5820f9f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Cluster",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegDogfoodEks",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "OpenIdConnectIssuerUrl": "https://oidc.eks.us-east-1.amazonaws.com/id/A0FCCA78DC1BF23F87B884594F0E8906"
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CertificateAuthorityData",
+      "ClusterSecurityGroupId",
+      "EncryptionConfigKeyArn",
+      "Endpoint",
+      "Id",
+      "OpenIdConnectIssuerUrl"
+    ],
+    "writeOnly": ["BootstrapSelfManagedAddons", "Force"],
+    "createOnly": [
+      "BootstrapSelfManagedAddons",
+      "EncryptionConfig",
+      "Name",
+      "OutpostConfig",
+      "RoleArn"
+    ],
+    "readOnlyPaths": [
+      "Arn",
+      "CertificateAuthorityData",
+      "ClusterSecurityGroupId",
+      "EncryptionConfigKeyArn",
+      "Endpoint",
+      "Id",
+      "KubernetesNetworkConfig.ServiceIpv6Cidr",
+      "OpenIdConnectIssuerUrl"
+    ],
+    "writeOnlyPaths": [
+      "AccessConfig.BootstrapClusterCreatorAdminPermissions",
+      "BootstrapSelfManagedAddons",
+      "Force"
+    ],
+    "createOnlyPaths": [
+      "AccessConfig.BootstrapClusterCreatorAdminPermissions",
+      "BootstrapSelfManagedAddons",
+      "EncryptionConfig",
+      "KubernetesNetworkConfig.IpFamily",
+      "KubernetesNetworkConfig.ServiceIpv4Cidr",
+      "Name",
+      "OutpostConfig",
+      "RoleArn"
+    ],
+    "defaults": {
+      "Force": false
+    },
+    "defaultPaths": {
+      "Force": false
+    },
+    "unorderedScalarPaths": [
+      "ComputeConfig.NodePools",
+      "OutpostConfig.OutpostArns",
+      "ResourcesVpcConfig.PublicAccessCidrs",
+      "ResourcesVpcConfig.SecurityGroupIds",
+      "ResourcesVpcConfig.SubnetIds"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "AccessConfig",
+      "actual": {
+        "AuthenticationMode": "CONFIG_MAP"
+      },
+      "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+      "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "KubernetesNetworkConfig",
+      "actual": {
+        "ServiceIpv4Cidr": "172.20.0.0/16",
+        "IpFamily": "ipv4",
+        "ElasticLoadBalancing": {
+          "Enabled": false
+        }
+      },
+      "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+      "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "UpgradePolicy",
+      "actual": {
+        "SupportType": "EXTENDED"
+      },
+      "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+      "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ControlPlaneScalingConfig",
+      "actual": {
+        "Tier": "standard"
+      },
+      "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+      "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ResourcesVpcConfig.ControlPlaneEgressMode",
+      "actual": "AWS_MANAGED",
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+      "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ResourcesVpcConfig.PublicAccessCidrs",
+      "actual": ["0.0.0.0/0"],
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegDogfoodEks-cluster",
+      "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
+    }
+  ],
+  "description": "EKS Cluster read clean via Cloud Control (fully CC-readable, no read-gap), harvested from the dogfood-eks bare control-plane stack. AWS injects AccessConfig/KubernetesNetworkConfig/UpgradePolicy/ControlPlaneScalingConfig as undeclared live-only config."
+}

--- a/tests/integration/dogfood-analytics/app.ts
+++ b/tests/integration/dogfood-analytics/app.ts
@@ -1,0 +1,76 @@
+// CDK app for the cdk-real-drift DOGFOOD (analytics domain): an Athena WorkGroup +
+// NamedQuery over a Glue data catalog (database + table) with results landing in S3.
+// Athena is free (no infra); NamedQuery is an uncovered type. Exercises the Athena <->
+// Glue <-> S3 interaction. A clean `record` -> `check` MUST be CLEAN; any declared
+// drift is a normalization / default-folding FP.
+import { App, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { CfnNamedQuery, CfnWorkGroup } from 'aws-cdk-lib/aws-athena';
+import { CfnDatabase, CfnTable } from 'aws-cdk-lib/aws-glue';
+import { BlockPublicAccess, Bucket, BucketEncryption } from 'aws-cdk-lib/aws-s3';
+import type { Construct } from 'constructs';
+
+class DogfoodAnalyticsStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const results = new Bucket(this, 'Results', {
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+    const data = new Bucket(this, 'Data', {
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    const db = new CfnDatabase(this, 'Db', {
+      catalogId: this.account,
+      databaseInput: { name: 'cdkrd_analytics' },
+    });
+    new CfnTable(this, 'Logs', {
+      catalogId: this.account,
+      databaseName: 'cdkrd_analytics',
+      tableInput: {
+        name: 'logs',
+        tableType: 'EXTERNAL_TABLE',
+        storageDescriptor: {
+          location: `s3://${data.bucketName}/logs/`,
+          columns: [
+            { name: 'ts', type: 'string' },
+            { name: 'level', type: 'string' },
+            { name: 'msg', type: 'string' },
+          ],
+          inputFormat: 'org.apache.hadoop.mapred.TextInputFormat',
+          outputFormat: 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat',
+          serdeInfo: {
+            serializationLibrary: 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe',
+          },
+        },
+      },
+    }).addDependency(db);
+
+    const wg = new CfnWorkGroup(this, 'Wg', {
+      name: 'cdkrd-analytics',
+      workGroupConfiguration: {
+        resultConfiguration: { outputLocation: `s3://${results.bucketName}/athena/` },
+        enforceWorkGroupConfiguration: true,
+        publishCloudWatchMetricsEnabled: true,
+      },
+    });
+
+    new CfnNamedQuery(this, 'TopErrors', {
+      database: 'cdkrd_analytics',
+      workGroup: wg.name,
+      name: 'top-errors',
+      queryString: "SELECT msg, count(*) c FROM logs WHERE level = 'ERROR' GROUP BY msg ORDER BY c DESC",
+    }).addDependency(wg);
+  }
+}
+
+const app = new App();
+new DogfoodAnalyticsStack(app, 'CdkRealDriftIntegDogfoodAnalytics', {
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-analytics/cdk.json
+++ b/tests/integration/dogfood-analytics/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-analytics/package.json
+++ b/tests/integration/dogfood-analytics/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-analytics",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Dogfood stack for cdk-real-drift FP integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-analytics/verify.sh
+++ b/tests/integration/dogfood-analytics/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): an Athena WorkGroup + NamedQuery
+# over a Glue data catalog (database + table) with results in S3. A clean `record` ->
+# `check` MUST be CLEAN; any declared drift is a normalization / default-folding FP from
+# a real property combination. See app.ts.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodAnalytics
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+export CDK_DEFAULT_ACCOUNT="${CDK_DEFAULT_ACCOUNT:-$(aws sts get-caller-identity --query Account --output text)}"
+export CDK_DEFAULT_REGION="$REGION"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/dogfood-cicd/app.ts
+++ b/tests/integration/dogfood-cicd/app.ts
@@ -1,0 +1,83 @@
+// CDK app for the cdk-real-drift DOGFOOD (CI/CD domain): a CodePipeline with an S3
+// source, a CodeBuild build stage, and an S3 deploy stage, plus the IAM roles wiring
+// them. Exercises the INTERACTION of CodePipeline (its Stages/Actions), CodeBuild, S3
+// and IAM. A clean `record` -> `check` MUST be CLEAN; any declared drift is an FP.
+import { App, RemovalPolicy, Stack, type StackProps } from 'aws-cdk-lib';
+import { BuildSpec, LinuxBuildImage, PipelineProject } from 'aws-cdk-lib/aws-codebuild';
+import { Artifact, Pipeline } from 'aws-cdk-lib/aws-codepipeline';
+import {
+  CodeBuildAction,
+  S3DeployAction,
+  S3SourceAction,
+} from 'aws-cdk-lib/aws-codepipeline-actions';
+import { Bucket, BucketEncryption, BlockPublicAccess } from 'aws-cdk-lib/aws-s3';
+import type { Construct } from 'constructs';
+
+class DogfoodCicdStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const sourceBucket = new Bucket(this, 'Source', {
+      versioned: true,
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+    const deployBucket = new Bucket(this, 'Deploy', {
+      encryption: BucketEncryption.S3_MANAGED,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true,
+    });
+
+    const project = new PipelineProject(this, 'Build', {
+      environment: { buildImage: LinuxBuildImage.STANDARD_7_0 },
+      buildSpec: BuildSpec.fromObject({
+        version: '0.2',
+        phases: { build: { commands: ['echo build'] } },
+        artifacts: { files: ['**/*'] },
+      }),
+    });
+
+    const sourceOut = new Artifact('Source');
+    const buildOut = new Artifact('Build');
+    new Pipeline(this, 'Pipeline', {
+      stages: [
+        {
+          stageName: 'Source',
+          actions: [
+            new S3SourceAction({
+              actionName: 'S3Source',
+              bucket: sourceBucket,
+              bucketKey: 'source.zip',
+              output: sourceOut,
+            }),
+          ],
+        },
+        {
+          stageName: 'Build',
+          actions: [
+            new CodeBuildAction({
+              actionName: 'Build',
+              project,
+              input: sourceOut,
+              outputs: [buildOut],
+            }),
+          ],
+        },
+        {
+          stageName: 'Deploy',
+          actions: [
+            new S3DeployAction({ actionName: 'Deploy', bucket: deployBucket, input: buildOut }),
+          ],
+        },
+      ],
+    });
+  }
+}
+
+const app = new App();
+new DogfoodCicdStack(app, 'CdkRealDriftIntegDogfoodCicd', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-cicd/cdk.json
+++ b/tests/integration/dogfood-cicd/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-cicd/package.json
+++ b/tests/integration/dogfood-cicd/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-cicd",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Dogfood stack for cdk-real-drift FP integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-cicd/verify.sh
+++ b/tests/integration/dogfood-cicd/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a CodePipeline (S3 source ->
+# CodeBuild -> S3 deploy) with the IAM roles + the artifacts KMS key/bucket wiring them.
+# A clean `record` -> `check` MUST be CLEAN; any declared drift is a normalization /
+# default-folding FP from a real property combination. See app.ts.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodCicd
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+export CDK_DEFAULT_REGION="$REGION"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/dogfood-eks/app.ts
+++ b/tests/integration/dogfood-eks/app.ts
@@ -1,0 +1,43 @@
+// CDK app for the cdk-real-drift DOGFOOD (EKS domain): a bare EKS control plane — a
+// VPC with two subnets, a cluster service role, and an AWS::EKS::Cluster (no managed
+// node group, to bound cost/time). EKS is an entirely uncovered domain; this checks
+// that a real cluster reads + classifies clean via Cloud Control. A clean `record` ->
+// `check` MUST be CLEAN; any declared drift is a normalization / default-folding FP.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import { SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
+import { CfnCluster } from 'aws-cdk-lib/aws-eks';
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import type { Construct } from 'constructs';
+
+class DogfoodEksStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const vpc = new Vpc(this, 'Vpc', {
+      maxAzs: 2,
+      natGateways: 0,
+      subnetConfiguration: [{ name: 'public', subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+    });
+
+    const role = new Role(this, 'ClusterRole', {
+      assumedBy: new ServicePrincipal('eks.amazonaws.com'),
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('AmazonEKSClusterPolicy')],
+    });
+
+    new CfnCluster(this, 'Cluster', {
+      name: `${id}-cluster`,
+      roleArn: role.roleArn,
+      version: '1.31',
+      resourcesVpcConfig: {
+        subnetIds: vpc.publicSubnets.map((s) => s.subnetId),
+        endpointPublicAccess: true,
+        endpointPrivateAccess: false,
+      },
+    });
+  }
+}
+
+const app = new App();
+new DogfoodEksStack(app, 'CdkRealDriftIntegDogfoodEks', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-eks/cdk.json
+++ b/tests/integration/dogfood-eks/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-eks/package.json
+++ b/tests/integration/dogfood-eks/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-eks",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Dogfood stack for cdk-real-drift FP integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-eks/verify.sh
+++ b/tests/integration/dogfood-eks/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a bare EKS control plane (a VPC
+# with two subnets, a cluster service role, and an AWS::EKS::Cluster with no node
+# group). EKS is an entirely uncovered domain; a clean `record` -> `check` MUST be
+# CLEAN; any declared drift is a normalization / default-folding FP. See app.ts.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodEks
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+export CDK_DEFAULT_REGION="$REGION"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/dogfood-sagemaker/app.ts
+++ b/tests/integration/dogfood-sagemaker/app.ts
@@ -1,0 +1,48 @@
+// CDK app for the cdk-real-drift DOGFOOD (SageMaker domain): a SageMaker Model + an
+// EndpointConfig (no running Endpoint, to avoid needing real model artifacts and to
+// bound cost). Model is covered but EndpointConfig is an uncovered type; this checks
+// the Model <-> EndpointConfig interaction reads + classifies clean via Cloud Control.
+// A clean `record` -> `check` MUST be CLEAN; any declared drift is a default-folding FP.
+import { App, Stack, type StackProps } from 'aws-cdk-lib';
+import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { CfnEndpointConfig, CfnModel } from 'aws-cdk-lib/aws-sagemaker';
+import type { Construct } from 'constructs';
+
+class DogfoodSageMakerStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    const role = new Role(this, 'ExecRole', {
+      assumedBy: new ServicePrincipal('sagemaker.amazonaws.com'),
+      managedPolicies: [ManagedPolicy.fromAwsManagedPolicyName('AmazonSageMakerFullAccess')],
+    });
+
+    // A built-in inference image (XGBoost in us-east-1); Model creation is metadata-only
+    // and does not require model artifacts (only a running Endpoint would).
+    const model = new CfnModel(this, 'Model', {
+      executionRoleArn: role.roleArn,
+      primaryContainer: {
+        image: '683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.7-1',
+        mode: 'SingleModel',
+        environment: { SAGEMAKER_PROGRAM: 'inference.py' },
+      },
+    });
+
+    new CfnEndpointConfig(this, 'EndpointConfig', {
+      productionVariants: [
+        {
+          modelName: model.attrModelName,
+          variantName: 'primary',
+          initialInstanceCount: 1,
+          instanceType: 'ml.t2.medium',
+          initialVariantWeight: 1,
+        },
+      ],
+    });
+  }
+}
+
+const app = new App();
+new DogfoodSageMakerStack(app, 'CdkRealDriftIntegDogfoodSageMaker', {
+  env: { region: process.env.CDK_DEFAULT_REGION ?? 'us-east-1' },
+});

--- a/tests/integration/dogfood-sagemaker/cdk.json
+++ b/tests/integration/dogfood-sagemaker/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/dogfood-sagemaker/package.json
+++ b/tests/integration/dogfood-sagemaker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-dogfood-sagemaker",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Dogfood stack for cdk-real-drift FP integration testing. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/dogfood-sagemaker/verify.sh
+++ b/tests/integration/dogfood-sagemaker/verify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# DOGFOOD false-positive integration test (real AWS): a SageMaker Model + EndpointConfig.
+# Model reads clean via Cloud Control; EndpointConfig is an UnsupportedActionException CC
+# read-gap (immutable, so transparently skipped, no FN). A clean `record` -> `check` MUST
+# be CLEAN; any declared drift is a normalization / default-folding FP. See app.ts.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDogfoodSageMaker
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+export CDK_DEFAULT_REGION="$REGION"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
Sweeps the dogfood strategy across four domains the single-type fixtures don't cover as realistic combinations. **All four are FP-clean** (`record` → `check` CLEAN) — no false positives from the real property combinations.

| Domain | Result |
| --- | --- |
| **EKS** (`dogfood-eks`) | A bare control plane (VPC + 2 subnets + cluster role + `AWS::EKS::Cluster`, no node group). An **entirely uncovered domain**; the cluster reads + classifies clean via Cloud Control (AWS injects `AccessConfig` / `KubernetesNetworkConfig` / `UpgradePolicy` / `ControlPlaneScalingConfig` as undeclared live-only config). → new corpus type `AWS::EKS::Cluster` |
| **Analytics** (`dogfood-analytics`) | An Athena WorkGroup + NamedQuery over a Glue catalog (database + table) with results in S3. → new corpus type `AWS::Athena::NamedQuery` |
| **CI/CD** (`dogfood-cicd`) | A CodePipeline (S3 source → CodeBuild → S3 deploy) with its IAM roles + artifacts KMS key/bucket. FP-clean; all types already covered |
| **SageMaker** (`dogfood-sagemaker`) | A Model + EndpointConfig. Model reads clean; `EndpointConfig` is an `UnsupportedActionException` CC read-gap — but it is **immutable** (all create-only), so the skip is transparent with **zero detection value** (no FN possible), deliberately NOT closed with an SDK reader (unlike the mutable LogStream composite gap closed in #397) |

## Findings summary
- 0 false positives across all four domains (the tool stays FP-clean on EKS / SageMaker / CI/CD / analytics interaction surfaces).
- 1 read-gap (SageMaker `EndpointConfig`, `UnsupportedActionException`) — ruled out for a fix because it is immutable (transparent skip, no FN).
- 2 new golden-corpus types (`AWS::EKS::Cluster`, `AWS::Athena::NamedQuery`).

Tests-only (no `src/**`) → verify-pr exempt. 1733 unit tests + 478 corpus-replay green.
