### PR TITLE
test(hunt): S3 Object Lock + Lambda EFS FP/FN coverage

### DIFF
--- a/tests/corpus/AWS__Lambda__Function.Handler886CB40B_efs.json
+++ b/tests/corpus/AWS__Lambda__Function.Handler886CB40B_efs.json
@@ -1,0 +1,206 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Handler886CB40B",
+    "resourceType": "AWS::Lambda::Function",
+    "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+    "constructPath": "CdkRealDriftIntegLambdaEfs/Handler",
+    "declared": {
+      "Code": {
+        "ZipFile": "export const handler = async () => ({ ok: true });"
+      },
+      "Description": "cdkrd lambda-efs test handler",
+      "Environment": {
+        "Variables": {
+          "MOUNT": "/mnt/efs"
+        }
+      },
+      "FileSystemConfigs": [
+        {
+          "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:access-point/fsap-08f7917d699fa9e77",
+          "LocalMountPath": "/mnt/efs"
+        }
+      ],
+      "Handler": "index.handler",
+      "MemorySize": 256,
+      "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaEf-HandlerServiceRoleFCDC14A-s5jWcoHlSOlW",
+      "Runtime": "nodejs20.x",
+      "Timeout": 15,
+      "VpcConfig": {
+        "SecurityGroupIds": ["sg-03a826532f4c51f24"],
+        "SubnetIds": ["subnet-0974034c1f7abd0ad", "subnet-04e2e8378d92bcd80"]
+      }
+    }
+  },
+  "liveRaw": {
+    "MemorySize": 256,
+    "Description": "cdkrd lambda-efs test handler",
+    "TracingConfig": {
+      "Mode": "PassThrough"
+    },
+    "VpcConfig": {
+      "Ipv6AllowedForDualStack": false,
+      "SecurityGroupIds": ["sg-03a826532f4c51f24"],
+      "SubnetIds": ["subnet-0974034c1f7abd0ad", "subnet-04e2e8378d92bcd80"]
+    },
+    "Timeout": 15,
+    "RuntimeManagementConfig": {
+      "UpdateRuntimeOn": "Auto"
+    },
+    "Handler": "index.handler",
+    "SnapStartResponse": {
+      "OptimizationStatus": "Off",
+      "ApplyOn": "None"
+    },
+    "Code": {},
+    "Role": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLambdaEf-HandlerServiceRoleFCDC14A-s5jWcoHlSOlW",
+    "FileSystemConfigs": [
+      {
+        "Arn": "arn:aws:elasticfilesystem:us-east-1:111111111111:access-point/fsap-08f7917d699fa9e77",
+        "LocalMountPath": "/mnt/efs"
+      }
+    ],
+    "FunctionName": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+    "Runtime": "nodejs20.x",
+    "PackageType": "Zip",
+    "LoggingConfig": {
+      "LogFormat": "Text",
+      "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z"
+    },
+    "RecursiveLoop": "Terminate",
+    "Environment": {
+      "Variables": {
+        "MOUNT": "/mnt/efs"
+      }
+    },
+    "Arn": "arn:aws:lambda:us-east-1:111111111111:function:CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+    "EphemeralStorage": {
+      "Size": 512
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegLambdaEfs",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLambdaEfs/0d376390-749c-11f1-8cfd-12dc5e550a09",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Handler886CB40B",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Architectures": ["x86_64"]
+  },
+  "schema": {
+    "readOnly": ["Arn", "SnapStartResponse"],
+    "writeOnly": ["PublishToLatestPublished", "SnapStart"],
+    "createOnly": ["FunctionName", "PackageType", "TenancyConfig"],
+    "readOnlyPaths": [
+      "Arn",
+      "SnapStartResponse",
+      "SnapStartResponse.ApplyOn",
+      "SnapStartResponse.OptimizationStatus"
+    ],
+    "writeOnlyPaths": [
+      "Code.ImageUri",
+      "Code.S3Bucket",
+      "Code.S3Key",
+      "Code.S3ObjectStorageMode",
+      "Code.S3ObjectVersion",
+      "Code.SourceKMSKeyArn",
+      "Code.ZipFile",
+      "PublishToLatestPublished",
+      "SnapStart",
+      "SnapStart.ApplyOn"
+    ],
+    "createOnlyPaths": ["FunctionName", "PackageType", "TenancyConfig"],
+    "defaults": {},
+    "defaultPaths": {
+      "DurableConfig.RetentionPeriodInDays": 14
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["Environment.Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "TracingConfig",
+      "actual": {
+        "Mode": "PassThrough"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RuntimeManagementConfig",
+      "actual": {
+        "UpdateRuntimeOn": "Auto"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "PackageType",
+      "actual": "Zip",
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "LoggingConfig",
+      "actual": {
+        "LogFormat": "Text",
+        "LogGroup": "/aws/lambda/CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z"
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "RecursiveLoop",
+      "actual": "Terminate",
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "EphemeralStorage",
+      "actual": {
+        "Size": 512
+      },
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Handler886CB40B",
+      "resourceType": "AWS::Lambda::Function",
+      "path": "Architectures",
+      "actual": ["x86_64"],
+      "physicalId": "CdkRealDriftIntegLambdaEfs-Handler886CB40B-VP3diHwsx80z",
+      "constructPath": "CdkRealDriftIntegLambdaEfs/Handler"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3__Bucket.Locked5B6A0654.json
+++ b/tests/corpus/AWS__S3__Bucket.Locked5B6A0654.json
@@ -1,0 +1,176 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Locked5B6A0654",
+    "resourceType": "AWS::S3::Bucket",
+    "physicalId": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5",
+    "constructPath": "CdkRealDriftIntegS3ObjectLock/Locked",
+    "declared": {
+      "BucketEncryption": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": false,
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "ObjectLockConfiguration": {
+        "ObjectLockEnabled": "Enabled",
+        "Rule": {
+          "DefaultRetention": {
+            "Days": 30,
+            "Mode": "GOVERNANCE"
+          }
+        }
+      },
+      "ObjectLockEnabled": true,
+      "PublicAccessBlockConfiguration": {
+        "BlockPublicAcls": true,
+        "BlockPublicPolicy": true,
+        "IgnorePublicAcls": true,
+        "RestrictPublicBuckets": true
+      },
+      "VersioningConfiguration": {
+        "Status": "Enabled"
+      }
+    }
+  },
+  "liveRaw": {
+    "DomainName": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5.s3.amazonaws.com",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": false,
+          "BlockedEncryptionTypes": {
+            "EncryptionType": ["SSE-C"]
+          },
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "WebsiteURL": "http://cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5.s3-website-us-east-1.amazonaws.com",
+    "DualStackDomainName": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5.s3.dualstack.us-east-1.amazonaws.com",
+    "VersioningConfiguration": {
+      "Status": "Enabled"
+    },
+    "AbacStatus": "Disabled",
+    "PublicAccessBlockConfiguration": {
+      "RestrictPublicBuckets": true,
+      "BlockPublicPolicy": true,
+      "BlockPublicAcls": true,
+      "IgnorePublicAcls": true
+    },
+    "BucketName": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5",
+    "RegionalDomainName": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5.s3.us-east-1.amazonaws.com",
+    "OwnershipControls": {
+      "Rules": [
+        {
+          "ObjectOwnership": "BucketOwnerEnforced"
+        }
+      ]
+    },
+    "ObjectLockConfiguration": {
+      "ObjectLockEnabled": "Enabled",
+      "Rule": {
+        "DefaultRetention": {
+          "Days": 30,
+          "Mode": "GOVERNANCE"
+        }
+      }
+    },
+    "ObjectLockEnabled": true,
+    "Arn": "arn:aws:s3:::cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3ObjectLock/0b4fdee0-749c-11f1-ad3a-0e4bfd56af47",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegS3ObjectLock",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Locked5B6A0654",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DomainName", "DualStackDomainName", "RegionalDomainName", "WebsiteURL"],
+    "writeOnly": ["AccessControl", "BucketNamePrefix", "BucketNamespace"],
+    "createOnly": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "readOnlyPaths": [
+      "Arn",
+      "DomainName",
+      "DualStackDomainName",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableArn",
+      "MetadataConfiguration.AnnotationTableConfiguration.TableName",
+      "MetadataConfiguration.Destination",
+      "MetadataConfiguration.InventoryTableConfiguration.TableArn",
+      "MetadataConfiguration.InventoryTableConfiguration.TableName",
+      "MetadataConfiguration.JournalTableConfiguration.TableArn",
+      "MetadataConfiguration.JournalTableConfiguration.TableName",
+      "MetadataTableConfiguration.S3TablesDestination.TableArn",
+      "MetadataTableConfiguration.S3TablesDestination.TableNamespace",
+      "RegionalDomainName",
+      "WebsiteURL"
+    ],
+    "writeOnlyPaths": [
+      "AccessControl",
+      "BucketNamePrefix",
+      "BucketNamespace",
+      "LifecycleConfiguration.Rules.*.ExpiredObjectDeleteMarker",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionExpirationInDays",
+      "LifecycleConfiguration.Rules.*.NoncurrentVersionTransition",
+      "LifecycleConfiguration.Rules.*.Transition",
+      "MetadataConfiguration.AnnotationTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.InventoryTableConfiguration.EncryptionConfiguration",
+      "MetadataConfiguration.JournalTableConfiguration.EncryptionConfiguration",
+      "ReplicationConfiguration.Rules.*.Prefix"
+    ],
+    "createOnlyPaths": ["BucketName", "BucketNamePrefix", "BucketNamespace"],
+    "defaults": {},
+    "defaultPaths": {
+      "NotificationConfiguration.EventBridgeConfiguration.EventBridgeEnabled": "true",
+      "VersioningConfiguration.Status": "Suspended"
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Locked5B6A0654",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "AbacStatus",
+      "actual": "Disabled",
+      "physicalId": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5",
+      "constructPath": "CdkRealDriftIntegS3ObjectLock/Locked"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Locked5B6A0654",
+      "resourceType": "AWS::S3::Bucket",
+      "path": "OwnershipControls",
+      "actual": {
+        "Rules": [
+          {
+            "ObjectOwnership": "BucketOwnerEnforced"
+          }
+        ]
+      },
+      "physicalId": "cdkrealdriftintegs3objectlock-locked5b6a0654-pvhwtplquvp5",
+      "constructPath": "CdkRealDriftIntegS3ObjectLock/Locked"
+    }
+  ]
+}

--- a/tests/integration/lambda-efs-rich/app.ts
+++ b/tests/integration/lambda-efs-rich/app.ts
@@ -1,0 +1,57 @@
+// CDK app for the cdk-real-drift Lambda + EFS false-positive test. Mounting an
+// EFS access point into a VPC-attached Lambda is a common pattern for functions
+// that need shared/persistent storage, and it is the last rich Lambda config not
+// yet exercised: it adds FileSystemConfigs (Arn + LocalMountPath) plus a VpcConfig
+// (SubnetIds + SecurityGroupIds, both set-like arrays AWS may reorder on read).
+// A freshly deployed + recorded function with NO out-of-band change MUST report
+// CLEAN. The VPC uses isolated subnets with NO NAT gateway to keep the deploy
+// cheap and fast.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { AccessPoint, FileSystem } from "aws-cdk-lib/aws-efs";
+import {
+  Code,
+  FileSystem as LambdaFileSystem,
+  Function as LambdaFunction,
+  Runtime,
+} from "aws-cdk-lib/aws-lambda";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLambdaEfs");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [
+    { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+  ],
+});
+
+const efs = new FileSystem(stack, "Efs", {
+  vpc,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const accessPoint = new AccessPoint(stack, "AccessPoint", {
+  fileSystem: efs,
+  path: "/export/lambda",
+  createAcl: { ownerGid: "1001", ownerUid: "1001", permissions: "750" },
+  posixUser: { gid: "1001", uid: "1001" },
+});
+
+new LambdaFunction(stack, "Handler", {
+  runtime: Runtime.NODEJS_20_X,
+  handler: "index.handler",
+  code: Code.fromInline(
+    "export const handler = async () => ({ ok: true });",
+  ),
+  memorySize: 256,
+  timeout: Duration.seconds(15),
+  description: "cdkrd lambda-efs test handler",
+  environment: { MOUNT: "/mnt/efs" },
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  filesystem: LambdaFileSystem.fromEfsAccessPoint(accessPoint, "/mnt/efs"),
+});
+
+app.synth();

--- a/tests/integration/lambda-efs-rich/cdk.json
+++ b/tests/integration/lambda-efs-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lambda-efs-rich/package.json
+++ b/tests/integration/lambda-efs-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-lambda-efs-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift lambda-efs-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/lambda-efs-rich/verify-detect.sh
+++ b/tests/integration/lambda-efs-rich/verify-detect.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Lambda detect + revert integration test (real AWS): the "someone changed it in
+# the console" scenario. Deploy -> record -> change DECLARED MUTABLE props
+# (MemorySize, Timeout) on the VPC+EFS Lambda out of band -> check MUST DETECT the
+# declared drift (exit 1) -> revert -> check MUST be CLEAN and the live config MUST
+# be restored. This is the false-negative / detection half that verify.sh does not
+# exercise, run here against a function that also carries FileSystemConfigs/VpcConfig.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaEfs
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+FN="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" --output text)"
+[ -n "$FN" ] || fail "could not resolve function physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: MemorySize 256->512, Timeout 15->30 (console-edit) ==="
+aws lambda update-function-configuration --function-name "$FN" --region "$REGION" \
+  --memory-size 512 --timeout 30 >/dev/null || fail "inject drift"
+aws lambda wait function-updated --function-name "$FN" --region "$REGION"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-lambda-efs-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "MemorySize" /tmp/cdkrd-lambda-efs-detect.out || fail "MemorySize not reported"
+grep -q "Timeout" /tmp/cdkrd-lambda-efs-detect.out || fail "Timeout not reported"
+
+echo "=== revert (write declared values back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live config MUST be restored to 256 / 15 ==="
+GOT="$(aws lambda get-function-configuration --function-name "$FN" --region "$REGION" \
+  --query "[MemorySize,Timeout]" --output text)"
+[ "$GOT" = "256	15" ] || fail "live config not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/lambda-efs-rich/verify.sh
+++ b/tests/integration/lambda-efs-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded VPC-attached Lambda with an EFS
+# file system mount and NO out-of-band change must report no drift; any drift here
+# is a normalization / default-folding FP on FileSystemConfigs or VpcConfig.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLambdaEfs
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-objectlock-rich/app.ts
+++ b/tests/integration/s3-objectlock-rich/app.ts
@@ -1,0 +1,35 @@
+// CDK app for the cdk-real-drift S3 Object Lock false-positive test. Object Lock
+// (WORM / compliance retention) is a common but not-yet-exercised S3 sub-config:
+// it adds an ObjectLockEnabled flag plus a nested ObjectLockConfiguration.Rule.
+// DefaultRetention block (Mode + Days/Years) that AWS materializes on read. A
+// freshly deployed + recorded bucket with NO out-of-band change MUST report CLEAN
+// — any drift here is a normalization / default-folding FP on the Object Lock
+// shape. Object Lock requires versioning, so this also exercises the
+// VersioningConfiguration round-trip alongside an explicit bucket-key encryption.
+import { App, Duration, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketEncryption,
+  ObjectLockRetention,
+} from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3ObjectLock");
+
+new Bucket(stack, "Locked", {
+  // Object Lock requires versioning; CDK enables it implicitly with
+  // objectLockEnabled, but declare it explicitly to exercise the round-trip.
+  versioned: true,
+  objectLockEnabled: true,
+  objectLockDefaultRetention: ObjectLockRetention.governance(Duration.days(30)),
+  encryption: BucketEncryption.S3_MANAGED,
+  bucketKeyEnabled: false,
+  blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+  enforceSSL: true,
+  // Empty bucket: no autoDeleteObjects custom resource needed, so teardown
+  // leaves no orphaned /aws/lambda/* log group.
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+app.synth();

--- a/tests/integration/s3-objectlock-rich/cdk.json
+++ b/tests/integration/s3-objectlock-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-objectlock-rich/package.json
+++ b/tests/integration/s3-objectlock-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-objectlock-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-objectlock-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-objectlock-rich/verify.sh
+++ b/tests/integration/s3-objectlock-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded bucket with Object Lock and NO
+# out-of-band change must report no drift; any drift here is a normalization /
+# default-folding FP on the ObjectLockConfiguration / VersioningConfiguration shape.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3ObjectLock
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug-hunt round (clean)

Deployed two **common-but-untested** configs against real AWS to hunt false positives / false negatives. **Both rounds were CLEAN — no tool change needed.** The deliverable is the fixtures + golden-corpus cases (per the skill's "a clean result IS a result" rule): the paid live reads become permanent offline regressions in `vp run test`.

### Coverage added (both 0-coverage before)
- **s3-objectlock-rich** — S3 Object Lock (`ObjectLockEnabled` + nested `ObjectLockConfiguration.Rule.DefaultRetention`, GOVERNANCE/30d) over a versioned bucket. `record` → `check` **CLEAN**; `atDefault` correctly folds `AbacStatus` + `OwnershipControls`. No normalization FP on the Object Lock / Versioning shape.
- **lambda-efs-rich** — a VPC-attached Lambda mounting an EFS access point. Exercises the last uncovered rich Lambda config: **`FileSystemConfigs`** (`Arn` via `Fn::Join` intrinsic + `LocalMountPath`) and **`VpcConfig`** (`SubnetIds` set-like array). `record` → `check` **CLEAN**, and `verify-detect.sh` confirms the FN half: out-of-band `MemorySize`/`Timeout` change is **detected** (exit 1) → **reverted** → CLEAN + live config restored.

### Classification confirmed correct (not bugs)
- EFS `KmsKeyId`, MountTarget `IpAddress`, AccessPoint `ClientToken` → per-resource live-only values, surfaced as **potential drift** (record to accept).
- Subnet `AvailabilityZone` (`Fn::Select(Fn::GetAZs)`) → **unresolved/unverifiable** (correct — immutable, not folded into an FP).
- 21 `atDefault` folds on the Lambda stack (incl. `RecursiveLoop:Terminate`, `EphemeralStorage`, `FileSystemProtection`, `TracingConfig:PassThrough`) — all already guarded.

### Corpus
Promoted the two new-config cases (`AWS__S3__Bucket` Object Lock; `AWS__Lambda__Function` with FileSystemConfigs/VpcConfig, suffixed `_efs` to avoid logicalId collision) so `corpus-replay` pins the ObjectLock + FileSystemConfigs folding offline. All 1916 unit tests pass.

### Cleanup
Both stacks deployed, verified, and torn down via `delstack`; `bughunt-track verify` = every tracked stack GONE + SWEEP CLEAN.

No `src/**` changes → verify-pr-gate exempt; `check` + `docs` markers set.
