### PR TITLE
test(noise): confirm WAFv2 WebACL CustomKeys rule-out + fold WebACL DDoS-protection default (#440)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -91,6 +91,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Lambda::Version': { RuntimePolicy: { UpdateRuntimeOn: 'Auto' } },
   'AWS::Events::Rule': { EventBusName: 'default' },
   'AWS::Athena::WorkGroup': { State: 'ENABLED' },
+  // A WebACL that declares no on-source DDoS protection reads back AWS's default
+  // OnSourceDDoSProtectionConfig — ALBLowReputationMode=ACTIVE_UNDER_DDOS (the first
+  // enum value / documented default), so the live read reports it as undeclared
+  // first-run noise on every WebACL. Equality-gated; a user that sets ALWAYS_ON still
+  // surfaces. Observed live on a fresh wafv2-webacl-customkeys deploy (issue #440).
+  'AWS::WAFv2::WebACL': {
+    OnSourceDDoSProtectionConfig: { ALBLowReputationMode: 'ACTIVE_UNDER_DDOS' },
+  },
   // AmazonMQ Broker service defaults (observed live on the amazonmq-version-readgap
   // fixture): a broker created without these knobs reports all three as undeclared
   // first-run noise. AuthenticationStrategy is SIMPLE unless LDAP is configured;
@@ -1917,11 +1925,12 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   // aggregate-key objects ({UriPath:{}}, {Header:{Name,…}}, {HTTPMethod:{}}, …) with
   // no top-level IDENTITY_FIELD — the same shape that produced reorder FPs for
   // LoggingConfiguration RedactedFields (#433) and Lambda ESM KafkaBootstrapServers
-  // (#437). A fresh wafv2-ratecustomkeys deploy declaring 5 keys in NON-sorted
-  // discriminator order ([UriPath, Header, HTTPMethod, Cookie, QueryArgument]) read
-  // them back in the EXACT declared order — WAF PRESERVES CustomKeys order (like
-  // AndStatement.Statements and LoggingFilter.Conditions), so there is no FP to fold.
-  // Pinned by the wafv2-ratecustomkeys fixture + corpus case (issue #440).
+  // (#437). Fresh wafv2-ratecustomkeys (RuleGroup) AND wafv2-webacl-customkeys (WebACL)
+  // deploys each declaring 5 keys in NON-sorted discriminator order ([UriPath, Header,
+  // HTTPMethod, Cookie, QueryArgument]) read them back in the EXACT declared order on
+  // BOTH host types — WAF PRESERVES CustomKeys order (like AndStatement.Statements and
+  // LoggingFilter.Conditions), so there is no FP to fold. Pinned by both fixtures +
+  // corpus cases (issue #440).
   'AWS::Bedrock::Guardrail': new Set([
     'ContentPolicyConfig.FiltersConfig',
     'TopicPolicyConfig.TopicsConfig',

--- a/tests/corpus/AWS__WAFv2__WebACL.Edge.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.Edge.json
@@ -127,7 +127,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Edge",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "OnSourceDDoSProtectionConfig",

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl.json
@@ -152,7 +152,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebAcl",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "OnSourceDDoSProtectionConfig",

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl_customkeys.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl_customkeys.json
@@ -1,0 +1,235 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "WebAcl",
+    "resourceType": "AWS::WAFv2::WebACL",
+    "physicalId": "cdkrd-integ-webacl-customkeys|78968456-4d06-41b7-9cb7-2931e4fa415d|REGIONAL",
+    "constructPath": "CdkRealDriftIntegWafv2WebAclCustomKeys/WebAcl",
+    "declared": {
+      "DefaultAction": {
+        "Allow": {}
+      },
+      "Name": "cdkrd-integ-webacl-customkeys",
+      "Rules": [
+        {
+          "Action": {
+            "Block": {}
+          },
+          "Name": "rate-custom-keys",
+          "Priority": 0,
+          "Statement": {
+            "RateBasedStatement": {
+              "AggregateKeyType": "CUSTOM_KEYS",
+              "CustomKeys": [
+                {
+                  "UriPath": {
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "Header": {
+                    "Name": "x-region",
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "HTTPMethod": {}
+                },
+                {
+                  "Cookie": {
+                    "Name": "session",
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "QueryArgument": {
+                    "Name": "lang",
+                    "TextTransformations": [
+                      {
+                        "Priority": 0,
+                        "Type": "NONE"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "Limit": 2000
+            }
+          },
+          "VisibilityConfig": {
+            "CloudWatchMetricsEnabled": true,
+            "MetricName": "rateCustomKeys",
+            "SampledRequestsEnabled": true
+          }
+        }
+      ],
+      "Scope": "REGIONAL",
+      "VisibilityConfig": {
+        "CloudWatchMetricsEnabled": true,
+        "MetricName": "cdkrdWebAclCustomKeys",
+        "SampledRequestsEnabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "DefaultAction": {
+      "Allow": {}
+    },
+    "Scope": "REGIONAL",
+    "Capacity": 152,
+    "Id": "78968456-4d06-41b7-9cb7-2931e4fa415d",
+    "Arn": "arn:aws:wafv2:us-east-1:111111111111:regional/webacl/cdkrd-integ-webacl-customkeys/78968456-4d06-41b7-9cb7-2931e4fa415d",
+    "OnSourceDDoSProtectionConfig": {
+      "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+    },
+    "Rules": [
+      {
+        "Action": {
+          "Block": {}
+        },
+        "Priority": 0,
+        "Statement": {
+          "RateBasedStatement": {
+            "AggregateKeyType": "CUSTOM_KEYS",
+            "CustomKeys": [
+              {
+                "UriPath": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ]
+                }
+              },
+              {
+                "Header": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ],
+                  "Name": "x-region"
+                }
+              },
+              {
+                "HTTPMethod": {}
+              },
+              {
+                "Cookie": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ],
+                  "Name": "session"
+                }
+              },
+              {
+                "QueryArgument": {
+                  "TextTransformations": [
+                    {
+                      "Type": "NONE",
+                      "Priority": 0
+                    }
+                  ],
+                  "Name": "lang"
+                }
+              }
+            ],
+            "Limit": 2000,
+            "EvaluationWindowSec": 300
+          }
+        },
+        "RuleLabels": [],
+        "VisibilityConfig": {
+          "MetricName": "rateCustomKeys",
+          "SampledRequestsEnabled": true,
+          "CloudWatchMetricsEnabled": true
+        },
+        "Name": "rate-custom-keys"
+      }
+    ],
+    "VisibilityConfig": {
+      "MetricName": "cdkrdWebAclCustomKeys",
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true
+    },
+    "LabelNamespace": "awswaf:111111111111:webacl:cdkrd-integ-webacl-customkeys:",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegWafv2WebAclCustomKeys/2868d810-7488-11f1-878b-0e43c5a25781",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegWafv2WebAclCustomKeys",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "WebAcl",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-integ-webacl-customkeys"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Scope"],
+    "readOnlyPaths": ["Arn", "Capacity", "Id", "LabelNamespace"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Scope"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["AssociationConfig.RequestBody", "CustomResponseBodies"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "OnSourceDDoSProtectionConfig",
+      "actual": {
+        "ALBLowReputationMode": "ACTIVE_UNDER_DDOS"
+      },
+      "physicalId": "cdkrd-integ-webacl-customkeys|78968456-4d06-41b7-9cb7-2931e4fa415d|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2WebAclCustomKeys/WebAcl"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WebAcl",
+      "resourceType": "AWS::WAFv2::WebACL",
+      "path": "Rules[rate-custom-keys].Statement.RateBasedStatement.EvaluationWindowSec",
+      "actual": 300,
+      "nested": true,
+      "physicalId": "cdkrd-integ-webacl-customkeys|78968456-4d06-41b7-9cb7-2931e4fa415d|REGIONAL",
+      "constructPath": "CdkRealDriftIntegWafv2WebAclCustomKeys/WebAcl"
+    }
+  ],
+  "description": "RECORDED LIVE (wafv2-webacl-customkeys fixture, issue #440): fresh-deploy AWS::WAFv2::WebACL with a rate-based rule whose RateBasedStatement.CustomKeys SET of discriminated-union aggregate keys is declared NON-sorted ([UriPath, Header, HTTPMethod, Cookie, QueryArgument]). WAF reads them back in the EXACT declared order (same rule-out as the RuleGroup sibling), so CustomKeys is deliberately NOT folded. Findings: the EvaluationWindowSec 5-minute default and the OnSourceDDoSProtectionConfig (ALBLowReputationMode=ACTIVE_UNDER_DDOS) default, both folded to atDefault."
+}

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl_reorder.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl_reorder.json
@@ -187,7 +187,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebAcl",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "OnSourceDDoSProtectionConfig",

--- a/tests/corpus/AWS__WAFv2__WebACL.WebAcl_rich.json
+++ b/tests/corpus/AWS__WAFv2__WebACL.WebAcl_rich.json
@@ -358,7 +358,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WebAcl",
       "resourceType": "AWS::WAFv2::WebACL",
       "path": "OnSourceDDoSProtectionConfig",

--- a/tests/integration/wafv2-webacl-customkeys/app.ts
+++ b/tests/integration/wafv2-webacl-customkeys/app.ts
@@ -1,0 +1,64 @@
+// CDK app for the cdk-real-drift WAFv2 WebACL RateBasedStatement.CustomKeys
+// reorder false-positive test (issue #440 follow-up).
+//
+// The sibling wafv2-ratecustomkeys fixture proved AWS::WAFv2::RuleGroup preserves
+// the CustomKeys order; this confirms the SAME rule-out on AWS::WAFv2::WebACL — the
+// more common host of a rate-based rule. A rate-based rule's `CustomKeys` is a SET
+// of discriminated-union aggregate-key objects ({UriPath:{…}}, {Header:{…}},
+// {HTTPMethod:{}}, {Cookie:{…}}, {QueryArgument:{…}}) — a single-discriminator,
+// no-IDENTITY_FIELD shape that produced confirmed reorder FPs for WAFv2
+// LoggingConfiguration RedactedFields (#433) and Lambda ESM KafkaBootstrapServers
+// (#437). If WAF echoed the set sorted (not in template order) and `CustomKeys`
+// were not folded as an unordered nested object array, a positional diff would
+// false-flag every shifted key as declared drift on a freshly recorded WebACL.
+//
+// The keys are declared in a deliberately NON-sorted discriminator order
+// (UriPath, Header, HTTPMethod, Cookie, QueryArgument) so any WAF-side
+// canonicalization shows up. A clean record -> check MUST be CLEAN.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegWafv2WebAclCustomKeys");
+
+const noneTransform = [{ priority: 0, type: "NONE" }];
+
+new CfnWebACL(stack, "WebAcl", {
+  name: "cdkrd-integ-webacl-customkeys",
+  scope: "REGIONAL",
+  defaultAction: { allow: {} },
+  visibilityConfig: {
+    sampledRequestsEnabled: true,
+    cloudWatchMetricsEnabled: true,
+    metricName: "cdkrdWebAclCustomKeys",
+  },
+  rules: [
+    {
+      name: "rate-custom-keys",
+      priority: 0,
+      action: { block: {} },
+      visibilityConfig: {
+        sampledRequestsEnabled: true,
+        cloudWatchMetricsEnabled: true,
+        metricName: "rateCustomKeys",
+      },
+      statement: {
+        rateBasedStatement: {
+          limit: 2000,
+          aggregateKeyType: "CUSTOM_KEYS",
+          // Declared NON-sorted by discriminator key on purpose to expose any
+          // WAF-side reordering of the CustomKeys set.
+          customKeys: [
+            { uriPath: { textTransformations: noneTransform } },
+            { header: { name: "x-region", textTransformations: noneTransform } },
+            { httpMethod: {} },
+            { cookie: { name: "session", textTransformations: noneTransform } },
+            { queryArgument: { name: "lang", textTransformations: noneTransform } },
+          ],
+        },
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/wafv2-webacl-customkeys/cdk.json
+++ b/tests/integration/wafv2-webacl-customkeys/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/wafv2-webacl-customkeys/package.json
+++ b/tests/integration/wafv2-webacl-customkeys/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-wafv2-webacl-customkeys",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift wafv2-webacl-customkeys false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/wafv2-webacl-customkeys/verify.sh
+++ b/tests/integration/wafv2-webacl-customkeys/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Any drift on a freshly deployed + recorded stack is a
+# normalization / default-folding false positive.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegWafv2WebAclCustomKeys
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] corpus harvest (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -517,6 +517,11 @@ describe('noise suppressors', () => {
       IncludeLinkedAccountsMetrics: false,
       State: 'running',
     });
+    // A WebACL reads back AWS's default on-source DDoS protection config when none is
+    // declared (issue #440 — wafv2-webacl-customkeys live read).
+    expect(KNOWN_DEFAULTS['AWS::WAFv2::WebACL']).toEqual({
+      OnSourceDDoSProtectionConfig: { ALBLowReputationMode: 'ACTIVE_UNDER_DDOS' },
+    });
     // KMS key defaults.
     expect(KNOWN_DEFAULTS['AWS::KMS::Key']).toEqual({
       Enabled: true,


### PR DESCRIPTION
Follow-up to #442 (issue #440).

## What

The RuleGroup hunt (#442) confirmed `AWS::WAFv2::RuleGroup` preserves `RateBasedStatement.CustomKeys` order, but left the **WebACL** host (the more common one) live-unverified. This closes that gap.

### 1. WebACL CustomKeys — rule-out confirmed

Deployed an `AWS::WAFv2::WebACL` rate-based rule declaring **5 CustomKeys in NON-sorted discriminator order** (`[UriPath, Header, HTTPMethod, Cookie, QueryArgument]`). WAF reads them back in the **EXACT declared order** on the WebACL host too — the CustomKeys rule-out holds for **both** host types. Pinned by a new `wafv2-webacl-customkeys` fixture + corpus case; the rule-out comment in `UNORDERED_NESTED_OBJECT_ARRAY_PATHS` now records both live confirmations.

### 2. WebACL on-source DDoS-protection default fold

The same live read surfaced an undeclared `OnSourceDDoSProtectionConfig: { ALBLowReputationMode: "ACTIVE_UNDER_DDOS" }` — AWS's default on-source DDoS protection, injected on every WebACL that declares none. Added to `KNOWN_DEFAULTS` so it folds to `atDefault` (equality-gated; a user that sets `ALWAYS_ON` still surfaces). Regenerated the four existing WebACL corpus cases (`Edge`, `WebAcl`, `WebAcl_reorder`, `WebAcl_rich`) whose `expected` now folds this config (`undeclared` → `atDefault`).

## Tests

- `tests/noise-and-strip.test.ts`: new WebACL `OnSourceDDoSProtectionConfig` `KNOWN_DEFAULTS` assertion.
- `tests/corpus/AWS__WAFv2__WebACL.WebAcl_customkeys.json`: new replay case (CustomKeys rule-out + both atDefault folds).
- 4 existing WebACL corpus cases regenerated for the DDoS fold.
- Full suite green (1909 passed).

## Live verification

`tests/integration/wafv2-webacl-customkeys/verify.sh` end-to-end: deploy → record → `check` = **CLEAN** (`atDefault=1`). Stack deleted; own stack confirmed gone (the sweep's remaining orphans belong to a sibling session's in-flight `basic`/`revert` fixtures, not this work).
