### PR TITLE
feat(diff): detect out-of-band changes in non-standard-keyed nested rule arrays (Backup, Route53Resolver)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -414,11 +414,13 @@ all live changes
          arrays (Tags/Origins/AttributeDefinitions/…): elements are aligned by identity
          value and a live-only sub-field inside a declared element is caught too
          (path `Prop[<id>].sub`). Identity-LESS arrays (SG rules) are not descended —
-         EXCEPT a per-type NESTED_ARRAY_IDENTITY override names a non-standard key
-         (API Gateway Method Integration.IntegrationResponses AND MethodResponses, both by
-         StatusCode), so an out-of-band SelectionPattern / ContentHandling on a declared
-         integration response — or a `responseModels` model attached to a declared method
-         response — surfaces
+         EXCEPT a per-type NESTED_ARRAY_IDENTITY override names a non-standard key, so an
+         out-of-band sub-key on a declared element surfaces (and an AWS-materialized DEFAULT
+         on those elements folds via KNOWN_DEFAULT_PATHS, so a clean stack stays clean):
+         API Gateway Method Integration.IntegrationResponses AND MethodResponses (StatusCode)
+         — SelectionPattern / ContentHandling / responseModels; Backup BackupPlan
+         BackupPlanRule (RuleName) — a changed CompletionWindowMinutes / window; Route53
+         Resolver FirewallRuleGroup FirewallRules (Priority) — a changed firewall-rule setting
 ```
 
 ### Why a given value does (or does not) appear

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -158,6 +158,19 @@ const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
     // attached in the console) surfaces as a genuine undeclared value, no FP.
     MethodResponses: 'StatusCode',
   },
+  // A Backup plan's rules are keyed by RuleName. AWS MATERIALIZES defaults into each live
+  // rule (CompletionWindowMinutes / StartWindowMinutes / ScheduleExpressionTimezone, plus
+  // empty CopyActions/ScanActions/IndexActions/RecoveryPointTags) — folded via
+  // KNOWN_DEFAULT_PATHS + isTrivialEmpty — so a clean plan stays clean, but an out-of-band
+  // change to a compliance-relevant rule setting (e.g. a shortened CompletionWindowMinutes)
+  // surfaces. Proven live.
+  'AWS::Backup::BackupPlan': { 'BackupPlan.BackupPlanRule': 'RuleName' },
+  // A Route53 Resolver DNS-firewall rule group's rules are keyed by Priority. AWS
+  // materializes defaults into each live rule (FirewallThreatProtectionId NOT_APPLICABLE,
+  // FirewallDomainRedirectionAction INSPECT_REDIRECTION_DOMAIN) — folded via
+  // KNOWN_DEFAULT_PATHS — so a security-relevant out-of-band change (a rule's Action /
+  // BlockResponse flipped in the console) surfaces. Proven live.
+  'AWS::Route53Resolver::FirewallRuleGroup': { FirewallRules: 'Priority' },
 };
 
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -554,6 +554,25 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // the parent Resource's id). Genuine resource-/account-/throughput inventory stays
 // EXCLUDED from both (Budgets `Budget.BudgetName`, DynamoDB GSI `*.WarmThroughput`).
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // AWS Backup materializes these defaults into each live BackupPlanRule (keyed by RuleName
+  // — descended via NESTED_ARRAY_IDENTITY). Folding them keeps a clean plan clean; an
+  // out-of-band change away from one still surfaces (equality-gated). Proven live: a
+  // CDK-default daily rule reads back StartWindowMinutes 480 / CompletionWindowMinutes 10080
+  // / ScheduleExpressionTimezone Etc/UTC (the empty CopyActions/ScanActions/IndexActions/
+  // RecoveryPointTags fold via isTrivialEmpty).
+  'AWS::Backup::BackupPlan': {
+    'BackupPlan.BackupPlanRule.*.CompletionWindowMinutes': 10080,
+    'BackupPlan.BackupPlanRule.*.StartWindowMinutes': 480,
+    'BackupPlan.BackupPlanRule.*.ScheduleExpressionTimezone': 'Etc/UTC',
+  },
+  // AWS Route53 Resolver materializes a FirewallDomainRedirectionAction default into each
+  // live FirewallRule (keyed by Priority — descended via NESTED_ARRAY_IDENTITY).
+  // Equality-gated, so a rule changed away from the default still surfaces. Proven live on a
+  // CDK-default BLOCK rule. (The sibling FirewallThreatProtectionId is readOnly — stripped
+  // before the nested loop — so it needs no entry here.)
+  'AWS::Route53Resolver::FirewallRuleGroup': {
+    'FirewallRules.*.FirewallDomainRedirectionAction': 'INSPECT_REDIRECTION_DOMAIN',
+  },
   'AWS::ApiGateway::DomainName': {
     // AWS sets a custom domain's IP address type to ipv4 when the template leaves
     // EndpointConfiguration.IpAddressType unset — a server default, not user intent.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3247,7 +3247,11 @@ describe('nested KNOWN_DEFAULT_PATHS folding (R108 — hand-coded nested service
     if (rest.length === 0) return [{}, { [head!]: value }];
     if (rest[0] === '*') {
       const [d, l] = buildNested(rest.slice(1), value);
-      return [{ [head!]: [{ Id: 'x', ...d }] }, { [head!]: [{ Id: 'x', ...l }] }];
+      // Carry every identity field the alignment might use — the generic IDENTITY_FIELDS
+      // `Id`, plus the NESTED_ARRAY_IDENTITY overrides (Backup RuleName, Route53 Priority) —
+      // all set to `x`, so the element aligns to `[x]` whichever key the type uses.
+      const id = { Id: 'x', RuleName: 'x', Priority: 'x' };
+      return [{ [head!]: [{ ...id, ...d }] }, { [head!]: [{ ...id, ...l }] }];
     }
     const [d, l] = buildNested(rest, value);
     return [{ [head!]: d }, { [head!]: l }];
@@ -4637,5 +4641,88 @@ describe('NESTED_ARRAY_IDENTITY: ApiGateway Method MethodResponses keyed by Stat
       bare
     );
     expect(findings.filter((f) => f.tier === 'undeclared')).toHaveLength(0);
+  });
+});
+
+describe('NESTED_ARRAY_IDENTITY: materialized-default array elements (Backup / Route53Resolver)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'R',
+    resourceType,
+    physicalId: 'p',
+    declared,
+  });
+  const undeclaredPaths = (r: DesiredResource, live: Record<string, unknown>): string[] =>
+    classifyResource(r, live, bare)
+      .filter((f) => f.tier === 'undeclared')
+      .map((f) => f.path)
+      .sort();
+
+  it('Backup BackupPlanRule (keyed by RuleName): AWS defaults fold, a changed window surfaces', () => {
+    const declared = res('AWS::Backup::BackupPlan', {
+      BackupPlan: {
+        BackupPlanRule: [{ RuleName: 'Daily', ScheduleExpression: 'cron(0 3 * * ? *)' }],
+      },
+    });
+    const clean = {
+      BackupPlan: {
+        BackupPlanRule: [
+          {
+            RuleName: 'Daily',
+            ScheduleExpression: 'cron(0 3 * * ? *)',
+            CompletionWindowMinutes: 10080,
+            StartWindowMinutes: 480,
+            ScheduleExpressionTimezone: 'Etc/UTC',
+            CopyActions: [],
+          },
+        ],
+      },
+    };
+    // all materialized defaults fold (atDefault) or are trivially empty -> no undeclared drift
+    expect(undeclaredPaths(declared, clean)).toEqual([]);
+    // an out-of-band CompletionWindowMinutes surfaces (no longer the default)
+    const drifted = structuredClone(clean);
+    (drifted.BackupPlan.BackupPlanRule[0] as Record<string, unknown>).CompletionWindowMinutes =
+      5000;
+    expect(undeclaredPaths(declared, drifted)).toContain(
+      'BackupPlan.BackupPlanRule[Daily].CompletionWindowMinutes'
+    );
+  });
+
+  it('Route53Resolver FirewallRules (keyed by Priority): redirection default folds, a change surfaces', () => {
+    const declared = res('AWS::Route53Resolver::FirewallRuleGroup', {
+      FirewallRules: [{ Priority: 100, Action: 'BLOCK' }],
+    });
+    const clean = {
+      FirewallRules: [
+        {
+          Priority: 100,
+          Action: 'BLOCK',
+          FirewallDomainRedirectionAction: 'INSPECT_REDIRECTION_DOMAIN',
+        },
+      ],
+    };
+    expect(undeclaredPaths(declared, clean)).toEqual([]);
+    const drifted = {
+      FirewallRules: [
+        {
+          Priority: 100,
+          Action: 'BLOCK',
+          FirewallDomainRedirectionAction: 'TRUST_REDIRECTION_DOMAIN',
+        },
+      ],
+    };
+    expect(undeclaredPaths(declared, drifted)).toContain(
+      'FirewallRules[100].FirewallDomainRedirectionAction'
+    );
   });
 });

--- a/tests/corpus/AWS__Backup__BackupPlan.PlanDAF4E53A.json
+++ b/tests/corpus/AWS__Backup__BackupPlan.PlanDAF4E53A.json
@@ -68,5 +68,36 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "PlanDAF4E53A",
+      "resourceType": "AWS::Backup::BackupPlan",
+      "path": "BackupPlan.BackupPlanRule[Daily].CompletionWindowMinutes",
+      "actual": 10080,
+      "nested": true,
+      "physicalId": "4e662c50-8d81-4e43-b41d-703cacbe0e34",
+      "constructPath": "CdkrdIntegHarvest3/Plan"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PlanDAF4E53A",
+      "resourceType": "AWS::Backup::BackupPlan",
+      "path": "BackupPlan.BackupPlanRule[Daily].StartWindowMinutes",
+      "actual": 480,
+      "nested": true,
+      "physicalId": "4e662c50-8d81-4e43-b41d-703cacbe0e34",
+      "constructPath": "CdkrdIntegHarvest3/Plan"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PlanDAF4E53A",
+      "resourceType": "AWS::Backup::BackupPlan",
+      "path": "BackupPlan.BackupPlanRule[Daily].ScheduleExpressionTimezone",
+      "actual": "Etc/UTC",
+      "nested": true,
+      "physicalId": "4e662c50-8d81-4e43-b41d-703cacbe0e34",
+      "constructPath": "CdkrdIntegHarvest3/Plan"
+    }
+  ]
 }

--- a/tests/corpus/AWS__Route53Resolver__FirewallRuleGroup.FwRuleGroup.json
+++ b/tests/corpus/AWS__Route53Resolver__FirewallRuleGroup.FwRuleGroup.json
@@ -91,5 +91,16 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FwRuleGroup",
+      "resourceType": "AWS::Route53Resolver::FirewallRuleGroup",
+      "path": "FirewallRules[100].FirewallDomainRedirectionAction",
+      "actual": "INSPECT_REDIRECTION_DOMAIN",
+      "nested": true,
+      "physicalId": "rslvr-frg-4b70eb88fb1c45ef",
+      "constructPath": "CdkdriftIntegHarvest8/FwRuleGroup"
+    }
+  ]
 }

--- a/tests/integration/nested-array-defaults/app.ts
+++ b/tests/integration/nested-array-defaults/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift "nested array materialized-default" integration test.
+// Two resources whose array elements are keyed by a NON-standard field (not Key/Id/Name/…),
+// so collectNestedUndeclared could not descend them before NESTED_ARRAY_IDENTITY — a silent
+// FN. AWS materializes DEFAULTS into each live element (folded via KNOWN_DEFAULT_PATHS), so a
+// clean stack stays clean, but an out-of-band change to a rule setting surfaces:
+//   - AWS::Backup::BackupPlan  BackupPlanRule (keyed by RuleName) — compliance
+//   - AWS::Route53Resolver::FirewallRuleGroup FirewallRules (keyed by Priority) — security
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { BackupPlan, BackupPlanRule, BackupVault } from "aws-cdk-lib/aws-backup";
+import { Schedule } from "aws-cdk-lib/aws-events";
+import { CfnFirewallDomainList, CfnFirewallRuleGroup } from "aws-cdk-lib/aws-route53resolver";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegNestedDefaults");
+
+const vault = new BackupVault(stack, "Vault", { removalPolicy: RemovalPolicy.DESTROY });
+new BackupPlan(stack, "Plan", {
+  backupVault: vault,
+  backupPlanRules: [
+    new BackupPlanRule({ backupVault: vault, ruleName: "DailyRule", scheduleExpression: Schedule.cron({ hour: "3", minute: "0" }) }),
+  ],
+});
+
+const dl = new CfnFirewallDomainList(stack, "DL", { domains: ["example.com."] });
+dl.applyRemovalPolicy(RemovalPolicy.DESTROY);
+const rg = new CfnFirewallRuleGroup(stack, "RG", {
+  firewallRules: [{ firewallDomainListId: dl.attrId, priority: 100, action: "BLOCK", blockResponse: "NODATA" }],
+});
+rg.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/nested-array-defaults/cdk.json
+++ b/tests/integration/nested-array-defaults/cdk.json
@@ -1,0 +1,1 @@
+{ "app": "node --experimental-strip-types app.ts" }

--- a/tests/integration/nested-array-defaults/package.json
+++ b/tests/integration/nested-array-defaults/package.json
@@ -1,0 +1,2 @@
+{ "name": "cdk-real-drift-integ-nested-array-defaults", "private": true, "version": "0.0.0", "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" } }

--- a/tests/integration/nested-array-defaults/verify.sh
+++ b/tests/integration/nested-array-defaults/verify.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# cdk-real-drift nested-array materialized-default integration test (real AWS).
+#
+# AWS::Backup::BackupPlan rules (keyed by RuleName) and AWS::Route53Resolver::FirewallRuleGroup
+# rules (keyed by Priority) are object-arrays keyed by a NON-standard field, so
+# collectNestedUndeclared could not descend them before NESTED_ARRAY_IDENTITY (a silent FN).
+# AWS materializes defaults into each live element (folded via KNOWN_DEFAULT_PATHS), so:
+#   deploy -> record a baseline -> check is CLEAN (the materialized defaults fold)
+#   -> mutate a rule setting out of band -> check DETECTS it.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNestedDefaults
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp pack) >/dev/null 2>&1 || fail "build"
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+RG_ID="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Route53Resolver::FirewallRuleGroup'].PhysicalResourceId" --output text)"
+PLAN_ID="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Backup::BackupPlan'].PhysicalResourceId" --output text)"
+VAULT="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Backup::BackupVault'].PhysicalResourceId" --output text)"
+DL_ID="$(aws route53resolver list-firewall-rules --firewall-rule-group-id "$RG_ID" --region "$REGION" --query 'FirewallRules[0].FirewallDomainListId' --output text)"
+
+echo "=== record a baseline, then check must be CLEAN (materialized rule defaults fold) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record — a rule default did not fold"
+
+echo "=== mutate a Backup rule (CompletionWindowMinutes 10080->5000) out of band ==="
+PLAN_NAME="$(aws backup get-backup-plan --backup-plan-id "$PLAN_ID" --region "$REGION" --query 'BackupPlan.BackupPlanName' --output text)"
+aws backup update-backup-plan --backup-plan-id "$PLAN_ID" --region "$REGION" \
+  --backup-plan "{\"BackupPlanName\":\"$PLAN_NAME\",\"Rules\":[{\"RuleName\":\"DailyRule\",\"TargetBackupVaultName\":\"$VAULT\",\"ScheduleExpression\":\"cron(0 3 * * ? *)\",\"StartWindowMinutes\":480,\"CompletionWindowMinutes\":5000}]}" >/dev/null \
+  || fail "mutate backup rule"
+
+echo "=== mutate a Route53 firewall rule (FirewallDomainRedirectionAction) out of band ==="
+aws route53resolver update-firewall-rule --firewall-rule-group-id "$RG_ID" --firewall-domain-list-id "$DL_ID" \
+  --region "$REGION" --priority 100 --action BLOCK --block-response NODATA \
+  --firewall-domain-redirection-action TRUST_REDIRECTION_DOMAIN >/dev/null || fail "mutate firewall rule"
+
+echo "=== check must DETECT both out-of-band rule changes ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-integ-nested.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "BackupPlanRule\[DailyRule\].CompletionWindowMinutes" /tmp/cdkrd-integ-nested.out \
+  || fail "Backup rule CompletionWindowMinutes change not detected (RuleName descent missing?)"
+grep -q "FirewallRules\[100\].FirewallDomainRedirectionAction" /tmp/cdkrd-integ-nested.out \
+  || fail "Route53 firewall rule change not detected (Priority descent missing?)"
+
+echo "INTEG PASS"


### PR DESCRIPTION
Closes the silent-FN audit (#3 from the API Gateway thread): object-arrays keyed by a NON-standard field (not Key/Id/Name/AttributeName/IndexName) were never descended by `collectNestedUndeclared`, so an out-of-band change to a sub-field of a declared element was invisible. #405/#409 fixed API Gateway Method; this extends `NESTED_ARRAY_IDENTITY` to two more, both live-verified.

## What & why
AWS MATERIALIZES defaults into each live rule element of these arrays, so the descent is FP-safe only with the defaults catalogued (`KNOWN_DEFAULT_PATHS`) — a clean stack stays clean, a real change surfaces:

- **AWS::Backup::BackupPlan** `BackupPlanRule` (keyed by **RuleName**) — compliance. AWS fills `CompletionWindowMinutes=10080` / `StartWindowMinutes=480` / `ScheduleExpressionTimezone=Etc/UTC` (+ empty CopyActions/ScanActions/IndexActions/RecoveryPointTags → `isTrivialEmpty`). A shortened backup-completion window now surfaces.
- **AWS::Route53Resolver::FirewallRuleGroup** `FirewallRules` (keyed by **Priority**) — security. AWS fills `FirewallDomainRedirectionAction=INSPECT_REDIRECTION_DOMAIN` (the sibling `FirewallThreatProtectionId` is readOnly → already stripped). A DNS-firewall rule flipped in the console now surfaces.

## Audit (the rest)
The descent-gap FN is specific: it only matters when AWS materializes a sub-field into a DECLARED element. I live-checked the candidates from the corpus scan:
- **Ruled OUT** (static config — AWS stores exactly what's declared, no enrichment): EC2 LaunchTemplate BlockDeviceMappings/TagSpecifications, Logs MetricFilter MetricTransformations.
- **Already handled**: policy-statement arrays (`isPolicyStatementArray`), IAM inline Policies, EC2 Instance BlockDeviceMappings/Volumes (`IDENTITY_KEYED_SUBSET_ARRAYS`), the reorder-folded sets (ELB/WAF/ECS/Cognito/GlobalTable per prior PRs).
- The remaining infra-heavy candidates (SNS/Glue/CloudWatch/ELB/etc.) are left to `/hunt-bugs` live probing — the `NESTED_ARRAY_IDENTITY` + `KNOWN_DEFAULT_PATHS` mechanism makes each a ~2-line add once an enrichment is confirmed.

## Live integ (INTEG PASS)
New `tests/integration/nested-array-defaults`: deploy a Backup plan + a Route53 DNS-firewall rule group → record a baseline → check is CLEAN (materialized defaults fold) → mutate a Backup rule's CompletionWindowMinutes and a firewall rule's redirection action out of band → check detects BOTH (2 drift).

## Tests
Unit: classify descent + default-folding for both types; the generic KNOWN_DEFAULT_PATHS folding test taught the non-standard identity keys. Corpus `expected` regenerated for the two harvested cases (real data also exhibits the enrichment). Full suite 1785 green, typecheck 0, lint 0.

Detection only (these nested rule values revert via a per-type SDK writer, a follow-up like the API Gateway one); recorded baselines + the differentiator detection are the win here.
