### PR TITLE
fix(schema): exclude map-shaped Tags from freeFormMapPaths (consistent tag folding)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -402,7 +402,10 @@ all live changes
          .LogConfiguration.Options): every such key is user-authored data, NOT an
          AWS default, so it is flagged `freeFormKey` and SURFACED in full (never
          folded) — a console-added env var is real, reviewable drift, not
-         first-run noise.
+         first-run noise. A `Tags` bag is EXCLUDED even when map-shaped
+         (AWS::SSM::Parameter models Tags as a patternProperties map; most types
+         use a {Key,Value}[] LIST) so map-tag keys FOLD consistently with
+         list-tag keys — a map-tagged resource is not noisier on the first run.
          R98 extends the recursion into the MATCHED elements of identity-keyed object
          arrays (Tags/Origins/AttributeDefinitions/…): elements are aligned by identity
          value and a live-only sub-field inside a declared element is caught too

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -205,7 +205,9 @@ function collectUnorderedScalarPaths(
 // .DockerVolumeConfiguration.Labels): classify matches via `startsWith` on the live
 // `[id]`->`*`-normalized path, so the `*` aligns (unlike the EXACT-match collectors above,
 // which skip `*`). Such a key is still surfaced (visibility); revert stays barred for it
-// because its live path carries the array bracket (isUnrevertableNested).
+// because its live path carries the array bracket (isUnrevertableNested). A `Tags` bag is
+// EXCLUDED even when map-shaped — see the inline note (tags fold consistently with the
+// dominant LIST-shaped Tags, so map-tagged resources are not noisier on the first run).
 function collectFreeFormMapPaths(
   definitions: Record<string, SchemaNode>,
   properties: Record<string, SchemaNode>
@@ -227,7 +229,16 @@ function collectFreeFormMapPaths(
       !hasFixedProps &&
       ((node.patternProperties && Object.keys(node.patternProperties).length > 0) ||
         isObjectSchema(node.additionalProperties));
-    if (isMap && path) out.push(path);
+    // A `Tags` bag is EXCLUDED even when MAP-shaped (AWS::SSM::Parameter et al. model
+    // Tags as a patternProperties map, while most types use a {Key,Value}[] LIST). Tags
+    // are a special low-signal category the pipeline already handles separately
+    // (canonicalizeTagLists / stripAwsTagsDeep / tagPreservingOps); surfacing an undeclared
+    // map-tag key as freeFormKey would make map-tagged resources noisier on the first run
+    // than LIST-tagged ones (whose nested `Tags[<id>]` keys fold) — an inconsistency users
+    // can't see the cause of. So a map-tag key FOLDS like a list-tag key (still recorded by
+    // record; a change after record surfaces as drift; still revertable via path shape).
+    const lastSeg = path.split('.').at(-1);
+    if (isMap && path && lastSeg !== 'Tags') out.push(path);
     if (node.properties)
       for (const [k, child] of Object.entries(node.properties))
         walk(child, path ? `${path}.${k}` : k, seen);

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -930,6 +930,9 @@ describe('parseSchema', () => {
               },
             },
           },
+          // a MAP-shaped Tags bag (AWS::SSM::Parameter shape) -> EXCLUDED, so map-tag keys
+          // fold like the dominant LIST-shaped Tags rather than surfacing as freeFormKey.
+          Tags: { type: 'object', additionalProperties: { type: 'string' } },
         },
       })
     );
@@ -938,6 +941,21 @@ describe('parseSchema', () => {
       'Environment.Variables',
       'Parameters',
     ]);
+  });
+
+  it('parseSchema EXCLUDES a map-shaped Tags bag from freeFormMapPaths (tags fold consistently)', () => {
+    // AWS::SSM::Parameter models Tags as a patternProperties map; most types use a LIST.
+    // Either way an undeclared tag key folds (not freeFormKey), so map-tagged resources are
+    // not noisier on the first run than list-tagged ones.
+    const info = parseSchema(
+      JSON.stringify({
+        properties: {
+          Tags: { type: 'object', patternProperties: { '.*': { type: 'string' } } },
+          Env: { type: 'object', additionalProperties: { type: 'string' } },
+        },
+      })
+    );
+    expect(info.freeFormMapPaths).toEqual(['Env']);
   });
 
   // R130: RDS DBInstance EngineVersion declared `"8.0"` reads back the provisioned


### PR DESCRIPTION
Follow-up QA to #401/#403 — prevents an unintended first-run noise inconsistency from the free-form-map work.

## The wart
`AWS::SSM::Parameter` (and a few others) model `Tags` as a **patternProperties map**, while most types use a `{Key,Value}[]` **LIST**. #401's `collectFreeFormMapPaths` therefore flagged a map-shaped `Tags` bag as a free-form map, so an **undeclared tag key surfaced as `freeFormKey` Potential Drift on the first run** — whereas a LIST-shaped resource's undeclared tag (`Tags[<id>]`, bracketed) **folds** into the `undeclared-subkey` count. Same kind of value, opposite visibility, driven by a schema shape users can't see.

## Fix
Exclude a `Tags` bag from `freeFormMapPaths` even when map-shaped. Tags are a low-signal category the pipeline already handles separately (`canonicalizeTagLists` / `stripAwsTagsDeep` / `tagPreservingOps`), so a map-tag key now **folds consistently** with a list-tag key on the first run. Unchanged: `record` still snapshots it, a change after record still surfaces as drift, and it stays **revertable** (revertability is path-shape based — see #403, proven live on SSM Parameter).

## Verification
- Unit: `parseSchema` excludes a map-shaped `Tags` from `freeFormMapPaths` (keeps `Environment.Variables` / Glue `Parameters` / ECS `*.DockerLabels`).
- Live: deployed an SSM Parameter, added an out-of-band tag, `check` with no baseline — the undeclared tag now folds into `undeclared-subkey` instead of surfacing.
- 1750 unit tests / corpus replay pass; typecheck / lint / build green. Docs: `ARCHITECTURE.md` updated.
