### PR TITLE
feat(check): offer Record (establish baseline) even when only a declared drift exists

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -997,7 +997,17 @@ R141: it ALSO fires when there is simply NO baseline file yet — even on a CLEA
 baseline is established through `check`'s own flow (the chosen Record writes the initial
 snapshot-complete baseline with zero undeclared entries) rather than a separate `cdkrd
 record` step; once a baseline exists, a clean run prompts nothing. `availableActions`
-offers `record` when there are undeclared/added findings OR (no baseline AND no drift).
+offers `record` whenever there are undeclared/added findings OR there is no
+baseline yet — including when the only drift is a declared/deleted one Record
+cannot itself resolve. Establishing the baseline STARTS undeclared watching,
+which is orthogonal to that drift: the drift keeps being reported until the user
+reverts/ignores it (Record never resolves a declared drift). Withholding `record`
+there would have forced the user to clear (or permanently `ignore`) the declared
+drift before they could even begin watching undeclared state — defeating the
+tool's core value. So `record` stays offered, and `buildResolveOptions` words the
+establish option honestly when a declared drift coexists (`Record current state
+as the .cdkrd baseline (start watching undeclared now — the declared drift stays
+reported; revert/ignore it separately)`) so it never reads as "all done".
 In `--json` the findings keep `tier: "undeclared"` (the documented enum) plus
 an `"unrecorded": true` field, and `drifted` excludes them. `--show-all`
 ignores the recorded baseline — it lists EVERY current undeclared value with no

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -215,6 +215,30 @@ interface SubResult {
 }
 
 /**
+ * How to word the Record option (its action is always the same — snapshot undeclared into
+ * the baseline, R141-establishing the file if absent — but the label must describe what it
+ * actually does HERE so it never over-promises):
+ *  - 'snapshot'        — there ARE undeclared/added values to record (baseline present or not).
+ *  - 'establish'       — nothing undeclared to record and no baseline yet, on an otherwise
+ *                        CLEAN stack: Record just establishes the day-1 baseline (marks reviewed).
+ *  - 'establish-drift' — nothing undeclared to record and no baseline yet, but a declared/deleted
+ *                        drift coexists: Record establishes the baseline + STARTS undeclared
+ *                        watching, while that drift stays reported (revert/ignore it separately).
+ */
+export type RecordLabelKind = 'snapshot' | 'establish' | 'establish-drift';
+
+function recordOptionLabel(kind: RecordLabelKind): string {
+  switch (kind) {
+    case 'establish':
+      return 'Record current state as the .cdkrd baseline (marks this stack reviewed)';
+    case 'establish-drift':
+      return 'Record current state as the .cdkrd baseline (start watching undeclared now — the declared drift stays reported; revert/ignore it separately)';
+    default:
+      return 'Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)';
+  }
+}
+
+/**
  * Build the top-menu options for the current action surface (R133). Nothing is FIRST so
  * the safe no-op is the top row AND the default cursor — Enter is a harmless exit, never
  * an accidental write. "Decide per finding" appears only when >1 finding is decidable
@@ -223,20 +247,12 @@ interface SubResult {
 export function buildResolveOptions(
   actions: Actions,
   decidableCount: number,
-  establishOnly = false
+  recordLabel: RecordLabelKind = 'snapshot'
 ): { value: string; label: string }[] {
   const options: { value: string; label: string }[] = [
     { value: 'nothing', label: 'Nothing (decide later)' },
   ];
-  if (actions.record)
-    options.push({
-      value: 'record-all',
-      // R141: when there is nothing to record but no baseline yet, Record establishes the
-      // initial baseline (marks the stack reviewed) — name that, not "all undeclared".
-      label: establishOnly
-        ? 'Record current state as the .cdkrd baseline (marks this stack reviewed)'
-        : 'Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)',
-    });
+  if (actions.record) options.push({ value: 'record-all', label: recordOptionLabel(recordLabel) });
   if (actions.revert)
     options.push({ value: 'revert-all', label: 'Revert — write the desired values back to AWS' });
   if (actions.ignore)
@@ -291,7 +307,20 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
     // R141: nothing to act on, but no baseline yet → Record establishes the day-1 baseline.
     // The only available action is `record` and there are no actionable findings to decide.
     const establishOnly = baseline === undefined && decidable.length === 0;
-    const options = buildResolveOptions(actions, decidable.length, establishOnly);
+    // Word the Record option for what it does HERE. With undeclared/added to snapshot it is a
+    // plain snapshot; with none and no baseline it establishes the baseline — and when a
+    // declared drift coexists (R141 relaxed), say so honestly so "Record" never reads as "all
+    // done" next to a drift it does not itself resolve. Scoped to `declared` (not `deleted`)
+    // because the honest label points the user at revert/ignore, which apply to a declared
+    // drift; a deleted resource is fixed by re-deploying, not from this menu.
+    const recordable = reconciled.some((f) => f.tier === 'undeclared' || f.tier === 'added');
+    const declaredDrift = reconciled.some((f) => f.tier === 'declared');
+    const recordLabel: RecordLabelKind = recordable
+      ? 'snapshot'
+      : declaredDrift
+        ? 'establish-drift'
+        : 'establish';
+    const options = buildResolveOptions(actions, decidable.length, recordLabel);
 
     const choice = await select({
       message: resolveMenuMessage(p.stackName, code, establishOnly),

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -985,17 +985,18 @@ export function availableActions(
   removeUnrecorded: boolean
 ): Actions {
   const recordable = findings.some((f) => f.tier === 'undeclared' || f.tier === 'added');
-  // R141: with NO baseline file yet, `record` is offered even on a CLEAN stack — it writes
-  // the initial baseline (snapshot-complete resources, zero undeclared entries), so a fresh
-  // deploy can be blessed as the day-1 baseline through `check`'s own prompt (no separate
-  // `cdkrd record` step). Gated to a clean stack (no actionable drift) so the establish
-  // option never wears the "Record all undeclared" label next to a declared/deleted drift it
-  // does not address. Once a baseline exists, a clean run offers nothing.
-  const anyDrift = findings.some(
-    (f) =>
-      f.tier === 'declared' || f.tier === 'deleted' || f.tier === 'undeclared' || f.tier === 'added'
-  );
-  const record = recordable || (baseline === undefined && !anyDrift);
+  // R141: with NO baseline file yet, `record` is ALWAYS offered — it writes the initial
+  // baseline (snapshot-complete resources, plus any undeclared entries) so a fresh deploy can
+  // be blessed as the day-1 baseline through `check`'s own prompt (no separate `cdkrd record`
+  // step). It is offered EVEN when the only drift is a declared/deleted one it cannot itself
+  // resolve: establishing the baseline STARTS undeclared watching, which is orthogonal to that
+  // drift — the drift keeps being reported until the user reverts/ignores it. Withholding
+  // `record` here used to force the user to clear (or permanently `ignore`) the declared drift
+  // before they could even begin watching undeclared state, defeating the tool's core value.
+  // `buildResolveOptions` worded the establish option honestly for that case ("the declared
+  // drift stays reported"), so it no longer reads as "all done". Once a baseline exists,
+  // `record` is offered only when there is undeclared/added state to snapshot.
+  const record = recordable || baseline === undefined;
   const ignore = findings.some(
     (f) => f.tier === 'declared' || f.tier === 'undeclared' || f.tier === 'added'
   );

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -151,13 +151,19 @@ describe('buildResolveOptions (R133 — the chain menu surface)', () => {
     expect(values(A({ revert: true }), 2)).toContain('per-finding');
   });
 
-  it('R141: establishOnly relabels Record to "establish the baseline", not "all undeclared"', () => {
-    const label = (establish: boolean): string =>
-      buildResolveOptions(A({ record: true }), 0, establish).find((o) => o.value === 'record-all')!
+  it('R141: the Record label is worded per recordLabel kind (snapshot / establish / establish-drift)', () => {
+    const label = (kind: 'snapshot' | 'establish' | 'establish-drift'): string =>
+      buildResolveOptions(A({ record: true }), 0, kind).find((o) => o.value === 'record-all')!
         .label;
-    expect(label(true)).toContain('Record current state as the .cdkrd baseline');
-    expect(label(true)).not.toContain('undeclared');
-    expect(label(false)).toContain('Record undeclared');
+    // clean establish: "baseline", never "undeclared"
+    expect(label('establish')).toContain('Record current state as the .cdkrd baseline');
+    expect(label('establish')).not.toContain('undeclared');
+    // plain snapshot: "undeclared"
+    expect(label('snapshot')).toContain('Record undeclared');
+    // establish next to a declared drift: still a baseline establish, but honest that the
+    // declared drift stays reported (so it never reads as "all done").
+    expect(label('establish-drift')).toContain('Record current state as the .cdkrd baseline');
+    expect(label('establish-drift')).toContain('declared drift stays reported');
   });
 });
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -90,8 +90,18 @@ const baselineWith = (entries: BaselineFile['recorded']): BaselineFile => ({
 });
 
 describe('availableActions (R28 interactive choice logic)', () => {
-  it('declared-only → Record hidden (cannot record declared), Ignore + Revert shown', () => {
+  it('declared-only + NO baseline → Record SHOWN (establish + start watching; declared stays reported), Ignore + Revert too', () => {
+    // A declared drift no longer blocks establishing the day-1 baseline: Record begins
+    // undeclared watching (orthogonal to the declared drift, which keeps being reported).
     expect(availableActions([declared()], undefined, NO_SCHEMAS, false)).toEqual({
+      record: true,
+      ignore: true,
+      revert: true,
+    });
+  });
+
+  it('declared-only WITH a baseline → Record hidden (baseline exists, nothing new undeclared to snapshot)', () => {
+    expect(availableActions([declared()], baselineWith([]), NO_SCHEMAS, false)).toEqual({
       record: false,
       ignore: true,
       revert: true,
@@ -119,8 +129,18 @@ describe('availableActions (R28 interactive choice logic)', () => {
     });
   });
 
-  it('deleted-only → none (deleted is not revertable, not ignorable, nothing to record)', () => {
+  it('deleted-only + NO baseline → only Record (establish day-1 baseline); deleted is not revertable/ignorable, and snapshots nothing', () => {
+    // Record here establishes the baseline (starts undeclared watching). The deleted finding
+    // itself stays unaddressable: not revertable, not ignorable, and never recorded.
     expect(availableActions([deleted()], undefined, NO_SCHEMAS, false)).toEqual({
+      record: true,
+      ignore: false,
+      revert: false,
+    });
+  });
+
+  it('deleted-only WITH a baseline → none (baseline exists, deleted is unaddressable)', () => {
+    expect(availableActions([deleted()], baselineWith([]), NO_SCHEMAS, false)).toEqual({
       record: false,
       ignore: false,
       revert: false,
@@ -195,16 +215,6 @@ describe('availableActions (R28 interactive choice logic)', () => {
       record: false,
       ignore: false,
       revert: false,
-    });
-  });
-
-  it('R141: drift + NO baseline → establish NOT mixed in (Record gated off, only its real actions)', () => {
-    // declared drift on a never-recorded stack: Record must NOT appear wearing the
-    // "all undeclared" label for a declared drift it cannot address.
-    expect(availableActions([declared()], undefined, NO_SCHEMAS, false)).toEqual({
-      record: false,
-      ignore: true,
-      revert: true,
     });
   });
 });


### PR DESCRIPTION
## Problem

When there is **no baseline yet** and the only outstanding finding is a
`[CFn-Declared Drift]` (or a deleted-resource drift), `check`'s interactive menu
hid **Record** entirely:

```
ApiStack: drift found — what do you want to do?
  ❯ Nothing (decide later)
    Revert — write the desired values back to AWS
    Ignore — stop reporting it (writes .cdkrd/ignore.yaml)
```

Record's only candidate there is the R141 day-1 *establish*, which was gated to a
**clean** stack (`baseline === undefined && !anyDrift`). That silently blocked a
legitimate workflow:

> "This declared drift can't be fixed right now — set it aside and start watching
> undeclared state."

The user's only escapes were `revert` (often not yet possible) or `ignore` —
which is **wrong**: `ignore` STOPS watching (a permanent accept), but the user
wants the declared drift to keep showing until they fix it. Meanwhile the tool's
core value — undeclared watching — couldn't even begin, all because of one
unrelated declared drift. And the option just *vanished* with no explanation.

## Fix

Establishing the baseline (writing `completeResources`) **starts undeclared
watching** and is **orthogonal** to the declared drift: that drift keeps being
reported until reverted/ignored. Record never resolves a declared drift — before
or after this change — so there is no data reason to withhold it.

- `availableActions`: with no baseline, Record is **always** offered
  (`record = recordable || baseline === undefined`). Once a baseline exists,
  Record is offered only when there's undeclared/added state to snapshot
  (unchanged).
- The old "this reads as *all done*" concern is handled by **wording, not
  hiding**: `buildResolveOptions` now picks the Record label per situation via a
  `RecordLabelKind` (`snapshot` / `establish` / `establish-drift`). With a
  declared drift coexisting it reads:

  > `Record current state as the .cdkrd baseline (start watching undeclared now — the declared drift stays reported; revert/ignore it separately)`

After establishing, the post-record note already states the declared drift remains
un-addressed and the menu re-shows revert/ignore for it; exit stays 1.

## Tests

- `availableActions`: declared-only / deleted-only + **no baseline** now show
  Record; both stay hidden once a baseline exists.
- `buildResolveOptions`: the three `RecordLabelKind` labels (snapshot / establish
  / establish-drift) are asserted.
- Full suite: 42 files / 1915 tests green; typecheck + lint/format + build pass.

## Docs

`docs/ARCHITECTURE.md` R141 section updated to the new rule and the honest
establish-with-declared label.