### PR TITLE
fix(noise): merge duplicate ESM KNOWN_DEFAULTS key dropping retry/age fold

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -63,7 +63,18 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // re-surfaces as real undeclared drift. (SQS event sources don't carry these props at
   // all, so the entry can't mis-fold there.) Observed live on a fresh esm-sourceaccess-rich
   // deploy.
-  'AWS::Lambda::EventSourceMapping': { MaximumRetryAttempts: -1, MaximumRecordAgeInSeconds: -1 },
+  // Enabled: an ESM (e.g. CDK's SqsEventSource) is created enabled; the construct omits
+  // Enabled when it leaves the default true, so the live read reports an undeclared
+  // Enabled=true on every first run — observed live on a dev LineLink stack with no
+  // out-of-band edit. (The off state Enabled=false is dropped upstream as trivially-empty
+  // before this fold, mirroring the KMS Key Enabled case.) Merged into the single
+  // EventSourceMapping entry — a duplicate object-literal key silently drops the earlier
+  // retry/age fold (JS last-key-wins; #438 regressed it).
+  'AWS::Lambda::EventSourceMapping': {
+    MaximumRetryAttempts: -1,
+    MaximumRecordAgeInSeconds: -1,
+    Enabled: true,
+  },
   // An alias created without a Description reads back the empty string. Folded as
   // atDefault so a never-declared alias does not report `Description=""` as drift; it
   // is also the value REVERT_SET_DEFAULT_PATHS writes to undo an out-of-band Description
@@ -78,12 +89,6 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // content hash (not a constant default) — folded as `generated` via
   // GENERATED_TOPLEVEL_PATHS instead.
   'AWS::Lambda::Version': { RuntimePolicy: { UpdateRuntimeOn: 'Auto' } },
-  // An event source mapping (e.g. CDK's SqsEventSource) is created enabled; the
-  // construct omits Enabled when it leaves the default true, so the live read reports
-  // an undeclared Enabled=true on every first run — observed live on a dev LineLink
-  // stack with no out-of-band edit. (The off state Enabled=false is dropped upstream as
-  // trivially-empty before this fold, mirroring the KMS Key Enabled case.)
-  'AWS::Lambda::EventSourceMapping': { Enabled: true },
   'AWS::Events::Rule': { EventBusName: 'default' },
   'AWS::Athena::WorkGroup': { State: 'ENABLED' },
   // AmazonMQ Broker service defaults (observed live on the amazonmq-version-readgap

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.Esm.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.Esm.json
@@ -126,7 +126,7 @@
       "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Esm",
       "resourceType": "AWS::Lambda::EventSourceMapping",
       "path": "Enabled",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -481,12 +481,16 @@ describe('noise suppressors', () => {
     });
   });
 
-  it('Lambda EventSourceMapping stream retry/age infinite defaults (found by esm-sourceaccess-rich)', () => {
+  it('Lambda EventSourceMapping stream retry/age + Enabled defaults (found by esm-sourceaccess-rich)', () => {
     // -1 is the documented "infinite" default for stream / Kafka event sources (retry
-    // forever / no record-age cap); equality-gated, so a finite override still surfaces.
+    // forever / no record-age cap); Enabled=true is the first-run default an omitting
+    // construct reads back. All three live on the SINGLE EventSourceMapping entry —
+    // #438 added Enabled as a SECOND object-literal key, which (JS last-key-wins) silently
+    // dropped the retry/age fold; this asserts they coexist so that regression can't recur.
     expect(KNOWN_DEFAULTS['AWS::Lambda::EventSourceMapping']).toEqual({
       MaximumRetryAttempts: -1,
       MaximumRecordAgeInSeconds: -1,
+      Enabled: true,
     });
   });
 


### PR DESCRIPTION
## Summary

PR #438 added a SECOND `'AWS::Lambda::EventSourceMapping'` key to `KNOWN_DEFAULTS`
in `src/normalize/noise.ts` (`{ Enabled: true }`) while the #437 entry
(`{ MaximumRetryAttempts: -1, MaximumRecordAgeInSeconds: -1 }`) already existed.
By JS object-literal **last-key-wins**, the retry/age entry was silently
overridden — so those props re-surfaced as **undeclared first-run drift** on
every fresh stream / self-managed-Kafka ESM, and `tsgo` flagged the duplicate
(TS1117). `main` was left red on typecheck **and** two tests
(`noise-and-strip` ESM assertion + the `Esm.json` corpus replay).

## Fix

- Merge all three defaults onto the single `AWS::Lambda::EventSourceMapping`
  entry so the retry/age and Enabled folds coexist.
- Regenerate the `AWS__Lambda__EventSourceMapping.Esm.json` corpus case
  (`Enabled` now folds to `atDefault`).
- Tighten the unit test to assert all three coexist so the dup-key drop cannot
  recur.

## Verification

- typecheck / lint / build / **all 1895 unit tests** pass.
- **Live-proven** on a fresh deploy (us-east-1): a first-run `check` lands all
  three (`MaximumRetryAttempts=-1`, `MaximumRecordAgeInSeconds=-1`,
  `Enabled=true`) in `atDefault`, none in `undeclared`. Teardown clean.

Found while working issue #441; split out as its own fix PR.
