### PR TITLE
fix(noise): fold WAFv2 LoggingConfiguration RedactedFields reorder FP

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1819,6 +1819,20 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
   // folded by the same set-semantics reasoning.
   'AWS::ElastiCache::CacheCluster': new Set(['LogDeliveryConfigurations']),
   'AWS::ElastiCache::ReplicationGroup': new Set(['LogDeliveryConfigurations']),
+  // A WAFv2 LoggingConfiguration's `RedactedFields` is a SET of discriminated-union
+  // FieldToMatch objects ({SingleHeader: {Name}}, {Method: {}}, {QueryString: {}}, …)
+  // that WAF echoes SORTED by the discriminator key, not in template order (declared
+  // [SingleHeader, Method, QueryString] reads back [Method, QueryString, SingleHeader]),
+  // so a positional compare false-flags every shifted field as declared drift on a
+  // freshly recorded LoggingConfiguration. The elements carry NO top-level identity
+  // field (the discriminator IS the single object key, not one of canonicalizeTagListsDeep's
+  // IDENTITY_FIELDS Key/Id/AttributeName/IndexName/Name), so that keyed canonicalizer can't
+  // align them — hence the per-type opt-in. Sorting both sides by canonical JSON aligns
+  // equal fields; a genuine redacted-field add/remove still differs. Observed live on a
+  // fresh wafv2-logging-rich deploy. (The sibling `LoggingFilter.Filters[].Conditions`
+  // set was tested in the SAME deploy with two conditions and WAF PRESERVED their order,
+  // so it is NOT folded — observed-only.)
+  'AWS::WAFv2::LoggingConfiguration': new Set(['RedactedFields']),
 };
 
 // Per-type NESTED array paths AWS returns reordered (dotted from the resource

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2387,6 +2387,38 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('WAFv2 LoggingConfiguration RedactedFields reordered (discriminated-union FieldToMatch set, no identity field, found by wafv2-logging-rich)', () => {
+    const T = 'AWS::WAFv2::LoggingConfiguration';
+    const declared = {
+      RedactedFields: [
+        { SingleHeader: { Name: 'authorization' } },
+        { Method: {} },
+        { QueryString: {} },
+      ],
+    };
+
+    it('WAF returning RedactedFields sorted by discriminator key is NOT drift', () => {
+      // WAF echoes the fields alphabetically by their single object key
+      // (Method, QueryString, SingleHeader) — sorting both sides aligns them.
+      const live = {
+        RedactedFields: [
+          { Method: {} },
+          { QueryString: {} },
+          { SingleHeader: { Name: 'authorization' } },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine redacted-field change still surfaces (no over-fold)', () => {
+      // authorization -> cookie header is a real change to a redacted field.
+      const live = {
+        RedactedFields: [{ Method: {} }, { QueryString: {} }, { SingleHeader: { Name: 'cookie' } }],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('AutoScaling group MetricsCollection.Metrics / NotificationConfigurations.NotificationTypes reordered (nested scalar sets, found by asg-notification-metrics)', () => {
     const T = 'AWS::AutoScaling::AutoScalingGroup';
 

--- a/tests/corpus/AWS__Pipes__Pipe.Pipe_rich.json
+++ b/tests/corpus/AWS__Pipes__Pipe.Pipe_rich.json
@@ -1,0 +1,110 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Pipe",
+    "resourceType": "AWS::Pipes::Pipe",
+    "physicalId": "cdkrd-pipe-rich",
+    "constructPath": "CdkRealDriftIntegPipesRich/Pipe",
+    "declared": {
+      "DesiredState": "RUNNING",
+      "Name": "cdkrd-pipe-rich",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegPipesRich-PipeRole-brptaFh584wa",
+      "Source": "arn:aws:sqs:us-east-1:111111111111:cdkrd-pipe-src",
+      "SourceParameters": {
+        "FilterCriteria": {
+          "Filters": [
+            {
+              "Pattern": "{\"body\":{\"type\":[\"order\"]}}"
+            }
+          ]
+        },
+        "SqsQueueParameters": {
+          "BatchSize": 5,
+          "MaximumBatchingWindowInSeconds": 10
+        }
+      },
+      "Tags": {
+        "env": "hunt",
+        "owner": "cdkrd"
+      },
+      "Target": "arn:aws:sqs:us-east-1:111111111111:cdkrd-pipe-tgt"
+    }
+  },
+  "liveRaw": {
+    "Target": "arn:aws:sqs:us-east-1:111111111111:cdkrd-pipe-tgt",
+    "DesiredState": "RUNNING",
+    "StateReason": "USER_INITIATED",
+    "CurrentState": "RUNNING",
+    "CreationTime": "2026-06-30T10:03:17Z",
+    "LastModifiedTime": "2026-06-30T10:03:36Z",
+    "Arn": "arn:aws:pipes:us-east-1:111111111111:pipe/cdkrd-pipe-rich",
+    "EnrichmentParameters": {},
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegPipesRich-PipeRole-brptaFh584wa",
+    "Source": "arn:aws:sqs:us-east-1:111111111111:cdkrd-pipe-src",
+    "Tags": {
+      "owner": "cdkrd",
+      "env": "hunt"
+    },
+    "Name": "cdkrd-pipe-rich"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreationTime", "CurrentState", "LastModifiedTime", "StateReason"],
+    "writeOnly": ["SourceParameters", "TargetParameters"],
+    "createOnly": ["Name", "Source"],
+    "readOnlyPaths": ["Arn", "CreationTime", "CurrentState", "LastModifiedTime", "StateReason"],
+    "writeOnlyPaths": ["SourceParameters", "TargetParameters"],
+    "createOnlyPaths": [
+      "Name",
+      "Source",
+      "SourceParameters.ActiveMQBrokerParameters.QueueName",
+      "SourceParameters.DynamoDBStreamParameters.StartingPosition",
+      "SourceParameters.KinesisStreamParameters.StartingPosition",
+      "SourceParameters.KinesisStreamParameters.StartingPositionTimestamp",
+      "SourceParameters.ManagedStreamingKafkaParameters.ConsumerGroupID",
+      "SourceParameters.ManagedStreamingKafkaParameters.StartingPosition",
+      "SourceParameters.ManagedStreamingKafkaParameters.TopicName",
+      "SourceParameters.RabbitMQBrokerParameters.QueueName",
+      "SourceParameters.RabbitMQBrokerParameters.VirtualHost",
+      "SourceParameters.SelfManagedKafkaParameters.AdditionalBootstrapServers",
+      "SourceParameters.SelfManagedKafkaParameters.ConsumerGroupID",
+      "SourceParameters.SelfManagedKafkaParameters.StartingPosition",
+      "SourceParameters.SelfManagedKafkaParameters.TopicName"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "TargetParameters.EcsTaskParameters.CapacityProviderStrategy.*.Weight": 0,
+      "TargetParameters.EcsTaskParameters.CapacityProviderStrategy.*.Base": 0,
+      "TargetParameters.EcsTaskParameters.EnableECSManagedTags": false,
+      "TargetParameters.EcsTaskParameters.EnableExecuteCommand": false,
+      "TargetParameters.EcsTaskParameters.Overrides.EphemeralStorage.SizeInGiB": 0,
+      "TargetParameters.BatchJobParameters.ArrayProperties.Size": 0,
+      "TargetParameters.BatchJobParameters.RetryStrategy.Attempts": 0,
+      "TargetParameters.RedshiftDataParameters.WithEvent": false
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": [
+      "EnrichmentParameters.HttpParameters.HeaderParameters",
+      "EnrichmentParameters.HttpParameters.QueryStringParameters",
+      "TargetParameters.BatchJobParameters.Parameters",
+      "TargetParameters.HttpParameters.HeaderParameters",
+      "TargetParameters.HttpParameters.QueryStringParameters"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Pipe",
+      "resourceType": "AWS::Pipes::Pipe",
+      "path": "SourceParameters",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-pipe-rich",
+      "constructPath": "CdkRealDriftIntegPipesRich/Pipe"
+    }
+  ]
+}

--- a/tests/corpus/AWS__SNS__Subscription.Subscription_redrive.json
+++ b/tests/corpus/AWS__SNS__Subscription.Subscription_redrive.json
@@ -1,0 +1,63 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Subscription",
+    "resourceType": "AWS::SNS::Subscription",
+    "physicalId": "arn:aws:sns:us-east-1:111111111111:cdkrd-sub-topic:e8767dde-8b81-4fd8-8dec-5937bcc4fa85",
+    "constructPath": "CdkRealDriftIntegSnsSubscriptionRich/Subscription",
+    "declared": {
+      "Endpoint": "arn:aws:sqs:us-east-1:111111111111:cdkrd-sub-queue",
+      "FilterPolicy": {
+        "eventType": ["order_placed", "order_cancelled"],
+        "priority": [
+          {
+            "numeric": [">=", 5]
+          }
+        ]
+      },
+      "FilterPolicyScope": "MessageAttributes",
+      "Protocol": "sqs",
+      "RawMessageDelivery": true,
+      "RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:111111111111:cdkrd-sub-dlq\"}",
+      "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-sub-topic"
+    }
+  },
+  "liveRaw": {
+    "RawMessageDelivery": true,
+    "Endpoint": "arn:aws:sqs:us-east-1:111111111111:cdkrd-sub-queue",
+    "FilterPolicy": {
+      "eventType": ["order_placed", "order_cancelled"],
+      "priority": [
+        {
+          "numeric": [">=", 5]
+        }
+      ]
+    },
+    "TopicArn": "arn:aws:sns:us-east-1:111111111111:cdkrd-sub-topic",
+    "RedrivePolicy": {
+      "deadLetterTargetArn": "arn:aws:sqs:us-east-1:111111111111:cdkrd-sub-dlq"
+    },
+    "FilterPolicyScope": "MessageAttributes",
+    "Arn": "arn:aws:sns:us-east-1:111111111111:cdkrd-sub-topic:e8767dde-8b81-4fd8-8dec-5937bcc4fa85",
+    "Protocol": "sqs"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["Region"],
+    "createOnly": ["Endpoint", "Protocol", "TopicArn"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["Region"],
+    "createOnlyPaths": ["Endpoint", "Protocol", "TopicArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__WAFv2__LoggingConfiguration.WafLogging.json
+++ b/tests/corpus/AWS__WAFv2__LoggingConfiguration.WafLogging.json
@@ -1,0 +1,109 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WafLogging",
+    "resourceType": "AWS::WAFv2::LoggingConfiguration",
+    "physicalId": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-wafv2-logging/76687f9a-e850-41d9-8125-40247134c290",
+    "constructPath": "CdkRealDriftIntegWafv2LoggingRich/WafLogging",
+    "declared": {
+      "LogDestinationConfigs": [
+        "arn:aws:logs:us-east-1:111111111111:log-group:aws-waf-logs-cdkrd-rich"
+      ],
+      "LoggingFilter": {
+        "DefaultBehavior": "KEEP",
+        "Filters": [
+          {
+            "Behavior": "DROP",
+            "Requirement": "MEETS_ANY",
+            "Conditions": [
+              {
+                "ActionCondition": {
+                  "Action": "COUNT"
+                }
+              },
+              {
+                "ActionCondition": {
+                  "Action": "BLOCK"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "RedactedFields": [
+        {
+          "SingleHeader": {
+            "Name": "authorization"
+          }
+        },
+        {
+          "Method": {}
+        },
+        {
+          "QueryString": {}
+        }
+      ],
+      "ResourceArn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-wafv2-logging/76687f9a-e850-41d9-8125-40247134c290"
+    }
+  },
+  "liveRaw": {
+    "ResourceArn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-wafv2-logging/76687f9a-e850-41d9-8125-40247134c290",
+    "LogDestinationConfigs": [
+      "arn:aws:logs:us-east-1:111111111111:log-group:aws-waf-logs-cdkrd-rich"
+    ],
+    "ManagedByFirewallManager": false,
+    "RedactedFields": [
+      {
+        "Method": {}
+      },
+      {
+        "QueryString": {}
+      },
+      {
+        "SingleHeader": {
+          "Name": "authorization"
+        }
+      }
+    ],
+    "LoggingFilter": {
+      "Filters": [
+        {
+          "Requirement": "MEETS_ANY",
+          "Behavior": "DROP",
+          "Conditions": [
+            {
+              "ActionCondition": {
+                "Action": "COUNT"
+              }
+            },
+            {
+              "ActionCondition": {
+                "Action": "BLOCK"
+              }
+            }
+          ]
+        }
+      ],
+      "DefaultBehavior": "KEEP"
+    }
+  },
+  "schema": {
+    "readOnly": ["ManagedByFirewallManager"],
+    "writeOnly": [],
+    "createOnly": ["ResourceArn"],
+    "readOnlyPaths": ["ManagedByFirewallManager"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ResourceArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/pipes-rich/app.ts
+++ b/tests/integration/pipes-rich/app.ts
@@ -1,0 +1,70 @@
+// CDK app for the cdk-real-drift EventBridge Pipes false-positive test. A Pipe
+// (source -> optional filter/enrichment -> target) is a common point-to-point
+// integration. It packs the FP-prone surfaces: nested SourceParameters /
+// TargetParameters bags with enums (BatchSize, MaximumBatchingWindowInSeconds),
+// a FilterCriteria whose Pattern is a JSON-STRING (object-vs-string shape), and
+// the standard Tags map. A freshly deployed + recorded Pipe with NO out-of-band
+// change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnQueue } from "aws-cdk-lib/aws-sqs";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnPipe } from "aws-cdk-lib/aws-pipes";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegPipesRich");
+
+const source = new CfnQueue(stack, "SourceQueue", { queueName: "cdkrd-pipe-src" });
+const target = new CfnQueue(stack, "TargetQueue", { queueName: "cdkrd-pipe-tgt" });
+
+const role = new CfnRole(stack, "PipeRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "pipes.amazonaws.com" },
+        Action: "sts:AssumeRole",
+      },
+    ],
+  },
+  policies: [
+    {
+      policyName: "pipe",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: ["sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes"],
+            Resource: source.attrArn,
+          },
+          {
+            Effect: "Allow",
+            Action: ["sqs:SendMessage"],
+            Resource: target.attrArn,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+new CfnPipe(stack, "Pipe", {
+  name: "cdkrd-pipe-rich",
+  roleArn: role.attrArn,
+  source: source.attrArn,
+  target: target.attrArn,
+  desiredState: "RUNNING",
+  sourceParameters: {
+    sqsQueueParameters: {
+      batchSize: 5,
+      maximumBatchingWindowInSeconds: 10,
+    },
+    // FilterCriteria.Filter.Pattern is a JSON-STRING in CFn — exercises the
+    // object-vs-JSON-string shape class.
+    filterCriteria: {
+      filters: [{ pattern: '{"body":{"type":["order"]}}' }],
+    },
+  },
+  tags: { owner: "cdkrd", env: "hunt" },
+});

--- a/tests/integration/pipes-rich/cdk.json
+++ b/tests/integration/pipes-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/pipes-rich/package.json
+++ b/tests/integration/pipes-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-pipes-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift pipes-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/pipes-rich/verify.sh
+++ b/tests/integration/pipes-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegPipesRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/sns-subscription-rich/app.ts
+++ b/tests/integration/sns-subscription-rich/app.ts
@@ -1,0 +1,48 @@
+// CDK app for the cdk-real-drift standalone SNS Subscription false-positive test.
+// A standalone AWS::SNS::Subscription (topic -> SQS) with a FilterPolicy is one of
+// the most common fan-out patterns. It packs the FP-prone surfaces: FilterPolicy
+// (declared as a JSON OBJECT, often read back as a JSON-STRING — the object-vs-string
+// shape class), RedrivePolicy (a JSON-string with an ARN), RawMessageDelivery (a
+// boolean), and FilterPolicyScope (an enum). A freshly deployed + recorded
+// Subscription with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnTopic, CfnSubscription } from "aws-cdk-lib/aws-sns";
+import { CfnQueue, CfnQueuePolicy } from "aws-cdk-lib/aws-sqs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSnsSubscriptionRich");
+
+const topic = new CfnTopic(stack, "Topic", { topicName: "cdkrd-sub-topic" });
+const queue = new CfnQueue(stack, "Queue", { queueName: "cdkrd-sub-queue" });
+const dlq = new CfnQueue(stack, "Dlq", { queueName: "cdkrd-sub-dlq" });
+
+new CfnQueuePolicy(stack, "QueuePolicy", {
+  queues: [queue.ref],
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { Service: "sns.amazonaws.com" },
+        Action: "sqs:SendMessage",
+        Resource: queue.attrArn,
+        Condition: { ArnEquals: { "aws:SourceArn": topic.ref } },
+      },
+    ],
+  },
+});
+
+new CfnSubscription(stack, "Subscription", {
+  topicArn: topic.ref,
+  protocol: "sqs",
+  endpoint: queue.attrArn,
+  rawMessageDelivery: true,
+  filterPolicyScope: "MessageAttributes",
+  // Declared as a JSON OBJECT — the object-vs-JSON-string shape class.
+  filterPolicy: {
+    eventType: ["order_placed", "order_cancelled"],
+    priority: [{ numeric: [">=", 5] }],
+  },
+  // RedrivePolicy is a JSON-STRING with a dead-letter ARN.
+  redrivePolicy: JSON.stringify({ deadLetterTargetArn: dlq.attrArn }),
+});

--- a/tests/integration/sns-subscription-rich/cdk.json
+++ b/tests/integration/sns-subscription-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/sns-subscription-rich/package.json
+++ b/tests/integration/sns-subscription-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-sns-subscription-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift sns-subscription-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/sns-subscription-rich/verify-detect.sh
+++ b/tests/integration/sns-subscription-rich/verify-detect.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Standalone SNS Subscription detect + revert (real AWS). Drift the declared MUTABLE
+# RawMessageDelivery true->false out of band (the "someone flipped it in the console"
+# scenario) -> check MUST DETECT -> revert (Cloud Control SetSubscriptionAttributes)
+# -> CLEAN + restored to true.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegSnsSubscriptionRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+export AWS_CLI_AUTO_PROMPT=off
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+TOPIC="$(aws sns list-topics --region "$REGION" --query "Topics[?contains(TopicArn,'cdkrd-sub-topic')].TopicArn" --output text)"
+[ -n "$TOPIC" ] && [ "$TOPIC" != "None" ] || fail "no topic arn"
+SUB="$(aws sns list-subscriptions-by-topic --topic-arn "$TOPIC" --region "$REGION" --query "Subscriptions[0].SubscriptionArn" --output text)"
+[ -n "$SUB" ] && [ "$SUB" != "None" ] || fail "no subscription arn"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob RawMessageDelivery true->false ==="
+aws sns set-subscription-attributes --subscription-arn "$SUB" --attribute-name RawMessageDelivery --attribute-value false --region "$REGION" || fail inject
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-sns-sub-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "RawMessageDelivery" /tmp/cdkrd-sns-sub-detect.out || fail "drift not reported"
+echo "=== revert (Cloud Control SetSubscriptionAttributes) ==="; $CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-sns-sub-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-sns-sub-revert.out || fail "revert did not converge"
+GOT="$(aws sns get-subscription-attributes --subscription-arn "$SUB" --region "$REGION" --query 'Attributes.RawMessageDelivery' --output text)"
+[ "$GOT" = "true" ] || fail "RawMessageDelivery not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/sns-subscription-rich/verify.sh
+++ b/tests/integration/sns-subscription-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSnsSubscriptionRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/wafv2-logging-rich/app.ts
+++ b/tests/integration/wafv2-logging-rich/app.ts
@@ -1,0 +1,78 @@
+// CDK app for the cdk-real-drift WAFv2 LoggingConfiguration false-positive test.
+// WAF logging (to a CloudWatch `aws-waf-logs-*` group) is a daily compliance setup
+// for any WebACL. It packs the FP-prone surfaces: RedactedFields (a set-like array
+// of FieldToMatch objects) and LoggingFilter.Filters[].Conditions[] (nested object
+// arrays) that AWS may default-fill / re-serialize / reorder server-side. A freshly
+// deployed + recorded LoggingConfiguration with NO out-of-band change MUST be CLEAN.
+import { App, Aws, Stack } from "aws-cdk-lib";
+import { CfnLogGroup } from "aws-cdk-lib/aws-logs";
+import { CfnLoggingConfiguration, CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2LoggingRich");
+
+const acl = new CfnWebACL(stack, "WebAcl", {
+  name: "cdkrd-wafv2-logging",
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdLogWebAcl",
+  },
+  rules: [
+    {
+      name: "AWSCommon",
+      priority: 0,
+      overrideAction: { none: {} },
+      statement: {
+        managedRuleGroupStatement: {
+          vendorName: "AWS",
+          name: "AWSManagedRulesCommonRuleSet",
+        },
+      },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "AWSCommon",
+      },
+    },
+  ],
+});
+
+// WAF logging requires the destination CloudWatch log group name to start with
+// `aws-waf-logs-`. The LoggingConfiguration destination ARN must NOT carry the
+// trailing `:*` that CfnLogGroup.attrArn includes, so build it explicitly.
+const logGroup = new CfnLogGroup(stack, "WafLogGroup", {
+  logGroupName: "aws-waf-logs-cdkrd-rich",
+  retentionInDays: 7,
+});
+const logGroupArn = `arn:${Aws.PARTITION}:logs:${Aws.REGION}:${Aws.ACCOUNT_ID}:log-group:aws-waf-logs-cdkrd-rich`;
+
+const logging = new CfnLoggingConfiguration(stack, "WafLogging", {
+  resourceArn: acl.attrArn,
+  logDestinationConfigs: [logGroupArn],
+  // RedactedFields declared NON-sorted and with three distinct shapes — a set-like
+  // array AWS may reorder. authorization header, then method, then query string.
+  redactedFields: [
+    { singleHeader: { Name: "authorization" } },
+    { method: {} },
+    { queryString: {} },
+  ],
+  // Nested filter with two conditions in a deliberate order — exercises descent into
+  // LoggingFilter.Filters[].Conditions[] (a nested object array).
+  loggingFilter: {
+    DefaultBehavior: "KEEP",
+    Filters: [
+      {
+        Behavior: "DROP",
+        Requirement: "MEETS_ANY",
+        Conditions: [
+          { ActionCondition: { Action: "COUNT" } },
+          { ActionCondition: { Action: "BLOCK" } },
+        ],
+      },
+    ],
+  },
+});
+logging.addDependency(logGroup);

--- a/tests/integration/wafv2-logging-rich/cdk.json
+++ b/tests/integration/wafv2-logging-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-logging-rich/package.json
+++ b/tests/integration/wafv2-logging-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-logging-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-logging-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-logging-rich/verify.sh
+++ b/tests/integration/wafv2-logging-rich/verify.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2LoggingRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

Bug-hunt round: deploy 3 uncovered common types against real AWS, catch FP/FN.

**Real FP found + fixed** — WAFv2 `LoggingConfiguration.RedactedFields` is a set-like array of discriminated-union `FieldToMatch` objects (`{SingleHeader}`, `{Method}`, `{QueryString}`) that WAF echoes SORTED by the discriminator key, not in template order. Declared `[SingleHeader, Method, QueryString]` reads back `[Method, QueryString, SingleHeader]` → a positional compare false-flagged **3 phantom declared drifts** on a freshly recorded LoggingConfiguration. The elements carry no top-level `IDENTITY_FIELD`, so `canonicalizeTagListsDeep` can't align them → added the per-type opt-in to `UNORDERED_OBJECT_ARRAY_PROPS`. Live-proven: 3 drifts → CLEAN after fix.

The sibling `LoggingFilter.Filters[].Conditions` set was tested in the same deploy and WAF **preserved** its order, so it is not folded (observed-only).

## Also in this PR

- **pipes-rich** (EventBridge Pipes) and **sns-subscription-rich** (standalone SNS Subscription) fixtures — both CLEAN, FP-free across rich nested params / JSON-string FilterCriteria / FilterPolicy object / RedrivePolicy.
- **FN regression**: SNS Subscription `RawMessageDelivery` true→false detect → revert (Cloud Control) → CLEAN + restored. Live-proven.
- **Golden corpus**: WAFv2 LoggingConfiguration (new type — the fix's offline regression), Pipes Pipe (rich FilterCriteria/Tags), SNS Subscription (RedrivePolicy/FilterPolicyScope).

## Tests

- `tests/classify.test.ts`: RedactedFields reorder-NOT-drift + genuine-change-still-surfaces.
- `tests/corpus-replay`: 3 new cases replay clean (511 total).
- Full suite: 1880 passing.

## Cleanup

All 3 stacks deleted via delstack; `bughunt-track.sh verify` → all gone + SWEEP CLEAN.