### PR TITLE
fix(lambda): surface free-form map keys, revert nested env vars + Alias Description

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,12 +407,12 @@ info:
 - **`info:` footer** folds the informational tiers to per-reason counts
   (`--verbose` expands them):
 
-| tier                                             | what it folds                                                                                                                                                        |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `atDefault`                                      | an undeclared value sitting at a known AWS default (e.g. Lambda `TracingConfig: PassThrough`). Equality-gated, so a change away from it re-surfaces; never recorded. |
-| `generated`                                      | an undeclared value AWS/CDK minted, like an auto `TopicName`. Equality-gated; never recorded.                                                                        |
-| `nested`                                         | an undeclared sub-key inside a property you _did_ declare (e.g. a CloudFront origin gaining `ConnectionTimeout`). Recordable; `--show-all` lists it.                 |
-| `readGap` / `unresolved` / `skipped` / `ignored` | values cdkrd can't confidently compare, reported honestly rather than guessed (never false drift).                                                                   |
+| tier                                             | what it folds                                                                                                                                                                                                                                                                          |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `atDefault`                                      | an undeclared value sitting at a known AWS default (e.g. Lambda `TracingConfig: PassThrough`). Equality-gated, so a change away from it re-surfaces; never recorded.                                                                                                                   |
+| `generated`                                      | an undeclared value AWS/CDK minted, like an auto `TopicName`. Equality-gated; never recorded.                                                                                                                                                                                          |
+| `nested`                                         | an undeclared sub-key inside a property you _did_ declare (e.g. a CloudFront origin gaining `ConnectionTimeout`). Recordable; `--show-all` lists it. A key under a free-form map (Lambda `Environment.Variables`, Glue `Parameters`) is user data, so it is shown in full, not folded. |
+| `readGap` / `unresolved` / `skipped` / `ignored` | values cdkrd can't confidently compare, reported honestly rather than guessed (never false drift).                                                                                                                                                                                     |
 
 `^result:` is the greppable verdict. Colorized on a TTY (`NO_COLOR` respected);
 piped / CI / `--json` output is plain text.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -301,7 +301,7 @@ checked.
   - **drift-calculator.ts** — pure structural diff (`calculateResourceDrift`), copied from cdkd.
 - **baseline/baseline-file.ts** — git-committed baseline I/O (`.cdkrd/<stack>.<accountId>.<region>.json`), `applyBaseline`, `writeBaseline`.
 - **config/config-file.ts** — git-committed project config (`.cdkrd/config.json`): `loadConfig` + `applyIgnores` (R32 path-level ignore rules → `ignored` tier).
-- **revert/** — the write path (section 7): **plan.ts** (incl. a `delete`-kind item for an out-of-band `added` resource, and `REVERT_SET_DEFAULT_PATHS` — properties whose undeclared "appeared since record" revert must WRITE the known `KNOWN_DEFAULTS` default explicitly (an `add`) instead of an RFC6902 `remove`, because the provider leaves the value UNCHANGED when it is merely absent so a bare `remove` is a silent no-op: IAM Role `MaxSessionDuration` is the proven case — `UpdateRole` ignores an omitted value, so reverting an out-of-band 7200 back toward the 3600 default never converged. Curated, not "every `KNOWN_DEFAULTS` entry": most properties already converge via `remove` (S3 `DeleteBucketOwnershipControls` re-defaults), and `KNOWN_DEFAULTS` holds read-side COMPARE shapes some of which are not valid CC write inputs), **apply.ts** (CC UpdateResource / DeleteResource + poll), **apply-ops.ts** (pure RFC6902 apply), **writers.ts** (SDK writers).
+- **revert/** — the write path (section 7): **plan.ts** (incl. a `delete`-kind item for an out-of-band `added` resource, and `REVERT_SET_DEFAULT_PATHS` — properties whose undeclared "appeared since record" revert must WRITE the known `KNOWN_DEFAULTS` default explicitly (an `add`) instead of an RFC6902 `remove`, because the provider leaves the value UNCHANGED when it is merely absent so a bare `remove` is a silent no-op: IAM Role `MaxSessionDuration` is the proven case — `UpdateRole` ignores an omitted value, so reverting an out-of-band 7200 back toward the 3600 default never converged; Lambda Alias `Description` is the same shape — `UpdateAlias` ignores an omitted description, so revert writes the empty-string default to clear it (both proven live). Curated, not "every `KNOWN_DEFAULTS` entry": most properties already converge via `remove` (S3 `DeleteBucketOwnershipControls` re-defaults), and `KNOWN_DEFAULTS` holds read-side COMPARE shapes some of which are not valid CC write inputs), **apply.ts** (CC UpdateResource / DeleteResource + poll), **apply-ops.ts** (pure RFC6902 apply), **writers.ts** (SDK writers).
 - **synth/** — **synth.ts** (`@aws-cdk/toolkit-lib` synth + `discoverStacks`), **resolve-app.ts**, **io-host.ts** (`QuietIoHost`).
 - **report/report.ts** — tiered text + JSON + exit code. **report/style.ts** —
   TTY-only semantic colors (R43). **aws-errors.ts** — `isStackNotDeployed` etc.
@@ -391,6 +391,13 @@ all live changes
          nested:true) — folded in the report by default (the live model carries many
          nested AWS defaults), expanded by --show-all/--verbose, recorded by record
          like any undeclared value so a later out-of-band change to it surfaces.
+         EXCEPTION — a key under a FREE-FORM MAP property
+         (SchemaInfo.freeFormMapPaths: a `type:object` schema node with no fixed
+         `properties`, just `patternProperties`/object `additionalProperties` —
+         Lambda Environment.Variables, Glue Parameters): every such key is
+         user-authored data, NOT an AWS default, so it is flagged `freeFormKey`
+         and SURFACED in full (never folded) — a console-added env var is real,
+         reviewable drift, not first-run noise.
          R98 extends the recursion into the MATCHED elements of identity-keyed object
          arrays (Tags/Origins/AttributeDefinitions/…): elements are aligned by identity
          value and a live-only sub-field inside a declared element is caught too
@@ -675,8 +682,14 @@ only when non-zero — unrecorded values are named as such, never folded into
 deploy`: a patch can't recreate a resource), a **create-only** property (drift on a
   `createOnlyProperties` / `conditionalCreateOnlyProperties` field needs a resource
   replacement, which an in-place `UpdateResource` can't do — caught from the schema
-  at plan time, not at apply time), plus any `readGap` / `unresolved` / `skipped`
-  finding. KMS keys need no SDK writer — they revert via the generic CC path.
+  at plan time, not at apply time), and a nested undeclared value whose path
+  addresses an **array element** (`Prop[<id>].sub` — the bracket can't be expressed
+  as an RFC6902 pointer) or is **rooted at `Tags`** (a deep `/Tags/<key>` patch would
+  bypass the `aws:*` managed-tag preservation), plus any `readGap` / `unresolved` /
+  `skipped` finding. A nested undeclared value on a PURE-DOTTED path (a free-form map
+  key like a Lambda env var, or an object sub-field) IS revertable — Cloud
+  Control applies the dotted pointer read-modify-write (`isUnrevertableNested`).
+  KMS keys need no SDK writer — they revert via the generic CC path.
 - **Canonical-form write**: a declared-drift revert target (`finding.desired`) is the
   _normalized_ value (policy statements sorted, scalar-vs-array collapsed, tag / id
   arrays sorted), not the template verbatim. It is semantically equal to the template

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -21,7 +21,7 @@
 // and unit-tested; the prompt is a thin rendering/key shell.
 import { isCancel, Prompt } from '@clack/core';
 import { S_BAR, S_BAR_END, S_BAR_START } from '@clack/prompts';
-import { isManagedPolicyAttachmentMember, isNestedUndeclared } from '../revert/plan.js';
+import { isManagedPolicyAttachmentMember, isUnrevertableNested } from '../revert/plan.js';
 import type { Finding } from '../types.js';
 import { style } from '../report/style.js';
 
@@ -33,20 +33,22 @@ export type FindingAction = 'record' | 'ignore' | 'revert' | 'skip';
  * `skip`). Mirrors the verbs' scope:
  *  - undeclared → record (snapshot the norm; gentlest, keeps watching), then ignore
  *    (stop watching), then revert (REMOVE the live value — destructive, so last) —
- *    BUT revert is dropped for a NESTED undeclared value, which is detect/record-only
- *    (R99): offering it would let the user pick an action revert can't run;
+ *    BUT revert is dropped for a nested undeclared value revert CANNOT target (an
+ *    array-element or Tags-rooted path, `isUnrevertableNested`): offering it would let
+ *    the user pick an action revert can't run. A pure-dotted nested value (a free-form
+ *    map key like an env var) stays revertable;
  *  - added → record (snapshot the out-of-band resource; keeps watching for changes),
  *    ignore (stop watching), revert (DELETE the resource — destructive, so last). PR4
  *    makes added the resource-level sibling of undeclared, so it takes the same verbs;
  *  - declared → revert (restore the template intent — the natural fix), then ignore;
  *  - everything else (deleted / readGap / unresolved / atDefault / generated / skipped)
  *    has no in-tool action → an empty list, so it is not a decidable row.
- * Pure + exported. `isNestedUndeclared` is the SAME predicate buildRevertPlan uses, so
+ * Pure + exported. `isUnrevertableNested` is the SAME predicate buildRevertPlan uses, so
  * the picker's revert offer and revert's actual capability never diverge.
  */
 export function applicableActions(finding: Finding): FindingAction[] {
   if (finding.tier === 'undeclared')
-    return isNestedUndeclared(finding) && !isManagedPolicyAttachmentMember(finding)
+    return isUnrevertableNested(finding) && !isManagedPolicyAttachmentMember(finding)
       ? ['record', 'ignore']
       : ['record', 'ignore', 'revert'];
   if (finding.tier === 'added')

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -116,9 +116,10 @@ const pickerLabel = (f: Finding): string =>
 // behind an explicit "include folded" choice, so a picker never silently balloons from the
 // report's small drift count to a wall of nested values (the 3-vs-26 surprise) — and, for
 // ignore, never blind-ignores values the user never saw. `--verbose` means the report
-// already listed them in full, so nothing is folded. Pure + exported for unit tests.
+// already listed them in full, so nothing is folded. A free-form map key (freeFormKey) is
+// NEVER folded — the report shows it, so the picker itemizes it too. Pure + exported for tests.
 export const isFoldedFinding = (f: Finding, verbose: boolean): boolean =>
-  !verbose && f.unrecorded === true && f.nested === true;
+  !verbose && f.unrecorded === true && f.nested === true && !f.freeFormKey;
 
 // The two scope rows shown when check folded undeclared inventory out of the report:
 // decide on just what was shown, or pull the folded values in too. Pure + exported.

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -111,7 +111,8 @@ export function recordSelectMessage(stackName: string, foldedCount = 0): string 
  * (nested live-only sub-keys — the `undeclared-subkey` mass the report folds, R96). Folded
  * entries are auto-recorded as a summarized count instead of dozens of rows. `expandNested`
  * (--verbose) turns the fold off so every nested value is itemized. An entry is folded when
- * its matching gather finding is a `nested` undeclared value. Pure + exported.
+ * its matching gather finding is a `nested` undeclared value — EXCEPT a free-form map key
+ * (freeFormKey), which the report shows in full, so the picker itemizes it too. Pure + exported.
  */
 export function splitFoldedNested<T extends { logicalId: string; path: string }>(
   changed: T[],
@@ -121,7 +122,7 @@ export function splitFoldedNested<T extends { logicalId: string; path: string }>
   if (expandNested) return { standout: changed, folded: [] };
   const nestedKeys = new Set(
     findings
-      .filter((f) => f.nested === true && f.tier === 'undeclared')
+      .filter((f) => f.nested === true && f.tier === 'undeclared' && !f.freeFormKey)
       .map((f) => `${f.logicalId}::${f.path}`)
   );
   const isFolded = (e: T): boolean => nestedKeys.has(`${e.logicalId}::${e.path}`);

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -65,6 +65,7 @@ export interface CorpusCase {
     defaults: Record<string, unknown>;
     defaultPaths: Record<string, unknown>;
     unorderedScalarPaths?: string[]; // optional for backward compat with pre-insertionOrder cases
+    freeFormMapPaths?: string[]; // optional for backward compat with pre-free-form-map cases
   };
   opts: {
     accountId: string;
@@ -127,6 +128,7 @@ export function buildCorpusCase(
       defaults: schema.defaults,
       defaultPaths: schema.defaultPaths,
       unorderedScalarPaths: [...(schema.unorderedScalarPaths ?? [])].sort(),
+      freeFormMapPaths: [...(schema.freeFormMapPaths ?? [])].sort(),
     },
     opts,
     expected: findings,
@@ -146,6 +148,7 @@ export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
     defaults: s.defaults,
     defaultPaths: s.defaultPaths ?? {},
     unorderedScalarPaths: s.unorderedScalarPaths ?? [],
+    freeFormMapPaths: s.freeFormMapPaths ?? [],
   };
 }
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -975,6 +975,13 @@ export function classifyResource(
   // R140: nested paths that are always an AWS-assigned generated id (value-independent),
   // folded as `generated` like the top-level isGeneratedName/GENERATED_DEFAULTS cases.
   const generatedPaths = GENERATED_PATHS[resourceType] ?? [];
+  // Schema-detected FREE-FORM MAP properties (Lambda Environment.Variables, Glue
+  // Parameters): a live-only sub-key directly under one is user-authored data, not an
+  // AWS-materialized nested default — so flag it `freeFormKey` to surface it in the report
+  // (the generic nested fold would hide a console-added env var as first-run noise).
+  const freeFormMapPaths = schema.freeFormMapPaths ?? [];
+  const underFreeFormMap = (schemaPath: string): boolean =>
+    freeFormMapPaths.some((ff) => schemaPath.startsWith(`${ff}.`));
   for (const [k, dv] of Object.entries(declared)) {
     // Only skip a WHOLLY-unresolved property: collectNestedUndeclared descends to emit
     // LIVE-only keys, and an UNRESOLVED declared leaf is inert there (isNestedObject/
@@ -1001,7 +1008,18 @@ export function classifyResource(
           generatedPaths.includes(schemaPath) && isPhysicalIdSegment(value, physicalId)
           ? 'generated'
           : 'undeclared';
-      findings.push({ tier, logicalId, resourceType, path, actual: value, nested: true });
+      // A free-form map key surfaces (not folded), but only when it is a real undeclared
+      // value — an atDefault/generated one stays informational like any other.
+      const freeFormKey = tier === 'undeclared' && underFreeFormMap(schemaPath);
+      findings.push({
+        tier,
+        logicalId,
+        resourceType,
+        path,
+        actual: value,
+        nested: true,
+        ...(freeFormKey && { freeFormKey: true }),
+      });
     });
   }
 

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -56,6 +56,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Timeout: 3,
   },
   'AWS::Lambda::Url': { InvokeMode: 'BUFFERED' },
+  // An alias created without a Description reads back the empty string. Folded as
+  // atDefault so a never-declared alias does not report `Description=""` as drift; it
+  // is also the value REVERT_SET_DEFAULT_PATHS writes to undo an out-of-band Description
+  // (UpdateAlias ignores an OMITTED description, so a bare `remove` is a silent no-op —
+  // the alias must be sent Description:"" explicitly; proven live).
+  'AWS::Lambda::Alias': { Description: '' },
   // A published version inherits the function's runtime-management config; a version
   // that pins nothing reads back the Auto default (observed live across every
   // `currentVersion` in a multi-function stack). The twin of the AWS::Lambda::Function

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -205,9 +205,15 @@ export function report(findings: Finding[], header: string, opts: ReportOptions 
   // Top-level unrecorded values still list in full in [Potential Drift]; the nested ones
   // collapse to one `info:` count, expanded by --verbose or --show-all. Either way
   // record records them, so a later out-of-band change to one surfaces as drift.
+  // EXCEPTION: a free-form map key (freeFormKey — a live-only sub-key under Lambda
+  // Environment.Variables, Glue Parameters, …) is user-authored, NOT an AWS-materialized
+  // nested default, so it is shown in full like a top-level value, never folded.
   const expandNested = !!opts.verbose || !!opts.expandAtDefault;
-  const unrecordedShown = expandNested ? unrecordedItems : unrecordedItems.filter((f) => !f.nested);
-  const nestedFolded = expandNested ? [] : unrecordedItems.filter((f) => f.nested === true);
+  const isFolded = (f: Finding): boolean => f.nested === true && !f.freeFormKey;
+  const unrecordedShown = expandNested
+    ? unrecordedItems
+    : unrecordedItems.filter((f) => !isFolded(f));
+  const nestedFolded = expandNested ? [] : unrecordedItems.filter(isFolded);
   // Count inside the brackets (`[NAME: N]`), explanation outside (dim) — see the
   // layout comment at the top (R48). `leadingBlank` separates a section from
   // whatever precedes it; the FIRST drift section sits directly under the header.

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -43,20 +43,43 @@ const CC_REVERTABLE_DESPITE_READ_OVERRIDE = new Set<string>(['AWS::Scheduler::Sc
 // projected/normalized, not valid CC write inputs), and most entries already converge
 // via `remove` — broadening blindly would regress them and risk writing an unwritable
 // shape. Add a property here only once a `remove` no-op is observed for it.
-const REVERT_SET_DEFAULT_PATHS = new Set<string>(['AWS::IAM::Role\0MaxSessionDuration']);
+//   - AWS::Lambda::Alias Description: UpdateAlias ignores an OMITTED description (keeps
+//     the existing value), so a bare `remove` is a silent no-op — Cloud Control reports
+//     SUCCESS yet the live description persists. Writing the empty-string default (an
+//     `add /Description ""`) clears it. Both behaviours proven live.
+const REVERT_SET_DEFAULT_PATHS = new Set<string>([
+  'AWS::IAM::Role\0MaxSessionDuration',
+  'AWS::Lambda::Alias\0Description',
+]);
 
 /**
- * A nested undeclared value (a live sub-key inside a declared object, R96/R98) is
- * detect/record-only — never revertable (toPointer can't build a safe RFC6902 patch for
- * a dotted/bracketed path; R99). Detected by PATH SHAPE, not just `Finding.nested`: a
- * baseline value removed since record is reconstructed without the flag but keeps its
- * nested path. A top-level undeclared path is a single key (no '.'/'['). Pure + exported
- * so the interactive action picker offers `revert` ONLY where revert can actually run.
+ * A nested undeclared value (a live sub-key inside a declared object, R96/R98) — a dotted
+ * path (`Conf.Destination`) or an identity-keyed array element (`Prop[<id>].sub`). Pure +
+ * exported. Detected by PATH SHAPE, not just `Finding.nested`: a baseline value removed
+ * since record is reconstructed without the flag but keeps its nested path. A top-level
+ * undeclared path is a single key (no '.'/'[').
  */
 export function isNestedUndeclared(f: Finding): boolean {
   return (
     f.tier === 'undeclared' && (Boolean(f.nested) || f.path.includes('.') || f.path.includes('['))
   );
+}
+
+/**
+ * Of the nested undeclared values, the ones revert genuinely CANNOT target: an ARRAY
+ * ELEMENT path (it contains a `[<id>]`/`[<index>]` bracket). `toPointer` builds an RFC6902
+ * pointer by splitting on '.', so a bracket survives as a literal segment (`/Prop[<id>]/sub`)
+ * that addresses a key named `Prop[<id>]`, not the array element — the patch is malformed
+ * (the same reason R78 abandoned index-based array patches). A PURE-DOTTED nested path
+ * (`Environment.Variables.<key>` free-form map keys, or a sub-field of a declared object)
+ * IS a valid pointer that Cloud Control applies read-modify-write — proven live removing an
+ * out-of-band Lambda env var — so it stays revertable. A nested path ROOTED at `Tags` is
+ * also kept record-only: the top-level `/Tags` rewrite (tagPreservingOps) re-attaches the
+ * live `aws:*` managed tags, and a deep `/Tags/<key>` patch would bypass that preservation.
+ * Pure + exported so the action picker offers `revert` exactly where revert can run.
+ */
+export function isUnrevertableNested(f: Finding): boolean {
+  return isNestedUndeclared(f) && (f.path.includes('[') || f.path.split('.')[0] === 'Tags');
 }
 
 // An out-of-band ManagedPolicy attachment member (a live-only `Roles[x]`/`Users[x]`/
@@ -246,25 +269,24 @@ export function buildRevertPlan(
       });
       continue;
     }
-    // Nested undeclared values (R96/R98) are detect/record-only, NOT revertable. Their
-    // path addresses a sub-key INSIDE a declared object or array element — dotted
-    // (`Conf.Destination`) or, for an identity-keyed array element, `Prop[<id>].sub`.
-    // `toPointer` builds a flat RFC6902 pointer by splitting on '.', so the bracket
-    // form yields the malformed `/Prop[<id>]/sub` (the bracket is not RFC6902 and the
-    // CC patch would target a literal key, not the array element). Even the dotted form
-    // is a fragile deep patch (the same reason R78 abandoned index-based array patches).
-    // These are overwhelmingly AWS-materialized defaults — report + baseline them, and
-    // fix any real divergence in your IaC or by re-recording the live value. Detect by
-    // PATH SHAPE, not Finding.nested: a baseline value REMOVED since record is
-    // reconstructed (baseline-file.ts) WITHOUT the flag, but keeps its nested path. A
-    // top-level undeclared path is a single key (never contains '.'/'['), and declared
-    // drift is a different tier — so this never blocks a top-level revert.
-    if (isNestedUndeclared(f) && !isManagedPolicyAttachmentMember(f)) {
+    // A nested undeclared value whose path addresses an ARRAY ELEMENT (`Prop[<id>].sub`)
+    // is detect/record-only, NOT revertable: `toPointer` builds a flat RFC6902 pointer by
+    // splitting on '.', so the bracket survives as a literal segment (`/Prop[<id>]/sub`)
+    // that targets a key named `Prop[<id>]`, not the array element — a malformed patch (the
+    // same reason R78 abandoned index-based array patches). A PURE-DOTTED nested path
+    // (`Environment.Variables.<key>` free-form map keys, or a sub-field of a declared
+    // object) IS a valid pointer that Cloud Control applies read-modify-write (proven live
+    // removing an out-of-band Lambda env var), so it falls through to the normal revert
+    // below. Detect by PATH SHAPE, not Finding.nested: a baseline value REMOVED since
+    // record is reconstructed (baseline-file.ts) WITHOUT the flag, but keeps its nested
+    // path. A top-level undeclared path is a single key (never contains '.'/'['), and
+    // declared drift is a different tier — so this never blocks a top-level revert.
+    if (isUnrevertableNested(f) && !isManagedPolicyAttachmentMember(f)) {
       notRevertable.push({
         displayId,
         resourceType: f.resourceType,
         path: f.path,
-        reason: 'nested undeclared value — detect/record only, not revertable',
+        reason: 'nested undeclared array-element value — detect/record only, not revertable',
       });
       continue;
     }

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -15,6 +15,7 @@ const EMPTY: SchemaInfo = {
   defaults: {},
   defaultPaths: {},
   unorderedScalarPaths: [],
+  freeFormMapPaths: [],
 };
 
 export async function getSchemaInfo(
@@ -99,6 +100,8 @@ type SchemaNode = {
   enum?: unknown[];
   properties?: Record<string, SchemaNode>;
   items?: SchemaNode;
+  patternProperties?: Record<string, SchemaNode>;
+  additionalProperties?: boolean | SchemaNode;
 };
 function collectDefaultPaths(
   definitions: Record<string, SchemaNode>,
@@ -184,6 +187,47 @@ function collectUnorderedScalarPaths(
   return [...new Set(out)].sort();
 }
 
+// Collect the dotted paths of FREE-FORM MAP properties: a `type: object` schema node with
+// NO fixed `properties` whose contents are open — declared via `patternProperties` (regex
+// keys, e.g. Lambda Environment.Variables `[a-zA-Z][a-zA-Z0-9_]+`) or an object-valued
+// `additionalProperties` (Glue Parameters, ECS DockerLabels). Every key under such a node
+// is user-authored data, never an AWS-materialized nested default, so classify surfaces a
+// live-only sub-key there instead of folding it (R96 `undeclared-subkey`). A node with
+// fixed `properties` (a structured object) is NOT a free-form map even if it also allows
+// additionalProperties. Same $ref-resolving, recursion-guarded walk as the collectors
+// above; best-effort (a missed map just keeps folding — never a false positive). Array
+// elements contribute a `*` segment, matching the live `[id]`->`*`-normalized finding path.
+function collectFreeFormMapPaths(
+  definitions: Record<string, SchemaNode>,
+  properties: Record<string, SchemaNode>
+): string[] {
+  const out: string[] = [];
+  const isObjectSchema = (v: boolean | SchemaNode | undefined): v is SchemaNode =>
+    typeof v === 'object' && v !== null;
+  const walk = (node: SchemaNode | undefined, path: string, seen: ReadonlySet<string>): void => {
+    if (!node || typeof node !== 'object') return;
+    if (node.$ref) {
+      const name = node.$ref.replace('#/definitions/', '');
+      if (seen.has(name)) return; // recursive — stop
+      walk(definitions[name], path, new Set(seen).add(name));
+      return;
+    }
+    const hasFixedProps = node.properties && Object.keys(node.properties).length > 0;
+    const isMap =
+      node.type === 'object' &&
+      !hasFixedProps &&
+      ((node.patternProperties && Object.keys(node.patternProperties).length > 0) ||
+        isObjectSchema(node.additionalProperties));
+    if (isMap && path && !path.includes('*')) out.push(path);
+    if (node.properties)
+      for (const [k, child] of Object.entries(node.properties))
+        walk(child, path ? `${path}.${k}` : k, seen);
+    if (node.items) walk(node.items, path ? `${path}.*` : '*', seen);
+  };
+  for (const [k, child] of Object.entries(properties)) walk(child, k, new Set());
+  return [...new Set(out)].sort();
+}
+
 /** Exported for unit testing without an AWS call. */
 export function parseSchema(schemaJson: string): SchemaInfo {
   const schema = JSON.parse(schemaJson) as {
@@ -213,6 +257,10 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     schema.definitions ?? {},
     schema.properties ?? {}
   );
+  const freeFormMapPaths = collectFreeFormMapPaths(
+    schema.definitions ?? {},
+    schema.properties ?? {}
+  );
   return {
     readOnly: topLevel(readOnlyPaths),
     writeOnly: topLevel(writeOnlyPaths),
@@ -223,5 +271,6 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     defaults,
     defaultPaths,
     unorderedScalarPaths,
+    freeFormMapPaths,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,13 @@ export interface Finding {
   // expanded by --show-all; recorded by record like any undeclared value, so a later
   // out-of-band change to it surfaces.
   nested?: boolean;
+  // undeclared tier only: a nested undeclared value (so `nested` is also set) that lives
+  // inside a FREE-FORM MAP property (SchemaInfo.freeFormMapPaths — Lambda
+  // Environment.Variables, Glue Parameters, …). Every key in such a map is user-authored,
+  // never an AWS-materialized default, so unlike a generic nested value it is NOT folded:
+  // the report surfaces it in full (a console-added env var is real, reviewable drift, not
+  // first-run noise). Revertability is independent (path-shape based, isUnrevertableNested).
+  freeFormKey?: boolean;
   // undeclared tier only (R128): a recorded undeclared identity-keyed object array
   // (e.g. an IAM Role's inline Policies keyed by PolicyName) whose value CHANGED vs
   // the baseline — set by applyBaseline for the REPORT only. The finding still names
@@ -91,6 +98,13 @@ export interface SchemaInfo {
   // Optional: production (parseSchema / reviveSchema / EMPTY) always sets it; test
   // fixtures and pre-insertionOrder corpus cases may omit it (classify reads it with `?.`).
   unorderedScalarPaths?: string[];
+  // Dotted paths of FREE-FORM MAP properties — `type: object` schema nodes with no fixed
+  // `properties`, just `patternProperties`/object `additionalProperties` (Lambda
+  // Environment.Variables, Glue Parameters, DockerLabels). Every KEY in such a map is
+  // user-authored, NOT an AWS-materialized nested default, so a live-only sub-key under one
+  // is surfaced in the report rather than folded into the `undeclared-subkey` count (R96).
+  // Optional like the above; classify reads it with `?.`.
+  freeFormMapPaths?: string[];
 }
 
 export interface ResolverContext {

--- a/tests/action-picker.test.ts
+++ b/tests/action-picker.test.ts
@@ -26,21 +26,33 @@ describe('applicableActions (cycle order mirrors the verbs scope)', () => {
   it('undeclared (top-level) → record, ignore, revert (destructive revert last)', () => {
     expect(applicableActions(F('undeclared'))).toEqual(['record', 'ignore', 'revert']);
   });
-  it('NESTED undeclared drops revert — it is detect/record-only (R99)', () => {
-    // dotted, bracketed, or flagged-nested undeclared → no revert offered (revert can't
-    // build a safe RFC6902 patch for a nested path), matching buildRevertPlan.
-    expect(applicableActions({ ...F('undeclared'), path: 'Origins.0.Timeout' })).toEqual([
-      'record',
-      'ignore',
-    ]);
+  it('ARRAY-ELEMENT / Tags-rooted nested undeclared drops revert — detect/record-only', () => {
+    // A bracketed array-element path (revert can't build an RFC6902 pointer) or a Tags-rooted
+    // nested path (would bypass the aws:* tag-preservation rewrite) → no revert, matching
+    // buildRevertPlan.
     expect(applicableActions({ ...F('undeclared'), path: 'Origins[o1].Timeout' })).toEqual([
       'record',
       'ignore',
     ]);
-    expect(applicableActions({ ...F('undeclared'), path: 'P', nested: true })).toEqual([
+    expect(applicableActions({ ...F('undeclared'), path: 'Tags.myKey', nested: true })).toEqual([
       'record',
       'ignore',
     ]);
+  });
+  it('PURE-DOTTED nested undeclared (free-form map key) KEEPS revert — CC applies the pointer', () => {
+    // A clean dotted path is a valid RFC6902 pointer Cloud Control applies read-modify-write
+    // (a Lambda env var under Environment.Variables), so revert IS offered.
+    expect(
+      applicableActions({
+        ...F('undeclared'),
+        path: 'Environment.Variables.testtesttess',
+        nested: true,
+        freeFormKey: true,
+      })
+    ).toEqual(['record', 'ignore', 'revert']);
+    expect(
+      applicableActions({ ...F('undeclared'), path: 'Conf.Destination', nested: true })
+    ).toEqual(['record', 'ignore', 'revert']);
   });
   it('declared → revert (the natural fix), ignore — never record', () => {
     expect(applicableActions(F('declared'))).toEqual(['revert', 'ignore']);

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2944,6 +2944,39 @@ describe('nested undeclared detection (R96 — the differentiator at depth)', ()
     expect(out.some((x) => x.tier === 'undeclared' && x.path === 'A.B.D' && x.nested)).toBe(true);
   });
 
+  it('a live-only key under a FREE-FORM MAP property is flagged freeFormKey (surfaced, not folded)', () => {
+    // The reported Lambda Environment.Variables case: a console-added env var is a real,
+    // reviewable value (every map key is user-authored), so it carries freeFormKey -> the
+    // report shows it in full rather than folding it into the undeclared-subkey count.
+    const schema: SchemaInfo = { ...emptySchema, freeFormMapPaths: ['Environment.Variables'] };
+    const out = classifyResource(
+      res('AWS::Lambda::Function', {
+        Environment: { Variables: { USER_POOL_ID: '/a/b' } },
+      }),
+      { Environment: { Variables: { USER_POOL_ID: '/a/b', testtesttess: 'testtesttess' } } },
+      schema
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      tier: 'undeclared',
+      path: 'Environment.Variables.testtesttess',
+      nested: true,
+      freeFormKey: true,
+    });
+  });
+
+  it('a nested key NOT under a free-form map is plain nested (no freeFormKey)', () => {
+    const schema: SchemaInfo = { ...emptySchema, freeFormMapPaths: ['Environment.Variables'] };
+    const out = classifyResource(
+      res('AWS::X::Y', { Conf: { Level: 'INFO' } }),
+      { Conf: { Level: 'INFO', Destination: 's3' } },
+      schema
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ tier: 'undeclared', path: 'Conf.Destination', nested: true });
+    expect(out[0]!.freeFormKey).toBeUndefined();
+  });
+
   it('a CHANGE to a declared nested field is DECLARED drift, not nested-undeclared', () => {
     const out = f('AWS::X::Y', { Conf: { Level: 'INFO' } }, { Conf: { Level: 'CHANGED' } });
     expect(out).toHaveLength(1);

--- a/tests/integration/lambda-freeform/app.ts
+++ b/tests/integration/lambda-freeform/app.ts
@@ -1,0 +1,23 @@
+// CDK app for the cdk-real-drift Lambda free-form-map + Alias-revert integration test.
+// One Lambda with a DECLARED env var (a free-form Environment.Variables map), plus an
+// Alias on its current version with NO declared Description. verify.sh injects an
+// out-of-band UNDECLARED env var and an out-of-band Alias Description, then asserts:
+//   - the undeclared env var is SURFACED (a free-form map key, not folded into the
+//     undeclared-subkey count);
+//   - reverting the undeclared env var REMOVES it (a pure-dotted nested path is
+//     revertable via Cloud Control);
+//   - reverting the undeclared Alias Description CLEARS it (UpdateAlias ignores an
+//     omitted description, so revert must write the empty-string default, not `remove`).
+import { App, Stack } from "aws-cdk-lib";
+import { Alias, Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaFreeform");
+const fn = new Function(stack, "Fn", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ statusCode: 200 });"),
+  environment: { USER_POOL_ID_PARAMETER_STORE_NAME: "/auth/goto/user-pool-id" },
+});
+new Alias(stack, "Alias", { aliasName: "live", version: fn.currentVersion });
+app.synth();

--- a/tests/integration/lambda-freeform/cdk.json
+++ b/tests/integration/lambda-freeform/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-freeform/package.json
+++ b/tests/integration/lambda-freeform/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-freeform",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift Lambda free-form-map + Alias-revert integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-freeform/verify.sh
+++ b/tests/integration/lambda-freeform/verify.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# cdk-real-drift Lambda free-form-map + Alias-revert integration test (real AWS).
+#
+# Covers three reported bugs, all on a Lambda + its Alias:
+#   (1) an UNDECLARED env var added to a free-form Environment.Variables map is SURFACED
+#       (a free-form map key, not folded into the undeclared-subkey count);
+#   (2) reverting an UNDECLARED Alias Description CLEARS it — UpdateAlias ignores an
+#       omitted description (a bare `remove` is a silent no-op), so revert must write the
+#       empty-string default;
+#   (3) reverting the UNDECLARED env var REMOVES it — a pure-dotted nested path is a valid
+#       RFC6902 pointer Cloud Control applies.
+#
+# Flow:
+#   deploy
+#   PHASE 1 (problem 1): inject undeclared env var (NO baseline) -> check SURFACES the
+#     Environment.Variables.<key> path (proof it is not folded into undeclared-subkey)
+#   reset env -> record a CLEAN baseline
+#   PHASE 2 (problems 2+3): inject undeclared env var + Alias Description -> check DETECTS
+#     both as drift -> revert -> re-read live: env var GONE, Description "" -> declared var survives
+# A cleanup trap force-deletes the stack (delstack) and removes the baseline even on
+# failure, so a failed run leaves no orphans.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/lambda-freeform && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaFreeform
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+DECLARED_ENV='USER_POOL_ID_PARAMETER_STORE_NAME=/auth/goto/user-pool-id'
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN_NAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN_NAME" ] || fail "could not resolve function physical id"
+
+set_env() { # $1 = full Variables={...} spec
+  aws lambda update-function-configuration --function-name "$FN_NAME" --region "$REGION" \
+    --environment "$1" >/dev/null || fail "update env"
+  aws lambda wait function-updated --function-name "$FN_NAME" --region "$REGION" || true
+}
+
+echo "=== PHASE 1: inject undeclared env var, NO baseline (problem 1: surfaced, not folded) ==="
+set_env "Variables={${DECLARED_ENV},testtesttess=testtesttess}"
+$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-integ-lff-p1.out
+grep -q "Environment.Variables.testtesttess" /tmp/cdkrd-integ-lff-p1.out \
+  || fail "problem 1: undeclared env var not surfaced (still folded into undeclared-subkey?)"
+
+echo "=== reset env to clean, record CLEAN baseline ==="
+set_env "Variables={${DECLARED_ENV}}"
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record"
+
+echo "=== PHASE 2: inject undeclared env var + Alias Description out of band ==="
+set_env "Variables={${DECLARED_ENV},testtesttess=testtesttess}"
+aws lambda update-alias --function-name "$FN_NAME" --name live --description "test" --region "$REGION" >/dev/null \
+  || fail "inject alias description"
+
+echo "=== check should DETECT both as drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-integ-lff-p2.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "Environment.Variables.testtesttess" /tmp/cdkrd-integ-lff-p2.out || fail "env var drift not reported"
+grep -qi "Description" /tmp/cdkrd-integ-lff-p2.out || fail "alias Description drift not reported"
+
+echo "=== revert (clears the out-of-band values; only these are drift vs baseline) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-integ-lff-revert.out \
+  || fail "revert command errored"
+
+echo "=== verify convergence on the live resources ==="
+aws lambda wait function-updated --function-name "$FN_NAME" --region "$REGION" || true
+ENV_AFTER="$(aws lambda get-function-configuration --function-name "$FN_NAME" --region "$REGION" \
+  --query 'Environment.Variables' --output json | tr -d ' \n')"
+echo "env after revert: $ENV_AFTER"
+echo "$ENV_AFTER" | grep -q "testtesttess" && fail "problem 3: undeclared env var NOT removed by revert"
+
+DESC_AFTER="$(aws lambda get-alias --function-name "$FN_NAME" --name live --region "$REGION" \
+  --query 'Description' --output text)"
+echo "alias description after revert: '$DESC_AFTER'"
+[ "$DESC_AFTER" = "None" ] || [ -z "$DESC_AFTER" ] || fail "problem 2: alias Description NOT cleared (still '$DESC_AFTER')"
+
+echo "$ENV_AFTER" | grep -q "USER_POOL_ID_PARAMETER_STORE_NAME" \
+  || fail "declared env var was wrongly removed"
+
+echo "INTEG PASS"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -872,6 +872,40 @@ describe('parseSchema', () => {
     expect(info.unorderedScalarPaths).toEqual(['HealthCheckConfig.Regions', 'Launch']);
   });
 
+  // free-form map properties (patternProperties / object additionalProperties, no fixed
+  // `properties`) -> freeFormMapPaths, so a live-only key under one is surfaced not folded.
+  it('parseSchema collects free-form map properties into freeFormMapPaths', () => {
+    const info = parseSchema(
+      JSON.stringify({
+        definitions: {
+          // mirrors the real Lambda Environment definition: Variables is a patternProperties map
+          Environment: {
+            type: 'object',
+            properties: {
+              Variables: {
+                type: 'object',
+                additionalProperties: false,
+                patternProperties: { '[a-zA-Z][a-zA-Z0-9_]+': { type: 'string' } },
+              },
+            },
+          },
+        },
+        properties: {
+          Environment: { $ref: '#/definitions/Environment' },
+          // object additionalProperties (Glue-style free-form map) -> collected
+          Parameters: { type: 'object', additionalProperties: { type: 'string' } },
+          // STRUCTURED object (fixed properties) -> NOT a free-form map
+          Conf: { type: 'object', properties: { Mode: { type: 'string' } } },
+          // additionalProperties:false with no patternProperties -> NOT a map
+          Closed: { type: 'object', additionalProperties: false },
+          // a plain scalar -> ignored
+          Name: { type: 'string' },
+        },
+      })
+    );
+    expect(info.freeFormMapPaths).toEqual(['Environment.Variables', 'Parameters']);
+  });
+
   // R130: RDS DBInstance EngineVersion declared `"8.0"` reads back the provisioned
   // full patch `"8.0.45"`. A declared dotted-version that is a leading-segment PREFIX
   // of the live full version is not drift; a genuine track change still differs.

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -45,6 +45,23 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     );
   });
 
+  it('a free-form map key (freeFormKey) is SHOWN as potential drift, never folded into the subkey count', () => {
+    // A console-added Lambda env var is nested but user-authored (freeFormKey), so it is
+    // surfaced in [Potential Drift] like a top-level value — unlike a plain nested default,
+    // which folds into undeclared-subkey.
+    const nested = (p: string): Finding => ({ ...U(p), nested: true });
+    const freeForm = (p: string): Finding => ({ ...U(p), nested: true, freeFormKey: true });
+    const { text } = run([
+      freeForm('Environment.Variables.testtesttess'),
+      nested('a'),
+      nested('b'),
+    ]);
+    expect(text).toContain('[Potential Drift: 1]'); // the free-form key is listed
+    expect(text).toContain('Environment.Variables.testtesttess');
+    expect(text).toContain('undeclared-subkey=2'); // the 2 plain nested values still fold
+    expect(text).toContain('result: no confirmed drift · 1 potential drift');
+  });
+
   it('FOLDED-only (untouched fresh deploy): no potential drift, just "to record" inventory', () => {
     // No standout values, only nested AWS-populated ones — must NOT read as potential
     // drift, and must NOT print the "can't be confirmed as drift" preamble.

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -244,6 +244,26 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Lambda Alias Description (SET-DEFAULT) -> add op writing the empty-string default, not a no-op remove', () => {
+    // AWS::Lambda::Alias Description is in REVERT_SET_DEFAULT_PATHS: UpdateAlias leaves the
+    // description UNCHANGED when it is OMITTED, so a bare `remove` is a silent no-op (Cloud
+    // Control reports SUCCESS yet the live "test" persists; proven live). Revert must write
+    // the empty-string default explicitly to clear it.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Lambda::Alias',
+      path: 'Description',
+      actual: 'test',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Description',
+      value: '',
+      prior: 'test',
+    });
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.
@@ -825,14 +845,48 @@ describe('buildRevertPlan — nested undeclared is not revertable (R99)', () => 
     expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
   });
 
-  it('R96 dotted object-nested value -> notRevertable (fragile deep patch)', () => {
+  it('a PURE-DOTTED object-nested value IS revertable (valid RFC6902 pointer, CC applies it)', () => {
+    // A clean dotted path (no array bracket) is a valid pointer Cloud Control applies
+    // read-modify-write — e.g. a free-form map key like a Lambda env var. A recorded value
+    // reverts by restoring the baseline; the op targets the nested pointer `/Conf/Destination`.
     const f = F({ tier: 'undeclared', path: 'Conf.Destination', actual: 's3', nested: true });
     const b = baseline([
       { logicalId: 'R', resourceType: 'AWS::S3::Bucket', path: 'Conf.Destination', value: 'old' },
     ]);
     const plan = buildRevertPlan([f], b);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.ops[0]!.path).toBe('/Conf/Destination');
+  });
+
+  it('a free-form map key (env var) appeared since record IS revertable -> remove op', () => {
+    // The reported Lambda Environment.Variables case: an undeclared env var present in live
+    // but gone from the baseline reverts by REMOVING the nested key via Cloud Control.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Environment.Variables.testtesttess',
+      actual: 'testtesttess',
+      nested: true,
+      freeFormKey: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'remove',
+      path: '/Environment/Variables/testtesttess',
+    });
+  });
+
+  it('a Tags-rooted nested value stays notRevertable (tag-preservation invariant)', () => {
+    const f = F({ tier: 'undeclared', path: 'Tags.myKey', actual: 'v', nested: true });
+    const b = baseline([
+      { logicalId: 'R', resourceType: 'AWS::S3::Bucket', path: 'Tags.myKey', value: 'old' },
+    ]);
+    const plan = buildRevertPlan([f], b);
     expect(plan.items).toHaveLength(0);
-    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
+    expect(plan.notRevertable[0]!.reason).toContain('not revertable');
   });
 
   it('nested guard fires by PATH SHAPE even without the flag (baseline value removed since record)', () => {
@@ -849,17 +903,18 @@ describe('buildRevertPlan — nested undeclared is not revertable (R99)', () => 
     expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
   });
 
-  it('--remove-unrecorded does NOT override the nested guard', () => {
+  it('--remove-unrecorded does NOT override the array-element guard', () => {
     const f = F({
       tier: 'undeclared',
-      path: 'Conf.Destination',
-      actual: 's3',
+      resourceType: 'AWS::CloudFront::Distribution',
+      path: 'DistributionConfig.Origins[o1].ConnectionTimeout',
+      actual: 60,
       nested: true,
       unrecorded: true,
     });
     const plan = buildRevertPlan([f], baseline([]), { removeUnrecorded: true });
     expect(plan.items).toHaveLength(0);
-    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared');
+    expect(plan.notRevertable[0]!.reason).toContain('nested undeclared array-element');
   });
 
   it('a TOP-LEVEL undeclared value (single-key path) is still revertable — guard does not over-fire', () => {


### PR DESCRIPTION
Fixes three reported Lambda bugs, each proven live (integ fixture `tests/integration/lambda-freeform`, run on real AWS — `INTEG PASS`).

## 1. Free-form map keys were hidden (`undeclared-subkey` fold)
An undeclared key added to a **free-form map** (`AWS::Lambda::Function` `Environment.Variables`, Glue `Parameters`, …) was folded into the `undeclared-subkey=N` count, so a console-added env var read as "not detected".

**Fix:** detect free-form map properties from the schema (`patternProperties` / object `additionalProperties`, no fixed `properties` → `SchemaInfo.freeFormMapPaths`) and flag a live-only key under one as `freeFormKey`. Every such key is **user-authored data**, never an AWS default, so the report surfaces it in full instead of folding it.

## 2. `AWS::Lambda::Alias` Description revert silently no-op'd
`UpdateAlias` ignores an **omitted** description, so a bare RFC6902 `remove` is a no-op — Cloud Control reports SUCCESS yet the value persists (reproduced live). Same class as IAM Role `MaxSessionDuration`.

**Fix:** add the path to `REVERT_SET_DEFAULT_PATHS` + `KNOWN_DEFAULTS` (`Description: ''`), so revert writes the empty-string default explicitly (`add /Description ""`) instead of a no-op `remove`.

## 3. Nested undeclared env var could not be reverted
The revert bar rejected **any** dotted path, so an out-of-band env var was detect/record-only and the Revert menu never appeared.

**Fix:** relax the bar to **array-element (bracketed)** and **`Tags`-rooted** paths only (`isUnrevertableNested`). A pure-dotted nested path (`Environment.Variables.<key>`) is a valid pointer Cloud Control applies read-modify-write (proven live removing an env var). Array brackets still can't form an RFC6902 pointer; `Tags` stays record-only to preserve the `aws:*` managed-tag rewrite.

## Live verification (`INTEG PASS`)
- `Fn.Environment.Variables.testtesttess` **surfaced** as an itemized finding (not folded). _(bug 1)_
- revert plan: `Description -> AWS default` + `Environment.Variables.testtesttess -> remove`.
- after revert: alias description `''` _(bug 2)_, env var **gone**, declared var **survived** _(bug 3)_.

## Tests
Unit: free-form map schema detection, `freeFormKey` classify + report no-fold, Alias Description default-write revert, pure-dotted nested revertable / bracketed + Tags not. 1741 unit tests pass; typecheck / lint / build green. Docs: `ARCHITECTURE.md` + `README.md` updated.
