### PR TITLE
fix(revert): map-shaped tag keys revertable; surface free-form maps under array elements

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -394,10 +394,12 @@ all live changes
          EXCEPTION — a key under a FREE-FORM MAP property
          (SchemaInfo.freeFormMapPaths: a `type:object` schema node with no fixed
          `properties`, just `patternProperties`/object `additionalProperties` —
-         Lambda Environment.Variables, Glue Parameters): every such key is
-         user-authored data, NOT an AWS default, so it is flagged `freeFormKey`
-         and SURFACED in full (never folded) — a console-added env var is real,
-         reviewable drift, not first-run noise.
+         Lambda Environment.Variables, Glue Parameters, and maps nested under an
+         array element via a `*` path: ECS ContainerDefinitions.*.DockerLabels /
+         .LogConfiguration.Options): every such key is user-authored data, NOT an
+         AWS default, so it is flagged `freeFormKey` and SURFACED in full (never
+         folded) — a console-added env var is real, reviewable drift, not
+         first-run noise.
          R98 extends the recursion into the MATCHED elements of identity-keyed object
          arrays (Tags/Origins/AttributeDefinitions/…): elements are aligned by identity
          value and a live-only sub-field inside a declared element is caught too
@@ -684,12 +686,13 @@ deploy`: a patch can't recreate a resource), a **create-only** property (drift o
   replacement, which an in-place `UpdateResource` can't do — caught from the schema
   at plan time, not at apply time), and a nested undeclared value whose path
   addresses an **array element** (`Prop[<id>].sub` — the bracket can't be expressed
-  as an RFC6902 pointer) or is **rooted at `Tags`** (a deep `/Tags/<key>` patch would
-  bypass the `aws:*` managed-tag preservation), plus any `readGap` / `unresolved` /
-  `skipped` finding. A nested undeclared value on a PURE-DOTTED path (a free-form map
-  key like a Lambda env var, or an object sub-field) IS revertable — Cloud
-  Control applies the dotted pointer read-modify-write (`isUnrevertableNested`).
-  KMS keys need no SDK writer — they revert via the generic CC path.
+  as an RFC6902 pointer), plus any `readGap` / `unresolved` / `skipped` finding. A
+  nested undeclared value on a PURE-DOTTED path IS revertable — Cloud Control applies
+  the dotted pointer read-modify-write (`isUnrevertableNested`): a free-form map key
+  (a Lambda env var), an object sub-field, OR a **map-shaped tag key** (`Tags.<key>`,
+  e.g. AWS::SSM::Parameter — a single-key `remove`/`add` leaves the live `aws:*`
+  managed tags untouched, proven live). KMS keys need no SDK writer — they revert via
+  the generic CC path.
 - **Canonical-form write**: a declared-drift revert target (`finding.desired`) is the
   _normalized_ value (policy statements sorted, scalar-vs-array collapsed, tag / id
   arrays sorted), not the template verbatim. It is semantically equal to the template

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -34,9 +34,9 @@ export type FindingAction = 'record' | 'ignore' | 'revert' | 'skip';
  *  - undeclared → record (snapshot the norm; gentlest, keeps watching), then ignore
  *    (stop watching), then revert (REMOVE the live value — destructive, so last) —
  *    BUT revert is dropped for a nested undeclared value revert CANNOT target (an
- *    array-element or Tags-rooted path, `isUnrevertableNested`): offering it would let
- *    the user pick an action revert can't run. A pure-dotted nested value (a free-form
- *    map key like an env var) stays revertable;
+ *    array-element bracketed path, `isUnrevertableNested`): offering it would let the user
+ *    pick an action revert can't run. A pure-dotted nested value (a free-form map key like
+ *    an env var, or a map-shaped tag key) stays revertable;
  *  - added → record (snapshot the out-of-band resource; keeps watching for changes),
  *    ignore (stop watching), revert (DELETE the resource — destructive, so last). PR4
  *    makes added the resource-level sibling of undeclared, so it takes the same verbs;

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -73,13 +73,15 @@ export function isNestedUndeclared(f: Finding): boolean {
  * (the same reason R78 abandoned index-based array patches). A PURE-DOTTED nested path
  * (`Environment.Variables.<key>` free-form map keys, or a sub-field of a declared object)
  * IS a valid pointer that Cloud Control applies read-modify-write — proven live removing an
- * out-of-band Lambda env var — so it stays revertable. A nested path ROOTED at `Tags` is
- * also kept record-only: the top-level `/Tags` rewrite (tagPreservingOps) re-attaches the
- * live `aws:*` managed tags, and a deep `/Tags/<key>` patch would bypass that preservation.
+ * out-of-band Lambda env var — so it stays revertable. That INCLUDES a MAP-shaped tag key
+ * (`Tags.<key>`, e.g. AWS::SSM::Parameter): a single-key `remove /Tags/<key>` is proven live
+ * to succeed AND leave the live `aws:*` managed tags untouched (Cloud Control's read-modify-
+ * write keeps every other key, so the provider never untags the managed ones — no rewrite
+ * needed). A LIST-shaped tag element (`Tags[<id>].sub`) stays barred by the bracket rule.
  * Pure + exported so the action picker offers `revert` exactly where revert can run.
  */
 export function isUnrevertableNested(f: Finding): boolean {
-  return isNestedUndeclared(f) && (f.path.includes('[') || f.path.split('.')[0] === 'Tags');
+  return isNestedUndeclared(f) && f.path.includes('[');
 }
 
 // An out-of-band ManagedPolicy attachment member (a live-only `Roles[x]`/`Users[x]`/
@@ -557,9 +559,12 @@ export function writeOnlyReincludeOps(
 // tags — so the provider leaves the managed tags untouched and only the user tag changes.
 // A `remove` becomes `add []`-of-managed-only; an `add` keeps its value plus the managed
 // tags. With no managed tags present (or no live model) the op is returned unchanged, so
-// this never alters a tag revert that wasn't at risk. Only `/Tags` LIST-shaped values are
-// handled (the {Key,Value}[] shape awsManagedTags understands); nested tag paths are
-// already not-revertable (isNestedUndeclared), so only the top-level pointer can appear.
+// this never alters a tag revert that wasn't at risk. Only the top-level `/Tags` pointer is
+// rewritten here (LIST-shaped, the {Key,Value}[] shape awsManagedTags understands). A NESTED
+// map-tag key op (`/Tags/<key>`, e.g. AWS::SSM::Parameter) does NOT need this rewrite and
+// passes through unchanged: a single-key `remove`/`add` leaves every OTHER key — including
+// the live `aws:*` managed ones — in Cloud Control's read-modify-write model, so the
+// provider never untags the managed keys (proven live on an SSM Parameter).
 const TAGS_POINTER = '/Tags';
 function asTagList(v: unknown): unknown[] {
   return Array.isArray(v) ? v : [];

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -195,8 +195,13 @@ function collectUnorderedScalarPaths(
 // live-only sub-key there instead of folding it (R96 `undeclared-subkey`). A node with
 // fixed `properties` (a structured object) is NOT a free-form map even if it also allows
 // additionalProperties. Same $ref-resolving, recursion-guarded walk as the collectors
-// above; best-effort (a missed map just keeps folding — never a false positive). Array
-// elements contribute a `*` segment, matching the live `[id]`->`*`-normalized finding path.
+// above; best-effort (a missed map just keeps folding — never a false positive). A map
+// NESTED UNDER AN ARRAY ELEMENT is KEPT (its path carries a `*` segment — ECS
+// ContainerDefinitions.*.DockerLabels / .LogConfiguration.Options, Volumes.*
+// .DockerVolumeConfiguration.Labels): classify matches via `startsWith` on the live
+// `[id]`->`*`-normalized path, so the `*` aligns (unlike the EXACT-match collectors above,
+// which skip `*`). Such a key is still surfaced (visibility); revert stays barred for it
+// because its live path carries the array bracket (isUnrevertableNested).
 function collectFreeFormMapPaths(
   definitions: Record<string, SchemaNode>,
   properties: Record<string, SchemaNode>
@@ -218,7 +223,7 @@ function collectFreeFormMapPaths(
       !hasFixedProps &&
       ((node.patternProperties && Object.keys(node.patternProperties).length > 0) ||
         isObjectSchema(node.additionalProperties));
-    if (isMap && path && !path.includes('*')) out.push(path);
+    if (isMap && path) out.push(path);
     if (node.properties)
       for (const [k, child] of Object.entries(node.properties))
         walk(child, path ? `${path}.${k}` : k, seen);

--- a/tests/action-picker.test.ts
+++ b/tests/action-picker.test.ts
@@ -26,22 +26,18 @@ describe('applicableActions (cycle order mirrors the verbs scope)', () => {
   it('undeclared (top-level) → record, ignore, revert (destructive revert last)', () => {
     expect(applicableActions(F('undeclared'))).toEqual(['record', 'ignore', 'revert']);
   });
-  it('ARRAY-ELEMENT / Tags-rooted nested undeclared drops revert — detect/record-only', () => {
-    // A bracketed array-element path (revert can't build an RFC6902 pointer) or a Tags-rooted
-    // nested path (would bypass the aws:* tag-preservation rewrite) → no revert, matching
+  it('ARRAY-ELEMENT (bracketed) nested undeclared drops revert — detect/record-only', () => {
+    // A bracketed array-element path can't form an RFC6902 pointer → no revert, matching
     // buildRevertPlan.
     expect(applicableActions({ ...F('undeclared'), path: 'Origins[o1].Timeout' })).toEqual([
       'record',
       'ignore',
     ]);
-    expect(applicableActions({ ...F('undeclared'), path: 'Tags.myKey', nested: true })).toEqual([
-      'record',
-      'ignore',
-    ]);
   });
-  it('PURE-DOTTED nested undeclared (free-form map key) KEEPS revert — CC applies the pointer', () => {
-    // A clean dotted path is a valid RFC6902 pointer Cloud Control applies read-modify-write
-    // (a Lambda env var under Environment.Variables), so revert IS offered.
+  it('PURE-DOTTED nested undeclared KEEPS revert — CC applies the pointer', () => {
+    // A clean dotted path is a valid RFC6902 pointer Cloud Control applies read-modify-write:
+    // a Lambda env var under Environment.Variables, an object sub-field, OR a map-shaped tag
+    // key (Tags.<key>, proven live to preserve aws:* tags) — so revert IS offered.
     expect(
       applicableActions({
         ...F('undeclared'),
@@ -53,6 +49,11 @@ describe('applicableActions (cycle order mirrors the verbs scope)', () => {
     expect(
       applicableActions({ ...F('undeclared'), path: 'Conf.Destination', nested: true })
     ).toEqual(['record', 'ignore', 'revert']);
+    expect(applicableActions({ ...F('undeclared'), path: 'Tags.myKey', nested: true })).toEqual([
+      'record',
+      'ignore',
+      'revert',
+    ]);
   });
   it('declared → revert (the natural fix), ignore — never record', () => {
     expect(applicableActions(F('declared'))).toEqual(['revert', 'ignore']);

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2977,6 +2977,29 @@ describe('nested undeclared detection (R96 — the differentiator at depth)', ()
     expect(out[0]!.freeFormKey).toBeUndefined();
   });
 
+  it('a free-form map key NESTED UNDER AN ARRAY ELEMENT (ECS DockerLabels) is flagged freeFormKey', () => {
+    // The `*`-segment free-form map path aligns with the live `[id]`->`*`-normalized path
+    // via startsWith, so a container's out-of-band DockerLabels key is surfaced too.
+    const schema: SchemaInfo = {
+      ...emptySchema,
+      freeFormMapPaths: ['ContainerDefinitions.*.DockerLabels'],
+    };
+    const out = classifyResource(
+      res('AWS::ECS::TaskDefinition', {
+        ContainerDefinitions: [{ Name: 'app', DockerLabels: { team: 'a' } }],
+      }),
+      { ContainerDefinitions: [{ Name: 'app', DockerLabels: { team: 'a', rogue: 'x' } }] },
+      schema
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      tier: 'undeclared',
+      path: 'ContainerDefinitions[app].DockerLabels.rogue',
+      nested: true,
+      freeFormKey: true,
+    });
+  });
+
   it('a CHANGE to a declared nested field is DECLARED drift, not nested-undeclared', () => {
     const out = f('AWS::X::Y', { Conf: { Level: 'INFO' } }, { Conf: { Level: 'CHANGED' } });
     expect(out).toHaveLength(1);

--- a/tests/corpus/AWS__Lambda__Function.FreeFormEnvVar.json
+++ b/tests/corpus/AWS__Lambda__Function.FreeFormEnvVar.json
@@ -1,0 +1,213 @@
+{
+  "corpusVersion": 1,
+  "description": "Lambda Function with an out-of-band UNDECLARED env var under the free-form Environment.Variables map: the real CFn schema marks Variables as a patternProperties map, so freeFormMapPaths detects it and the live-only key is classified undeclared+nested+freeFormKey (surfaced in full, not folded). Harvested live from tests/integration/lambda-freeform.",
+  "resource": {
+    "logicalId": "Fn9270CBC0",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+    "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => ({ statusCode: 200 });"
+      },
+      "Environment": {
+        "Variables": {
+          "USER_POOL_ID_PARAMETER_STORE_NAME": "/auth/goto/user-pool-id"
+        }
+      },
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaFreefo-FnServiceRoleB9001A96-2Nxr4KajVHDr",
+      "Runtime": "nodejs20.x"
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaFreefo-FnServiceRoleB9001A96-2Nxr4KajVHDr",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB"
+    },
+    "RecursiveLoop": "Terminate",
+    "Environment": {
+      "Variables": {
+        "USER_POOL_ID_PARAMETER_STORE_NAME": "/auth/goto/user-pool-id",
+        "testtesttess": "testtesttess"
+      }
+    },
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "Fn9270CBC0",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegLambdaFreeform",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambdaFreeform/ae968600-730f-11f1-8cfa-12ac51daf2b5",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Environment.Variables.testtesttess",
+      "actual": "testtesttess",
+      "nested": true,
+      "freeFormKey": true,
+      "physicalId": "CdkRealDriftIntegLambdaFreeform-Fn9270CBC0-uFHmWzyw0ZLB",
+      "constructPath": "CdkRealDriftIntegLambdaFreeform/Fn"
+    }
+  ]
+}

--- a/tests/integration/ssm-maptag-revert/app.ts
+++ b/tests/integration/ssm-maptag-revert/app.ts
@@ -1,0 +1,13 @@
+// CDK app for the cdk-real-drift map-shaped-Tags revert integration test.
+// An AWS::SSM::Parameter has MAP-shaped Tags (key->value object, not a {Key,Value}[] list).
+// verify.sh records a clean baseline, adds an out-of-band tag key, then asserts cdkrd
+// detects it as a nested `Tags.<key>` undeclared drift and REVERTS it — a single-key
+// `remove /Tags/<key>` Cloud Control applies while leaving the aws:* managed tags untouched.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSsmMapTag");
+const p = new StringParameter(stack, "P", { stringValue: "hello" });
+Tags.of(p).add("declaredKey", "declaredVal");
+app.synth();

--- a/tests/integration/ssm-maptag-revert/cdk.json
+++ b/tests/integration/ssm-maptag-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ssm-maptag-revert/package.json
+++ b/tests/integration/ssm-maptag-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ssm-maptag-revert",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift map-shaped-Tags revert integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ssm-maptag-revert/verify.sh
+++ b/tests/integration/ssm-maptag-revert/verify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# cdk-real-drift map-shaped-Tags revert integration test (real AWS).
+#
+# An AWS::SSM::Parameter carries MAP-shaped Tags (key->value object). cdkrd surfaces an
+# out-of-band tag key as a nested `Tags.<key>` undeclared drift; this verifies the revert
+# of such a key WORKS — a single-key `remove /Tags/<key>` Cloud Control applies while
+# leaving the aws:cloudformation:* managed tags (and the declared tag) untouched.
+#
+# Flow: deploy -> record CLEAN baseline -> check CLEAN -> add out-of-band tag (rogueKey)
+#   -> check DETECTS `Tags.rogueKey` -> revert -> re-read tags: rogueKey GONE, declaredKey
+#   + aws:* PRESERVED.
+# A cleanup trap force-deletes the stack and removes the baseline even on failure.
+#
+# Requires: AWS credentials, a bootstrapped account (CDKToolkit).
+# Usage:  cd tests/integration/ssm-maptag-revert && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSsmMapTag
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+PNAME="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SSM::Parameter'].PhysicalResourceId" --output text)"
+[ -n "$PNAME" ] || fail "could not resolve parameter physical id"
+
+echo "=== record CLEAN baseline + check CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record"
+
+echo "=== add out-of-band tag rogueKey ==="
+aws ssm add-tags-to-resource --resource-type Parameter --resource-id "$PNAME" \
+  --tags Key=rogueKey,Value=rogueVal --region "$REGION" || fail "inject tag"
+
+echo "=== check should DETECT Tags.rogueKey ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-integ-ssmtag.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "Tags.rogueKey" /tmp/cdkrd-integ-ssmtag.out || fail "Tags.rogueKey not reported"
+
+echo "=== revert (removes the out-of-band tag key) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-integ-ssmtag-revert.out \
+  || fail "revert command errored"
+
+echo "=== verify convergence on live tags ==="
+TAGS_AFTER="$(aws ssm list-tags-for-resource --resource-type Parameter --resource-id "$PNAME" \
+  --region "$REGION" --query 'TagList' --output json | tr -d ' \n')"
+echo "tags after revert: $TAGS_AFTER"
+echo "$TAGS_AFTER" | grep -q "rogueKey" && fail "rogueKey NOT removed by revert"
+echo "$TAGS_AFTER" | grep -q "declaredKey" || fail "declared tag wrongly removed"
+echo "$TAGS_AFTER" | grep -q "aws:cloudformation:" || fail "aws:* managed tags wrongly removed"
+
+echo "INTEG PASS"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -900,10 +900,25 @@ describe('parseSchema', () => {
           Closed: { type: 'object', additionalProperties: false },
           // a plain scalar -> ignored
           Name: { type: 'string' },
+          // a free-form map NESTED UNDER AN ARRAY ELEMENT (ECS DockerLabels shape) -> KEPT
+          // with a `*` segment, so classify's startsWith match aligns the [id]->* live path.
+          Containers: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                DockerLabels: { type: 'object', additionalProperties: { type: 'string' } },
+              },
+            },
+          },
         },
       })
     );
-    expect(info.freeFormMapPaths).toEqual(['Environment.Variables', 'Parameters']);
+    expect(info.freeFormMapPaths).toEqual([
+      'Containers.*.DockerLabels',
+      'Environment.Variables',
+      'Parameters',
+    ]);
   });
 
   // R130: RDS DBInstance EngineVersion declared `"8.0"` reads back the provisioned

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -879,14 +879,34 @@ describe('buildRevertPlan — nested undeclared is not revertable (R99)', () => 
     });
   });
 
-  it('a Tags-rooted nested value stays notRevertable (tag-preservation invariant)', () => {
-    const f = F({ tier: 'undeclared', path: 'Tags.myKey', actual: 'v', nested: true });
-    const b = baseline([
-      { logicalId: 'R', resourceType: 'AWS::S3::Bucket', path: 'Tags.myKey', value: 'old' },
-    ]);
-    const plan = buildRevertPlan([f], b);
+  it('a MAP-shaped tag key (Tags.<key>) IS revertable — single-key CC remove preserves aws:* tags', () => {
+    // Proven live on an AWS::SSM::Parameter: `remove /Tags/<key>` succeeds and leaves the
+    // aws:cloudformation:* managed tags untouched (Cloud Control read-modify-write keeps
+    // every other key). A LIST-shaped tag element (`Tags[<id>].sub`) stays barred (bracket).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::SSM::Parameter',
+      path: 'Tags.rogueKey',
+      actual: 'rogueVal',
+      nested: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'remove', path: '/Tags/rogueKey' });
+  });
+
+  it('a LIST-shaped tag element (Tags[<id>].sub) stays notRevertable (bracket can not form a pointer)', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::S3::Bucket',
+      path: 'Tags[k1].Value',
+      actual: 'v',
+      nested: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
     expect(plan.items).toHaveLength(0);
-    expect(plan.notRevertable[0]!.reason).toContain('not revertable');
+    expect(plan.notRevertable[0]!.reason).toContain('array-element');
   });
 
   it('nested guard fires by PATH SHAPE even without the flag (baseline value removed since record)', () => {


### PR DESCRIPTION
Follow-ups to #401 — extends the free-form-map + nested-revert work, plus a sweep for analogous resource/property cases.

## 1. Map-shaped tag keys (`Tags.<key>`) are now revertable
#401 barred ALL `Tags`-rooted nested paths from revert (over-conservative). Probed live on an `AWS::SSM::Parameter`: a single-key `remove /Tags/<key>` via Cloud Control SUCCEEDS and leaves the `aws:cloudformation:*` managed tags untouched (CC's read-modify-write keeps every other key, so the provider never untags the managed ones — no rewrite needed).

**Fix:** `isUnrevertableNested` now bars only **array-element (bracketed)** paths. A map-shaped tag key is a clean dotted path, so it is revertable; a LIST-shaped tag element (`Tags[<id>].sub`) stays barred by the bracket rule.

## 2. (Sweep) Free-form maps NESTED UNDER AN ARRAY ELEMENT are surfaced too
#401's `collectFreeFormMapPaths` skipped `*`-paths, so a free-form map inside an array element — ECS `ContainerDefinitions.*.DockerLabels` / `.LogConfiguration.Options`, `Volumes.*.DockerVolumeConfiguration.Labels` — was NOT detected and a live-only key under it stayed folded.

**Fix:** keep `*`-paths in `freeFormMapPaths`. classify matches via `startsWith` on the `[id]`→`*`-normalized live path, so the `*` aligns. Such a key is surfaced (visibility); revert stays correctly barred (its live path carries the array bracket).

## Sweep — ruled out
- **Lambda `Function` Description** (predicted sibling of Alias Description / the `REVERT_SET_DEFAULT_PATHS` no-op class): probed live — CC `remove /Description` CLEARS it (unlike `UpdateAlias`, `UpdateFunctionConfiguration` honors the removal). NOT a no-op, no fix needed.

## Live verification (`INTEG PASS`)
- New fixture `tests/integration/ssm-maptag-revert`: deploy SSM Parameter → record → add out-of-band tag → `check` detects `P.Tags.rogueKey` → `revert` removes it → live tags: rogueKey gone, `declaredKey` + `aws:cloudformation:*` preserved → `CLEAN after revert`.

## Tests
Updated revert-plan / action-picker tests (map-tag revertable, list-tag-element + bracketed not), schema-strip + classify tests for nested-under-array free-form maps. All unit tests pass; typecheck / lint / build green. Docs: `ARCHITECTURE.md` updated.
