### PR TITLE
test(revert): data-driven invariant for conditional/hard create-only split (#421 TASK 3)

### DIFF
--- a/tests/fixtures/cfn-create-only.json
+++ b/tests/fixtures/cfn-create-only.json
@@ -1,0 +1,217 @@
+[
+  {
+    "resourceType": "AWS::RDS::DBInstance",
+    "createOnlyProperties": [
+      "/properties/BackupTarget",
+      "/properties/CharacterSetName",
+      "/properties/CustomIAMInstanceProfile",
+      "/properties/DBClusterIdentifier",
+      "/properties/DBInstanceIdentifier",
+      "/properties/DBName",
+      "/properties/DBSubnetGroupName",
+      "/properties/DBSystemId",
+      "/properties/KmsKeyId",
+      "/properties/MasterUsername",
+      "/properties/NcharCharacterSetName",
+      "/properties/SourceRegion",
+      "/properties/StorageEncrypted",
+      "/properties/Timezone"
+    ],
+    "conditionalCreateOnlyProperties": [
+      "/properties/AutoMinorVersionUpgrade",
+      "/properties/AvailabilityZone",
+      "/properties/BackupRetentionPeriod",
+      "/properties/DBClusterSnapshotIdentifier",
+      "/properties/DBParameterGroupName",
+      "/properties/DBSnapshotIdentifier",
+      "/properties/Engine",
+      "/properties/MultiAZ",
+      "/properties/PerformanceInsightsKMSKeyId",
+      "/properties/PreferredMaintenanceWindow",
+      "/properties/RestoreTime",
+      "/properties/SourceDBClusterIdentifier",
+      "/properties/SourceDBInstanceAutomatedBackupsArn",
+      "/properties/SourceDBInstanceIdentifier",
+      "/properties/SourceDbiResourceId",
+      "/properties/StorageType",
+      "/properties/UseLatestRestorableTime"
+    ]
+  },
+  {
+    "resourceType": "AWS::RDS::DBCluster",
+    "createOnlyProperties": [
+      "/properties/AvailabilityZones",
+      "/properties/ClusterScalabilityType",
+      "/properties/DBClusterIdentifier",
+      "/properties/DBSubnetGroupName",
+      "/properties/DBSystemId",
+      "/properties/DatabaseName",
+      "/properties/EngineMode",
+      "/properties/KmsKeyId",
+      "/properties/PubliclyAccessible",
+      "/properties/RestoreToTime",
+      "/properties/RestoreType",
+      "/properties/SnapshotIdentifier",
+      "/properties/SourceDBClusterIdentifier",
+      "/properties/SourceDbClusterResourceId",
+      "/properties/SourceRegion",
+      "/properties/StorageEncrypted",
+      "/properties/UseLatestRestorableTime"
+    ],
+    "conditionalCreateOnlyProperties": [
+      "/properties/Engine",
+      "/properties/GlobalClusterIdentifier",
+      "/properties/MasterUsername"
+    ]
+  },
+  {
+    "resourceType": "AWS::OpenSearchService::Domain",
+    "createOnlyProperties": ["/properties/DomainName"],
+    "conditionalCreateOnlyProperties": [
+      "/properties/EncryptionAtRestOptions/properties",
+      "/properties/AdvancedSecurityOptions/properties/Enabled"
+    ]
+  },
+  {
+    "resourceType": "AWS::ElastiCache::ReplicationGroup",
+    "createOnlyProperties": [
+      "/properties/AtRestEncryptionEnabled",
+      "/properties/CacheSubnetGroupName",
+      "/properties/DataTieringEnabled",
+      "/properties/GlobalReplicationGroupId",
+      "/properties/KmsKeyId",
+      "/properties/NetworkType",
+      "/properties/Port",
+      "/properties/PreferredCacheClusterAZs",
+      "/properties/ReplicationGroupId",
+      "/properties/SnapshotArns",
+      "/properties/SnapshotName"
+    ],
+    "conditionalCreateOnlyProperties": [
+      "/properties/AuthToken",
+      "/properties/NodeGroupConfiguration"
+    ]
+  },
+  {
+    "resourceType": "AWS::EC2::Instance",
+    "createOnlyProperties": [
+      "/properties/AvailabilityZone",
+      "/properties/CpuOptions",
+      "/properties/ElasticGpuSpecifications",
+      "/properties/ElasticInferenceAccelerators",
+      "/properties/EnclaveOptions",
+      "/properties/HibernationOptions",
+      "/properties/HostResourceGroupArn",
+      "/properties/ImageId",
+      "/properties/Ipv6AddressCount",
+      "/properties/Ipv6Addresses",
+      "/properties/KeyName",
+      "/properties/LaunchTemplate",
+      "/properties/LicenseSpecifications",
+      "/properties/NetworkInterfaces",
+      "/properties/PlacementGroupName",
+      "/properties/PrivateIpAddress",
+      "/properties/SecurityGroups",
+      "/properties/SubnetId"
+    ],
+    "conditionalCreateOnlyProperties": [
+      "/properties/AdditionalInfo",
+      "/properties/Affinity",
+      "/properties/EbsOptimized",
+      "/properties/HostId",
+      "/properties/InstanceType",
+      "/properties/KernelId",
+      "/properties/PrivateDnsNameOptions",
+      "/properties/RamdiskId",
+      "/properties/Tenancy",
+      "/properties/UserData",
+      "/properties/BlockDeviceMappings",
+      "/properties/SecurityGroupIds"
+    ]
+  },
+  {
+    "resourceType": "AWS::DynamoDB::Table",
+    "createOnlyProperties": ["/properties/TableName", "/properties/ImportSourceSpecification"],
+    "conditionalCreateOnlyProperties": ["/properties/KeySchema"]
+  },
+  {
+    "resourceType": "AWS::Lambda::Function",
+    "createOnlyProperties": [
+      "/properties/FunctionName",
+      "/properties/PackageType",
+      "/properties/TenancyConfig"
+    ],
+    "conditionalCreateOnlyProperties": ["/properties/DurableConfig"]
+  },
+  {
+    "resourceType": "AWS::ECS::Service",
+    "createOnlyProperties": [
+      "/properties/Cluster",
+      "/properties/Role",
+      "/properties/SchedulingStrategy",
+      "/properties/ServiceName"
+    ],
+    "conditionalCreateOnlyProperties": ["/properties/LaunchType"]
+  },
+  {
+    "resourceType": "AWS::S3::Bucket",
+    "createOnlyProperties": [
+      "/properties/BucketName",
+      "/properties/BucketNamePrefix",
+      "/properties/BucketNamespace"
+    ],
+    "conditionalCreateOnlyProperties": []
+  },
+  {
+    "resourceType": "AWS::EKS::Cluster",
+    "createOnlyProperties": [
+      "/properties/OutpostConfig",
+      "/properties/EncryptionConfig",
+      "/properties/KubernetesNetworkConfig/IpFamily",
+      "/properties/KubernetesNetworkConfig/ServiceIpv4Cidr",
+      "/properties/AccessConfig/BootstrapClusterCreatorAdminPermissions",
+      "/properties/Name",
+      "/properties/RoleArn",
+      "/properties/BootstrapSelfManagedAddons"
+    ],
+    "conditionalCreateOnlyProperties": []
+  },
+  {
+    "resourceType": "AWS::MSK::Cluster",
+    "createOnlyProperties": [
+      "/properties/BrokerNodeGroupInfo/BrokerAZDistribution",
+      "/properties/BrokerNodeGroupInfo/ClientSubnets",
+      "/properties/BrokerNodeGroupInfo/SecurityGroups",
+      "/properties/EncryptionInfo/EncryptionAtRest",
+      "/properties/EncryptionInfo/EncryptionInTransit/InCluster",
+      "/properties/ClusterName"
+    ],
+    "conditionalCreateOnlyProperties": []
+  },
+  {
+    "resourceType": "AWS::EFS::FileSystem",
+    "createOnlyProperties": [
+      "/properties/AvailabilityZoneName",
+      "/properties/Encrypted",
+      "/properties/KmsKeyId",
+      "/properties/PerformanceMode"
+    ],
+    "conditionalCreateOnlyProperties": []
+  },
+  {
+    "resourceType": "AWS::RDS::DBProxy",
+    "createOnlyProperties": [
+      "/properties/DBProxyName",
+      "/properties/EngineFamily",
+      "/properties/EndpointNetworkType",
+      "/properties/TargetConnectionNetworkType",
+      "/properties/VpcSubnetIds"
+    ],
+    "conditionalCreateOnlyProperties": []
+  },
+  {
+    "resourceType": "AWS::Logs::LogGroup",
+    "createOnlyProperties": ["/properties/LogGroupName"],
+    "conditionalCreateOnlyProperties": []
+  }
+]

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -12,6 +12,7 @@ import {
   toPatchDocument,
   writeOnlyReincludeOps,
 } from '../src/revert/plan.js';
+import { parseSchema } from '../src/schema/schema-strip.js';
 import type { Finding, SchemaInfo } from '../src/types.js';
 
 const schemaWithWriteOnly = (...names: string[]): SchemaInfo => ({
@@ -1495,5 +1496,115 @@ describe('writeOnlyReincludeOps create-only invariant over all real corpus schem
     // refactor drops the schema field), this surfaces it instead of passing vacuously.
     expect(typesExercised).toBeGreaterThan(5);
     expect(propsAsserted).toBeGreaterThan(0);
+  });
+});
+
+// Issue #421 TASK 3 — data-driven invariant for the conditional/hard create-only split.
+//
+// #413/#416 made `conditionalCreateOnlyProperties` NOT bar a revert (only the HARD
+// `createOnlyProperties` bar): a conditional-create-only prop (e.g. RDS DBInstance
+// BackupRetentionPeriod / MultiAZ / StorageType) is mutable in place in the common case,
+// so barring it would be a revert false negative on a very common resource. The split is
+// implemented in `parseSchema` (only `createOnlyProperties` flows into `createOnlyPaths`)
+// and consumed by `plan.ts::isUnderCreateOnly` (segment-wise prefix over `createOnlyPaths`).
+//
+// The corpus only stores the POST-parse SchemaInfo (`createOnlyPaths` already excludes
+// conditional), so a corpus replay can't tell hard from conditional and would pass
+// vacuously if the split regressed. So this invariant is driven by a fixture of REAL
+// CloudFormation schemas' create-only declarations (`tests/fixtures/cfn-create-only.json`,
+// the literal `createOnlyProperties` + `conditionalCreateOnlyProperties` arrays captured
+// from `describe-type` for 14 high-frequency types). Re-parsing them through `parseSchema`
+// makes the test FAIL if conditional props are ever re-merged into `createOnlyPaths`.
+// Self-extends: add a type to the fixture and it is covered. (RDS/EC2/OpenSearch/ECS/
+// Lambda/ElastiCache/DynamoDB carry conditional props; S3/EKS/MSK/EFS/Logs are hard-only.)
+interface CreateOnlyFixture {
+  resourceType: string;
+  createOnlyProperties: string[];
+  conditionalCreateOnlyProperties: string[];
+}
+const pointerToDotted = (p: string): string => p.replace(/^\/properties\//, '').replace(/\//g, '.');
+
+describe('conditional/hard create-only split invariant over real CFn schemas (issue #421 TASK 3)', () => {
+  const fixtures = JSON.parse(
+    readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), 'fixtures', 'cfn-create-only.json'),
+      'utf8'
+    )
+  ) as CreateOnlyFixture[];
+
+  it('parseSchema: every HARD create-only prop IS in createOnlyPaths; every CONDITIONAL one is NOT', () => {
+    let hardAsserted = 0;
+    let condAsserted = 0;
+    let typesWithConditional = 0;
+    for (const fx of fixtures) {
+      const info = parseSchema(
+        JSON.stringify({
+          createOnlyProperties: fx.createOnlyProperties,
+          conditionalCreateOnlyProperties: fx.conditionalCreateOnlyProperties,
+        })
+      );
+      const createOnly = new Set(info.createOnlyPaths);
+      for (const p of fx.createOnlyProperties) {
+        // HARD create-only must bar revert → present in createOnlyPaths
+        expect(createOnly.has(pointerToDotted(p))).toBe(true);
+        hardAsserted++;
+      }
+      if (fx.conditionalCreateOnlyProperties.length > 0) typesWithConditional++;
+      for (const p of fx.conditionalCreateOnlyProperties) {
+        // CONDITIONAL create-only must NOT bar revert → absent from createOnlyPaths
+        // (this is the exact assertion that regresses if conditional is re-merged)
+        expect(createOnly.has(pointerToDotted(p))).toBe(false);
+        condAsserted++;
+      }
+    }
+    // guard the guard: the fixture must actually exercise both arms broadly
+    expect(hardAsserted).toBeGreaterThan(50);
+    expect(condAsserted).toBeGreaterThan(20);
+    expect(typesWithConditional).toBeGreaterThan(3);
+  });
+
+  it('consumer (buildRevertPlan/isUnderCreateOnly): a HARD create-only top-level prop bars revert, a CONDITIONAL one does not', () => {
+    // For every fixture type that has BOTH a hard and a conditional TOP-LEVEL prop, build a
+    // declared finding at each and prove the revert plan bars the hard one (notRevertable)
+    // and keeps the conditional one revertable — the behavioral consequence of the split.
+    const topLevel = (p: string): string | undefined => {
+      const d = pointerToDotted(p);
+      return d.includes('.') ? undefined : d;
+    };
+    let exercised = 0;
+    for (const fx of fixtures) {
+      const hardTop = fx.createOnlyProperties.map(topLevel).find(Boolean);
+      const condTop = fx.conditionalCreateOnlyProperties.map(topLevel).find(Boolean);
+      if (!hardTop || !condTop) continue;
+      exercised++;
+      const info = parseSchema(
+        JSON.stringify({
+          createOnlyProperties: fx.createOnlyProperties,
+          conditionalCreateOnlyProperties: fx.conditionalCreateOnlyProperties,
+        })
+      );
+      const schemas = new Map<string, SchemaInfo>([[fx.resourceType, info]]);
+      const find = (path: string): Finding => ({
+        tier: 'declared',
+        logicalId: 'R',
+        physicalId: 'phys-1',
+        resourceType: fx.resourceType,
+        path,
+        desired: 'x',
+        actual: 'y',
+      });
+
+      // HARD create-only → notRevertable with the create-only reason
+      const hardPlan = buildRevertPlan([find(hardTop)], undefined, { schemas });
+      expect(hardPlan.items).toHaveLength(0);
+      expect(hardPlan.notRevertable.map((n) => n.reason).join(' ')).toContain('create-only');
+
+      // CONDITIONAL create-only → revertable (a Cloud Control item, never barred)
+      const condPlan = buildRevertPlan([find(condTop)], undefined, { schemas });
+      expect(condPlan.notRevertable).toEqual([]);
+      expect(condPlan.items).toHaveLength(1);
+      expect(condPlan.items[0].kind).toBe('cc');
+    }
+    expect(exercised).toBeGreaterThan(2);
   });
 });


### PR DESCRIPTION
## Summary

Closes **TASK 3** of #421. Adds a data-driven invariant test locking in the #413/#416 conditional/hard create-only split, so a regression fails CI.

## Background

#413/#416 made `conditionalCreateOnlyProperties` **NOT** bar a revert (only HARD `createOnlyProperties` bar): a conditional-create-only prop (e.g. RDS DBInstance `BackupRetentionPeriod` / `MultiAZ` / `StorageType`) is mutable in place in the common case, so barring it would be a revert false-negative on a very common resource. The split lives in `parseSchema` (only `createOnlyProperties` flows into `createOnlyPaths`) and is consumed by `plan.ts::isUnderCreateOnly`. There was a per-shape unit test but no data-driven invariant.

## Why not the corpus

The corpus stores the **post-parse** `SchemaInfo` — `createOnlyPaths` already excludes conditional — so it cannot tell hard from conditional and a corpus replay would pass **vacuously** if the split regressed. So the invariant is driven by a fixture of **real** create-only declarations.

## What's added

- `tests/fixtures/cfn-create-only.json` — the literal `createOnlyProperties` + `conditionalCreateOnlyProperties` arrays captured from `describe-type` for **14 high-frequency real types** (97 hard + 39 conditional pointers). RDS/EC2/OpenSearch/ECS/Lambda/ElastiCache/DynamoDB carry conditional props; S3/EKS/MSK/EFS/Logs are hard-only.
- `tests/revert-plan.test.ts` — two data-driven tests re-parsing each fixture through `parseSchema`:
  1. every **HARD** create-only prop **IS** in `createOnlyPaths`; every **CONDITIONAL** one is **NOT** (the assertion that regresses if conditional is re-merged).
  2. consumer behaviour: `buildRevertPlan` bars a hard top-level prop (`notRevertable` / `create-only`) and keeps a conditional one revertable (a `cc` item).

## Verification

Mutation-tested: temporarily merging `conditionalCreateOnlyProperties` into `createOnlyPaths` in `parseSchema` makes **both** new tests fail; reverting restores green. Self-extends — add a type to the fixture and it is covered.

## Gates

- tests + fixtures only (no `src/**`) → verify-pr-EXEMPT (`check` + `docs` markers cover it)
- typecheck / lint+format / build / full unit suite (1819 tests) all green
