### PR TITLE
feat(region): fall back to the AWS profile's configured region for env-agnostic stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ CI (with `--yes`).
 
 | option                     | meaning                                                                                                                                         |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); stacks with explicit `env.region` are auto-detected                                      |
+| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); else `env.region` per stack, else the `--profile`'s region                               |
 | `--profile <p>`            | AWS profile (or `$AWS_PROFILE`)                                                                                                                 |
 | `-a, --app <cmd\|cdk.out>` | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`); stack auto-discovery + construct paths                    |
 | `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                                      |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -186,7 +186,9 @@ signals this via `RevertOutcome.aborted` so the standalone `revert` command keep
 its own exit-0-on-abort behaviour (R30).
 
 Flags (all parsed in [src/cli-args.ts](../src/cli-args.ts)): `--region` (no silent
-default — resolves via SDK chain, errors if absent), `--profile`, `-a/--app <cmd|cdk.out>`
+default — per stack: explicit `env.region`, else `--region` / `$AWS_REGION`, else
+the `--profile`'s configured region from `~/.aws/config`; errors if all absent),
+`--profile`, `-a/--app <cmd|cdk.out>`
 (+ `$CDKRD_APP` / cdk.json `"app"`), `-c/--context key=value` (repeatable),
 `--json`, `--fail` (check: exit 1 on drift + never prompt — automation mode, R53),
 `--show-all` (inventory mode:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,9 @@ USAGE
 
 OPTIONS
   --region <r>                AWS region (or $AWS_REGION / $AWS_DEFAULT_REGION);
-                              CDK stacks with explicit env.region are auto-detected
+                              CDK stacks with explicit env.region are auto-detected.
+                              An env-agnostic stack with none of these falls back to
+                              the active --profile's configured region (~/.aws/config)
   --profile <p>               AWS profile (or $AWS_PROFILE)
   -a, --app <cmd|cdk.out>     CDK app command or pre-synthesized assembly dir
                               (or $CDKRD_APP / cdk.json "app") — enables stack

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -218,7 +218,9 @@ export async function runCheck(args: string[]): Promise<number> {
   const separate = stackSeparator();
   for (const { stackName, region, template } of stacks) {
     if (!region) {
-      console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
+      console.error(
+        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
+      );
       worst = Math.max(worst, 2);
       continue;
     }

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -45,7 +45,9 @@ export async function runIgnore(args: string[]): Promise<number> {
   let wroteAny = false;
   for (const { stackName, region, template } of stacks) {
     if (!region) {
-      console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
+      console.error(
+        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
+      );
       worst = Math.max(worst, 2);
       continue;
     }

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -36,7 +36,9 @@ export async function runRecord(args: string[]): Promise<number> {
   let worst = 0;
   for (const { stackName, region, template } of stacks) {
     if (!region) {
-      console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
+      console.error(
+        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
+      );
       worst = Math.max(worst, 2);
       continue;
     }

--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -7,13 +7,36 @@
 // (and, downstream, construct-path display).
 //
 //   no positional args    → every stack the app defines, each in its OWN env.region
-//                           (falling back to --region for env-agnostic stacks)
+//                           (env-agnostic stacks fall back to --region / $AWS_REGION,
+//                           then the active profile's configured region)
 //   <stack>... positional → exact names must exist in the app; a name with a glob
 //                           char (`*`/`?`) is matched against the app's stack names
+import { CloudControlClient } from '@aws-sdk/client-cloudcontrol';
 import type { CommonArgs } from '../cli-args.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { discoverStacks } from '../synth/synth.js';
 import { isGlob, matchesGlob } from './glob-match.js';
+
+// Resolve the region the AWS SDK would use for the active profile (the `region`
+// set for that profile in ~/.aws/config). Used as the LAST region fallback for an
+// env-agnostic CDK stack — one with no `env` on the stack and no --region /
+// $AWS_REGION — so it still has a region to query instead of erroring. Reads the
+// shared config only (no network call) and returns undefined if the profile sets
+// no region. AWS_PROFILE is already exported into the environment by the calling
+// command, so the SDK's region provider chain selects the right profile even when
+// `profile` is undefined here (e.g. $AWS_PROFILE was used instead of --profile).
+export async function resolveProfileRegion(
+  profile: string | undefined
+): Promise<string | undefined> {
+  try {
+    const client = new CloudControlClient(profile ? { profile } : {});
+    const region = await client.config.region();
+    client.destroy();
+    return typeof region === 'string' && region.length > 0 ? region : undefined;
+  } catch {
+    return undefined; // the SDK throws "Region is missing" when nothing resolves
+  }
+}
 
 export interface ResolvedStack {
   stackName: string;
@@ -36,12 +59,27 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
     context: a.context,
   });
 
+  // Region fallback chain for an env-agnostic stack (no `env` on the stack): an
+  // explicit --region / $AWS_REGION (`a.region`) first, then the active AWS
+  // profile's configured region. Resolve the profile region only when it is
+  // actually needed — no explicit region AND at least one discovered stack lacks
+  // its own — so a fully-region-pinned app makes no extra config read.
+  let fallbackRegion = a.region;
+  if (!fallbackRegion && discovered.some((s) => !s.region)) {
+    fallbackRegion = await resolveProfileRegion(a.profile);
+    // Backfill so EVERY downstream `?? a.region` site (notably check's --pre-deploy
+    // synthTemplates keying) resolves an env-agnostic stack to the same region the
+    // loop queries it in — otherwise the synthKey would mismatch and the stack would
+    // wrongly read as "not in the synth output".
+    a.region = fallbackRegion;
+  }
+
   // --all, or no names → every stack the app defines. --all is the explicit form of the
   // no-argument default; it also overrides any positional names (target everything).
   if (a.all || a.stackNames.length === 0) {
     return discovered.map((s) => ({
       stackName: s.stackName,
-      region: s.region ?? a.region,
+      region: s.region ?? fallbackRegion,
       template: s.template,
     }));
   }
@@ -63,13 +101,14 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
   for (const name of a.stackNames) {
     if (isGlob(name)) {
       for (const s of discovered) {
-        if (matchesGlob(name, s.stackName)) add(s.stackName, s.region ?? a.region, s.template);
+        if (matchesGlob(name, s.stackName))
+          add(s.stackName, s.region ?? fallbackRegion, s.template);
       }
     } else {
       const hit = discovered.find((s) => s.stackName === name);
       if (!hit)
         throw new Error(`stack "${name}" is not defined by the CDK app (found: ${known()})`);
-      add(hit.stackName, hit.region ?? a.region, hit.template);
+      add(hit.stackName, hit.region ?? fallbackRegion, hit.template);
     }
   }
   if (out.length === 0) {

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -45,7 +45,9 @@ export async function runRevert(args: string[]): Promise<number> {
   let worst = 0;
   for (const { stackName, region, template } of stacks) {
     if (!region) {
-      console.error(`error: ${stackName}: no region — set env on the stack or pass --region`);
+      console.error(
+        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
+      );
       worst = Math.max(worst, 2);
       continue;
     }

--- a/tests/resolve-stacks.test.ts
+++ b/tests/resolve-stacks.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { resolveProfileRegion } from '../src/commands/resolve-stacks.js';
+
+// resolveProfileRegion is the LAST region fallback for an env-agnostic CDK stack:
+// when neither the stack's `env` nor --region / $AWS_REGION supply a region, it
+// reads the active AWS profile's configured region from ~/.aws/config so the run
+// still has a region to query instead of erroring.
+describe('resolveProfileRegion', () => {
+  let configPath: string;
+  let tmp: string;
+  const saved: Record<string, string | undefined> = {};
+  const ENVS = [
+    'AWS_CONFIG_FILE',
+    'AWS_PROFILE',
+    'AWS_DEFAULT_PROFILE',
+    'AWS_REGION',
+    'AWS_DEFAULT_REGION',
+  ];
+
+  beforeEach(() => {
+    for (const k of ENVS) saved[k] = process.env[k];
+    // A profile's region must come from the shared config file alone — clear any
+    // ambient region/profile env that would otherwise win in the provider chain.
+    for (const k of ENVS) delete process.env[k];
+    tmp = mkdtempSync(join(tmpdir(), 'cdkrd-region-'));
+    configPath = join(tmp, 'config');
+    writeFileSync(
+      configPath,
+      [
+        '[profile haszone]',
+        'region = eu-west-2',
+        '',
+        '[profile noregion]',
+        'output = json',
+        '',
+      ].join('\n')
+    );
+    process.env.AWS_CONFIG_FILE = configPath;
+  });
+
+  afterEach(() => {
+    for (const k of ENVS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns the named profile's configured region", async () => {
+    expect(await resolveProfileRegion('haszone')).toBe('eu-west-2');
+  });
+
+  it('returns undefined when the profile sets no region', async () => {
+    expect(await resolveProfileRegion('noregion')).toBeUndefined();
+  });
+
+  it('returns undefined when the profile does not exist', async () => {
+    expect(await resolveProfileRegion('missing')).toBeUndefined();
+  });
+
+  it('falls back to $AWS_PROFILE when no profile is passed', async () => {
+    process.env.AWS_PROFILE = 'haszone';
+    expect(await resolveProfileRegion(undefined)).toBe('eu-west-2');
+  });
+});


### PR DESCRIPTION
## What

An env-agnostic CDK stack (no `env` on the stack) previously failed with:

```
error: <stack>: no region — set env on the stack or pass --region
```

…even when the active `--profile` had a `region` configured in `~/.aws/config`.
Now `cdkrd check --profile <p>` resolves that profile region as the **last**
fallback in the region chain.

## Region fallback chain (per stack)

1. the stack's explicit `env.region` (unchanged)
2. `--region` / `$AWS_REGION` / `$AWS_DEFAULT_REGION` (unchanged)
3. **NEW:** the active `--profile`'s configured region (`~/.aws/config`), via the
   AWS SDK region provider chain — read-only, no network call. Resolved only when
   actually needed (no explicit region AND a discovered stack lacks its own), so a
   fully region-pinned app makes no extra config read.

The resolved value is backfilled into `a.region` so every downstream `?? a.region`
site (notably check's `--pre-deploy` `synthKey` keying) stays consistent.

## Notes

- The four `no region` error messages now also mention the profile.
- Help text / README options table / ARCHITECTURE region note updated.
- New unit test `tests/resolve-stacks.test.ts` exercises `resolveProfileRegion`
  against a temp shared-config file (named profile, no-region profile, missing
  profile, `$AWS_PROFILE` fallback).
- Verified live: `<dev-profile>` profile (`region = ap-northeast-1`) now resolves
  instead of erroring.
