### PR TITLE
chore(hooks): add worktree-guard hook (block editing main src/tests while a worktree exists)

### DIFF
--- a/.claude/hooks/worktree-guard.sh
+++ b/.claude/hooks/worktree-guard.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# worktree-guard.sh
+#
+# PreToolUse hook (Edit / Write / NotebookEdit). Blocks an edit to the MAIN
+# checkout's `src/**` or `tests/**` while a development worktree exists under
+# `.worktrees/`. Per CLAUDE.md the main checkout is reserved for integration
+# (`git checkout <branch> -- <files>` / pulls / PR plumbing) — all real work
+# happens in a per-line-of-work worktree.
+#
+# Editing main directly while a worktree is active has repeatedly caused
+# cross-session collisions: a session edits main's src, then a `cp`-recovery of
+# those files into its worktree pulls ANOTHER session's freshly-MERGED work into
+# its branch (the #408 contamination), and a `git checkout` in main can clobber a
+# parallel session's staged work. This hook makes that foot-gun unreachable.
+#
+# Fail-OPEN by design: any ambiguity (no path, not absolute, no git context,
+# parse error, only the main worktree exists) passes through — the hook only
+# blocks the one unambiguous foot-gun.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+# Edit/Write carry .tool_input.file_path; NotebookEdit carries .notebook_path.
+path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.notebook_path // ""' 2>/dev/null || echo "")
+[ -n "$path" ] || exit 0
+
+# Only reason about absolute paths (Edit/Write require them).
+case "$path" in
+  /*) ;;
+  *) exit 0 ;;
+esac
+
+# An edit INSIDE a worktree is the CORRECT place — always allow.
+case "$path" in
+  */.worktrees/*) exit 0 ;;
+esac
+
+# Resolve a git context from the nearest existing ancestor of the target (the
+# file itself may not exist yet for a Write of a new file / new dir).
+probe="$path"
+while [ ! -d "$probe" ] && [ "$probe" != "/" ]; do
+  probe=$(dirname "$probe")
+done
+git -C "$probe" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+# The MAIN checkout root is the FIRST worktree git lists (the primary worktree),
+# and the worktree list is shared, so this is correct even from inside a worktree.
+main_root=$(git -C "$probe" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+[ -n "$main_root" ] || exit 0
+
+# No collision risk unless at least one OTHER worktree exists.
+wt_count=$(git -C "$probe" worktree list --porcelain 2>/dev/null | grep -c '^worktree ')
+[ "${wt_count:-0}" -ge 2 ] || exit 0
+
+# Canonicalize (resolve symlinks) so a /tmp -> /private/tmp style alias does not
+# defeat the prefix match. The target file may not exist yet, so canonicalize its
+# nearest existing ancestor (probe) and re-attach the remainder.
+canon() { (cd "$1" 2>/dev/null && pwd -P) || printf '%s' "$1"; }
+canon_main=$(canon "$main_root")
+canon_probe=$(canon "$probe")
+rest="${path#"$probe"}" # the part of the path below the existing ancestor
+canon_path="${canon_probe}${rest}"
+
+# Only guard the MAIN checkout's src/ and tests/ (where the foot-gun bites and
+# where a code/test collision actually matters).
+case "$canon_path" in
+  "$canon_main"/src/*|"$canon_main"/tests/*) ;;
+  *) exit 0 ;;
+esac
+
+rel="${canon_path#"$canon_main"/}"
+others=$((wt_count - 1))
+echo "Blocked by worktree-guard: editing the MAIN checkout ($rel) while ${others} worktree(s) exist under .worktrees/. Per CLAUDE.md, all src/** and tests/** work belongs in a worktree — the path must contain .worktrees/<name>. Editing main directly has caused cross-session collisions (e.g. a cp-recovery pulling another session's merged PR into your branch). Edit the file under .worktrees/<name>/ instead; the main checkout is for integration only (git checkout / pulls / PR plumbing)." >&2
+exit 2

--- a/.claude/hooks/worktree-guard.test.sh
+++ b/.claude/hooks/worktree-guard.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Smoke tests for worktree-guard.sh
+#
+# Builds a throwaway git repo (optionally with a worktree under .worktrees/),
+# runs the hook against simulated Edit/Write/NotebookEdit tool input, and asserts
+# the expected pass (0) / block (2) behavior.
+# Run: bash .claude/hooks/worktree-guard.test.sh
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/worktree-guard.sh"
+PASS=0
+FAIL=0
+
+# make_repo <with_worktree:0|1> -> echoes the repo root path
+make_repo() {
+  local with_wt="$1" tmp
+  tmp=$(mktemp -d)
+  git -C "$tmp" init -q -b main
+  git -C "$tmp" config user.email t@t
+  git -C "$tmp" config user.name t
+  mkdir -p "$tmp/src" "$tmp/tests" "$tmp/docs"
+  : > "$tmp/src/seed.ts"
+  : > "$tmp/seed"
+  git -C "$tmp" add -A
+  git -C "$tmp" commit -q -m init
+  if [ "$with_wt" = "1" ]; then
+    git -C "$tmp" worktree add -q "$tmp/.worktrees/wt" -b wt main
+  fi
+  printf '%s' "$tmp"
+}
+
+# run <name> <repo_root> <field> <path> <expect_exit>
+#   field = file_path | notebook_path
+run() {
+  local name="$1" root="$2" field="$3" path="$4" expect="$5"
+  local payload code
+  payload="{\"tool_input\":{\"${field}\":$(printf '%s' "$path" | jq -Rs .)},\"cwd\":\"$root\"}"
+  set +e
+  printf '%s' "$payload" | bash "$HOOK" >/dev/null 2>&1
+  code=$?
+  set -e
+  if [ "$code" -eq "$expect" ]; then
+    PASS=$((PASS + 1)); echo "ok   - $name (exit $code)"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL - $name (got $code, expected $expect)"
+  fi
+}
+
+# --- no worktree: editing main src/tests is allowed (solo / integration) ---
+R0=$(make_repo 0)
+run "no worktree: edit main src passes"        "$R0" file_path "$R0/src/foo.ts"          0
+run "no worktree: edit main tests passes"      "$R0" file_path "$R0/tests/foo.test.ts"   0
+
+# --- worktree present: editing the MAIN checkout's src/tests is BLOCKED ---
+R1=$(make_repo 1)
+run "worktree: edit main src blocks"           "$R1" file_path "$R1/src/foo.ts"          2
+run "worktree: edit main nested src blocks"    "$R1" file_path "$R1/src/a/b/c.ts"        2
+run "worktree: edit main tests blocks"         "$R1" file_path "$R1/tests/x.test.ts"     2
+run "worktree: write NEW main src file blocks" "$R1" file_path "$R1/src/new/dir/n.ts"    2
+run "worktree: NotebookEdit main src blocks"   "$R1" notebook_path "$R1/src/nb.ipynb"    2
+
+# --- worktree present: editing INSIDE the worktree is allowed (correct place) ---
+run "worktree: edit inside worktree passes"    "$R1" file_path "$R1/.worktrees/wt/src/foo.ts" 0
+
+# --- worktree present: non-src/tests main files are not guarded ---
+run "worktree: edit main docs passes"          "$R1" file_path "$R1/docs/x.md"           0
+run "worktree: edit main README passes"        "$R1" file_path "$R1/README.md"           0
+
+# --- defensive: ambiguous inputs fail OPEN ---
+run "worktree: relative path passes"           "$R1" file_path "src/foo.ts"              0
+run "worktree: empty path passes"              "$R1" file_path ""                        0
+run "non-git absolute path passes"             "$R1" file_path "/tmp/$$/elsewhere.ts"    0
+
+rm -rf "$R0" "$R1"
+
+echo "----"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; bughunt-clean-gate blocks `git commit`/`gh pr create`/`gh pr merge` while the .markgate-bughunt-pending sentinel is non-empty (armed by /hunt-bugs via bughunt-track.sh add before any integ deploy; released by bughunt-track.sh clear only after every tracked stack is deleted + SWEEP CLEAN); stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule). NOT wired: pr-review and the read-only integ gate — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
+  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; bughunt-clean-gate blocks `git commit`/`gh pr create`/`gh pr merge` while the .markgate-bughunt-pending sentinel is non-empty (armed by /hunt-bugs via bughunt-track.sh add before any integ deploy; released by bughunt-track.sh clear only after every tracked stack is deleted + SWEEP CLEAN); stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule); worktree-guard (matcher Edit|Write|NotebookEdit) blocks an Edit/Write to the MAIN checkout's `src/**`/`tests/**` while a `.worktrees/` worktree exists (CLAUDE.md: main is integration-only; direct main edits have caused cross-session collisions — the #408 contamination). NOT wired: pr-review and the read-only integ gate — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
   "hooks": {
     "PreToolUse": [
       {
@@ -46,6 +46,17 @@
             "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/worktree-guard.sh",
+            "timeout": 10,
+            "statusMessage": "Checking edit targets a worktree, not the main checkout..."
           }
         ]
       }


### PR DESCRIPTION
Adds a PreToolUse hook that makes the recurring **edit-main-not-worktree** foot-gun unreachable.

## Why
Per CLAUDE.md the main checkout is integration-only; all `src/**` and `tests/**` work happens in a worktree under `.worktrees/`. Editing main directly while a worktree is active has repeatedly caused cross-session collisions — most recently (PR #413's hunt) a `cp`-recovery of main files into a worktree pulled **another session's freshly-merged PR #408** into the branch diff, caught only by a later `git rebase origin/main`.

## What
`worktree-guard.sh` (PreToolUse on `Edit|Write|NotebookEdit`):
- **Blocks** an edit whose target is the **main checkout's** `src/**` or `tests/**` while at least one other worktree exists (exit 2, with guidance to edit under `.worktrees/<name>/`).
- **Allows**: edits inside a worktree, edits when no worktree exists, and anything outside `src`/`tests` (docs, README, `.claude`, config).
- **Fail-OPEN** on any ambiguity (no path, relative path, no git context). Canonicalizes paths so a `/tmp` to `/private/tmp` alias does not defeat the prefix match.

## Tests
`worktree-guard.test.sh` — 13 cases (block main src/tests incl. a brand-new file and NotebookEdit; allow inside-worktree / no-worktree / docs / relative / empty / non-git). All pass. Verified live against the real repo path too.

Wired in `.claude/settings.json` (new matcher `Edit|Write|NotebookEdit`). Tooling-only (no `src/**`), so verify-pr-exempt; check and docs markers set.
