### PR TITLE
feat(apigw): detect & revert out-of-band Method MethodResponses ResponseModels

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -415,8 +415,10 @@ all live changes
          value and a live-only sub-field inside a declared element is caught too
          (path `Prop[<id>].sub`). Identity-LESS arrays (SG rules) are not descended —
          EXCEPT a per-type NESTED_ARRAY_IDENTITY override names a non-standard key
-         (API Gateway Method Integration.IntegrationResponses by StatusCode), so an
-         out-of-band SelectionPattern / ContentHandling on a declared response surfaces
+         (API Gateway Method Integration.IntegrationResponses AND MethodResponses, both by
+         StatusCode), so an out-of-band SelectionPattern / ContentHandling on a declared
+         integration response — or a `responseModels` model attached to a declared method
+         response — surfaces
 ```
 
 ### Why a given value does (or does not) appear
@@ -707,12 +709,14 @@ deploy`: a patch can't recreate a resource), a **create-only** property (drift o
   managed tags untouched, proven live). EXCEPTION — even an ARRAY-ELEMENT nested path
   a type-specific `SDK_NESTED_WRITERS` entry can target PRECISELY is revertable
   (`isNestedSdkWritable`, the same lift `isManagedPolicyAttachmentMember` gets): an
-  API Gateway Method's `Integration.{PassthroughBehavior,ContentHandling,TimeoutInMillis}`
-  and `IntegrationResponses[<statusCode>].{SelectionPattern,ContentHandling}` revert via
-  the native granular patch API (UpdateIntegration / UpdateIntegrationResponse
-  PatchOperations) — API Gateway REJECTS `op: remove` for these, so the reset is a
-  `replace` (to the AWS default, or `""` which reads back absent/folded — proven live).
-  KMS keys need no SDK writer — they revert via the generic CC path.
+  API Gateway Method's `Integration.{PassthroughBehavior,ContentHandling,TimeoutInMillis}`,
+  `IntegrationResponses[<statusCode>].{SelectionPattern,ContentHandling}`, and
+  `MethodResponses[<statusCode>].ResponseModels` revert via the native granular patch API
+  (UpdateIntegration / UpdateIntegrationResponse / UpdateMethodResponse PatchOperations) —
+  API Gateway REJECTS `op: remove` for the integration knobs (so the reset is a `replace`
+  to the AWS default, or `""` which reads back absent/folded), but ACCEPTS `op: remove` for
+  a `responseModels` entry (removed per media key) — all proven live. KMS keys need no SDK
+  writer — they revert via the generic CC path.
 - **Canonical-form write**: a declared-drift revert target (`finding.desired`) is the
   _normalized_ value (policy statements sorted, scalar-vs-array collapsed, tag / id
   arrays sorted), not the template verbatim. It is semantically equal to the template

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -150,7 +150,14 @@ const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpe
 //     out-of-band SelectionPattern / ContentHandling added to a declared response (the
 //     "HTTP error regex" / "content handling" console knobs) is otherwise invisible.
 const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
-  'AWS::ApiGateway::Method': { 'Integration.IntegrationResponses': 'StatusCode' },
+  'AWS::ApiGateway::Method': {
+    'Integration.IntegrationResponses': 'StatusCode',
+    // MethodResponses is keyed by StatusCode too. AWS does NOT auto-materialize its
+    // ResponseModels (a CFn-created method response declaring none reads back null —
+    // proven live), so an out-of-band `responseModels` (e.g. the built-in "Error" model
+    // attached in the console) surfaces as a genuine undeclared value, no FP.
+    MethodResponses: 'StatusCode',
+  },
 };
 
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -26,6 +26,7 @@ import {
   type PatchOperation,
   UpdateIntegrationCommand,
   UpdateIntegrationResponseCommand,
+  UpdateMethodResponseCommand,
 } from '@aws-sdk/client-api-gateway';
 import {
   CloudFrontClient,
@@ -989,29 +990,31 @@ const writeCognitoIdentityPoolEvents: SdkWriter = async (ctx, ops) => {
   await c.send(new SetCognitoEventsCommand({ IdentityPoolId: id, Events: events }));
 };
 
-// An ApiGateway Method's Integration knobs live under a NESTED path Cloud Control cannot
-// patch reliably: the array-element ones (Integration.IntegrationResponses[<sc>].*) are
-// unaddressable by a flat RFC6902 pointer (the `[sc]` bracket survives as a literal key,
-// the same reason R78 abandoned index array patches), and CC's whole-Method read-modify-
-// write is fiddly for the integration sub-object. API Gateway's native granular patch API
-// (UpdateIntegration / UpdateIntegrationResponse with PatchOperations) targets each knob
-// exactly, so route these specific paths here. Mirrors isManagedPolicyAttachmentMember: a
-// nested undeclared value WITH a precise flat SDK op is exempt from the record-only bar.
+// An ApiGateway Method's nested knobs live under a NESTED path Cloud Control cannot patch
+// reliably: the array-element ones (Integration.IntegrationResponses[<sc>].*,
+// MethodResponses[<sc>].*) are unaddressable by a flat RFC6902 pointer (the `[sc]` bracket
+// survives as a literal key, the same reason R78 abandoned index array patches), and CC's
+// whole-Method read-modify-write is fiddly for these sub-objects. API Gateway's native
+// granular patch API targets each knob exactly, so route these specific paths here. Mirrors
+// isManagedPolicyAttachmentMember: a nested undeclared value WITH a precise flat SDK op is
+// exempt from the record-only bar.
 //   - Integration-level:  Integration.{PassthroughBehavior,ContentHandling,TimeoutInMillis}
-//   - Response-level:      Integration.IntegrationResponses[<statusCode>].{SelectionPattern,ContentHandling}
-const APIGW_INTEGRATION_KNOB =
-  /^Integration\.(PassthroughBehavior|ContentHandling|TimeoutInMillis)$|^Integration\.IntegrationResponses\[[^\]]+\]\.(SelectionPattern|ContentHandling)$/;
-export const isApiGatewayIntegrationKnobPath = (path: string): boolean =>
-  APIGW_INTEGRATION_KNOB.test(path);
+//   - IntegrationResponse: Integration.IntegrationResponses[<sc>].{SelectionPattern,ContentHandling}
+//   - MethodResponse:     MethodResponses[<sc>].ResponseModels (the whole live-only map —
+//     classify emits a live-only sub-OBJECT whole, so the media keys ride the op's value)
+const APIGW_METHOD_KNOB =
+  /^Integration\.(PassthroughBehavior|ContentHandling|TimeoutInMillis)$|^Integration\.IntegrationResponses\[[^\]]+\]\.(SelectionPattern|ContentHandling)$|^MethodResponses\[[^\]]+\]\.ResponseModels$/;
+export const isApiGatewayMethodKnobPath = (path: string): boolean => APIGW_METHOD_KNOB.test(path);
 
 // Per-knob revert target: the API Gateway patch path + the value to RESET to when the knob
-// was undeclared. API Gateway REJECTS `op: remove` for every one of these (`Invalid patch
-// path /selectionPattern` — proven live), so the reset is always a `replace`:
+// was undeclared. API Gateway REJECTS `op: remove` for these INTEGRATION knobs (`Invalid
+// patch path /selectionPattern` — proven live), so the reset is always a `replace`:
 //   - PassthroughBehavior / TimeoutInMillis -> their AWS default (WHEN_NO_MATCH / 29000).
 //   - ContentHandling / SelectionPattern    -> the EMPTY STRING, which is the cleared state:
 //     `replace /contentHandling ""` makes CC read it ABSENT, and `replace /selectionPattern
-//     ""` leaves a "" the compare folds as trivially-empty (both proven live). So after a
-//     revert the knob no longer surfaces.
+//     ""` leaves a "" the compare folds as trivially-empty (both proven live).
+// (MethodResponses ResponseModels is the EXCEPTION — UpdateMethodResponse DOES accept
+// `op: remove /responseModels/<media>`, proven live — handled separately below.)
 // A declared-drift revert (`add` op) replaces with the desired template value instead.
 const APIGW_KNOB_RESET: Record<string, { patchPath: string; resetTo: string }> = {
   PassthroughBehavior: { patchPath: '/passthroughBehavior', resetTo: 'WHEN_NO_MATCH' },
@@ -1020,50 +1023,80 @@ const APIGW_KNOB_RESET: Record<string, { patchPath: string; resetTo: string }> =
   SelectionPattern: { patchPath: '/selectionPattern', resetTo: '' },
 };
 
-// dotted finding leaf field for a revert op whose RFC6902 pointer is `/Integration/<field>`
-// or `/Integration/IntegrationResponses[<sc>]/<field>`. Returns the patch op + which call
-// (integration-level, or response-level keyed by statusCode) applies it.
-function apigwKnobPatch(op: PatchOp): {
-  statusCode?: string;
-  patch: PatchOperation;
-} {
+const ptrEscape = (s: string): string => s.replace(/~/g, '~0').replace(/\//g, '~1');
+
+type ApiGwPatch =
+  | { kind: 'integration'; patch: PatchOperation }
+  | { kind: 'integrationResponse'; statusCode: string; patch: PatchOperation }
+  | { kind: 'methodResponse'; statusCode: string; patch: PatchOperation };
+
+const asRecord = (v: unknown): Record<string, unknown> =>
+  v !== null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : {};
+
+// Translate a revert op (RFC6902 pointer into the Method model) into the matching API Gateway
+// PatchOperation(s) + which sub-resource call applies each. ResponseModels yields ONE patch
+// per media key (the finding is the whole map); the others yield a single patch.
+function apigwKnobPatches(op: PatchOp): ApiGwPatch[] {
   const segs = op.path
     .split('/')
     .slice(1)
     .map((s) => s.replace(/~1/g, '/').replace(/~0/g, '~'));
-  const responseSeg = segs[1]?.match(/^IntegrationResponses\[(.+)\]$/);
-  const field = (responseSeg ? segs[2] : segs[1]) ?? '';
+  // MethodResponses[<sc>].ResponseModels -> UpdateMethodResponse, one patch per media key.
+  // UpdateMethodResponse ACCEPTS op:remove for a responseModels entry (proven live), so an
+  // undeclared map is removed key-by-key (its keys ride op.prior); a declared one is restored
+  // with op:add from op.value.
+  const mr = segs[0]?.match(/^MethodResponses\[(.+)\]$/);
+  if (mr && segs[1] === 'ResponseModels') {
+    const statusCode = mr[1] ?? '';
+    const media = op.op === 'add' ? asRecord(op.value) : asRecord(op.prior);
+    return Object.keys(media).map((k) => ({
+      kind: 'methodResponse' as const,
+      statusCode,
+      patch:
+        op.op === 'add'
+          ? { op: 'add', path: `/responseModels/${ptrEscape(k)}`, value: String(media[k]) }
+          : { op: 'remove', path: `/responseModels/${ptrEscape(k)}` },
+    }));
+  }
+  const ir = segs[1]?.match(/^IntegrationResponses\[(.+)\]$/);
+  const field = (ir ? segs[2] : segs[1]) ?? '';
   const knob = APIGW_KNOB_RESET[field];
-  if (!knob) throw new Error(`unsupported ApiGateway integration knob: ${op.path}`);
-  // `add` = restore the declared value; `remove` = reset an undeclared one. API Gateway
-  // rejects `op: remove` for these knobs, so always `replace` (with the desired, or the
-  // reset value).
+  if (!knob) throw new Error(`unsupported ApiGateway method knob: ${op.path}`);
   const value = op.op === 'add' ? String(op.value) : knob.resetTo;
-  return {
-    ...(responseSeg && { statusCode: responseSeg[1] }),
-    patch: { op: 'replace', path: knob.patchPath, value },
-  };
+  const patch: PatchOperation = { op: 'replace', path: knob.patchPath, value };
+  return [
+    ir
+      ? { kind: 'integrationResponse', statusCode: ir[1] ?? '', patch }
+      : { kind: 'integration', patch },
+  ];
 }
 
-// Revert an ApiGateway Method's nested Integration knobs (see isApiGatewayIntegrationKnobPath)
-// via API Gateway's native granular patch API. Integration-level ops batch into one
-// UpdateIntegration; response-level ops batch per statusCode into UpdateIntegrationResponse.
-const writeApiGatewayMethodIntegration: SdkWriter = async (ctx, ops) => {
+const pushByKey = (m: Map<string, PatchOperation[]>, k: string, p: PatchOperation): void => {
+  const arr = m.get(k);
+  if (arr) arr.push(p);
+  else m.set(k, [p]);
+};
+
+// Revert an ApiGateway Method's nested knobs (see isApiGatewayMethodKnobPath) via API
+// Gateway's native granular patch API: integration-level ops batch into one UpdateIntegration;
+// per-statusCode integration-response ops into UpdateIntegrationResponse; per-statusCode
+// method-response ops into UpdateMethodResponse.
+const writeApiGatewayMethod: SdkWriter = async (ctx, ops) => {
   const [restApiId, resourceId, httpMethod] = ctx.physicalId.split('|');
   if (!restApiId || !resourceId || !httpMethod)
     throw new Error(
       `cannot parse ApiGateway Method id "${ctx.physicalId}" (RestApiId|ResourceId|HttpMethod)`
     );
   const integrationPatches: PatchOperation[] = [];
-  const responsePatches = new Map<string, PatchOperation[]>();
-  for (const op of ops) {
-    const { statusCode, patch } = apigwKnobPatch(op);
-    if (statusCode === undefined) integrationPatches.push(patch);
-    else
-      (
-        responsePatches.get(statusCode) ?? responsePatches.set(statusCode, []).get(statusCode)!
-      ).push(patch);
-  }
+  const integrationRespPatches = new Map<string, PatchOperation[]>();
+  const methodRespPatches = new Map<string, PatchOperation[]>();
+  for (const op of ops)
+    for (const p of apigwKnobPatches(op)) {
+      if (p.kind === 'integration') integrationPatches.push(p.patch);
+      else if (p.kind === 'integrationResponse')
+        pushByKey(integrationRespPatches, p.statusCode, p.patch);
+      else pushByKey(methodRespPatches, p.statusCode, p.patch);
+    }
   const c = new APIGatewayClient({ region: ctx.region });
   if (integrationPatches.length > 0)
     await c.send(
@@ -1074,9 +1107,19 @@ const writeApiGatewayMethodIntegration: SdkWriter = async (ctx, ops) => {
         patchOperations: integrationPatches,
       })
     );
-  for (const [statusCode, patchOperations] of responsePatches)
+  for (const [statusCode, patchOperations] of integrationRespPatches)
     await c.send(
       new UpdateIntegrationResponseCommand({
+        restApiId,
+        resourceId,
+        httpMethod,
+        statusCode,
+        patchOperations,
+      })
+    );
+  for (const [statusCode, patchOperations] of methodRespPatches)
+    await c.send(
+      new UpdateMethodResponseCommand({
         restApiId,
         resourceId,
         httpMethod,
@@ -1136,8 +1179,8 @@ export interface NestedWriterSpec {
 }
 export const SDK_NESTED_WRITERS: Record<string, NestedWriterSpec> = {
   'AWS::ApiGateway::Method': {
-    match: isApiGatewayIntegrationKnobPath,
-    writer: writeApiGatewayMethodIntegration,
+    match: isApiGatewayMethodKnobPath,
+    writer: writeApiGatewayMethod,
   },
 };
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4593,3 +4593,49 @@ describe('NESTED_ARRAY_IDENTITY (ApiGateway Method IntegrationResponses keyed by
     expect(findings.filter((f) => f.tier === 'undeclared')).toHaveLength(0);
   });
 });
+
+describe('NESTED_ARRAY_IDENTITY: ApiGateway Method MethodResponses keyed by StatusCode', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const method = (methodResponses: unknown): DesiredResource => ({
+    logicalId: 'ApiGET',
+    resourceType: 'AWS::ApiGateway::Method',
+    physicalId: 'abc|res|GET',
+    declared: { HttpMethod: 'GET', AuthorizationType: 'NONE', MethodResponses: methodResponses },
+  });
+
+  it('an out-of-band responseModels added to a declared method response surfaces as undeclared', () => {
+    const declared = method([{ StatusCode: '200' }]); // template declares NO responseModels
+    const live = {
+      HttpMethod: 'GET',
+      AuthorizationType: 'NONE',
+      MethodResponses: [{ StatusCode: '200', ResponseModels: { 'application/json': 'Error' } }],
+    };
+    const undeclared = classifyResource(declared, live, bare)
+      .filter((f) => f.tier === 'undeclared')
+      .map((f) => f.path);
+    expect(undeclared).toContain('MethodResponses[200].ResponseModels');
+  });
+
+  it('a declared responseModels matching live is NOT drift (no FP)', () => {
+    const el = { StatusCode: '200', ResponseModels: { 'application/json': 'Empty' } };
+    const findings = classifyResource(
+      method([el]),
+      {
+        HttpMethod: 'GET',
+        AuthorizationType: 'NONE',
+        MethodResponses: [el],
+      },
+      bare
+    );
+    expect(findings.filter((f) => f.tier === 'undeclared')).toHaveLength(0);
+  });
+});

--- a/tests/integration/apigw-method-integration/verify.sh
+++ b/tests/integration/apigw-method-integration/verify.sh
@@ -65,11 +65,17 @@ aws apigateway update-integration-response --rest-api-id "$API_ID" --resource-id
   --patch-operations 'op=replace,path=/selectionPattern,value=5\d\d' \
                      op=replace,path=/contentHandling,value=CONVERT_TO_TEXT >/dev/null \
   || fail "set selectionPattern/contentHandling"
+# MethodResponses ResponseModels: AWS does NOT auto-materialize it (CFn-created reads null),
+# so attaching the built-in "Error" model is a genuine undeclared value.
+aws apigateway update-method-response --rest-api-id "$API_ID" --resource-id "$ROOT_ID" \
+  --http-method GET --status-code 200 --region "$REGION" \
+  --patch-operations op=add,path=/responseModels/application~1json,value=Error >/dev/null \
+  || fail "set responseModels"
 
-echo "=== PHASE B+C1: check must DETECT + SURFACE all 3 undeclared knobs ==="
+echo "=== PHASE B+C1: check must DETECT + SURFACE all 4 undeclared knobs ==="
 # No baseline yet, so these are POTENTIAL drift (unrecorded) — that is exit 0 by design
-# (only confirmed declared/undeclared drift sets exit 1). The assertion is that all three
-# are SURFACED in the default report (B) — including the array-element ones (C1).
+# (only confirmed declared/undeclared drift sets exit 1). The assertion is that all are
+# SURFACED in the default report (B) — including the array-element + method-response ones (C1).
 $CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-integ-apigw-p2.out
 grep -q "Integration.PassthroughBehavior" /tmp/cdkrd-integ-apigw-p2.out \
   || fail "PassthroughBehavior not surfaced"
@@ -77,6 +83,8 @@ grep -q "IntegrationResponses\[200\].SelectionPattern" /tmp/cdkrd-integ-apigw-p2
   || fail "C1: array-element SelectionPattern not detected (StatusCode descent missing?)"
 grep -q "IntegrationResponses\[200\].ContentHandling" /tmp/cdkrd-integ-apigw-p2.out \
   || fail "C1: array-element ContentHandling not detected"
+grep -q "MethodResponses\[200\].ResponseModels" /tmp/cdkrd-integ-apigw-p2.out \
+  || fail "C1: MethodResponses ResponseModels not detected (StatusCode descent missing?)"
 
 echo "=== PHASE C2: revert (remove unrecorded) -> the SDK writer resets every knob ==="
 $CLI revert "$STACK" --region "$REGION" --yes --remove-unrecorded | tee /tmp/cdkrd-integ-apigw-revert.out \
@@ -98,6 +106,11 @@ CH_AFTER="$(aws apigateway get-integration-response --rest-api-id "$API_ID" --re
   --http-method GET --status-code 200 --region "$REGION" --query 'contentHandling' --output text)"
 echo "contentHandling after revert: '$CH_AFTER'"
 [ "$CH_AFTER" = "None" ] || [ -z "$CH_AFTER" ] || fail "C2: ContentHandling not removed (still '$CH_AFTER')"
+
+RM_AFTER="$(aws apigateway get-method-response --rest-api-id "$API_ID" --resource-id "$ROOT_ID" \
+  --http-method GET --status-code 200 --region "$REGION" --query 'responseModels' --output text)"
+echo "responseModels after revert: '$RM_AFTER'"
+[ "$RM_AFTER" = "None" ] || [ -z "$RM_AFTER" ] || fail "C2: ResponseModels not removed (still '$RM_AFTER')"
 
 echo "=== PHASE D: check must be CLEAN again after revert ==="
 $CLI check "$STACK" --region "$REGION" --fail

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -2,6 +2,7 @@ import {
   APIGatewayClient,
   UpdateIntegrationCommand,
   UpdateIntegrationResponseCommand,
+  UpdateMethodResponseCommand,
 } from '@aws-sdk/client-api-gateway';
 import {
   CloudFrontClient,
@@ -223,6 +224,29 @@ describe('ApiGateway Method integration writer (nested knobs CC cannot patch)', 
     await expect(
       resolveSdkWriter('AWS::ApiGateway::Method', ops)!(ctx({ physicalId: 'bad' }), ops)
     ).rejects.toThrow(/cannot parse ApiGateway Method id/);
+  });
+
+  it('reverts an out-of-band MethodResponses ResponseModels via UpdateMethodResponse (remove per media key)', async () => {
+    apigw.on(UpdateMethodResponseCommand).resolves({});
+    // classify emits the whole live-only ResponseModels map; revertOp carries it as `prior`.
+    const ops: PatchOp[] = [
+      {
+        op: 'remove',
+        path: '/MethodResponses[200]/ResponseModels',
+        prior: { 'application/json': 'Error' },
+        human: 'remove',
+      },
+    ];
+    await resolveSdkWriter('AWS::ApiGateway::Method', ops)!(apigwCtx(), ops);
+    const calls = apigw.commandCalls(UpdateMethodResponseCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toMatchObject({
+      restApiId: 'abc',
+      resourceId: '9zav19',
+      httpMethod: 'OPTIONS',
+      statusCode: '200',
+      patchOperations: [{ op: 'remove', path: '/responseModels/application~1json' }],
+    });
   });
 });
 


### PR DESCRIPTION
Follow-up to #405 (API Gateway Method nested knobs). Extends the same detection + revert mechanisms to a Method's **MethodResponses** — closing the last out-of-band-detection gap the user hit on a hand-fiddled CORS method.

## What & why
A Method's `MethodResponses` is keyed by `StatusCode` (not a generic IDENTITY_FIELD), so `collectNestedUndeclared` never descended it — an out-of-band `responseModels` (e.g. the built-in **"Error"** model attached in the console to a declared method response) was a **silent FN**.

**FP-safe without cataloguing** — proven live: a CFn-created method response that declares no `responseModels` reads back **null** (AWS does NOT auto-materialize it). So a declared `responseModels` matches live (no FP), and only a genuinely out-of-band one surfaces.

## Detection
`NESTED_ARRAY_IDENTITY['AWS::ApiGateway::Method']` gains `MethodResponses: 'StatusCode'`.

## Revert
The API Gateway nested writer (`SDK_NESTED_WRITERS`, from #405) is generalized to also handle `MethodResponses[<sc>].ResponseModels` via **`UpdateMethodResponse`**. Unlike the integration knobs (which reject `op: remove`), `UpdateMethodResponse` **accepts `op: remove`** for a `responseModels` entry (proven live) — so an undeclared map is removed key-by-key (its media keys ride the op's `prior`); a declared one is restored with `op: add`.

## Live integ (INTEG PASS)
`tests/integration/apigw-method-integration` now also sets `responseModels=Error` out of band and asserts: `cdkrd check` surfaces `MethodResponses[200].ResponseModels`, `cdkrd revert` removes it via UpdateMethodResponse, and the live read returns to `null` → check CLEAN. All 4 knobs (PassthroughBehavior + Selection/ContentHandling + ResponseModels) detect & revert together.

## Tests
Unit: classify StatusCode descent for MethodResponses (+ no-FP when declared==live); writer UpdateMethodResponse remove-per-media-key. Full suite 1778 green, typecheck 0, lint 0.
