### PR TITLE
fix(sg): fold SecurityGroup sibling-rule reflection FP + preserve siblings on revert

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -136,6 +136,50 @@ interface ClassifyOpts {
   region: string;
   kmsAliasTargets: Record<string, string>;
   oaiCanonicalIds: Record<string, string>;
+  siblingSgRules: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+}
+
+// Rules declared by standalone AWS::EC2::SecurityGroupIngress / ::SecurityGroupEgress
+// resources, keyed by the target SG's resolved GroupId (== the SG's physical id). CDK emits
+// such a resource whenever a rule references a token it cannot inline (self/peer SG ref,
+// prefix list, imported SG). The live SecurityGroup REFLECTS these rules in its own ingress/
+// egress arrays, so classify subtracts them to avoid double-counting (see SG_RULE_REFLECTION
+// in diff/classify.ts). Fail-open: a rule whose GroupId did not resolve to a concrete sg-id
+// is skipped (the SG keeps the reflected rule -> a one-time visible FP, never a hidden change).
+const SG_RULE_RESOURCE_SIDE: Record<string, 'ingress' | 'egress'> = {
+  'AWS::EC2::SecurityGroupIngress': 'ingress',
+  'AWS::EC2::SecurityGroupEgress': 'egress',
+};
+export function buildSiblingSgRules(
+  desired: Desired
+): Record<string, { ingress: unknown[]; egress: unknown[] }> {
+  const map: Record<string, { ingress: unknown[]; egress: unknown[] }> = {};
+  for (const r of desired.resources) {
+    const side = SG_RULE_RESOURCE_SIDE[r.resourceType];
+    if (!side) continue;
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const groupId = (decl as Record<string, unknown>).GroupId;
+    if (typeof groupId !== 'string' || !groupId) continue; // unresolved intrinsic -> skip
+    const rule = { ...(decl as Record<string, unknown>) };
+    delete rule.GroupId;
+    // A same-account SG-to-SG reference reads back a SourceSecurityGroupOwnerId AWS injects
+    // (the account that owns the referenced SG) that the template never declares. Fill it in
+    // with the stack's own account so (a) the classify subset-match still matches the live
+    // reflected rule and (b) a revert's whole-array CC replacement re-sends the rule in its
+    // EXACT live form — otherwise CC treats the owner-less rule as different and replaces it,
+    // orphaning the sibling resource (observed live). A cross-account peer DECLARES the owner
+    // id (CDK requires it), so it is already present and not overwritten.
+    if (
+      typeof rule.SourceSecurityGroupId === 'string' &&
+      rule.SourceSecurityGroupOwnerId === undefined &&
+      desired.accountId
+    ) {
+      rule.SourceSecurityGroupOwnerId = desired.accountId;
+    }
+    (map[groupId] ??= { ingress: [], egress: [] })[side].push(rule);
+  }
+  return map;
 }
 
 // CloudFront legacy OAI id -> S3CanonicalUserId, harvested from the stack's own
@@ -340,7 +384,13 @@ export async function gatherFindings(
       console.error(kmsListAliasesDeniedWarning(region));
     }
   }
-  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets, oaiCanonicalIds };
+  const classifyOpts = {
+    accountId: desired.accountId,
+    region,
+    kmsAliasTargets,
+    oaiCanonicalIds,
+    siblingSgRules: buildSiblingSgRules(desired),
+  };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
   // CDKRD_CORPUS_DIR records every readable resource as a golden-corpus case
@@ -417,7 +467,13 @@ export async function regatherTouched(
   // Built from desired.ctx.liveAttrs (populated by the original gather), so the OAI
   // map is complete even though regather only re-reads the touched resources.
   const oaiCanonicalIds = buildOaiCanonicalIds(desired);
-  const classifyOpts = { accountId: desired.accountId, region, kmsAliasTargets, oaiCanonicalIds };
+  const classifyOpts = {
+    accountId: desired.accountId,
+    region,
+    kmsAliasTargets,
+    oaiCanonicalIds,
+    siblingSgRules: buildSiblingSgRules(desired),
+  };
 
   const fresh: Finding[] = [];
   for (const r of targets) {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -38,7 +38,7 @@ import {
 import { resolveSdkWriter } from '../revert/writers.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
-import { type GatherResult, regatherTouched } from './gather.js';
+import { buildSiblingSgRules, type GatherResult, regatherTouched } from './gather.js';
 
 // unrecorded values (R62) are awaiting a decision, not drift — they never count
 // toward "drift(s) remain" messaging or the convergence check.
@@ -719,6 +719,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   let plan = buildRevertPlan(drifted, baseline, {
     removeUnrecorded: includeRemovals,
     schemas: gathered.schemas,
+    siblingSgRules: buildSiblingSgRules(gathered.desired),
   });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {

--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -72,6 +72,10 @@ export interface CorpusCase {
     region: string;
     kmsAliasTargets: Record<string, string>;
     oaiCanonicalIds: Record<string, string>;
+    // Sibling SecurityGroupIngress/Egress rules reflected into an SG's live arrays, keyed by
+    // the SG's physical id. Only present (and only its own entry) on an AWS::EC2::SecurityGroup
+    // case, so replay reproduces the sibling-rule subtraction; optional for back-compat.
+    siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -102,9 +106,16 @@ export function buildCorpusCase(
     region: string;
     kmsAliasTargets: Record<string, string>;
     oaiCanonicalIds: Record<string, string>;
+    siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
   },
   findings: Finding[]
 ): CorpusCase {
+  // Carry only THIS SG's sibling-rule entry (keyed by its own physical id) into the case, so
+  // replay reproduces the subtraction without bloating every case with the stack-wide map.
+  const sgSibling =
+    resource.resourceType === 'AWS::EC2::SecurityGroup' && resource.physicalId
+      ? opts.siblingSgRules?.[resource.physicalId]
+      : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
     resource: {
@@ -130,7 +141,15 @@ export function buildCorpusCase(
       unorderedScalarPaths: [...(schema.unorderedScalarPaths ?? [])].sort(),
       freeFormMapPaths: [...(schema.freeFormMapPaths ?? [])].sort(),
     },
-    opts,
+    opts: {
+      accountId: opts.accountId,
+      region: opts.region,
+      kmsAliasTargets: opts.kmsAliasTargets,
+      oaiCanonicalIds: opts.oaiCanonicalIds,
+      ...(sgSibling && resource.physicalId
+        ? { siblingSgRules: { [resource.physicalId]: sgSibling } }
+        : {}),
+    },
     expected: findings,
   };
   return sanitizeAccountId(c, opts.accountId);

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -205,6 +205,49 @@ const REFLECTED_CHILD_PROPS: Record<string, string> = {
   'AWS::SNS::Topic': 'Subscription',
 };
 
+// AWS::EC2::SecurityGroup reflects, in its live SecurityGroupIngress / SecurityGroupEgress
+// arrays, the rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress /
+// ::SecurityGroupEgress resources that target it. CDK emits such a standalone rule resource
+// whenever a rule references a token it cannot safely inline — a self/peer SG reference, a
+// prefix list, an imported SG (`addIngressRule(otherSg, …)`, `Peer.prefixList(…)`, self-ref).
+// Those sibling rules are tracked + compared as their OWN resources, so leaving them in the
+// SG's live arrays double-counts them: the SG's DECLARED arrays hold only the INLINE rules, so
+// every sibling-reflected live rule reads as a false declared drift (a very common shape — a
+// self-referencing SG rule is the canonical ALB↔ASG / intra-cluster pattern). The fix mirrors
+// REFLECTED_CHILD_PROPS, but a SUBSET not the whole property: subtract each sibling-declared
+// rule from the live array, leaving the inline-declared rules (and any out-of-band rule, which
+// matches no sibling) to compare normally.
+const SG_RULE_REFLECTION: Record<string, 'ingress' | 'egress'> = {
+  SecurityGroupIngress: 'ingress',
+  SecurityGroupEgress: 'egress',
+};
+
+// Remove from `arr` the first element each sibling rule is a SUBSET of (every sibling key
+// deep-equals the live element's — the live element carries AWS-injected extras the sibling
+// resource never declared, e.g. SourceSecurityGroupOwnerId on a self/peer-ref rule, so an
+// exact equality compare would miss the match). One removal per sibling rule preserves a
+// duplicate inline rule that legitimately repeats the shape.
+function subtractSiblingSgRules(
+  live: Record<string, unknown>,
+  prop: string,
+  siblingRules: unknown[]
+): void {
+  const arr = live[prop];
+  if (!Array.isArray(arr) || siblingRules.length === 0) return;
+  for (const rule of siblingRules) {
+    if (!rule || typeof rule !== 'object') continue;
+    const sub = rule as Record<string, unknown>;
+    const i = arr.findIndex(
+      (el) =>
+        el !== null &&
+        typeof el === 'object' &&
+        Object.entries(sub).every(([k, v]) => deepEqual((el as Record<string, unknown>)[k], v))
+    );
+    if (i >= 0) arr.splice(i, 1);
+  }
+  if (arr.length === 0) delete live[prop]; // empty array == absent; don't introduce a []-vs-absent FP
+}
+
 // Cloud Control returns an ALTERNATIVE representation of a declared value as a separate
 // live-only field. Keyed resourceType -> { liveOnlyField: declaredSiblingField }: drop the
 // live-only field when its declared sibling is present (the template already pins the value
@@ -479,6 +522,10 @@ export function classifyResource(
     region?: string;
     kmsAliasTargets?: Record<string, string>; // alias/aws/* -> target key id, for strict KMS match
     oaiCanonicalIds?: Record<string, string>; // OAI id -> S3CanonicalUserId, for CloudFront OAI principal match
+    // Rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress/::SecurityGroupEgress
+    // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
+    // from an AWS::EC2::SecurityGroup's reflected live rule arrays so they are not double-counted.
+    siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -518,6 +565,19 @@ export function classifyResource(
   // (see REFLECTED_CHILD_PROPS). Fail-open: a declared inline value is still compared.
   const reflected = REFLECTED_CHILD_PROPS[resourceType];
   if (reflected && !(reflected in declared)) delete live[reflected];
+  // Subtract rules declared by sibling standalone SecurityGroupIngress/Egress resources from
+  // an AWS::EC2::SecurityGroup's reflected live rule arrays (see SG_RULE_REFLECTION). Keyed by
+  // the SG's resolved GroupId (== its physical id). The sibling rules are themselves compared
+  // as their own resources, so this leaves only the inline-declared rules (plus any out-of-band
+  // rule, which matches no sibling) to compare.
+  if (resourceType === 'AWS::EC2::SecurityGroup') {
+    const sib = physicalId ? opts.siblingSgRules?.[physicalId] : undefined;
+    if (sib) {
+      for (const [prop, side] of Object.entries(SG_RULE_REFLECTION)) {
+        subtractSiblingSgRules(live, prop, sib[side]);
+      }
+    }
+  }
   // ManagedPolicy attachment lists (Roles/Users/Groups). A DECLARED list is handled
   // per-member in the declared loop below (declared-but-missing = detach; live-only =
   // undeclared inventory). A list the template does NOT declare at all is left in `live`

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -857,6 +857,15 @@ export const GENERATED_PATHS: Record<string, string[]> = {
 // a fresh apigwv2-http-rich deploy.
 export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::ApiGatewayV2::Stage': new Set(['DeploymentId']),
+  // A standalone SG rule that references another security group (self-ref or peer) reads back
+  // a SourceSecurityGroupOwnerId AWS injects — the account that owns the referenced SG. The
+  // template never declares it (CDK derives it from SourceSecurityGroupId), so on a fresh
+  // self-referencing SG rule — the canonical ALB↔ASG / intra-cluster pattern — it floods the
+  // first run as undeclared. It is tied to SourceSecurityGroupId (which IS compared), not an
+  // independently-editable property, so folding it `generated` (inventory: never drift) is
+  // safe; a meaningful change is a change to SourceSecurityGroupId itself. Observed live on
+  // the securitygroup-protocols-rich fixture's self-ref rule.
+  'AWS::EC2::SecurityGroupIngress': new Set(['SourceSecurityGroupOwnerId']),
   // A published version's CodeSha256 is the base64 hash of the deployed code package —
   // a per-deploy, opaque, service-minted value (NOT a constant default, so KNOWN_DEFAULTS
   // cannot fold it). It is live-only ONLY when the template does not pin it; a version

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -184,6 +184,13 @@ function toPointer(dotted: string): string {
 
 const DRIFT_TIERS = new Set(['declared', 'undeclared']);
 
+// SecurityGroup rule property -> the buildSiblingSgRules side key, for the sibling-rule
+// merge below (see RevertOptions.siblingSgRules).
+const SG_REVERT_SIDE: Record<string, 'ingress' | 'egress'> = {
+  SecurityGroupIngress: 'ingress',
+  SecurityGroupEgress: 'egress',
+};
+
 export interface RevertOptions {
   // UNRECORDED undeclared values are removed only if this is set. Without it they
   // are reported as notRevertable (a bulk REMOVE of every undecided value that
@@ -192,6 +199,13 @@ export interface RevertOptions {
   // resourceType -> schema, so create-only property drift is reported as
   // notRevertable up front (an in-place patch would fail at apply time).
   schemas?: Map<string, SchemaInfo>;
+  // Rules declared by sibling standalone SecurityGroupIngress/Egress resources, keyed by the
+  // SG's physical id. Reverting an AWS::EC2::SecurityGroup's SecurityGroupIngress/Egress is a
+  // whole-array Cloud Control replacement; the live SG REFLECTS these sibling-declared rules,
+  // so a revert built from only the inline declared rules would DELETE them (silent data loss
+  // — a self-ref / peer / prefix-list rule wiped). Merge them back into the revert value so
+  // CC preserves them. Same shape classify uses to subtract them (buildSiblingSgRules).
+  siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
 }
 
 // True when a finding path is AT or UNDER any create-only schema path. The schema's
@@ -478,7 +492,19 @@ export function buildRevertPlan(
     const kind: RevertItem['kind'] =
       SDK_WRITERS[f.resourceType] || propScoped || nestedScoped ? 'sdk' : 'cc';
 
-    const op = revertOp(f, recorded);
+    // Reverting an SG's reflected SecurityGroupIngress/Egress is a whole-array CC replacement;
+    // merge back the rules declared by sibling standalone SG-rule resources (which the live SG
+    // reflects but the inline declared value omits) so the replacement does not DELETE them.
+    let toRevert = f;
+    const sgSide =
+      f.tier === 'declared' && f.resourceType === 'AWS::EC2::SecurityGroup'
+        ? SG_REVERT_SIDE[f.path]
+        : undefined;
+    if (sgSide && Array.isArray(f.desired) && f.physicalId) {
+      const sib = opts.siblingSgRules?.[f.physicalId]?.[sgSide] ?? [];
+      if (sib.length > 0) toRevert = { ...f, desired: [...(f.desired as unknown[]), ...sib] };
+    }
+    const op = revertOp(toRevert, recorded);
     const key = `${f.logicalId} ${kind}${propScoped ? ` ${f.path}` : ''}`;
     const item =
       itemsByLogical.get(key) ??

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5224,3 +5224,108 @@ describe('Cloud Control field mis-echo / alternative-representation folds (VPC n
     expect(f?.tier).toBe('undeclared');
   });
 });
+
+// SecurityGroup reflects, in its live SecurityGroupIngress/Egress, the rules declared by
+// SIBLING standalone AWS::EC2::SecurityGroupIngress/::SecurityGroupEgress resources (self-ref,
+// peer, prefix-list — anything CDK cannot inline). Comparing the SG's INLINE declared rules to
+// the full reflected live set false-drifts on every sibling rule. classify subtracts the
+// sibling rules (passed in opts.siblingSgRules) before comparing.
+describe('SecurityGroup sibling-rule reflection (subtraction)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const sg: DesiredResource = {
+    logicalId: 'Sg',
+    resourceType: 'AWS::EC2::SecurityGroup',
+    physicalId: 'sg-1',
+    declared: {
+      SecurityGroupIngress: [
+        { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+      ],
+    },
+  };
+  // live = the one inline rule PLUS two sibling-declared rules AWS merged in (the prefix-list
+  // rule reads back verbatim; the self-ref rule reads back with an injected OwnerId).
+  const live = {
+    SecurityGroupIngress: [
+      { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+      { SourcePrefixListId: 'pl-1', IpProtocol: 'tcp', FromPort: 3306, ToPort: 3306 },
+      {
+        SourceSecurityGroupId: 'sg-1',
+        SourceSecurityGroupOwnerId: '111111111111',
+        IpProtocol: 'tcp',
+        FromPort: 9000,
+        ToPort: 9000,
+      },
+    ],
+  };
+  const siblingSgRules = {
+    'sg-1': {
+      ingress: [
+        { SourcePrefixListId: 'pl-1', IpProtocol: 'tcp', FromPort: 3306, ToPort: 3306 },
+        {
+          SourceSecurityGroupId: 'sg-1',
+          SourceSecurityGroupOwnerId: '111111111111',
+          IpProtocol: 'tcp',
+          FromPort: 9000,
+          ToPort: 9000,
+        },
+      ],
+      egress: [] as unknown[],
+    },
+  };
+
+  it('does NOT false-drift when live reflects sibling-declared rules', () => {
+    const t = tiers(classifyResource(sg, structuredClone(live), bare, { siblingSgRules }));
+    expect(t.declared).toEqual([]);
+  });
+
+  it('without sibling context the reflected rules DO drift (the guard is load-bearing)', () => {
+    const t = tiers(classifyResource(sg, structuredClone(live), bare));
+    expect(t.declared).toEqual(['SecurityGroupIngress']);
+  });
+
+  it('an out-of-band rule matching NO sibling still surfaces as drift', () => {
+    const rogue = {
+      SecurityGroupIngress: [
+        ...live.SecurityGroupIngress,
+        { CidrIp: '0.0.0.0/0', IpProtocol: 'tcp', FromPort: 22, ToPort: 22 },
+      ],
+    };
+    const t = tiers(classifyResource(sg, rogue, bare, { siblingSgRules }));
+    expect(t.declared).toEqual(['SecurityGroupIngress']);
+  });
+
+  it('SecurityGroupIngress SourceSecurityGroupOwnerId folds to generated, not undeclared', () => {
+    const ingress: DesiredResource = {
+      logicalId: 'SgIn',
+      resourceType: 'AWS::EC2::SecurityGroupIngress',
+      physicalId: 'sgr-1',
+      declared: {
+        GroupId: 'sg-1',
+        SourceSecurityGroupId: 'sg-1',
+        IpProtocol: 'tcp',
+        FromPort: 9000,
+        ToPort: 9000,
+      },
+    };
+    const liveIn = {
+      GroupId: 'sg-1',
+      SourceSecurityGroupId: 'sg-1',
+      IpProtocol: 'tcp',
+      FromPort: 9000,
+      ToPort: 9000,
+      SourceSecurityGroupOwnerId: '111111111111',
+    };
+    const t = tiers(classifyResource(ingress, liveIn, bare));
+    expect(t.generated).toContain('SourceSecurityGroupOwnerId');
+    expect(t.undeclared).not.toContain('SourceSecurityGroupOwnerId');
+  });
+});

--- a/tests/corpus/AWS__BedrockAgentCore__BrowserCustom.Browser.json
+++ b/tests/corpus/AWS__BedrockAgentCore__BrowserCustom.Browser.json
@@ -1,0 +1,87 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Browser",
+    "resourceType": "AWS::BedrockAgentCore::BrowserCustom",
+    "physicalId": "cdkrd_agentcore_browser-x58FIIdykt",
+    "constructPath": "CdkRealDriftIntegAgentCore/Browser",
+    "declared": {
+      "Description": "cdkrd agentcore-rich fixture browser",
+      "Name": "cdkrd_agentcore_browser",
+      "NetworkConfiguration": {
+        "NetworkMode": "PUBLIC"
+      }
+    }
+  },
+  "liveRaw": {
+    "BrowserId": "cdkrd_agentcore_browser-x58FIIdykt",
+    "Status": "READY",
+    "Description": "cdkrd agentcore-rich fixture browser",
+    "LastUpdatedAt": "2026-06-29T11:27:53.566197944Z",
+    "BrowserArn": "arn:aws:bedrock-agentcore:us-east-1:111111111111:browser-custom/cdkrd_agentcore_browser-x58FIIdykt",
+    "FailureReason": "",
+    "CreatedAt": "2026-06-29T11:27:53.566197944Z",
+    "NetworkConfiguration": {
+      "NetworkMode": "PUBLIC"
+    },
+    "Tags": {},
+    "Name": "cdkrd_agentcore_browser"
+  },
+  "schema": {
+    "readOnly": [
+      "BrowserArn",
+      "BrowserId",
+      "CreatedAt",
+      "FailureReason",
+      "LastUpdatedAt",
+      "Status"
+    ],
+    "writeOnly": [],
+    "createOnly": [
+      "BrowserSigning",
+      "Certificates",
+      "Description",
+      "EnterprisePolicies",
+      "ExecutionRoleArn",
+      "Name",
+      "NetworkConfiguration",
+      "RecordingConfig"
+    ],
+    "readOnlyPaths": [
+      "BrowserArn",
+      "BrowserId",
+      "CreatedAt",
+      "FailureReason",
+      "LastUpdatedAt",
+      "Status"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "BrowserSigning",
+      "Certificates",
+      "Description",
+      "EnterprisePolicies",
+      "ExecutionRoleArn",
+      "Name",
+      "NetworkConfiguration",
+      "RecordingConfig"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "RecordingConfig.Enabled": false,
+      "BrowserSigning.Enabled": false
+    },
+    "unorderedScalarPaths": [
+      "NetworkConfiguration.VpcConfig.SecurityGroups",
+      "NetworkConfiguration.VpcConfig.Subnets"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__BedrockAgentCore__CodeInterpreterCustom.CodeInterpreter.json
+++ b/tests/corpus/AWS__BedrockAgentCore__CodeInterpreterCustom.CodeInterpreter.json
@@ -1,0 +1,78 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CodeInterpreter",
+    "resourceType": "AWS::BedrockAgentCore::CodeInterpreterCustom",
+    "physicalId": "cdkrd_agentcore_codeint-etgiGGrBLc",
+    "constructPath": "CdkRealDriftIntegAgentCore/CodeInterpreter",
+    "declared": {
+      "Description": "cdkrd agentcore-rich fixture code interpreter",
+      "Name": "cdkrd_agentcore_codeint",
+      "NetworkConfiguration": {
+        "NetworkMode": "PUBLIC"
+      }
+    }
+  },
+  "liveRaw": {
+    "Status": "READY",
+    "Description": "cdkrd agentcore-rich fixture code interpreter",
+    "LastUpdatedAt": "2026-06-29T11:27:53.496011315Z",
+    "FailureReason": "",
+    "CreatedAt": "2026-06-29T11:27:53.496011315Z",
+    "NetworkConfiguration": {
+      "NetworkMode": "PUBLIC"
+    },
+    "CodeInterpreterArn": "arn:aws:bedrock-agentcore:us-east-1:111111111111:code-interpreter-custom/cdkrd_agentcore_codeint-etgiGGrBLc",
+    "CodeInterpreterId": "cdkrd_agentcore_codeint-etgiGGrBLc",
+    "Tags": {},
+    "Name": "cdkrd_agentcore_codeint"
+  },
+  "schema": {
+    "readOnly": [
+      "CodeInterpreterArn",
+      "CodeInterpreterId",
+      "CreatedAt",
+      "FailureReason",
+      "LastUpdatedAt",
+      "Status"
+    ],
+    "writeOnly": [],
+    "createOnly": [
+      "Certificates",
+      "Description",
+      "ExecutionRoleArn",
+      "Name",
+      "NetworkConfiguration"
+    ],
+    "readOnlyPaths": [
+      "CodeInterpreterArn",
+      "CodeInterpreterId",
+      "CreatedAt",
+      "FailureReason",
+      "LastUpdatedAt",
+      "Status"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "Certificates",
+      "Description",
+      "ExecutionRoleArn",
+      "Name",
+      "NetworkConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "NetworkConfiguration.VpcConfig.SecurityGroups",
+      "NetworkConfiguration.VpcConfig.Subnets"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__BedrockAgentCore__Memory.Memory.json
+++ b/tests/corpus/AWS__BedrockAgentCore__Memory.Memory.json
@@ -1,0 +1,77 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Memory",
+    "resourceType": "AWS::BedrockAgentCore::Memory",
+    "physicalId": "arn:aws:bedrock-agentcore:us-east-1:111111111111:memory/cdkrd_agentcore_memory-pasoHjAjfH",
+    "constructPath": "CdkRealDriftIntegAgentCore/Memory",
+    "declared": {
+      "Description": "cdkrd agentcore-rich fixture memory",
+      "EventExpiryDuration": 30,
+      "Name": "cdkrd_agentcore_memory"
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "Description": "cdkrd agentcore-rich fixture memory",
+    "MemoryArn": "arn:aws:bedrock-agentcore:us-east-1:111111111111:memory/cdkrd_agentcore_memory-pasoHjAjfH",
+    "FailureReason": "",
+    "CreatedAt": "2026-06-29T11:27:53.934Z",
+    "EventExpiryDuration": 30,
+    "MemoryId": "cdkrd_agentcore_memory-pasoHjAjfH",
+    "UpdatedAt": "2026-06-29T11:27:59.575Z",
+    "Tags": {},
+    "Name": "cdkrd_agentcore_memory"
+  },
+  "schema": {
+    "readOnly": ["CreatedAt", "FailureReason", "MemoryArn", "MemoryId", "Status", "UpdatedAt"],
+    "writeOnly": [],
+    "createOnly": ["EncryptionKeyArn", "Name"],
+    "readOnlyPaths": [
+      "CreatedAt",
+      "FailureReason",
+      "MemoryArn",
+      "MemoryId",
+      "MemoryStrategies.*.CustomMemoryStrategy.CreatedAt",
+      "MemoryStrategies.*.CustomMemoryStrategy.Status",
+      "MemoryStrategies.*.CustomMemoryStrategy.StrategyId",
+      "MemoryStrategies.*.CustomMemoryStrategy.Type",
+      "MemoryStrategies.*.CustomMemoryStrategy.UpdatedAt",
+      "MemoryStrategies.*.EpisodicMemoryStrategy.CreatedAt",
+      "MemoryStrategies.*.EpisodicMemoryStrategy.Status",
+      "MemoryStrategies.*.EpisodicMemoryStrategy.StrategyId",
+      "MemoryStrategies.*.EpisodicMemoryStrategy.Type",
+      "MemoryStrategies.*.EpisodicMemoryStrategy.UpdatedAt",
+      "MemoryStrategies.*.SemanticMemoryStrategy.CreatedAt",
+      "MemoryStrategies.*.SemanticMemoryStrategy.Status",
+      "MemoryStrategies.*.SemanticMemoryStrategy.StrategyId",
+      "MemoryStrategies.*.SemanticMemoryStrategy.Type",
+      "MemoryStrategies.*.SemanticMemoryStrategy.UpdatedAt",
+      "MemoryStrategies.*.SummaryMemoryStrategy.CreatedAt",
+      "MemoryStrategies.*.SummaryMemoryStrategy.Status",
+      "MemoryStrategies.*.SummaryMemoryStrategy.StrategyId",
+      "MemoryStrategies.*.SummaryMemoryStrategy.Type",
+      "MemoryStrategies.*.SummaryMemoryStrategy.UpdatedAt",
+      "MemoryStrategies.*.UserPreferenceMemoryStrategy.CreatedAt",
+      "MemoryStrategies.*.UserPreferenceMemoryStrategy.Status",
+      "MemoryStrategies.*.UserPreferenceMemoryStrategy.StrategyId",
+      "MemoryStrategies.*.UserPreferenceMemoryStrategy.Type",
+      "MemoryStrategies.*.UserPreferenceMemoryStrategy.UpdatedAt",
+      "Status",
+      "UpdatedAt"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["EncryptionKeyArn", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__BedrockAgentCore__WorkloadIdentity.WorkloadIdentity.json
+++ b/tests/corpus/AWS__BedrockAgentCore__WorkloadIdentity.WorkloadIdentity.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WorkloadIdentity",
+    "resourceType": "AWS::BedrockAgentCore::WorkloadIdentity",
+    "physicalId": "cdkrd_agentcore_workload",
+    "constructPath": "CdkRealDriftIntegAgentCore/WorkloadIdentity",
+    "declared": {
+      "Name": "cdkrd_agentcore_workload"
+    }
+  },
+  "liveRaw": {
+    "CreatedTime": 1782732473567,
+    "WorkloadIdentityArn": "arn:aws:bedrock-agentcore:us-east-1:111111111111:workload-identity-directory/default/workload-identity/cdkrd_agentcore_workload",
+    "LastUpdatedTime": 1782732473567,
+    "AllowedResourceOauth2ReturnUrls": [],
+    "Tags": [],
+    "Name": "cdkrd_agentcore_workload"
+  },
+  "schema": {
+    "readOnly": ["CreatedTime", "LastUpdatedTime", "WorkloadIdentityArn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["CreatedTime", "LastUpdatedTime", "WorkloadIdentityArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["AllowedResourceOauth2ReturnUrls"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__SecurityGroup.SgD4954771.protocols.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.SgD4954771.protocols.json
@@ -1,0 +1,230 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SgD4954771",
+    "resourceType": "AWS::EC2::SecurityGroup",
+    "physicalId": "sg-0ba527d158588a09f",
+    "constructPath": "CdkRealDriftIntegSgProto/Sg",
+    "declared": {
+      "GroupDescription": "CdkRealDriftIntegSgProto/Sg",
+      "SecurityGroupEgress": [
+        {
+          "CidrIpv6": "::/0",
+          "Description": "https out ipv6",
+          "FromPort": 443,
+          "IpProtocol": "tcp",
+          "ToPort": 443
+        },
+        {
+          "CidrIp": "0.0.0.0/0",
+          "Description": "https out",
+          "FromPort": 443,
+          "IpProtocol": "tcp",
+          "ToPort": 443
+        }
+      ],
+      "SecurityGroupIngress": [
+        {
+          "CidrIp": "10.0.0.0/24",
+          "Description": "https",
+          "FromPort": 443,
+          "IpProtocol": "tcp",
+          "ToPort": 443
+        },
+        {
+          "CidrIp": "10.0.1.0/24",
+          "Description": "app range",
+          "FromPort": 8000,
+          "IpProtocol": "tcp",
+          "ToPort": 8100
+        },
+        {
+          "CidrIp": "10.0.2.0/24",
+          "Description": "udp range",
+          "FromPort": 5000,
+          "IpProtocol": "udp",
+          "ToPort": 5010
+        },
+        {
+          "CidrIp": "10.0.3.0/24",
+          "Description": "icmp ping",
+          "FromPort": 8,
+          "IpProtocol": "icmp",
+          "ToPort": -1
+        },
+        {
+          "CidrIp": "10.0.4.0/24",
+          "Description": "icmp all",
+          "FromPort": -1,
+          "IpProtocol": "icmp",
+          "ToPort": -1
+        },
+        {
+          "CidrIpv6": "2001:db8::/32",
+          "Description": "ssh ipv6",
+          "FromPort": 22,
+          "IpProtocol": "tcp",
+          "ToPort": 22
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "team",
+          "Value": "platform"
+        }
+      ],
+      "VpcId": "vpc-079229bdc16536c07"
+    }
+  },
+  "liveRaw": {
+    "GroupDescription": "CdkRealDriftIntegSgProto/Sg",
+    "GroupName": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+    "VpcId": "vpc-079229bdc16536c07",
+    "Id": "sg-0ba527d158588a09f",
+    "SecurityGroupIngress": [
+      {
+        "Description": "self ref",
+        "FromPort": 9000,
+        "ToPort": 9000,
+        "SourceSecurityGroupOwnerId": "111111111111",
+        "IpProtocol": "tcp",
+        "SourceSecurityGroupId": "sg-0ba527d158588a09f"
+      },
+      {
+        "CidrIpv6": "2001:db8::/32",
+        "Description": "ssh ipv6",
+        "FromPort": 22,
+        "ToPort": 22,
+        "IpProtocol": "tcp"
+      },
+      {
+        "CidrIp": "10.0.1.0/24",
+        "Description": "app range",
+        "FromPort": 8000,
+        "ToPort": 8100,
+        "IpProtocol": "tcp"
+      },
+      {
+        "Description": "mysql from prefix list",
+        "FromPort": 3306,
+        "ToPort": 3306,
+        "IpProtocol": "tcp",
+        "SourcePrefixListId": "pl-0767c9e96a31aed5a"
+      },
+      {
+        "CidrIp": "10.0.2.0/24",
+        "Description": "udp range",
+        "FromPort": 5000,
+        "ToPort": 5010,
+        "IpProtocol": "udp"
+      },
+      {
+        "CidrIp": "10.0.4.0/24",
+        "Description": "icmp all",
+        "FromPort": -1,
+        "ToPort": -1,
+        "IpProtocol": "icmp"
+      },
+      {
+        "CidrIp": "10.0.0.0/24",
+        "Description": "https",
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
+      },
+      {
+        "CidrIp": "10.0.3.0/24",
+        "Description": "icmp ping",
+        "FromPort": 8,
+        "ToPort": -1,
+        "IpProtocol": "icmp"
+      }
+    ],
+    "SecurityGroupEgress": [
+      {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "https out",
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
+      },
+      {
+        "CidrIpv6": "::/0",
+        "Description": "https out ipv6",
+        "FromPort": 443,
+        "ToPort": 443,
+        "IpProtocol": "tcp"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSgProto/317721e0-73b2-11f1-a85f-0e8ee8a3d53b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "SgD4954771",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSgProto",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "platform",
+        "Key": "team"
+      }
+    ],
+    "GroupId": "sg-0ba527d158588a09f"
+  },
+  "schema": {
+    "readOnly": ["GroupId", "Id"],
+    "writeOnly": [],
+    "createOnly": ["GroupDescription", "GroupName", "VpcId"],
+    "readOnlyPaths": ["GroupId", "Id"],
+    "writeOnlyPaths": ["SecurityGroupIngress.*.SourceSecurityGroupName"],
+    "createOnlyPaths": ["GroupDescription", "GroupName", "VpcId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "siblingSgRules": {
+      "sg-0ba527d158588a09f": {
+        "ingress": [
+          {
+            "Description": "mysql from prefix list",
+            "FromPort": 3306,
+            "IpProtocol": "tcp",
+            "SourcePrefixListId": "pl-0767c9e96a31aed5a",
+            "ToPort": 3306
+          },
+          {
+            "Description": "self ref",
+            "FromPort": 9000,
+            "IpProtocol": "tcp",
+            "SourceSecurityGroupId": "sg-0ba527d158588a09f",
+            "ToPort": 9000,
+            "SourceSecurityGroupOwnerId": "111111111111"
+          }
+        ],
+        "egress": []
+      }
+    }
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "SgD4954771",
+      "resourceType": "AWS::EC2::SecurityGroup",
+      "path": "GroupName",
+      "actual": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+      "physicalId": "sg-0ba527d158588a09f",
+      "constructPath": "CdkRealDriftIntegSgProto/Sg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SecurityGroupIngress.SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupIngress.SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB.json
@@ -1,0 +1,100 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB",
+    "resourceType": "AWS::EC2::SecurityGroupIngress",
+    "physicalId": "sgr-0ed4eddeb0c690cd4",
+    "constructPath": "CdkRealDriftIntegSgProto/Sg/from CdkRealDriftIntegSgProtoSg90F3118B:9000",
+    "declared": {
+      "Description": "self ref",
+      "FromPort": 9000,
+      "GroupId": "sg-0ba527d158588a09f",
+      "IpProtocol": "tcp",
+      "SourceSecurityGroupId": "sg-0ba527d158588a09f",
+      "ToPort": 9000
+    }
+  },
+  "liveRaw": {
+    "GroupName": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+    "Description": "self ref",
+    "FromPort": 9000,
+    "SourceSecurityGroupName": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+    "ToPort": 9000,
+    "SourceSecurityGroupOwnerId": "111111111111",
+    "IpProtocol": "tcp",
+    "Id": "sgr-0ed4eddeb0c690cd4",
+    "SourceSecurityGroupId": "sg-0ba527d158588a09f",
+    "GroupId": "sg-0ba527d158588a09f"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "CidrIp",
+      "CidrIpv6",
+      "FromPort",
+      "GroupId",
+      "GroupName",
+      "IpProtocol",
+      "SourcePrefixListId",
+      "SourceSecurityGroupId",
+      "SourceSecurityGroupName",
+      "SourceSecurityGroupOwnerId",
+      "ToPort"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "CidrIp",
+      "CidrIpv6",
+      "FromPort",
+      "GroupId",
+      "GroupName",
+      "IpProtocol",
+      "SourcePrefixListId",
+      "SourceSecurityGroupId",
+      "SourceSecurityGroupName",
+      "SourceSecurityGroupOwnerId",
+      "ToPort"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "GroupName",
+      "actual": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+      "physicalId": "sgr-0ed4eddeb0c690cd4",
+      "constructPath": "CdkRealDriftIntegSgProto/Sg/from CdkRealDriftIntegSgProtoSg90F3118B:9000"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "SourceSecurityGroupName",
+      "actual": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+      "physicalId": "sgr-0ed4eddeb0c690cd4",
+      "constructPath": "CdkRealDriftIntegSgProto/Sg/from CdkRealDriftIntegSgProtoSg90F3118B:9000"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "SourceSecurityGroupOwnerId",
+      "actual": "111111111111",
+      "physicalId": "sgr-0ed4eddeb0c690cd4",
+      "constructPath": "CdkRealDriftIntegSgProto/Sg/from CdkRealDriftIntegSgProtoSg90F3118B:9000"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SecurityGroupIngress.SgfromIndirectPeer3306317FA3C9.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupIngress.SgfromIndirectPeer3306317FA3C9.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SgfromIndirectPeer3306317FA3C9",
+    "resourceType": "AWS::EC2::SecurityGroupIngress",
+    "physicalId": "sgr-09d8cafad64d71a3d",
+    "constructPath": "CdkRealDriftIntegSgProto/Sg/from {IndirectPeer}:3306",
+    "declared": {
+      "Description": "mysql from prefix list",
+      "FromPort": 3306,
+      "GroupId": "sg-0ba527d158588a09f",
+      "IpProtocol": "tcp",
+      "SourcePrefixListId": "pl-0767c9e96a31aed5a",
+      "ToPort": 3306
+    }
+  },
+  "liveRaw": {
+    "GroupName": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+    "Description": "mysql from prefix list",
+    "FromPort": 3306,
+    "ToPort": 3306,
+    "IpProtocol": "tcp",
+    "Id": "sgr-09d8cafad64d71a3d",
+    "SourcePrefixListId": "pl-0767c9e96a31aed5a",
+    "GroupId": "sg-0ba527d158588a09f"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "CidrIp",
+      "CidrIpv6",
+      "FromPort",
+      "GroupId",
+      "GroupName",
+      "IpProtocol",
+      "SourcePrefixListId",
+      "SourceSecurityGroupId",
+      "SourceSecurityGroupName",
+      "SourceSecurityGroupOwnerId",
+      "ToPort"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "CidrIp",
+      "CidrIpv6",
+      "FromPort",
+      "GroupId",
+      "GroupName",
+      "IpProtocol",
+      "SourcePrefixListId",
+      "SourceSecurityGroupId",
+      "SourceSecurityGroupName",
+      "SourceSecurityGroupOwnerId",
+      "ToPort"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "SgfromIndirectPeer3306317FA3C9",
+      "resourceType": "AWS::EC2::SecurityGroupIngress",
+      "path": "GroupName",
+      "actual": "CdkRealDriftIntegSgProto-SgD4954771-OOLlldBndUMd",
+      "physicalId": "sgr-09d8cafad64d71a3d",
+      "constructPath": "CdkRealDriftIntegSgProto/Sg/from {IndirectPeer}:3306"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__SecurityGroupIngress.WebSgIngress.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupIngress.WebSgIngress.json
@@ -87,7 +87,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/Service/SecurityGroup/from CdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F40:80"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "WebServiceSecurityGroupfromCdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F408013CF9C8D",
       "resourceType": "AWS::EC2::SecurityGroupIngress",
       "path": "SourceSecurityGroupOwnerId",

--- a/tests/corpus/AWS__EC2__VPCEndpoint.SecretsEp58436907.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.SecretsEp58436907.json
@@ -1,0 +1,161 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SecretsEp58436907",
+    "resourceType": "AWS::EC2::VPCEndpoint",
+    "physicalId": "vpce-0cd38450554634ba9",
+    "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp",
+    "declared": {
+      "PrivateDnsEnabled": true,
+      "SecurityGroupIds": ["sg-035ce553fc212c297", "sg-081e609bf9677251b"],
+      "ServiceName": "com.amazonaws.us-east-1.secretsmanager",
+      "SubnetIds": ["subnet-042b794751fa16b59", "subnet-000df36a222416e52"],
+      "VpcEndpointType": "Interface",
+      "VpcId": "vpc-053a3c6cd0915bc9d"
+    }
+  },
+  "liveRaw": {
+    "PrivateDnsEnabled": true,
+    "IpAddressType": "ipv4",
+    "ServiceRegion": "us-east-1",
+    "CreationTimestamp": "Mon 6 29 11:28:29 UTC 2026",
+    "DnsOptions": {
+      "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
+      "PrivateDnsSpecifiedDomains": ["*"],
+      "DnsRecordIpType": "ipv4",
+      "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
+    },
+    "NetworkInterfaceIds": ["eni-0aea09510bcfc45e5", "eni-0d8b8f420b1fa4899"],
+    "DnsEntries": [
+      "Z7HUB22UULQXV:vpce-0cd38450554634ba9-huhcgxu7.secretsmanager.us-east-1.vpce.amazonaws.com",
+      "Z7HUB22UULQXV:vpce-0cd38450554634ba9-huhcgxu7-us-east-1a.secretsmanager.us-east-1.vpce.amazonaws.com",
+      "Z7HUB22UULQXV:vpce-0cd38450554634ba9-huhcgxu7-us-east-1b.secretsmanager.us-east-1.vpce.amazonaws.com",
+      "Z09789611UEJSFDVXZFY9:secretsmanager.us-east-1.amazonaws.com"
+    ],
+    "ResourceConfigurationArn": "",
+    "SecurityGroupIds": ["sg-035ce553fc212c297", "sg-081e609bf9677251b"],
+    "SubnetIds": ["subnet-000df36a222416e52", "subnet-042b794751fa16b59"],
+    "ServiceNetworkArn": "",
+    "VpcId": "vpc-053a3c6cd0915bc9d",
+    "RouteTableIds": [],
+    "ServiceName": "com.amazonaws.us-east-1.secretsmanager",
+    "PolicyDocument": {
+      "Statement": [
+        {
+          "Action": "*",
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": "*"
+        }
+      ]
+    },
+    "VpcEndpointType": "Interface",
+    "Id": "vpce-0cd38450554634ba9",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcEpRich/906942f0-73ad-11f1-96d2-126eaffbf82f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegVpcEpRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SecretsEp58436907",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["CreationTimestamp", "DnsEntries", "Id", "NetworkInterfaceIds"],
+    "writeOnly": [],
+    "createOnly": [
+      "ResourceConfigurationArn",
+      "ServiceName",
+      "ServiceNetworkArn",
+      "ServiceRegion",
+      "VpcEndpointType",
+      "VpcId"
+    ],
+    "readOnlyPaths": ["CreationTimestamp", "DnsEntries", "Id", "NetworkInterfaceIds"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DnsOptions.PrivateDnsPreference",
+      "DnsOptions.PrivateDnsSpecifiedDomains",
+      "ResourceConfigurationArn",
+      "ServiceName",
+      "ServiceNetworkArn",
+      "ServiceRegion",
+      "VpcEndpointType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "DnsEntries",
+      "NetworkInterfaceIds",
+      "RouteTableIds",
+      "SecurityGroupIds",
+      "SubnetIds"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SecretsEp58436907",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "vpce-0cd38450554634ba9",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SecretsEp58436907",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "ServiceRegion",
+      "actual": "us-east-1",
+      "physicalId": "vpce-0cd38450554634ba9",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SecretsEp58436907",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "DnsOptions",
+      "actual": {
+        "PrivateDnsOnlyForInboundResolverEndpoint": "NotSpecified",
+        "PrivateDnsSpecifiedDomains": ["*"],
+        "DnsRecordIpType": "ipv4",
+        "PrivateDnsPreference": "VERIFIED_DOMAINS_ONLY"
+      },
+      "physicalId": "vpce-0cd38450554634ba9",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "SecretsEp58436907",
+      "resourceType": "AWS::EC2::VPCEndpoint",
+      "path": "PolicyDocument",
+      "actual": {
+        "Statement": [
+          {
+            "Action": ["*"],
+            "Effect": "Allow",
+            "Principal": "*",
+            "Resource": ["*"]
+          }
+        ]
+      },
+      "physicalId": "vpce-0cd38450554634ba9",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Volume.Gp2Vol0A540FFC.json
+++ b/tests/corpus/AWS__EC2__Volume.Gp2Vol0A540FFC.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Gp2Vol0A540FFC",
+    "resourceType": "AWS::EC2::Volume",
+    "physicalId": "vol-035b5abfc83c3e495",
+    "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "Encrypted": true,
+      "MultiAttachEnabled": false,
+      "Size": 20,
+      "Tags": [
+        {
+          "Key": "role",
+          "Value": "gp2"
+        }
+      ],
+      "VolumeType": "gp2"
+    }
+  },
+  "liveRaw": {
+    "MultiAttachEnabled": false,
+    "VolumeId": "vol-035b5abfc83c3e495",
+    "VolumeType": "gp2",
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+    "Encrypted": true,
+    "Size": 20,
+    "AutoEnableIO": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "Iops": 100,
+    "Tags": [
+      {
+        "Value": "gp2",
+        "Key": "role"
+      },
+      {
+        "Value": "CdkRealDriftIntegVpcEpRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Gp2Vol0A540FFC",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcEpRich/906942f0-73ad-11f1-96d2-126eaffbf82f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VolumeId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["VolumeId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "Gp2Vol0A540FFC",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZone",
+      "physicalId": "vol-035b5abfc83c3e495",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Gp2Vol0A540FFC",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+      "physicalId": "vol-035b5abfc83c3e495",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Gp2Vol0A540FFC",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "vol-035b5abfc83c3e495",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Gp2Vol0A540FFC",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "Iops",
+      "actual": 100,
+      "physicalId": "vol-035b5abfc83c3e495",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__Volume.Io2VolB902C7A4.json
+++ b/tests/corpus/AWS__EC2__Volume.Io2VolB902C7A4.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Io2VolB902C7A4",
+    "resourceType": "AWS::EC2::Volume",
+    "physicalId": "vol-0f12afde5901a01f1",
+    "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol",
+    "declared": {
+      "AvailabilityZone": "__cdkrd_corpus_unresolved__",
+      "Encrypted": true,
+      "Iops": 1000,
+      "MultiAttachEnabled": false,
+      "Size": 10,
+      "Tags": [
+        {
+          "Key": "role",
+          "Value": "io2"
+        }
+      ],
+      "VolumeType": "io2"
+    }
+  },
+  "liveRaw": {
+    "MultiAttachEnabled": false,
+    "VolumeId": "vol-0f12afde5901a01f1",
+    "VolumeType": "io2",
+    "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+    "Encrypted": true,
+    "Size": 10,
+    "AutoEnableIO": false,
+    "AvailabilityZoneId": "use1-az1",
+    "AvailabilityZone": "us-east-1a",
+    "Iops": 1000,
+    "Tags": [
+      {
+        "Value": "io2",
+        "Key": "role"
+      },
+      {
+        "Value": "Io2VolB902C7A4",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegVpcEpRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcEpRich/906942f0-73ad-11f1-96d2-126eaffbf82f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VolumeId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["VolumeId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "Io2VolB902C7A4",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZone",
+      "physicalId": "vol-0f12afde5901a01f1",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Io2VolB902C7A4",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+      "physicalId": "vol-0f12afde5901a01f1",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Io2VolB902C7A4",
+      "resourceType": "AWS::EC2::Volume",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
+      "physicalId": "vol-0f12afde5901a01f1",
+      "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
@@ -1,0 +1,306 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ClusterEB0386A7",
+    "resourceType": "AWS::RDS::DBCluster",
+    "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+    "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster",
+    "declared": {
+      "BackupRetentionPeriod": 7,
+      "CopyTagsToSnapshot": true,
+      "DBClusterParameterGroupName": "default.aurora-mysql8.0",
+      "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-zupsaropnp1d",
+      "DeletionProtection": false,
+      "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"],
+      "EnableHttpEndpoint": true,
+      "Engine": "aurora-mysql",
+      "EngineVersion": "8.0.mysql_aurora.3.08.0",
+      "MasterUserPassword": "__cdkrd_corpus_unresolved__",
+      "MasterUsername": "__cdkrd_corpus_unresolved__",
+      "ServerlessV2ScalingConfiguration": {
+        "MaxCapacity": 2,
+        "MinCapacity": 0.5
+      },
+      "VpcSecurityGroupIds": ["sg-000cdddd33579002e"]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "AssociatedRoles": [],
+    "EnableHttpEndpoint": true,
+    "EngineMode": "provisioned",
+    "Port": 3306,
+    "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+    "PreferredBackupWindow": "03:33-04:03",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "3306"
+    },
+    "NetworkType": "IPV4",
+    "VpcSecurityGroupIds": ["sg-000cdddd33579002e"],
+    "CopyTagsToSnapshot": true,
+    "Engine": "aurora-mysql",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/7a227110-73ad-11f1-b4dd-0ebd39200b5f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "ClusterEB0386A7",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAuroraSv2",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "EngineVersion": "8.0.mysql_aurora.3.08.0",
+    "StorageType": "aurora",
+    "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1b"],
+    "ServerlessV2ScalingConfiguration": {
+      "MinCapacity": 0.5,
+      "MaxCapacity": 2
+    },
+    "StorageEncryptionType": "sse-rds",
+    "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+    "EnableLocalWriteForwarding": false,
+    "PreferredMaintenanceWindow": "mon:07:39-mon:08:09",
+    "DBClusterResourceId": "cluster-24T7NGPWKB2DUEHGOHHTMTH3L4",
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-zupsaropnp1d",
+    "DeletionProtection": false,
+    "AllocatedStorage": 1,
+    "ManageMasterUserPassword": false,
+    "MasterUserSecret": {},
+    "MasterUsername": "admin",
+    "ReadEndpoint": {
+      "Address": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+    },
+    "EnableIAMDatabaseAuthentication": false,
+    "DBClusterParameterGroupName": "default.aurora-mysql8.0",
+    "BackupRetentionPeriod": 7,
+    "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"]
+  },
+  "schema": {
+    "readOnly": [
+      "DBClusterArn",
+      "DBClusterResourceId",
+      "Endpoint",
+      "ReadEndpoint",
+      "StorageEncryptionType",
+      "StorageThroughput"
+    ],
+    "writeOnly": [
+      "ClusterScalabilityType",
+      "DBInstanceParameterGroupName",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "AvailabilityZones",
+      "ClusterScalabilityType",
+      "DBClusterIdentifier",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "DatabaseName",
+      "EngineMode",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "StorageEncrypted",
+      "UseLatestRestorableTime"
+    ],
+    "readOnlyPaths": [
+      "DBClusterArn",
+      "DBClusterResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "ReadEndpoint",
+      "ReadEndpoint.Address",
+      "StorageEncryptionType",
+      "StorageThroughput"
+    ],
+    "writeOnlyPaths": [
+      "ClusterScalabilityType",
+      "DBInstanceParameterGroupName",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "AvailabilityZones",
+      "ClusterScalabilityType",
+      "DBClusterIdentifier",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "DatabaseName",
+      "EngineMode",
+      "KmsKeyId",
+      "PubliclyAccessible",
+      "RestoreToTime",
+      "RestoreType",
+      "SnapshotIdentifier",
+      "SourceDBClusterIdentifier",
+      "SourceDbClusterResourceId",
+      "SourceRegion",
+      "StorageEncrypted",
+      "UseLatestRestorableTime"
+    ],
+    "defaults": {
+      "BackupRetentionPeriod": 1
+    },
+    "defaultPaths": {
+      "BackupRetentionPeriod": 1
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "MasterUsername",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineMode",
+      "actual": "provisioned",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "Port",
+      "actual": 3306,
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "PreferredBackupWindow",
+      "actual": "03:33-04:03",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "StorageType",
+      "actual": "aurora",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b", "us-east-1c"],
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "mon:07:39-mon:08:09",
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "ClusterEB0386A7",
+      "resourceType": "AWS::RDS::DBCluster",
+      "path": "AllocatedStorage",
+      "actual": 1,
+      "physicalId": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
@@ -1,0 +1,487 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Clusterwriter2D9E9F4C",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+    "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer",
+    "declared": {
+      "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "DBInstanceClass": "db.serverless",
+      "Engine": "aurora-mysql",
+      "PromotionTier": 0,
+      "PubliclyAccessible": false
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-06-29T11:31:49Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "3306",
+    "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-F637HVJJ2LL6FWZA4FTG7RIFYY",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.aurora-mysql8.0",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "3306",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "MultiAZ": false,
+    "Engine": "aurora-mysql",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/7a227110-73ad-11f1-b4dd-0ebd39200b5f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAuroraSv2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Clusterwriter2D9E9F4C",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "EngineVersion": "8.0.mysql_aurora.3.08.0",
+    "StorageType": "aurora",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.serverless",
+    "AvailabilityZone": "us-east-1a",
+    "OptionGroupName": "default:aurora-mysql-8-0",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-zupsaropnp1d",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+    "AllocatedStorage": "1",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "admin",
+    "PromotionTier": 0,
+    "PubliclyAccessible": false,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-06-29T11:34:05.883Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "03:33-04:03",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "general-public-license",
+    "PreferredMaintenanceWindow": "mon:03:18-mon:03:48",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-000cdddd33579002e"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 7,
+    "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"]
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "3306",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.aurora-mysql8.0",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineVersion",
+      "actual": "8.0.mysql_aurora.3.08.0",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageType",
+      "actual": "aurora",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:aurora-mysql-8-0",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBSubnetGroupName",
+      "actual": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-zupsaropnp1d",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AllocatedStorage",
+      "actual": "1",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUsername",
+      "actual": "admin",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "03:33-04:03",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "general-public-license",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "mon:03:18-mon:03:48",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "VPCSecurityGroups",
+      "actual": ["sg-000cdddd33579002e"],
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupRetentionPeriod",
+      "actual": 7,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Clusterwriter2D9E9F4C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableCloudwatchLogsExports",
+      "actual": ["audit", "error", "general", "slowquery"],
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
+    }
+  ]
+}

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -13,9 +13,14 @@ import {
 } from '@aws-sdk/client-lambda';
 import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
-import { type GatherResult, gatherFindings, regatherTouched } from '../src/commands/gather.js';
+import {
+  buildSiblingSgRules,
+  type GatherResult,
+  gatherFindings,
+  regatherTouched,
+} from '../src/commands/gather.js';
 import type { Desired } from '../src/desired/template-adapter.js';
-import type { Finding, ResolverContext, SchemaInfo } from '../src/types.js';
+import type { DesiredResource, Finding, ResolverContext, SchemaInfo } from '../src/types.js';
 
 // Build N AWS::SQS::Queue resources whose declared props match the live read, so the
 // only differences are ordering-sensitive iteration (no real drift noise).
@@ -565,5 +570,117 @@ describe('gatherFindings pass-1.6 added-enumeration guards an unread parent (WAV
     expect(findings.some((f) => f.tier === 'added')).toBe(false);
     // ...and the unread parent surfaces its coverage gap as skipped
     expect(findings.some((f) => f.logicalId === 'Fn' && f.tier === 'skipped')).toBe(true);
+  });
+});
+
+describe('buildSiblingSgRules', () => {
+  const desiredWith = (resources: DesiredResource[], accountId = '111122223333'): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId,
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  it('keys rules by the SG GroupId, strips GroupId, and splits ingress/egress', () => {
+    const map = buildSiblingSgRules(
+      desiredWith([
+        {
+          logicalId: 'In',
+          resourceType: 'AWS::EC2::SecurityGroupIngress',
+          physicalId: 'sgr-in',
+          declared: {
+            GroupId: 'sg-1',
+            SourcePrefixListId: 'pl-1',
+            IpProtocol: 'tcp',
+            FromPort: 3306,
+            ToPort: 3306,
+          },
+        },
+        {
+          logicalId: 'Out',
+          resourceType: 'AWS::EC2::SecurityGroupEgress',
+          physicalId: 'sgr-out',
+          declared: {
+            GroupId: 'sg-1',
+            CidrIp: '0.0.0.0/0',
+            IpProtocol: 'tcp',
+            FromPort: 443,
+            ToPort: 443,
+          },
+        },
+      ])
+    );
+    expect(map['sg-1']!.ingress).toEqual([
+      { SourcePrefixListId: 'pl-1', IpProtocol: 'tcp', FromPort: 3306, ToPort: 3306 },
+    ]);
+    expect(map['sg-1']!.egress).toEqual([
+      { CidrIp: '0.0.0.0/0', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+    ]);
+  });
+
+  it('fills SourceSecurityGroupOwnerId with the account id for an SG-ref rule that omits it', () => {
+    const map = buildSiblingSgRules(
+      desiredWith([
+        {
+          logicalId: 'Self',
+          resourceType: 'AWS::EC2::SecurityGroupIngress',
+          physicalId: 'sgr-self',
+          declared: {
+            GroupId: 'sg-1',
+            SourceSecurityGroupId: 'sg-1',
+            IpProtocol: 'tcp',
+            FromPort: 9000,
+            ToPort: 9000,
+          },
+        },
+      ])
+    );
+    expect(map['sg-1']!.ingress[0]).toMatchObject({
+      SourceSecurityGroupId: 'sg-1',
+      SourceSecurityGroupOwnerId: '111122223333',
+    });
+  });
+
+  it('does NOT overwrite a declared (cross-account) SourceSecurityGroupOwnerId', () => {
+    const map = buildSiblingSgRules(
+      desiredWith([
+        {
+          logicalId: 'Peer',
+          resourceType: 'AWS::EC2::SecurityGroupIngress',
+          physicalId: 'sgr-peer',
+          declared: {
+            GroupId: 'sg-1',
+            SourceSecurityGroupId: 'sg-other',
+            SourceSecurityGroupOwnerId: '999988887777',
+            IpProtocol: 'tcp',
+            FromPort: 80,
+            ToPort: 80,
+          },
+        },
+      ])
+    );
+    expect(map['sg-1']!.ingress[0]).toMatchObject({ SourceSecurityGroupOwnerId: '999988887777' });
+  });
+
+  it('skips a rule whose GroupId is an unresolved intrinsic (not a concrete string)', () => {
+    const map = buildSiblingSgRules(
+      desiredWith([
+        {
+          logicalId: 'In',
+          resourceType: 'AWS::EC2::SecurityGroupIngress',
+          physicalId: 'sgr-in',
+          declared: {
+            GroupId: { 'Fn::GetAtt': ['Sg', 'GroupId'] },
+            IpProtocol: 'tcp',
+            FromPort: 1,
+            ToPort: 1,
+          },
+        },
+      ])
+    );
+    expect(Object.keys(map)).toHaveLength(0);
   });
 });

--- a/tests/integration/agentcore-rich/app.ts
+++ b/tests/integration/agentcore-rich/app.ts
@@ -1,0 +1,46 @@
+// CDK app for the cdk-real-drift Bedrock AgentCore false-positive integration test.
+// Bedrock AgentCore is a brand-new service family cdkrd had never exercised. All its
+// types are Cloud-Control readable (FULLY_MUTABLE, read handler present) but entirely
+// uncovered by corpus/fixtures. This fixture deploys the four LIGHTWEIGHT types (no
+// ECR container / no VPC required) so a clean read can be classified end-to-end:
+//   - Memory               — Name + EventExpiryDuration (+ AWS-injected status/defaults).
+//   - WorkloadIdentity     — Name only (minimal; AWS mints a WorkloadIdentityArn).
+//   - CodeInterpreterCustom — Name + NetworkConfiguration { NetworkMode: PUBLIC }.
+//   - BrowserCustom        — Name + NetworkConfiguration { NetworkMode: PUBLIC }.
+// A freshly deployed + recorded stack with NO out-of-band change MUST report CLEAN —
+// this surfaces any AgentCore-specific default-fold / read-gap (e.g. a service default
+// AWS materializes that the template never declared).
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnBrowserCustom,
+  CfnCodeInterpreterCustom,
+  CfnMemory,
+  CfnWorkloadIdentity,
+} from "aws-cdk-lib/aws-bedrockagentcore";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAgentCore");
+
+new CfnMemory(stack, "Memory", {
+  name: "cdkrd_agentcore_memory",
+  description: "cdkrd agentcore-rich fixture memory",
+  eventExpiryDuration: 30, // days
+});
+
+new CfnWorkloadIdentity(stack, "WorkloadIdentity", {
+  name: "cdkrd_agentcore_workload",
+});
+
+new CfnCodeInterpreterCustom(stack, "CodeInterpreter", {
+  name: "cdkrd_agentcore_codeint",
+  description: "cdkrd agentcore-rich fixture code interpreter",
+  networkConfiguration: { networkMode: "PUBLIC" },
+});
+
+new CfnBrowserCustom(stack, "Browser", {
+  name: "cdkrd_agentcore_browser",
+  description: "cdkrd agentcore-rich fixture browser",
+  networkConfiguration: { networkMode: "PUBLIC" },
+});
+
+app.synth();

--- a/tests/integration/agentcore-rich/cdk.json
+++ b/tests/integration/agentcore-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/agentcore-rich/package.json
+++ b/tests/integration/agentcore-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-agentcore-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift agentcore-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/agentcore-rich/verify.sh
+++ b/tests/integration/agentcore-rich/verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# cdk-real-drift agentcore-rich false-positive integration test (real AWS).
+# Deploy -> check --fail (no baseline) MUST exit 0 (no declared drift; every declared
+# value normalizes equal to live) -> record -> check stays CLEAN. A normalizer/read
+# regression turns a declared value into a false declared drift and fails here.
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAgentCore
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-agentcore-rich-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-agentcore-rich-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/aurora-serverless-v2-rich/app.ts
+++ b/tests/integration/aurora-serverless-v2-rich/app.ts
@@ -1,0 +1,46 @@
+// CDK app for the cdk-real-drift Aurora Serverless v2 false-positive integration test.
+// Aurora Serverless v2 (post-2023) is now a daily-driver RDS shape the corpus did not
+// cover. It declares normalization-prone properties whose live AWS form may differ:
+//   - ServerlessV2ScalingConfiguration { MinCapacity, MaxCapacity } — a nested object
+//     AWS may enrich (e.g. SecondsUntilAutoPause default) or fold.
+//   - EngineVersion declared partial ("8.0.mysql_aurora.3.08.x"-style) vs the concrete
+//     value AWS reads back (VERSION_PREFIX_PATHS territory).
+//   - EnableCloudwatchLogsExports (an unordered set) + a custom DB cluster parameter
+//     group. The two serverless-v2 instances (writer + reader) round-trip too.
+// A freshly deployed + recorded cluster with NO out-of-band change MUST report CLEAN.
+// NAT-free isolated subnets keep cost down; removalPolicy DESTROY + no deletion
+// protection keep teardown clean.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  AuroraMysqlEngineVersion,
+  ClusterInstance,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+} from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAuroraSv2");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+new DatabaseCluster(stack, "Cluster", {
+  engine: DatabaseClusterEngine.auroraMysql({ version: AuroraMysqlEngineVersion.VER_3_08_0 }),
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  serverlessV2MinCapacity: 0.5,
+  serverlessV2MaxCapacity: 2,
+  writer: ClusterInstance.serverlessV2("writer"),
+  readers: [ClusterInstance.serverlessV2("reader", { scaleWithWriter: true })],
+  enableDataApi: true,
+  cloudwatchLogsExports: ["audit", "error", "general", "slowquery"],
+  backup: { retention: Duration.days(7) },
+  removalPolicy: RemovalPolicy.DESTROY,
+  deletionProtection: false,
+});
+
+app.synth();

--- a/tests/integration/aurora-serverless-v2-rich/cdk.json
+++ b/tests/integration/aurora-serverless-v2-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/aurora-serverless-v2-rich/package.json
+++ b/tests/integration/aurora-serverless-v2-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-aurora-serverless-v2-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift aurora-serverless-v2-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/aurora-serverless-v2-rich/verify.sh
+++ b/tests/integration/aurora-serverless-v2-rich/verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# cdk-real-drift aurora-serverless-v2-rich false-positive integration test (real AWS).
+# Deploy -> check --fail (no baseline) MUST exit 0 (no declared drift; every declared
+# value normalizes equal to live) -> record -> check stays CLEAN. A normalizer/read
+# regression turns a declared value into a false declared drift and fails here.
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAuroraSv2
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-aurora-serverless-v2-rich-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-aurora-serverless-v2-rich-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/securitygroup-protocols-rich/app.ts
+++ b/tests/integration/securitygroup-protocols-rich/app.ts
@@ -1,0 +1,61 @@
+// CDK app for the cdk-real-drift SecurityGroup *protocol-rich* false-positive +
+// detection integration test. The existing `securitygroup` fixture only exercises
+// single-port TCP CIDR ingress; a huge fraction of real SGs also carry rule shapes
+// whose live AWS form is textually different from the declared template:
+//   - TCP / UDP PORT RANGES (FromPort != ToPort).
+//   - ICMP rules (IpProtocol "icmp" with FromPort=type / ToPort=code, e.g. echo -1).
+//   - IPv6 CIDR rules (CidrIpv6, which AWS may canonicalize) + an all-traffic egress.
+//   - A PREFIX-LIST rule (SourcePrefixListId resolved from a customer-managed list).
+//   - A SELF-REFERENCING rule (SourceSecurityGroupId == the SG's own GroupId via a
+//     Fn::GetAtt intrinsic cdkrd must resolve).
+// SecurityGroupIngress/SecurityGroupEgress are UNORDERED_OBJECT_ARRAY_PROPS — AWS may
+// return the rules in a different order than declared. A freshly deployed + recorded SG
+// with NO out-of-band change MUST report CLEAN; a normalizer/intrinsic regression turns
+// one of these into a false declared drift.
+// A minimal single-AZ VPC with no NAT keeps it cheap and self-cleaning.
+import { App, Stack, Tags } from "aws-cdk-lib";
+import { Peer, Port, PrefixList, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSgProto");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+// A customer-managed prefix list referenced from a rule below — self-contained, so the
+// fixture needs no hardcoded region-specific AWS-managed prefix-list id.
+const pl = new PrefixList(stack, "Pl", {
+  maxEntries: 4,
+  entries: [{ cidr: "10.5.0.0/16", description: "corp" }],
+});
+
+// allowAllOutbound:false + explicit egress rules below avoids CDK's dummy deny-all rule.
+const sg = new SecurityGroup(stack, "Sg", { vpc, allowAllOutbound: false });
+
+// TCP single port + TCP port range.
+sg.addIngressRule(Peer.ipv4("10.0.0.0/24"), Port.tcp(443), "https");
+sg.addIngressRule(Peer.ipv4("10.0.1.0/24"), Port.tcpRange(8000, 8100), "app range");
+// UDP port range.
+sg.addIngressRule(Peer.ipv4("10.0.2.0/24"), Port.udpRange(5000, 5010), "udp range");
+// ICMP echo (ping): IpProtocol "icmp", FromPort=8, ToPort=-1.
+sg.addIngressRule(Peer.ipv4("10.0.3.0/24"), Port.icmpPing(), "icmp ping");
+// All ICMP: IpProtocol "icmp", FromPort=-1, ToPort=-1.
+sg.addIngressRule(Peer.ipv4("10.0.4.0/24"), Port.allIcmp(), "icmp all");
+// IPv6 ingress (CidrIpv6).
+sg.addIngressRule(Peer.ipv6("2001:db8::/32"), Port.tcp(22), "ssh ipv6");
+// Prefix-list ingress (SourcePrefixListId).
+sg.addIngressRule(Peer.prefixList(pl.prefixListId), Port.tcp(3306), "mysql from prefix list");
+// Self-referencing ingress (SourceSecurityGroupId == own GroupId).
+sg.addIngressRule(sg, Port.tcp(9000), "self ref");
+
+// Egress: a specific IPv6 rule (CidrIpv6 ::/0) + a specific IPv4 rule. (An IPv6
+// all-traffic egress can only be expressed via allowAllIpv6Outbound, not addEgressRule.)
+sg.addEgressRule(Peer.ipv6("::/0"), Port.tcp(443), "https out ipv6");
+sg.addEgressRule(Peer.ipv4("0.0.0.0/0"), Port.tcp(443), "https out");
+
+Tags.of(sg).add("team", "platform");
+
+app.synth();

--- a/tests/integration/securitygroup-protocols-rich/cdk.json
+++ b/tests/integration/securitygroup-protocols-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/securitygroup-protocols-rich/package.json
+++ b/tests/integration/securitygroup-protocols-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-securitygroup-protocols-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift securitygroup-protocols-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/securitygroup-protocols-rich/verify-detect.sh
+++ b/tests/integration/securitygroup-protocols-rich/verify-detect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# SecurityGroup detect (+ revert) integration test (real AWS): the "someone changed it in
+# the console" scenario for an INLINE SG rule, alongside the FP fix verify.sh proves. Deploy
+# -> record -> REVOKE a declared inline ingress rule out of band -> check MUST DETECT the
+# declared drift (the rule is now missing from live) -> revert MUST re-authorize it -> check
+# MUST be CLEAN. This is the false-negative / detection half. It also guards the sibling-rule
+# subtraction fix from the OTHER side: the 2 sibling-declared rules (prefix-list + self-ref)
+# must NOT be re-reported here — only the genuinely-removed inline rule.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSgProto
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+SG="$(aws ec2 describe-security-groups --region "$REGION" \
+  --filters "Name=tag:aws:cloudformation:stack-name,Values=$STACK" \
+  --query "SecurityGroups[?GroupName!='default']|[0].GroupId" --output text)"
+[ -n "$SG" ] && [ "$SG" != "None" ] || fail "could not resolve security group id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: revoke the declared inline https ingress rule (10.0.0.0/24:443) ==="
+aws ec2 revoke-security-group-ingress --group-id "$SG" --region "$REGION" \
+  --ip-permissions 'IpProtocol=tcp,FromPort=443,ToPort=443,IpRanges=[{CidrIp=10.0.0.0/24}]' \
+  >/dev/null || fail "revoke rule"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sgproto-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "SecurityGroupIngress" /tmp/cdkrd-sgproto-detect.out || fail "SecurityGroupIngress drift not reported"
+
+echo "=== revert (re-authorize the missing rule) ==="
+if $CLI revert "$STACK" --region "$REGION" --yes; then
+  echo "=== check MUST be CLEAN after revert ==="
+  $CLI check "$STACK" --region "$REGION" --fail
+  [ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+  echo "INTEG PASS ($STACK detect+revert)"
+else
+  echo "NOTE: revert not supported for the inline SG rule (SDK_WRITERS candidate); detection PASS only"
+  echo "INTEG PASS ($STACK detect-only)"
+fi

--- a/tests/integration/securitygroup-protocols-rich/verify.sh
+++ b/tests/integration/securitygroup-protocols-rich/verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# cdk-real-drift securitygroup-protocols-rich false-positive integration test (real AWS).
+# Deploy -> check --fail (no baseline) MUST exit 0 (no declared drift; every declared
+# value normalizes equal to live) -> record -> check stays CLEAN. A normalizer/read
+# regression turns a declared value into a false declared drift and fails here.
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSgProto
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-securitygroup-protocols-rich-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-securitygroup-protocols-rich-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/vpc-endpoint-nacl-ebs-rich/app.ts
+++ b/tests/integration/vpc-endpoint-nacl-ebs-rich/app.ts
@@ -1,0 +1,94 @@
+// CDK app for the cdk-real-drift Interface VPC Endpoint / NetworkAcl entries / EBS
+// volume-type false-positive integration test. Three commonly-deployed, previously
+// thin-on-corpus networking shapes packed into one cheap (NAT-free, isolated-subnet)
+// VPC:
+//   - InterfaceVpcEndpoint (Secrets Manager) across 2 subnets with 2 security groups
+//     + PrivateDnsEnabled. SubnetIds / SecurityGroupIds are ID arrays AWS may REORDER
+//     relative to the template (canonicalizeIdArraysDeep should fold this) and the
+//     corpus previously only covered a GATEWAY endpoint (S3, RouteTableIds shape).
+//   - A NetworkAcl with several NetworkAclEntry resources (ingress/egress, varied
+//     RuleNumber). Entries are separate resources AWS returns ordered by RuleNumber.
+//   - EBS Volumes of types the corpus did not cover: gp2 (implicit size-derived Iops)
+//     and io2 (explicit Iops). The existing corpus only had a gp3 volume.
+// A freshly deployed + recorded stack with NO out-of-band change MUST report CLEAN.
+import { App, Size, Stack, Tags } from "aws-cdk-lib";
+import {
+  AclCidr,
+  AclTraffic,
+  Action,
+  EbsDeviceVolumeType,
+  InterfaceVpcEndpoint,
+  InterfaceVpcEndpointAwsService,
+  NetworkAcl,
+  SecurityGroup,
+  SubnetType,
+  TrafficDirection,
+  Volume,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegVpcEpRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const epSg1 = new SecurityGroup(stack, "EpSg1", { vpc, description: "endpoint sg 1" });
+const epSg2 = new SecurityGroup(stack, "EpSg2", { vpc, description: "endpoint sg 2" });
+
+new InterfaceVpcEndpoint(stack, "SecretsEp", {
+  vpc,
+  service: InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+  subnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  securityGroups: [epSg1, epSg2],
+  privateDnsEnabled: true,
+});
+
+const nacl = new NetworkAcl(stack, "Nacl", {
+  vpc,
+  subnetSelection: { subnetType: SubnetType.PRIVATE_ISOLATED },
+});
+nacl.addEntry("InHttps", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.tcpPort(443),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 100,
+  ruleAction: Action.ALLOW,
+});
+nacl.addEntry("InEphemeral", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.tcpPortRange(1024, 65535),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 110,
+  ruleAction: Action.ALLOW,
+});
+nacl.addEntry("OutAll", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.allTraffic(),
+  direction: TrafficDirection.EGRESS,
+  ruleNumber: 100,
+  ruleAction: Action.ALLOW,
+});
+
+const az = vpc.availabilityZones[0]!;
+const gp2 = new Volume(stack, "Gp2Vol", {
+  availabilityZone: az,
+  size: Size.gibibytes(20),
+  volumeType: EbsDeviceVolumeType.GP2, // AWS derives Iops from size (≈100 here) — undeclared
+  encrypted: true,
+});
+Tags.of(gp2).add("role", "gp2");
+
+const io2 = new Volume(stack, "Io2Vol", {
+  availabilityZone: az,
+  size: Size.gibibytes(10),
+  volumeType: EbsDeviceVolumeType.IO2,
+  iops: 1000, // io2 requires explicit provisioned Iops — declared
+  encrypted: true,
+});
+Tags.of(io2).add("role", "io2");
+
+app.synth();

--- a/tests/integration/vpc-endpoint-nacl-ebs-rich/cdk.json
+++ b/tests/integration/vpc-endpoint-nacl-ebs-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/vpc-endpoint-nacl-ebs-rich/package.json
+++ b/tests/integration/vpc-endpoint-nacl-ebs-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-vpc-endpoint-nacl-ebs-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift vpc-endpoint-nacl-ebs-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/vpc-endpoint-nacl-ebs-rich/verify.sh
+++ b/tests/integration/vpc-endpoint-nacl-ebs-rich/verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# cdk-real-drift vpc-endpoint-nacl-ebs-rich false-positive integration test (real AWS).
+# Deploy -> check --fail (no baseline) MUST exit 0 (no declared drift; every declared
+# value normalizes equal to live) -> record -> check stays CLEAN. A normalizer/read
+# regression turns a declared value into a false declared drift and fails here.
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegVpcEpRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-vpc-endpoint-nacl-ebs-rich-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift on a noise-prone property (exit $rc) — a normalizer regressed"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-vpc-endpoint-nacl-ebs-rich-pre.out \
+  && fail "a declared property was wrongly reported as drift (false positive)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -957,6 +957,61 @@ describe('buildRevertPlan', () => {
       { op: 'add', path: '/B/0', value: 2 },
     ]);
   });
+
+  it('SecurityGroup ingress revert merges sibling-declared rules into the value (no clobber)', () => {
+    // Reverting an SG's reflected SecurityGroupIngress is a whole-array Cloud Control
+    // replacement. The live SG reflects rules declared by sibling standalone SG-rule resources
+    // (a self-ref / prefix-list rule CDK could not inline); without merging them back, the
+    // replacement DELETES them (silent data loss, observed live). The merged value preserves
+    // them — including the injected SourceSecurityGroupOwnerId so CC sees the rule unchanged.
+    const inlineDeclared = [
+      { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+    ];
+    const siblingRule = {
+      SourceSecurityGroupId: 'sg-1',
+      SourceSecurityGroupOwnerId: '111122223333',
+      IpProtocol: 'tcp',
+      FromPort: 9000,
+      ToPort: 9000,
+    };
+    const f = F({
+      tier: 'declared',
+      resourceType: 'AWS::EC2::SecurityGroup',
+      physicalId: 'sg-1',
+      path: 'SecurityGroupIngress',
+      desired: inlineDeclared,
+      actual: inlineDeclared,
+    });
+    const plan = buildRevertPlan([f], undefined, {
+      siblingSgRules: { 'sg-1': { ingress: [siblingRule], egress: [] } },
+    });
+    expect(plan.items[0]!.kind).toBe('cc');
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SecurityGroupIngress',
+      value: [...inlineDeclared, siblingRule],
+    });
+  });
+
+  it('SecurityGroup ingress revert without siblings leaves the declared value unchanged', () => {
+    const inlineDeclared = [
+      { CidrIp: '10.0.0.0/24', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 },
+    ];
+    const f = F({
+      tier: 'declared',
+      resourceType: 'AWS::EC2::SecurityGroup',
+      physicalId: 'sg-1',
+      path: 'SecurityGroupIngress',
+      desired: inlineDeclared,
+      actual: [],
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SecurityGroupIngress',
+      value: inlineDeclared,
+    });
+  });
 });
 
 describe('property-scoped SDK writer routing (IAM Role inline Policies)', () => {


### PR DESCRIPTION
## What

Bug-hunt round (EC2 / SecurityGroup / VPC / EBS / RDS + Bedrock AgentCore). Found and fixed a **real false positive** and a **real revert data-loss bug** on SecurityGroup, plus shipped rich fixtures + golden-corpus coverage (incl. several clean rounds).

## The bug (FP) — SecurityGroup sibling-rule reflection

Any SG rule CDK cannot inline — a **self-reference** (`addIngressRule(sg, …)`), a **peer SG**, a **prefix list** (`Peer.prefixList(…)`), an **imported SG** — becomes a standalone `AWS::EC2::SecurityGroupIngress` / `::SecurityGroupEgress` resource. The **live** SecurityGroup reflects those rules in its own `SecurityGroupIngress` / `Egress` arrays (the union of inline + standalone), but the SG's **declared** arrays hold only the inline rules → every sibling rule read as a false declared drift. This hits the canonical ALB↔ASG / intra-cluster self-ref pattern that a large fraction of stacks use.

**Fix (`classify`):** subtract the sibling-declared rules (`buildSiblingSgRules`, keyed by the SG's resolved `GroupId` == physical id) from the live arrays before comparing, by **subset match** (the live element carries an AWS-injected `SourceSecurityGroupOwnerId` the sibling never declared). An out-of-band rule that matches no sibling still surfaces.

## The second bug (revert data loss)

Reverting the SG's reflected `SecurityGroupIngress` is a whole-array Cloud Control replacement → it **deleted the sibling-managed rules** (the standalone resources then read `deleted`). Observed live.

**Fix (`revert/plan`):** merge the sibling rules back into the revert value. A self/peer-ref rule must be re-sent **with** `SourceSecurityGroupOwnerId` (= account for same-account refs) or CC treats the owner-less rule as different, replaces it (new rule id), and orphans the sibling resource. Verified live: revert now restores the changed inline rule **and** preserves the siblings → clean.

## Also

- **noise:** fold `SourceSecurityGroupOwnerId` to the `generated` tier (`GENERATED_TOPLEVEL_PATHS`) — value-derived from `SourceSecurityGroupId`, pure first-run noise on every self/peer-ref rule.
- **corpus:** carry `siblingSgRules` in the `CorpusCase` opts (it is external cross-resource context) so `corpus-replay` reproduces the subtraction.
- **clean rounds (corpus assets, no bug):** Bedrock AgentCore lightweight types (Memory / WorkloadIdentity / CodeInterpreterCustom / BrowserCustom), Aurora Serverless v2 (`ServerlessV2ScalingConfiguration`), interface VPCEndpoint (SubnetIds/SecurityGroupIds reorder already folded), gp2 / io2 EBS volumes — all declared-clean.

## Tests

- New unit tests: classify sibling subtraction + OwnerId fold (`classify.test.ts`), revert sibling merge (`revert-plan.test.ts`), `buildSiblingSgRules` (`gather.test.ts`).
- 12 new golden-corpus cases (collisions suffixed `.protocols` / `.sv2`); updated the existing `WebSgIngress` case's `expected` for the OwnerId fold.
- 4 new integration fixtures with `verify.sh` (+ `verify-detect.sh` for SG detect→revert).
- Full suite green (1858 tests). All bug-hunt stacks deployed, then deleted + swept clean.

## Notes / follow-ups

- `AWS::EC2::NetworkAclEntry` is a Cloud Control gap (`UnsupportedActionException` → `skipped`) — an `SDK_OVERRIDES` candidate, not addressed here.
