### PR TITLE
fix(noise): fold EFS AccessPoint ClientToken as generated, not potential drift

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -945,6 +945,16 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // `currentVersion` in a stack flooding the first run — observed across a 7-function
   // stack. The version resource is immutable, so the hash can never be an out-of-band edit.
   'AWS::Lambda::Version': new Set(['CodeSha256']),
+  // An EFS AccessPoint's ClientToken is the idempotency token CloudFormation mints at
+  // create time as `<logicalId>-<random>` (e.g. "AccessPointE936DE82-b6xKi37R0Uio"). It
+  // is createOnly (immutable) and the CDK L2 never declares it, so it floods the first
+  // run as undeclared on every AccessPoint. The value is opaque and not derivable from
+  // the physical id (an fsap-… ARN), so neither isGeneratedName nor a physical-id echo
+  // folds it. A raw-CFn user who DOES set ClientToken carries it in the template and
+  // never reaches this undeclared loop, so folding the live-only case as `generated`
+  // (inventory: never drift, recorded, or reverted) is safe — and necessary, since an
+  // immutable token can never be an out-of-band edit. Observed live on lambda-efs-rich.
+  'AWS::EFS::AccessPoint': new Set(['ClientToken']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1780,6 +1780,47 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  // Found live by the lambda-efs-rich bug-hunt fixture: an EFS AccessPoint's ClientToken
+  // is the idempotency token CloudFormation mints at create time (`<logicalId>-<random>`).
+  // It is createOnly (immutable) and the CDK L2 never declares it, so it is live-only on
+  // every AccessPoint; without folding it floods the first run as undeclared. The value is
+  // opaque (not derivable from the fsap-… ARN physical id), so it folds via the
+  // value-independent GENERATED_TOPLEVEL_PATHS, not isGeneratedName.
+  describe('value-independent generated top-level path (EFS AccessPoint ClientToken)', () => {
+    const T = 'AWS::EFS::AccessPoint';
+
+    it('a live-only AccessPoint ClientToken folds as generated (not undeclared/drift)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { FileSystemId: 'fs-123' }),
+          { FileSystemId: 'fs-123', ClientToken: 'AccessPointE936DE82-b6xKi37R0Uio' },
+          emptySchema
+        )
+      );
+      expect(t.generated).toEqual(['ClientToken']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('a DIFFERENT token still folds (value-independent — opaque, not id-derived)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { FileSystemId: 'fs-123' }),
+          { FileSystemId: 'fs-123', ClientToken: 'FsApCFF9572D-dRkYh637cpxN' },
+          emptySchema
+        )
+      );
+      expect(t.generated).toEqual(['ClientToken']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('the fold is scoped per-type (a ClientToken on another type stays undeclared)', () => {
+      expect(
+        tiers(classifyResource(res('AWS::S3::Bucket', {}), { ClientToken: 'abc-123' }, emptySchema))
+          .undeclared
+      ).toEqual(['ClientToken']);
+    });
+  });
+
   // Found live by the synthetics-rich bug-hunt fixture: AWS Synthetics rewrites a
   // canary's rate() schedule to whole units (CDK emits `rate(60 minutes)` from
   // Duration.hours(1); AWS returns `rate(1 hour)`), false-flagging declared drift.

--- a/tests/corpus/AWS__EFS__AccessPoint.FsApCFF9572D.json
+++ b/tests/corpus/AWS__EFS__AccessPoint.FsApCFF9572D.json
@@ -63,7 +63,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "FsApCFF9572D",
       "resourceType": "AWS::EFS::AccessPoint",
       "path": "ClientToken",


### PR DESCRIPTION
## Summary

Follow-up to the #454 bug-hunt: fold an EFS AccessPoint's **`ClientToken`** into the `generated` tier instead of surfacing it as first-run `[Potential Drift]`.

`ClientToken` is the idempotency token CloudFormation mints at create time as `<logicalId>-<random>` (e.g. `AccessPointE936DE82-b6xKi37R0Uio`). It is **createOnly** (immutable), **not** writeOnly (so it is readable and surfaces), and the CDK L2 never declares it — so it is live-only on every AccessPoint and floods the first run. The value is opaque and not derivable from the `fsap-…` ARN physical id, so neither `isGeneratedName` nor a physical-id echo folds it.

## Fix
- `noise.ts`: `GENERATED_TOPLEVEL_PATHS += AWS::EFS::AccessPoint → ClientToken`. Value-independent, per-type scoped — same mechanism as the apigwv2 AutoDeploy `DeploymentId` and Lambda Version `CodeSha256` entries. Folding to `generated` (inventory: never drift, recorded, or reverted) is safe and necessary: an immutable token can never be an out-of-band edit, and a raw-CFn user who *declares* `ClientToken` carries it in the template (never reaching the undeclared loop), so a meaningful value still surfaces.
- `classify.test.ts`: 3 tests (folds; value-independent; per-type scoped). **Negative control confirmed**: the 2 folding tests fail without the src change, pass with it.
- `corpus AWS__EFS__AccessPoint.FsApCFF9572D`: `ClientToken` expected `undeclared` → `generated` — the real harvested live read now pins the fold offline via `corpus-replay`.

## Verification (full `/verify-pr`)
- typecheck / lint / build / **1921 unit tests** pass.
- **Live-test**: a fresh `CfnFileSystem` + `CfnAccessPoint` deploy reports `ClientToken` under **[AWS Generated]**, result CLEAN (was `[Potential Drift]` before the fix). Stack torn down + swept clean.
- **7 core integration fixtures** (basic ×3, iam, lambda, revert, policies) all `INTEG PASS`; all stacks + orphan log groups swept clean.

Class check: `ClientToken` as a *readable* createOnly token is EFS-AccessPoint-specific in the corpus (most types mark it writeOnly → stripped), so a per-type entry is correct.
