### PR TITLE
fix(noise): rule out WAFv2 RuleGroup CustomKeys reorder + fold rate-window (#440)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -744,6 +744,12 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // A rate-based rule with no explicit window reads back the 5-minute (300s) default.
     'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,
   },
+  'AWS::WAFv2::RuleGroup': {
+    // A RuleGroup hosts the SAME rate-based statement shape as a WebACL, so an
+    // undeclared rate-based window reads back the identical 5-minute (300s) default.
+    // Observed live on a fresh wafv2-ratecustomkeys deploy (issue #440).
+    'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,
+  },
   'AWS::SES::EmailIdentity': {
     // A custom MAIL FROM domain reads back the documented default fallback behavior.
     'MailFromAttributes.BehaviorOnMxFailure': 'USE_DEFAULT_VALUE',
@@ -1900,6 +1906,16 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
 // elements positionally; a genuine element add/remove/change still differs after the
 // sort. Observed live on a fresh bedrock-guardrail-rich deploy.
 export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<string>> = {
+  // RULE-OUT (observed-only, NOT folded): a WAFv2 RuleGroup/WebACL rate-based rule's
+  // `Rules[].Statement.RateBasedStatement.CustomKeys` is a SET of discriminated-union
+  // aggregate-key objects ({UriPath:{}}, {Header:{Name,…}}, {HTTPMethod:{}}, …) with
+  // no top-level IDENTITY_FIELD — the same shape that produced reorder FPs for
+  // LoggingConfiguration RedactedFields (#433) and Lambda ESM KafkaBootstrapServers
+  // (#437). A fresh wafv2-ratecustomkeys deploy declaring 5 keys in NON-sorted
+  // discriminator order ([UriPath, Header, HTTPMethod, Cookie, QueryArgument]) read
+  // them back in the EXACT declared order — WAF PRESERVES CustomKeys order (like
+  // AndStatement.Statements and LoggingFilter.Conditions), so there is no FP to fold.
+  // Pinned by the wafv2-ratecustomkeys fixture + corpus case (issue #440).
   'AWS::Bedrock::Guardrail': new Set([
     'ContentPolicyConfig.FiltersConfig',
     'TopicPolicyConfig.TopicsConfig',

--- a/tests/corpus/AWS__WAFv2__RuleGroup.RuleGroup_customkeys.json
+++ b/tests/corpus/AWS__WAFv2__RuleGroup.RuleGroup_customkeys.json
@@ -1,0 +1,224 @@
+{
+  "corpusVersion": 1,
+  "description": "RECORDED LIVE (wafv2-ratecustomkeys fixture, issue #440): fresh-deploy AWS::WAFv2::RuleGroup with a rate-based rule whose RateBasedStatement.CustomKeys SET of discriminated-union aggregate keys is declared NON-sorted ([UriPath, Header, HTTPMethod, Cookie, QueryArgument]). WAF reads them back in the EXACT declared order, so CustomKeys is deliberately NOT folded as an unordered set — this case pins that rule-out (no declared drift). The only finding is the undeclared 5-minute EvaluationWindowSec default, folded to atDefault.",
+  "resource": {
+    "logicalId": "RuleGroup",
+    "resourceType": "AWS::WAFv2::RuleGroup",
+    "physicalId": "cdkrd-integ-rate-customkeys|95be4f4a-b243-4294-ab01-dc7a1affe955|REGIONAL",
+    "constructPath": "CdkRealDriftIntegWafv2RateCustomKeys/RuleGroup",
+    "declared": {
+      "Capacity": 500,
+      "Name": "cdkrd-integ-rate-customkeys",
+      "Rules": [
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "rate-custom-keys",
+          "Priority": 0,
+          "Statement": {
+            "RateBasedStatement": {
+              "AggregateKeyType": "CUSTOM_KEYS",
+              "CustomKeys": [
+                {
+                  "UriPath": {
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Header": {
+                    "Name": "x-region",
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "HTTPMethod": {}
+                },
+                {
+                  "Cookie": {
+                    "Name": "session",
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "QueryArgument": {
+                    "Name": "lang",
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "Limit": 2000
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "rateCustomKeys",
+            "SampledRequestsEnabled": true
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "cdkrdRateCustomKeys",
+        "SampledRequestsEnabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "Scope": "REGIONAL",
+    "Capacity": 500,
+    "AvailableLabels": [],
+    "Id": "95be4f4a-b243-4294-ab01-dc7a1affe955",
+    "ConsumedLabels": [],
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/rulegroup/cdkrd-integ-rate-customkeys/95be4f4a-b243-4294-ab01-dc7a1affe955",
+    "Rules": [
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 0,
+        "Statement": {
+          "RateBasedStatement": {
+            "AggregateKeyType": "CUSTOM_KEYS",
+            "CustomKeys": [
+              {
+                "UriPath": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "Header": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ],
+                  "Name": "x-region"
+                }
+              },
+              {
+                "HTTPMethod": {}
+              },
+              {
+                "Cookie": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ],
+                  "Name": "session"
+                }
+              },
+              {
+                "QueryArgument": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ],
+                  "Name": "lang"
+                }
+              }
+            ],
+            "Limit": 2000,
+            "EvaluationWindowSec": 300
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "rateCustomKeys",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "rate-custom-keys"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdRateCustomKeys",
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true
+    },
+    "LabelNamespace": "awswaf:111111111111:rulegroup:cdkrd-integ-rate-customkeys:",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegWafv2RateCustomKeys/155a99c0-7479-11f1-a3d5-0affe23ffc23",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegWafv2RateCustomKeys",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "RuleGroup",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-rate-customkeys"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": [
+      "Arn",
+      "AvailableLabels.*.Name",
+      "ConsumedLabels.*.Name",
+      "Id",
+      "LabelNamespace"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["CustomResponseBodies"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RuleGroup",
+      "resourceType": "AWS::WAFv2::RuleGroup",
+      "path": "Rules[rate-custom-keys].Statement.RateBasedStatement.EvaluationWindowSec",
+      "actual": 300,
+      "nested": true,
+      "physicalId": "cdkrd-integ-rate-customkeys|95be4f4a-b243-4294-ab01-dc7a1affe955|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2RateCustomKeys/RuleGroup"
+    }
+  ]
+}

--- a/tests/integration/wafv2-ratecustomkeys/app.ts
+++ b/tests/integration/wafv2-ratecustomkeys/app.ts
@@ -1,0 +1,62 @@
+// CDK app for the cdk-real-drift WAFv2 RuleGroup RateBasedStatement.CustomKeys
+// reorder false-positive test (issue #440).
+//
+// A rate-based rule's `CustomKeys` is a SET of discriminated-union aggregate-key
+// objects ({UriPath:{…}}, {Header:{…}}, {HTTPMethod:{}}, {Cookie:{…}},
+// {QueryArgument:{…}}) — the same single-discriminator, no-IDENTITY_FIELD shape
+// that produced confirmed reorder FPs for WAFv2 LoggingConfiguration RedactedFields
+// (#433) and Lambda ESM KafkaBootstrapServers (#437). If WAF echoes the set sorted
+// (by the discriminator key, not in template order) and `CustomKeys` is not folded
+// as an unordered nested object array, a positional diff false-flags every shifted
+// key as declared drift on a freshly deployed + recorded RuleGroup.
+//
+// The keys are declared in a deliberately NON-sorted discriminator order
+// (UriPath, Header, HTTPMethod, Cookie, QueryArgument) so any WAF-side
+// canonicalization shows up. A clean record -> check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnRuleGroup } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2RateCustomKeys");
+
+const noneTransform = [{ priority: 0, type: "NONE" }];
+
+new CfnRuleGroup(stack, "RuleGroup", {
+  name: "cdkrd-integ-rate-customkeys",
+  scope: "REGIONAL",
+  capacity: 500,
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdRateCustomKeys",
+  },
+  rules: [
+    {
+      name: "rate-custom-keys",
+      priority: 0,
+      action: { block: {} },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "rateCustomKeys",
+      },
+      statement: {
+        rateBasedStatement: {
+          limit: 2000,
+          aggregateKeyType: "CUSTOM_KEYS",
+          // Declared NON-sorted by discriminator key on purpose to expose any
+          // WAF-side reordering of the CustomKeys set.
+          customKeys: [
+            { uriPath: { textTransformations: noneTransform } },
+            { header: { name: "x-region", textTransformations: noneTransform } },
+            { httpMethod: {} },
+            { cookie: { name: "session", textTransformations: noneTransform } },
+            { queryArgument: { name: "lang", textTransformations: noneTransform } },
+          ],
+        },
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/wafv2-ratecustomkeys/cdk.json
+++ b/tests/integration/wafv2-ratecustomkeys/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-ratecustomkeys/package.json
+++ b/tests/integration/wafv2-ratecustomkeys/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-ratecustomkeys",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-ratecustomkeys false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-ratecustomkeys/verify.sh
+++ b/tests/integration/wafv2-ratecustomkeys/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2RateCustomKeys
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -614,6 +614,11 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULT_PATHS['AWS::WAFv2::WebACL']).toEqual({
       'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,
     });
+    // A RuleGroup hosts the same rate-based statement, so it carries the identical
+    // 5-minute window default (issue #440 — wafv2-ratecustomkeys live read).
+    expect(KNOWN_DEFAULT_PATHS['AWS::WAFv2::RuleGroup']).toEqual({
+      'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,
+    });
     expect(KNOWN_DEFAULT_PATHS['AWS::SES::EmailIdentity']).toEqual({
       'MailFromAttributes.BehaviorOnMxFailure': 'USE_DEFAULT_VALUE',
     });


### PR DESCRIPTION
Closes #440.

## What

A micro-hunt for the issue #440 candidate.

### 1. WAFv2 `RateBasedStatement.CustomKeys` — rule-out (issue #440)

Deployed a real `AWS::WAFv2::RuleGroup` with a rate-based rule declaring **5 CustomKeys in NON-sorted discriminator order** (`[UriPath, Header, HTTPMethod, Cookie, QueryArgument]`). `CustomKeys` is a discriminated-union SET with no top-level identity field — the exact shape that produced confirmed reorder FPs for `LoggingConfiguration.RedactedFields` (#433) and Lambda ESM `KafkaBootstrapServers` (#437).

**Result: WAF reads them back in the EXACT declared order.** Order is preserved (like `AndStatement.Statements` and `LoggingFilter.Conditions`), so there is **no FP to fold** — recorded as an observed-only rule-out comment in `UNORDERED_NESTED_OBJECT_ARRAY_PATHS`, and pinned by a new `wafv2-ratecustomkeys` fixture + golden-corpus case.

### 2. RuleGroup rate-window default fold

The same live read surfaced an undeclared `EvaluationWindowSec=300`. `KNOWN_DEFAULT_PATHS` only carried that 5-minute default for `WAFv2::WebACL`, but a `RuleGroup` hosts the identical rate-based statement. Added the `RuleGroup` entry so it folds to `atDefault`.

## Tests

- `tests/noise-and-strip.test.ts`: new `WAFv2::RuleGroup` EvaluationWindowSec assertion.
- `tests/corpus/AWS__WAFv2__RuleGroup.RuleGroup_customkeys.json`: new replay case pinning the CustomKeys rule-out (no declared drift) + atDefault window fold.
- Full suite green (1896 passed).

## Live verification

`tests/integration/wafv2-ratecustomkeys/verify.sh` end-to-end with the fixed binary: deploy → record → `check` = **CLEAN** (`atDefault=1`). Stack deleted; `bughunt-track.sh verify` = SWEEP CLEAN.
