### PR TITLE
feat(read): SDK_OVERRIDES reader for AWS::EC2::NetworkAclEntry (close CC read-gap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,8 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `sns:GetTopicAttributes`, `sqs:GetQueueAttributes`, `iam:GetRolePolicy`,
   `iam:GetUserPolicy`, `iam:GetGroupPolicy`, `iam:GetPolicy`, `iam:GetPolicyVersion`,
   `lambda:GetPolicy`, `budgets:ViewBudget`, `ec2:DescribeAddresses`,
-  `ec2:DescribeLaunchTemplateVersions`, `route53:ListResourceRecordSets`,
+  `ec2:DescribeLaunchTemplateVersions`, `ec2:DescribeNetworkAcls`,
+  `route53:ListResourceRecordSets`,
   `glue:GetTable`, `logs:DescribeMetricFilters`, `scheduler:GetSchedule`,
   `ssm:DescribeParameters` (supplements the Cloud Control read of an
   `AWS::SSM::Parameter` with its writeOnly `Description` / `AllowedPattern`),

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -25,6 +25,7 @@ import {
 import {
   DescribeAddressesCommand,
   DescribeLaunchTemplateVersionsCommand,
+  DescribeNetworkAclsCommand,
   EC2Client,
 } from '@aws-sdk/client-ec2';
 import {
@@ -385,6 +386,54 @@ const readEc2Eip: OverrideReader = async ({ physicalId, region }) => {
   // `undeclared` drift on EVERY associated EIP on the first check.
   if (str(addr.PublicIpv4Pool)) model.PublicIpv4Pool = addr.PublicIpv4Pool; // declarable; absent for AWS-pool EIPs (FP-safe)
   if (tags && tags.length > 0) model.Tags = tags;
+  return model;
+};
+
+// AWS::EC2::NetworkAclEntry — Cloud Control has no read handler for this type
+// (GetResource throws UnsupportedActionException), so every NACL entry was silently
+// `skipped`: a NACL rule changed out of band (a CidrBlock widened, an action flipped
+// allow->deny) was invisible. Read the parent NACL via EC2 DescribeNetworkAcls and pick
+// the entry by its identity (RuleNumber + Egress — a NACL holds at most one entry per
+// (RuleNumber, Egress) pair). The EC2 entry shape mirrors the CFn property shape, except
+// Protocol comes back as a STRING ("6") while CFn declares it as an INTEGER (6) — coerce
+// it to a number so a tcp/udp/icmp rule does not false-drift on a typed-vs-string Protocol.
+const readEc2NetworkAclEntry: OverrideReader = async ({ declared, region }) => {
+  const naclId = str(declared.NetworkAclId);
+  const ruleNumber = declared.RuleNumber;
+  const egress = declared.Egress;
+  // RuleNumber + Egress are required identity; an unresolved NetworkAclId (Symbol) or a
+  // missing identity field -> skipped (fail-open, never a false read).
+  if (!naclId || typeof ruleNumber !== 'number' || typeof egress !== 'boolean') return undefined;
+
+  const c = new EC2Client({ region, ...READ_RETRY });
+  // InvalidNetworkAclID.NotFound surfaces if the NACL itself was deleted out of band —
+  // let it propagate so the router maps it to `deleted`.
+  const r = await c.send(new DescribeNetworkAclsCommand({ NetworkAclIds: [naclId] }));
+  const nacl = r.NetworkAcls?.[0];
+  if (!nacl) return undefined;
+  const entry = nacl.Entries?.find((e) => e.RuleNumber === ruleNumber && e.Egress === egress);
+  if (!entry)
+    throw new ResourceGoneError(
+      `NetworkAclEntry rule=${ruleNumber} egress=${egress} absent from NACL ${naclId}`
+    );
+
+  const model: Record<string, unknown> = {
+    NetworkAclId: naclId,
+    RuleNumber: entry.RuleNumber,
+    Egress: entry.Egress,
+    RuleAction: entry.RuleAction,
+  };
+  // Protocol: EC2 returns a numeric STRING; CFn declares an integer.
+  if (entry.Protocol !== undefined && entry.Protocol !== null)
+    model.Protocol = Number(entry.Protocol);
+  if (str(entry.CidrBlock)) model.CidrBlock = entry.CidrBlock;
+  if (str(entry.Ipv6CidrBlock)) model.Ipv6CidrBlock = entry.Ipv6CidrBlock;
+  // PortRange (TCP/UDP) and Icmp (ICMP/ICMPv6) are mutually exclusive and protocol-derived;
+  // project each only when AWS returns it so a non-port / non-icmp rule stays absent (FP-safe).
+  if (entry.PortRange) model.PortRange = { From: entry.PortRange.From, To: entry.PortRange.To };
+  // EC2 names the ICMP field IcmpTypeCode; the CFn property is Icmp (same {Code, Type}).
+  if (entry.IcmpTypeCode)
+    model.Icmp = { Code: entry.IcmpTypeCode.Code, Type: entry.IcmpTypeCode.Type };
   return model;
 };
 
@@ -1202,6 +1251,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::Budgets::Budget': readBudget,
   'AWS::EC2::EIP': readEc2Eip,
   'AWS::EC2::LaunchTemplate': readEc2LaunchTemplate,
+  'AWS::EC2::NetworkAclEntry': readEc2NetworkAclEntry,
   'AWS::Route53::RecordSet': readRoute53RecordSet,
   'AWS::Glue::Table': readGlueTable,
   'AWS::Glue::Classifier': readGlueClassifier,

--- a/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInDenySmtp00E01CD6.json
+++ b/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInDenySmtp00E01CD6.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NaclInDenySmtp00E01CD6",
+    "resourceType": "AWS::EC2::NetworkAclEntry",
+    "physicalId": "CdkRea-NaclI-mzaNfCKJXOJF",
+    "constructPath": "CdkRealDriftIntegNaclEntry/Nacl/InDenySmtp",
+    "declared": {
+      "CidrBlock": "10.0.0.0/8",
+      "Egress": false,
+      "NetworkAclId": "acl-0487d047096d72ead",
+      "PortRange": {
+        "From": 25,
+        "To": 25
+      },
+      "Protocol": 6,
+      "RuleAction": "deny",
+      "RuleNumber": 130
+    }
+  },
+  "liveRaw": {
+    "NetworkAclId": "acl-0487d047096d72ead",
+    "RuleNumber": 130,
+    "Egress": false,
+    "RuleAction": "deny",
+    "Protocol": 6,
+    "CidrBlock": "10.0.0.0/8",
+    "PortRange": {
+      "From": 25,
+      "To": 25
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Egress", "NetworkAclId", "RuleNumber"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Egress", "NetworkAclId", "RuleNumber"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInEphemeralA6340825.json
+++ b/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInEphemeralA6340825.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NaclInEphemeralA6340825",
+    "resourceType": "AWS::EC2::NetworkAclEntry",
+    "physicalId": "CdkRea-NaclI-2INW3gKs4PHh",
+    "constructPath": "CdkRealDriftIntegNaclEntry/Nacl/InEphemeral",
+    "declared": {
+      "CidrBlock": "0.0.0.0/0",
+      "Egress": false,
+      "NetworkAclId": "acl-0487d047096d72ead",
+      "PortRange": {
+        "From": 1024,
+        "To": 65535
+      },
+      "Protocol": 6,
+      "RuleAction": "allow",
+      "RuleNumber": 110
+    }
+  },
+  "liveRaw": {
+    "NetworkAclId": "acl-0487d047096d72ead",
+    "RuleNumber": 110,
+    "Egress": false,
+    "RuleAction": "allow",
+    "Protocol": 6,
+    "CidrBlock": "0.0.0.0/0",
+    "PortRange": {
+      "From": 1024,
+      "To": 65535
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Egress", "NetworkAclId", "RuleNumber"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Egress", "NetworkAclId", "RuleNumber"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInHttpsDF846A4B.json
+++ b/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInHttpsDF846A4B.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NaclInHttpsDF846A4B",
+    "resourceType": "AWS::EC2::NetworkAclEntry",
+    "physicalId": "CdkRea-NaclI-6KHrxgYSW0Bx",
+    "constructPath": "CdkRealDriftIntegNaclEntry/Nacl/InHttps",
+    "declared": {
+      "CidrBlock": "0.0.0.0/0",
+      "Egress": false,
+      "NetworkAclId": "acl-0487d047096d72ead",
+      "PortRange": {
+        "From": 443,
+        "To": 443
+      },
+      "Protocol": 6,
+      "RuleAction": "allow",
+      "RuleNumber": 100
+    }
+  },
+  "liveRaw": {
+    "NetworkAclId": "acl-0487d047096d72ead",
+    "RuleNumber": 100,
+    "Egress": false,
+    "RuleAction": "allow",
+    "Protocol": 6,
+    "CidrBlock": "0.0.0.0/0",
+    "PortRange": {
+      "From": 443,
+      "To": 443
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Egress", "NetworkAclId", "RuleNumber"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Egress", "NetworkAclId", "RuleNumber"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInIcmp620C9B48.json
+++ b/tests/corpus/AWS__EC2__NetworkAclEntry.NaclInIcmp620C9B48.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NaclInIcmp620C9B48",
+    "resourceType": "AWS::EC2::NetworkAclEntry",
+    "physicalId": "CdkRea-NaclI-9PdI5qm5zhwG",
+    "constructPath": "CdkRealDriftIntegNaclEntry/Nacl/InIcmp",
+    "declared": {
+      "CidrBlock": "0.0.0.0/0",
+      "Egress": false,
+      "Icmp": {
+        "Code": -1,
+        "Type": 8
+      },
+      "NetworkAclId": "acl-0487d047096d72ead",
+      "Protocol": 1,
+      "RuleAction": "allow",
+      "RuleNumber": 120
+    }
+  },
+  "liveRaw": {
+    "NetworkAclId": "acl-0487d047096d72ead",
+    "RuleNumber": 120,
+    "Egress": false,
+    "RuleAction": "allow",
+    "Protocol": 1,
+    "CidrBlock": "0.0.0.0/0",
+    "Icmp": {
+      "Code": -1,
+      "Type": 8
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Egress", "NetworkAclId", "RuleNumber"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Egress", "NetworkAclId", "RuleNumber"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__NetworkAclEntry.NaclOutAll59E5E3A6.json
+++ b/tests/corpus/AWS__EC2__NetworkAclEntry.NaclOutAll59E5E3A6.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NaclOutAll59E5E3A6",
+    "resourceType": "AWS::EC2::NetworkAclEntry",
+    "physicalId": "CdkRea-NaclO-npEo8XEarCjP",
+    "constructPath": "CdkRealDriftIntegNaclEntry/Nacl/OutAll",
+    "declared": {
+      "CidrBlock": "0.0.0.0/0",
+      "Egress": true,
+      "NetworkAclId": "acl-0487d047096d72ead",
+      "Protocol": -1,
+      "RuleAction": "allow",
+      "RuleNumber": 100
+    }
+  },
+  "liveRaw": {
+    "NetworkAclId": "acl-0487d047096d72ead",
+    "RuleNumber": 100,
+    "Egress": true,
+    "RuleAction": "allow",
+    "Protocol": -1,
+    "CidrBlock": "0.0.0.0/0"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Egress", "NetworkAclId", "RuleNumber"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Egress", "NetworkAclId", "RuleNumber"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/nacl-entry-readgap/app.ts
+++ b/tests/integration/nacl-entry-readgap/app.ts
@@ -1,0 +1,77 @@
+// CDK app for the cdk-real-drift NetworkAclEntry read-gap integration test.
+// AWS::EC2::NetworkAclEntry has NO Cloud Control read handler (GetResource throws
+// UnsupportedActionException), so every NACL entry was silently `skipped` — a rule changed
+// out of band (a CidrBlock widened, an action flipped allow->deny) was invisible (a silent
+// false negative on a security-relevant resource). The SDK_OVERRIDES reader (EC2
+// DescribeNetworkAcls, matched by RuleNumber + Egress) closes the gap. This fixture declares
+// a NACL with a spread of entry shapes — TCP single port, TCP port range, all-protocols,
+// ICMP, and an egress rule — so the read + field mapping (Protocol number-coercion, PortRange,
+// Icmp, Egress) is exercised end to end. A freshly deployed + recorded NACL with NO out-of-band
+// change MUST report CLEAN, and crucially the entries must be READ (not `skipped`).
+import { App, Stack } from "aws-cdk-lib";
+import {
+  AclCidr,
+  AclTraffic,
+  Action,
+  NetworkAcl,
+  SubnetType,
+  TrafficDirection,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegNaclEntry");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const nacl = new NetworkAcl(stack, "Nacl", {
+  vpc,
+  subnetSelection: { subnetType: SubnetType.PRIVATE_ISOLATED },
+});
+
+// TCP single port (Protocol 6, PortRange From==To).
+nacl.addEntry("InHttps", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.tcpPort(443),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 100,
+  ruleAction: Action.ALLOW,
+});
+// TCP port range (PortRange From!=To).
+nacl.addEntry("InEphemeral", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.tcpPortRange(1024, 65535),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 110,
+  ruleAction: Action.ALLOW,
+});
+// ICMP echo (Protocol 1, Icmp {Type, Code}).
+nacl.addEntry("InIcmp", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.icmp({ type: 8, code: -1 }),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 120,
+  ruleAction: Action.ALLOW,
+});
+// Explicit DENY (RuleAction allow vs deny — the security-relevant field).
+nacl.addEntry("InDenySmtp", {
+  cidr: AclCidr.ipv4("10.0.0.0/8"),
+  traffic: AclTraffic.tcpPort(25),
+  direction: TrafficDirection.INGRESS,
+  ruleNumber: 130,
+  ruleAction: Action.DENY,
+});
+// Egress all-protocols (Protocol -1, Egress true, no PortRange).
+nacl.addEntry("OutAll", {
+  cidr: AclCidr.anyIpv4(),
+  traffic: AclTraffic.allTraffic(),
+  direction: TrafficDirection.EGRESS,
+  ruleNumber: 100,
+  ruleAction: Action.ALLOW,
+});
+
+app.synth();

--- a/tests/integration/nacl-entry-readgap/cdk.json
+++ b/tests/integration/nacl-entry-readgap/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/nacl-entry-readgap/package.json
+++ b/tests/integration/nacl-entry-readgap/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-nacl-entry-readgap",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift NetworkAclEntry read-gap integration test. Run via verify.sh / verify-detect.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/nacl-entry-readgap/verify-detect.sh
+++ b/tests/integration/nacl-entry-readgap/verify-detect.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# NetworkAclEntry detect integration test (real AWS): the false-negative this fix closes.
+# Before the SDK_OVERRIDES reader, a NACL entry changed out of band was SILENTLY skipped —
+# the drift was invisible. Deploy -> record -> change a declared entry out of band
+# (RuleAction allow->deny on rule 130, the security-relevant field) -> check MUST DETECT the
+# declared drift (exit 1). NetworkAclEntry has no Cloud Control write handler and no SDK
+# writer, so revert is not available — this is a detect-only test (the entry is restored
+# manually before teardown).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNaclEntry
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+NACL="$(aws ec2 describe-network-acls --region "$REGION" \
+  --filters "Name=tag:aws:cloudformation:stack-name,Values=$STACK" \
+  --query "NetworkAcls[?Entries[?RuleNumber==\`130\`]]|[0].NetworkAclId" --output text)"
+[ -n "$NACL" ] && [ "$NACL" != "None" ] || fail "could not resolve network ACL id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: flip rule 130 RuleAction deny -> allow ==="
+aws ec2 replace-network-acl-entry --network-acl-id "$NACL" --region "$REGION" \
+  --rule-number 130 --protocol 6 --rule-action allow --ingress \
+  --cidr-block 10.0.0.0/8 --port-range From=25,To=25 >/dev/null || fail "mutate entry"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-naclentry-detect.out
+rc=${PIPESTATUS[0]}
+restore() {
+  aws ec2 replace-network-acl-entry --network-acl-id "$NACL" --region "$REGION" \
+    --rule-number 130 --protocol 6 --rule-action deny --ingress \
+    --cidr-block 10.0.0.0/8 --port-range From=25,To=25 >/dev/null 2>&1 || true
+}
+[ "$rc" -eq 1 ] || { restore; fail "expected drift exit 1, got $rc"; }
+grep -q "RuleAction" /tmp/cdkrd-naclentry-detect.out || { restore; fail "RuleAction drift not reported"; }
+
+echo "=== restore the live entry (no CC/SDK revert for NetworkAclEntry) ==="
+restore
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after manual restore"
+
+echo "INTEG PASS ($STACK detect-only)"

--- a/tests/integration/nacl-entry-readgap/verify.sh
+++ b/tests/integration/nacl-entry-readgap/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift NetworkAclEntry read-gap integration test (real AWS).
+# AWS::EC2::NetworkAclEntry has no Cloud Control read handler, so before the SDK_OVERRIDES
+# reader every entry was silently `skipped`. This asserts the entries are now actually READ
+# (NOT skipped) and that a freshly deployed + recorded NACL reports CLEAN (no FP from the
+# new reader's field mapping — Protocol number-coercion, PortRange, Icmp, Egress).
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegNaclEntry
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check --fail (no baseline) must find ZERO declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail --verbose | tee /tmp/cdkrd-naclentry-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift (exit $rc) — the NetworkAclEntry reader mapping regressed"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-naclentry-pre.out \
+  && fail "a NetworkAclEntry property was wrongly reported as drift (false positive)"
+
+echo "=== NetworkAclEntry entries must be READ, not skipped (UnsupportedActionException) ==="
+grep -E "NetworkAclEntry.*(UnsupportedActionException|CC API)" /tmp/cdkrd-naclentry-pre.out \
+  && fail "NetworkAclEntry still skipped — the SDK_OVERRIDES reader did not take effect"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1,6 +1,7 @@
 import { AppSyncClient, ListApiKeysCommand } from '@aws-sdk/client-appsync';
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
 import { BatchGetProjectsCommand, CodeBuildClient } from '@aws-sdk/client-codebuild';
+import { DescribeNetworkAclsCommand, EC2Client } from '@aws-sdk/client-ec2';
 import {
   DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
@@ -55,6 +56,7 @@ const codebuild = mockClient(CodeBuildClient);
 const appsync = mockClient(AppSyncClient);
 const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
+const ec2 = mockClient(EC2Client);
 
 const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
   physicalId,
@@ -81,6 +83,7 @@ beforeEach(() => {
     serviceDiscovery,
     docdb,
     appsync,
+    ec2,
   ])
     m.reset();
 });
@@ -1614,5 +1617,130 @@ describe('SDK overrides', () => {
     it('undefined when no apiId can be resolved', async () => {
       expect(await SDK_OVERRIDES['AWS::AppSync::ApiKey'](ctx({}))).toBeUndefined();
     });
+  });
+});
+
+describe('EC2 NetworkAclEntry (Cloud Control read-gap: UnsupportedActionException)', () => {
+  const ingress = {
+    NetworkAclId: 'acl-123',
+    RuleNumber: 100,
+    Egress: false,
+    Protocol: 6,
+    RuleAction: 'allow',
+    CidrBlock: '0.0.0.0/0',
+    PortRange: { From: 443, To: 443 },
+  };
+
+  it('reads an ingress TCP rule by RuleNumber+Egress; coerces Protocol to a number', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [
+        {
+          NetworkAclId: 'acl-123',
+          Entries: [
+            // a decoy entry with the SAME RuleNumber but the OTHER direction must not match
+            { RuleNumber: 100, Egress: true, Protocol: '-1', RuleAction: 'deny' },
+            {
+              RuleNumber: 100,
+              Egress: false,
+              Protocol: '6', // EC2 returns a numeric STRING
+              RuleAction: 'allow',
+              CidrBlock: '0.0.0.0/0',
+              PortRange: { From: 443, To: 443 },
+            },
+          ],
+        },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](ctx(ingress));
+    expect(out).toEqual(ingress); // Protocol comes back as number 6, not "6"
+  });
+
+  it('reads an egress IPv6 ICMP rule (IcmpTypeCode -> Icmp; Ipv6CidrBlock; no PortRange)', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [
+        {
+          NetworkAclId: 'acl-ipv6',
+          Entries: [
+            {
+              RuleNumber: 200,
+              Egress: true,
+              Protocol: '58',
+              RuleAction: 'allow',
+              Ipv6CidrBlock: '::/0',
+              IcmpTypeCode: { Code: -1, Type: -1 },
+            },
+          ],
+        },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+      ctx({ NetworkAclId: 'acl-ipv6', RuleNumber: 200, Egress: true })
+    );
+    expect(out).toEqual({
+      NetworkAclId: 'acl-ipv6',
+      RuleNumber: 200,
+      Egress: true,
+      Protocol: 58,
+      RuleAction: 'allow',
+      Ipv6CidrBlock: '::/0',
+      Icmp: { Code: -1, Type: -1 },
+    });
+    expect(out?.CidrBlock).toBeUndefined();
+    expect(out?.PortRange).toBeUndefined();
+  });
+
+  it('omits PortRange + Icmp for an all-protocols rule (FP-safe)', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [
+        {
+          NetworkAclId: 'acl-all',
+          Entries: [
+            {
+              RuleNumber: 50,
+              Egress: false,
+              Protocol: '-1',
+              RuleAction: 'allow',
+              CidrBlock: '10.0.0.0/8',
+            },
+          ],
+        },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+      ctx({ NetworkAclId: 'acl-all', RuleNumber: 50, Egress: false })
+    );
+    expect(out).toEqual({
+      NetworkAclId: 'acl-all',
+      RuleNumber: 50,
+      Egress: false,
+      Protocol: -1,
+      RuleAction: 'allow',
+      CidrBlock: '10.0.0.0/8',
+    });
+  });
+
+  it('NACL present but the entry is gone -> ResourceGoneError (deleted, not skipped)', async () => {
+    ec2.on(DescribeNetworkAclsCommand).resolves({
+      NetworkAcls: [{ NetworkAclId: 'acl-123', Entries: [{ RuleNumber: 999, Egress: false }] }],
+    });
+    await expect(SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](ctx(ingress))).rejects.toBeInstanceOf(
+      ResourceGoneError
+    );
+  });
+
+  it('undefined (skipped) when NetworkAclId is unresolved or identity is missing', async () => {
+    expect(
+      await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](ctx({ RuleNumber: 100, Egress: false }))
+    ).toBeUndefined();
+    expect(
+      await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+        ctx({ NetworkAclId: 'acl-123', Egress: false })
+      )
+    ).toBeUndefined();
+    expect(
+      await SDK_OVERRIDES['AWS::EC2::NetworkAclEntry'](
+        ctx({ NetworkAclId: 'acl-123', RuleNumber: 100 })
+      )
+    ).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Follow-up from the SecurityGroup bug-hunt (PR #430): close the **`AWS::EC2::NetworkAclEntry` Cloud Control read-gap**.

NetworkAclEntry has no Cloud Control read handler — `GetResource` throws `UnsupportedActionException` — so every NACL entry was silently `skipped`. A rule changed out of band (a `CidrBlock` widened, a `RuleAction` flipped allow→deny) was **invisible**: a silent false negative on a security-relevant resource. The `vpc-endpoint-nacl-ebs-rich` fixture surfaced this as `skipped=3`.

## Fix

A new `SDK_OVERRIDES` reader (`readEc2NetworkAclEntry`) reads the parent NACL via EC2 `DescribeNetworkAcls` and picks the entry by its identity (**RuleNumber + Egress** — a NACL holds at most one entry per `(RuleNumber, Egress)` pair). Because an `SDK_OVERRIDES` entry fully replaces the CC `GetResource`, the type is no longer `skipped`.

Field-mapping care points:
- **Protocol**: EC2 returns a numeric **string** (`"6"`) while CFn declares an **integer** (`6`) → coerced with `Number()` so a tcp/udp/icmp rule does not false-drift on a typed-vs-string `Protocol`. (Proven load-bearing by the corpus: `liveRaw.Protocol` is the coerced number, `expected: []`.)
- **Icmp**: EC2 names the field `IcmpTypeCode`; the CFn property is `Icmp` (same `{Code, Type}`).
- `PortRange` / `Icmp` / `CidrBlock` / `Ipv6CidrBlock` projected only when present (protocol-derived, mutually exclusive) → FP-safe.
- A missing entry under a present NACL → `ResourceGoneError` (→ `deleted`, not `skipped`); an unresolved `NetworkAclId` / missing identity → `undefined` (→ `skipped`, fail-open).

## Tests

- **Unit** (`overrides.test.ts`): TCP single-port + decoy-direction match, IPv6 ICMP (`IcmpTypeCode`→`Icmp`), all-protocols (no PortRange/Icmp), entry-gone → `ResourceGoneError`, unresolved-identity → `undefined`.
- **Integration** (`nacl-entry-readgap`): `verify.sh` asserts the entries are **READ, not skipped**, and a recorded NACL is CLEAN (no mapping FP). `verify-detect.sh` proves the previously-silent FN is now **detected** (flip rule 130 `RuleAction` deny→allow → `check` exit 1). NetworkAclEntry has no CC/SDK write path, so it is detect-only (the entry is restored manually).
- **5 golden-corpus cases** (one per entry shape) — replayed offline by `corpus-replay`.
- Full suite green (1868 tests). Stack deployed, then deleted + swept clean.
- README IAM-permission list updated with `ec2:DescribeNetworkAcls`.
