### PR TITLE
docs(readme): tighten Quick start first-run paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Each block above is one kind of finding, and neither needed a baseline:
   confirmed against your template right away (deletes of declared resources are
   confirmed the same way).
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
-  your template. cdkrd detects these too: it hides the obvious noise (AWS defaults,
-  auto-generated names) and shows the meaningful rest, including a value nested
-  inside something you _did_ declare. With no baseline it can't confirm them as
-  drift yet, though.
+  your template. cdkrd detects these too: it strips the obvious noise (AWS
+  defaults, auto-generated names) so what's left is the values most likely to be
+  real drift, including one nested inside something you _did_ declare. It just
+  can't confirm them yet without a baseline.
 
 ### Recording is the recommended next step
 
@@ -98,6 +98,17 @@ Recording snapshots those live-only values into a git-committed `.cdkrd` baselin
 so from then on any later out-of-band change to them is confirmed drift. That's the
 day-to-day loop: run `check`, record what's intended, commit the baseline, and the
 next out-of-band change stands out on its own.
+
+With `Role.Policies` recorded, an inline policy added later out of band is now
+confirmed drift, the undeclared kind `cdk drift` can't see:
+
+```console
+=== cdkrd check: ApiStack (us-east-1) ===
+[CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
+  ApiStack/Role.Policies (AWS::IAM::Role) — changed since record = [{"PolicyName":"adhoc", ...}, {"PolicyName":"manual-debug-access", ...}]
+
+result: 1 drift(s) (undeclared=1)
+```
 
 `record` covers undeclared and added state only. The standalone verbs (and how
 `ignore` can accept even a declared drift) are in

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift. They're _potential_, not confirmed: with no baseline, cdkrd can't
-  tell whether you set them on purpose.
+  real drift. They're only _potential_ because there's no baseline yet; record
+  them next and any later change is caught as confirmed drift.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ can't see:
 result: 1 drift(s) (undeclared=1)
 ```
 
-`record` covers undeclared and added state only. The standalone verbs (and how
-`ignore` can accept even a declared drift) are in
-[The model](#the-model-one-verb-you-run-three-it-offers).
+`record` handles undeclared and added state only.
+[The model](#the-model-one-verb-you-run-three-it-offers) covers all four verbs,
+including how `ignore` can accept even a declared drift.
 
 ### In CI
 

--- a/README.md
+++ b/README.md
@@ -53,22 +53,14 @@ It prints what it found, then offers three actions right in the prompt:
 
 - **Record**: accept the live-only values as the norm and watch them. Writes a
   git-committed `.cdkrd` baseline file; later out-of-band changes are then drift.
-- **Revert**: write the desired value back to AWS (_removes_ an undeclared
-  live-only value, or restores a declared one).
+- **Revert**: write the desired value back to AWS.
 - **Ignore**: stop reporting it, for good.
 
-Even on the first run, with no baseline yet, `check` already surfaces the likely
-drift. Properties you **declared**, plus anything deleted out-of-band, are
-compared against your template, so they're reported as confirmed drift right
-away. For values that live only on the real resource (never in your template),
-`check` folds away the ones it can explain (AWS defaults, generated names) and
-surfaces the rest as _Potential Drift_, including a non-default value nested
-inside an object you _did_ declare. These are most likely real divergence too,
-just not yet confirmable without a baseline. Record them to confirm, and any
-later out-of-band change becomes real drift.
-
-So a typical first run reports no _confirmed_ drift yet, but it does flag the
-live-only values (potential drift) worth recording:
+Even on a fresh project, the first run already surfaces the likely drift.
+Declared changes and out-of-band deletes are confirmed against your template
+right away; values that live only on the real resource show up as _Potential
+Drift_ (most likely real divergence too, just not confirmable until you record a
+baseline):
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ your CloudFormation template, the kind `cdk drift` can't see:
 result: 1 drift(s) (undeclared=1)
 ```
 
-`record` is for live-only state, not declared drift. To accept a declared drift
-instead of fixing it, use `ignore` (see
-[The model](#the-model-one-verb-you-run-three-it-offers)).
+`record` is for live-only state, not a `[CFn-Declared Drift]` (a value you
+declared that changed out of band). To accept one of those rather than fix it, use
+`ignore` (see [The model](#the-model-one-verb-you-run-three-it-offers)).
 
 ### In CI
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ so from then on any later out-of-band change to them is confirmed drift. That's 
 day-to-day loop: run `check`, record what's intended, commit the baseline, and the
 next out-of-band change stands out on its own.
 
-With `Role.Policies` recorded, an inline policy added later out of band is now
-confirmed drift, the undeclared kind `cdk drift` can't see:
+With `Role.Policies` recorded, an inline policy added later out of band now
+surfaces as **`[CFn-Undeclared Drift]`**, the confirmed live-only kind `cdk drift`
+can't see:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===

--- a/README.md
+++ b/README.md
@@ -96,9 +96,8 @@ so from then on any later out-of-band change to them is confirmed drift. That's 
 day-to-day loop: run `check`, record what's intended, commit the baseline, and the
 next out-of-band change stands out on its own.
 
-`record` covers undeclared and added state only. A declared drift you fix in code
-or `revert`; `ignore` accepts anything you want to stop hearing about. The
-standalone verbs are in
+`record` covers undeclared and added state only. The standalone verbs (and how
+`ignore` can accept even a declared drift) are in
 [The model](#the-model-one-verb-you-run-three-it-offers).
 
 ### In CI
@@ -174,12 +173,12 @@ baseline-file axis: whether you've snapshotted that value yet.)
 
 The mechanics:
 
-- **Recording arms undeclared / added detection.** Until a stack's first `record`,
-  a live-only value or added resource is `unrecorded` (informational, CLEAN, never
-  fails `--fail`); once recorded, a later out-of-band change is failing drift. The
-  baseline is a git-committed JSON file at
-  `.cdkrd/<stack>.<accountId>.<region>.json` (so a change to it is reviewable;
-  account id + region in the name prevent cross-account collisions).
+- **Until a stack's first `record`, undeclared / added state is `unrecorded`:**
+  informational, CLEAN, never fails `--fail`.
+  [Recording](#recording-is-the-recommended-next-step) is what arms detection,
+  turning a later out-of-band change into failing drift. The baseline is a
+  git-committed JSON file at `.cdkrd/<stack>.<accountId>.<region>.json`
+  (reviewable; account id + region in the name prevent cross-account collisions).
 - **There is no watch-list to maintain.** Every `check` snapshots the full live
   model (Cloud Control API + SDK readers for the gap types) and subtracts everything
   explainable: schema read-only/write-only/defaults, AWS-managed fields, `aws:*`

--- a/README.md
+++ b/README.md
@@ -56,11 +56,7 @@ It prints what it found, then offers three actions right in the prompt:
 - **Revert**: write the desired value back to AWS.
 - **Ignore**: stop reporting it, for good.
 
-Even on your first run, before any baseline exists, `check` already surfaces the
-likely drift. Declared changes and out-of-band deletes are confirmed against your
-template right away; values that live only on the real resource show up as
-_Potential Drift_ (most likely real divergence too, just not confirmable until
-you record a baseline):
+Here's a first run:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
@@ -79,6 +75,12 @@ ApiStack: potential drift found (live-only, no baseline yet) — what do you wan
     Ignore — stop reporting it (writes .cdkrd/config.json)
     Decide per finding — assign a different action to each
 ```
+
+Note that it already found something with no baseline at all. Declared changes and
+out-of-band deletes are confirmed against your template right away; values that
+live only on the real resource can't be confirmed yet, so they surface as
+_Potential Drift_ (most likely real divergence too, just not confirmable until you
+record a baseline).
 
 Recording is the usual next step: it snapshots those values into the
 git-committed `.cdkrd` baseline, so from then on `cdkrd check` flags any later

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift. They're only _potential_ because there's no baseline yet. Record
-  them as your baseline next, and any later change to them is caught as confirmed
+  real drift. They're only _potential_ because there's no baseline yet: if you
+  record them as your baseline, any later change to them is caught as confirmed
   drift.
 
 ### Recording is the recommended next step

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ ApiStack: drift found — what do you want to do?
     Decide per finding — assign a different action to each
 ```
 
-It caught drift two ways, neither needing a baseline. **Declared changes and
-out-of-band deletes** are confirmed against your template right away (the
+Two kinds of finding showed up, neither needing a baseline. **Declared changes and
+out-of-band deletes** are confirmed drift against your template right away (the
 `CFn-Declared Drift` block). **Values that live only on the real resource** can't
 be confirmed yet, so `check` folds away the ones it can explain (AWS defaults,
 generated names) and surfaces the rest as _Potential Drift_, including a

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ ApiStack: potential drift found (live-only, no baseline yet) — what do you wan
     Decide per finding — assign a different action to each
 ```
 
+Recording is the usual next step: it snapshots those values into the
+git-committed `.cdkrd` baseline, so from then on `cdkrd check` flags any later
+out-of-band change to them as confirmed drift.
+
 In CI, run `npx cdkrd check --fail`. It's read-only, never prompts, and exits 1 on
 drift; it never writes a baseline (you record locally and commit the file).
 

--- a/README.md
+++ b/README.md
@@ -81,13 +81,16 @@ ApiStack: drift found — what do you want to do?
     Decide per finding — assign a different action to each
 ```
 
-Two kinds of finding showed up, neither needing a baseline. **Declared changes and
-out-of-band deletes** are confirmed drift against your template right away (the
-`CFn-Declared Drift` block). **Values that live only on the real resource** can't
-be confirmed yet, so `check` folds away the ones it can explain (AWS defaults,
-generated names) and surfaces the rest as _Potential Drift_, including a
-non-default value nested inside an object you _did_ declare. These are most likely
-real divergence too, just not confirmable until you record them.
+Each block above is one kind of finding, and neither needed a baseline:
+
+- **`[CFn-Declared Drift]`**: a property you declared changed out of band, so it's
+  confirmed against your template right away (deletes of declared resources are
+  confirmed the same way).
+- **`[Potential Drift]`**: values that live only on the real resource. cdkrd can't
+  confirm these yet, so it folds away the ones it can explain (AWS defaults,
+  generated names) and surfaces the rest, including a non-default value nested
+  inside an object you _did_ declare. Most likely real divergence too, just not
+  confirmable until you record them.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift, including one nested inside something you _did_ declare. It just
-  can't confirm them yet without a baseline.
+  real drift, including one nested inside something you _did_ declare. They're
+  _potential_, not confirmed, because without a baseline cdkrd can't be sure you
+  didn't set them on purpose.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -48,27 +48,32 @@ npm install -D cdk-real-drift   # in your CDK project
 npx cdkrd check                 # checks every stack your app defines
 ```
 
-`check` is the only command you run by hand, and there's nothing to set up first.
-It prints what it found, then offers three actions right in the prompt:
+`check` is the only command you run by hand, with nothing to set up first: it
+finds drift and offers **Record**, **Revert**, and **Ignore** inline on what it
+turns up.
 
-- **Record**: accept the live-only values as the norm and watch them. Writes a
-  git-committed `.cdkrd` baseline file; later out-of-band changes are then drift.
-- **Revert**: write the desired value back to AWS.
-- **Ignore**: stop reporting it, for good.
+## How to use
 
-Here's a first run:
+### Your first run needs no baseline
+
+The first time you run `check` on a stack, before recording anything:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
-No baseline yet — these live-only values can't be confirmed as drift. Record them right from this `cdkrd check` prompt, or run `cdkrd record`.
+No baseline yet — live-only values can't be confirmed as drift, but declared drift and out-of-band deletes always can.
+
+[CFn-Declared Drift: 1] (declared in your CloudFormation template — the live value differs)
+  ApiStack/Topic.DisplayName (AWS::SNS::Topic)
+      desired="prod-alerts"
+      actual ="test"
 
 [Potential Drift: 2] (live-only and not yet in your .cdkrd baseline, so cdkrd can't tell whether it's intended or an out-of-band change — Record to accept it, or Revert to remove it)
-  ApiStack/Topic.DisplayName (AWS::SNS::Topic) = "test"
+  ApiStack/Queue.RedrivePolicy (AWS::SQS::Queue) = {"maxReceiveCount":5}
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
 
-result: no confirmed drift · 2 potential drift
+result: 3 findings — 1 drift (declared=1) + 2 potential drift
 
-ApiStack: potential drift found (live-only, no baseline yet) — what do you want to do?
+ApiStack: drift found — what do you want to do?
   ❯ Nothing (decide later)
     Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)
     Revert — write the desired values back to AWS
@@ -76,19 +81,30 @@ ApiStack: potential drift found (live-only, no baseline yet) — what do you wan
     Decide per finding — assign a different action to each
 ```
 
-Notice it surfaced drift before you've recorded any baseline. Declared changes and
-out-of-band deletes are confirmed against your template right away. For values that
-live only on the real resource, `check` folds away the ones it can explain (AWS
-defaults, generated names) and surfaces the rest as _Potential Drift_, including a
+It caught drift two ways, neither needing a baseline. **Declared changes and
+out-of-band deletes** are confirmed against your template right away (the
+`CFn-Declared Drift` block). **Values that live only on the real resource** can't
+be confirmed yet, so `check` folds away the ones it can explain (AWS defaults,
+generated names) and surfaces the rest as _Potential Drift_, including a
 non-default value nested inside an object you _did_ declare. These are most likely
-real divergence too, just not confirmable until you record a baseline.
+real divergence too, just not confirmable until you record them.
 
-Recording is the usual next step: it snapshots those values into the
-git-committed `.cdkrd` baseline, so from then on `cdkrd check` flags any later
-out-of-band change to them as confirmed drift.
+### Recording is the recommended next step
 
-In CI, run `npx cdkrd check --fail`. It's read-only, never prompts, and exits 1 on
-drift; it never writes a baseline (you record locally and commit the file).
+Recording snapshots those live-only values into a git-committed `.cdkrd` baseline,
+so from then on any later out-of-band change to them is confirmed drift. That's the
+day-to-day loop: run `check`, record what's intended, commit the baseline, and the
+next out-of-band change stands out on its own.
+
+`record` covers undeclared and added state only. A declared drift you fix in code
+or `revert`; `ignore` accepts anything you want to stop hearing about. The
+standalone verbs are in
+[The model](#the-model-one-verb-you-run-three-it-offers).
+
+### In CI
+
+Run `npx cdkrd check --fail`. It's read-only, never prompts, and exits 1 on drift;
+it never writes a baseline (you record locally and commit the file).
 
 ## The model: one verb you run, three it offers
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ day-to-day loop: run `check`, record what's intended, commit the baseline, and t
 next out-of-band change stands out on its own.
 
 With `Role.Policies` recorded, an inline policy added later out of band now
-surfaces as **`[CFn-Undeclared Drift]`**, the confirmed live-only kind `cdk drift`
-can't see:
+surfaces as **`[CFn-Undeclared Drift]`**: confirmed drift on a value that isn't in
+your CloudFormation template, the kind `cdk drift` can't see:
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Ignore the prompt re-offers anything still drifting, so you finish in one run. F
 prompt mechanics (multiselect, Decide per finding, key bindings) are under
 [Interactive prompts](#interactive-prompts-tty-only-ci-is-never-prompted).
 
-## How it works
+## How drift is judged
 
 cdkrd compares the **live AWS resource** against your deployed **CloudFormation
 template** (or your local synth with `--pre-deploy`). It's reality vs intent,

--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ It prints what it found, then offers three actions right in the prompt:
 - **Revert**: write the desired value back to AWS.
 - **Ignore**: stop reporting it, for good.
 
-Even on a fresh project, the first run already surfaces the likely drift.
-Declared changes and out-of-band deletes are confirmed against your template
-right away; values that live only on the real resource show up as _Potential
-Drift_ (most likely real divergence too, just not confirmable until you record a
-baseline):
+Even on your first run, before any baseline exists, `check` already surfaces the
+likely drift. Declared changes and out-of-band deletes are confirmed against your
+template right away; values that live only on the real resource show up as
+_Potential Drift_ (most likely real divergence too, just not confirmable until
+you record a baseline):
 
 ```console
 === cdkrd check: ApiStack (us-east-1) ===

--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ Each block above is one kind of finding, and neither needed a baseline:
   confirmed against your template right away (deletes of declared resources are
   confirmed the same way).
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
-  your template. cdkrd shows them but can't call them confirmed drift yet: with no
-  baseline, it has no record of what you intended. It hides the obvious noise (AWS
-  defaults, auto-generated names) and shows the meaningful rest, including a value
-  nested inside something you _did_ declare.
+  your template. cdkrd detects these too: it hides the obvious noise (AWS defaults,
+  auto-generated names) and shows the meaningful rest, including a value nested
+  inside something you _did_ declare. With no baseline it can't confirm them as
+  drift yet, though.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ can't see:
 result: 1 drift(s) (undeclared=1)
 ```
 
-`record` handles undeclared and added state only.
+`record` is for live-only state (not declared drift).
 [The model](#the-model-one-verb-you-run-three-it-offers) covers all four verbs,
 including how `ignore` can accept even a declared drift.
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,12 @@ ApiStack: potential drift found (live-only, no baseline yet) — what do you wan
     Decide per finding — assign a different action to each
 ```
 
-Note that it already found something with no baseline at all. Declared changes and
-out-of-band deletes are confirmed against your template right away; values that
-live only on the real resource can't be confirmed yet, so they surface as
-_Potential Drift_ (most likely real divergence too, just not confirmable until you
-record a baseline).
+Notice it surfaced drift before you've recorded any baseline. Declared changes and
+out-of-band deletes are confirmed against your template right away. For values that
+live only on the real resource, `check` folds away the ones it can explain (AWS
+defaults, generated names) and surfaces the rest as _Potential Drift_, including a
+non-default value nested inside an object you _did_ declare. These are most likely
+real divergence too, just not confirmable until you record a baseline.
 
 Recording is the usual next step: it snapshots those values into the
 git-committed `.cdkrd` baseline, so from then on `cdkrd check` flags any later

--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift. They're only _potential_ because there's no baseline yet: if you
-  record them as your baseline, any later change to them is caught as confirmed
-  drift.
+  real drift. They're only _potential_ because there's no baseline yet.
 
-### Recording is the recommended next step
+At the prompt you act on each finding: **record** it (accept and watch),
+**revert** it (undo the change), or **ignore** it (stop reporting).
+
+### Recording
 
 Recording snapshots those live-only values into a git-committed `.cdkrd` baseline,
 so from then on any later out-of-band change to them is confirmed drift. That's the
@@ -112,9 +113,8 @@ your CloudFormation template, the kind `cdk drift` can't see:
 result: 1 drift(s) (undeclared=1)
 ```
 
-`record` is for live-only state, not a `[CFn-Declared Drift]` (a value you
-declared that changed out of band). To accept one of those rather than fix it, use
-`ignore` (see [The model](#the-model-one-verb-you-run-three-it-offers)).
+`record` covers live-only state only, not a `[CFn-Declared Drift]`; the other
+verbs are in [The model](#the-model-one-verb-you-run-three-it-offers).
 
 ### In CI
 
@@ -191,7 +191,7 @@ The mechanics:
 
 - **Until a stack's first `record`, undeclared / added state is `unrecorded`:**
   informational, CLEAN, never fails `--fail`.
-  [Recording](#recording-is-the-recommended-next-step) is what arms detection,
+  [Recording](#recording) is what arms detection,
   turning a later out-of-band change into failing drift. The baseline is a
   git-committed JSON file at `.cdkrd/<stack>.<accountId>.<region>.json`
   (reviewable; account id + region in the name prevent cross-account collisions).

--- a/README.md
+++ b/README.md
@@ -89,9 +89,8 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift, including one nested inside something you _did_ declare. They're
-  _potential_, not confirmed, because without a baseline cdkrd can't be sure you
-  didn't set them on purpose.
+  real drift. They're _potential_, not confirmed, because without a baseline cdkrd
+  can't be sure you didn't set them on purpose.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,9 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift. They're only _potential_ because there's no baseline yet; record
-  them next and any later change is caught as confirmed drift.
+  real drift. They're only _potential_ because there's no baseline yet. Record
+  them as your baseline next, and any later change to them is caught as confirmed
+  drift.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift. They're _potential_, not confirmed, because without a baseline cdkrd
-  can't be sure you didn't set them on purpose.
+  real drift. They're _potential_, not confirmed: with no baseline, cdkrd can't
+  tell whether you set them on purpose.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ can't see:
 result: 1 drift(s) (undeclared=1)
 ```
 
-`record` is for live-only state (not declared drift).
-[The model](#the-model-one-verb-you-run-three-it-offers) covers all four verbs,
-including how `ignore` can accept even a declared drift.
+`record` is for live-only state, not declared drift. To accept a declared drift
+instead of fixing it, use `ignore` (see
+[The model](#the-model-one-verb-you-run-three-it-offers)).
 
 ### In CI
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,13 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[CFn-Declared Drift]`**: a property you declared changed out of band, so it's
   confirmed against your template right away (deletes of declared resources are
   confirmed the same way).
-- **`[Potential Drift]`**: values that live only on the real resource. cdkrd can't
-  confirm these yet, so it folds away the ones it can explain (AWS defaults,
-  generated names) and surfaces the rest, including a non-default value nested
-  inside an object you _did_ declare. Most likely real divergence too, just not
-  confirmable until you record them.
+- **`[Potential Drift]`**: settings that live only on the real resource, never in
+  your template. With no baseline, cdkrd has no record of what you intended, so it
+  can't yet tell a setting you chose on purpose from an out-of-band change. It
+  hides the obvious noise (values sitting at an AWS default, auto-generated names)
+  and lists the rest, including a meaningful value nested inside something you
+  _did_ declare. Those are probably real differences, which is why recording them
+  is the usual next move.
 
 ### Recording is the recommended next step
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,11 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[CFn-Declared Drift]`**: a property you declared changed out of band, so it's
   confirmed against your template right away (deletes of declared resources are
   confirmed the same way).
-- **`[Potential Drift]`**: settings that live only on the real resource, never in
-  your template. With no baseline, cdkrd has no record of what you intended, so it
-  can't yet tell a setting you chose on purpose from an out-of-band change. It
-  hides the obvious noise (values sitting at an AWS default, auto-generated names)
-  and lists the rest, including a meaningful value nested inside something you
-  _did_ declare. Those are probably real differences, which is why recording them
-  is the usual next move.
+- **`[Potential Drift]`**: settings that live only on the real resource, not in
+  your template. cdkrd shows them but can't call them confirmed drift yet: with no
+  baseline, it has no record of what you intended. It hides the obvious noise (AWS
+  defaults, auto-generated names) and shows the meaningful rest, including a value
+  nested inside something you _did_ declare.
 
 ### Recording is the recommended next step
 


### PR DESCRIPTION
## What

Tightens the Quick start "first run" section, which had grown long and flat.

- Collapses the 9-line first-run paragraph **and** the duplicate "So a typical first run reports..." sentence into a single 4-line paragraph that doubles as the lead-in to the example block.
- Drops detail already covered later in "How it works" (folding AWS defaults / generated names).
- Trims the **Revert** bullet's parenthetical (the remove-vs-restore nuance is explained later in the verb table).

Keeps the positive framing: "the first run already surfaces the likely drift" + potential drift as "most likely real divergence too, just not confirmable until you record a baseline".

## Why

For a Quick start, the section should read fast: install → run → see output → act. The detailed first-run explanation was redundant with the example block right below it and with the dedicated drift-kinds section.

Docs-only; no src change. check + docs markgate markers set.
