### PR TITLE
fix(noise): drop CC field mis-echo + alt-representation (EC2 Route VpcEndpointId, Subnet AvailabilityZoneId)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,6 +374,12 @@ all live changes
     like atDefault, equality-gated against the physical-id-substituted template; never
     drift, never recorded by record. (`GENERATED_DEFAULTS` / `resolveGeneratedDefault`.)
   − pure structural noise (aws:* tags, physical-id echo, trivially-empty {}/[]) → dropped
+  − Cloud Control MIS-ECHOES / ALT-REPRESENTS a value → dropped: AWS::EC2::Route's
+    `VpcEndpointId` reflects the route's gateway target (`igw-…`/`nat-…`) on a non-endpoint
+    route (a real VPC-endpoint route is `vpce-…`); AWS::EC2::Subnet's `AvailabilityZoneId`
+    (`apne1-az4`) is CC's resolved form of the declared `AvailabilityZone`
+    (`ap-northeast-1a`) — `CC_ALT_REPRESENTATION`, dropped when the declared sibling is
+    present. Both are first-run noise on every public-subnet VPC.
   − tag-list / id-array / method-set ORDER → canonicalized (see below)
   − name↔ARN (either side), alias/aws/*↔key-ARN → collapsed (see below)
   − stringly-typed scalar (true vs "true", 5432 vs "5432") → equal (isStringlyEqualScalar)

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -194,6 +194,20 @@ const REFLECTED_CHILD_PROPS: Record<string, string> = {
   'AWS::SNS::Topic': 'Subscription',
 };
 
+// Cloud Control returns an ALTERNATIVE representation of a declared value as a separate
+// live-only field. Keyed resourceType -> { liveOnlyField: declaredSiblingField }: drop the
+// live-only field when its declared sibling is present (the template already pins the value
+// in the other form). AWS::EC2::Subnet is the case — declaring `AvailabilityZone`
+// ("ap-northeast-1a") makes CC also echo the resolved `AvailabilityZoneId` ("apne1-az4"), a
+// different form of the SAME AZ, on EVERY subnet. Symmetric, so declaring either form drops
+// the other.
+const CC_ALT_REPRESENTATION: Record<string, Record<string, string>> = {
+  'AWS::EC2::Subnet': {
+    AvailabilityZoneId: 'AvailabilityZone',
+    AvailabilityZone: 'AvailabilityZoneId',
+  },
+};
+
 // Per-type attachment-list properties handled by tier rather than a positional compare.
 // AWS::IAM::ManagedPolicy's `Roles`/`Users`/`Groups` name the principals a managed
 // policy is attached to — but the same policy is commonly attached from SEVERAL places
@@ -1058,6 +1072,23 @@ export function classifyResource(
       findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
       continue;
     }
+    // Cloud Control MIS-POPULATES a field by echoing a sibling: AWS::EC2::Route's
+    // `VpcEndpointId` reflects the route's GATEWAY target (`igw-…`/`nat-…`/`tgw-…`) on a
+    // NON-endpoint route — a value the template never set, duplicated from GatewayId. A REAL
+    // VPC-endpoint route's VpcEndpointId is `vpce-…` (and declared). Drop the mis-echo so a
+    // public-subnet route table is not first-run noise. (Proven live: an IGW default route
+    // reads back VpcEndpointId === GatewayId === `igw-…`.)
+    if (
+      resourceType === 'AWS::EC2::Route' &&
+      k === 'VpcEndpointId' &&
+      typeof v === 'string' &&
+      !v.startsWith('vpce-')
+    )
+      continue;
+    // CC echoed an ALTERNATIVE representation of a declared value (e.g. a Subnet's
+    // AvailabilityZoneId for the declared AvailabilityZone) — drop it (see CC_ALT_REPRESENTATION).
+    const altSibling = CC_ALT_REPRESENTATION[resourceType]?.[k];
+    if (altSibling !== undefined && altSibling in declared) continue;
     // A top-level key that is ALWAYS a service-minted generated id (value-independent):
     // the ApiGatewayV2 AutoDeploy Stage's DeploymentId, re-minted on every auto-deploy
     // and un-settable. Folded as `generated` (never drift, recorded, or reverted) so it

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4929,3 +4929,74 @@ describe('CFn auto-generated name folding (generated tier)', () => {
     expect(f?.tier).toBe('undeclared');
   });
 });
+
+describe('Cloud Control field mis-echo / alternative-representation folds (VPC noise)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  it('AWS::EC2::Route: a non-vpce VpcEndpointId (CC echoing the gateway target) is dropped', () => {
+    const r: DesiredResource = {
+      logicalId: 'Route',
+      resourceType: 'AWS::EC2::Route',
+      physicalId: 'rtb-x|0.0.0.0/0',
+      declared: { DestinationCidrBlock: '0.0.0.0/0', GatewayId: 'igw-0025d639c24016041' },
+    };
+    const live = {
+      DestinationCidrBlock: '0.0.0.0/0',
+      GatewayId: 'igw-0025d639c24016041',
+      VpcEndpointId: 'igw-0025d639c24016041',
+    };
+    expect(classifyResource(r, live, bare).find((f) => f.path === 'VpcEndpointId')).toBeUndefined();
+  });
+  it('AWS::EC2::Route: a REAL vpce VpcEndpointId still surfaces (not over-dropped)', () => {
+    const r: DesiredResource = {
+      logicalId: 'Route',
+      resourceType: 'AWS::EC2::Route',
+      physicalId: 'rtb-x|0.0.0.0/0',
+      declared: { DestinationCidrBlock: '0.0.0.0/0' },
+    };
+    const f = classifyResource(
+      r,
+      { DestinationCidrBlock: '0.0.0.0/0', VpcEndpointId: 'vpce-abc123' },
+      bare
+    ).find((x) => x.path === 'VpcEndpointId');
+    expect(f?.tier).toBe('undeclared');
+  });
+  it('AWS::EC2::Subnet: AvailabilityZoneId is dropped when AvailabilityZone is declared', () => {
+    const r: DesiredResource = {
+      logicalId: 'Subnet',
+      resourceType: 'AWS::EC2::Subnet',
+      physicalId: 'subnet-x',
+      declared: { AvailabilityZone: 'ap-northeast-1a', CidrBlock: '10.0.0.0/24' },
+    };
+    const live = {
+      AvailabilityZone: 'ap-northeast-1a',
+      AvailabilityZoneId: 'apne1-az4',
+      CidrBlock: '10.0.0.0/24',
+    };
+    expect(
+      classifyResource(r, live, bare).find((f) => f.path === 'AvailabilityZoneId')
+    ).toBeUndefined();
+  });
+  it('AWS::EC2::Subnet: AvailabilityZoneId still surfaces when AvailabilityZone is NOT declared', () => {
+    const r: DesiredResource = {
+      logicalId: 'Subnet',
+      resourceType: 'AWS::EC2::Subnet',
+      physicalId: 'subnet-x',
+      declared: { CidrBlock: '10.0.0.0/24' },
+    };
+    const f = classifyResource(
+      r,
+      { AvailabilityZoneId: 'apne1-az4', CidrBlock: '10.0.0.0/24' },
+      bare
+    ).find((x) => x.path === 'AvailabilityZoneId');
+    expect(f?.tier).toBe('undeclared');
+  });
+});

--- a/tests/corpus/AWS__EC2__Route.NetpublicSubnet1DefaultRoute05F98207.json
+++ b/tests/corpus/AWS__EC2__Route.NetpublicSubnet1DefaultRoute05F98207.json
@@ -43,15 +43,5 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": [
-    {
-      "tier": "undeclared",
-      "logicalId": "NetpublicSubnet1DefaultRoute05F98207",
-      "resourceType": "AWS::EC2::Route",
-      "path": "VpcEndpointId",
-      "actual": "igw-0c7816775f3353a51",
-      "physicalId": "rtb-0f55fd2a2deab184b|0.0.0.0/0",
-      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/DefaultRoute"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__EC2__Route.NetpublicSubnet2DefaultRouteE6C085C4.json
+++ b/tests/corpus/AWS__EC2__Route.NetpublicSubnet2DefaultRouteE6C085C4.json
@@ -43,15 +43,5 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": [
-    {
-      "tier": "undeclared",
-      "logicalId": "NetpublicSubnet2DefaultRouteE6C085C4",
-      "resourceType": "AWS::EC2::Route",
-      "path": "VpcEndpointId",
-      "actual": "igw-0c7816775f3353a51",
-      "physicalId": "rtb-09f760c55f4a567d2|0.0.0.0/0",
-      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/DefaultRoute"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__EC2__Route.VpcpublicSubnet1DefaultRouteB88F9E93.json
+++ b/tests/corpus/AWS__EC2__Route.VpcpublicSubnet1DefaultRouteB88F9E93.json
@@ -42,15 +42,5 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": [
-    {
-      "tier": "undeclared",
-      "logicalId": "VpcpublicSubnet1DefaultRouteB88F9E93",
-      "resourceType": "AWS::EC2::Route",
-      "path": "VpcEndpointId",
-      "actual": "igw-09d610db1e1a48943",
-      "physicalId": "rtb-09f1f01d82cbfdfcc|0.0.0.0/0",
-      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/DefaultRoute"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet1DefaultRoute10E419CD.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet1DefaultRoute10E419CD.json
@@ -58,15 +58,5 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": [
-    {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPublicSubnet1DefaultRoute10E419CD",
-      "resourceType": "AWS::EC2::Route",
-      "path": "VpcEndpointId",
-      "actual": "igw-06facc81e0936ee08",
-      "physicalId": "rtb-01daf7af05f3a8d19|0.0.0.0/0",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/DefaultRoute"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet2DefaultRoute27847E35.json
+++ b/tests/corpus/AWS__EC2__Route.WorkersVpcPublicSubnet2DefaultRoute27847E35.json
@@ -58,15 +58,5 @@
       "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
     }
   },
-  "expected": [
-    {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPublicSubnet2DefaultRoute27847E35",
-      "resourceType": "AWS::EC2::Route",
-      "path": "VpcEndpointId",
-      "actual": "igw-06facc81e0936ee08",
-      "physicalId": "rtb-03ec6bc9b1e2562e5|0.0.0.0/0",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/DefaultRoute"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet1SubnetA0498A0F.json
@@ -140,15 +140,6 @@
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "NetpublicSubnet1SubnetA0498A0F",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
-      "physicalId": "subnet-0f3317e0d9ac5df28",
-      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet1/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "NetpublicSubnet1SubnetA0498A0F",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
+++ b/tests/corpus/AWS__EC2__Subnet.NetpublicSubnet2Subnet5183DBBB.json
@@ -140,15 +140,6 @@
       "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "NetpublicSubnet2Subnet5183DBBB",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az2",
-      "physicalId": "subnet-0e4bae13856face36",
-      "constructPath": "CdkrdIntegHarvest4/Net/publicSubnet2/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "NetpublicSubnet2Subnet5183DBBB",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
+++ b/tests/corpus/AWS__EC2__Subnet.VpcpublicSubnet1Subnet2BB74ED7.json
@@ -139,15 +139,6 @@
       "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
-      "physicalId": "subnet-0a9a838411f55ddb0",
-      "constructPath": "CdkRealDriftIntegSg/Vpc/publicSubnet1/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "VpcpublicSubnet1Subnet2BB74ED7",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet1SubnetFE152C46.json
@@ -155,15 +155,6 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
-      "physicalId": "subnet-011f0a2e9cbd7ebab",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet1/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "WorkersVpcPrivateSubnet1SubnetFE152C46",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPrivateSubnet2Subnet0E2657D2.json
@@ -155,15 +155,6 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az2",
-      "physicalId": "subnet-0b456bc01025cb129",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PrivateSubnet2/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "WorkersVpcPrivateSubnet2Subnet0E2657D2",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet1Subnet76E41816.json
@@ -155,15 +155,6 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
-      "physicalId": "subnet-0434e5718302e4709",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1Subnet76E41816",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
+++ b/tests/corpus/AWS__EC2__Subnet.WorkersVpcPublicSubnet2Subnet2C3BFBD2.json
@@ -155,15 +155,6 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
-      "resourceType": "AWS::EC2::Subnet",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az2",
-      "physicalId": "subnet-0433dc95b5f60dbbc",
-      "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/Subnet"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2Subnet2C3BFBD2",
       "resourceType": "AWS::EC2::Subnet",

--- a/tests/integration/securitygroup/verify.sh
+++ b/tests/integration/securitygroup/verify.sh
@@ -42,6 +42,13 @@ grep -q "CFn-Declared Drift" /tmp/cdkrd-securitygroup-pre.out \
 # as `generated`, NOT surface as undeclared potential-drift noise on the first run.
 grep -q "GroupName" /tmp/cdkrd-securitygroup-pre.out \
   && fail "auto-generated GroupName surfaced as potential drift (should fold as generated)"
+# CC mis-echoes the IGW gateway id into a public route's VpcEndpointId, and echoes the
+# resolved AvailabilityZoneId for each subnet's declared AvailabilityZone — both common VPC
+# first-run noise that must be dropped, not surfaced.
+grep -q "VpcEndpointId" /tmp/cdkrd-securitygroup-pre.out \
+  && fail "Route VpcEndpointId (CC echoing the gateway id) surfaced — should be dropped"
+grep -q "AvailabilityZoneId" /tmp/cdkrd-securitygroup-pre.out \
+  && fail "Subnet AvailabilityZoneId (alt form of declared AvailabilityZone) surfaced — should be dropped"
 
 echo "=== record then check must stay CLEAN ==="
 $CLI record "$STACK" --region "$REGION" --yes || fail "record"


### PR DESCRIPTION
Two common VPC first-run-noise FPs — every stack with a public subnet hit both. Found while probing follow-ups; live-verified (an IGW default-route + public subnets), integ-confirmed CLEAN in the `securitygroup` integ.

## Fixes
1. **`AWS::EC2::Route` `VpcEndpointId` mis-echo** — Cloud Control duplicates the route's GATEWAY target into `VpcEndpointId` on a NON-endpoint route, so an IGW default route reads back `VpcEndpointId = "igw-…"` (== its `GatewayId`), a value the template never set. A REAL VPC-endpoint route's `VpcEndpointId` is `vpce-…` (and declared). Drop the mis-echo (`VpcEndpointId` not starting with `vpce-`).
2. **`AWS::EC2::Subnet` `AvailabilityZoneId` alt-representation** — declaring `AvailabilityZone` ("ap-northeast-1a") makes CC also echo the resolved `AvailabilityZoneId` ("apne1-az4"), a different form of the SAME AZ the template already pins, on EVERY subnet. New `CC_ALT_REPRESENTATION`: drop a live-only field when its declared sibling is present (symmetric).

Both run only in the UNDECLARED loop and are tightly scoped, so a genuinely undeclared value is never hidden.

## Live integ (INTEG PASS)
The `securitygroup` integ (a VPC with public subnets + an SG) now also asserts `VpcEndpointId` / `AvailabilityZoneId` do NOT surface. First-run `check` is now **CLEAN** (was 2 potential-drift lines from these + already-folded GroupName).

## Tests
Unit: Route VpcEndpointId dropped for `igw-…` / kept for `vpce-…`; Subnet AvailabilityZoneId dropped when AvailabilityZone declared / kept otherwise. 12 harvested EC2 Route+Subnet corpus cases regenerated (the real noise these fix). Full suite 1812 green, typecheck 0, lint 0.
