### PR TITLE
fix(noise): apply subset-tolerant default match to the nested atDefault compare

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1251,10 +1251,15 @@ export function classifyResource(
       (path, value) => {
         if (isAllAwsTags(value) || isTrivialEmpty(value)) return;
         const schemaPath = path.replace(/\[[^\]]*\]/g, '.*');
+        // Same subset-tolerant default match as the top-level atDefault compare: an
+        // OBJECT-valued nested default (CloudFront GeoRestriction, Scheduler RetryPolicy,
+        // Cognito SignInPolicy, …) that AWS returns with a sub-key omitted still folds,
+        // while a sub-key changed away from the default — or an extra key — surfaces.
+        // Falls back to deepEqual for scalars/arrays, so nothing else changes.
         const atDefault =
           (schemaPath in schema.defaultPaths &&
-            deepEqual(value, schema.defaultPaths[schemaPath])) ||
-          (schemaPath in knownDefPaths && deepEqual(value, knownDefPaths[schemaPath]));
+            matchesKnownDefault(value, schema.defaultPaths[schemaPath])) ||
+          (schemaPath in knownDefPaths && matchesKnownDefault(value, knownDefPaths[schemaPath]));
         const tier = atDefault
           ? 'atDefault'
           : // R142: a GENERATED_PATHS value folds as `generated` ONLY when it echoes a

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5463,4 +5463,40 @@ describe('API Gateway default-config first-run folds', () => {
     expect(t2.undeclared).toContain('MethodSettings[*].ThrottlingBurstLimit');
     expect(t2.atDefault).toEqual(['MethodSettings[*].ThrottlingRateLimit']);
   });
+
+  // The nested atDefault compare uses the SAME subset-tolerant match as the top-level
+  // one, so an OBJECT-valued nested default (KNOWN_DEFAULT_PATHS) that AWS returns with a
+  // sub-key omitted folds too — the nested twin of the RestApi EndpointConfiguration fix.
+  it('nested object default folds to atDefault when AWS omits a sub-key (Scheduler RetryPolicy)', () => {
+    const sched: DesiredResource = {
+      logicalId: 'Sched',
+      resourceType: 'AWS::Scheduler::Schedule',
+      physicalId: 'my-sched',
+      declared: { Target: { Arn: 'arn:aws:lambda:us-east-1:1:function:fn', RoleArn: 'arn:role' } },
+    };
+    // AWS materializes RetryPolicy but returns only MaximumRetryAttempts (omits the
+    // MaximumEventAgeInSeconds default) — a strict deepEqual would leak this as undeclared.
+    const live = {
+      Target: {
+        Arn: 'arn:aws:lambda:us-east-1:1:function:fn',
+        RoleArn: 'arn:role',
+        RetryPolicy: { MaximumRetryAttempts: 185 },
+      },
+    };
+    const t = tiers(classifyResource(sched, live, bare));
+    expect(t.atDefault).toContain('Target.RetryPolicy');
+    expect(t.undeclared).not.toContain('Target.RetryPolicy');
+
+    // A retry attempt set away from the default still surfaces (equality-gated).
+    const liveChanged = {
+      Target: {
+        Arn: 'arn:aws:lambda:us-east-1:1:function:fn',
+        RoleArn: 'arn:role',
+        RetryPolicy: { MaximumRetryAttempts: 3 },
+      },
+    };
+    const t2 = tiers(classifyResource(sched, liveChanged, bare));
+    expect(t2.undeclared).toContain('Target.RetryPolicy');
+    expect(t2.atDefault).not.toContain('Target.RetryPolicy');
+  });
 });


### PR DESCRIPTION
## What

Follow-up to #434. `matchesKnownDefault` (accept a live value that is a *sub-object* of the default — closing the "AWS returns a partial default object" FP class) was only wired into the **top-level** undeclared `atDefault` compare. The **nested** compare still used a strict `deepEqual`.

So the same region-variance FP class stays open for the **object-valued** `KNOWN_DEFAULT_PATHS` / `schema.defaultPaths` entries:

| Type | Nested object default |
|------|----------------------|
| CloudFront | `Restrictions.GeoRestriction`, `OriginGroups` |
| Scheduler | `Target.RetryPolicy` |
| Cognito | `Policies.SignInPolicy` |
| Glue | `Principal` |

If AWS returns any of those with a sub-key omitted (exactly what #434 proved happens — RestApi `EndpointConfiguration` dropping `IpAddressType` in ap-northeast-1), it leaks as undeclared.

## Fix

Swap both nested compares (`schema.defaultPaths` and `knownDefPaths`) to `matchesKnownDefault` for symmetry with the top-level compare. It falls back to `deepEqual` for scalars/arrays, so nothing else changes and the existing corpus replay is unaffected (1886 tests pass).

## Test

`Target.RetryPolicy` returned with only `MaximumRetryAttempts` (AWS omits the `MaximumEventAgeInSeconds` default) folds to `atDefault`; a non-default attempt still surfaces (equality-gated).
