### PR TITLE
test(integ): metric-math Alarm + multi-behavior CloudFront FP/FN coverage

### DIFF
--- a/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD_multibehavior.json
+++ b/tests/corpus/AWS__CloudFront__Distribution.Cdn9963B1AD_multibehavior.json
@@ -1,0 +1,542 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cdn9963B1AD",
+    "resourceType": "AWS::CloudFront::Distribution",
+    "physicalId": "EQSY74ZS7ASCV",
+    "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn",
+    "declared": {
+      "DistributionConfig": {
+        "CacheBehaviors": [
+          {
+            "AllowedMethods": ["GET", "HEAD", "OPTIONS", "PUT", "PATCH", "POST", "DELETE"],
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "PathPattern": "/api/*",
+            "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920",
+            "ViewerProtocolPolicy": "https-only"
+          },
+          {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "PathPattern": "/images/*",
+            "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C",
+            "ViewerProtocolPolicy": "redirect-to-https"
+          },
+          {
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "PathPattern": "/static/*",
+            "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C",
+            "ViewerProtocolPolicy": "allow-all"
+          }
+        ],
+        "Comment": "cdkrd cloudfront multi-behavior",
+        "DefaultCacheBehavior": {
+          "AllowedMethods": ["GET", "HEAD"],
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+          "Compress": true,
+          "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477",
+          "ViewerProtocolPolicy": "redirect-to-https"
+        },
+        "Enabled": true,
+        "HttpVersion": "http2",
+        "IPV6Enabled": true,
+        "Origins": [
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "OriginSSLProtocols": ["TLSv1.2"]
+            },
+            "DomainName": "origin.example.com",
+            "Id": "CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477"
+          },
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "OriginSSLProtocols": ["TLSv1.2"]
+            },
+            "DomainName": "api.example.com",
+            "Id": "CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920"
+          },
+          {
+            "CustomOriginConfig": {
+              "OriginProtocolPolicy": "https-only",
+              "OriginSSLProtocols": ["TLSv1.2"]
+            },
+            "DomainName": "img.example.com",
+            "Id": "CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C"
+          }
+        ],
+        "PriceClass": "PriceClass_100"
+      }
+    }
+  },
+  "liveRaw": {
+    "DistributionConfig": {
+      "Logging": {
+        "IncludeCookies": false,
+        "Bucket": "",
+        "Prefix": ""
+      },
+      "Comment": "cdkrd cloudfront multi-behavior",
+      "DefaultRootObject": "",
+      "Origins": [
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "api.example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["TLSv1.2"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        },
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "img.example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["TLSv1.2"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        },
+        {
+          "ConnectionTimeout": 10,
+          "OriginAccessControlId": "",
+          "ConnectionAttempts": 3,
+          "OriginCustomHeaders": [],
+          "DomainName": "origin.example.com",
+          "OriginShield": {
+            "Enabled": false
+          },
+          "OriginPath": "",
+          "Id": "CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477",
+          "CustomOriginConfig": {
+            "OriginReadTimeout": 30,
+            "HTTPSPort": 443,
+            "OriginKeepaliveTimeout": 5,
+            "OriginSSLProtocols": ["TLSv1.2"],
+            "HTTPPort": 80,
+            "OriginProtocolPolicy": "https-only"
+          }
+        }
+      ],
+      "ViewerCertificate": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "PriceClass": "PriceClass_100",
+      "DefaultCacheBehavior": {
+        "Compress": true,
+        "FunctionAssociations": [],
+        "LambdaFunctionAssociations": [],
+        "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477",
+        "ViewerProtocolPolicy": "redirect-to-https",
+        "GrpcConfig": {
+          "Enabled": false
+        },
+        "TrustedSigners": [],
+        "FieldLevelEncryptionId": "",
+        "TrustedKeyGroups": [],
+        "AllowedMethods": ["HEAD", "GET"],
+        "CachedMethods": ["HEAD", "GET"],
+        "SmoothStreaming": false,
+        "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+      },
+      "Staging": false,
+      "CustomErrorResponses": [],
+      "ContinuousDeploymentPolicyId": "",
+      "OriginGroups": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "Enabled": true,
+      "Aliases": [],
+      "IPV6Enabled": true,
+      "WebACLId": "",
+      "HttpVersion": "http2",
+      "Restrictions": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "CacheBehaviors": [
+        {
+          "Compress": true,
+          "FunctionAssociations": [],
+          "LambdaFunctionAssociations": [],
+          "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920",
+          "ViewerProtocolPolicy": "https-only",
+          "GrpcConfig": {
+            "Enabled": false
+          },
+          "TrustedSigners": [],
+          "FieldLevelEncryptionId": "",
+          "TrustedKeyGroups": [],
+          "AllowedMethods": ["HEAD", "DELETE", "POST", "GET", "OPTIONS", "PUT", "PATCH"],
+          "PathPattern": "/api/*",
+          "CachedMethods": ["HEAD", "GET"],
+          "SmoothStreaming": false,
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+        },
+        {
+          "Compress": true,
+          "FunctionAssociations": [],
+          "LambdaFunctionAssociations": [],
+          "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C",
+          "ViewerProtocolPolicy": "redirect-to-https",
+          "GrpcConfig": {
+            "Enabled": false
+          },
+          "TrustedSigners": [],
+          "FieldLevelEncryptionId": "",
+          "TrustedKeyGroups": [],
+          "AllowedMethods": ["HEAD", "GET"],
+          "PathPattern": "/images/*",
+          "CachedMethods": ["HEAD", "GET"],
+          "SmoothStreaming": false,
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+        },
+        {
+          "Compress": true,
+          "FunctionAssociations": [],
+          "LambdaFunctionAssociations": [],
+          "TargetOriginId": "CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C",
+          "ViewerProtocolPolicy": "allow-all",
+          "GrpcConfig": {
+            "Enabled": false
+          },
+          "TrustedSigners": [],
+          "FieldLevelEncryptionId": "",
+          "TrustedKeyGroups": [],
+          "AllowedMethods": ["HEAD", "GET"],
+          "PathPattern": "/static/*",
+          "CachedMethods": ["HEAD", "GET"],
+          "SmoothStreaming": false,
+          "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6"
+        }
+      ]
+    },
+    "DomainName": "d1bro1tsqc4bto.cloudfront.net",
+    "Id": "EQSY74ZS7ASCV",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["DomainName", "Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["DomainName", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "DistributionConfig.CacheBehaviors.*.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.CacheBehaviors.*.Compress": false,
+      "DistributionConfig.CacheBehaviors.*.DefaultTTL": 86400,
+      "DistributionConfig.CacheBehaviors.*.FieldLevelEncryptionId": "",
+      "DistributionConfig.CacheBehaviors.*.MaxTTL": 31536000,
+      "DistributionConfig.CacheBehaviors.*.MinTTL": 0,
+      "DistributionConfig.CacheBehaviors.*.SmoothStreaming": false,
+      "DistributionConfig.Comment": "",
+      "DistributionConfig.CustomErrorResponses.*.ErrorCachingMinTTL": 300,
+      "DistributionConfig.CustomOrigin.HTTPPort": 80,
+      "DistributionConfig.CustomOrigin.HTTPSPort": 443,
+      "DistributionConfig.DefaultCacheBehavior.AllowedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.CachePolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.CachedMethods": ["GET", "HEAD"],
+      "DistributionConfig.DefaultCacheBehavior.Compress": false,
+      "DistributionConfig.DefaultCacheBehavior.DefaultTTL": 86400,
+      "DistributionConfig.DefaultCacheBehavior.FieldLevelEncryptionId": "",
+      "DistributionConfig.DefaultCacheBehavior.MaxTTL": 31536000,
+      "DistributionConfig.DefaultCacheBehavior.MinTTL": 0,
+      "DistributionConfig.DefaultCacheBehavior.OriginRequestPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.RealtimeLogConfigArn": "",
+      "DistributionConfig.DefaultCacheBehavior.ResponseHeadersPolicyId": "",
+      "DistributionConfig.DefaultCacheBehavior.SmoothStreaming": false,
+      "DistributionConfig.DefaultRootObject": "",
+      "DistributionConfig.HttpVersion": "http1.1",
+      "DistributionConfig.Logging.IncludeCookies": false,
+      "DistributionConfig.Logging.Prefix": "",
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPPort": 80,
+      "DistributionConfig.Origins.*.CustomOriginConfig.HTTPSPort": 443,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.CustomOriginConfig.OriginSSLProtocols": ["TLSv1", "SSLv3"],
+      "DistributionConfig.Origins.*.OriginPath": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginAccessIdentity": "",
+      "DistributionConfig.Origins.*.S3OriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginKeepaliveTimeout": 5,
+      "DistributionConfig.Origins.*.VpcOriginConfig.OriginReadTimeout": 30,
+      "DistributionConfig.PriceClass": "PriceClass_All",
+      "DistributionConfig.S3Origin.OriginAccessIdentity": "",
+      "DistributionConfig.WebACLId": ""
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin1E5189477].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin286716920].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C].ConnectionTimeout",
+      "actual": 10,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C].ConnectionAttempts",
+      "actual": 3,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C].CustomOriginConfig.OriginReadTimeout",
+      "actual": 30,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C].CustomOriginConfig.HTTPSPort",
+      "actual": 443,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C].CustomOriginConfig.OriginKeepaliveTimeout",
+      "actual": 5,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Origins[CdkRealDriftIntegCloudfrontMultiCdnOrigin334D7E61C].CustomOriginConfig.HTTPPort",
+      "actual": 80,
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.ViewerCertificate",
+      "actual": {
+        "SslSupportMethod": "vip",
+        "MinimumProtocolVersion": "TLSv1",
+        "CloudFrontDefaultCertificate": true
+      },
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.DefaultCacheBehavior.CachedMethods",
+      "actual": ["GET", "HEAD"],
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.OriginGroups",
+      "actual": {
+        "Quantity": 0,
+        "Items": []
+      },
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cdn9963B1AD",
+      "resourceType": "AWS::CloudFront::Distribution",
+      "path": "DistributionConfig.Restrictions",
+      "actual": {
+        "GeoRestriction": {
+          "Locations": [],
+          "RestrictionType": "none"
+        }
+      },
+      "nested": true,
+      "physicalId": "EQSY74ZS7ASCV",
+      "constructPath": "CdkRealDriftIntegCloudfrontMulti/Cdn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudWatch__Alarm.MathAlarmC1B2E17F.json
+++ b/tests/corpus/AWS__CloudWatch__Alarm.MathAlarmC1B2E17F.json
@@ -1,0 +1,174 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MathAlarmC1B2E17F",
+    "resourceType": "AWS::CloudWatch::Alarm",
+    "physicalId": "CdkRealDriftIntegMathAlarm-MathAlarmC1B2E17F-Lwr4zYDeOHuE",
+    "constructPath": "CdkRealDriftIntegMathAlarm/MathAlarm",
+    "declared": {
+      "AlarmDescription": "cdkrd metric-math error-rate alarm",
+      "ComparisonOperator": "GreaterThanThreshold",
+      "EvaluationPeriods": 3,
+      "Metrics": [
+        {
+          "Expression": "(errors / invocations) * 100",
+          "Id": "expr_1",
+          "Label": "Error Rate (%)",
+          "ReturnData": true
+        },
+        {
+          "Id": "errors",
+          "MetricStat": {
+            "Metric": {
+              "Dimensions": [
+                {
+                  "Name": "FunctionName",
+                  "Value": "cdkrd-mathalarm-fn"
+                }
+              ],
+              "MetricName": "Errors",
+              "Namespace": "AWS/Lambda"
+            },
+            "Period": 300,
+            "Stat": "Sum"
+          },
+          "ReturnData": false
+        },
+        {
+          "Id": "invocations",
+          "MetricStat": {
+            "Metric": {
+              "Dimensions": [
+                {
+                  "Name": "FunctionName",
+                  "Value": "cdkrd-mathalarm-fn"
+                }
+              ],
+              "MetricName": "Invocations",
+              "Namespace": "AWS/Lambda"
+            },
+            "Period": 300,
+            "Stat": "Sum"
+          },
+          "ReturnData": false
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "Threshold": 5,
+      "TreatMissingData": "notBreaching"
+    }
+  },
+  "liveRaw": {
+    "ComparisonOperator": "GreaterThanThreshold",
+    "TreatMissingData": "notBreaching",
+    "EvaluationPeriods": 3,
+    "OKActions": [],
+    "AlarmActions": [],
+    "ActionsEnabled": true,
+    "Metrics": [
+      {
+        "ReturnData": true,
+        "Expression": "(errors / invocations) * 100",
+        "Label": "Error Rate (%)",
+        "Id": "expr_1"
+      },
+      {
+        "ReturnData": false,
+        "MetricStat": {
+          "Stat": "Sum",
+          "Period": 300,
+          "Metric": {
+            "MetricName": "Errors",
+            "Dimensions": [
+              {
+                "Value": "cdkrd-mathalarm-fn",
+                "Name": "FunctionName"
+              }
+            ],
+            "Namespace": "AWS/Lambda"
+          }
+        },
+        "Id": "errors"
+      },
+      {
+        "ReturnData": false,
+        "MetricStat": {
+          "Stat": "Sum",
+          "Period": 300,
+          "Metric": {
+            "MetricName": "Invocations",
+            "Dimensions": [
+              {
+                "Value": "cdkrd-mathalarm-fn",
+                "Name": "FunctionName"
+              }
+            ],
+            "Namespace": "AWS/Lambda"
+          }
+        },
+        "Id": "invocations"
+      }
+    ],
+    "AlarmDescription": "cdkrd metric-math error-rate alarm",
+    "AlarmName": "CdkRealDriftIntegMathAlarm-MathAlarmC1B2E17F-Lwr4zYDeOHuE",
+    "InsufficientDataActions": [],
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:alarm:CdkRealDriftIntegMathAlarm-MathAlarmC1B2E17F-Lwr4zYDeOHuE",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegMathAlarm",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "MathAlarmC1B2E17F",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMathAlarm/ed2b2840-7381-11f1-af39-0e2723484ce7",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Threshold": 5
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AlarmName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AlarmName"],
+    "defaults": {
+      "ActionsEnabled": true
+    },
+    "defaultPaths": {
+      "ActionsEnabled": true
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "MathAlarmC1B2E17F",
+      "resourceType": "AWS::CloudWatch::Alarm",
+      "path": "ActionsEnabled",
+      "actual": true,
+      "physicalId": "CdkRealDriftIntegMathAlarm-MathAlarmC1B2E17F-Lwr4zYDeOHuE",
+      "constructPath": "CdkRealDriftIntegMathAlarm/MathAlarm"
+    }
+  ]
+}

--- a/tests/integration/cloudfront-multibehavior/app.ts
+++ b/tests/integration/cloudfront-multibehavior/app.ts
@@ -1,0 +1,52 @@
+// CDK app for the cdk-real-drift CloudFront multi-behavior false-positive integ test.
+// UNTESTED structural gap: `DistributionConfig.CacheBehaviors` is an object array whose
+// elements are keyed by `PathPattern` — NOT a standard IDENTITY_FIELD (Key/Id/
+// AttributeName/IndexName/Name) — and it is absent from every UNORDERED_* table. The
+// existing cloudfront-rich fixture declares only ONE additional behavior, so a reorder
+// of the CacheBehaviors array has never been exercised. Distributions with several
+// path-pattern behaviors are an everyday CloudFront pattern (static assets / API /
+// images on different origins). If AWS returns CacheBehaviors in a different order than
+// declared, a positional diff would false-flag declared drift on every check. This
+// fixture declares THREE behaviors across two origins to surface that ordering risk.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  AllowedMethods,
+  Distribution,
+  PriceClass,
+  ViewerProtocolPolicy,
+} from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCloudfrontMulti");
+
+const apiOrigin = new HttpOrigin("api.example.com");
+const imgOrigin = new HttpOrigin("img.example.com");
+
+new Distribution(stack, "Cdn", {
+  comment: "cdkrd cloudfront multi-behavior",
+  priceClass: PriceClass.PRICE_CLASS_100,
+  defaultBehavior: {
+    origin: new HttpOrigin("origin.example.com"),
+    viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+    allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
+  },
+  additionalBehaviors: {
+    "/api/*": {
+      origin: apiOrigin,
+      viewerProtocolPolicy: ViewerProtocolPolicy.HTTPS_ONLY,
+      allowedMethods: AllowedMethods.ALLOW_ALL,
+    },
+    "/images/*": {
+      origin: imgOrigin,
+      viewerProtocolPolicy: ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      compress: true,
+    },
+    "/static/*": {
+      origin: imgOrigin,
+      viewerProtocolPolicy: ViewerProtocolPolicy.ALLOW_ALL,
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/cloudfront-multibehavior/cdk.json
+++ b/tests/integration/cloudfront-multibehavior/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-multibehavior/package.json
+++ b/tests/integration/cloudfront-multibehavior/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-multibehavior",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/cloudfront-multibehavior/verify.sh
+++ b/tests/integration/cloudfront-multibehavior/verify.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): a CloudFront distribution with THREE
+# path-pattern CacheBehaviors -> record -> check MUST be CLEAN. Probes the untested
+# CacheBehaviors ordering gap (PathPattern-keyed object array, absent from UNORDERED_*).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegCloudfrontMulti; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-cfmulti $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-cfmulti-pre.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || fail "false declared drift on multi-behavior CloudFront (exit $rc)"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-cfmulti-pre.out && fail "a declared property wrongly reported as drift (FP)"
+echo "=== record then check MUST be CLEAN ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after record"
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/cloudwatch-mathalarm/app.ts
+++ b/tests/integration/cloudwatch-mathalarm/app.ts
@@ -1,0 +1,52 @@
+// CDK app for the cdk-real-drift CloudWatch metric-math Alarm false-positive integ
+// test. UNCOVERED config: a MathExpression alarm synthesizes a `Metrics` array of
+// MetricDataQuery objects (two MetricStat entries + one Expression entry), instead of
+// the flat top-level MetricName/Namespace/Statistic of a single-metric alarm. AWS
+// fills defaults into each element (ReturnData, the MetricStat Period) and may return
+// the Id-keyed array reordered — so a positional/default-naive diff false-flags
+// declared drift on the error-rate alarm pattern every SRE deploys. This fixture is
+// the FP probe for that Metrics-array shape; the existing cloudwatch-alarm fixture
+// covers the single-metric (Dimensions) shape.
+import { App, Duration, Stack, Tags } from "aws-cdk-lib";
+import {
+  Alarm,
+  ComparisonOperator,
+  MathExpression,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMathAlarm");
+
+const errors = new Metric({
+  namespace: "AWS/Lambda",
+  metricName: "Errors",
+  dimensionsMap: { FunctionName: "cdkrd-mathalarm-fn" },
+  statistic: "Sum",
+  period: Duration.minutes(5),
+});
+const invocations = new Metric({
+  namespace: "AWS/Lambda",
+  metricName: "Invocations",
+  dimensionsMap: { FunctionName: "cdkrd-mathalarm-fn" },
+  statistic: "Sum",
+  period: Duration.minutes(5),
+});
+const errorRate = new MathExpression({
+  expression: "(errors / invocations) * 100",
+  usingMetrics: { errors, invocations },
+  label: "Error Rate (%)",
+});
+
+const alarm = new Alarm(stack, "MathAlarm", {
+  metric: errorRate,
+  threshold: 5,
+  evaluationPeriods: 3,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+  treatMissingData: TreatMissingData.NOT_BREACHING,
+  alarmDescription: "cdkrd metric-math error-rate alarm",
+});
+Tags.of(alarm).add("team", "platform");
+
+app.synth();

--- a/tests/integration/cloudwatch-mathalarm/cdk.json
+++ b/tests/integration/cloudwatch-mathalarm/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudwatch-mathalarm/package.json
+++ b/tests/integration/cloudwatch-mathalarm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudwatch-mathalarm",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift CloudWatch metric-math Alarm false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudwatch-mathalarm/verify-detect.sh
+++ b/tests/integration/cloudwatch-mathalarm/verify-detect.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Metric-math Alarm detect + revert (real AWS): flip the declared MUTABLE Threshold
+# 5->9 out of band (put-metric-alarm upsert, preserving the Metrics array) -> check
+# MUST DETECT -> revert (Cloud Control UpdateResource) -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegMathAlarm; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out al.json al2.json; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+ANAME="$(aws cloudwatch describe-alarms --region "$REGION" --query "MetricAlarms[?contains(AlarmName,'CdkRealDriftIntegMathAlarm')].AlarmName" --output text | head -1)"
+[ -n "$ANAME" ] && [ "$ANAME" != "None" ] || fail "no alarm name"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob Threshold 5->9 (preserve Metrics array) ==="
+aws cloudwatch describe-alarms --alarm-names "$ANAME" --region "$REGION" --query "MetricAlarms[0]" > al.json
+node -e "const a=require('./al.json');const p={AlarmName:a.AlarmName,ComparisonOperator:a.ComparisonOperator,EvaluationPeriods:a.EvaluationPeriods,Threshold:9,Metrics:a.Metrics,...(a.TreatMissingData?{TreatMissingData:a.TreatMissingData}:{}),...(a.AlarmDescription?{AlarmDescription:a.AlarmDescription}:{})};require('fs').writeFileSync('al2.json',JSON.stringify(p));"
+aws cloudwatch put-metric-alarm --cli-input-json file://al2.json --region "$REGION" >/dev/null || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-mathalarm-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "Threshold" /tmp/cdkrd-mathalarm-detect.out || fail "Threshold drift not reported"
+echo "=== revert ==="; $CLI revert "$STACK" --region "$REGION" --yes || fail revert
+GOT="$(aws cloudwatch describe-alarms --alarm-names "$ANAME" --region "$REGION" --query 'MetricAlarms[0].Threshold' --output text)"
+[ "$GOT" = "5.0" ] || fail "Threshold not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/cloudwatch-mathalarm/verify.sh
+++ b/tests/integration/cloudwatch-mathalarm/verify.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# cdk-real-drift CloudWatch metric-math Alarm false-positive integration test (real AWS).
+#
+# Deploys a MathExpression alarm (Metrics array of MetricStat + Expression elements).
+# The strong assertion: with NO baseline, `check --fail` must exit 0 — every declared
+# value normalizes equal to live despite AWS default-filling each Metrics element
+# (ReturnData, MetricStat Period) and possibly reordering the Id-keyed array. A
+# normalizer regression turns one into a false declared drift and fails here. Then
+# record + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/cloudwatch-mathalarm && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMathAlarm
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-mathalarm $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-mathalarm-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a metric-math alarm (exit $rc) — a normalizer regressed"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-mathalarm-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Bug hunt — clean round (0 FP, 0 FN), grows offline regression coverage

A periodic real-AWS bug hunt targeting genuinely-uncovered **common** configs, preceded by an offline FP-class audit of the `src/normalize/noise.ts` fold tables (corpus-replay over ~486 cases via parallel read-only agents). The audit found the existing fold machinery comprehensive — no unguarded FP in the corpus — and surfaced two deploy-worthy structural gaps, both probed live here and proven benign.

### What was deployed + checked (then deleted — SWEEP CLEAN)

**`cloudwatch-mathalarm` — metric-math CloudWatch Alarm (NEW shape)**
- A `MathExpression` alarm synthesizes a `Metrics` array of `MetricDataQuery` objects (two `MetricStat` entries + one `Expression` entry), unlike the flat top-level `MetricName`/`Namespace`/`Statistic` of a single-metric alarm (the existing `cloudwatch-alarm` fixture). Everyday SRE error-rate pattern.
- **FP:** `check` on the fresh deploy is **CLEAN** — AWS echoes the Id-keyed Metrics array back in declared order and fills no surprising defaults (only `ActionsEnabled` atDefault). Declared `Metrics` == live `Metrics` exactly (order, keys, `Period`, `ReturnData`).
- **FN:** `verify-detect.sh` flips the declared mutable `Threshold` 5→9 out of band → `check` **detects** → `revert` (Cloud Control `UpdateResource`) restores it → CLEAN. Proves detect+revert work for the Metrics-array shape.

**`cloudfront-multibehavior` — distribution with 3 PathPattern CacheBehaviors**
- `DistributionConfig.CacheBehaviors` is an object array whose elements carry **no** standard `IDENTITY_FIELD` and it is absent from every `UNORDERED_*` table — so a reorder would false-positive. The existing `cloudfront-rich` fixture declares only **one** additional behavior, so this ordering was never exercised.
- **FP:** **CLEAN** — AWS preserves `CacheBehaviors` order (precedence-ordered): declared order `['/api/*','/images/*','/static/*']` == live order, 0 declared findings, 22 atDefault. The structural gap is benign; no fold needed.

### Deliverable
Both live reads are harvested into `tests/corpus/` as `corpus-replay` regression cases (account ids sanitized), so a future normalization change that would re-introduce an FP/FN on these shapes fails a unit test instead of waiting for the next paid hunt:
- `AWS__CloudWatch__Alarm.MathAlarmC1B2E17F.json`
- `AWS__CloudFront__Distribution.Cdn9963B1AD_multibehavior.json` (suffixed — logical-id collision with the rich case)

### Verification
- `vp run typecheck` / `vp run check` / `vp pack` / `vp test run` — all green (41 files, 1834 tests; corpus-replay 489).
- All deployed stacks deleted via `delstack`; `bughunt-track.sh verify` → every stack GONE + `sweep-orphans.sh` SWEEP CLEAN.
- Tests/tooling-only (no `src/**`) → `verify-pr-gate` EXEMPT.