### PR TITLE
fix(noise): fold Lambda EventSourceMapping KafkaBootstrapServers reorder FP

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -56,6 +56,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Timeout: 3,
   },
   'AWS::Lambda::Url': { InvokeMode: 'BUFFERED' },
+  // A stream / self-managed-Kafka event source mapping created without these reads
+  // them back as -1 (the documented "infinite" default: retry forever / no record-age
+  // cap). A never-declared ESM otherwise reports both on every first run. Equality-gated
+  // — set either to a finite value out of band and it no longer matches, so it
+  // re-surfaces as real undeclared drift. (SQS event sources don't carry these props at
+  // all, so the entry can't mis-fold there.) Observed live on a fresh esm-sourceaccess-rich
+  // deploy.
+  'AWS::Lambda::EventSourceMapping': { MaximumRetryAttempts: -1, MaximumRecordAgeInSeconds: -1 },
   // An alias created without a Description reads back the empty string. Folded as
   // atDefault so a never-declared alias does not report `Description=""` as drift; it
   // is also the value REVERT_SET_DEFAULT_PATHS writes to undo an out-of-band Description
@@ -1973,6 +1981,21 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   'AWS::AutoScaling::AutoScalingGroup': new Set([
     'MetricsCollection.Metrics',
     'NotificationConfigurations.NotificationTypes',
+  ]),
+  // A self-managed Apache Kafka event source's `SelfManagedEventSource.Endpoints.
+  // KafkaBootstrapServers` is a SET of `host:port` broker strings that Lambda echoes
+  // REORDERED, not in template order (declared [b-1…:9092, b-2…:9092] reads back
+  // [b-2…:9092, b-1…:9092]), so a positional compare false-flags the identical
+  // bootstrap-server set as declared drift on a freshly recorded ESM. The brokers are a
+  // SET (a Kafka client connects to ANY one to discover the rest — order carries no
+  // meaning), and the `host:port` strings aren't id/ARN/HTTP/AZ-shaped so
+  // canonicalizeIdArraysDeep leaves them; this nested scalar path folds them. A genuine
+  // broker add/remove still changes the multiset. Observed live on a fresh
+  // esm-sourceaccess-rich deploy. (The sibling `SourceAccessConfigurations` set — the
+  // {Type, URI} VPC/SASL entries — was tested in the SAME deploy with a deliberately
+  // non-sorted list and Lambda PRESERVED its order, so it is NOT folded — observed-only.)
+  'AWS::Lambda::EventSourceMapping': new Set([
+    'SelfManagedEventSource.Endpoints.KafkaBootstrapServers',
   ]),
 };
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2762,6 +2762,39 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('Lambda EventSourceMapping KafkaBootstrapServers reordered (nested scalar set under SelfManagedEventSource.Endpoints, found by esm-sourceaccess-rich)', () => {
+    const T = 'AWS::Lambda::EventSourceMapping';
+    const declared = {
+      SelfManagedEventSource: {
+        Endpoints: {
+          KafkaBootstrapServers: ['b-1.cdkrd.example.com:9092', 'b-2.cdkrd.example.com:9092'],
+        },
+      },
+    };
+
+    it('Lambda returning the bootstrap-server set reordered is NOT drift', () => {
+      const live = {
+        SelfManagedEventSource: {
+          Endpoints: {
+            KafkaBootstrapServers: ['b-2.cdkrd.example.com:9092', 'b-1.cdkrd.example.com:9092'],
+          },
+        },
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine broker change still surfaces (no over-fold)', () => {
+      const live = {
+        SelfManagedEventSource: {
+          Endpoints: {
+            KafkaBootstrapServers: ['b-2.cdkrd.example.com:9092', 'b-3.cdkrd.example.com:9092'],
+          },
+        },
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   // The siblings of the GSI fold above, found by ddb-nested-sets: the SAME nested
   // INCLUDE-projection NonKeyAttributes set lives on a Table's LocalSecondaryIndexes
   // and on the AWS::DynamoDB::GlobalTable (TableV2) type's GSI *and* LSI, all of which

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.Esm.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.Esm.json
@@ -1,0 +1,158 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Esm",
+    "resourceType": "AWS::Lambda::EventSourceMapping",
+    "physicalId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+    "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm",
+    "declared": {
+      "BatchSize": 100,
+      "FunctionName": "cdkrd-esm-consumer",
+      "SelfManagedEventSource": {
+        "Endpoints": {
+          "KafkaBootstrapServers": ["b-1.cdkrd.example.com:9092", "b-2.cdkrd.example.com:9092"]
+        }
+      },
+      "SourceAccessConfigurations": [
+        {
+          "Type": "VPC_SECURITY_GROUP",
+          "URI": "security_group:sg-09b7a49d40764ee3b"
+        },
+        {
+          "Type": "SASL_SCRAM_512_AUTH",
+          "URI": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-esm-kafka-auth-jkRwP8"
+        },
+        {
+          "Type": "VPC_SUBNET",
+          "URI": "subnet:subnet-0e264d7f91aa8723e"
+        },
+        {
+          "Type": "VPC_SUBNET",
+          "URI": "subnet:subnet-069a10494aa974154"
+        }
+      ],
+      "StartingPosition": "TRIM_HORIZON",
+      "Topics": ["cdkrd-topic"]
+    }
+  },
+  "liveRaw": {
+    "StartingPosition": "TRIM_HORIZON",
+    "BatchSize": 100,
+    "MaximumRetryAttempts": -1,
+    "Topics": ["cdkrd-topic"],
+    "SelfManagedEventSource": {
+      "Endpoints": {
+        "KafkaBootstrapServers": ["b-2.cdkrd.example.com:9092", "b-1.cdkrd.example.com:9092"]
+      }
+    },
+    "Enabled": true,
+    "SelfManagedKafkaEventSourceConfig": {
+      "ConsumerGroupId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec"
+    },
+    "FunctionName": "arn:aws:lambda:us-east-1:111111111111:function:cdkrd-esm-consumer",
+    "BisectBatchOnFunctionError": false,
+    "EventSourceMappingArn": "arn:aws:lambda:us-east-1:111111111111:event-source-mapping:81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+    "MaximumRecordAgeInSeconds": -1,
+    "Id": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+    "SourceAccessConfigurations": [
+      {
+        "Type": "VPC_SECURITY_GROUP",
+        "URI": "security_group:sg-09b7a49d40764ee3b"
+      },
+      {
+        "Type": "SASL_SCRAM_512_AUTH",
+        "URI": "arn:aws:secretsmanager:us-east-1:111111111111:secret:cdkrd-esm-kafka-auth-jkRwP8"
+      },
+      {
+        "Type": "VPC_SUBNET",
+        "URI": "subnet:subnet-0e264d7f91aa8723e"
+      },
+      {
+        "Type": "VPC_SUBNET",
+        "URI": "subnet:subnet-069a10494aa974154"
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegEsmSourceaccessRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEsmSourceaccessRich/d4a37f80-7470-11f1-b812-0affe9c039e9",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Esm",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["EventSourceMappingArn", "Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "readOnlyPaths": ["EventSourceMappingArn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "EventSourceArn",
+      "SelfManagedEventSource",
+      "StartingPosition",
+      "StartingPositionTimestamp"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Esm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumRetryAttempts",
+      "actual": -1,
+      "physicalId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+      "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Esm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "Enabled",
+      "actual": true,
+      "physicalId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+      "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Esm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "SelfManagedKafkaEventSourceConfig",
+      "actual": {
+        "ConsumerGroupId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec"
+      },
+      "physicalId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+      "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Esm",
+      "resourceType": "AWS::Lambda::EventSourceMapping",
+      "path": "MaximumRecordAgeInSeconds",
+      "actual": -1,
+      "physicalId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
+      "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
+    }
+  ]
+}

--- a/tests/integration/esm-sourceaccess-rich/app.ts
+++ b/tests/integration/esm-sourceaccess-rich/app.ts
@@ -1,0 +1,99 @@
+// CDK app for the cdk-real-drift Lambda EventSourceMapping SourceAccessConfigurations
+// false-positive test. A self-managed Apache Kafka event source (a common streaming
+// integration) carries SourceAccessConfigurations: a SET of {Type, URI} entries
+// (VPC_SUBNET x2, VPC_SECURITY_GROUP, SASL_SCRAM_512_AUTH) whose `Type` is NOT one of
+// canonicalizeTagListsDeep's IDENTITY_FIELDS — so if Lambda echoes the set SORTED (not
+// in template order) a positional compare would false-flag every shifted entry as
+// declared drift. We declare the set NON-sorted on purpose to expose any reorder.
+// A freshly deployed + recorded ESM with NO out-of-band change MUST report CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnVPC, CfnSubnet, CfnSecurityGroup } from "aws-cdk-lib/aws-ec2";
+import { CfnFunction, CfnEventSourceMapping } from "aws-cdk-lib/aws-lambda";
+import { CfnRole } from "aws-cdk-lib/aws-iam";
+import { CfnSecret } from "aws-cdk-lib/aws-secretsmanager";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEsmSourceaccessRich");
+
+// Minimal VPC + two subnets + a security group — only their IDs are referenced by the
+// ESM's VPC SourceAccessConfigurations; no IGW/NAT is needed for the mapping to create.
+const vpc = new CfnVPC(stack, "Vpc", { cidrBlock: "10.0.0.0/16" });
+const subnet1 = new CfnSubnet(stack, "Subnet1", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.0.0/24",
+  availabilityZone: "us-east-1a",
+});
+const subnet2 = new CfnSubnet(stack, "Subnet2", {
+  vpcId: vpc.ref,
+  cidrBlock: "10.0.1.0/24",
+  availabilityZone: "us-east-1b",
+});
+const sg = new CfnSecurityGroup(stack, "Sg", {
+  groupDescription: "cdkrd esm kafka",
+  vpcId: vpc.ref,
+});
+
+const secret = new CfnSecret(stack, "KafkaAuth", {
+  name: "cdkrd-esm-kafka-auth",
+  secretString: JSON.stringify({ username: "cdkrd", password: "cdkrd-placeholder" }),
+});
+
+const role = new CfnRole(stack, "FnRole", {
+  assumeRolePolicyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      { Effect: "Allow", Principal: { Service: "lambda.amazonaws.com" }, Action: "sts:AssumeRole" },
+    ],
+  },
+  managedPolicyArns: ["arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"],
+  policies: [
+    {
+      policyName: "esm",
+      policyDocument: {
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Effect: "Allow",
+            Action: [
+              "ec2:CreateNetworkInterface",
+              "ec2:DescribeNetworkInterfaces",
+              "ec2:DeleteNetworkInterface",
+              "ec2:DescribeVpcs",
+              "ec2:DescribeSubnets",
+              "ec2:DescribeSecurityGroups",
+            ],
+            Resource: "*",
+          },
+          { Effect: "Allow", Action: ["secretsmanager:GetSecretValue"], Resource: secret.ref },
+        ],
+      },
+    },
+  ],
+});
+
+const fn = new CfnFunction(stack, "Fn", {
+  functionName: "cdkrd-esm-consumer",
+  runtime: "python3.12",
+  handler: "index.handler",
+  role: role.attrArn,
+  code: { zipFile: "def handler(e, c):\n    return None\n" },
+});
+
+new CfnEventSourceMapping(stack, "Esm", {
+  functionName: fn.ref,
+  selfManagedEventSource: {
+    endpoints: { kafkaBootstrapServers: ["b-1.cdkrd.example.com:9092", "b-2.cdkrd.example.com:9092"] },
+  },
+  topics: ["cdkrd-topic"],
+  startingPosition: "TRIM_HORIZON",
+  batchSize: 100,
+  // Declared NON-sorted (VPC_SECURITY_GROUP first, SASL second, subnets last) so that
+  // an alphabetical-by-Type reorder by Lambda (SASL_SCRAM_512_AUTH, VPC_SECURITY_GROUP,
+  // VPC_SUBNET, VPC_SUBNET) would surface as a positional diff if cdkrd doesn't fold it.
+  sourceAccessConfigurations: [
+    { type: "VPC_SECURITY_GROUP", uri: `security_group:${sg.attrGroupId}` },
+    { type: "SASL_SCRAM_512_AUTH", uri: secret.ref },
+    { type: "VPC_SUBNET", uri: `subnet:${subnet1.ref}` },
+    { type: "VPC_SUBNET", uri: `subnet:${subnet2.ref}` },
+  ],
+});

--- a/tests/integration/esm-sourceaccess-rich/cdk.json
+++ b/tests/integration/esm-sourceaccess-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/esm-sourceaccess-rich/package.json
+++ b/tests/integration/esm-sourceaccess-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-esm-sourceaccess-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift esm-sourceaccess-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/esm-sourceaccess-rich/verify-detect.sh
+++ b/tests/integration/esm-sourceaccess-rich/verify-detect.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Lambda EventSourceMapping detect + revert (real AWS). Drift the declared MUTABLE
+# BatchSize 100->50 out of band (the "someone changed it in the console" scenario)
+# -> check MUST DETECT -> revert (Cloud Control UpdateResource) -> CLEAN + restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegEsmSourceaccessRich; FN=cdkrd-esm-consumer; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+export AWS_CLI_AUTO_PROMPT=off
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+UUID="$(aws lambda list-event-source-mappings --function-name "$FN" --region "$REGION" --query 'EventSourceMappings[0].UUID' --output text)"
+[ -n "$UUID" ] && [ "$UUID" != "None" ] || fail "no esm uuid"
+wait_enabled(){ while [ "$(aws lambda get-event-source-mapping --uuid "$UUID" --region "$REGION" --query State --output text 2>/dev/null)" = "Updating" ]; do sleep 5; done; }
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== oob BatchSize 100->50 ==="
+aws lambda update-event-source-mapping --uuid "$UUID" --batch-size 50 --region "$REGION" >/dev/null || fail inject
+wait_enabled
+echo "=== check MUST DETECT ==="; $CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-esm-detect.out
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 1 ] || fail "expected exit 1 got $rc"
+grep -qi "BatchSize" /tmp/cdkrd-esm-detect.out || fail "drift not reported"
+echo "=== revert (Cloud Control UpdateResource) ==="; $CLI revert "$STACK" --region "$REGION" --yes | tee /tmp/cdkrd-esm-revert.out
+grep -qi "CLEAN after revert" /tmp/cdkrd-esm-revert.out || fail "revert did not converge"
+wait_enabled
+GOT="$(aws lambda get-event-source-mapping --uuid "$UUID" --region "$REGION" --query BatchSize --output text)"
+[ "$GOT" = "100" ] || fail "BatchSize not restored (got $GOT)"
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/esm-sourceaccess-rich/verify.sh
+++ b/tests/integration/esm-sourceaccess-rich/verify.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift here is a normalization / default-folding FP — in
+# particular a SourceAccessConfigurations reorder.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEsmSourceaccessRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -481,6 +481,15 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('Lambda EventSourceMapping stream retry/age infinite defaults (found by esm-sourceaccess-rich)', () => {
+    // -1 is the documented "infinite" default for stream / Kafka event sources (retry
+    // forever / no record-age cap); equality-gated, so a finite override still surfaces.
+    expect(KNOWN_DEFAULTS['AWS::Lambda::EventSourceMapping']).toEqual({
+      MaximumRetryAttempts: -1,
+      MaximumRecordAgeInSeconds: -1,
+    });
+  });
+
   it('PR #355-followup noise sweep: constant defaults on common daily-driver types', () => {
     // Each value was OBSERVED unanimous (>=2 cases) across the golden corpus and is a
     // documented constant service default — equality-gated, so a non-default value still


### PR DESCRIPTION
## What

Bug-hunt round: predicted a discriminated-union-set reorder FP class might recur in other resources, audited offline, then deployed the top candidate.

**Predicted target ruled out, sibling FP found.** I hunted Lambda EventSourceMapping `SourceAccessConfigurations` (a `{Type, URI}` set) — but Lambda **preserved** its order (observed-only rule-out). The sibling `SelfManagedEventSource.Endpoints.KafkaBootstrapServers` surfaced the **real FP**: a set of `host:port` broker strings Lambda echoes **reordered** (declared `[b-1, b-2]` → live `[b-2, b-1]`) → 1 phantom declared drift on a freshly recorded ESM. Brokers are a set (a client connects to any one to discover the rest), so added the nested-scalar path to `UNORDERED_NESTED_OBJECT_ARRAY_PATHS`. Live-proven: 1 drift → CLEAN.

## Also in this PR

- **FN regression**: `BatchSize` 100→50 detect → revert (Cloud Control) → CLEAN + restored. Live-proven (`verify-detect.sh`).
- **First-run noise**: `MaximumRetryAttempts=-1` / `MaximumRecordAgeInSeconds=-1` (the documented "infinite" defaults for stream/Kafka ESMs) → `KNOWN_DEFAULTS` (equality-gated; SQS ESMs lack these props so it can't mis-fold).
- **Golden corpus**: a self-managed-Kafka EventSourceMapping case (distinct from the existing SQS `QueueTrigger`).

## Tests

- `tests/classify.test.ts`: KafkaBootstrapServers reorder-NOT-drift + genuine-broker-change-surfaces.
- `tests/noise-and-strip.test.ts`: asserts the ESM `KNOWN_DEFAULTS` entry.
- `tests/corpus-replay`: new case replays clean. Full suite: 1894 passing.

## Cleanup

Stack deleted; the self-managed-Kafka ESM left Lambda Hyperplane ENIs that delayed VPC teardown — reaped + ENIs deleted + stack re-deleted → `bughunt-track.sh verify` GONE + SWEEP CLEAN.