### PR TITLE
feat(nested): detect+revert Secret ReplicaRegions KmsKeyId + ApiGW Stage MethodSettings

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -426,7 +426,14 @@ all live changes
          API Gateway Method Integration.IntegrationResponses AND MethodResponses (StatusCode)
          — SelectionPattern / ContentHandling / responseModels; Backup BackupPlan
          BackupPlanRule (RuleName) — a changed CompletionWindowMinutes / window; Route53
-         Resolver FirewallRuleGroup FirewallRules (Priority) — a changed firewall-rule setting
+         Resolver FirewallRuleGroup FirewallRules (Priority) — a changed firewall-rule setting;
+         SecretsManager Secret ReplicaRegions (Region) — a replica re-keyed to a different
+         KmsKeyId (the alias/aws/secretsmanager default folds); ApiGateway Stage MethodSettings
+         (HttpMethod) — a per-method CacheTtlInSeconds change (the 300 / false caching defaults
+         fold). The CC-mutable ones (Backup, Route53 Resolver, Secret, ApiGateway Stage) revert
+         via the generic Cloud Control index-revert writer (SDK_NESTED_WRITERS); a
+         composite-identifier type addresses the resource by its CC_IDENTIFIER_ADAPTERS
+         identifier (ApiGateway Stage `RestApiId|StageName`), not the bare physical id
 ```
 
 ### Why a given value does (or does not) appear
@@ -730,10 +737,15 @@ deploy`: a patch can't recreate a resource), a **create-only** property (drift o
   a `responseModels` entry (removed per media key) — all proven live. For a CC-MUTABLE type
   the array-element nested value reverts via the generic **Cloud Control index-revert**
   writer (`writeCloudControlIndexNested`, registered for Backup BackupPlan + Route53Resolver
-  FirewallRuleGroup): it GetResources the live model, RE-POINTS each op's identity bracket to
+  FirewallRuleGroup + SecretsManager Secret ReplicaRegions + ApiGateway Stage MethodSettings):
+  it GetResources the live model, RE-POINTS each op's identity bracket to
   the live-array INDEX (`/FirewallRules[100]/…` → `/FirewallRules/1/…` — valid because the
   index is taken against the SAME model CC read-modify-writes; R78's index problem was
-  indexing the DECLARED subset), then one UpdateResource. A value AWS materialized as a
+  indexing the DECLARED subset), then one UpdateResource. It addresses the resource by the
+  CC identifier the READ path resolves (`CC_IDENTIFIER_ADAPTERS`, e.g. ApiGateway Stage
+  `RestApiId|StageName`) carried on `ctx.identifier`, NOT the bare physical id, or a
+  composite-identifier type ValidationExceptions (`Identifier prod is not valid …` — found
+  live for #419). A value AWS materialized as a
   default (KNOWN_DEFAULT_PATHS) reverts by SETTING that default (`add`), not a bare `remove`
   some providers silently ignore (Route53 FirewallDomainRedirectionAction — proven live).
   KMS keys need no SDK writer — they revert via the generic CC path.

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -810,9 +810,17 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       try {
         const writer = resolveSdkWriter(item.resourceType, item.ops);
         if (!writer) throw new Error(`no SDK writer for ${item.resourceType}`);
+        // A Cloud-Control-routed nested writer addresses the resource by the composite CC
+        // identifier (e.g. AWS::ApiGateway::Stage `RestApiId|StageName`) the READ path
+        // resolves — pass it so its GetResource/UpdateResource doesn't ValidationException
+        // on the bare physical id. Falls back to the physical id when no adapter applies.
+        const identifier =
+          CC_IDENTIFIER_ADAPTERS[item.resourceType]?.(item.physicalId, res?.declared ?? {}) ??
+          item.physicalId;
         await writer(
           {
             physicalId: item.physicalId,
+            identifier,
             declared: res?.declared ?? {},
             region,
             accountId: gathered.desired.accountId,

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -172,6 +172,17 @@ export const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
   // KNOWN_DEFAULT_PATHS — so a security-relevant out-of-band change (a rule's Action /
   // BlockResponse flipped in the console) surfaces. Proven live.
   'AWS::Route53Resolver::FirewallRuleGroup': { FirewallRules: 'Priority' },
+  // A multi-region secret's replicas are keyed by Region. AWS materializes the default
+  // AWS-managed KMS key (KmsKeyId `alias/aws/secretsmanager`) into each declared replica
+  // that did not pin one — folded via KNOWN_DEFAULT_PATHS — so a replica re-keyed to a
+  // different CMK out of band (a compliance-relevant change) surfaces. Proven live.
+  'AWS::SecretsManager::Secret': { ReplicaRegions: 'Region' },
+  // A REST API stage's per-method settings are keyed by HttpMethod (the dominant CDK shape
+  // is a single `*` deployment-wide default). AWS materializes the caching scalar default
+  // into each declared method setting (CacheTtlInSeconds 300 — folded via
+  // KNOWN_DEFAULT_PATHS; the sibling `false` defaults fold via isTrivialEmpty) — so an
+  // out-of-band caching change on a declared method surfaces. Proven live.
+  'AWS::ApiGateway::Stage': { MethodSettings: 'HttpMethod' },
 };
 
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -573,6 +573,13 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::Route53Resolver::FirewallRuleGroup': {
     'FirewallRules.*.FirewallDomainRedirectionAction': 'INSPECT_REDIRECTION_DOMAIN',
   },
+  // AWS materializes the default AWS-managed KMS key into each live replica region (keyed
+  // by Region — descended via NESTED_ARRAY_IDENTITY) when the replica declares no KmsKeyId.
+  // Folding keeps a clean multi-region secret clean; a replica re-keyed to a different CMK
+  // out of band no longer matches and surfaces. Proven live.
+  'AWS::SecretsManager::Secret': {
+    'ReplicaRegions.*.KmsKeyId': 'alias/aws/secretsmanager',
+  },
   'AWS::ApiGateway::DomainName': {
     // AWS sets a custom domain's IP address type to ipv4 when the template leaves
     // EndpointConfiguration.IpAddressType unset — a server default, not user intent.
@@ -582,6 +589,16 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'Integration.PassthroughBehavior': 'WHEN_NO_MATCH',
     'Integration.ResponseTransferMode': 'BUFFERED',
     'Integration.TimeoutInMillis': 29000,
+  },
+  // AWS materializes the caching scalar default into every live MethodSettings element
+  // (keyed by HttpMethod — descended via NESTED_ARRAY_IDENTITY) when the stage declares
+  // only throttling/tracing. Folding keeps a clean stage clean; a method whose cache TTL
+  // was changed out of band no longer matches and surfaces. The sibling defaults
+  // CacheDataEncrypted / CachingEnabled / MetricsEnabled all read back `false` and fold via
+  // isTrivialEmpty (so enabling any of them out of band — a non-`false` value — surfaces).
+  // Proven live.
+  'AWS::ApiGateway::Stage': {
+    'MethodSettings.*.CacheTtlInSeconds': 300,
   },
   'AWS::ApiGateway::UsagePlan': {
     'Quota.Offset': 0,

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -78,6 +78,12 @@ export interface OverrideCtx {
   // type-agnostic writer (the Cloud Control index-revert for nested array-element values)
   // can GetResource/UpdateResource it. Unused by the read (OverrideReader) path.
   resourceType?: string;
+  // The Cloud Control identifier — the composite the READ path resolves via
+  // CC_IDENTIFIER_ADAPTERS (e.g. AWS::ApiGateway::Stage = `RestApiId|StageName`), set on the
+  // REVERT (SdkWriter) path. A Cloud-Control-routed writer (writeCloudControlIndexNested)
+  // MUST address the resource by this, not the bare CFn physical id, or GetResource /
+  // UpdateResource ValidationException. Falls back to `physicalId` when no adapter applies.
+  identifier?: string;
 }
 export type OverrideReader = (ctx: OverrideCtx) => Promise<Record<string, unknown> | undefined>;
 

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -1285,8 +1285,13 @@ function reindexNestedPointer(
 const writeCloudControlIndexNested: SdkWriter = async (ctx, ops) => {
   const type = ctx.resourceType;
   if (!type) throw new Error('writeCloudControlIndexNested: resourceType missing on ctx');
+  // Address the resource by the resolved Cloud Control identifier (the composite the READ
+  // path builds via CC_IDENTIFIER_ADAPTERS — e.g. AWS::ApiGateway::Stage `RestApiId|
+  // StageName`), not the bare CFn physical id, or CC ValidationExceptions. Falls back to the
+  // physical id when no adapter applies (single-segment types: Backup plan, Route53 group).
+  const identifier = ctx.identifier ?? ctx.physicalId;
   const cc = new CloudControlClient({ region: ctx.region });
-  const got = await cc.send(new GetResourceCommand({ TypeName: type, Identifier: ctx.physicalId }));
+  const got = await cc.send(new GetResourceCommand({ TypeName: type, Identifier: identifier }));
   const live = JSON.parse(got.ResourceDescription?.Properties ?? '{}') as Record<string, unknown>;
   const patch = ops.map((op) => {
     const path = reindexNestedPointer(op.path, live, type);
@@ -1295,7 +1300,7 @@ const writeCloudControlIndexNested: SdkWriter = async (ctx, ops) => {
   await cc.send(
     new UpdateResourceCommand({
       TypeName: type,
-      Identifier: ctx.physicalId,
+      Identifier: identifier,
       PatchDocument: JSON.stringify(patch),
     })
   );
@@ -1337,6 +1342,20 @@ export const SDK_NESTED_WRITERS: Record<string, NestedWriterSpec> = {
   },
   'AWS::Route53Resolver::FirewallRuleGroup': {
     match: (p) => p.startsWith('FirewallRules['),
+    writer: writeCloudControlIndexNested,
+  },
+  // A multi-region secret's replica KmsKeyId (keyed by Region — descended via
+  // NESTED_ARRAY_IDENTITY). CC-mutable, so revert re-points the identity bracket to the
+  // live-array index. Proven live.
+  'AWS::SecretsManager::Secret': {
+    match: (p) => p.startsWith('ReplicaRegions['),
+    writer: writeCloudControlIndexNested,
+  },
+  // A REST API stage's per-method caching/metrics knobs (keyed by HttpMethod — descended
+  // via NESTED_ARRAY_IDENTITY). CC-mutable, so revert re-points the identity bracket to the
+  // live-array index. Proven live.
+  'AWS::ApiGateway::Stage': {
+    match: (p) => p.startsWith('MethodSettings['),
     writer: writeCloudControlIndexNested,
   },
 };

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3248,9 +3248,10 @@ describe('nested KNOWN_DEFAULT_PATHS folding (R108 — hand-coded nested service
     if (rest[0] === '*') {
       const [d, l] = buildNested(rest.slice(1), value);
       // Carry every identity field the alignment might use — the generic IDENTITY_FIELDS
-      // `Id`, plus the NESTED_ARRAY_IDENTITY overrides (Backup RuleName, Route53 Priority) —
-      // all set to `x`, so the element aligns to `[x]` whichever key the type uses.
-      const id = { Id: 'x', RuleName: 'x', Priority: 'x' };
+      // `Id`, plus the NESTED_ARRAY_IDENTITY overrides (Backup RuleName, Route53 Priority,
+      // Secret Region, ApiGateway Stage HttpMethod) — all set to `x`, so the element aligns
+      // to `[x]` whichever key the type uses.
+      const id = { Id: 'x', RuleName: 'x', Priority: 'x', Region: 'x', HttpMethod: 'x' };
       return [{ [head!]: [{ ...id, ...d }] }, { [head!]: [{ ...id, ...l }] }];
     }
     const [d, l] = buildNested(rest, value);
@@ -4724,6 +4725,57 @@ describe('NESTED_ARRAY_IDENTITY: materialized-default array elements (Backup / R
     expect(undeclaredPaths(declared, drifted)).toContain(
       'FirewallRules[100].FirewallDomainRedirectionAction'
     );
+  });
+
+  it('SecretsManager ReplicaRegions (keyed by Region): default KmsKeyId folds, a re-key surfaces', () => {
+    const declared = res('AWS::SecretsManager::Secret', {
+      ReplicaRegions: [{ Region: 'us-west-2' }, { Region: 'eu-west-1' }],
+    });
+    // AWS materializes the default AWS-managed key into each declared replica (and reorders).
+    const clean = {
+      ReplicaRegions: [
+        { Region: 'eu-west-1', KmsKeyId: 'alias/aws/secretsmanager' },
+        { Region: 'us-west-2', KmsKeyId: 'alias/aws/secretsmanager' },
+      ],
+    };
+    expect(undeclaredPaths(declared, clean)).toEqual([]);
+    // a replica re-keyed to a custom CMK out of band surfaces (no longer the default)
+    const drifted = structuredClone(clean);
+    (drifted.ReplicaRegions[1] as Record<string, unknown>).KmsKeyId =
+      'arn:aws:kms:us-west-2:111111111111:key/abcd';
+    expect(undeclaredPaths(declared, drifted)).toContain('ReplicaRegions[us-west-2].KmsKeyId');
+  });
+
+  it('ApiGateway Stage MethodSettings (keyed by HttpMethod): caching defaults fold, a TTL change surfaces', () => {
+    const declared = res('AWS::ApiGateway::Stage', {
+      MethodSettings: [
+        { HttpMethod: '*', ResourcePath: '/*', ThrottlingRateLimit: 100, ThrottlingBurstLimit: 50 },
+      ],
+    });
+    // AWS materializes the caching/metrics defaults into the declared method setting.
+    const clean = {
+      MethodSettings: [
+        {
+          HttpMethod: '*',
+          ResourcePath: '/*',
+          ThrottlingRateLimit: 100,
+          ThrottlingBurstLimit: 50,
+          CacheTtlInSeconds: 300,
+          CacheDataEncrypted: false,
+          CachingEnabled: false,
+          MetricsEnabled: false,
+        },
+      ],
+    };
+    expect(undeclaredPaths(declared, clean)).toEqual([]);
+    // an out-of-band cache TTL change surfaces (no longer the 300 default)
+    const ttl = structuredClone(clean);
+    (ttl.MethodSettings[0] as Record<string, unknown>).CacheTtlInSeconds = 600;
+    expect(undeclaredPaths(declared, ttl)).toContain('MethodSettings[*].CacheTtlInSeconds');
+    // enabling caching out of band (a non-`false` value) surfaces past the isTrivialEmpty fold
+    const caching = structuredClone(clean);
+    (caching.MethodSettings[0] as Record<string, unknown>).CachingEnabled = true;
+    expect(undeclaredPaths(declared, caching)).toContain('MethodSettings[*].CachingEnabled');
   });
 });
 

--- a/tests/corpus/AWS__ApiGateway__Stage.ApiDeploymentStageprod3EB9684E.json
+++ b/tests/corpus/AWS__ApiGateway__Stage.ApiDeploymentStageprod3EB9684E.json
@@ -73,5 +73,16 @@
     "kmsAliasTargets": {},
     "oaiCanonicalIds": {}
   },
-  "expected": []
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiDeploymentStageprod3EB9684E",
+      "resourceType": "AWS::ApiGateway::Stage",
+      "path": "MethodSettings[*].CacheTtlInSeconds",
+      "actual": 300,
+      "nested": true,
+      "physicalId": "prod",
+      "constructPath": "CdkRealDriftIntegApigwRestRich/Api/DeploymentStage.prod"
+    }
+  ]
 }

--- a/tests/corpus/AWS__SecretsManager__Secret.ReplicaRegions.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.ReplicaRegions.json
@@ -59,6 +59,26 @@
       "note": "write-only — cannot be read back",
       "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
       "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SecretA720EF05",
+      "resourceType": "AWS::SecretsManager::Secret",
+      "path": "ReplicaRegions[us-west-2].KmsKeyId",
+      "actual": "alias/aws/secretsmanager",
+      "nested": true,
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
+      "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SecretA720EF05",
+      "resourceType": "AWS::SecretsManager::Secret",
+      "path": "ReplicaRegions[eu-west-1].KmsKeyId",
+      "actual": "alias/aws/secretsmanager",
+      "nested": true,
+      "physicalId": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-secret-replica-regions-SOXFX4",
+      "constructPath": "CdkRealDriftIntegSecretReplicaRegions/Secret"
     }
   ]
 }

--- a/tests/integration/apigw-rest-rich/verify-detect-methodsettings.sh
+++ b/tests/integration/apigw-rest-rich/verify-detect-methodsettings.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# API Gateway Stage MethodSettings nested detect + revert integration test (real AWS):
+# the "someone changed a method's cache TTL in the console" scenario. The Stage declares
+# only throttling MethodSettings; AWS materializes the caching scalar defaults
+# (CacheTtlInSeconds 300, the `false` siblings) into the live `*/*` setting — folded via
+# NESTED_ARRAY_IDENTITY + KNOWN_DEFAULT_PATHS so a clean record->check is CLEAN. Here we
+# flip the UNDECLARED CacheTtlInSeconds (300->600) out of band -> check MUST DETECT the
+# nested undeclared drift (exit 1) -> revert (SETs the 300 default at the live index) ->
+# check MUST be CLEAN and the live value restored to 300.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApigwRestRich
+APINAME=cdkrd-apigw-rest-rich
+STAGE=prod
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+APIID="$(aws apigateway get-rest-apis --region "$REGION" \
+  --query "items[?name=='$APINAME'].id | [0]" --output text)"
+[ -n "$APIID" ] && [ "$APIID" != "None" ] || fail "could not resolve rest-api id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check MUST be CLEAN (caching defaults fold) ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN before mutation"
+
+echo "=== out-of-band: MethodSettings */* CacheTtlInSeconds 300->600 (console-edit) ==="
+aws apigateway update-stage --rest-api-id "$APIID" --stage-name "$STAGE" \
+  --patch-operations 'op=replace,path=/*/*/caching/ttlInSeconds,value=600' \
+  --region "$REGION" >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT nested undeclared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-apigw-methodsettings-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "CacheTtlInSeconds" /tmp/cdkrd-apigw-methodsettings-detect.out || fail "CacheTtlInSeconds not reported"
+
+echo "=== revert (SET the 300 default back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live CacheTtlInSeconds MUST be restored to 300 ==="
+GOT="$(aws apigateway get-stage --rest-api-id "$APIID" --stage-name "$STAGE" \
+  --region "$REGION" --query "methodSettings.\"*/*\".cacheTtlInSeconds" --output text)"
+[ "$GOT" = "300" ] || fail "live CacheTtlInSeconds not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK MethodSettings nested detect+revert)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -572,6 +572,46 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('SecretsManager ReplicaRegions array-element nested -> revertable sdk item, sets default KmsKeyId', () => {
+    const f = F({
+      tier: 'undeclared',
+      logicalId: 'Secret',
+      physicalId: 'arn:aws:secretsmanager:us-east-1:111111111111:secret:s-AbCdEf',
+      resourceType: 'AWS::SecretsManager::Secret',
+      path: 'ReplicaRegions[us-west-2].KmsKeyId',
+      actual: 'arn:aws:kms:us-west-2:111111111111:key/abcd',
+      nested: true,
+      unrecorded: false,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items[0]).toMatchObject({
+      kind: 'sdk',
+      resourceType: 'AWS::SecretsManager::Secret',
+    });
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      value: 'alias/aws/secretsmanager',
+    });
+  });
+
+  it('ApiGateway Stage MethodSettings array-element nested -> revertable sdk item, sets default TTL', () => {
+    const f = F({
+      tier: 'undeclared',
+      logicalId: 'Stage',
+      physicalId: 'prod',
+      resourceType: 'AWS::ApiGateway::Stage',
+      path: 'MethodSettings[*].CacheTtlInSeconds',
+      actual: 600,
+      nested: true,
+      unrecorded: false,
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toHaveLength(0);
+    expect(plan.items[0]).toMatchObject({ kind: 'sdk', resourceType: 'AWS::ApiGateway::Stage' });
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'add', value: 300 });
+  });
+
   it('an `added` finding with no physical id -> notRevertable (cannot address the delete)', () => {
     const f = F({ tier: 'added', logicalId: 'X/y', physicalId: undefined, path: '' });
     const plan = buildRevertPlan([f], undefined);

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1610,8 +1610,9 @@ describe('writeConfigRuleInputParameters (AWS::Config::ConfigRule, JSON-string p
 });
 
 describe('Cloud Control index-revert writer (array-element nested values)', () => {
-  const ctx = (resourceType: string, physicalId: string): OverrideCtx => ({
+  const ctx = (resourceType: string, physicalId: string, identifier?: string): OverrideCtx => ({
     physicalId,
+    ...(identifier !== undefined && { identifier }),
     declared: {},
     region: 'us-east-1',
     accountId: '123456789012',
@@ -1683,6 +1684,71 @@ describe('Cloud Control index-revert writer (array-element nested values)', () =
     expect(patch).toEqual([
       { op: 'add', path: '/BackupPlan/BackupPlanRule/0/CompletionWindowMinutes', value: 10080 },
     ]);
+  });
+
+  it('resolves a Secret ReplicaRegions element (keyed by Region) to its live index', async () => {
+    // live reorders the replicas: us-west-2 is at index 1.
+    cloudcontrol.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Properties: JSON.stringify({
+          ReplicaRegions: [
+            { Region: 'eu-west-1', KmsKeyId: 'alias/aws/secretsmanager' },
+            { Region: 'us-west-2', KmsKeyId: 'arn:aws:kms:us-west-2:111111111111:key/abcd' },
+          ],
+        }),
+      },
+    });
+    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    const ops: PatchOp[] = [
+      {
+        op: 'add',
+        path: '/ReplicaRegions[us-west-2]/KmsKeyId',
+        value: 'alias/aws/secretsmanager',
+        human: 'x',
+      },
+    ];
+    await resolveSdkWriter('AWS::SecretsManager::Secret', ops)!(
+      ctx('AWS::SecretsManager::Secret', 'arn:secret'),
+      ops
+    );
+    const patch = JSON.parse(
+      cloudcontrol.commandCalls(UpdateResourceCommand)[0]!.args[0].input.PatchDocument as string
+    );
+    expect(patch).toEqual([
+      { op: 'add', path: '/ReplicaRegions/1/KmsKeyId', value: 'alias/aws/secretsmanager' },
+    ]);
+  });
+
+  it('resolves an ApiGateway Stage MethodSettings element (keyed by HttpMethod) to its live index', async () => {
+    cloudcontrol.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Properties: JSON.stringify({
+          MethodSettings: [
+            { HttpMethod: 'GET', ResourcePath: '/foo', CacheTtlInSeconds: 300 },
+            { HttpMethod: '*', ResourcePath: '/*', CacheTtlInSeconds: 600 },
+          ],
+        }),
+      },
+    });
+    cloudcontrol.on(UpdateResourceCommand).resolves({});
+    const ops: PatchOp[] = [
+      { op: 'add', path: '/MethodSettings[*]/CacheTtlInSeconds', value: 300, human: 'x' },
+    ];
+    // AWS::ApiGateway::Stage is a COMPOSITE-identifier type (RestApiId|StageName): the writer
+    // MUST address it by the resolved identifier, not the bare physical id (`prod`), or CC
+    // rejects "Identifier prod is not valid". The stack-actions sdk path resolves this via
+    // CC_IDENTIFIER_ADAPTERS and sets ctx.identifier — observed live (PR for #419).
+    await resolveSdkWriter('AWS::ApiGateway::Stage', ops)!(
+      ctx('AWS::ApiGateway::Stage', 'prod', 'abc123|prod'),
+      ops
+    );
+    expect(cloudcontrol.commandCalls(GetResourceCommand)[0]!.args[0].input.Identifier).toBe(
+      'abc123|prod'
+    );
+    const update = cloudcontrol.commandCalls(UpdateResourceCommand)[0]!.args[0].input;
+    expect(update.Identifier).toBe('abc123|prod');
+    const patch = JSON.parse(update.PatchDocument as string);
+    expect(patch).toEqual([{ op: 'add', path: '/MethodSettings/1/CacheTtlInSeconds', value: 300 }]);
   });
 
   it('throws (honest failure) when the identity cannot be located in the live array', async () => {


### PR DESCRIPTION
Closes the open tail of the `NESTED_ARRAY_IDENTITY` audit (#411 detect / #415 revert), driven by #419.

## Offline audit (all 6 candidates probed from existing golden corpus — already-harvested live reads)

| Candidate | Verdict | Evidence |
|---|---|---|
| **SecretsManager Secret `ReplicaRegions` (Region)** | ✅ **ADD** | live materializes `KmsKeyId: alias/aws/secretsmanager` (mutable, non-readOnly) into each declared replica → silent FN |
| **ApiGateway Stage `MethodSettings` (HttpMethod)** | ✅ **ADD** | live materializes `CacheTtlInSeconds: 300` (+ `false` caching/metrics siblings) into the declared `*/*` setting → silent FN |
| CE AnomalySubscription `Subscribers` | ❌ rule out | only `Status` enriches, and it is `readOnly` → stripped before the nested loop |
| CloudWatch MetricStream `IncludeFilters` | ❌ rule out | only `MetricNames: []` enriches → empty-array, already folds via `isTrivialEmpty` |
| SNS Topic `DeliveryStatusLogging` | ❌ rule out | corpus shows declared == live (reorder only, no enrichment) |
| ELBv2 ListenerRule `Conditions` | ❌ rule out | the live-only `Values` is an alt-representation **mirror** of `<Type>Config.Values`, not a constant default — descending would FP (separate alt-representation concern) |

## Added
- `NESTED_ARRAY_IDENTITY` + `KNOWN_DEFAULT_PATHS` make the descent fire and keep a clean stack clean; a real change surfaces.
- Both types are CC-mutable → revert via the generic `writeCloudControlIndexNested` (`SDK_NESTED_WRITERS`).

## Live-found fix (real bug the integ surfaced)
The `sdk`-kind revert path passed the **bare** CFn physical id to `writeCloudControlIndexNested`, so a composite-identifier type failed:

```
FAILED: … — Identifier prod is not valid for identifier [/properties/RestApiId, /properties/StageName]
```

Fix: resolve the CC identifier via `CC_IDENTIFIER_ADAPTERS` on the sdk path too (new `OverrideCtx.identifier`; the writer uses `ctx.identifier ?? ctx.physicalId`) — the same composite the READ path already uses (`AWS::ApiGateway::Stage` = `RestApiId|StageName`).

## Live proof (real AWS, us-east-1)
- **ApiGateway Stage** (`verify-detect-methodsettings.sh`, committed): deploy → record → check **CLEAN** (atDefault=13) → out-of-band `CacheTtlInSeconds 300→600` → check **DETECTS** `MethodSettings[*].CacheTtlInSeconds=600` → revert (SET 300) → check **CLEAN** → live restored to 300. **INTEG PASS.**
- **Secret ReplicaRegions** (`verify.sh` FP-clean committed; FN+revert ad-hoc): deploy → record → check CLEAN (atDefault=2 KmsKeyId folds) → out-of-band re-key us-west-2 replica to a custom CMK → check **DETECTS** `ReplicaRegions[us-west-2].KmsKeyId=<custom>` → revert (SET `alias/aws/secretsmanager`) → check **CLEAN**. CC UpdateResource reverts the replica re-key in place. **PASS.**

All bug-hunt stacks deleted (`delstack`), the ad-hoc CMK scheduled for deletion + alias removed, `sweep-orphans.sh` SWEEP CLEAN, sentinel cleared.

## Tests
- Regen the two golden-corpus `expected` (now fold to `atDefault`).
- `classify.test.ts`: fold + FN-surface for both types; data-driven `KNOWN_DEFAULT_PATHS` fold test extended with Region/HttpMethod identity.
- `revert-plan.test.ts`: SET-default revert op for both.
- `writers.test.ts`: reindex to live index for both; ApiGW Stage asserts the **composite identifier** is used for Get/Update.

Local gates: typecheck / lint+format / build / 1823 unit tests all green.
