### PR TITLE
feat(revert): revert array-element nested rule values via Cloud Control index-revert (Backup, Route53Resolver)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -721,8 +721,16 @@ deploy`: a patch can't recreate a resource), a **create-only** property (drift o
   (UpdateIntegration / UpdateIntegrationResponse / UpdateMethodResponse PatchOperations) —
   API Gateway REJECTS `op: remove` for the integration knobs (so the reset is a `replace`
   to the AWS default, or `""` which reads back absent/folded), but ACCEPTS `op: remove` for
-  a `responseModels` entry (removed per media key) — all proven live. KMS keys need no SDK
-  writer — they revert via the generic CC path.
+  a `responseModels` entry (removed per media key) — all proven live. For a CC-MUTABLE type
+  the array-element nested value reverts via the generic **Cloud Control index-revert**
+  writer (`writeCloudControlIndexNested`, registered for Backup BackupPlan + Route53Resolver
+  FirewallRuleGroup): it GetResources the live model, RE-POINTS each op's identity bracket to
+  the live-array INDEX (`/FirewallRules[100]/…` → `/FirewallRules/1/…` — valid because the
+  index is taken against the SAME model CC read-modify-writes; R78's index problem was
+  indexing the DECLARED subset), then one UpdateResource. A value AWS materialized as a
+  default (KNOWN_DEFAULT_PATHS) reverts by SETTING that default (`add`), not a bare `remove`
+  some providers silently ignore (Route53 FirewallDomainRedirectionAction — proven live).
+  KMS keys need no SDK writer — they revert via the generic CC path.
 - **Canonical-form write**: a declared-drift revert target (`finding.desired`) is the
   _normalized_ value (policy statements sorted, scalar-vs-array collapsed, tag / id
   arrays sorted), not the template verbatim. It is semantically equal to the template

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -10,11 +10,11 @@ the full design.
 - **Revert can't do everything.** Not revertable, and reported as such: unrecorded
   values (record them, or opt into removal with `--remove-unrecorded`); a `deleted`
   resource (recreate with `cdk deploy`); an **array-element** nested undeclared
-  value (`Prop[<id>].sub`) — a flat patch can't safely target it — UNLESS a
-  type-specific SDK writer can (an API Gateway method's integration knobs like
-  `Integration.IntegrationResponses[<status>].SelectionPattern` revert via the native
-  patch API); a pure-dotted nested value (a free-form map key, an object sub-field,
-  or a map-shaped tag key) IS revertable via Cloud Control; create-only
+  value (`Prop[<id>].sub`) on a type cdkrd neither has a type-specific SDK writer for
+  (e.g. API Gateway method integration knobs) nor can revert via the Cloud Control
+  index-revert (Backup / Route53Resolver rules — the identity bracket is re-pointed to
+  the live-array index); a pure-dotted nested value (a free-form map key, an object
+  sub-field, or a map-shaped tag key) IS revertable via Cloud Control; create-only
   properties (changing them needs replacement); toggle-style properties with no
   "absent" state (e.g. S3 transfer acceleration); `AWS::Lambda::Permission` and
   `AWS::Budgets::Budget` (their write APIs can't reconstruct the desired state).

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -816,6 +816,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
             declared: res?.declared ?? {},
             region,
             accountId: gathered.desired.accountId,
+            resourceType: item.resourceType,
           },
           item.ops
         );

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -150,7 +150,7 @@ const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpe
 //   - AWS::ApiGateway::Method Integration.IntegrationResponses is keyed by StatusCode, so an
 //     out-of-band SelectionPattern / ContentHandling added to a declared response (the
 //     "HTTP error regex" / "content handling" console knobs) is otherwise invisible.
-const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
+export const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
   'AWS::ApiGateway::Method': {
     'Integration.IntegrationResponses': 'StatusCode',
     // MethodResponses is keyed by StatusCode too. AWS does NOT auto-materialize its

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -74,6 +74,10 @@ export interface OverrideCtx {
   declared: Record<string, unknown>;
   region: string;
   accountId: string;
+  // The resource's CloudFormation type — set on the REVERT (SdkWriter) path so a
+  // type-agnostic writer (the Cloud Control index-revert for nested array-element values)
+  // can GetResource/UpdateResource it. Unused by the read (OverrideReader) path.
+  resourceType?: string;
 }
 export type OverrideReader = (ctx: OverrideCtx) => Promise<Record<string, unknown> | undefined>;
 

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -11,7 +11,12 @@
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
-import { awsManagedTags, JSON_STRING_PROPS, KNOWN_DEFAULTS } from '../normalize/noise.js';
+import {
+  awsManagedTags,
+  JSON_STRING_PROPS,
+  KNOWN_DEFAULT_PATHS,
+  KNOWN_DEFAULTS,
+} from '../normalize/noise.js';
 import { SDK_OVERRIDES } from '../read/overrides.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { SDK_NESTED_WRITERS, SDK_PROP_WRITERS, SDK_WRITERS } from './writers.js';
@@ -558,6 +563,21 @@ function revertOp(f: Finding, recorded: BaselineFile['recorded']): PatchOp {
       op: 'add',
       path: pointer,
       value: knownDefault,
+      prior: f.actual,
+      human: `${f.path} -> AWS default (undeclared, not in baseline)`,
+    };
+  }
+  // A NESTED value AWS materializes as a default (KNOWN_DEFAULT_PATHS, descended via
+  // NESTED_ARRAY_IDENTITY): SET that default rather than `remove` it. Some providers keep
+  // the existing value when a field is merely absent from the patch, so a bare `remove` is a
+  // silent no-op (Route53Resolver FirewallDomainRedirectionAction — proven live). The
+  // schemaPath normalizes the identity bracket to the `.*` the table is keyed by.
+  const nestedDefault = KNOWN_DEFAULT_PATHS[f.resourceType]?.[f.path.replace(/\[[^\]]*\]/g, '.*')];
+  if (nestedDefault !== undefined) {
+    return {
+      op: 'add',
+      path: pointer,
+      value: nestedDefault,
       prior: f.actual,
       human: `${f.path} -> AWS default (undeclared, not in baseline)`,
     };

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -29,6 +29,11 @@ import {
   UpdateMethodResponseCommand,
 } from '@aws-sdk/client-api-gateway';
 import {
+  CloudControlClient,
+  GetResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
+import {
   CloudFrontClient,
   GetDistributionConfigCommand,
   UpdateDistributionCommand,
@@ -112,6 +117,8 @@ import {
 } from '@aws-sdk/client-servicediscovery';
 import { SetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { SetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { NESTED_ARRAY_IDENTITY } from '../diff/classify.js';
+import { identityField } from '../normalize/noise.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
 import { type OverrideCtx, SDK_OVERRIDES } from '../read/overrides.js';
 import { applyOps } from './apply-ops.js';
@@ -1222,6 +1229,78 @@ export const SDK_PROP_WRITERS: Record<string, Record<string, SdkWriter>> = {
   },
 };
 
+// Re-point an RFC6902 pointer's IDENTITY-bracket array segments (`/Prop[<id>]/sub`, which
+// Cloud Control would read as a literal key named `Prop[<id>]`) to the matching LIVE-array
+// INDEX (`/Prop/<index>/sub`, a valid pointer CC applies read-modify-write). The index is
+// located by the array's identity field (NESTED_ARRAY_IDENTITY override, else the generic
+// identityField) against the live model — the SAME model CC will read-modify-write, so the
+// index aligns. This is why an array-element nested value IS revertable via CC after all
+// (R78 abandoned index patches against the DECLARED subset, whose indices differ from live;
+// here we index the LIVE array). Throws if a segment can't be located → an honest revert
+// failure, never a wrong write.
+function reindexNestedPointer(
+  pointer: string,
+  live: Record<string, unknown>,
+  resourceType: string
+): string {
+  const out: string[] = [];
+  let node: unknown = live;
+  let dotted = '';
+  for (const raw of pointer.split('/').slice(1)) {
+    const seg = raw.replace(/~1/g, '/').replace(/~0/g, '~');
+    const m = seg.match(/^(.+)\[(.+)\]$/);
+    if (m) {
+      const prop = m[1] as string;
+      const id = m[2] as string;
+      const arrPath = dotted ? `${dotted}.${prop}` : prop;
+      const arr =
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[prop] : undefined;
+      if (!Array.isArray(arr)) throw new Error(`cannot resolve array "${arrPath}" for ${pointer}`);
+      const idField = NESTED_ARRAY_IDENTITY[resourceType]?.[arrPath] ?? identityField(arr);
+      const idx = idField
+        ? arr.findIndex(
+            (el) =>
+              el &&
+              typeof el === 'object' &&
+              String((el as Record<string, unknown>)[idField]) === id
+          )
+        : -1;
+      if (idx < 0) throw new Error(`cannot locate ${arrPath}[${id}] in live ${resourceType}`);
+      out.push(ptrEscape(prop), String(idx));
+      node = arr[idx];
+      dotted = arrPath;
+    } else {
+      out.push(ptrEscape(seg));
+      node = node && typeof node === 'object' ? (node as Record<string, unknown>)[seg] : undefined;
+      dotted = dotted ? `${dotted}.${seg}` : seg;
+    }
+  }
+  return `/${out.join('/')}`;
+}
+
+// Revert an array-element nested value (e.g. Backup BackupPlanRule[<RuleName>].window,
+// Route53Resolver FirewallRules[<Priority>].setting) via Cloud Control: GetResource for the
+// live model, re-point each op's identity-bracket to the live-array index (reindexNestedPointer),
+// then one UpdateResource. CC-mutable types only (Backup / Route53Resolver) — proven live.
+const writeCloudControlIndexNested: SdkWriter = async (ctx, ops) => {
+  const type = ctx.resourceType;
+  if (!type) throw new Error('writeCloudControlIndexNested: resourceType missing on ctx');
+  const cc = new CloudControlClient({ region: ctx.region });
+  const got = await cc.send(new GetResourceCommand({ TypeName: type, Identifier: ctx.physicalId }));
+  const live = JSON.parse(got.ResourceDescription?.Properties ?? '{}') as Record<string, unknown>;
+  const patch = ops.map((op) => {
+    const path = reindexNestedPointer(op.path, live, type);
+    return op.op === 'remove' ? { op: op.op, path } : { op: op.op, path, value: op.value };
+  });
+  await cc.send(
+    new UpdateResourceCommand({
+      TypeName: type,
+      Identifier: ctx.physicalId,
+      PatchDocument: JSON.stringify(patch),
+    })
+  );
+};
+
 // SDK writers for NESTED finding paths (a sub-key inside a declared object — dotted or
 // array-element). Unlike SDK_PROP_WRITERS, which keys on an EXACT top-level finding path,
 // these match by PREDICATE because the targetable knob is deep (e.g. an ApiGateway Method's
@@ -1248,6 +1327,17 @@ export const SDK_NESTED_WRITERS: Record<string, NestedWriterSpec> = {
       p.startsWith('VolumeConfigurations.') ||
       p.startsWith('VolumeConfigurations['),
     writer: writeEcsServiceWriteOnlyProps,
+  },
+  // Array-element nested rule settings (keyed by RuleName / Priority — descended via
+  // NESTED_ARRAY_IDENTITY). CC-mutable, so revert via the generic Cloud Control index-revert:
+  // the identity bracket is re-pointed to the live-array index, which CC applies. Proven live.
+  'AWS::Backup::BackupPlan': {
+    match: (p) => p.startsWith('BackupPlan.BackupPlanRule['),
+    writer: writeCloudControlIndexNested,
+  },
+  'AWS::Route53Resolver::FirewallRuleGroup': {
+    match: (p) => p.startsWith('FirewallRules['),
+    writer: writeCloudControlIndexNested,
   },
 };
 

--- a/tests/integration/nested-array-defaults/verify.sh
+++ b/tests/integration/nested-array-defaults/verify.sh
@@ -59,4 +59,22 @@ grep -q "BackupPlanRule\[DailyRule\].CompletionWindowMinutes" /tmp/cdkrd-integ-n
 grep -q "FirewallRules\[100\].FirewallDomainRedirectionAction" /tmp/cdkrd-integ-nested.out \
   || fail "Route53 firewall rule change not detected (Priority descent missing?)"
 
+echo "=== revert: both array-element nested values revert via the Cloud Control index-revert writer ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-integ-nested-revert.out || fail "revert errored"
+grep -qi "FAILED" /tmp/cdkrd-integ-nested-revert.out && fail "revert reported a FAILED op"
+
+echo "=== verify convergence on the live resources ==="
+CW_AFTER="$(aws backup get-backup-plan --backup-plan-id "$PLAN_ID" --region "$REGION" \
+  --query 'BackupPlan.Rules[0].CompletionWindowMinutes' --output text)"
+echo "CompletionWindowMinutes after revert: $CW_AFTER"
+[ "$CW_AFTER" = "10080" ] || fail "Backup CompletionWindowMinutes not reverted (still $CW_AFTER)"
+RD_AFTER="$(aws route53resolver list-firewall-rules --firewall-rule-group-id "$RG_ID" --region "$REGION" \
+  --query 'FirewallRules[0].FirewallDomainRedirectionAction' --output text)"
+echo "FirewallDomainRedirectionAction after revert: $RD_AFTER"
+[ "$RD_AFTER" = "INSPECT_REDIRECTION_DOMAIN" ] || fail "Route53 rule not reverted (still $RD_AFTER)"
+
+echo "=== check must be CLEAN again after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
 echo "INTEG PASS"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -529,6 +529,49 @@ describe('buildRevertPlan', () => {
     expect(plan.items[0]!.ops).toHaveLength(2);
   });
 
+  it('Backup BackupPlanRule array-element nested -> revertable sdk item, op SETS the AWS default', () => {
+    // A value that "appeared since record" inside a non-standard-keyed array element is now
+    // revertable (Cloud Control index-revert writer), and a KNOWN_DEFAULT_PATHS default makes
+    // the op SET the default (not a `remove` the provider may ignore).
+    const f = F({
+      tier: 'undeclared',
+      logicalId: 'Plan',
+      physicalId: 'plan|abc',
+      resourceType: 'AWS::Backup::BackupPlan',
+      path: 'BackupPlan.BackupPlanRule[Daily].CompletionWindowMinutes',
+      actual: 5000,
+      nested: true,
+      unrecorded: false,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items[0]).toMatchObject({ kind: 'sdk', resourceType: 'AWS::Backup::BackupPlan' });
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'add', value: 10080 });
+  });
+
+  it('Route53Resolver FirewallRules array-element nested -> revertable sdk item, sets default', () => {
+    const f = F({
+      tier: 'undeclared',
+      logicalId: 'RG',
+      physicalId: 'rslvr-frg-x',
+      resourceType: 'AWS::Route53Resolver::FirewallRuleGroup',
+      path: 'FirewallRules[100].FirewallDomainRedirectionAction',
+      actual: 'TRUST_REDIRECTION_DOMAIN',
+      nested: true,
+      unrecorded: false,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items[0]).toMatchObject({
+      kind: 'sdk',
+      resourceType: 'AWS::Route53Resolver::FirewallRuleGroup',
+    });
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      value: 'INSPECT_REDIRECTION_DOMAIN',
+    });
+  });
+
   it('an `added` finding with no physical id -> notRevertable (cannot address the delete)', () => {
     const f = F({ tier: 'added', logicalId: 'X/y', physicalId: undefined, path: '' });
     const plan = buildRevertPlan([f], undefined);

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -94,6 +94,11 @@ import {
   EventBridgeClient,
   PutPermissionCommand,
 } from '@aws-sdk/client-eventbridge';
+import {
+  CloudControlClient,
+  GetResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
@@ -116,6 +121,7 @@ const configService = mockClient(ConfigServiceClient);
 const eventbridge = mockClient(EventBridgeClient);
 const apigw = mockClient(APIGatewayClient);
 const ecs = mockClient(ECSClient);
+const cloudcontrol = mockClient(CloudControlClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -161,6 +167,7 @@ beforeEach(() => {
   eventbridge.reset();
   apigw.reset();
   ecs.reset();
+  cloudcontrol.reset();
 });
 
 describe('ECS ServiceConnect writer (re-supplies the whole writeOnly config via UpdateService)', () => {
@@ -1599,5 +1606,102 @@ describe('writeConfigRuleInputParameters (AWS::Config::ConfigRule, JSON-string p
     await expect(writer(ctx({ physicalId: 'missing' }), [inputParamsOp({ a: 1 })])).rejects.toThrow(
       /Config rule not found/
     );
+  });
+});
+
+describe('Cloud Control index-revert writer (array-element nested values)', () => {
+  const ctx = (resourceType: string, physicalId: string): OverrideCtx => ({
+    physicalId,
+    declared: {},
+    region: 'us-east-1',
+    accountId: '123456789012',
+    resourceType,
+  });
+
+  it('re-points an identity bracket to the live-array INDEX and sends ONE UpdateResource', async () => {
+    // live model: the rule of interest is at index 1 (Priority 100), NOT index 0.
+    cloudcontrol.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Properties: JSON.stringify({
+          FirewallRules: [
+            { Priority: 50, FirewallDomainRedirectionAction: 'INSPECT_REDIRECTION_DOMAIN' },
+            { Priority: 100, FirewallDomainRedirectionAction: 'TRUST_REDIRECTION_DOMAIN' },
+          ],
+        }),
+      },
+    });
+    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    const ops: PatchOp[] = [
+      {
+        op: 'add',
+        path: '/FirewallRules[100]/FirewallDomainRedirectionAction',
+        value: 'INSPECT_REDIRECTION_DOMAIN',
+        human: 'x',
+      },
+    ];
+    await resolveSdkWriter('AWS::Route53Resolver::FirewallRuleGroup', ops)!(
+      ctx('AWS::Route53Resolver::FirewallRuleGroup', 'rslvr-frg-x'),
+      ops
+    );
+    const calls = cloudcontrol.commandCalls(UpdateResourceCommand);
+    expect(calls).toHaveLength(1);
+    const patch = JSON.parse(calls[0]!.args[0].input.PatchDocument as string);
+    // [100] (Priority) -> live index 1
+    expect(patch).toEqual([
+      {
+        op: 'add',
+        path: '/FirewallRules/1/FirewallDomainRedirectionAction',
+        value: 'INSPECT_REDIRECTION_DOMAIN',
+      },
+    ]);
+  });
+
+  it('resolves a non-standard-keyed nested array (Backup BackupPlanRule by RuleName)', async () => {
+    cloudcontrol.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Properties: JSON.stringify({
+          BackupPlan: { BackupPlanRule: [{ RuleName: 'Daily', CompletionWindowMinutes: 5000 }] },
+        }),
+      },
+    });
+    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    const ops: PatchOp[] = [
+      {
+        op: 'add',
+        path: '/BackupPlan/BackupPlanRule[Daily]/CompletionWindowMinutes',
+        value: 10080,
+        human: 'x',
+      },
+    ];
+    await resolveSdkWriter('AWS::Backup::BackupPlan', ops)!(
+      ctx('AWS::Backup::BackupPlan', 'plan|abc'),
+      ops
+    );
+    const patch = JSON.parse(
+      cloudcontrol.commandCalls(UpdateResourceCommand)[0]!.args[0].input.PatchDocument as string
+    );
+    expect(patch).toEqual([
+      { op: 'add', path: '/BackupPlan/BackupPlanRule/0/CompletionWindowMinutes', value: 10080 },
+    ]);
+  });
+
+  it('throws (honest failure) when the identity cannot be located in the live array', async () => {
+    cloudcontrol.on(GetResourceCommand).resolves({
+      ResourceDescription: { Properties: JSON.stringify({ FirewallRules: [{ Priority: 50 }] }) },
+    });
+    const ops: PatchOp[] = [
+      {
+        op: 'add',
+        path: '/FirewallRules[999]/FirewallDomainRedirectionAction',
+        value: 'X',
+        human: 'x',
+      },
+    ];
+    await expect(
+      resolveSdkWriter('AWS::Route53Resolver::FirewallRuleGroup', ops)!(
+        ctx('AWS::Route53Resolver::FirewallRuleGroup', 'rg'),
+        ops
+      )
+    ).rejects.toThrow(/cannot locate/);
   });
 });


### PR DESCRIPTION
Follow-up to #411: makes the array-element nested rule values it DETECTS actually **revertable** — closing the "if it's shown, it should be revertable" gap. Discovered a GENERIC solution that needs no per-type SDK writers.

## The insight
An array-element nested finding path uses an IDENTITY bracket (`FirewallRules[100]`, `BackupPlanRule[DailyRule]`) which `toPointer` can't turn into a valid RFC6902 pointer — the historical reason these were `not revertable` (R78 abandoned index patches because it indexed the DECLARED subset, whose indices differ from live). But re-pointing the bracket to the **LIVE-array INDEX** (`/FirewallRules/1/…`) IS valid, because the index is taken against the SAME model Cloud Control read-modify-writes. **Proven live** for both Backup and Route53Resolver.

## Implementation
- `writeCloudControlIndexNested` (one generic writer, registered in `SDK_NESTED_WRITERS` for `AWS::Backup::BackupPlan` + `AWS::Route53Resolver::FirewallRuleGroup`): GetResource → `reindexNestedPointer` (bracket → live index, by NESTED_ARRAY_IDENTITY/identityField) → one UpdateResource. Throws (honest failure, never a wrong write) if an identity can't be located.
- `revertOp`: a nested value AWS materialized as a default (`KNOWN_DEFAULT_PATHS`) now reverts by SETTING that default (`add`), not a bare `remove` — Route53's `FirewallDomainRedirectionAction` keeps its value when the field is merely removed (a silent no-op, proven live), so the default must be written explicitly.
- `OverrideCtx` gains `resourceType` (set on the revert path) so the type-agnostic writer can GetResource/UpdateResource.
- These reuse the existing `isNestedSdkWritable` wiring (plan routing + the interactive action picker), so array-element nested becomes revertable with no churn to those.

ApiGateway Method keeps its native SDK writer (CC's whole-Method RMW is fiddly + it rejects `op: remove`); this CC-index path is for CC-mutable types.

## Live integ (INTEG PASS)
`tests/integration/nested-array-defaults` now also REVERTS: deploy → record → mutate a Backup rule window + a Route53 firewall rule → check detects → **revert** (both via the CC index-revert writer, set-to-default) → live re-read shows 10080 / INSPECT_REDIRECTION_DOMAIN → check CLEAN.

## Tests
Unit: plan routing (both types → revertable sdk item, op sets the AWS default); the writer re-points a bracket to the correct live index (incl. a rule NOT at index 0, and the non-standard RuleName key) + honest-throw when unlocatable. Full suite 1805 green, typecheck 0, lint 0.
