### PR TITLE
feat(resolve): resolve Fn::Base64 so EC2 UserData drift is detected

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -55,6 +55,20 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
         return resolveRef(String(v), ctx);
       case 'Fn::Sub':
         return resolveSub(v, ctx);
+      case 'Fn::Base64': {
+        // Fn::Base64 returns the base64 encoding of its (String) argument — a pure,
+        // deterministic, environment-INDEPENDENT transform (unlike Fn::GetAZs, which
+        // is deliberately left unresolved). CDK emits it for EC2 UserData
+        // (`{ "Fn::Base64": { "Fn::Sub": "#!/bin/bash …" } }`), which is a readable,
+        // mutable property on AWS::EC2::Instance / the LaunchTemplate's
+        // LaunchTemplateData — so without resolving it the declared UserData is a blind
+        // spot (UNRESOLVED) and out-of-band UserData drift is missed. Resolve the inner
+        // first; CFn only accepts a String argument, so a non-string (or unresolved)
+        // inner fails closed to UNRESOLVED rather than encoding `[object Object]`.
+        const inner = resolve(v, ctx);
+        if (typeof inner !== 'string') return UNRESOLVED;
+        return Buffer.from(inner, 'utf8').toString('base64');
+      }
       case 'Fn::If': {
         if (!Array.isArray(v)) return UNRESOLVED;
         const [cond, t, f] = v as [string, unknown, unknown];

--- a/tests/integration/ec2-userdata/app.ts
+++ b/tests/integration/ec2-userdata/app.ts
@@ -1,0 +1,54 @@
+// CDK app for the cdk-real-drift EC2 UserData false-positive test. CDK wraps an
+// instance's UserData in `{ "Fn::Base64": { "Fn::Join"/"Fn::Sub": "…script…" } }`.
+// UserData is a readable, mutable property on AWS::EC2::Instance, so until the
+// resolver handles Fn::Base64 the declared value is UNRESOLVED — a blind spot that
+// misses out-of-band UserData drift. With Fn::Base64 resolved, a freshly deployed +
+// recorded instance with NO out-of-band change MUST report CLEAN: it proves the
+// base64 of the resolved declared script matches the live (base64) UserData exactly,
+// with no normalization FP. A single-AZ public subnet with NO NAT keeps it cheap.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  AmazonLinuxCpuType,
+  Instance,
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  MachineImage,
+  SubnetType,
+  UserData,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEc2UserData");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [
+    { name: "public", subnetType: SubnetType.PUBLIC, cidrMask: 24 },
+  ],
+});
+
+const userData = UserData.forLinux();
+userData.addCommands(
+  "set -euo pipefail",
+  "echo cdkrd-ec2-userdata-test > /tmp/marker",
+  "yum install -y jq || true",
+);
+
+const instance = new Instance(stack, "Host", {
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PUBLIC },
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: MachineImage.latestAmazonLinux2023({
+    cpuType: AmazonLinuxCpuType.X86_64,
+    cachedInContext: false,
+  }),
+  userData,
+  // The default Amazon Linux 2023 SSM-managed AMI lookup pins via SSM parameter,
+  // so no environment-specific context lookup is needed for synth.
+});
+instance.applyRemovalPolicy(RemovalPolicy.DESTROY);
+
+app.synth();

--- a/tests/integration/ec2-userdata/cdk.json
+++ b/tests/integration/ec2-userdata/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ec2-userdata/package.json
+++ b/tests/integration/ec2-userdata/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ec2-userdata",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ec2-userdata false-positive integration test (Fn::Base64 UserData resolution). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ec2-userdata/verify.sh
+++ b/tests/integration/ec2-userdata/verify.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. CDK wraps the instance's UserData in Fn::Base64(Fn::Join/Fn::Sub);
+# the resolver now resolves Fn::Base64, so the declared UserData is compared against
+# the live (base64) value instead of being left UNRESOLVED. A clean recorded instance
+# with NO out-of-band change must report no drift — any drift here is an FP proving
+# base64(resolved declared) != live UserData.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEc2UserData
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+# The whole point of the change: UserData must be RESOLVED (compared), not skipped as
+# an unresolved intrinsic. Assert it is not sitting in the unresolved tier.
+if $CLI check "$STACK" --region "$REGION" --verbose 2>&1 | grep -A40 "Unresolved" | grep -q "Host.UserData"; then
+  fail "UserData still UNRESOLVED — Fn::Base64 not resolved"
+fi
+echo "UserData is resolved (not in the unresolved tier)."
+
+echo "INTEG PASS ($STACK)"

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -48,6 +48,25 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::Sub': 'v=${Thing.Arn}' }, c)).toBe('v=arn:aws:x:::thing');
   });
 
+  // Fn::Base64 is the deterministic transform CDK wraps EC2 UserData in; resolving it
+  // lets the (readable, mutable) UserData property be compared instead of left a blind
+  // spot. base64('hello') === 'aGVsbG8='.
+  it('resolves Fn::Base64 of a literal string', () => {
+    expect(resolve({ 'Fn::Base64': 'hello' }, ctx())).toBe('aGVsbG8=');
+  });
+
+  it('resolves Fn::Base64 of a nested Fn::Sub (the EC2 UserData shape)', () => {
+    // base64('echo prod') === 'ZWNobyBwcm9k'
+    expect(resolve({ 'Fn::Base64': { 'Fn::Sub': 'echo ${Env}' } }, ctx())).toBe('ZWNobyBwcm9k');
+  });
+
+  it('Fn::Base64 fails closed (UNRESOLVED) when its inner is unresolved or not a string', () => {
+    // inner GetAtt with no live attrs -> UNRESOLVED propagates (never encode the symbol)
+    expect(resolve({ 'Fn::Base64': { 'Fn::GetAtt': ['X', 'Arn'] } }, ctx())).toBe(UNRESOLVED);
+    // CFn Fn::Base64 takes only a String; a non-string inner fails closed, not `[object Object]`
+    expect(resolve({ 'Fn::Base64': { foo: 'bar' } }, ctx())).toBe(UNRESOLVED);
+  });
+
   it('evaluates Fn::If via conditions', () => {
     const c = ctx({ conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } } });
     expect(resolve({ 'Fn::If': ['IsProd', 'yes', 'no'] }, c)).toBe('yes');


### PR DESCRIPTION
## Summary

Resolve **`Fn::Base64`** in the intrinsic resolver so declared values wrapped in it are compared against live instead of being left `UNRESOLVED`. The motivating case is **EC2 UserData**: CDK emits it as `{ "Fn::Base64": { "Fn::Sub"/"Fn::Join": "…script…" } }`, and `UserData` is a **readable, mutable** property on `AWS::EC2::Instance` (and the LaunchTemplate's `LaunchTemplateData`) — so out-of-band UserData edits were a silent **blind spot**.

cdkrd already resolves the deterministic intrinsics (`Fn::Join` / `Sub` / `Select` / `Split` / `FindInMap` / `If` / …); `Fn::Base64` was the missing one. It is a pure, deterministic, **environment-independent** transform (unlike `Fn::GetAZs`, which is deliberately left unresolved), so resolving it can never introduce an environment-mismatch FP.

## Change
- `intrinsic-resolver.ts`: add the `Fn::Base64` case — resolve the inner; if it is a String, return its base64; a non-string or unresolved inner **fails closed** to `UNRESOLVED` (never encodes `[object Object]` or the symbol).
- `intrinsic-resolver.test.ts`: 3 unit tests (literal; nested `Fn::Sub` = the UserData shape; fail-closed). **Negative control confirmed** — the two resolve tests fail without the src change.
- `tests/integration/ec2-userdata`: committed real-AWS regression fixture (an EC2 instance with UserData, single-AZ public subnet, no NAT).

## Verification (full `/verify-pr`)
- typecheck / lint / build / **1924 unit tests** pass.
- **Live-test (end to end)** on a fresh deploy:
  - `record` → `check` **CLEAN** — base64 of the resolved declared UserData matches the live (base64) UserData **exactly**, no normalization FP.
  - `UserData` is **resolved** (no longer in the unresolved tier; only the two `Fn::GetAZs` `AvailabilityZone`s remain unresolved, as intended).
  - **FN**: an out-of-band UserData mutation (`stop-instances` + `modify-instance-attribute`) is now **DETECTED** as declared `Host.UserData` drift — previously invisible.
  - Stack + orphan log groups torn down, SWEEP CLEAN.
- **7 core integration fixtures** (basic ×3, iam, lambda, revert, policies) all `INTEG PASS`.

Scope note: `Fn::Cidr` / `Fn::GetAZs` / `Fn::ForEach` / `Fn::Length` / `Fn::ToJsonString` remain unresolved on purpose — `GetAZs`/`Cidr` are environment-dependent and/or land only on immutable properties (zero detection benefit), and the language-extension macros are rare; none appear in any of the ~516 corpus cases. `Fn::Base64` was the one with real, FP-safe value.
