### PR TITLE
fix(noise): fold three first-run GlobalTable/ESM/Authorizer FPs

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -70,6 +70,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // content hash (not a constant default) — folded as `generated` via
   // GENERATED_TOPLEVEL_PATHS instead.
   'AWS::Lambda::Version': { RuntimePolicy: { UpdateRuntimeOn: 'Auto' } },
+  // An event source mapping (e.g. CDK's SqsEventSource) is created enabled; the
+  // construct omits Enabled when it leaves the default true, so the live read reports
+  // an undeclared Enabled=true on every first run — observed live on a dev LineLink
+  // stack with no out-of-band edit. (The off state Enabled=false is dropped upstream as
+  // trivially-empty before this fold, mirroring the KMS Key Enabled case.)
+  'AWS::Lambda::EventSourceMapping': { Enabled: true },
   'AWS::Events::Rule': { EventBusName: 'default' },
   'AWS::Athena::WorkGroup': { State: 'ENABLED' },
   // AmazonMQ Broker service defaults (observed live on the amazonmq-version-readgap
@@ -174,6 +180,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ApiGateway::DomainName': {
     SecurityPolicy: 'TLS_1_2',
   },
+  // A Cognito authorizer declares only Type: COGNITO_USER_POOLS; AWS derives and
+  // returns AuthType "cognito_user_pools" (the lowercase form), which the template
+  // never carries, so the live read reports it as undeclared on every first run —
+  // observed live on a dev LineLink stack with no out-of-band edit. AuthType is purely
+  // derived from Type and cannot be set independently, so only this Cognito value is
+  // folded; a TOKEN/REQUEST authorizer's "custom" AuthType is unobserved and left to
+  // surface (observed-only discipline). Equality-gated like every other entry.
+  'AWS::ApiGateway::Authorizer': {
+    AuthType: 'cognito_user_pools',
+  },
   // A VPC is in nearly every CDK stack. AWS reports these two constant defaults on
   // every first run when the template does not declare them (raw CfnVPC, or an L2 Vpc
   // that sets only DNS hostnames): InstanceTenancy "default" (vs dedicated/host) and
@@ -230,6 +246,17 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::DynamoDB::Table': {
     BillingMode: 'PROVISIONED',
     DeletionProtectionEnabled: false,
+  },
+  // A PAY_PER_REQUEST (on-demand) TableV2 reads back a baseline WarmThroughput that
+  // AWS assigns to every fresh table (12000 read / 4000 write units) even though the
+  // template never declares it — observed live on a dev LineLink stack with no
+  // out-of-band edit. Equality-gated: a table that has WARMED UP to a higher value
+  // under traffic no longer matches and surfaces as a real undeclared value (the warm
+  // throughput auto-ratchets and never decreases), and an explicitly declared
+  // WarmThroughput compares as declared instead. Top-level WarmThroughput only — the
+  // GSI-nested `*.WarmThroughput` stays surfaced (see KNOWN_DEFAULT_PATHS note below).
+  'AWS::DynamoDB::GlobalTable': {
+    WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
   },
   'AWS::ECR::Repository': {
     EncryptionConfiguration: { EncryptionType: 'AES256' },
@@ -551,8 +578,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // generated ID (not a constant) are EXCLUDED here and folded as `generated`
 // instead — via GENERATED_DEFAULTS / isGeneratedName, or GENERATED_PATHS for a
 // nested id cdkrd cannot template (ApiGateway Method `Integration.CacheNamespace`,
-// the parent Resource's id). Genuine resource-/account-/throughput inventory stays
-// EXCLUDED from both (Budgets `Budget.BudgetName`, DynamoDB GSI `*.WarmThroughput`).
+// the parent Resource's id). Genuine resource-/account-specific inventory stays
+// EXCLUDED from both (Budgets `Budget.BudgetName`, the GSI-nested
+// `*.WarmThroughput`). The TOP-LEVEL TableV2 `WarmThroughput`, by contrast, IS a
+// constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
+// equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   // AWS Backup materializes these defaults into each live BackupPlanRule (keyed by RuleName
   // — descended via NESTED_ARRAY_IDENTITY). Folding them keeps a clean plan clean; an

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -770,6 +770,41 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ]);
   });
 
+  it('LineLink first-run folds: GlobalTable WarmThroughput / ESM Enabled / Authorizer AuthType', () => {
+    // Three undeclared values a fresh dev LineLink stack reported with NO out-of-band
+    // edit — first-run noise that must fold to atDefault, while a meaningful change to
+    // each still surfaces (equality-gated).
+    const t = (rt: string, live: Record<string, unknown>) =>
+      tiers(classifyResource(bare(rt), live, emptySchema));
+
+    // PAY_PER_REQUEST TableV2 baseline warm throughput → folds; a warmed-up table surfaces.
+    expect(
+      t('AWS::DynamoDB::GlobalTable', {
+        WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
+      }).atDefault
+    ).toEqual(['WarmThroughput']);
+    expect(
+      t('AWS::DynamoDB::GlobalTable', {
+        WarmThroughput: { ReadUnitsPerSecond: 24000, WriteUnitsPerSecond: 8000 },
+      }).undeclared
+    ).toEqual(['WarmThroughput']);
+
+    // ESM created enabled → folds. (Enabled:false is dropped upstream as trivially-empty,
+    // like the KMS Key Enabled case — neither undeclared nor atDefault.)
+    expect(t('AWS::Lambda::EventSourceMapping', { Enabled: true }).atDefault).toEqual(['Enabled']);
+    const disabled = t('AWS::Lambda::EventSourceMapping', { Enabled: false });
+    expect(disabled.undeclared).toEqual([]);
+    expect(disabled.atDefault).toEqual([]);
+
+    // Cognito-derived AuthType folds; a different (e.g. custom) AuthType surfaces.
+    expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'cognito_user_pools' }).atDefault).toEqual([
+      'AuthType',
+    ]);
+    expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'custom' }).undeclared).toEqual([
+      'AuthType',
+    ]);
+  });
+
   it('R104: StateMachineType STANDARD folds, EXPRESS stays undeclared (equality-gated curation)', () => {
     const t = (v: string) =>
       tiers(

--- a/tests/corpus/AWS__DynamoDB__GlobalTable.Data666C94C7.json
+++ b/tests/corpus/AWS__DynamoDB__GlobalTable.Data666C94C7.json
@@ -328,7 +328,7 @@
       "constructPath": "CdkRealDriftIntegDdbGlobalTableRich/Data"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::DynamoDB::GlobalTable",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__GlobalTable.GT.replicas.json
+++ b/tests/corpus/AWS__DynamoDB__GlobalTable.GT.replicas.json
@@ -108,7 +108,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "GT",
       "resourceType": "AWS::DynamoDB::GlobalTable",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__GlobalTable.Global7C59AC82.json
+++ b/tests/corpus/AWS__DynamoDB__GlobalTable.Global7C59AC82.json
@@ -204,7 +204,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Global7C59AC82",
       "resourceType": "AWS::DynamoDB::GlobalTable",
       "path": "WarmThroughput",


### PR DESCRIPTION
## What

A fresh dev <real-app> stack with **no out-of-band edit** reported four undeclared values as `Potential Drift`. All four are constant first-run defaults AWS materializes on deploy, so they should fold to `atDefault`, not surface. This adds three equality-gated `KNOWN_DEFAULTS` entries.

| Type | Prop | Value | Note |
|---|---|---|---|
| `AWS::DynamoDB::GlobalTable` | `WarmThroughput` | `{Read:12000, Write:4000}` | PAY_PER_REQUEST baseline; warmed-up tables still surface (equality-gated). GSI-nested `*.WarmThroughput` stays surfaced as before. |
| `AWS::Lambda::EventSourceMapping` | `Enabled` | `true` | created-default; off-state `false` is dropped upstream as trivially-empty (like KMS Key `Enabled`) |
| `AWS::ApiGateway::Authorizer` | `AuthType` | `cognito_user_pools` | derived from `Type`; observed-only, so non-cognito `AuthType` still surfaces |

## Why

The project invariant: a fresh deploy with no out-of-band change must `check` CLEAN. These four were first-run noise (missed folds), not drift.

## Verification

Live-verified against the real dev <real-app> stack:
- **Before:** 5 findings — 1 declared + **4 potential drift**, atDefault=87
- **After:** 1 finding — 1 declared, **0 potential drift**, atDefault=**91**

The one remaining finding is a **genuine** `IntegrationResponses` declared drift (the method declares 200/400/500 integration responses with no `SelectionPattern`, so API Gateway only materializes the single default 200 — confirmed via native `get-integration`). Correctly left surfaced.

## Tests

- New focused test in `classify.test.ts` pinning the live shapes + equality-gating (warmed-up WarmThroughput / custom AuthType still surface; `Enabled:false` is trivially-empty-dropped).
- Generic `KNOWN_DEFAULTS` fold test (every entry → atDefault) covers the fold direction automatically.
- Regenerated the 3 `AWS__DynamoDB__GlobalTable` corpus cases (top-level WarmThroughput `undeclared`→`atDefault`; GSI-nested stays `undeclared`).

`vp run check` (CI: typecheck / lint+format / build / 1891 tests) passes.