### PR TITLE
fix(report): per-key delta for map-valued declared drift (key-order/dotted-key legibility)

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -17,6 +17,7 @@
 // one-line-per-tier bullet list when 2+ (R37); `--verbose` expands them to full
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
+import { deepEqual } from '../diff/drift-calculator.js';
 import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
 
@@ -106,21 +107,75 @@ export function formatFinding(f: Finding): string {
   let s = `${pathDisplay ? `${id}.${pathDisplay}` : id} (${f.resourceType})`;
   if (f.note) s += ` — ${f.note}`;
   if (f.tier === 'declared') {
-    const { a: d, b: act } = jPair(f.desired, f.actual);
-    s += `\n      desired=${style.desired(d)}\n      actual =${style.actual(act)}`;
+    // A map-valued drift (both sides objects) is shown as a per-KEY delta, not a truncated
+    // whole-object dump (see formatMapDelta) — the user's case: one ResponseParameters
+    // header value changed but the raw pair-truncation windowed on the template-vs-live key
+    // ORDER and hid it. A scalar drift keeps the plain desired/actual lines.
+    if (isRecord(f.desired) && isRecord(f.actual)) s += formatMapDelta(f.desired, f.actual, false);
+    else {
+      const { a: d, b: act } = jPair(f.desired, f.actual);
+      s += `\n      desired=${style.desired(d)}\n      actual =${style.actual(act)}`;
+    }
   } else if (f.tier === 'added' && f.desired !== undefined) {
     // PR4: a recorded `added` resource whose live model CHANGED since record — show the
-    // recorded baseline model vs the live one (pair-truncated to the divergence) so the
-    // user sees WHAT changed, mirroring the declared tier's desired/actual layout. A
-    // first-seen / unrecorded added resource has no `desired`, so it stays a one-liner.
-    const { a: base, b: act } = jPair(f.desired, f.actual);
-    s += `\n      baseline=${style.desired(base)}\n      actual  =${style.actual(act)}`;
+    // recorded baseline model vs the live one so the user sees WHAT changed. Both are full
+    // models (objects), so the same per-key delta applies (baseline-vs-actual labels).
+    if (isRecord(f.desired) && isRecord(f.actual)) s += formatMapDelta(f.desired, f.actual, true);
+    else {
+      const { a: base, b: act } = jPair(f.desired, f.actual);
+      s += `\n      baseline=${style.desired(base)}\n      actual  =${style.actual(act)}`;
+    }
   } else if (f.tier === 'undeclared' && f.arrayDelta)
     // R128: a recorded identity-keyed array changed — show the element delta, not the
     // whole array dump (the property stays recorded; this is the WHICH-element view).
     s += formatArrayDelta(f.arrayDelta);
   else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
     s += ` = ${style.actual(j(f.actual))}`;
+  return s;
+}
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+// Render a CHANGED MAP as a per-key delta — only the keys that actually differ — instead of
+// a truncated whole-object dump of both sides. A free-form map whose keys hold the path
+// grammar's separators (`method.response.header.X`, a Docker label `com.example.x`, a tag
+// key with a `.`) is emitted WHOLE by the drift calculator (the dotted key can't ride the
+// finding path safely — drift-calculator `hasPathUnsafeKey`). So `desired`/`actual` are the
+// full maps, and because the deployed template's key ORDER differs from the live read's, a
+// raw `jPair` pair-truncation windows on the key-order divergence and HIDES the one value
+// the user changed (e.g. an Access-Control-Allow-Origin header). Showing only the diverging
+// keys pinpoints the change. Walks the UNION so a key present on one side only is shown too;
+// a value change uses `jPair` so a long value still truncates around its divergence.
+// `baselineLabels` swaps desired/actual wording for the `added` (baseline-vs-live) tier.
+function formatMapDelta(
+  desired: Record<string, unknown>,
+  actual: Record<string, unknown>,
+  baselineLabels: boolean
+): string {
+  const lhs = baselineLabels ? 'baseline' : 'desired';
+  const rhs = baselineLabels ? 'actual  ' : 'actual ';
+  const keys = [...new Set([...Object.keys(desired), ...Object.keys(actual)])].sort();
+  let s = '';
+  for (const k of keys) {
+    const inD = Object.hasOwn(desired, k);
+    const inA = Object.hasOwn(actual, k);
+    if (inD && inA) {
+      if (deepEqual(desired[k], actual[k])) continue;
+      const { a, b } = jPair(desired[k], actual[k]);
+      s += `\n      ~ ${k}\n          ${lhs}=${style.desired(a)}\n          ${rhs}=${style.actual(b)}`;
+    } else if (inD) {
+      s += `\n      - ${k} (in ${baselineLabels ? 'baseline' : 'template'}, absent in live)\n          ${lhs}=${style.desired(j(desired[k]))}`;
+    } else {
+      s += `\n      + ${k} (in live, not in ${baselineLabels ? 'baseline' : 'template'})\n          ${rhs}=${style.actual(j(actual[k]))}`;
+    }
+  }
+  // A whole-object swap with NO per-key difference shouldn't happen (deepEqual gates the
+  // finding), but fall back to the plain pair so a finding never renders value-less.
+  if (s === '') {
+    const { a, b } = jPair(desired, actual);
+    s = `\n      ${lhs}=${style.desired(a)}\n      ${rhs}=${style.actual(b)}`;
+  }
   return s;
 }
 

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { jPair, report, safeSlice, stackSeparator } from '../src/report/report.js';
+import { formatFinding, jPair, report, safeSlice, stackSeparator } from '../src/report/report.js';
 import type { Finding } from '../src/types.js';
 
 const F = (tier: Finding['tier'], path = 'P'): Finding => ({
@@ -705,5 +705,67 @@ describe('safeSlice (boundary-safe truncation — no split surrogate / escape)',
 
   it('leaves a clean boundary untouched', () => {
     expect(safeSlice('hello world', 0, 5)).toBe('hello');
+  });
+});
+
+describe('map-valued declared drift shows a per-KEY delta (not a key-order-confused dump)', () => {
+  // The user's case: an Integration.IntegrationResponses[].ResponseParameters map (dotted
+  // header keys → emitted WHOLE by the drift calculator) where ONE header value changed,
+  // and the deployed-template key order differs from the live read's. A raw pair-truncation
+  // would window on the key-order divergence; the per-key delta shows the one changed header.
+  const declaredMap = (desired: unknown, actual: unknown): Finding => ({
+    tier: 'declared',
+    logicalId: 'Api',
+    resourceType: 'AWS::ApiGateway::Method',
+    path: 'Integration.IntegrationResponses.0.ResponseParameters',
+    desired,
+    actual,
+  });
+
+  it('renders ONLY the changed key, with desired/actual values, despite differing key order', () => {
+    const f = declaredMap(
+      {
+        'method.response.header.Access-Control-Allow-Headers': "'Content-Type'",
+        'method.response.header.Access-Control-Allow-Origin': "'https://app.example.com'",
+        'method.response.header.Vary': "'Origin'",
+      },
+      {
+        // live read: different key ORDER + the one out-of-band value change
+        'method.response.header.Vary': "'Origin'",
+        'method.response.header.Access-Control-Allow-Headers': "'Content-Type'",
+        'method.response.header.Access-Control-Allow-Origin': "'https://evil.example.com'",
+      }
+    );
+    const out = formatFinding(f);
+    // the changed key is named, with both values visible
+    expect(out).toContain('~ method.response.header.Access-Control-Allow-Origin');
+    expect(out).toContain(`desired="'https://app.example.com'"`);
+    expect(out).toContain(`actual ="'https://evil.example.com'"`);
+    // unchanged keys are NOT dumped
+    expect(out).not.toContain('Access-Control-Allow-Headers');
+    expect(out).not.toContain('Vary');
+  });
+
+  it('a scalar declared drift keeps the plain desired/actual lines', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Api',
+      resourceType: 'AWS::ApiGateway::Method',
+      path: 'AuthorizationType',
+      desired: 'NONE',
+      actual: 'AWS_IAM',
+    };
+    const out = formatFinding(f);
+    expect(out).toContain('desired="NONE"');
+    expect(out).toContain('actual ="AWS_IAM"');
+    expect(out).not.toContain('~ ');
+  });
+
+  it('a template-only / live-only key is shown as removed / added', () => {
+    const f = declaredMap({ 'a.b': 1, 'c.d': 2 }, { 'a.b': 1, 'e.f': 9 });
+    const out = formatFinding(f);
+    expect(out).toContain('- c.d (in template, absent in live)');
+    expect(out).toContain('+ e.f (in live, not in template)');
+    expect(out).not.toContain('~ a.b'); // unchanged
   });
 });


### PR DESCRIPTION
## The problem (user-reported, live)
Changing ONE value inside a map-valued declared property (an Integration response's `ResponseParameters` — `method.response.header.Access-Control-Allow-Origin`) produced a confusing diff: the WHOLE map was dumped as `desired=…` / `actual=…`, and because the deployed template's key ORDER differs from the live (Cloud Control) read's, the pair-truncation windowed on the key-order divergence and **hid the one value that actually changed**.

Root cause is correct-but-coarse: the drift calculator emits such a map WHOLE (its dotted keys can't ride the finding path safely — `hasPathUnsafeKey`), so the revert rewrites it as a unit (right). Only the **display** was poor.

## Fix (display-only, general)
`formatFinding` now renders a map-valued `declared` (and `added`) drift as a **per-KEY delta** — only the keys that differ — instead of a truncated whole-object dump:

```
dev-goto-Auth/.../OPTIONS.Integration.IntegrationResponses.0.ResponseParameters (AWS::ApiGateway::Method)
      ~ method.response.header.Access-Control-Allow-Origin
          desired="'https://app.example.com'"
          actual ="'https://evil.example.com'"
```

- Walks the key UNION (a template-only key shows `-`, a live-only key `+`), each changed value still `jPair`-truncated around its own divergence.
- Scalar declared drifts keep the plain `desired=`/`actual=` lines.
- General, not API-Gateway-specific: every dotted-key map emitted whole benefits — **Tags**, ECS **DockerLabels**, Glue **Parameters**, API Gateway **Request/ResponseParameters**, etc. (the user asked for the same fix across other resources — this covers them by construction).
- Revert/classification unchanged (the finding still carries the whole map); this is purely how it's shown.

## Tests
New report tests render the exact user scenario (differing key order + one changed value → only that key shown), the scalar fallback, and the template-only/live-only key cases. Full suite 1768 green, typecheck 0, lint 0.

Display-only change — verified by the unit tests rendering the real output (no AWS deploy needed).
