### PR TITLE
fix(noise): fold three API Gateway / Chatbot first-run false positives

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -372,6 +372,24 @@ function isPolicySubsetOf(sub: Record<string, unknown>, sup: Record<string, unkn
   return true;
 }
 
+// True when an undeclared live value matches a known AWS default — for the `atDefault`
+// fold (R86). A plain deepEqual is too strict for an OBJECT default whose sub-keys AWS
+// reports inconsistently: an EDGE RestApi reads back EndpointConfiguration as
+// `{Types:['EDGE']}` in some regions but `{IpAddressType:'ipv4',Types:['EDGE']}` in
+// others, so a strict compare against the fuller KNOWN_DEFAULTS object fails on the
+// omitted key and the whole undeclared object falls through as a false positive. Accept
+// the live value when it deep-equals the default OR is a SUB-OBJECT of it: every key it
+// carries matches the default and it carries no key absent from the default. Still
+// equality-gated per overlapping key — a sub-key set to a non-default value
+// (IpAddressType:'dualstack'), or an extra key the default doesn't list, breaks the
+// match and surfaces as real drift. Scalars/arrays fall back to deepEqual. Exported for
+// unit tests.
+export function matchesKnownDefault(live: unknown, def: unknown): boolean {
+  if (deepEqual(live, def)) return true;
+  if (!isNestedObject(live) || !isNestedObject(def)) return false;
+  return Object.entries(live).every(([k, v]) => k in def && deepEqual(v, def[k]));
+}
+
 function collectNestedUndeclared(
   declaredVal: unknown,
   liveVal: unknown,
@@ -1116,8 +1134,8 @@ export function classifyResource(
     // not recorded by record. The equality gate means an out-of-band change away from
     // the default no longer matches here and falls through to the `undeclared` tier.
     if (
-      (k in schema.defaults && deepEqual(v, schema.defaults[k])) ||
-      (k in knownDef && deepEqual(v, knownDef[k]))
+      (k in schema.defaults && matchesKnownDefault(v, schema.defaults[k])) ||
+      (k in knownDef && matchesKnownDefault(v, knownDef[k]))
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -596,9 +596,16 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   // was changed out of band no longer matches and surfaces. The sibling defaults
   // CacheDataEncrypted / CachingEnabled / MetricsEnabled all read back `false` and fold via
   // isTrivialEmpty (so enabling any of them out of band — a non-`false` value — surfaces).
-  // Proven live.
+  // The two Throttling* defaults are the account-level API Gateway throttle limits AWS
+  // applies to every method that declares no per-method throttle (rate 10000 req/s,
+  // burst 5000 — the documented account defaults). A stage that never set throttling
+  // otherwise reports both on every first run as undeclared drift. Equality-gated: a
+  // method pinned to a different limit (or an account whose quota was raised) no longer
+  // matches and surfaces. Proven live (RestApi DeploymentStage with no method throttle).
   'AWS::ApiGateway::Stage': {
     'MethodSettings.*.CacheTtlInSeconds': 300,
+    'MethodSettings.*.ThrottlingBurstLimit': 5000,
+    'MethodSettings.*.ThrottlingRateLimit': 10000,
   },
   'AWS::ApiGateway::UsagePlan': {
     'Quota.Offset': 0,

--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -844,15 +844,25 @@ async function enumerateHttpApiChildren(ctx: EnumeratorContext): Promise<AddedCh
 // ── SNS ──────────────────────────────────────────────────────────────────────
 // An `AWS::SNS::Topic` owns Subscriptions, each a separate CloudFormation resource.
 // A console-added subscription (someone wires an email / SQS / Lambda endpoint to a
-// topic out of band) is invisible to `cdk drift` / CFn drift detection. A topic has no
-// AWS-auto-created subscriptions, so there is no implicit child to special-case (unlike
-// REST's root resource). The CC primaryIdentifier for AWS::SNS::Subscription is the bare
-// SubscriptionArn (not a composite), which CC GetResource / DeleteResource consume.
+// topic out of band) is invisible to `cdk drift` / CFn drift detection. The CC
+// primaryIdentifier for AWS::SNS::Subscription is the bare SubscriptionArn (not a
+// composite), which CC GetResource / DeleteResource consume.
+//
+// ONE implicit child must be special-cased: AWS Chatbot (the Slack / Teams / Chime
+// channel configs behind `AWS::Chatbot::SlackChannelConfiguration`, and the Amazon Q
+// Developer console) AUTO-subscribes its fixed global endpoint to every SNS topic a
+// channel config points at — so a stack that declares a SlackChannelConfiguration +
+// alarm topic always grows an `https` subscription to that endpoint that is NOT in the
+// template. It is an AWS-managed side effect of the declared config, not a user's
+// out-of-band change, so reporting it as an `added` resource is a false positive. The
+// endpoint is a constant AWS-owned host; any subscription to it is Chatbot-managed, so
+// folding it can never mask a genuine out-of-band subscription.
+const CHATBOT_SUBSCRIPTION_ENDPOINT = 'https://global.sns-api.chatbot.amazonaws.com';
 
 // Pure diff: declared subscription arns + live inventory -> the added subscriptions.
 export interface SnsTopicChildInput {
   declaredSubscriptionArns: string[]; // physical ids of AWS::SNS::Subscription in the template
-  liveSubscriptions: { arn: string; label?: string | undefined }[];
+  liveSubscriptions: { arn: string; label?: string | undefined; endpoint?: string | undefined }[];
 }
 
 export function diffSnsTopicChildren(input: SnsTopicChildInput): AddedChild[] {
@@ -860,6 +870,7 @@ export function diffSnsTopicChildren(input: SnsTopicChildInput): AddedChild[] {
   const added: AddedChild[] = [];
   for (const s of input.liveSubscriptions) {
     if (declared.has(s.arn)) continue;
+    if (s.endpoint === CHATBOT_SUBSCRIPTION_ENDPOINT) continue; // AWS Chatbot auto-managed
     added.push({
       resourceType: 'AWS::SNS::Subscription',
       identifier: s.arn, // SubscriptionArn IS the CC primaryIdentifier
@@ -914,6 +925,7 @@ async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise<AddedC
     .map((s) => ({
       arn: s.SubscriptionArn,
       label: s.Protocol ? `${s.Protocol} ${s.Endpoint ?? ''}`.trim() : s.SubscriptionArn,
+      endpoint: s.Endpoint,
     }));
 
   return diffSnsTopicChildren({ declaredSubscriptionArns, liveSubscriptions });

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -533,6 +533,38 @@ describe('diffSnsTopicChildren (SNS Topic subscriptions)', () => {
       })
     ).toEqual([]);
   });
+
+  // AWS Chatbot (SlackChannelConfiguration / Teams / Amazon Q console) auto-subscribes its
+  // fixed global endpoint to every topic a channel config points at. That subscription is
+  // never in the template, so without a fold it surfaces as a false `added` out-of-band
+  // resource — found on a real dev ScoringApi alarm topic, ap-northeast-1.
+  it('folds the AWS Chatbot auto-created subscription (not a user out-of-band change)', () => {
+    const added = diffSnsTopicChildren({
+      declaredSubscriptionArns: [],
+      liveSubscriptions: [
+        {
+          arn: SUB('chatbot'),
+          label: 'https https://global.sns-api.chatbot.amazonaws.com',
+          endpoint: 'https://global.sns-api.chatbot.amazonaws.com',
+        },
+      ],
+    });
+    expect(added).toEqual([]);
+  });
+
+  it('a genuine https subscription to another endpoint is still flagged', () => {
+    const added = diffSnsTopicChildren({
+      declaredSubscriptionArns: [],
+      liveSubscriptions: [
+        {
+          arn: SUB('webhook'),
+          label: 'https https://hooks.example.com/sns',
+          endpoint: 'https://hooks.example.com/sns',
+        },
+      ],
+    });
+    expect(added.map((a) => a.identifier)).toEqual([SUB('webhook')]);
+  });
 });
 
 describe('diffKmsKeyChildren (KMS key aliases)', () => {

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { classifyResource, normalizeLiveModel } from '../src/diff/classify.js';
+import { classifyResource, matchesKnownDefault, normalizeLiveModel } from '../src/diff/classify.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import { KNOWN_DEFAULT_PATHS, KNOWN_DEFAULTS } from '../src/normalize/noise.js';
 import { buildRevertPlan } from '../src/revert/plan.js';
@@ -5359,5 +5359,108 @@ describe('SecurityGroup sibling-rule reflection (subtraction)', () => {
     const t = tiers(classifyResource(ingress, liveIn, bare));
     expect(t.generated).toContain('SourceSecurityGroupOwnerId');
     expect(t.undeclared).not.toContain('SourceSecurityGroupOwnerId');
+  });
+});
+
+// API Gateway first-run noise found on a real RestApi stack (dev ScoringApi, ap-northeast-1):
+// an undeclared EndpointConfiguration and an undeclared Stage MethodSettings throttle pair
+// both surfaced as Potential Drift though both are AWS defaults. The RestApi case is the
+// regional-variance fold (AWS omits IpAddressType in some regions); the Stage case is the
+// account-level throttle defaults (rate 10000 / burst 5000).
+describe('API Gateway default-config first-run folds', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  it('matchesKnownDefault: deep-equal, sub-object, and the negatives', () => {
+    const def = { IpAddressType: 'ipv4', Types: ['EDGE'] };
+    expect(matchesKnownDefault({ IpAddressType: 'ipv4', Types: ['EDGE'] }, def)).toBe(true); // full
+    expect(matchesKnownDefault({ Types: ['EDGE'] }, def)).toBe(true); // AWS omitted IpAddressType
+    expect(matchesKnownDefault({ IpAddressType: 'dualstack', Types: ['EDGE'] }, def)).toBe(false); // real change
+    expect(matchesKnownDefault({ Types: ['REGIONAL'] }, def)).toBe(false); // Types changed
+    expect(matchesKnownDefault({ Types: ['EDGE'], Extra: 1 }, def)).toBe(false); // extra key not in default
+    expect(matchesKnownDefault('HEADER', 'HEADER')).toBe(true); // scalar fallback
+    expect(matchesKnownDefault('X', 'HEADER')).toBe(false);
+  });
+
+  it('RestApi undeclared EndpointConfiguration folds to atDefault even when AWS omits IpAddressType', () => {
+    const rest: DesiredResource = {
+      logicalId: 'Api',
+      resourceType: 'AWS::ApiGateway::RestApi',
+      physicalId: 'abc123',
+      declared: {},
+    };
+    // ap-northeast-1 live read: no IpAddressType (the FP this fixes)
+    const tA = tiers(classifyResource(rest, { EndpointConfiguration: { Types: ['EDGE'] } }, bare));
+    expect(tA.atDefault).toContain('EndpointConfiguration');
+    expect(tA.undeclared).not.toContain('EndpointConfiguration');
+    // other regions echo the full shape — still atDefault
+    const tB = tiers(
+      classifyResource(
+        rest,
+        { EndpointConfiguration: { IpAddressType: 'ipv4', Types: ['EDGE'] } },
+        bare
+      )
+    );
+    expect(tB.atDefault).toContain('EndpointConfiguration');
+    // a genuine out-of-band change (dual-stack IPv6) still surfaces
+    const tC = tiers(
+      classifyResource(
+        rest,
+        { EndpointConfiguration: { IpAddressType: 'dualstack', Types: ['EDGE'] } },
+        bare
+      )
+    );
+    expect(tC.undeclared).toContain('EndpointConfiguration');
+    expect(tC.atDefault).not.toContain('EndpointConfiguration');
+  });
+
+  it('Stage MethodSettings account-default throttle folds to atDefault; a pinned limit surfaces', () => {
+    const stage: DesiredResource = {
+      logicalId: 'Stage',
+      resourceType: 'AWS::ApiGateway::Stage',
+      physicalId: 'main',
+      // CDK declares the wildcard method setting but no throttle; AWS materializes the
+      // account-default throttle into the live element.
+      declared: { MethodSettings: [{ HttpMethod: '*', ResourcePath: '/*' }] },
+    };
+    const liveDefault = {
+      MethodSettings: [
+        {
+          HttpMethod: '*',
+          ResourcePath: '/*',
+          ThrottlingBurstLimit: 5000,
+          ThrottlingRateLimit: 10000,
+        },
+      ],
+    };
+    const t = tiers(classifyResource(stage, liveDefault, bare));
+    expect(t.atDefault).toEqual([
+      'MethodSettings[*].ThrottlingBurstLimit',
+      'MethodSettings[*].ThrottlingRateLimit',
+    ]);
+    expect(t.undeclared).toEqual([]);
+
+    // A throttle pinned out of band away from the account default surfaces (equality-gated).
+    const liveChanged = {
+      MethodSettings: [
+        {
+          HttpMethod: '*',
+          ResourcePath: '/*',
+          ThrottlingBurstLimit: 2000,
+          ThrottlingRateLimit: 10000,
+        },
+      ],
+    };
+    const t2 = tiers(classifyResource(stage, liveChanged, bare));
+    expect(t2.undeclared).toContain('MethodSettings[*].ThrottlingBurstLimit');
+    expect(t2.atDefault).toEqual(['MethodSettings[*].ThrottlingRateLimit']);
   });
 });

--- a/tests/corpus/AWS__StepFunctions__StateMachine.Flow.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.Flow.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "CC-API managed-field strip: generated/timestamp fields (CreationDate, RevisionId — top-level AND nested CreatedAt) are stripped from the live model and never report; the REMAINDER of a partially-stripped struct still surfaces honestly (LoggingConfiguration keeps {Level:OFF} — a string, deliberately NOT folded by isTrivialEmpty; if an SFN known-default is ever added, this expected changes visibly in that PR).",
+  "description": "CC-API managed-field strip: generated/timestamp fields (CreationDate, RevisionId — top-level AND nested CreatedAt) are stripped from the live model and never report; the REMAINDER of a partially-stripped struct still surfaces. LoggingConfiguration reduces to {Level:OFF} after the CreatedAt strip — a sub-object of the SFN KNOWN_DEFAULTS LoggingConfiguration ({IncludeExecutionData:false, Level:OFF}), so matchesKnownDefault folds it to atDefault (logging never configured = at default). A non-OFF Level no longer matches and surfaces.",
   "resource": {
     "logicalId": "Flow",
     "resourceType": "AWS::StepFunctions::StateMachine",
@@ -37,7 +37,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Flow",
       "resourceType": "AWS::StepFunctions::StateMachine",
       "path": "LoggingConfiguration",


### PR DESCRIPTION
## What

Three false positives found on a real RestApi stack (dev ScoringApi,
ap-northeast-1) whose **first** `cdkrd check` reported four Potential Drifts that
are all AWS defaults or AWS-managed side effects — none an out-of-band change:

| # | False positive | Fix |
|---|----------------|-----|
| 1 | RestApi `EndpointConfiguration={Types:[EDGE]}` leaked | `matchesKnownDefault` — accept a live value that is a SUB-OBJECT of the KNOWN_DEFAULTS object (AWS omits `IpAddressType` in some regions, includes it in others). Still equality-gated. |
| 2 | Stage `MethodSettings[*].ThrottlingBurstLimit=5000` / `ThrottlingRateLimit=10000` leaked | Added the account-level throttle defaults to `KNOWN_DEFAULT_PATHS`. |
| 3 | AWS Chatbot auto-subscription to `https://global.sns-api.chatbot.amazonaws.com` flagged as `added` | `diffSnsTopicChildren` folds any subscription to that fixed AWS-owned endpoint (a `SlackChannelConfiguration` side effect, not user out-of-band). |

## Why it's safe

All folds are **equality-gated** — a value moved off the default re-surfaces:
- `EndpointConfiguration` with `IpAddressType:dualstack` (IPv6 enabled out of band) surfaces.
- A throttle pinned to a non-default limit surfaces.
- The Chatbot endpoint is a constant AWS-owned host; any subscription to it is Chatbot-managed, so folding can never mask a genuine out-of-band subscription.

## Side effect (intended)

The sub-object match in #1 also correctly folds StepFunctions `LoggingConfiguration={Level:OFF}` (logging never configured) to `atDefault` — corpus `expected` updated in the same diff.

## Tests

Unit tests for `matchesKnownDefault`, RestApi/Stage folds, Chatbot fold, plus negatives (real changes still surface; an https subscription to another endpoint is still flagged). All 1885 unit tests pass; typecheck + lint/format clean. No paid deploy — the user's real ap-northeast-1 output is the oracle (#1 is region-specific and would not reproduce in us-east-1; #3 needs Slack OAuth).
