### PR TITLE
test(check): cover establish Record end-to-end; add re-deploy hint for deleted-only

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1007,7 +1007,10 @@ drift before they could even begin watching undeclared state — defeating the
 tool's core value. So `record` stays offered, and `buildResolveOptions` words the
 establish option honestly when a declared drift coexists (`Record current state
 as the .cdkrd baseline (start watching undeclared now — the declared drift stays
-reported; revert/ignore it separately)`) so it never reads as "all done".
+reported; revert/ignore it separately)`) so it never reads as "all done". A
+coexisting DELETED declared resource gets its own variant of that hint
+(`re-deploy to restore it` — it is not revert/ignore-able from this menu); a
+declared drift takes priority when both are present.
 In `--json` the findings keep `tier: "undeclared"` (the documented enum) plus
 an `"unrecorded": true` field, and `drifted` excludes them. `--show-all`
 ignores the recorded baseline — it lists EVERY current undeclared value with no

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -218,14 +218,17 @@ interface SubResult {
  * How to word the Record option (its action is always the same — snapshot undeclared into
  * the baseline, R141-establishing the file if absent — but the label must describe what it
  * actually does HERE so it never over-promises):
- *  - 'snapshot'        — there ARE undeclared/added values to record (baseline present or not).
- *  - 'establish'       — nothing undeclared to record and no baseline yet, on an otherwise
- *                        CLEAN stack: Record just establishes the day-1 baseline (marks reviewed).
- *  - 'establish-drift' — nothing undeclared to record and no baseline yet, but a declared/deleted
- *                        drift coexists: Record establishes the baseline + STARTS undeclared
- *                        watching, while that drift stays reported (revert/ignore it separately).
+ *  - 'snapshot'          — there ARE undeclared/added values to record (baseline present or not).
+ *  - 'establish'         — nothing undeclared to record and no baseline yet, on an otherwise
+ *                          CLEAN stack: Record just establishes the day-1 baseline (marks reviewed).
+ *  - 'establish-drift'   — nothing undeclared to record and no baseline yet, but a DECLARED drift
+ *                          coexists: Record establishes the baseline + STARTS undeclared watching,
+ *                          while that drift stays reported (revert/ignore it separately).
+ *  - 'establish-deleted' — same, but the coexisting drift is a DELETED declared resource: it stays
+ *                          reported and is restored by re-deploying (NOT revert/ignore), so the
+ *                          hint differs. Only used when there is no declared drift to take priority.
  */
-export type RecordLabelKind = 'snapshot' | 'establish' | 'establish-drift';
+export type RecordLabelKind = 'snapshot' | 'establish' | 'establish-drift' | 'establish-deleted';
 
 function recordOptionLabel(kind: RecordLabelKind): string {
   switch (kind) {
@@ -233,6 +236,8 @@ function recordOptionLabel(kind: RecordLabelKind): string {
       return 'Record current state as the .cdkrd baseline (marks this stack reviewed)';
     case 'establish-drift':
       return 'Record current state as the .cdkrd baseline (start watching undeclared now — the declared drift stays reported; revert/ignore it separately)';
+    case 'establish-deleted':
+      return 'Record current state as the .cdkrd baseline (start watching undeclared now — the deleted-resource drift stays reported; re-deploy to restore it)';
     default:
       return 'Record undeclared (live-only) — snapshot into the .cdkrd baseline (keeps watching)';
   }
@@ -308,18 +313,21 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
     // The only available action is `record` and there are no actionable findings to decide.
     const establishOnly = baseline === undefined && decidable.length === 0;
     // Word the Record option for what it does HERE. With undeclared/added to snapshot it is a
-    // plain snapshot; with none and no baseline it establishes the baseline — and when a
-    // declared drift coexists (R141 relaxed), say so honestly so "Record" never reads as "all
-    // done" next to a drift it does not itself resolve. Scoped to `declared` (not `deleted`)
-    // because the honest label points the user at revert/ignore, which apply to a declared
-    // drift; a deleted resource is fixed by re-deploying, not from this menu.
+    // plain snapshot; with none and no baseline it establishes the baseline — and when a hard
+    // drift coexists (R141 relaxed), say so honestly so "Record" never reads as "all done" next
+    // to a drift it does not itself resolve. A DECLARED drift takes priority (its hint points at
+    // revert/ignore); a DELETED declared resource gets its own hint (re-deploy to restore — it
+    // is not revert/ignore-able from this menu).
     const recordable = reconciled.some((f) => f.tier === 'undeclared' || f.tier === 'added');
     const declaredDrift = reconciled.some((f) => f.tier === 'declared');
+    const deletedDrift = reconciled.some((f) => f.tier === 'deleted');
     const recordLabel: RecordLabelKind = recordable
       ? 'snapshot'
       : declaredDrift
         ? 'establish-drift'
-        : 'establish';
+        : deletedDrift
+          ? 'establish-deleted'
+          : 'establish';
     const options = buildResolveOptions(actions, decidable.length, recordLabel);
 
     const choice = await select({

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -151,8 +151,10 @@ describe('buildResolveOptions (R133 — the chain menu surface)', () => {
     expect(values(A({ revert: true }), 2)).toContain('per-finding');
   });
 
-  it('R141: the Record label is worded per recordLabel kind (snapshot / establish / establish-drift)', () => {
-    const label = (kind: 'snapshot' | 'establish' | 'establish-drift'): string =>
+  it('R141: the Record label is worded per recordLabel kind (snapshot / establish / establish-drift / establish-deleted)', () => {
+    const label = (
+      kind: 'snapshot' | 'establish' | 'establish-drift' | 'establish-deleted'
+    ): string =>
       buildResolveOptions(A({ record: true }), 0, kind).find((o) => o.value === 'record-all')!
         .label;
     // clean establish: "baseline", never "undeclared"
@@ -164,6 +166,9 @@ describe('buildResolveOptions (R133 — the chain menu surface)', () => {
     // declared drift stays reported (so it never reads as "all done").
     expect(label('establish-drift')).toContain('Record current state as the .cdkrd baseline');
     expect(label('establish-drift')).toContain('declared drift stays reported');
+    // establish next to a DELETED declared resource: hint is re-deploy, not revert/ignore.
+    expect(label('establish-deleted')).toContain('deleted-resource drift stays reported');
+    expect(label('establish-deleted')).toContain('re-deploy to restore it');
   });
 });
 

--- a/tests/interactive-resolve.test.ts
+++ b/tests/interactive-resolve.test.ts
@@ -15,6 +15,7 @@ vi.mock('../src/commands/stack-actions.js', async (importOriginal) => {
     ...actual,
     revertStack: vi.fn().mockResolvedValue({ exit: 0, aborted: false }),
     ignoreStack: vi.fn().mockResolvedValue({ wrote: false, refused: false, added: 0 }),
+    recordStack: vi.fn().mockResolvedValue({ wrote: true, refused: false }),
   };
 });
 
@@ -24,7 +25,7 @@ import {
   isFoldedFinding,
   resolveInteractively,
 } from '../src/commands/interactive-resolve.js';
-import { ignoreStack, revertStack } from '../src/commands/stack-actions.js';
+import { ignoreStack, recordStack, revertStack } from '../src/commands/stack-actions.js';
 import type { Finding } from '../src/types.js';
 
 const declaredDrift: Finding = {
@@ -72,6 +73,37 @@ describe('resolveInteractively — read-only check never auto-confirms an AWS wr
     vi.mocked(select).mockResolvedValueOnce('revert-all');
     await resolveInteractively(params(false));
     expect(vi.mocked(revertStack).mock.calls[0]![0]).toMatchObject({ yes: false });
+  });
+});
+
+// PR #452: a declared-only stack with NO baseline yet must still OFFER Record (establish the
+// day-1 baseline + start undeclared watching), worded honestly that the declared drift stays
+// reported. This drives the whole menu end-to-end: the option appears, and choosing it routes
+// to recordStack (the establish write) rather than being silently absent.
+describe('resolveInteractively — declared-only + no baseline still offers + routes Record (establish)', () => {
+  beforeEach(() => {
+    vi.mocked(recordStack).mockClear();
+    vi.mocked(recordStack).mockResolvedValue({ wrote: true, refused: false });
+    vi.mocked(select).mockReset();
+  });
+
+  it('offers record-all (establish-drift label) and routes the choice to recordStack', async () => {
+    vi.mocked(select)
+      .mockResolvedValueOnce('record-all') // top menu: choose Record (establish)
+      .mockResolvedValueOnce('nothing'); // re-shown menu (declared drift remains) → exit
+    await resolveInteractively(params(false));
+
+    // the Record option WAS in the first menu, worded for the coexisting declared drift
+    const firstMenu = vi.mocked(select).mock.calls[0]![0] as {
+      options: { value: string; label: string }[];
+    };
+    const recordOpt = firstMenu.options.find((o) => o.value === 'record-all');
+    expect(recordOpt).toBeDefined();
+    expect(recordOpt!.label).toContain('Record current state as the .cdkrd baseline');
+    expect(recordOpt!.label).toContain('the declared drift stays reported');
+
+    // choosing it routed to the establish write (recordStack), not a no-op
+    expect(recordStack).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
Follow-ups to #452.

## 1. End-to-end menu test (the "live verification", made deterministic)

#452 unit-tested `availableActions` and the Record label *separately*. This adds an integration test that drives `resolveInteractively` for the **declared-only + no-baseline** case through the whole menu:

- asserts `record-all` IS in the first menu's options, worded `…the declared drift stays reported…`;
- asserts choosing it routes to `recordStack` (the establish write) — proving the option isn't just present but wired.

(A real-AWS interactive-menu test isn't automatable in a non-TTY runner; this deterministic end-to-end test is the feasible equivalent.)

## 2. Deleted-only label gets an accurate hint

The `establish-drift` label points the user at **revert/ignore** — which don't apply to a **deleted** declared resource (that's a `cdk deploy` to recreate). So a `deleted`-only + no-baseline stack used to fall back to the plain `establish` label (`marks this stack reviewed`), which slightly under-states that a drift is still reported.

New `establish-deleted` `RecordLabelKind`:

> `Record current state as the .cdkrd baseline (start watching undeclared now — the deleted-resource drift stays reported; re-deploy to restore it)`

A declared drift still takes priority when both coexist.

## Tests / docs

- `buildResolveOptions` label test extended to all four kinds.
- New `resolveInteractively` integration test (declared-only + no baseline).
- 42 files / 1916 tests green; typecheck + lint/format + build pass.
- `docs/ARCHITECTURE.md` R141 note mentions the deleted-resource variant.
