### PR TITLE
fix(diff): detect any removed declared collection by default (close the omit-when-empty FN class)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -852,15 +852,21 @@ always exit 2. All three of `deleted` / `declared` / `undeclared` count as
 failing drift. `ignored` / `readGap` / `unresolved` / `skipped` are
 informational — surfaced, never silently dropped, but never false drift.
 
-A declared property absent from the live read defaults to `readGap` — EXCEPT for the
-curated `OMITTED_WHEN_EMPTY_PATHS` (`normalize/noise.ts`): properties Cloud Control
-RETURNS when set but OMITS when empty (EC2 SecurityGroup ingress/egress rules, IAM
-inline `Policies`, S3 `Cors`/`LifecycleConfiguration`, Lambda `Environment`). For
-those, absence means the whole collection was removed out of band — a real
-`declared` drift (one whole-property finding so revert re-applies it with a single
-top-level `add`), not a `readGap`. It is curated, not a blanket rule: many genuine
-non-writeOnly readGaps (Batch `Timeout`, DynamoDB `SSESpecification`, …) AWS never
-returns even when set, so treating every absence as drift would false-positive them.
+A declared property absent from the live read: a declared NON-EMPTY **collection**
+(object/array) is real `declared` drift BY DEFAULT — many services OMIT a sub-config
+when empty but RETURN it when set (EC2 SecurityGroup ingress/egress rules, IAM inline
+`Policies`, every S3 sub-config — `Cors`/`Lifecycle`/`Website`/`OwnershipControls`/…,
+Lambda `Environment`), so its absence means the whole config was removed out of band.
+Swallowing that as a `readGap` was a silent FALSE NEGATIVE (the removal reported
+CLEAN). classify emits one whole-property finding so revert re-applies it with a
+single top-level `add`. The EXCEPTIONS stay `readGap` (informational, never false
+drift): a **scalar** (AWS may legitimately not echo one), an **empty** declared
+collection (declared `{}`/`[]` vs absent is not drift), and the small curated
+`READGAP_COLLECTION_PATHS` (`normalize/noise.ts`) DENYLIST of collections AWS never
+returns even when set (Batch `Timeout`, Budgets `NotificationsWithSubscribers`,
+DynamoDB `SSESpecification`) — derived from a full golden-corpus audit. This closes
+the whole removed-collection FN class for every type at once; a new genuine readGap
+surfaces as a VISIBLE, denylist-able false positive, never a silent FN.
 
 `ignored` (R32) is for properties an external system legitimately keeps rewriting —
 Application Auto Scaling moving an ECS Service `DesiredCount`, DynamoDB autoscaled

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -47,7 +47,7 @@ import {
   isEpochHourEqual,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
-  OMITTED_WHEN_EMPTY_PATHS,
+  READGAP_COLLECTION_PATHS,
   ELB_ATTRIBUTE_DEFAULTS,
   PARAMETER_NAME_SUBSET_PATHS,
   alignParameterNameSubset,
@@ -577,19 +577,27 @@ export function classifyResource(
       // The compare below skips any per-leaf record whose declared side is unresolved.
       if (v === UNRESOLVED || !(k in live)) continue;
     } else if (!(k in live)) {
-      // A property AWS's CC read OMITS when empty but RETURNS when set (SecurityGroup
-      // ingress/egress rules, IAM inline Policies, S3 Cors/LifecycleConfiguration):
-      // its absence is NOT a readGap — the whole declared collection was emptied/
-      // removed out of band. Emit ONE WHOLE-PROPERTY declared finding so the removal
-      // surfaces as drift AND revert re-applies the entire config via a single
-      // top-level `add` (a nested sub-path patch fails — the parent it targets, e.g.
-      // `/CorsConfiguration`, does not exist in the live model). FP-safe: a non-empty
-      // value is always returned by AWS, so this only fires on a genuine removal.
-      // Curated per-type — a general "absent → drift" rule would false-positive the
-      // legitimate non-writeOnly readGaps AWS never returns (Batch Timeout, DynamoDB
-      // SSESpecification, …). (See OMITTED_WHEN_EMPTY_PATHS.)
-      const isCollection = Array.isArray(v) || (v !== null && typeof v === 'object');
-      if (OMITTED_WHEN_EMPTY_PATHS[resourceType]?.has(k) && isCollection) {
+      // A declared key absent from the live read. A declared NON-EMPTY COLLECTION
+      // (object/array) absent from live means the whole config was emptied/removed out
+      // of band — many services OMIT a sub-config entirely when empty but RETURN it
+      // when set (SecurityGroup ingress/egress, IAM inline Policies, every S3 sub-config,
+      // Lambda Environment, …). Treating that as an informational readGap was a SILENT
+      // FALSE NEGATIVE (the removal reported CLEAN). So DETECT it by default — emit ONE
+      // WHOLE-PROPERTY declared finding (revert then re-applies the entire config via a
+      // single top-level `add`; a nested sub-path patch fails because the parent, e.g.
+      // `/CorsConfiguration`, is absent in the live model). FP-safe: a populated
+      // collection is always returned by AWS, so this only fires on a genuine removal.
+      //
+      // EXCEPTIONS stay readGap (informational, never false drift): a SCALAR (AWS may
+      // legitimately not echo a scalar), an EMPTY declared collection (declared `{}`/`[]`
+      // vs absent is not drift), and the curated READGAP_COLLECTION_PATHS denylist —
+      // collections AWS genuinely never returns even when set (Batch Timeout, DynamoDB
+      // SSESpecification, Budgets NotificationsWithSubscribers). A new genuine readGap
+      // surfaces as a VISIBLE, denylist-able false positive, never a silent FN.
+      const isNonEmptyCollection =
+        (Array.isArray(v) && v.length > 0) ||
+        (v !== null && typeof v === 'object' && Object.keys(v as object).length > 0);
+      if (isNonEmptyCollection && !READGAP_COLLECTION_PATHS[resourceType]?.has(k)) {
         findings.push({
           tier: 'declared',
           logicalId,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1649,46 +1649,33 @@ export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
   return sa.every((v, i) => v === sb[i]);
 }
 
-// Per-type properties whose Cloud Control read OMITS the key entirely when it has no
-// value, yet RETURNS it when set. The default classify rule treats "declared key
-// absent from the live read" as a readGap (declared-but-unreadable) — correct for a
-// genuinely unreadable/write-only prop, but a SILENT FALSE NEGATIVE here: the key is
-// readable, so its absence means the declared value was emptied/removed out of band
-// (someone deleted the SecurityGroup ingress rule in the console) and MUST surface as
-// drift. classify synthesizes an empty live value (`[]`) for these so the removal
-// flows through the normal compare + revert path instead of being swallowed as a
-// readGap. FP-safe: on a clean stack the declared value is non-empty, so AWS returns
-// it (present in live) and this branch never fires. EC2 SecurityGroup ingress/egress
-// is the confirmed case (live-observed: revoking the only ingress rule made CC omit
-// `SecurityGroupIngress`, which classify reported CLEAN). Curated per-type opt-in —
-// a prop that is a genuine readGap on some type must NOT be added here.
-export const OMITTED_WHEN_EMPTY_PATHS: Record<string, ReadonlySet<string>> = {
-  'AWS::EC2::SecurityGroup': new Set(['SecurityGroupIngress', 'SecurityGroupEgress']),
-  // IAM inline `Policies`: Cloud Control returns the array when the principal has
-  // inline policies and OMITS it entirely when it has none. Deleting the only inline
-  // policy out of band (`aws iam delete-role-policy`) — a security-relevant change —
-  // therefore looked CLEAN (readGap) pre-fix. Live-confirmed on AWS::IAM::Role; User
-  // and Group share the identical inline-policy mechanism (PutUserPolicy /
-  // PutGroupPolicy, same `Policies` shape). FP-safe: a non-empty `Policies` is always
-  // returned, so this only fires on a genuine removal.
-  'AWS::IAM::Role': new Set(['Policies']),
-  'AWS::IAM::User': new Set(['Policies']),
-  'AWS::IAM::Group': new Set(['Policies']),
-  // S3 bucket sub-configs (the most-deployed resource): Cloud Control returns these
-  // object-valued configs when set and OMITS them once removed
-  // (`aws s3api delete-bucket-cors` / `delete-bucket-lifecycle`). A declared CORS or
-  // lifecycle policy deleted out of band therefore looked CLEAN (readGap) pre-fix.
-  // Live-confirmed on AWS::S3::Bucket. These are OBJECT-valued (Cors = {CorsRules},
-  // Lifecycle = {Rules}); classify synthesizes an empty object so the removal compares
-  // as declared drift. Only the two live-proven configs are listed — other S3 configs
-  // (Notification/Replication/Website/…) are candidates for a future probe.
-  'AWS::S3::Bucket': new Set(['CorsConfiguration', 'LifecycleConfiguration']),
-  // Lambda `Environment`: Cloud Control returns it when the function has env vars and
-  // OMITS it once they are all cleared (`update-function-configuration --environment
-  // '{"Variables":{}}'`). A declared env config wiped out of band therefore looked
-  // CLEAN (readGap) pre-fix. Live-confirmed on AWS::Lambda::Function. Object-valued
-  // ({Variables:{…}}); reverts via a top-level CC add → UpdateFunctionConfiguration.
-  'AWS::Lambda::Function': new Set(['Environment']),
+// A declared COLLECTION (object/array) property absent from the live read is, BY
+// DEFAULT, a real `declared` drift — not a readGap. Many AWS services OMIT a
+// sub-config entirely once it is empty/removed but RETURN it when set (EC2
+// SecurityGroup ingress/egress rules, IAM inline Policies, S3 Cors/Lifecycle/Website/
+// OwnershipControls/Metrics/IntelligentTiering/Analytics/…, Lambda Environment). The
+// old rule "absent declared key → readGap (informational, never drift)" SILENTLY
+// swallowed every such removal (someone deletes the SSH rule / inline policy / S3
+// lifecycle / Lambda env in the console → cdkrd reported CLEAN). Live-confirmed that
+// S3 omits ALL its sub-configs when empty, so a per-type allowlist was hopelessly
+// incomplete; classify therefore DETECTS an absent declared collection by default and
+// re-applies the whole property on revert. FP-safe: a populated collection is always
+// returned by AWS, so this only fires on a genuine removal — and an empty declared
+// collection is exempted (declared `{}`/`[]` vs absent is not drift).
+//
+// READGAP_COLLECTION_PATHS is the small DENYLIST of the EXCEPTIONS: declared collection
+// properties AWS genuinely NEVER returns even when set (a true readGap), so their
+// absence must stay informational, not false drift. Derived from a full golden-corpus
+// audit (only these few in ~480 cases). A new genuine-readGap collection surfaces as a
+// VISIBLE, denylist-able false positive — never a silent false negative.
+export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
+  // `Timeout` ({AttemptDurationSeconds}) — not echoed by Cloud Control's JobDefinition read.
+  'AWS::Batch::JobDefinition': new Set(['Timeout']),
+  // `NotificationsWithSubscribers` — write-only-style budget notifications, not read back.
+  'AWS::Budgets::Budget': new Set(['NotificationsWithSubscribers']),
+  // `SSESpecification` — the SSE config is reflected via other readOnly props, not echoed verbatim.
+  'AWS::DynamoDB::GlobalTable': new Set(['SSESpecification']),
+  'AWS::DynamoDB::Table': new Set(['SSESpecification']),
 };
 
 // Per-type OBJECT-array props AWS treats as UNORDERED SETS whose element objects

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4727,13 +4727,14 @@ describe('NESTED_ARRAY_IDENTITY: materialized-default array elements (Backup / R
   });
 });
 
-// A property AWS's Cloud Control read OMITS entirely when it has no value, yet
-// RETURNS when set (EC2 SecurityGroup SecurityGroupIngress/Egress). Its absence from
-// the live read must NOT be swallowed as a readGap — it means the declared rule was
-// removed out of band (the canonical "someone deleted the SSH rule in the console"),
-// which is a silent FALSE NEGATIVE. Live-observed: revoking the only ingress rule made
-// CC drop the key and classify reported CLEAN. See OMITTED_WHEN_EMPTY_PATHS.
-describe('OMITTED_WHEN_EMPTY_PATHS — readable prop AWS omits when empty', () => {
+// A declared NON-EMPTY COLLECTION absent from the live read is, by DEFAULT, real
+// `declared` drift (the whole config was removed out of band — AWS omits a sub-config
+// when empty but returns it when set). Treating it as a readGap was a silent FALSE
+// NEGATIVE ("someone deleted the SSH rule / S3 lifecycle / inline policy in the
+// console" reported CLEAN). The exceptions that stay readGap are scalars, EMPTY declared
+// collections, and the curated READGAP_COLLECTION_PATHS denylist (collections AWS never
+// returns even when set). See READGAP_COLLECTION_PATHS.
+describe('absent declared collection → declared drift by default (readGap only by exception)', () => {
   const sgSchema: SchemaInfo = {
     readOnly: new Set(['Id', 'GroupId']),
     writeOnly: new Set(),
@@ -4866,7 +4867,7 @@ describe('OMITTED_WHEN_EMPTY_PATHS — readable prop AWS omits when empty', () =
     );
   });
 
-  it('curated, not blanket: an absent declared array on a type NOT in the table stays a readGap', () => {
+  it('default: an absent declared collection on ANY type detects (no allowlist needed)', () => {
     const findings = classifyResource(
       {
         logicalId: 'T',
@@ -4877,8 +4878,59 @@ describe('OMITTED_WHEN_EMPTY_PATHS — readable prop AWS omits when empty', () =
       {},
       sgSchema
     );
-    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'SomeArray')).toBe(true);
-    expect(findings.some((f) => f.tier === 'declared' && f.path === 'SomeArray')).toBe(false);
+    // the whole class is closed by default — a brand-new type's removed collection
+    // surfaces as drift, not a silent readGap
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'SomeArray')).toBe(true);
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'SomeArray')).toBe(false);
+  });
+
+  it('exception (denylist): a genuine non-writeOnly readGap collection stays readGap', () => {
+    // Batch JobDefinition Timeout / DynamoDB SSESpecification etc. — AWS never returns
+    // them even when set, so their absence must NOT be false drift.
+    const findings = classifyResource(
+      {
+        logicalId: 'D',
+        resourceType: 'AWS::DynamoDB::Table',
+        physicalId: 'd',
+        declared: { TableName: 'd', SSESpecification: { SSEEnabled: true } },
+      },
+      { TableName: 'd' },
+      sgSchema
+    );
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'SSESpecification')).toBe(true);
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'SSESpecification')).toBe(
+      false
+    );
+  });
+
+  it('exception (scalar): an absent declared SCALAR stays readGap, not drift', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'T',
+        resourceType: 'AWS::SomeOther::Type',
+        physicalId: 'p',
+        declared: { Port: 5432 },
+      },
+      {},
+      sgSchema
+    );
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'Port')).toBe(true);
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'Port')).toBe(false);
+  });
+
+  it('exception (empty collection): an absent EMPTY declared collection is not drift', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'T',
+        resourceType: 'AWS::SomeOther::Type',
+        physicalId: 'p',
+        declared: { EmptyArr: [], EmptyObj: {} },
+      },
+      {},
+      sgSchema
+    );
+    // empty declared collection vs absent live is not a removal — stays readGap, never declared
+    expect(findings.some((f) => f.tier === 'declared')).toBe(false);
   });
 });
 

--- a/tests/corpus/AWS__S3__Bucket.BucketConfigsOmit2.json
+++ b/tests/corpus/AWS__S3__Bucket.BucketConfigsOmit2.json
@@ -1,0 +1,255 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Bucket",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+    "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket",
+    "declared": {
+      "AnalyticsConfigurations": [
+        {
+          "Id": "a1",
+          "StorageClassAnalysis": {}
+        }
+      ],
+      "IntelligentTieringConfigurations": [
+        {
+          "Id": "archive",
+          "Status": "Enabled",
+          "Tierings": [
+            {
+              "AccessTier": "ARCHIVE_ACCESS",
+              "Days": 90
+            }
+          ]
+        }
+      ],
+      "MetricsConfigurations": [
+        {
+          "Id": "EntireBucket"
+        }
+      ],
+      "OwnershipControls": {
+        "Rules": [
+          {
+            "ObjectOwnership": "ObjectWriter"
+          }
+        ]
+      },
+      "WebsiteConfiguration": {
+        "ErrorDocument": "error.html",
+        "IndexDocument": "index.html"
+      }
+    }
+  },
+  "liveRaw": {
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+    "RegionalDomainName": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk.s3.us-east-1.amazonaws.com",
+    "DomainName": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk.s3.dualstack.us-east-1.amazonaws.com",
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3ConfigsOmit2/58568de0-7363-11f1-9bfa-1224aa199479",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegS3ConfigsOmit2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Bucket",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "declared",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AnalyticsConfigurations",
+      "desired": [
+        {
+          "Id": "a1",
+          "StorageClassAnalysis": {}
+        }
+      ],
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "declared",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "IntelligentTieringConfigurations",
+      "desired": [
+        {
+          "Id": "archive",
+          "Status": "Enabled",
+          "Tierings": [
+            {
+              "AccessTier": "ARCHIVE_ACCESS",
+              "Days": 90
+            }
+          ]
+        }
+      ],
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "declared",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "MetricsConfigurations",
+      "desired": [
+        {
+          "Id": "EntireBucket"
+        }
+      ],
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "declared",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "desired": {
+        "Rules": [
+          {
+            "ObjectOwnership": "ObjectWriter"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "declared",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "WebsiteConfiguration",
+      "desired": {
+        "ErrorDocument": "error.html",
+        "IndexDocument": "index.html"
+      },
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "PublicAccessBlockConfiguration",
+      "actual": {
+        "RestrictPublicBuckets": true,
+        "BlockPublicPolicy": true,
+        "BlockPublicAcls": true,
+        "IgnorePublicAcls": true
+      },
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Bucket",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "BlockedEncryptionTypes": {
+              "EncryptionType": ["SSE-C"]
+            },
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3configsomit2-bucket-wspnmyk7nfkk",
+      "constructPath": "CdkRealDriftIntegS3ConfigsOmit2/Bucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SecretsManager__SecretTargetAttachment.Attachment.json
+++ b/tests/corpus/AWS__SecretsManager__SecretTargetAttachment.Attachment.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ClusterSecretAttachment769E6258",
+    "resourceType": "AWS::SecretsManager::SecretTargetAttachment",
+    "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:ClusterSecret6368BD0F-ehTEYXyOYiRs-F7k1mt",
+    "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/Secret/Attachment",
+    "declared": {
+      "SecretId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:ClusterSecret6368BD0F-ehTEYXyOYiRs-F7k1mt",
+      "TargetId": "cdkrealdriftintegaurorarich-clustereb0386a7-dq3id2u4jh9p",
+      "TargetType": "AWS::RDS::DBCluster"
+    }
+  },
+  "liveRaw": {
+    "SecretId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:ClusterSecret6368BD0F-ehTEYXyOYiRs-F7k1mt",
+    "TargetType": "AWS::RDS::DBCluster",
+    "Id": "arn:aws:secretsmanager:us-east-1:111111111111:secret:ClusterSecret6368BD0F-ehTEYXyOYiRs-F7k1mt",
+    "TargetId": "cdkrealdriftintegaurorarich-clustereb0386a7-dq3id2u4jh9p"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["SecretId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["SecretId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/s3-configs-omit2/app.ts
+++ b/tests/integration/s3-configs-omit2/app.ts
@@ -1,0 +1,21 @@
+// Probe: which additional S3 sub-configs does Cloud Control OMIT when removed
+// (→ same OMITTED_WHEN_EMPTY false-negative as Cors/Lifecycle)? Self-contained
+// configs only (no extra resources): Website, OwnershipControls, Metrics,
+// IntelligentTiering, Analytics, InventoryConfigurations (skipped — needs dest).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnBucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3ConfigsOmit2");
+
+new CfnBucket(stack, "Bucket", {
+  websiteConfiguration: { indexDocument: "index.html", errorDocument: "error.html" },
+  ownershipControls: { rules: [{ objectOwnership: "ObjectWriter" }] },
+  metricsConfigurations: [{ id: "EntireBucket" }],
+  intelligentTieringConfigurations: [
+    { id: "archive", status: "Enabled", tierings: [{ accessTier: "ARCHIVE_ACCESS", days: 90 }] },
+  ],
+  analyticsConfigurations: [{ id: "a1", storageClassAnalysis: {} }],
+});
+
+app.synth();

--- a/tests/integration/s3-configs-omit2/cdk.json
+++ b/tests/integration/s3-configs-omit2/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-configs-omit2/package.json
+++ b/tests/integration/s3-configs-omit2/package.json
@@ -1,0 +1,2 @@
+{ "name": "cdk-real-drift-integ-s3-configs-omit2", "private": true, "version": "0.0.0",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }, "type": "module" }

--- a/tests/integration/s3-configs-omit2/verify.sh
+++ b/tests/integration/s3-configs-omit2/verify.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for "absent declared collection → drift by
+# default". S3 OMITS every sub-config when removed; this fixture declares five of them
+# (Website, OwnershipControls, Metrics, IntelligentTiering, Analytics) — NONE of which
+# is in any per-type table — and proves they are ALL detected on removal and reverted.
+# deploy -> record -> delete all 5 configs -> check MUST detect 5 -> revert -> CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3ConfigsOmit2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+BUCKET=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::S3::Bucket'].PhysicalResourceId" --output text)
+[ -n "$BUCKET" ] || fail "no bucket"
+
+echo "=== [$STACK] record ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] remove all 5 sub-configs out of band (CC omits them) ==="
+aws s3api delete-bucket-website --bucket "$BUCKET" --region "$REGION" || fail "rm website"
+aws s3api delete-bucket-ownership-controls --bucket "$BUCKET" --region "$REGION" || fail "rm ownership"
+aws s3api delete-bucket-metrics-configuration --bucket "$BUCKET" --id EntireBucket --region "$REGION" || fail "rm metrics"
+aws s3api delete-bucket-intelligent-tiering-configuration --bucket "$BUCKET" --id archive --region "$REGION" || fail "rm tiering"
+aws s3api delete-bucket-analytics-configuration --bucket "$BUCKET" --id a1 --region "$REGION" || fail "rm analytics"
+
+echo "=== [$STACK] check MUST detect all 5 (regression: were silent readGap FNs) ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: removed S3 configs not detected (got CLEAN)"
+N=$($CLI check "$STACK" --region "$REGION" 2>/dev/null | grep -cE "AWS::S3::Bucket")
+[ "$N" -ge 5 ] || fail "expected >=5 declared S3 findings, got $N"
+
+echo "=== [$STACK] revert all 5 ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## ⚠️ This flips a default — please review the tradeoff before merging

Closes the **omit-when-empty false-negative class comprehensively** (your "他に出ないようにしたい"). Builds on #413.

### The problem with #413's approach
#413 fixed this per-type via an allowlist (`OMITTED_WHEN_EMPTY_PATHS`). But live-probing this round showed **S3 omits _every_ sub-config when empty** — Website, OwnershipControls, Metrics, IntelligentTiering, Analytics, Cors, Lifecycle, … I'd added only 2 of ~7+. A curated allowlist is hopelessly incomplete; new silent FNs keep slipping through (exactly the fear).

### The fix: flip the default
A declared **non-empty collection** (object/array) absent from the live read is now **`declared` drift by default** — its absence means the whole config was removed out of band. This closes the class for **every service at once**, no enumeration.

The `OMITTED_WHEN_EMPTY_PATHS` allowlist becomes a tiny `READGAP_COLLECTION_PATHS` **denylist** of the exceptions.

### Why it's FP-safe
A full golden-corpus audit (~480 cases) found only **3** genuine non-writeOnly readGap collections AWS never returns even when set:
- `AWS::Batch::JobDefinition` `Timeout`
- `AWS::Budgets::Budget` `NotificationsWithSubscribers`
- `AWS::DynamoDB::Table`/`GlobalTable` `SSESpecification`

Those 3 are denylisted. Also exempt (stay `readGap`): **scalars** and **empty** declared collections. Corpus replay (485 cases) stays green.

### The tradeoff (your call)
- **Eliminates** the entire silent-FN class for every type (the security-relevant one you flagged as 超やばい).
- **Residual risk**: a genuine readGap collection on an *untested* type would now show as a **visible, denylist-able** false positive (never a silent FN). Given the corpus found only 3 in ~480 cases, the density is ~0.6%.
- This aligns with "a visible FP I can fix beats a silent FN I can't see" — but it **flips a deliberate default** (`A3: absent = readGap`), so I left the merge decision to you.

### Live-proven
Fresh S3 stack, 5 configs (Website/OwnershipControls/Metrics/IntelligentTiering/Analytics) each removed out of band → `check` detects **all 5** (none in any table) → `revert` restores all → CLEAN. `INTEG PASS`.

### Tests
Unit (default-detect / denylist / scalar / empty exceptions), golden-corpus case, `s3-configs-omit2` regression fixture, ARCHITECTURE.md updated. 1804 unit tests green.

**Note:** src change → `/verify-pr` required before merge (not run yet — awaiting your decision on the default flip). If you prefer the conservative allowlist instead, say so and I'll revert to that shape.
