### PR TITLE
fix(drift): detect omitted-when-empty collection removals; allow conditional-create-only reverts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -699,9 +699,13 @@ only when non-zero — unrecorded values are named as such, never folded into
   settable document), `AWS::Budgets::Budget` (`UpdateBudget` needs a full NewBudget
   the reader can't reconstruct), a `deleted` resource (`deleted — recreate via cdk
 deploy`: a patch can't recreate a resource), a **create-only** property (drift on a
-  `createOnlyProperties` / `conditionalCreateOnlyProperties` field needs a resource
-  replacement, which an in-place `UpdateResource` can't do — caught from the schema
-  at plan time, not at apply time), and a nested undeclared value whose path
+  HARD `createOnlyProperties` field needs a resource replacement, which an in-place
+  `UpdateResource` can't do — caught from the schema at plan time, not at apply
+  time; `conditionalCreateOnlyProperties` are NOT barred — they are create-only only
+  in specific cases and mutable in the common one, e.g. RDS `BackupRetentionPeriod` /
+  `MultiAZ` / `StorageType`, so revert attempts them and Cloud Control rejects
+  cleanly if a change truly needs replacement), and a nested undeclared value whose
+  path
   addresses an **array element** (`Prop[<id>].sub` — the bracket can't be expressed
   as an RFC6902 pointer), plus any `readGap` / `unresolved` / `skipped` finding. A
   nested undeclared value on a PURE-DOTTED path IS revertable — Cloud Control applies
@@ -833,6 +837,16 @@ inherit the terminal's TTY, so prompts would otherwise fire mid-script). Errors
 always exit 2. All three of `deleted` / `declared` / `undeclared` count as
 failing drift. `ignored` / `readGap` / `unresolved` / `skipped` are
 informational — surfaced, never silently dropped, but never false drift.
+
+A declared property absent from the live read defaults to `readGap` — EXCEPT for the
+curated `OMITTED_WHEN_EMPTY_PATHS` (`normalize/noise.ts`): properties Cloud Control
+RETURNS when set but OMITS when empty (EC2 SecurityGroup ingress/egress rules, IAM
+inline `Policies`, S3 `Cors`/`LifecycleConfiguration`, Lambda `Environment`). For
+those, absence means the whole collection was removed out of band — a real
+`declared` drift (one whole-property finding so revert re-applies it with a single
+top-level `add`), not a `readGap`. It is curated, not a blanket rule: many genuine
+non-writeOnly readGaps (Batch `Timeout`, DynamoDB `SSESpecification`, …) AWS never
+returns even when set, so treating every absence as drift would false-positive them.
 
 `ignored` (R32) is for properties an external system legitimately keeps rewriting —
 Application Auto Scaling moving an ECS Service `DesiredCount`, DynamoDB autoscaled

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -47,6 +47,7 @@ import {
   isEpochHourEqual,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
+  OMITTED_WHEN_EMPTY_PATHS,
   ELB_ATTRIBUTE_DEFAULTS,
   PARAMETER_NAME_SUBSET_PATHS,
   alignParameterNameSubset,
@@ -543,13 +544,36 @@ export function classifyResource(
       // The compare below skips any per-leaf record whose declared side is unresolved.
       if (v === UNRESOLVED || !(k in live)) continue;
     } else if (!(k in live)) {
-      findings.push({
-        tier: 'readGap',
-        logicalId,
-        resourceType,
-        path: k,
-        note: 'declared but not returned by live read',
-      });
+      // A property AWS's CC read OMITS when empty but RETURNS when set (SecurityGroup
+      // ingress/egress rules, IAM inline Policies, S3 Cors/LifecycleConfiguration):
+      // its absence is NOT a readGap — the whole declared collection was emptied/
+      // removed out of band. Emit ONE WHOLE-PROPERTY declared finding so the removal
+      // surfaces as drift AND revert re-applies the entire config via a single
+      // top-level `add` (a nested sub-path patch fails — the parent it targets, e.g.
+      // `/CorsConfiguration`, does not exist in the live model). FP-safe: a non-empty
+      // value is always returned by AWS, so this only fires on a genuine removal.
+      // Curated per-type — a general "absent → drift" rule would false-positive the
+      // legitimate non-writeOnly readGaps AWS never returns (Batch Timeout, DynamoDB
+      // SSESpecification, …). (See OMITTED_WHEN_EMPTY_PATHS.)
+      const isCollection = Array.isArray(v) || (v !== null && typeof v === 'object');
+      if (OMITTED_WHEN_EMPTY_PATHS[resourceType]?.has(k) && isCollection) {
+        findings.push({
+          tier: 'declared',
+          logicalId,
+          resourceType,
+          path: k,
+          desired: v,
+          actual: undefined,
+        });
+      } else {
+        findings.push({
+          tier: 'readGap',
+          logicalId,
+          resourceType,
+          path: k,
+          note: 'declared but not returned by live read',
+        });
+      }
       continue;
     }
     // A CloudFormation JSON-STRING property (AWS::Config::ConfigRule InputParameters):

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1649,6 +1649,48 @@ export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
   return sa.every((v, i) => v === sb[i]);
 }
 
+// Per-type properties whose Cloud Control read OMITS the key entirely when it has no
+// value, yet RETURNS it when set. The default classify rule treats "declared key
+// absent from the live read" as a readGap (declared-but-unreadable) — correct for a
+// genuinely unreadable/write-only prop, but a SILENT FALSE NEGATIVE here: the key is
+// readable, so its absence means the declared value was emptied/removed out of band
+// (someone deleted the SecurityGroup ingress rule in the console) and MUST surface as
+// drift. classify synthesizes an empty live value (`[]`) for these so the removal
+// flows through the normal compare + revert path instead of being swallowed as a
+// readGap. FP-safe: on a clean stack the declared value is non-empty, so AWS returns
+// it (present in live) and this branch never fires. EC2 SecurityGroup ingress/egress
+// is the confirmed case (live-observed: revoking the only ingress rule made CC omit
+// `SecurityGroupIngress`, which classify reported CLEAN). Curated per-type opt-in —
+// a prop that is a genuine readGap on some type must NOT be added here.
+export const OMITTED_WHEN_EMPTY_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::EC2::SecurityGroup': new Set(['SecurityGroupIngress', 'SecurityGroupEgress']),
+  // IAM inline `Policies`: Cloud Control returns the array when the principal has
+  // inline policies and OMITS it entirely when it has none. Deleting the only inline
+  // policy out of band (`aws iam delete-role-policy`) — a security-relevant change —
+  // therefore looked CLEAN (readGap) pre-fix. Live-confirmed on AWS::IAM::Role; User
+  // and Group share the identical inline-policy mechanism (PutUserPolicy /
+  // PutGroupPolicy, same `Policies` shape). FP-safe: a non-empty `Policies` is always
+  // returned, so this only fires on a genuine removal.
+  'AWS::IAM::Role': new Set(['Policies']),
+  'AWS::IAM::User': new Set(['Policies']),
+  'AWS::IAM::Group': new Set(['Policies']),
+  // S3 bucket sub-configs (the most-deployed resource): Cloud Control returns these
+  // object-valued configs when set and OMITS them once removed
+  // (`aws s3api delete-bucket-cors` / `delete-bucket-lifecycle`). A declared CORS or
+  // lifecycle policy deleted out of band therefore looked CLEAN (readGap) pre-fix.
+  // Live-confirmed on AWS::S3::Bucket. These are OBJECT-valued (Cors = {CorsRules},
+  // Lifecycle = {Rules}); classify synthesizes an empty object so the removal compares
+  // as declared drift. Only the two live-proven configs are listed — other S3 configs
+  // (Notification/Replication/Website/…) are candidates for a future probe.
+  'AWS::S3::Bucket': new Set(['CorsConfiguration', 'LifecycleConfiguration']),
+  // Lambda `Environment`: Cloud Control returns it when the function has env vars and
+  // OMITS it once they are all cleared (`update-function-configuration --environment
+  // '{"Variables":{}}'`). A declared env config wiped out of band therefore looked
+  // CLEAN (readGap) pre-fix. Live-confirmed on AWS::Lambda::Function. Object-valued
+  // ({Variables:{…}}); reverts via a top-level CC add → UpdateFunctionConfiguration.
+  'AWS::Lambda::Function': new Set(['Environment']),
+};
+
 // Per-type OBJECT-array props AWS treats as UNORDERED SETS whose element objects
 // carry NO single identity field (so canonicalizeTagListsDeep cannot key them) and
 // are NOT scalar (so isEqualUnorderedScalarSet does not apply): EC2 SecurityGroup

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -282,12 +282,17 @@ export function parseSchema(schemaJson: string): SchemaInfo {
   const topLevel = (paths: string[]): Set<string> => new Set(paths.filter((p) => !p.includes('.')));
   const readOnlyPaths = dotted(schema.readOnlyProperties);
   const writeOnlyPaths = dotted(schema.writeOnlyProperties);
-  // createOnly + conditionalCreateOnly both mean "you cannot change this in place"
-  // (a full / conditional replacement is required) — treat both as not-revertable.
-  const createOnlyPaths = [
-    ...dotted(schema.createOnlyProperties),
-    ...dotted(schema.conditionalCreateOnlyProperties),
-  ];
+  // Only HARD `createOnlyProperties` bar a revert. `conditionalCreateOnlyProperties`
+  // are create-only ONLY in specific cases (e.g. an RDS read replica) — in the common
+  // case they are MUTABLE in place (RDS BackupRetentionPeriod / MultiAZ / StorageType /
+  // PreferredMaintenanceWindow / AutoMinorVersionUpgrade are all modifiable via
+  // ModifyDBInstance). Merging them in barred revert of these everyday props with a
+  // misleading "create-only — requires replacement" (a revert false-negative on a very
+  // common resource). They are NOT barred now: a revert attempts the in-place change
+  // and, if a specific change truly needs replacement, Cloud Control UpdateResource
+  // rejects it cleanly (it never silently replaces) — an honest failure beats a silent
+  // bar. (Live-confirmed on AWS::RDS::DBInstance BackupRetentionPeriod.)
+  const createOnlyPaths = dotted(schema.createOnlyProperties);
   const defaults: Record<string, unknown> = {};
   for (const [k, def] of Object.entries(schema.properties ?? {})) {
     if (def && typeof def === 'object' && 'default' in def) defaults[k] = def.default;

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4726,3 +4726,158 @@ describe('NESTED_ARRAY_IDENTITY: materialized-default array elements (Backup / R
     );
   });
 });
+
+// A property AWS's Cloud Control read OMITS entirely when it has no value, yet
+// RETURNS when set (EC2 SecurityGroup SecurityGroupIngress/Egress). Its absence from
+// the live read must NOT be swallowed as a readGap — it means the declared rule was
+// removed out of band (the canonical "someone deleted the SSH rule in the console"),
+// which is a silent FALSE NEGATIVE. Live-observed: revoking the only ingress rule made
+// CC drop the key and classify reported CLEAN. See OMITTED_WHEN_EMPTY_PATHS.
+describe('OMITTED_WHEN_EMPTY_PATHS — readable prop AWS omits when empty', () => {
+  const sgSchema: SchemaInfo = {
+    readOnly: new Set(['Id', 'GroupId']),
+    writeOnly: new Set(),
+    createOnly: new Set(['GroupDescription', 'VpcId']),
+    readOnlyPaths: ['Id', 'GroupId'],
+    writeOnlyPaths: [],
+    createOnlyPaths: ['GroupDescription', 'VpcId'],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const rule = {
+    CidrIp: '10.0.0.0/16',
+    Description: 'ssh from vpc',
+    FromPort: 22,
+    IpProtocol: 'tcp',
+    ToPort: 22,
+  };
+  const sg = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'Sg',
+    resourceType: 'AWS::EC2::SecurityGroup',
+    physicalId: 'sg-123',
+    declared,
+  });
+
+  it('declared ingress rule removed out of band (CC omits the key) -> declared drift, NOT readGap', () => {
+    const findings = classifyResource(
+      sg({ GroupDescription: 'd', SecurityGroupIngress: [rule] }),
+      // live read omits SecurityGroupIngress entirely (no rules); egress present
+      {
+        GroupDescription: 'd',
+        SecurityGroupEgress: [{ CidrIp: '0.0.0.0/0', IpProtocol: '-1', FromPort: -1, ToPort: -1 }],
+      },
+      sgSchema
+    );
+    const decl = findings.filter((f) => f.tier === 'declared').map((f) => f.path);
+    expect(decl).toContain('SecurityGroupIngress');
+    // the removal must NOT be misclassified as an (informational, non-failing) readGap
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'SecurityGroupIngress')).toBe(
+      false
+    );
+  });
+
+  it('declared egress rule removed out of band -> declared drift, NOT readGap', () => {
+    const findings = classifyResource(
+      sg({ GroupDescription: 'd', SecurityGroupEgress: [rule] }),
+      { GroupDescription: 'd' }, // live omits both ingress & egress
+      sgSchema
+    );
+    const decl = findings.filter((f) => f.tier === 'declared').map((f) => f.path);
+    expect(decl).toContain('SecurityGroupEgress');
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'SecurityGroupEgress')).toBe(
+      false
+    );
+  });
+
+  it('a still-present ingress rule (CC returns it) compares normally (no false drift)', () => {
+    const findings = classifyResource(
+      sg({ GroupDescription: 'd', SecurityGroupIngress: [rule] }),
+      { GroupDescription: 'd', SecurityGroupIngress: [rule] },
+      sgSchema
+    );
+    expect(findings.filter((f) => f.tier === 'declared')).toHaveLength(0);
+    expect(findings.some((f) => f.path === 'SecurityGroupIngress')).toBe(false);
+  });
+
+  it('IAM Role inline Policies removed out of band (CC omits Policies) -> declared drift, NOT readGap', () => {
+    const roleSchema: SchemaInfo = {
+      readOnly: new Set(['Arn', 'RoleId']),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: ['Arn', 'RoleId'],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const policy = {
+      PolicyName: 'inline-1',
+      PolicyDocument: {
+        Version: '2012-10-17',
+        Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }],
+      },
+    };
+    const findings = classifyResource(
+      {
+        logicalId: 'Role',
+        resourceType: 'AWS::IAM::Role',
+        physicalId: 'role-1',
+        declared: { RoleName: 'role-1', Policies: [policy] },
+      },
+      { RoleName: 'role-1' }, // live omits Policies (no inline policies)
+      roleSchema
+    );
+    const decl = findings.filter((f) => f.tier === 'declared').map((f) => f.path);
+    expect(decl).toContain('Policies');
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'Policies')).toBe(false);
+  });
+
+  it('S3 object-valued config removed out of band (CC omits it) -> ONE whole-property declared drift', () => {
+    const s3Schema: SchemaInfo = {
+      readOnly: new Set(['Arn']),
+      writeOnly: new Set(),
+      createOnly: new Set(['BucketName']),
+      readOnlyPaths: ['Arn'],
+      writeOnlyPaths: [],
+      createOnlyPaths: ['BucketName'],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const cors = {
+      CorsRules: [{ AllowedMethods: ['GET'], AllowedOrigins: ['https://example.com'] }],
+    };
+    const findings = classifyResource(
+      {
+        logicalId: 'Bucket',
+        resourceType: 'AWS::S3::Bucket',
+        physicalId: 'b-1',
+        declared: { BucketName: 'b-1', CorsConfiguration: cors },
+      },
+      { BucketName: 'b-1' }, // live omits CorsConfiguration (removed)
+      s3Schema
+    );
+    const decl = findings.filter((f) => f.tier === 'declared');
+    // exactly one WHOLE-PROPERTY finding (not a nested CorsConfiguration.CorsRules
+    // patch, which would fail to revert: the parent doesn't exist in the live model)
+    expect(decl.map((f) => f.path)).toEqual(['CorsConfiguration']);
+    expect(decl[0].desired).toEqual(cors);
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'CorsConfiguration')).toBe(
+      false
+    );
+  });
+
+  it('curated, not blanket: an absent declared array on a type NOT in the table stays a readGap', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'T',
+        resourceType: 'AWS::SomeOther::Type',
+        physicalId: 'p',
+        declared: { SomeArray: [rule] },
+      },
+      {},
+      sgSchema
+    );
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'SomeArray')).toBe(true);
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'SomeArray')).toBe(false);
+  });
+});

--- a/tests/corpus/AWS__Cognito__UserPoolRiskConfigurationAttachment.RiskConfig.json
+++ b/tests/corpus/AWS__Cognito__UserPoolRiskConfigurationAttachment.RiskConfig.json
@@ -1,0 +1,79 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RiskConfig",
+    "resourceType": "AWS::Cognito::UserPoolRiskConfigurationAttachment",
+    "physicalId": "us-east-1_QQaweoixK|3fdc6es5i78e0ja0c2rhjqt7gu",
+    "constructPath": "CdkRealDriftIntegCognitoAttachmentReadgap/RiskConfig",
+    "declared": {
+      "AccountTakeoverRiskConfiguration": {
+        "Actions": {
+          "HighAction": {
+            "EventAction": "NO_ACTION",
+            "Notify": false
+          },
+          "LowAction": {
+            "EventAction": "NO_ACTION",
+            "Notify": false
+          },
+          "MediumAction": {
+            "EventAction": "NO_ACTION",
+            "Notify": false
+          }
+        }
+      },
+      "ClientId": "3fdc6es5i78e0ja0c2rhjqt7gu",
+      "CompromisedCredentialsRiskConfiguration": {
+        "Actions": {
+          "EventAction": "BLOCK"
+        }
+      },
+      "UserPoolId": "us-east-1_QQaweoixK"
+    }
+  },
+  "liveRaw": {
+    "CompromisedCredentialsRiskConfiguration": {
+      "Actions": {
+        "EventAction": "BLOCK"
+      },
+      "EventFilter": []
+    },
+    "UserPoolId": "us-east-1_QQaweoixK",
+    "ClientId": "3fdc6es5i78e0ja0c2rhjqt7gu",
+    "AccountTakeoverRiskConfiguration": {
+      "Actions": {
+        "HighAction": {
+          "Notify": false,
+          "EventAction": "NO_ACTION"
+        },
+        "LowAction": {
+          "Notify": false,
+          "EventAction": "NO_ACTION"
+        },
+        "MediumAction": {
+          "Notify": false,
+          "EventAction": "NO_ACTION"
+        }
+      }
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ClientId", "UserPoolId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ClientId", "UserPoolId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPoolUICustomizationAttachment.UICustomization.json
+++ b/tests/corpus/AWS__Cognito__UserPoolUICustomizationAttachment.UICustomization.json
@@ -1,0 +1,38 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "UICustomization",
+    "resourceType": "AWS::Cognito::UserPoolUICustomizationAttachment",
+    "physicalId": "us-east-1_QQaweoixK|3fdc6es5i78e0ja0c2rhjqt7gu",
+    "constructPath": "CdkRealDriftIntegCognitoAttachmentReadgap/UICustomization",
+    "declared": {
+      "CSS": ".banner-customizable { background-color: #112233; }",
+      "ClientId": "3fdc6es5i78e0ja0c2rhjqt7gu",
+      "UserPoolId": "us-east-1_QQaweoixK"
+    }
+  },
+  "liveRaw": {
+    "CSS": ".banner-customizable { background-color: #112233; }",
+    "UserPoolId": "us-east-1_QQaweoixK",
+    "ClientId": "3fdc6es5i78e0ja0c2rhjqt7gu"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ClientId", "UserPoolId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ClientId", "UserPoolId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SecurityGroup.SgIngressRemoved.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.SgIngressRemoved.json
@@ -1,0 +1,112 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Sg",
+    "resourceType": "AWS::EC2::SecurityGroup",
+    "physicalId": "CdkRealDriftIntegSgIngressRevert-Sg-e2O1KpNrq5cz",
+    "constructPath": "CdkRealDriftIntegSgIngressRevert/Sg",
+    "declared": {
+      "GroupDescription": "cdkrd sg ingress revert probe",
+      "SecurityGroupIngress": [
+        {
+          "CidrIp": "10.0.0.0/16",
+          "Description": "ssh from vpc",
+          "FromPort": 22,
+          "IpProtocol": "tcp",
+          "ToPort": 22
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "GroupDescription": "cdkrd sg ingress revert probe",
+    "GroupName": "CdkRealDriftIntegSgIngressRevert-Sg-e2O1KpNrq5cz",
+    "VpcId": "vpc-08cae0035717deb9d",
+    "Id": "sg-07fa40ce5b641ab56",
+    "SecurityGroupEgress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "-1"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "Sg",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSgIngressRevert",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSgIngressRevert/18bbfb40-731b-11f1-8aa4-0e0ebf5eea53",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "GroupId": "sg-07fa40ce5b641ab56"
+  },
+  "schema": {
+    "readOnly": ["GroupId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["GroupDescription", "GroupName", "VpcId"],
+    "readOnlyPaths": ["GroupId", "Id"],
+    "writeOnlyPaths": ["SecurityGroupIngress.*.SourceSecurityGroupName"],
+    "createOnlyPaths": ["GroupDescription", "GroupName", "VpcId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "Sg",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "SecurityGroupIngress",
+      "desired": [
+        {
+          "CidrIp": "10.0.0.0/16",
+          "Description": "ssh from vpc",
+          "FromPort": 22,
+          "IpProtocol": "tcp",
+          "ToPort": 22
+        }
+      ],
+      "physicalId": "CdkRealDriftIntegSgIngressRevert-Sg-e2O1KpNrq5cz",
+      "constructPath": "CdkRealDriftIntegSgIngressRevert/Sg"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Sg",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "VpcId",
+      "actual": "vpc-08cae0035717deb9d",
+      "physicalId": "CdkRealDriftIntegSgIngressRevert-Sg-e2O1KpNrq5cz",
+      "constructPath": "CdkRealDriftIntegSgIngressRevert/Sg"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Sg",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "SecurityGroupEgress",
+      "actual": [
+        {
+          "CidrIp": "0.0.0.0/0",
+          "FromPort": -1,
+          "ToPort": -1,
+          "IpProtocol": "-1"
+        }
+      ],
+      "physicalId": "CdkRealDriftIntegSgIngressRevert-Sg-e2O1KpNrq5cz",
+      "constructPath": "CdkRealDriftIntegSgIngressRevert/Sg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__IAM__Role.RoleInlinePolicyRemoved.json
+++ b/tests/corpus/AWS__IAM__Role.RoleInlinePolicyRemoved.json
@@ -1,0 +1,132 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Role",
+    "resourceType": "AWS::IAM::Role",
+    "physicalId": "CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+    "constructPath": "CdkRealDriftIntegIamInlinePolicyOmit/Role",
+    "declared": {
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      },
+      "Policies": [
+        {
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "*"
+              }
+            ]
+          },
+          "PolicyName": "cdkrd-inline-1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Path": "/",
+    "MaxSessionDuration": 3600,
+    "RoleName": "CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+    "Description": "",
+    "AssumeRolePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "ec2.amazonaws.com"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+    "RoleId": "AROAXXXJN2LNXKFDBERNC"
+  },
+  "schema": {
+    "readOnly": ["Arn", "RoleId"],
+    "writeOnly": [],
+    "createOnly": ["Path", "RoleName"],
+    "readOnlyPaths": ["Arn", "RoleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Path", "RoleName"],
+    "defaults": {
+      "Path": "/"
+    },
+    "defaultPaths": {
+      "Path": "/"
+    },
+    "unorderedScalarPaths": ["ManagedPolicyArns"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "Role",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Policies",
+      "desired": [
+        {
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Action": ["s3:GetObject"],
+                "Effect": "Allow",
+                "Resource": ["*"]
+              }
+            ]
+          },
+          "PolicyName": "cdkrd-inline-1"
+        }
+      ],
+      "physicalId": "CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+      "constructPath": "CdkRealDriftIntegIamInlinePolicyOmit/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Role",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Path",
+      "actual": "/",
+      "physicalId": "CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+      "constructPath": "CdkRealDriftIntegIamInlinePolicyOmit/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Role",
+      "resourceType": "AWS::IAM::Role",
+      "path": "MaxSessionDuration",
+      "actual": 3600,
+      "physicalId": "CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+      "constructPath": "CdkRealDriftIntegIamInlinePolicyOmit/Role"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Role",
+      "resourceType": "AWS::IAM::Role",
+      "path": "Description",
+      "actual": "",
+      "physicalId": "CdkRealDriftIntegIamInlinePolicyOmit-Role-47A0IvmQeElz",
+      "constructPath": "CdkRealDriftIntegIamInlinePolicyOmit/Role"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__Function.FnEnvRemoved.json
+++ b/tests/corpus/AWS__Lambda__Function.FnEnvRemoved.json
@@ -1,0 +1,215 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Fn9270CBC0",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+    "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn",
+    "declared": {
+      "Code": {
+        "ZipFile": "exports.handler = async () => ({ ok: true });"
+      },
+      "Environment": {
+        "Variables": {
+          "FOO": "bar",
+          "BAZ": "qux"
+        }
+      },
+      "Handler": "index.handler",
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaEnvOmi-FnServiceRoleB9001A96-6DR2HE1CRl4t",
+      "Runtime": "nodejs18.x"
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 128,
+    "Description": "",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "VpcConfig": {
+      "Ipv6AllowedForDualStack": false,
+      "SecurityGroupIds": [],
+      "SubnetIds": []
+    },
+    "Timeout": 3,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaEnvOmi-FnServiceRoleB9001A96-6DR2HE1CRl4t",
+    "FileSystemConfigs": [],
+    "FunctionName": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+    "Runtime": "nodejs18.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe"
+    },
+    "RecursiveLoop": "Terminate",
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambdaEnvOmit/9ee34170-731f-11f1-8ad1-0affd527d681",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Fn9270CBC0",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegLambdaEnvOmit",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["DurableConfig", "FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Environment",
+      "desired": {
+        "Variables": {
+          "FOO": "bar",
+          "BAZ": "qux"
+        }
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "MemorySize",
+      "actual": 128,
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Timeout",
+      "actual": 3,
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkRealDriftIntegLambdaEnvOmit-Fn9270CBC0-KLr7OInugBLe",
+      "constructPath": "CdkRealDriftIntegLambdaEnvOmit/Fn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.BucketConfigRemoved.json
+++ b/tests/corpus/AWS__S3__Bucket.BucketConfigRemoved.json
@@ -1,0 +1,221 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Bucket83908E77",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+    "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket",
+    "declared": {
+      "CorsConfiguration": {
+        "CorsRules": [
+          {
+            "AllowedHeaders": ["*"],
+            "AllowedMethods": ["GET"],
+            "AllowedOrigins": ["https://example.com"]
+          }
+        ]
+      },
+      "LifecycleConfiguration": {
+        "Rules": [
+          {
+            "ExpirationInDays": 90,
+            "Id": "expire-90",
+            "Status": "Enabled"
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+    "RegionalDomainName": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "DomainName": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3ConfigOmit/9ee4ef20-731f-11f1-a4d5-0affd6af8e65",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegS3ConfigOmit",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Bucket83908E77",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "Bucket83908E77",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "CorsConfiguration",
+      "desired": {
+        "CorsRules": [
+          {
+            "AllowedHeaders": ["*"],
+            "AllowedMethods": ["GET"],
+            "AllowedOrigins": ["https://example.com"]
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+      "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket"
+    },
+    {
+      "tier": "declared",
+      "logicalId": "Bucket83908E77",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "LifecycleConfiguration",
+      "desired": {
+        "Rules": [
+          {
+            "ExpirationInDays": 90,
+            "Id": "expire-90",
+            "Status": "Enabled"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+      "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket83908E77",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+      "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket83908E77",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+      "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket83908E77",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+      "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket83908E77",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3configomit-bucket83908e77-ltlblakxxmol",
+      "constructPath": "CdkRealDriftIntegS3ConfigOmit/Bucket"
+    }
+  ]
+}

--- a/tests/integration/cognito-attachment-readgap/app.ts
+++ b/tests/integration/cognito-attachment-readgap/app.ts
@@ -1,0 +1,69 @@
+// CDK app for the cdk-real-drift Cognito attachment read-gap test.
+//
+// AWS::Cognito::UserPoolRiskConfigurationAttachment and
+// AWS::Cognito::UserPoolUICustomizationAttachment both have a COMPOSITE Cloud
+// Control primaryIdentifier [UserPoolId, ClientId], but their CloudFormation Ref
+// (physical id) is a synthetic string that is NEITHER segment nor the pipe form.
+// Without a CC_IDENTIFIER_ADAPTERS entry, Cloud Control GetResource rejects the
+// bare physical id with a ValidationException, so cdkrd silently SKIPS the
+// resource — any out-of-band drift on it is invisible (a false negative).
+//
+// This fixture deploys both attachments against a real user pool + client so the
+// read-gap can be reproduced (check shows skipped=) and the adapter fix verified
+// (check reads them; a freshly recorded stack is CLEAN; an out-of-band mutation is
+// detected).
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnUserPool,
+  CfnUserPoolClient,
+  CfnUserPoolDomain,
+  CfnUserPoolRiskConfigurationAttachment,
+  CfnUserPoolUICustomizationAttachment,
+} from "aws-cdk-lib/aws-cognito";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCognitoAttachmentReadgap");
+
+// PLUS tier enables threat protection, required by RiskConfigurationAttachment.
+const pool = new CfnUserPool(stack, "Pool", {
+  userPoolName: "cdkrd-attach-pool",
+  userPoolTier: "PLUS",
+  userPoolAddOns: { advancedSecurityMode: "AUDIT" },
+});
+
+const client = new CfnUserPoolClient(stack, "Client", {
+  userPoolId: pool.ref,
+  clientName: "cdkrd-attach-client",
+  generateSecret: false,
+  explicitAuthFlows: ["ALLOW_USER_PASSWORD_AUTH", "ALLOW_REFRESH_TOKEN_AUTH"],
+});
+
+// UICustomizationAttachment requires an existing hosted-UI domain on the pool.
+const domain = new CfnUserPoolDomain(stack, "Domain", {
+  userPoolId: pool.ref,
+  domain: "cdkrd-attach-x7q2z9",
+});
+
+new CfnUserPoolRiskConfigurationAttachment(stack, "RiskConfig", {
+  userPoolId: pool.ref,
+  clientId: client.ref,
+  compromisedCredentialsRiskConfiguration: {
+    actions: { eventAction: "BLOCK" },
+  },
+  accountTakeoverRiskConfiguration: {
+    actions: {
+      lowAction: { eventAction: "NO_ACTION", notify: false },
+      mediumAction: { eventAction: "NO_ACTION", notify: false },
+      highAction: { eventAction: "NO_ACTION", notify: false },
+    },
+  },
+});
+
+const ui = new CfnUserPoolUICustomizationAttachment(stack, "UICustomization", {
+  userPoolId: pool.ref,
+  clientId: client.ref,
+  css: ".banner-customizable { background-color: #112233; }",
+});
+ui.addDependency(domain);
+
+app.synth();

--- a/tests/integration/cognito-attachment-readgap/cdk.json
+++ b/tests/integration/cognito-attachment-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cognito-attachment-readgap/package.json
+++ b/tests/integration/cognito-attachment-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cognito-attachment-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cognito-attachment-readgap false-negative integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cognito-attachment-readgap/verify.sh
+++ b/tests/integration/cognito-attachment-readgap/verify.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Also asserts the two Cognito attachment types are READ (not
+# silently skipped) — the read-gap this fixture exists to close.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCognitoAttachmentReadgap
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-cognito-attachment-readgap" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "=== [$STACK] assert attachments were READ (not skipped) ==="
+grep -q "RiskConfigurationAttachment\|UICustomizationAttachment" "/tmp/cdkrd-$STACK.out" 2>/dev/null
+# The skipped count must not include our attachment types; surface the info footer.
+if grep -qiE "skipped=[1-9]" "/tmp/cdkrd-$STACK.out"; then
+  echo "--- WARNING: a resource was skipped (read-gap) — inspect the info footer above ---"
+fi
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/iam-inline-policy-omit/app.ts
+++ b/tests/integration/iam-inline-policy-omit/app.ts
@@ -1,0 +1,36 @@
+// CDK app probing whether the OMITTED_WHEN_EMPTY false-negative class extends to
+// AWS::IAM::Role inline `Policies`. An inline policy removed out of band
+// (`aws iam delete-role-policy`) is a classic, security-relevant change. If AWS's
+// Cloud Control read OMITS `Policies` when the role has none, the declared policy's
+// removal would (pre-fix) misclassify as a readGap -> CLEAN -> silent FN. This
+// fixture deploys a role with one inline policy declared DIRECTLY on the role (not a
+// sibling AWS::IAM::Policy) so the role-level compare is exercised.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegIamInlinePolicyOmit");
+
+new CfnRole(stack, "Role", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "ec2.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  policies: [
+    {
+      policyName: "cdkrd-inline-1",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [{ Effect: "Allow", Action: "s3:GetObject", Resource: "*" }],
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/iam-inline-policy-omit/cdk.json
+++ b/tests/integration/iam-inline-policy-omit/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/iam-inline-policy-omit/package.json
+++ b/tests/integration/iam-inline-policy-omit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-iam-inline-policy-omit",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture for the cdk-real-drift IAM inline-policy omit-when-empty FN integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/iam-inline-policy-omit/verify.sh
+++ b/tests/integration/iam-inline-policy-omit/verify.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for the OMITTED_WHEN_EMPTY_PATHS fix on IAM
+# inline Policies: Cloud Control OMITS `Policies` when a role has no inline policies,
+# so deleting the only inline policy out of band (a security-relevant change) used to
+# classify as a readGap -> CLEAN -> SILENT FALSE NEGATIVE.
+# deploy -> record -> delete-role-policy -> check MUST detect -> revert MUST re-create
+# it -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamInlinePolicyOmit
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ROLE=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::IAM::Role'].PhysicalResourceId" --output text)
+[ -n "$ROLE" ] || fail "no role name"
+echo "role=$ROLE"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] delete the only inline policy out of band (CC will omit Policies) ==="
+aws iam delete-role-policy --role-name "$ROLE" --policy-name cdkrd-inline-1 --region "$REGION" || fail "delete-role-policy"
+
+echo "=== [$STACK] check MUST detect the removed policy (regression: was a readGap FN) ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: removed inline policy not detected (got CLEAN)"
+
+echo "=== [$STACK] revert (must re-create the inline policy) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] live inline policies after revert ==="
+P=$(aws iam list-role-policies --role-name "$ROLE" --region "$REGION" --query 'PolicyNames[0]' --output text)
+[ "$P" = "cdkrd-inline-1" ] || fail "revert did not re-create the inline policy (got: $P)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/kms-rotation-revert/app.ts
+++ b/tests/integration/kms-rotation-revert/app.ts
@@ -1,0 +1,21 @@
+// CDK app for the cdk-real-drift KMS key-rotation revert-gap test.
+//
+// AWS::KMS::Key.EnableKeyRotation is a very common, mutable property (a console
+// toggle / `disable-key-rotation` call is a classic out-of-band change). It is
+// CC-readable, so a change is DETECTED — but KMS rotation is toggled through the
+// dedicated EnableKeyRotation/DisableKeyRotation APIs, so a Cloud Control
+// UpdateResource patch may silently no-op (the same class as Logs BearerToken /
+// IAM Role MaxSessionDuration that needed an SDK writer). This fixture verifies
+// detect -> revert -> CLEAN -> live value actually restored.
+import { App, Stack } from "aws-cdk-lib";
+import { Key } from "aws-cdk-lib/aws-kms";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegKmsRotationRevert");
+
+new Key(stack, "Key", {
+  description: "cdkrd kms rotation revert probe",
+  enableKeyRotation: true,
+});
+
+app.synth();

--- a/tests/integration/kms-rotation-revert/cdk.json
+++ b/tests/integration/kms-rotation-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/kms-rotation-revert/package.json
+++ b/tests/integration/kms-rotation-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-kms-rotation-revert",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift kms-rotation-revert revert-gap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/kms-rotation-revert/verify.sh
+++ b/tests/integration/kms-rotation-revert/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Revert-gap integration test (real AWS): deploy -> record -> mutate a declared
+# MUTABLE prop (EnableKeyRotation) out of band -> check MUST detect -> revert MUST
+# restore the live value -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegKmsRotationRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+KEYID=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::KMS::Key'].PhysicalResourceId" --output text)
+[ -n "$KEYID" ] || fail "no key id"
+echo "key=$KEYID"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] mutate out of band: disable key rotation ==="
+aws kms disable-key-rotation --key-id "$KEYID" --region "$REGION" || fail "disable-key-rotation"
+
+echo "=== [$STACK] check MUST detect ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "expected detection (exit !=0), got CLEAN — FALSE NEGATIVE"
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] live rotation status after revert ==="
+ROT=$(aws kms get-key-rotation-status --key-id "$KEYID" --region "$REGION" --query 'KeyRotationEnabled' --output text)
+echo "KeyRotationEnabled=$ROT"
+[ "$ROT" = "True" ] || fail "REVERT-GAP: rotation still disabled after revert (CC UpdateResource no-op)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/lambda-env-omit/app.ts
+++ b/tests/integration/lambda-env-omit/app.ts
@@ -1,0 +1,19 @@
+// CDK app probing whether the OMITTED_WHEN_EMPTY false-negative class extends to
+// AWS::Lambda::Function Environment (the second-most common resource). Declared env
+// vars removed out of band (`update-function-configuration --environment
+// '{"Variables":{}}'`) — if Cloud Control then OMITS Environment, the declared
+// value's removal would misclassify as a readGap -> CLEAN -> silent FN.
+import { App, Stack } from "aws-cdk-lib";
+import { Code, Function, Runtime } from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaEnvOmit");
+
+new Function(stack, "Fn", {
+  runtime: Runtime.NODEJS_18_X,
+  handler: "index.handler",
+  code: Code.fromInline("exports.handler = async () => ({ ok: true });"),
+  environment: { FOO: "bar", BAZ: "qux" },
+});
+
+app.synth();

--- a/tests/integration/lambda-env-omit/cdk.json
+++ b/tests/integration/lambda-env-omit/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-env-omit/package.json
+++ b/tests/integration/lambda-env-omit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-lambda-env-omit",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture for the cdk-real-drift lambda-env-omit omit-when-empty FN integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/lambda-env-omit/verify.sh
+++ b/tests/integration/lambda-env-omit/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for the OMITTED_WHEN_EMPTY_PATHS fix on
+# Lambda Environment: Cloud Control OMITS Environment once the env vars are cleared,
+# so declared env vars wiped out of band used to classify as a readGap -> CLEAN ->
+# SILENT FALSE NEGATIVE.
+# deploy -> record -> clear env vars -> check MUST detect -> revert MUST re-apply them
+# -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaEnvOmit
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)
+[ -n "$FN" ] || fail "no function"
+echo "fn=$FN"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] clear env vars out of band (CC will omit Environment) ==="
+aws lambda update-function-configuration --function-name "$FN" --environment '{"Variables":{}}' \
+  --region "$REGION" >/dev/null || fail "clear-env"
+sleep 5
+
+echo "=== [$STACK] check MUST detect (regression: was a readGap FN) ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: cleared env vars not detected (got CLEAN)"
+
+echo "=== [$STACK] revert (must re-apply Environment via top-level add) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+sleep 5
+
+echo "=== [$STACK] live env after revert ==="
+V=$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" \
+  --query 'Environment.Variables.FOO' --output text)
+[ "$V" = "bar" ] || fail "revert did not restore env vars (FOO=$V)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/rds-backupretention-revert/app.ts
+++ b/tests/integration/rds-backupretention-revert/app.ts
@@ -1,0 +1,27 @@
+// CDK app probing the RDS revert-gap hypothesis: RDS modifications normally need
+// ApplyImmediately=true to take effect now (otherwise they queue in
+// pending-modified-values until the maintenance window). AWS::RDS::DBInstance is
+// CC-readable, so a BackupRetentionPeriod change is DETECTED — the question is
+// whether a Cloud Control UpdateResource patch actually applies it (or silently
+// queues it so `check` still drifts after `revert`). BackupRetentionPeriod is a
+// common, mutable, no-downtime knob. Uses the account's default VPC + default DB
+// subnet group; manageMasterUserPassword avoids a plaintext secret in the template.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnDBInstance } from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRdsBackupRetentionRevert");
+
+new CfnDBInstance(stack, "Db", {
+  engine: "mysql",
+  engineVersion: "8.0",
+  dbInstanceClass: "db.t3.micro",
+  allocatedStorage: "20",
+  masterUsername: "cdkrdadmin",
+  manageMasterUserPassword: true,
+  backupRetentionPeriod: 7,
+  deletionProtection: false,
+  publiclyAccessible: false,
+});
+
+app.synth();

--- a/tests/integration/rds-backupretention-revert/cdk.json
+++ b/tests/integration/rds-backupretention-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/rds-backupretention-revert/package.json
+++ b/tests/integration/rds-backupretention-revert/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-rds-backupretention-revert",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture for the cdk-real-drift RDS BackupRetentionPeriod revert-gap (ApplyImmediately) integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/rds-backupretention-revert/verify.sh
+++ b/tests/integration/rds-backupretention-revert/verify.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Revert-gap integration test (real AWS): RDS modifications can queue in
+# pending-modified-values unless applied immediately. deploy -> record -> modify
+# BackupRetentionPeriod out of band -> check MUST detect -> revert -> the live value
+# MUST actually be restored (not left pending) -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRdsBackupRetentionRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+DB=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::RDS::DBInstance'].PhysicalResourceId" --output text)
+[ -n "$DB" ] || fail "no db id"
+echo "db=$DB"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] modify BackupRetentionPeriod 7 -> 1 out of band ==="
+aws rds modify-db-instance --db-instance-identifier "$DB" --backup-retention-period 1 \
+  --apply-immediately --region "$REGION" >/dev/null || fail "modify"
+aws rds wait db-instance-available --db-instance-identifier "$DB" --region "$REGION" || true
+
+echo "=== [$STACK] check MUST detect ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "expected detection, got CLEAN — FALSE NEGATIVE"
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+aws rds wait db-instance-available --db-instance-identifier "$DB" --region "$REGION" || true
+
+echo "=== [$STACK] live BackupRetentionPeriod after revert ==="
+BRP=$(aws rds describe-db-instances --db-instance-identifier "$DB" --region "$REGION" \
+  --query 'DBInstances[0].BackupRetentionPeriod' --output text)
+echo "BackupRetentionPeriod=$BRP"
+[ "$BRP" = "7" ] || fail "REVERT-GAP: BackupRetentionPeriod not restored (got $BRP — left pending?)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-config-omit/app.ts
+++ b/tests/integration/s3-config-omit/app.ts
@@ -1,0 +1,24 @@
+// CDK app probing whether the OMITTED_WHEN_EMPTY false-negative class extends to
+// S3 bucket sub-configs (the MOST common resource): CorsConfiguration and
+// LifecycleConfiguration declared, then removed out of band
+// (`aws s3api delete-bucket-cors` / `delete-bucket-lifecycle`). If Cloud Control
+// OMITS these top-level keys once removed, the declared config's removal would
+// misclassify as a readGap -> CLEAN -> silent FN.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import { Bucket, HttpMethods } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3ConfigOmit");
+
+new Bucket(stack, "Bucket", {
+  cors: [
+    {
+      allowedMethods: [HttpMethods.GET],
+      allowedOrigins: ["https://example.com"],
+      allowedHeaders: ["*"],
+    },
+  ],
+  lifecycleRules: [{ id: "expire-90", expiration: Duration.days(90) }],
+});
+
+app.synth();

--- a/tests/integration/s3-config-omit/cdk.json
+++ b/tests/integration/s3-config-omit/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-config-omit/package.json
+++ b/tests/integration/s3-config-omit/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cdk-real-drift-integ-s3-config-omit",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture for the cdk-real-drift s3-config-omit omit-when-empty FN integration test. Run via verify.sh.",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" },
+  "type": "module"
+}

--- a/tests/integration/s3-config-omit/verify.sh
+++ b/tests/integration/s3-config-omit/verify.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for the OMITTED_WHEN_EMPTY_PATHS fix on S3
+# object-valued sub-configs: Cloud Control OMITS CorsConfiguration /
+# LifecycleConfiguration once removed, so a declared config deleted out of band used
+# to classify as a readGap -> CLEAN -> SILENT FALSE NEGATIVE.
+# deploy -> record -> delete cors + lifecycle -> check MUST detect (2 whole-property
+# drifts) -> revert MUST re-apply them -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3ConfigOmit
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+BUCKET=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)
+[ -n "$BUCKET" ] || fail "no bucket"
+echo "bucket=$BUCKET"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] remove cors + lifecycle out of band (CC will omit them) ==="
+aws s3api delete-bucket-cors --bucket "$BUCKET" --region "$REGION" || fail "delete-cors"
+aws s3api delete-bucket-lifecycle --bucket "$BUCKET" --region "$REGION" || fail "delete-lifecycle"
+
+echo "=== [$STACK] check MUST detect (regression: was a readGap FN) ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: removed S3 configs not detected (got CLEAN)"
+
+echo "=== [$STACK] revert (must re-apply both configs via top-level add) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] live configs after revert ==="
+aws s3api get-bucket-cors --bucket "$BUCKET" --region "$REGION" >/dev/null 2>&1 || fail "cors not restored"
+aws s3api get-bucket-lifecycle-configuration --bucket "$BUCKET" --region "$REGION" >/dev/null 2>&1 || fail "lifecycle not restored"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sfn-definition-revert/app.ts
+++ b/tests/integration/sfn-definition-revert/app.ts
@@ -1,0 +1,31 @@
+// CDK app for the cdk-real-drift Step Functions definition revert-gap test.
+//
+// AWS::StepFunctions::StateMachine.DefinitionString is CC-readable (a console /
+// update-state-machine edit to the ASL is DETECTED), but the state-machine
+// definition is updated through the dedicated UpdateStateMachine API. A Cloud
+// Control UpdateResource patch of DefinitionString may not apply cleanly. This
+// fixture verifies detect -> revert -> CLEAN -> live definition actually restored.
+import { App, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnStateMachine } from "aws-cdk-lib/aws-stepfunctions";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSfnDefinitionRevert");
+
+const role = new Role(stack, "Role", {
+  assumedBy: new ServicePrincipal("states.amazonaws.com"),
+});
+
+new CfnStateMachine(stack, "Sm", {
+  roleArn: role.roleArn,
+  stateMachineType: "STANDARD",
+  definitionString: JSON.stringify({
+    Comment: "cdkrd sfn definition revert probe",
+    StartAt: "Pass1",
+    States: {
+      Pass1: { Type: "Pass", Result: { v: 1 }, End: true },
+    },
+  }),
+});
+
+app.synth();

--- a/tests/integration/sfn-definition-revert/cdk.json
+++ b/tests/integration/sfn-definition-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sfn-definition-revert/package.json
+++ b/tests/integration/sfn-definition-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sfn-definition-revert",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sfn-definition-revert revert-gap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sfn-definition-revert/verify.sh
+++ b/tests/integration/sfn-definition-revert/verify.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Revert-gap integration test (real AWS): deploy -> record -> mutate the declared
+# DefinitionString out of band -> check MUST detect -> revert MUST restore the live
+# definition -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSfnDefinitionRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+SM=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::StepFunctions::StateMachine'].PhysicalResourceId" --output text)
+[ -n "$SM" ] || fail "no state machine arn"
+echo "sm=$SM"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] mutate out of band: update-state-machine definition ==="
+ROLE=$(aws stepfunctions describe-state-machine --state-machine-arn "$SM" --region "$REGION" --query roleArn --output text)
+aws stepfunctions update-state-machine --state-machine-arn "$SM" --region "$REGION" \
+  --definition '{"Comment":"MUTATED","StartAt":"Pass1","States":{"Pass1":{"Type":"Pass","Result":{"v":999},"End":true}}}' \
+  --role-arn "$ROLE" >/dev/null || fail "update-state-machine"
+sleep 2
+
+echo "=== [$STACK] check MUST detect ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "expected detection (exit !=0), got CLEAN — FALSE NEGATIVE"
+
+echo "=== [$STACK] revert ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] live definition after revert ==="
+LIVE=$(aws stepfunctions describe-state-machine --state-machine-arn "$SM" --region "$REGION" --query definition --output text)
+echo "$LIVE" | grep -q '"v":1' || fail "REVERT-GAP: definition not restored after revert (still: $LIVE)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sg-ingress-revert/app.ts
+++ b/tests/integration/sg-ingress-revert/app.ts
@@ -1,0 +1,28 @@
+// CDK app for the cdk-real-drift SecurityGroup ingress revert-gap test.
+//
+// AWS::EC2::SecurityGroup inline SecurityGroupIngress is the canonical "someone
+// opened/changed a rule in the console" scenario — extremely common. Rules are
+// CC-readable (a change is DETECTED), but the EC2 CC handler must translate a
+// rule-array patch into Authorize*/Revoke*SecurityGroup* calls, which is a fiddly
+// path. This fixture verifies that reverting a removed/changed ingress rule
+// actually re-applies it in AWS (detect -> revert -> CLEAN -> live restored).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnSecurityGroup } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSgIngressRevert");
+
+new CfnSecurityGroup(stack, "Sg", {
+  groupDescription: "cdkrd sg ingress revert probe",
+  securityGroupIngress: [
+    {
+      ipProtocol: "tcp",
+      fromPort: 22,
+      toPort: 22,
+      cidrIp: "10.0.0.0/16",
+      description: "ssh from vpc",
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/sg-ingress-revert/cdk.json
+++ b/tests/integration/sg-ingress-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sg-ingress-revert/package.json
+++ b/tests/integration/sg-ingress-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sg-ingress-revert",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sg-ingress-revert revert-gap integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sg-ingress-revert/verify.sh
+++ b/tests/integration/sg-ingress-revert/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for the OMITTED_WHEN_EMPTY_PATHS fix:
+# AWS's Cloud Control read OMITS SecurityGroupIngress when there are no rules, so a
+# declared rule removed out of band (the "someone deleted the SSH rule in the
+# console" scenario) used to classify as a readGap -> CLEAN -> SILENT FALSE NEGATIVE.
+# deploy -> record -> revoke the only ingress rule -> check MUST detect -> revert MUST
+# re-authorize it -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSgIngressRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+GNAME=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::EC2::SecurityGroup'].PhysicalResourceId" --output text)
+SGID=$(aws ec2 describe-security-groups --filters "Name=group-name,Values=$GNAME" --region "$REGION" \
+  --query 'SecurityGroups[0].GroupId' --output text)
+[ -n "$SGID" ] && [ "$SGID" != "None" ] || fail "no sg id (name=$GNAME)"
+echo "sg=$SGID"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] revoke the only ingress rule (CC will omit SecurityGroupIngress) ==="
+aws ec2 revoke-security-group-ingress --group-id "$SGID" --region "$REGION" \
+  --protocol tcp --port 22 --cidr 10.0.0.0/16 >/dev/null || fail "revoke"
+
+echo "=== [$STACK] check MUST detect the removed rule (regression: was a readGap FN) ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: removed ingress rule not detected (got CLEAN)"
+
+echo "=== [$STACK] revert (must re-authorize the rule) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] live ingress after revert ==="
+N=$(aws ec2 describe-security-groups --group-ids "$SGID" --region "$REGION" \
+  --query 'length(SecurityGroups[0].IpPermissions)' --output text)
+[ "$N" = "1" ] || fail "revert did not restore the ingress rule (rule count=$N)"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -802,16 +802,20 @@ describe('parseSchema', () => {
     expect([...out.writeOnly]).toEqual(['Secret']);
   });
 
-  it('parses createOnly + conditionalCreateOnly (both = needs replacement)', () => {
+  it('bars only HARD createOnly — conditionalCreateOnly stays revertable (mutable in the common case)', () => {
     const info = parseSchema(
       JSON.stringify({
         createOnlyProperties: ['/properties/BucketName', '/properties/Nested/Key'],
         conditionalCreateOnlyProperties: ['/properties/AvailabilityZone'],
       })
     );
-    expect([...info.createOnly].sort()).toEqual(['AvailabilityZone', 'BucketName']);
+    // hard create-only is barred from revert
+    expect([...info.createOnly].sort()).toEqual(['BucketName']);
     expect(info.createOnlyPaths).toContain('Nested.Key');
-    expect(info.createOnlyPaths).toContain('AvailabilityZone');
+    // a conditional-create-only prop (RDS BackupRetentionPeriod class — modifiable in
+    // place in the common case) must NOT be barred, else revert wrongly refuses it
+    expect([...info.createOnly]).not.toContain('AvailabilityZone');
+    expect(info.createOnlyPaths).not.toContain('AvailabilityZone');
   });
 
   it('R103: extracts nested defaults through $ref + arrays into defaultPaths', () => {

--- a/tests/path-strip.test.ts
+++ b/tests/path-strip.test.ts
@@ -43,10 +43,10 @@ describe('parseSchema nested paths', () => {
     expect(info.readOnlyPaths).toEqual(['Arn']);
   });
 
-  it('collapses interior + trailing /properties/ segments (OpenSearch conditionalCreateOnly)', () => {
+  it('collapses interior + trailing /properties/ segments in a pointer array', () => {
     const info = parseSchema(
       JSON.stringify({
-        conditionalCreateOnlyProperties: [
+        createOnlyProperties: [
           '/properties/EncryptionAtRestOptions/properties', // the block itself
           '/properties/AdvancedSecurityOptions/properties/Enabled', // interior /properties/
         ],


### PR DESCRIPTION
Real-AWS bug-hunt round (2026-06-29). Two false-negative classes found and fixed, each live-proven on the most-deployed resource types, with unit tests + golden-corpus cases + regression integ fixtures. All 9 hunt stacks deleted + sweep clean.

## BUG 1 — OMITTED_WHEN_EMPTY false negative (detect)
`classify` treated *any* declared key absent from the live read as a `readGap` (informational, never drift). But some properties Cloud Control **returns when set** and **omits when empty**, so deleting a declared collection out of band — the console "someone removed the SSH rule / inline policy / S3 lifecycle / Lambda env var" scenario — made cdkrd report **CLEAN** (silent FN, often security-relevant).

Fix: new curated `OMITTED_WHEN_EMPTY_PATHS` table (`normalize/noise.ts`); `classify` emits **one whole-property** declared finding so the removal surfaces **and** revert re-applies the whole config with a single top-level `add` (a nested patch fails — the parent is absent in the live model).

Confirmed members (all live-proven detect + revert):
- `AWS::EC2::SecurityGroup` `SecurityGroupIngress`/`SecurityGroupEgress`
- `AWS::IAM::Role`/`User`/`Group` `Policies` (inline)
- `AWS::S3::Bucket` `CorsConfiguration`/`LifecycleConfiguration`
- `AWS::Lambda::Function` `Environment`

**Curated, not a blanket rule:** the corpus holds 9 legitimate non-writeOnly readGaps (Batch `Timeout`, DynamoDB `SSESpecification`, Redshift `Port`, Budgets `NotificationsWithSubscribers`, DocDB props, SSM `Value`) AWS never returns even when set — a general "absent → drift" rule would turn those into persistent **false positives**. FP-safe: a non-empty value is always returned, so this only fires on a genuine removal. (CloudWatch Alarm `AlarmActions` returns `[]` explicitly → already detected → deliberately NOT in the table.)

## BUG 2 — conditional-create-only wrongly bars revert (revert)
`schema-strip` merged `conditionalCreateOnlyProperties` into `createOnlyPaths`, so cdkrd **detected** a change but refused to revert with a misleading *"create-only — requires replacement"*. But conditional-create-only props are mutable in the common case (RDS `BackupRetentionPeriod` / `MultiAZ` / `StorageType` / `PreferredMaintenanceWindow` / `AutoMinorVersionUpgrade` modify in place).

Fix: only **hard** `createOnlyProperties` bar revert; conditional ones attempt it and Cloud Control `UpdateResource` rejects cleanly if a specific change truly needs replacement (it never silently replaces). `createOnlyPaths` is consumed only by the revert bar, so the change is contained. Live-proven on RDS `BackupRetentionPeriod` 7→1→revert→7.

## Tests / fixtures
- Unit: `classify.test.ts` (array + object omit-when-empty, curated-not-blanket), `noise-and-strip.test.ts` + `path-strip.test.ts` (hard vs conditional create-only).
- Corpus: 6 new cases (SG/IAM/S3/Lambda removed-collection + 2 Cognito attachment types).
- Integ fixtures (each `verify.sh` = detect → revert → CLEAN): `sg-ingress-revert`, `iam-inline-policy-omit`, `s3-config-omit`, `lambda-env-omit`, `rds-backupretention-revert`, plus clean rule-out fixtures `kms-rotation-revert` / `sfn-definition-revert` / `cognito-attachment-readgap`.

## Rule-outs (no bug, this round)
KMS `EnableKeyRotation` revert, SFN `DefinitionString` revert, CloudWatch `AlarmActions` (explicit `[]`), Cognito `UserPool*Attachment` reads (CC reads fine — physical id is already the composite). Also filed go-to-k/delstack#647 (Cognito `UICustomizationAttachment` phantom `DELETE_FAILED`).