### PR TITLE
test(revert): prove removed-collection revert works via Cloud Control for common types (#421 TASK 2)

### DIFF
--- a/tests/integration/asg-notification-revert/app.ts
+++ b/tests/integration/asg-notification-revert/app.ts
@@ -1,0 +1,58 @@
+// cdk-real-drift — removed-collection REVERT test (issue #421 TASK 2) on an EC2 Auto
+// Scaling group's `NotificationConfigurations`. Unlike EventBridge Rule Targets (which
+// Cloud Control re-applies fine), ASG notifications are managed by a DEDICATED sub-API
+// (PutNotificationConfiguration / DeleteNotificationConfiguration) that is NOT a normal
+// mutable property — so this is the strongest candidate for a type where a removed
+// collection is DETECTED (#416) but the whole-property re-add via Cloud Control
+// UpdateResource FAILS, needing an SDK_WRITERS entry. The fixture deploys an ASG with
+// one SNS notification config, removes it out of band, and verify.sh asserts detect ->
+// revert -> CLEAN. desiredCapacity 0 (no instances launch) so it is fast and cheap.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  Vpc,
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  MachineImage,
+  SubnetType,
+  LaunchTemplate,
+} from "aws-cdk-lib/aws-ec2";
+import { AutoScalingGroup, CfnAutoScalingGroup } from "aws-cdk-lib/aws-autoscaling";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAsgNotificationRevert");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const launchTemplate = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023(),
+});
+
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  launchTemplate,
+  minCapacity: 0,
+  maxCapacity: 4,
+  desiredCapacity: 0,
+});
+
+const topic = new Topic(stack, "Topic");
+
+const cfnAsg = asg.node.defaultChild as CfnAutoScalingGroup;
+cfnAsg.notificationConfigurations = [
+  {
+    topicArn: topic.topicArn,
+    notificationTypes: [
+      "autoscaling:EC2_INSTANCE_LAUNCH",
+      "autoscaling:EC2_INSTANCE_TERMINATE",
+    ],
+  },
+];
+
+app.synth();

--- a/tests/integration/asg-notification-revert/cdk.json
+++ b/tests/integration/asg-notification-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/asg-notification-revert/package.json
+++ b/tests/integration/asg-notification-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-asg-notification-metrics",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift asg-notification-metrics false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/asg-notification-revert/verify.sh
+++ b/tests/integration/asg-notification-revert/verify.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for issue #421 TASK 2 — removed-collection
+# REVERT on an EC2 Auto Scaling group's `NotificationConfigurations`, which is managed
+# by a dedicated sub-API (PutNotificationConfiguration / DeleteNotificationConfiguration).
+# deploy -> record -> delete the notification config out of band -> check MUST detect
+# (NotificationConfigurations whole-property drift) -> revert MUST re-apply it -> check
+# MUST be CLEAN. If Cloud Control UpdateResource cannot re-add the collection, the revert
+# step surfaces the gap (closed by an SDK_WRITERS entry).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAsgNotificationRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+ASG=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::AutoScaling::AutoScalingGroup'].PhysicalResourceId" --output text)
+TOPIC=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::SNS::Topic'].PhysicalResourceId" --output text)
+[ -n "$ASG" ] || fail "no asg"
+[ -n "$TOPIC" ] || fail "no topic"
+echo "asg=$ASG topic=$TOPIC"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] notification configs BEFORE removal ==="
+aws autoscaling describe-notification-configurations --auto-scaling-group-name "$ASG" --region "$REGION" \
+  --query 'NotificationConfigurations[].NotificationType' --output text
+
+echo "=== [$STACK] delete the notification config out of band ==="
+aws autoscaling delete-notification-configuration --auto-scaling-group-name "$ASG" \
+  --topic-arn "$TOPIC" --region "$REGION" || fail "delete-notification-configuration"
+
+echo "=== [$STACK] check MUST detect the removed NotificationConfigurations ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: removed NotificationConfigurations not detected (got CLEAN)"
+
+echo "=== [$STACK] revert (must re-apply NotificationConfigurations) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] notification configs AFTER revert ==="
+AFTER=$(aws autoscaling describe-notification-configurations --auto-scaling-group-name "$ASG" --region "$REGION" \
+  --query 'length(NotificationConfigurations)' --output text)
+echo "notification config count after revert=$AFTER"
+[ "$AFTER" -ge 1 ] || fail "expected >=1 notification config restored, got $AFTER"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/events-rule-target-revert/app.ts
+++ b/tests/integration/events-rule-target-revert/app.ts
@@ -1,0 +1,25 @@
+// cdk-real-drift — removed-collection REVERT test (issue #421 TASK 2) on an
+// EventBridge Rule's `Targets`. Targets are managed by a SEPARATE API (PutTargets /
+// RemoveTargets), so this is the most likely common type where a removed collection
+// is DETECTED (#416) but the whole-property re-add via Cloud Control UpdateResource is
+// the question this fixture answers: deploy a rule with two targets, remove them out of
+// band, assert `check` detects the removal, then `revert` re-applies the whole Targets
+// collection and a re-check is CLEAN. Both targets are cheap (no VPC).
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { Rule, Schedule } from "aws-cdk-lib/aws-events";
+import { SnsTopic, SqsQueue } from "aws-cdk-lib/aws-events-targets";
+import { Topic } from "aws-cdk-lib/aws-sns";
+import { Queue } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEventsRuleTargetRevert");
+
+const topic = new Topic(stack, "Topic");
+const queue = new Queue(stack, "Queue", { removalPolicy: RemovalPolicy.DESTROY });
+
+new Rule(stack, "Rule", {
+  schedule: Schedule.rate(Duration.hours(1)),
+  targets: [new SnsTopic(topic), new SqsQueue(queue)],
+});
+
+app.synth();

--- a/tests/integration/events-rule-target-revert/cdk.json
+++ b/tests/integration/events-rule-target-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/events-rule-target-revert/package.json
+++ b/tests/integration/events-rule-target-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-hunt",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for a cdk-real-drift integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/events-rule-target-revert/verify.sh
+++ b/tests/integration/events-rule-target-revert/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Regression integration test (real AWS) for issue #421 TASK 2 — removed-collection
+# REVERT on an EventBridge Rule's `Targets`. Targets are managed by a separate API
+# (PutTargets/RemoveTargets), so this exercises whether a whole-property re-add via
+# Cloud Control UpdateResource works for a removed collection.
+# deploy -> record -> remove all targets out of band -> check MUST detect (Targets
+# whole-property drift) -> revert MUST re-apply Targets -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEventsRuleTargetRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+RULE=$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Events::Rule'].PhysicalResourceId" --output text)
+[ -n "$RULE" ] || fail "no rule"
+echo "rule=$RULE"
+
+echo "=== [$STACK] record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] targets BEFORE removal ==="
+IDS=$(aws events list-targets-by-rule --rule "$RULE" --region "$REGION" --query 'Targets[].Id' --output text)
+echo "target ids=$IDS"
+[ -n "$IDS" ] || fail "no targets to remove"
+
+echo "=== [$STACK] remove all targets out of band (CC will omit Targets) ==="
+aws events remove-targets --rule "$RULE" --ids $IDS --region "$REGION" || fail "remove-targets"
+
+echo "=== [$STACK] check MUST detect the removed Targets collection ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -ne 0 ] || fail "FALSE NEGATIVE: removed Targets not detected (got CLEAN)"
+
+echo "=== [$STACK] revert (must re-apply Targets) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert errored"
+
+echo "=== [$STACK] targets AFTER revert ==="
+AFTER=$(aws events list-targets-by-rule --rule "$RULE" --region "$REGION" --query 'length(Targets)' --output text)
+echo "target count after revert=$AFTER"
+[ "$AFTER" = "2" ] || fail "expected 2 targets restored, got $AFTER"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after revert, got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1648,3 +1648,62 @@ describe('conditional/hard create-only split invariant over real CFn schemas (is
     expect(exercised).toBeGreaterThan(2);
   });
 });
+
+// Issue #421 TASK 2 — a removed declared COLLECTION (whole property absent from the
+// live read, #416) reverts via a single top-level Cloud Control `add /Prop`, NO SDK
+// writer needed — even for collections managed by a dedicated sub-API.
+//
+// The hypothesis was that some common types' removed collection can't be re-applied via
+// Cloud Control UpdateResource (a separate SDK API is required, like the existing
+// SDK_WRITERS). Live-tested on the two strongest candidates — EventBridge Rule `Targets`
+// (PutTargets/RemoveTargets) and EC2 Auto Scaling `NotificationConfigurations`
+// (PutNotificationConfiguration/DeleteNotificationConfiguration): BOTH revert cleanly
+// via Cloud Control. The reason generalizes — CC UpdateResource invokes the resource
+// provider's UPDATE handler, the SAME path a CloudFormation stack update uses, which
+// already wires those sub-APIs. So a removed collection re-applies wherever CFn itself
+// can set the property; no new SDK writer is warranted for these common types. The
+// integ proof lives in tests/integration/{events-rule-target-revert,asg-notification-
+// revert}; this unit test locks the revert PLAN those fixtures exercise (a declared
+// removed-collection finding → one `cc` item with `add /Prop`).
+describe('removed declared collection reverts via Cloud Control add /Prop (issue #421 TASK 2)', () => {
+  const removedCollection = (over: Partial<Finding>): Finding => ({
+    tier: 'declared',
+    logicalId: 'R',
+    physicalId: 'phys-1',
+    resourceType: 'AWS::Events::Rule',
+    path: 'Targets',
+    desired: [{ Id: 'Target0', Arn: 'arn:aws:sns:us-east-1:111111111111:t' }],
+    actual: undefined,
+    ...over,
+  });
+
+  it('EventBridge Rule Targets removed -> one cc item: add /Targets (no SDK writer)', () => {
+    const f = removedCollection({});
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toEqual([]);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('cc');
+    expect(plan.items[0]!.ops).toEqual([
+      expect.objectContaining({ op: 'add', path: '/Targets', value: f.desired }),
+    ]);
+  });
+
+  it('ASG NotificationConfigurations removed (CC omits when empty) -> add /NotificationConfigurations', () => {
+    const f = removedCollection({
+      resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+      path: 'NotificationConfigurations',
+      desired: [{ TopicARN: 'arn:aws:sns:us-east-1:111111111111:t', NotificationTypes: ['x'] }],
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.notRevertable).toEqual([]);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('cc'); // Cloud Control, not a dedicated SDK writer
+    expect(plan.items[0]!.ops).toEqual([
+      expect.objectContaining({
+        op: 'add',
+        path: '/NotificationConfigurations',
+        value: f.desired,
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes **TASK 2** of #421. Live-tests the revert side of the #416 removed-collection detection and finds **no SDK-writer gap for common types** — Cloud Control re-applies a removed collection cleanly, even for collections managed by a dedicated sub-API. Ships two regression integ fixtures + a unit test.

## Background

#416 detects a declared collection removed out of band (absent from the live read) as `declared` drift. TASK 2 asked whether the **revert** side has a gap: for types whose collection cannot be re-applied via Cloud Control `UpdateResource` (needing a dedicated SDK API, like the existing `SDK_WRITERS`).

## What was tested (live, real AWS)

The two strongest candidates — collections managed by a **dedicated sub-API**, the most likely place CC would reject a whole-property re-add:

| Type | Collection | Sub-API | Removed → detected | Revert | Result |
|------|-----------|---------|-----|--------|--------|
| `AWS::Events::Rule` | `Targets` | PutTargets / RemoveTargets | `actual=[]` | CC `add /Targets` | **CLEAN**, 2 targets restored |
| `AWS::AutoScaling::AutoScalingGroup` | `NotificationConfigurations` | PutNotificationConfiguration / DeleteNotificationConfiguration | CC omits when empty → `actual=undefined` | CC `add /NotificationConfigurations` | **CLEAN** |

Both revert cleanly via **Cloud Control — no SDK writer needed**.

## Why this generalizes

CC `UpdateResource` invokes the resource provider's **UPDATE handler** — the same path a CloudFormation stack update uses — which already wires those sub-APIs. So a removed collection re-applies wherever CFn itself can set the property. The hypothesized revert gap is therefore **narrow**: it would only hit types whose whole resource is not CC-mutable at all (already covered by the whole-model `SDK_WRITERS`, which re-send the full model) or create-only props (already barred from revert). No new `SDK_WRITERS` entry is warranted for the common types.

## What's added

- `tests/integration/events-rule-target-revert/` — deploy Rule + 2 targets → `record` → `remove-targets` out of band → `check` detects → `revert` → `check` CLEAN.
- `tests/integration/asg-notification-revert/` — deploy ASG + SNS notification → `record` → `delete-notification-configuration` out of band → `check` detects → `revert` → `check` CLEAN.
- `tests/revert-plan.test.ts` — a unit test locking the revert plan the fixtures exercise (a declared removed-collection finding → one `cc` item with `add /Prop`).

## Cleanup

Both stacks deployed under the bug-hunt sentinel, torn down via each `verify.sh` trap, and `bughunt-track.sh verify` confirms both gone + `sweep-orphans.sh` SWEEP CLEAN before the gate was cleared.

## Gates

- tests + integ fixtures only (no `src/**`) → verify-pr-EXEMPT (`check` + `docs` markers cover it)
- typecheck / lint+format / build / full unit suite (1819 tests) all green
