### PR TITLE
fix(noise): fold EC2 KeyPair public-key comment rewrite + EMR Serverless Type case FP; add 13 zero-coverage corpus types

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -27,6 +27,8 @@ import {
   isJsonStringStructEqual,
   JSON_STRING_PROPS,
   isPemEqual,
+  isSshPublicKeyEqual,
+  SSH_PUBLIC_KEY_PATHS,
   isStringlyEqualScalar,
   isStringlyEqualScalarArray,
   isStringlyEqualDeep,
@@ -1010,6 +1012,15 @@ export function classifyResource(
       // round-trips with only surrounding-whitespace differences — AWS appends a
       // trailing newline after the END marker — is not drift.
       if (isPemEqual(d.stateValue, d.awsValue)) continue;
+      // Per-type OpenSSH public-key paths (EC2 KeyPair PublicKeyMaterial — EC2
+      // rewrites the comment field to the key pair name and appends a newline):
+      // the same key material (type + base64) is not drift; a genuine key change
+      // still differs.
+      if (
+        SSH_PUBLIC_KEY_PATHS[resourceType]?.has(d.path) &&
+        isSshPublicKeyEqual(d.stateValue, d.awsValue)
+      )
+        continue;
       // CloudFormation's GetTemplate returns non-ASCII string literals with every
       // non-ASCII character replaced by `?` (a documented API limitation). The DECLARED
       // side (fetched via GetTemplate) is therefore corrupted while the LIVE side is

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -570,6 +570,63 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Platform: 'Web',
     DeobfuscationConfiguration: { JavaScriptSourceMaps: { Status: 'DISABLED' } },
   },
+  // FIS experiment templates read back the documented option defaults (fail on
+  // empty target resolution, single-account targeting) when the template declares
+  // no ExperimentOptions. Observed live on the misc-0cov-rich fixture.
+  // Equality-gated: multi-account targeting or skip-mode no longer matches.
+  'AWS::FIS::ExperimentTemplate': {
+    ExperimentOptions: {
+      EmptyTargetResolutionMode: 'fail',
+      AccountTargeting: 'single-account',
+    },
+  },
+  // A Verified Permissions policy store is created without deletion protection by
+  // default. Observed live on the misc-0cov-rich fixture. Equality-gated: enabling
+  // protection out of band no longer matches and surfaces.
+  'AWS::VerifiedPermissions::PolicyStore': {
+    DeletionProtection: { Mode: 'DISABLED' },
+  },
+  // Amazon Keyspaces service defaults (observed live on the misc-0cov-rich
+  // fixture): a keyspace with no ReplicationSpecification is single-region; a
+  // table with no explicit settings reads back the account-constant warm
+  // throughput floor (12000/4000 — same constant DynamoDB TableV2 reports), the
+  // AWS-owned KMS key, and CDC disabled. All equality-gated.
+  'AWS::Cassandra::Keyspace': {
+    ReplicationSpecification: { ReplicationStrategy: 'SINGLE_REGION' },
+  },
+  'AWS::Cassandra::Table': {
+    WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
+    EncryptionSpecification: { EncryptionType: 'AWS_OWNED_KMS_KEY' },
+    CdcSpecification: { Status: 'DISABLED' },
+  },
+  // EMR Serverless application service defaults (observed live on the
+  // misc-0cov-rich fixture): x86_64 architecture and managed-persistence
+  // monitoring enabled. Equality-gated: an ARM64 app or disabled managed
+  // persistence no longer matches and surfaces.
+  'AWS::EMRServerless::Application': {
+    Architecture: 'X86_64',
+    MonitoringConfiguration: {
+      ManagedPersistenceMonitoringConfiguration: { Enabled: true },
+    },
+  },
+  // Amplify app service defaults (observed live on the amplify-codeconnections-rich
+  // fixture): the standard build compute size and the managed no-cookies CDN cache.
+  // Equality-gated: a larger build machine or cookie-forwarding cache no longer
+  // matches and surfaces.
+  'AWS::Amplify::App': {
+    JobConfig: { BuildComputeType: 'STANDARD_8GB' },
+    CacheConfig: { Type: 'AMPLIFY_MANAGED_NO_COOKIES' },
+  },
+  // A hostless connection (GitHub/Bitbucket cloud providers) reads HostArn back as
+  // this literal ALL-ZEROS placeholder ARN — a service sentinel for "no host", not
+  // a reference to anything in the user's account (region/account/id are all
+  // zeroed constants). Observed live on the amplify-codeconnections-rich fixture.
+  // Equality-gated: a real GitHub Enterprise / GitLab self-managed host ARN no
+  // longer matches and surfaces.
+  'AWS::CodeStarConnections::Connection': {
+    HostArn:
+      'arn:aws:codestar-connections:us-west-2:000000000000:host/00000000-0000-0000-0000-000000000000',
+  },
 };
 
 // R108: nested service defaults — the NESTED-path twin of KNOWN_DEFAULTS. The
@@ -605,6 +662,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // EMR Serverless fills MaximumCapacity.Disk with the service-wide maximum
+  // ("400000 GB") when the template declares only Cpu/Memory. A constant, not
+  // capacity-derived (observed with a 4 vCPU / 16 GB cap on the misc-0cov-rich
+  // fixture). Equality-gated: a real disk cap no longer matches and surfaces.
+  'AWS::EMRServerless::Application': {
+    'MaximumCapacity.Disk': '400000 GB',
+  },
   // AWS Backup materializes these defaults into each live BackupPlanRule (keyed by RuleName
   // — descended via NESTED_ARRAY_IDENTITY). Folding them keeps a clean plan clean; an
   // out-of-band change away from one still surfaces (equality-gated). Proven live: a
@@ -911,6 +975,10 @@ export const GENERATED_DEFAULTS: Record<string, Record<string, unknown>> = {
 // out-of-band change to it reports as drift (R142; was value-independent in R140).
 export const GENERATED_PATHS: Record<string, string[]> = {
   'AWS::ApiGateway::Method': ['Integration.CacheNamespace'],
+  // The live read echoes the rule's own ARN (== the resource's physical id) inside
+  // the declared SamplingRule object — pure identity, never user-editable.
+  // Observed live on the xray-insightrule-rich fixture.
+  'AWS::XRay::SamplingRule': ['SamplingRule.RuleARN'],
 };
 
 // Top-level UNDECLARED keys that are ALWAYS a service-minted, AWS-managed generated
@@ -963,6 +1031,10 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
 // `RestApiId|ResourceId|HttpMethod`), leaving a user-set custom value to surface.
 export function isPhysicalIdSegment(value: unknown, physicalId: string | undefined): boolean {
   if (typeof value !== 'string' || physicalId === undefined) return false;
+  // The whole-id echo (XRay SamplingRule.RuleARN returns the rule's own ARN — the
+  // physical id verbatim) is the purest physical-id segment; a split on `:` would
+  // otherwise never reassemble a full ARN.
+  if (value === physicalId) return true;
   return physicalId.split(/[|:/]/).includes(value);
 }
 
@@ -1330,9 +1402,46 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // two valid values differ beyond case, so case-insensitive equality hides no real
   // drift. Observed live on a fresh batch-rich deploy.
   'AWS::Batch::ComputeEnvironment': new Set(['Type']),
+  // EMR Serverless Application `Type` — the CFn schema enum is UPPERCASE
+  // (`SPARK`/`HIVE`) but the EMR Serverless API canonicalizes to mixed case on
+  // read (`Spark`/`Hive`), so a case-sensitive compare false-flags declared drift
+  // on every check of a freshly deployed application. `Type` is create-only and
+  // the two valid values differ beyond case, so case-insensitive equality hides
+  // no real drift. Observed live on a fresh misc-0cov-rich deploy.
+  'AWS::EMRServerless::Application': new Set(['Type']),
 };
 export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+}
+
+// Per-type OpenSSH public-key paths (EC2 KeyPair `PublicKeyMaterial`). EC2 stores
+// only the key MATERIAL: on read it rewrites the free-text comment field to the
+// key pair NAME and appends a trailing newline (declared
+// `ssh-ed25519 AAAA... me@laptop`, live `ssh-ed25519 AAAA... <KeyName>\n`), so a
+// string compare false-flags declared drift on every check of an imported key
+// pair. The comment is not part of the key and is unenforceable (AWS always
+// overwrites it), so compare only `<type> <base64>`; a genuine key-material
+// change still differs. `PublicKeyMaterial` is create-only, so the folded
+// comment hides nothing revertable. Observed live on a fresh misc-0cov-rich deploy.
+export const SSH_PUBLIC_KEY_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::EC2::KeyPair': new Set(['PublicKeyMaterial']),
+};
+// True when both values parse as OpenSSH public keys (`<type> <base64> [comment]`)
+// with the same type + base64 material. Non-parsing inputs never match, so the
+// fold can't fire on an arbitrary string pair.
+export function isSshPublicKeyEqual(a: unknown, b: unknown): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const material = (s: string): string | undefined => {
+    const parts = s.trim().split(/\s+/);
+    const type = parts[0];
+    const blob = parts[1];
+    if (type === undefined || blob === undefined) return undefined;
+    if (!/^(?:sk-)?(?:ssh|ecdsa)-[a-z0-9-]+(?:@[a-z0-9.-]+)?$/.test(type)) return undefined;
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(blob)) return undefined;
+    return `${type} ${blob}`;
+  };
+  const ma = material(a);
+  return ma !== undefined && ma === material(b);
 }
 
 // Per-type property paths whose value is a set of HTTP HEADER NAMES, which AWS

--- a/tests/corpus/AWS__Amplify__App.AmplifyApp.json
+++ b/tests/corpus/AWS__Amplify__App.AmplifyApp.json
@@ -1,0 +1,118 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AmplifyApp",
+    "resourceType": "AWS::Amplify::App",
+    "physicalId": "arn:aws:amplify:us-east-1:111111111111:apps/d29o73zx4mc67h",
+    "constructPath": "CdkRealDriftIntegAmplifyConnRich/AmplifyApp",
+    "declared": {
+      "CustomRules": [
+        {
+          "Source": "/docs/<*>",
+          "Status": "301",
+          "Target": "/documentation/<*>"
+        },
+        {
+          "Source": "/<*>",
+          "Status": "404-200",
+          "Target": "/index.html"
+        }
+      ],
+      "Description": "cdkrd amplify rich hunt fixture",
+      "EnableBranchAutoDeletion": false,
+      "EnvironmentVariables": [
+        {
+          "Name": "STAGE",
+          "Value": "hunt"
+        },
+        {
+          "Name": "API_URL",
+          "Value": "https://example.invalid/api"
+        }
+      ],
+      "Name": "cdkrd-hunt-amplify",
+      "Platform": "WEB"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd amplify rich hunt fixture",
+    "Platform": "WEB",
+    "EnableBranchAutoDeletion": false,
+    "DefaultDomain": "d29o73zx4mc67h.amplifyapp.com",
+    "JobConfig": {
+      "BuildComputeType": "STANDARD_8GB"
+    },
+    "AppName": "cdkrd-hunt-amplify",
+    "Name": "cdkrd-hunt-amplify",
+    "EnvironmentVariables": [
+      {
+        "Value": "https://example.invalid/api",
+        "Name": "API_URL"
+      },
+      {
+        "Value": "hunt",
+        "Name": "STAGE"
+      }
+    ],
+    "AppId": "d29o73zx4mc67h",
+    "CustomRules": [
+      {
+        "Status": "301",
+        "Target": "/documentation/<*>",
+        "Source": "/docs/<*>"
+      },
+      {
+        "Status": "404-200",
+        "Target": "/index.html",
+        "Source": "/<*>"
+      }
+    ],
+    "Arn": "arn:aws:amplify:us-east-1:111111111111:apps/d29o73zx4mc67h",
+    "CacheConfig": {
+      "Type": "AMPLIFY_MANAGED_NO_COOKIES"
+    },
+    "CustomHeaders": ""
+  },
+  "schema": {
+    "readOnly": ["AppId", "AppName", "Arn", "DefaultDomain"],
+    "writeOnly": ["AccessToken", "AutoBranchCreationConfig", "BasicAuthConfig", "OauthToken"],
+    "createOnly": [],
+    "readOnlyPaths": ["AppId", "AppName", "Arn", "DefaultDomain"],
+    "writeOnlyPaths": ["AccessToken", "AutoBranchCreationConfig", "BasicAuthConfig", "OauthToken"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AmplifyApp",
+      "resourceType": "AWS::Amplify::App",
+      "path": "CacheConfig",
+      "actual": {
+        "Type": "AMPLIFY_MANAGED_NO_COOKIES"
+      },
+      "physicalId": "arn:aws:amplify:us-east-1:111111111111:apps/d29o73zx4mc67h",
+      "constructPath": "CdkRealDriftIntegAmplifyConnRich/AmplifyApp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "AmplifyApp",
+      "resourceType": "AWS::Amplify::App",
+      "path": "JobConfig",
+      "actual": {
+        "BuildComputeType": "STANDARD_8GB"
+      },
+      "physicalId": "arn:aws:amplify:us-east-1:111111111111:apps/d29o73zx4mc67h",
+      "constructPath": "CdkRealDriftIntegAmplifyConnRich/AmplifyApp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Amplify__Branch.MainBranch.json
+++ b/tests/corpus/AWS__Amplify__Branch.MainBranch.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MainBranch",
+    "resourceType": "AWS::Amplify::Branch",
+    "physicalId": "arn:aws:amplify:us-east-1:111111111111:apps/d29o73zx4mc67h/branches/main",
+    "constructPath": "CdkRealDriftIntegAmplifyConnRich/MainBranch",
+    "declared": {
+      "AppId": "d29o73zx4mc67h",
+      "BranchName": "main",
+      "Description": "cdkrd hunt main branch",
+      "EnableAutoBuild": false,
+      "EnablePullRequestPreview": false,
+      "EnvironmentVariables": [
+        {
+          "Name": "BRANCH_FLAG",
+          "Value": "on"
+        }
+      ],
+      "Stage": "PRODUCTION"
+    }
+  },
+  "liveRaw": {
+    "Backend": {},
+    "Description": "cdkrd hunt main branch",
+    "EnvironmentVariables": [
+      {
+        "Value": "on",
+        "Name": "BRANCH_FLAG"
+      }
+    ],
+    "AppId": "d29o73zx4mc67h",
+    "EnablePullRequestPreview": false,
+    "EnableAutoBuild": false,
+    "EnablePerformanceMode": false,
+    "Stage": "PRODUCTION",
+    "BranchName": "main",
+    "Arn": "arn:aws:amplify:us-east-1:111111111111:apps/d29o73zx4mc67h/branches/main"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["BasicAuthConfig"],
+    "createOnly": ["AppId", "BranchName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["BasicAuthConfig"],
+    "createOnlyPaths": ["AppId", "BranchName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cassandra__Keyspace.HuntKeyspace.json
+++ b/tests/corpus/AWS__Cassandra__Keyspace.HuntKeyspace.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntKeyspace",
+    "resourceType": "AWS::Cassandra::Keyspace",
+    "physicalId": "cdkrd_hunt_ks",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntKeyspace",
+    "declared": {
+      "KeyspaceName": "cdkrd_hunt_ks"
+    }
+  },
+  "liveRaw": {
+    "KeyspaceName": "cdkrd_hunt_ks",
+    "ReplicationSpecification": {
+      "ReplicationStrategy": "SINGLE_REGION"
+    },
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["KeyspaceName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KeyspaceName"],
+    "defaults": {},
+    "defaultPaths": {
+      "ReplicationSpecification": {
+        "properties": {
+          "ReplicationStrategy": {
+            "type": "string",
+            "const": "SINGLE_REGION"
+          }
+        }
+      }
+    },
+    "unorderedScalarPaths": ["ReplicationSpecification.RegionList"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntKeyspace",
+      "resourceType": "AWS::Cassandra::Keyspace",
+      "path": "ReplicationSpecification",
+      "actual": {
+        "ReplicationStrategy": "SINGLE_REGION"
+      },
+      "physicalId": "cdkrd_hunt_ks",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntKeyspace"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cassandra__Table.HuntTable.json
+++ b/tests/corpus/AWS__Cassandra__Table.HuntTable.json
@@ -1,0 +1,164 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTable",
+    "resourceType": "AWS::Cassandra::Table",
+    "physicalId": "cdkrd_hunt_ks|hunt_table",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntTable",
+    "declared": {
+      "BillingMode": {
+        "Mode": "ON_DEMAND"
+      },
+      "ClusteringKeyColumns": [
+        {
+          "Column": {
+            "ColumnName": "sk",
+            "ColumnType": "int"
+          },
+          "OrderBy": "ASC"
+        }
+      ],
+      "DefaultTimeToLive": 0,
+      "KeyspaceName": "cdkrd_hunt_ks",
+      "PartitionKeyColumns": [
+        {
+          "ColumnName": "id",
+          "ColumnType": "text"
+        }
+      ],
+      "PointInTimeRecoveryEnabled": false,
+      "RegularColumns": [
+        {
+          "ColumnName": "payload",
+          "ColumnType": "text"
+        }
+      ],
+      "TableName": "hunt_table"
+    }
+  },
+  "liveRaw": {
+    "ClusteringKeyColumns": [
+      {
+        "OrderBy": "ASC",
+        "Column": {
+          "ColumnName": "sk",
+          "ColumnType": "int"
+        }
+      }
+    ],
+    "WarmThroughput": {
+      "ReadUnitsPerSecond": 12000,
+      "WriteUnitsPerSecond": 4000
+    },
+    "KeyspaceName": "cdkrd_hunt_ks",
+    "EncryptionSpecification": {
+      "EncryptionType": "AWS_OWNED_KMS_KEY"
+    },
+    "TableName": "hunt_table",
+    "PointInTimeRecoveryEnabled": false,
+    "CdcSpecification": {
+      "Status": "DISABLED"
+    },
+    "ClientSideTimestampsEnabled": false,
+    "PartitionKeyColumns": [
+      {
+        "ColumnName": "id",
+        "ColumnType": "text"
+      }
+    ],
+    "BillingMode": {
+      "Mode": "ON_DEMAND"
+    },
+    "DefaultTimeToLive": 0,
+    "RegularColumns": [
+      {
+        "ColumnName": "payload",
+        "ColumnType": "text"
+      }
+    ],
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AutoScalingSpecifications", "ReplicaSpecifications"],
+    "createOnly": [
+      "ClientSideTimestampsEnabled",
+      "ClusteringKeyColumns",
+      "KeyspaceName",
+      "PartitionKeyColumns",
+      "TableName"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AutoScalingSpecifications", "ReplicaSpecifications"],
+    "createOnlyPaths": [
+      "ClientSideTimestampsEnabled",
+      "ClusteringKeyColumns",
+      "KeyspaceName",
+      "PartitionKeyColumns",
+      "TableName"
+    ],
+    "defaults": {},
+    "defaultPaths": {
+      "ClusteringKeyColumns.*.OrderBy": "ASC",
+      "BillingMode.Mode": "ON_DEMAND",
+      "EncryptionSpecification.EncryptionType": "AWS_OWNED_KMS_KEY",
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.AutoScalingDisabled": false,
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "AutoScalingSpecifications.WriteCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.AutoScalingDisabled": false,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "AutoScalingSpecifications.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0,
+      "CdcSpecification.ViewType": "NEW_AND_OLD_IMAGES",
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.AutoScalingDisabled": false,
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.DisableScaleIn": "false",
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleInCooldown": 0,
+      "ReplicaSpecifications.*.ReadCapacityAutoScaling.ScalingPolicy.TargetTrackingScalingPolicyConfiguration.ScaleOutCooldown": 0
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "CdcSpecification",
+      "actual": {
+        "Status": "DISABLED"
+      },
+      "physicalId": "cdkrd_hunt_ks|hunt_table",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "EncryptionSpecification",
+      "actual": {
+        "EncryptionType": "AWS_OWNED_KMS_KEY"
+      },
+      "physicalId": "cdkrd_hunt_ks|hunt_table",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntTable"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntTable",
+      "resourceType": "AWS::Cassandra::Table",
+      "path": "WarmThroughput",
+      "actual": {
+        "ReadUnitsPerSecond": 12000,
+        "WriteUnitsPerSecond": 4000
+      },
+      "physicalId": "cdkrd_hunt_ks|hunt_table",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntTable"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudWatch__InsightRule.InsightRule.json
+++ b/tests/corpus/AWS__CloudWatch__InsightRule.InsightRule.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "InsightRule",
+    "resourceType": "AWS::CloudWatch::InsightRule",
+    "physicalId": "arn:aws:cloudwatch:us-east-1:111111111111:insight-rule/cdkrd-hunt-insight-rule",
+    "constructPath": "CdkRealDriftIntegXrayInsightRich/InsightRule",
+    "declared": {
+      "RuleBody": "{\"Schema\":{\"Name\":\"CloudWatchLogRule\",\"Version\":1},\"LogGroupNames\":[\"/cdkrd/hunt/insightrule\"],\"LogFormat\":\"JSON\",\"Contribution\":{\"Keys\":[\"$.requestId\"],\"Filters\":[{\"Match\":\"$.status\",\"GreaterThan\":499}]},\"AggregateOn\":\"Count\"}",
+      "RuleName": "cdkrd-hunt-insight-rule",
+      "RuleState": "ENABLED"
+    }
+  },
+  "liveRaw": {
+    "RuleState": "ENABLED",
+    "Arn": "arn:aws:cloudwatch:us-east-1:111111111111:insight-rule/cdkrd-hunt-insight-rule",
+    "RuleBody": "{\"Schema\":{\"Name\":\"CloudWatchLogRule\",\"Version\":1},\"LogGroupNames\":[\"/cdkrd/hunt/insightrule\"],\"LogFormat\":\"JSON\",\"Contribution\":{\"Keys\":[\"$.requestId\"],\"Filters\":[{\"Match\":\"$.status\",\"GreaterThan\":499}]},\"AggregateOn\":\"Count\"}",
+    "ApplyOnTransformedLogs": false,
+    "RuleName": "cdkrd-hunt-insight-rule",
+    "Tags": [
+      {
+        "Value": "InsightRule",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegXrayInsightRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegXrayInsightRich/95bd10d0-75cc-11f1-a377-12dea6fced63",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["RuleName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RuleName"],
+    "defaults": {
+      "ApplyOnTransformedLogs": false
+    },
+    "defaultPaths": {
+      "ApplyOnTransformedLogs": false
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "InsightRule",
+      "resourceType": "AWS::CloudWatch::InsightRule",
+      "path": "ApplyOnTransformedLogs",
+      "actual": false,
+      "physicalId": "arn:aws:cloudwatch:us-east-1:111111111111:insight-rule/cdkrd-hunt-insight-rule",
+      "constructPath": "CdkRealDriftIntegXrayInsightRich/InsightRule"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeStarConnections__Connection.GithubConnection.json
+++ b/tests/corpus/AWS__CodeStarConnections__Connection.GithubConnection.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GithubConnection",
+    "resourceType": "AWS::CodeStarConnections::Connection",
+    "physicalId": "arn:aws:codestar-connections:us-east-1:111111111111:connection/f631dda8-47dd-4116-8b29-5cf64ffd5a53",
+    "constructPath": "CdkRealDriftIntegAmplifyConnRich/GithubConnection",
+    "declared": {
+      "ConnectionName": "cdkrd-hunt-conn",
+      "ProviderType": "GitHub"
+    }
+  },
+  "liveRaw": {
+    "ConnectionName": "cdkrd-hunt-conn",
+    "HostArn": "arn:aws:codestar-connections:us-west-2:000000000000:host/00000000-0000-0000-0000-000000000000",
+    "ConnectionArn": "arn:aws:codestar-connections:us-east-1:111111111111:connection/f631dda8-47dd-4116-8b29-5cf64ffd5a53",
+    "ProviderType": "GitHub",
+    "ConnectionStatus": "PENDING",
+    "OwnerAccountId": "111111111111",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegAmplifyConnRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAmplifyConnRich/8b6b4fc0-75cc-11f1-83af-0affcafaad9f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "GithubConnection",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["ConnectionArn", "ConnectionStatus", "OwnerAccountId"],
+    "writeOnly": [],
+    "createOnly": ["ConnectionName", "HostArn", "ProviderType"],
+    "readOnlyPaths": ["ConnectionArn", "ConnectionStatus", "OwnerAccountId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ConnectionName", "HostArn", "ProviderType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "GithubConnection",
+      "resourceType": "AWS::CodeStarConnections::Connection",
+      "path": "HostArn",
+      "actual": "arn:aws:codestar-connections:us-west-2:000000000000:host/00000000-0000-0000-0000-000000000000",
+      "physicalId": "arn:aws:codestar-connections:us-east-1:111111111111:connection/f631dda8-47dd-4116-8b29-5cf64ffd5a53",
+      "constructPath": "CdkRealDriftIntegAmplifyConnRich/GithubConnection"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__KeyPair.HuntKeyPair.json
+++ b/tests/corpus/AWS__EC2__KeyPair.HuntKeyPair.json
@@ -1,0 +1,47 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntKeyPair",
+    "resourceType": "AWS::EC2::KeyPair",
+    "physicalId": "cdkrd-hunt-keypair",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntKeyPair",
+    "declared": {
+      "KeyName": "cdkrd-hunt-keypair",
+      "KeyType": "ed25519",
+      "PublicKeyMaterial": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJPRfhD3vb5rmS6P4rVU65OFl8aLIHppMwCNy0+r49tT cdkrd-hunt"
+    }
+  },
+  "liveRaw": {
+    "KeyName": "cdkrd-hunt-keypair",
+    "KeyType": "ed25519",
+    "KeyPairId": "key-00a03cde1f7c868e1",
+    "KeyFingerprint": "DelxzwGc+COUwB3s31Y6fgPw1bBs9df1V6Tzxjv6Xik=",
+    "PublicKeyMaterial": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJPRfhD3vb5rmS6P4rVU65OFl8aLIHppMwCNy0+r49tT cdkrd-hunt-keypair\n",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["KeyFingerprint", "KeyPairId"],
+    "writeOnly": ["KeyFormat"],
+    "createOnly": ["KeyFormat", "KeyName", "KeyType", "PublicKeyMaterial", "Tags"],
+    "readOnlyPaths": ["KeyFingerprint", "KeyPairId"],
+    "writeOnlyPaths": ["KeyFormat"],
+    "createOnlyPaths": ["KeyFormat", "KeyName", "KeyType", "PublicKeyMaterial", "Tags"],
+    "defaults": {
+      "KeyType": "rsa",
+      "KeyFormat": "pem"
+    },
+    "defaultPaths": {
+      "KeyType": "rsa",
+      "KeyFormat": "pem"
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EMRServerless__Application.HuntEmrApp.json
+++ b/tests/corpus/AWS__EMRServerless__Application.HuntEmrApp.json
@@ -1,0 +1,117 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntEmrApp",
+    "resourceType": "AWS::EMRServerless::Application",
+    "physicalId": "00g6t55ue4n9oc09",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntEmrApp",
+    "declared": {
+      "AutoStartConfiguration": {
+        "Enabled": true
+      },
+      "AutoStopConfiguration": {
+        "Enabled": true,
+        "IdleTimeoutMinutes": 5
+      },
+      "MaximumCapacity": {
+        "Cpu": "4 vCPU",
+        "Memory": "16 GB"
+      },
+      "Name": "cdkrd-hunt-emrsl",
+      "ReleaseLabel": "emr-7.0.0",
+      "Type": "SPARK"
+    }
+  },
+  "liveRaw": {
+    "AutoStartConfiguration": {
+      "Enabled": true
+    },
+    "Architecture": "X86_64",
+    "WorkerTypeSpecifications": {},
+    "MonitoringConfiguration": {
+      "ManagedPersistenceMonitoringConfiguration": {
+        "Enabled": true
+      }
+    },
+    "MaximumCapacity": {
+      "Memory": "16 GB",
+      "Cpu": "4 vCPU",
+      "Disk": "400000 GB"
+    },
+    "AutoStopConfiguration": {
+      "Enabled": true,
+      "IdleTimeoutMinutes": 5
+    },
+    "RuntimeConfiguration": [],
+    "Name": "cdkrd-hunt-emrsl",
+    "Type": "Spark",
+    "InitialCapacity": [],
+    "ReleaseLabel": "emr-7.0.0",
+    "Arn": "arn:aws:emr-serverless:us-east-1:111111111111:/applications/00g6t55ue4n9oc09",
+    "ApplicationId": "00g6t55ue4n9oc09",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["ApplicationId", "Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Type"],
+    "readOnlyPaths": ["ApplicationId", "Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Type"],
+    "defaults": {},
+    "defaultPaths": {
+      "AutoStartConfiguration.Enabled": true,
+      "AutoStopConfiguration.Enabled": true,
+      "MonitoringConfiguration.ManagedPersistenceMonitoringConfiguration.Enabled": true,
+      "MonitoringConfiguration.CloudWatchLoggingConfiguration.Enabled": false,
+      "InteractiveConfiguration.LivyEndpointEnabled": false,
+      "InteractiveConfiguration.StudioEnabled": false,
+      "InteractiveConfiguration.SessionEnabled": false
+    },
+    "unorderedScalarPaths": [
+      "NetworkConfiguration.SecurityGroupIds",
+      "NetworkConfiguration.SubnetIds"
+    ],
+    "freeFormMapPaths": ["RuntimeConfiguration.*.Properties", "WorkerTypeSpecifications"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEmrApp",
+      "resourceType": "AWS::EMRServerless::Application",
+      "path": "Architecture",
+      "actual": "X86_64",
+      "physicalId": "00g6t55ue4n9oc09",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntEmrApp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEmrApp",
+      "resourceType": "AWS::EMRServerless::Application",
+      "path": "MaximumCapacity.Disk",
+      "actual": "400000 GB",
+      "nested": true,
+      "physicalId": "00g6t55ue4n9oc09",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntEmrApp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntEmrApp",
+      "resourceType": "AWS::EMRServerless::Application",
+      "path": "MonitoringConfiguration",
+      "actual": {
+        "ManagedPersistenceMonitoringConfiguration": {
+          "Enabled": true
+        }
+      },
+      "physicalId": "00g6t55ue4n9oc09",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntEmrApp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__FIS__ExperimentTemplate.HuntExperiment.json
+++ b/tests/corpus/AWS__FIS__ExperimentTemplate.HuntExperiment.json
@@ -1,0 +1,93 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntExperiment",
+    "resourceType": "AWS::FIS::ExperimentTemplate",
+    "physicalId": "EXT8bzEM7ED1LXHiQ",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntExperiment",
+    "declared": {
+      "Actions": {
+        "justWait": {
+          "ActionId": "aws:fis:wait",
+          "Parameters": {
+            "duration": "PT1M"
+          }
+        }
+      },
+      "Description": "cdkrd hunt wait-only experiment",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegMisc0CovRich-FisRoleF2C479C1-SMZIFRzxNLee",
+      "StopConditions": [
+        {
+          "Source": "none"
+        }
+      ],
+      "Tags": {
+        "Name": "cdkrd-hunt-experiment"
+      },
+      "Targets": {}
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt wait-only experiment",
+    "Actions": {
+      "justWait": {
+        "ActionId": "aws:fis:wait",
+        "Parameters": {
+          "duration": "PT1M"
+        },
+        "Targets": {},
+        "StartAfter": []
+      }
+    },
+    "ExperimentOptions": {
+      "EmptyTargetResolutionMode": "fail",
+      "AccountTargeting": "single-account"
+    },
+    "StopConditions": [
+      {
+        "Source": "none"
+      }
+    ],
+    "Targets": {},
+    "Id": "EXT8bzEM7ED1LXHiQ",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegMisc0CovRich-FisRoleF2C479C1-SMZIFRzxNLee",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegMisc0CovRich",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0CovRich/8c547740-75cc-11f1-830d-0affe48f6bc1",
+      "aws:cloudformation:logical-id": "HuntExperiment",
+      "Name": "cdkrd-hunt-experiment"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ExperimentOptions.AccountTargeting"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["Actions", "Targets"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntExperiment",
+      "resourceType": "AWS::FIS::ExperimentTemplate",
+      "path": "ExperimentOptions",
+      "actual": {
+        "EmptyTargetResolutionMode": "fail",
+        "AccountTargeting": "single-account"
+      },
+      "physicalId": "EXT8bzEM7ED1LXHiQ",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntExperiment"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RAM__ResourceShare.HuntShare.json
+++ b/tests/corpus/AWS__RAM__ResourceShare.HuntShare.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntShare",
+    "resourceType": "AWS::RAM::ResourceShare",
+    "physicalId": "arn:aws:ram:us-east-1:111111111111:resource-share/c4b9ed31-c4c8-4804-bc3a-d2e9a3fc4c81",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntShare",
+    "declared": {
+      "AllowExternalPrincipals": false,
+      "Name": "cdkrd-hunt-share"
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "ResourceShareConfiguration": {
+      "RetainSharingOnAccountLeaveOrganization": false
+    },
+    "CreationTime": "2026-07-02T04:14:53.186Z",
+    "LastUpdatedTime": "2026-07-02T04:14:53.186Z",
+    "OwningAccountId": "111111111111",
+    "FeatureSet": "STANDARD",
+    "AllowExternalPrincipals": false,
+    "Arn": "arn:aws:ram:us-east-1:111111111111:resource-share/c4b9ed31-c4c8-4804-bc3a-d2e9a3fc4c81",
+    "Name": "cdkrd-hunt-share"
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CreationTime",
+      "FeatureSet",
+      "LastUpdatedTime",
+      "OwningAccountId",
+      "Status"
+    ],
+    "writeOnly": ["PermissionArns", "Principals", "ResourceArns", "Sources"],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "Arn",
+      "CreationTime",
+      "FeatureSet",
+      "LastUpdatedTime",
+      "OwningAccountId",
+      "Status"
+    ],
+    "writeOnlyPaths": ["PermissionArns", "Principals", "ResourceArns", "Sources"],
+    "createOnlyPaths": ["ResourceShareConfiguration.RetainSharingOnAccountLeaveOrganization"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["PermissionArns", "Principals", "ResourceArns", "Sources"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__VerifiedPermissions__PolicyStore.HuntPolicyStore.json
+++ b/tests/corpus/AWS__VerifiedPermissions__PolicyStore.HuntPolicyStore.json
@@ -1,0 +1,82 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPolicyStore",
+    "resourceType": "AWS::VerifiedPermissions::PolicyStore",
+    "physicalId": "Hb4xWipDFTXhjpffXbAtva",
+    "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntPolicyStore",
+    "declared": {
+      "Description": "cdkrd hunt policy store",
+      "Schema": {
+        "CedarJson": "{\"CdkrdHunt\":{\"entityTypes\":{\"User\":{\"shape\":{\"type\":\"Record\",\"attributes\":{}}},\"Doc\":{\"shape\":{\"type\":\"Record\",\"attributes\":{}}}},\"actions\":{\"view\":{\"appliesTo\":{\"principalTypes\":[\"User\"],\"resourceTypes\":[\"Doc\"]}}}}}"
+      },
+      "ValidationSettings": {
+        "Mode": "STRICT"
+      }
+    }
+  },
+  "liveRaw": {
+    "EncryptionState": {
+      "Default": {}
+    },
+    "Description": "cdkrd hunt policy store",
+    "ValidationSettings": {
+      "Mode": "STRICT"
+    },
+    "Schema": {
+      "CedarJson": "{\"CdkrdHunt\":{\"entityTypes\":{\"User\":{\"shape\":{\"type\":\"Record\",\"attributes\":{}}},\"Doc\":{\"shape\":{\"type\":\"Record\",\"attributes\":{}}}},\"actions\":{\"view\":{\"appliesTo\":{\"principalTypes\":[\"User\"],\"resourceTypes\":[\"Doc\"]}}}}}"
+    },
+    "PolicyStoreId": "Hb4xWipDFTXhjpffXbAtva",
+    "DeletionProtection": {
+      "Mode": "DISABLED"
+    },
+    "Arn": "arn:aws:verifiedpermissions::111111111111:policy-store/Hb4xWipDFTXhjpffXbAtva",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegMisc0CovRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0CovRich/8c547740-75cc-11f1-830d-0affe48f6bc1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "HuntPolicyStore",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "EncryptionState", "PolicyStoreId"],
+    "writeOnly": ["EncryptionSettings"],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "EncryptionState", "PolicyStoreId"],
+    "writeOnlyPaths": ["EncryptionSettings"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {
+      "DeletionProtection.Mode": "DISABLED"
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPolicyStore",
+      "resourceType": "AWS::VerifiedPermissions::PolicyStore",
+      "path": "DeletionProtection",
+      "actual": {
+        "Mode": "DISABLED"
+      },
+      "physicalId": "Hb4xWipDFTXhjpffXbAtva",
+      "constructPath": "CdkRealDriftIntegMisc0CovRich/HuntPolicyStore"
+    }
+  ]
+}

--- a/tests/corpus/AWS__XRay__Group.XrayGroup.json
+++ b/tests/corpus/AWS__XRay__Group.XrayGroup.json
@@ -1,0 +1,59 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "XrayGroup",
+    "resourceType": "AWS::XRay::Group",
+    "physicalId": "arn:aws:xray:us-east-1:111111111111:group/cdkrd-hunt-xray-group/DVNQJS5JPVPDLVRGFHHS7B5MMY3HK33CXLTF52NVKBFJTAGED3HQ",
+    "constructPath": "CdkRealDriftIntegXrayInsightRich/XrayGroup",
+    "declared": {
+      "FilterExpression": "service(\"cdkrd-hunt-svc\")",
+      "GroupName": "cdkrd-hunt-xray-group",
+      "InsightsConfiguration": {
+        "InsightsEnabled": true,
+        "NotificationsEnabled": false
+      }
+    }
+  },
+  "liveRaw": {
+    "GroupName": "cdkrd-hunt-xray-group",
+    "GroupARN": "arn:aws:xray:us-east-1:111111111111:group/cdkrd-hunt-xray-group/DVNQJS5JPVPDLVRGFHHS7B5MMY3HK33CXLTF52NVKBFJTAGED3HQ",
+    "InsightsConfiguration": {
+      "NotificationsEnabled": false,
+      "InsightsEnabled": true
+    },
+    "FilterExpression": "service(\"cdkrd-hunt-svc\")",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegXrayInsightRich/95bd10d0-75cc-11f1-a377-12dea6fced63",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegXrayInsightRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "XrayGroup",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["GroupARN"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["GroupARN"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__XRay__SamplingRule.XraySamplingRule.json
+++ b/tests/corpus/AWS__XRay__SamplingRule.XraySamplingRule.json
@@ -1,0 +1,105 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "XraySamplingRule",
+    "resourceType": "AWS::XRay::SamplingRule",
+    "physicalId": "arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling",
+    "constructPath": "CdkRealDriftIntegXrayInsightRich/XraySamplingRule",
+    "declared": {
+      "SamplingRule": {
+        "Attributes": {
+          "env": "hunt"
+        },
+        "FixedRate": 0.05,
+        "HTTPMethod": "GET",
+        "Host": "*",
+        "Priority": 9000,
+        "ReservoirSize": 1,
+        "ResourceARN": "*",
+        "RuleName": "cdkrd-hunt-sampling",
+        "ServiceName": "cdkrd-hunt-svc",
+        "ServiceType": "*",
+        "URLPath": "/api/*",
+        "Version": 1
+      }
+    }
+  },
+  "liveRaw": {
+    "RuleARN": "arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling",
+    "SamplingRule": {
+      "Priority": 9000,
+      "ReservoirSize": 1,
+      "RuleARN": "arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling",
+      "URLPath": "/api/*",
+      "Attributes": {
+        "env": "hunt"
+      },
+      "FixedRate": 0.05,
+      "Host": "*",
+      "ResourceARN": "*",
+      "HTTPMethod": "GET",
+      "ServiceName": "cdkrd-hunt-svc",
+      "Version": 1,
+      "ServiceType": "*",
+      "RuleName": "cdkrd-hunt-sampling"
+    },
+    "RuleName": "cdkrd-hunt-sampling",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegXrayInsightRich/95bd10d0-75cc-11f1-a377-12dea6fced63",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegXrayInsightRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "XraySamplingRule",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["RuleARN"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["RuleARN"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["SamplingRule.Version"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": [
+      "SamplingRule.Attributes",
+      "SamplingRuleRecord.SamplingRule.Attributes",
+      "SamplingRuleUpdate.Attributes"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "XraySamplingRule",
+      "resourceType": "AWS::XRay::SamplingRule",
+      "path": "RuleName",
+      "actual": "cdkrd-hunt-sampling",
+      "physicalId": "arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling",
+      "constructPath": "CdkRealDriftIntegXrayInsightRich/XraySamplingRule"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "XraySamplingRule",
+      "resourceType": "AWS::XRay::SamplingRule",
+      "path": "SamplingRule.RuleARN",
+      "actual": "arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling",
+      "nested": true,
+      "physicalId": "arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling",
+      "constructPath": "CdkRealDriftIntegXrayInsightRich/XraySamplingRule"
+    }
+  ]
+}

--- a/tests/integration/amplify-codeconnections-rich/app.ts
+++ b/tests/integration/amplify-codeconnections-rich/app.ts
@@ -1,0 +1,46 @@
+// CDK app for the cdk-real-drift amplify-codeconnections-rich false-positive
+// integration test. Zero-coverage CI/CD + frontend-hosting types:
+// AWS::Amplify::App (CustomRules order + EnvironmentVariables name/value pairs —
+// both reorder-FP probes), AWS::Amplify::Branch, and
+// AWS::CodeStarConnections::Connection (a GitHub connection stays PENDING until a
+// human completes the handshake — deploy/read/delete all work, which is exactly
+// how real pipelines hold it pre-handshake). A clean `record`->`check` is the FP
+// oracle.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnApp, CfnBranch } from "aws-cdk-lib/aws-amplify";
+import { CfnConnection } from "aws-cdk-lib/aws-codestarconnections";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAmplifyConnRich");
+
+const amplifyApp = new CfnApp(stack, "AmplifyApp", {
+  name: "cdkrd-hunt-amplify",
+  description: "cdkrd amplify rich hunt fixture",
+  platform: "WEB",
+  customRules: [
+    { source: "/docs/<*>", target: "/documentation/<*>", status: "301" },
+    { source: "/<*>", target: "/index.html", status: "404-200" },
+  ],
+  environmentVariables: [
+    { name: "STAGE", value: "hunt" },
+    { name: "API_URL", value: "https://example.invalid/api" },
+  ],
+  enableBranchAutoDeletion: false,
+});
+
+new CfnBranch(stack, "MainBranch", {
+  appId: amplifyApp.attrAppId,
+  branchName: "main",
+  description: "cdkrd hunt main branch",
+  enableAutoBuild: false,
+  enablePullRequestPreview: false,
+  stage: "PRODUCTION",
+  environmentVariables: [{ name: "BRANCH_FLAG", value: "on" }],
+});
+
+new CfnConnection(stack, "GithubConnection", {
+  connectionName: "cdkrd-hunt-conn",
+  providerType: "GitHub",
+});
+
+app.synth();

--- a/tests/integration/amplify-codeconnections-rich/cdk.json
+++ b/tests/integration/amplify-codeconnections-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/amplify-codeconnections-rich/package.json
+++ b/tests/integration/amplify-codeconnections-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-amplify-codeconnections-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift amplify-codeconnections-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/amplify-codeconnections-rich/verify.sh
+++ b/tests/integration/amplify-codeconnections-rich/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Amplify App (CustomRules + EnvironmentVariables object arrays)
+# + Branch + a PENDING CodeConnections GitHub connection; any drift on a clean
+# recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAmplifyConnRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/misc-0cov-rich/app.ts
+++ b/tests/integration/misc-0cov-rich/app.ts
@@ -1,0 +1,103 @@
+// CDK app for the cdk-real-drift misc-0cov-rich false-positive integration test.
+// A grab bag of cheap, fast, zero-coverage common types:
+// - AWS::EC2::KeyPair (imported PublicKeyMaterial is writeOnly — import so AWS
+//   stores NO private key in SSM Parameter Store, nothing to orphan)
+// - AWS::RAM::ResourceShare (org/multi-account staple)
+// - AWS::FIS::ExperimentTemplate (Actions/Targets are free-form MAPS keyed by
+//   user-chosen names — a map-shape probe; aws:fis:wait needs no real targets)
+// - AWS::VerifiedPermissions::PolicyStore (Schema.CedarJson is a JSON-STRING
+//   prop — the object<->string normalization FP class)
+// - AWS::Cassandra::Keyspace + Table (Table has a COMPOSITE primaryIdentifier
+//   KeyspaceName|TableName — a CC_IDENTIFIER_ADAPTERS read-gap probe)
+// - AWS::EMRServerless::Application (no InitialCapacity, so zero idle cost)
+// A clean `record`->`check` is the FP oracle.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnKeyspace, CfnTable } from "aws-cdk-lib/aws-cassandra";
+import { CfnKeyPair } from "aws-cdk-lib/aws-ec2";
+import { CfnApplication } from "aws-cdk-lib/aws-emrserverless";
+import { CfnExperimentTemplate } from "aws-cdk-lib/aws-fis";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnResourceShare } from "aws-cdk-lib/aws-ram";
+import { CfnPolicyStore } from "aws-cdk-lib/aws-verifiedpermissions";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMisc0CovRich");
+
+new CfnKeyPair(stack, "HuntKeyPair", {
+  keyName: "cdkrd-hunt-keypair",
+  keyType: "ed25519",
+  publicKeyMaterial:
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJPRfhD3vb5rmS6P4rVU65OFl8aLIHppMwCNy0+r49tT cdkrd-hunt",
+});
+
+new CfnResourceShare(stack, "HuntShare", {
+  name: "cdkrd-hunt-share",
+  allowExternalPrincipals: false,
+});
+
+const fisRole = new Role(stack, "FisRole", {
+  assumedBy: new ServicePrincipal("fis.amazonaws.com"),
+});
+
+new CfnExperimentTemplate(stack, "HuntExperiment", {
+  description: "cdkrd hunt wait-only experiment",
+  roleArn: fisRole.roleArn,
+  stopConditions: [{ source: "none" }],
+  targets: {},
+  actions: {
+    justWait: {
+      actionId: "aws:fis:wait",
+      parameters: { duration: "PT1M" },
+    },
+  },
+  tags: { Name: "cdkrd-hunt-experiment" },
+});
+
+new CfnPolicyStore(stack, "HuntPolicyStore", {
+  description: "cdkrd hunt policy store",
+  validationSettings: { mode: "STRICT" },
+  schema: {
+    cedarJson: JSON.stringify({
+      CdkrdHunt: {
+        entityTypes: {
+          User: { shape: { type: "Record", attributes: {} } },
+          Doc: { shape: { type: "Record", attributes: {} } },
+        },
+        actions: {
+          view: {
+            appliesTo: { principalTypes: ["User"], resourceTypes: ["Doc"] },
+          },
+        },
+      },
+    }),
+  },
+});
+
+const keyspace = new CfnKeyspace(stack, "HuntKeyspace", {
+  keyspaceName: "cdkrd_hunt_ks",
+});
+
+const table = new CfnTable(stack, "HuntTable", {
+  keyspaceName: keyspace.keyspaceName as string,
+  tableName: "hunt_table",
+  partitionKeyColumns: [{ columnName: "id", columnType: "text" }],
+  clusteringKeyColumns: [
+    { column: { columnName: "sk", columnType: "int" }, orderBy: "ASC" },
+  ],
+  regularColumns: [{ columnName: "payload", columnType: "text" }],
+  billingMode: { mode: "ON_DEMAND" },
+  pointInTimeRecoveryEnabled: false,
+  defaultTimeToLive: 0,
+});
+table.addDependency(keyspace);
+
+new CfnApplication(stack, "HuntEmrApp", {
+  name: "cdkrd-hunt-emrsl",
+  releaseLabel: "emr-7.0.0",
+  type: "SPARK",
+  autoStartConfiguration: { enabled: true },
+  autoStopConfiguration: { enabled: true, idleTimeoutMinutes: 5 },
+  maximumCapacity: { cpu: "4 vCPU", memory: "16 GB" },
+});
+
+app.synth();

--- a/tests/integration/misc-0cov-rich/cdk.json
+++ b/tests/integration/misc-0cov-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/misc-0cov-rich/package.json
+++ b/tests/integration/misc-0cov-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-misc-0cov-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift misc-0cov-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/misc-0cov-rich/verify.sh
+++ b/tests/integration/misc-0cov-rich/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Grab bag of zero-coverage cheap types (EC2 KeyPair import, RAM
+# ResourceShare, FIS ExperimentTemplate free-form maps, Verified Permissions
+# PolicyStore Cedar JSON-string schema, Cassandra Keyspace + composite-id Table,
+# EMR Serverless app); any drift on a clean recorded stack is a normalization /
+# default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMisc0CovRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/xray-insightrule-rich/app.ts
+++ b/tests/integration/xray-insightrule-rich/app.ts
@@ -1,0 +1,62 @@
+// CDK app for the cdk-real-drift xray-insightrule-rich false-positive integration test.
+// Zero-coverage observability types: AWS::XRay::Group (InsightsConfiguration),
+// AWS::XRay::SamplingRule (the full nested SamplingRule object with wildcard
+// matchers + Attributes map), and AWS::CloudWatch::InsightRule (Contributor
+// Insights — RuleBody is a JSON-STRING property, a recurring object<->string
+// normalization FP class). A clean `record`->`check` is the FP oracle; the
+// SamplingRule FixedRate is the mutable-prop FN probe (verify-detect.sh).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnInsightRule } from "aws-cdk-lib/aws-cloudwatch";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { CfnGroup, CfnSamplingRule } from "aws-cdk-lib/aws-xray";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegXrayInsightRich");
+
+new CfnGroup(stack, "XrayGroup", {
+  groupName: "cdkrd-hunt-xray-group",
+  filterExpression: 'service("cdkrd-hunt-svc")',
+  insightsConfiguration: {
+    insightsEnabled: true,
+    notificationsEnabled: false,
+  },
+});
+
+new CfnSamplingRule(stack, "XraySamplingRule", {
+  samplingRule: {
+    ruleName: "cdkrd-hunt-sampling",
+    priority: 9000,
+    fixedRate: 0.05,
+    reservoirSize: 1,
+    serviceName: "cdkrd-hunt-svc",
+    serviceType: "*",
+    host: "*",
+    httpMethod: "GET",
+    urlPath: "/api/*",
+    resourceArn: "*",
+    version: 1,
+    attributes: { env: "hunt" },
+  },
+});
+
+const logGroup = new LogGroup(stack, "InsightLogs", {
+  logGroupName: "/cdkrd/hunt/insightrule",
+  retention: RetentionDays.ONE_DAY,
+});
+
+new CfnInsightRule(stack, "InsightRule", {
+  ruleName: "cdkrd-hunt-insight-rule",
+  ruleState: "ENABLED",
+  ruleBody: JSON.stringify({
+    Schema: { Name: "CloudWatchLogRule", Version: 1 },
+    LogGroupNames: [logGroup.logGroupName],
+    LogFormat: "JSON",
+    Contribution: {
+      Keys: ["$.requestId"],
+      Filters: [{ Match: "$.status", GreaterThan: 499 }],
+    },
+    AggregateOn: "Count",
+  }),
+});
+
+app.synth();

--- a/tests/integration/xray-insightrule-rich/cdk.json
+++ b/tests/integration/xray-insightrule-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/xray-insightrule-rich/package.json
+++ b/tests/integration/xray-insightrule-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-xray-insightrule-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift xray-insightrule-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/xray-insightrule-rich/verify-detect.sh
+++ b/tests/integration/xray-insightrule-rich/verify-detect.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Missed-detection (FN) integration test (real AWS): deploy -> record -> mutate a
+# declared MUTABLE prop out of band (X-Ray SamplingRule FixedRate, the "someone
+# changed it in the console" scenario) -> check MUST detect (exit 1) -> revert ->
+# check MUST be CLEAN and the live value restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegXrayInsightRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] mutate SamplingRule FixedRate out of band (0.05 -> 0.5) ==="
+aws xray update-sampling-rule --region "$REGION" --cli-input-json '{
+  "SamplingRuleUpdate": { "RuleName": "cdkrd-hunt-sampling", "FixedRate": 0.5 }
+}' >/dev/null || fail "out-of-band mutation"
+
+echo "=== [$STACK] check MUST detect the drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || { echo "--- MISSED DETECTION: FixedRate mutation not reported ---"; fail "expected drift (exit 1), got $rc"; }
+grep -q "FixedRate" "/tmp/cdkrd-$STACK-detect.out" || fail "drift reported but not on FixedRate"
+
+echo "=== [$STACK] revert MUST restore the declared value ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+LIVE_RATE=$(aws xray get-sampling-rules --region "$REGION" \
+  --query 'SamplingRuleRecords[?SamplingRule.RuleName==`cdkrd-hunt-sampling`].SamplingRule.FixedRate' --output text)
+[ "$LIVE_RATE" = "0.05" ] || fail "live FixedRate is $LIVE_RATE, expected 0.05 after revert"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+echo "INTEG PASS ($STACK detect/revert)"

--- a/tests/integration/xray-insightrule-rich/verify.sh
+++ b/tests/integration/xray-insightrule-rich/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. X-Ray Group/SamplingRule + CloudWatch InsightRule (Contributor
+# Insights) — the InsightRule RuleBody is a JSON-string prop, a recurring
+# object<->string normalization FP class; any drift on a clean recorded stack is
+# a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegXrayInsightRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -7,6 +7,9 @@ import {
   isAllAwsTags,
   isCfnTemplateNonAsciiMask,
   isPemEqual,
+  isSshPublicKeyEqual,
+  SSH_PUBLIC_KEY_PATHS,
+  CASE_INSENSITIVE_PATHS,
   isPhysicalIdSegment,
   isTrivialEmpty,
   isVersionPrefixMatch,
@@ -685,6 +688,84 @@ describe('noise suppressors', () => {
     expect(isPemEqual(1, 1)).toBe(false);
   });
 
+  it('isSshPublicKeyEqual: EC2 rewrites the comment to the key name + appends a newline — same material is not drift', () => {
+    // Observed live (misc-0cov-rich): an imported KeyPair reads PublicKeyMaterial
+    // back with the comment replaced by the KeyName and a trailing newline.
+    const declared =
+      'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJPRfhD3vb5rmS6P4rVU65OFl8aLIHppMwCNy0+r49tT cdkrd-hunt';
+    const live =
+      'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJPRfhD3vb5rmS6P4rVU65OFl8aLIHppMwCNy0+r49tT cdkrd-hunt-keypair\n';
+    expect(isSshPublicKeyEqual(declared, live)).toBe(true);
+    // comment entirely absent on one side still folds
+    expect(
+      isSshPublicKeyEqual('ssh-rsa AAAAB3Nza+/x== me@laptop', 'ssh-rsa AAAAB3Nza+/x==\n')
+    ).toBe(true);
+    // sk-/ecdsa key types parse too
+    expect(
+      isSshPublicKeyEqual(
+        'sk-ssh-ed25519@openssh.com AAAAGnNr me@laptop',
+        'sk-ssh-ed25519@openssh.com AAAAGnNr imported-key\n'
+      )
+    ).toBe(true);
+    // a genuinely different key blob still differs (fail-closed)
+    expect(isSshPublicKeyEqual(declared, declared.replace('IJPRfhD3', 'IDIFFRNT'))).toBe(false);
+    // a different key TYPE still differs
+    expect(isSshPublicKeyEqual('ssh-ed25519 AAAAC3 c', 'ssh-rsa AAAAC3 c')).toBe(false);
+    // both sides must parse as OpenSSH public keys — arbitrary strings never fold
+    expect(isSshPublicKeyEqual('hello world', 'hello world\n')).toBe(false);
+    expect(isSshPublicKeyEqual(declared, 'not-a-key')).toBe(false);
+    // non-strings never match
+    expect(isSshPublicKeyEqual(1, 1)).toBe(false);
+    // the KeyPair path is registered
+    expect(SSH_PUBLIC_KEY_PATHS['AWS::EC2::KeyPair']?.has('PublicKeyMaterial')).toBe(true);
+  });
+
+  it('CASE_INSENSITIVE_PATHS: EMR Serverless Application Type is folded case-insensitively', () => {
+    // Observed live (misc-0cov-rich): declared "SPARK" reads back "Spark".
+    expect(CASE_INSENSITIVE_PATHS['AWS::EMRServerless::Application']?.has('Type')).toBe(true);
+  });
+
+  it('KNOWN_DEFAULTS: misc-0cov-rich first-run service defaults are registered', () => {
+    // Observed live (misc-0cov-rich): constant service defaults a fresh resource
+    // reads back without declaring them.
+    expect(KNOWN_DEFAULTS['AWS::FIS::ExperimentTemplate']).toEqual({
+      ExperimentOptions: {
+        EmptyTargetResolutionMode: 'fail',
+        AccountTargeting: 'single-account',
+      },
+    });
+    expect(KNOWN_DEFAULTS['AWS::VerifiedPermissions::PolicyStore']).toEqual({
+      DeletionProtection: { Mode: 'DISABLED' },
+    });
+    expect(KNOWN_DEFAULTS['AWS::Cassandra::Keyspace']).toEqual({
+      ReplicationSpecification: { ReplicationStrategy: 'SINGLE_REGION' },
+    });
+    expect(KNOWN_DEFAULTS['AWS::Cassandra::Table']).toEqual({
+      WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
+      EncryptionSpecification: { EncryptionType: 'AWS_OWNED_KMS_KEY' },
+      CdcSpecification: { Status: 'DISABLED' },
+    });
+    expect(KNOWN_DEFAULTS['AWS::EMRServerless::Application']).toEqual({
+      Architecture: 'X86_64',
+      MonitoringConfiguration: {
+        ManagedPersistenceMonitoringConfiguration: { Enabled: true },
+      },
+    });
+    expect(KNOWN_DEFAULT_PATHS['AWS::EMRServerless::Application']).toEqual({
+      'MaximumCapacity.Disk': '400000 GB',
+    });
+    // amplify-codeconnections-rich first-run defaults
+    expect(KNOWN_DEFAULTS['AWS::Amplify::App']).toEqual({
+      JobConfig: { BuildComputeType: 'STANDARD_8GB' },
+      CacheConfig: { Type: 'AMPLIFY_MANAGED_NO_COOKIES' },
+    });
+    // the all-zeros "no host" sentinel ARN AWS echoes for cloud-provider connections
+    expect(KNOWN_DEFAULTS['AWS::CodeStarConnections::Connection']).toEqual({
+      HostArn:
+        'arn:aws:codestar-connections:us-west-2:000000000000:host/00000000-0000-0000-0000-000000000000',
+    });
+  });
+
   it('isCfnTemplateNonAsciiMask: GetTemplate `?`-masked non-ASCII declared value is not drift', () => {
     // GetTemplate returns the deployed template with every non-ASCII char as `?`
     // (one per codepoint). The declared side is corrupted; the live side is intact.
@@ -1060,6 +1141,15 @@ describe('isPhysicalIdSegment (R142 — value echoes a physical-id segment)', ()
     expect(isPhysicalIdSegment('api1', pid)).toBe(true);
     expect(isPhysicalIdSegment('GET', pid)).toBe(true);
     expect(isPhysicalIdSegment('bucket-x', 'arn:aws:s3:::bucket-x')).toBe(true); // ':'-split segment
+  });
+
+  it('the WHOLE physical id echoed verbatim matches (XRay SamplingRule.RuleARN)', () => {
+    // The live read echoes the rule's own ARN inside the declared SamplingRule
+    // object — a full-ARN value a ':'-split could never reassemble.
+    const arn = 'arn:aws:xray:us-east-1:111111111111:sampling-rule/cdkrd-hunt-sampling';
+    expect(isPhysicalIdSegment(arn, arn)).toBe(true);
+    // a DIFFERENT rule's ARN still does not match
+    expect(isPhysicalIdSegment(arn.replace('hunt', 'other'), arn)).toBe(false);
   });
 
   it('a custom value that is NOT a segment does not match', () => {


### PR DESCRIPTION
## Summary

Bug-hunt round targeting zero-coverage common types (fold tables were saturated vs the existing ~516-case corpus, so this round hunted types with NO corpus/fixture coverage at all). 3 stacks deployed: X-Ray Group/SamplingRule + CloudWatch InsightRule, Amplify App/Branch + CodeConnections Connection, and a cheap grab bag (EC2 KeyPair / RAM ResourceShare / FIS ExperimentTemplate / Verified Permissions PolicyStore / Cassandra Keyspace+Table / EMR Serverless Application).

## Two live-proven false positives (clean recorded stack reported declared drift)

- **EC2 KeyPair `PublicKeyMaterial`** — EC2 rewrites the OpenSSH comment field to the key pair name and appends a trailing newline on read (`... cdkrd-hunt` → `... cdkrd-hunt-keypair\n`). New `SSH_PUBLIC_KEY_PATHS` fold compares only the key material (type + base64); a genuine key change still differs (fail-closed: both sides must parse as OpenSSH keys).
- **EMR Serverless Application `Type`** — declared `SPARK` reads back `Spark`; added to `CASE_INSENSITIVE_PATHS` (create-only enum whose valid values differ beyond case).

## First-run noise folds (all equality-gated, observed live)

FIS `ExperimentOptions`, Verified Permissions `DeletionProtection`, Cassandra Keyspace `ReplicationSpecification` + Table `WarmThroughput`/`EncryptionSpecification`/`CdcSpecification`, EMR Serverless `Architecture`/`MonitoringConfiguration` + nested `MaximumCapacity.Disk`, Amplify `JobConfig`/`CacheConfig`, CodeConnections all-zeros `HostArn` placeholder sentinel, and X-Ray `SamplingRule.RuleARN` self-ARN echo via `GENERATED_PATHS` (`isPhysicalIdSegment` now also accepts the whole-physical-id echo — previously only `:`-split segments, which can never reassemble a full ARN).

## FN half + rule-outs

- SamplingRule `FixedRate` mutated out of band → `check` detects (exit 1) → `revert` restores 0.05 → `check` CLEAN (verify-detect.sh, live PASS).
- Cassandra Table's composite `primaryIdentifier` (`KeyspaceName|TableName`) ruled OUT as a read-gap — the CFn physical id is already the pipe composite (no `skipped=`).
- CloudWatch AnomalyDetector probed offline: NON_PROVISIONABLE, no CC read → not a hunt target.

## Assets

- 13 new golden-corpus types (Amplify App/Branch, CodeStarConnections Connection, CloudWatch InsightRule, X-Ray Group/SamplingRule, Cassandra Keyspace/Table, EC2 KeyPair, EMRServerless Application, FIS ExperimentTemplate, RAM ResourceShare, VerifiedPermissions PolicyStore), `expected` regenerated with the fixed classifier.
- 3 committed integ fixtures (`xray-insightrule-rich` incl. verify-detect.sh, `amplify-codeconnections-rich`, `misc-0cov-rich`).
- misc-0cov-rich re-deployed and re-verified **CLEAN** with the fixed binary; all stacks deleted, `bughunt-track.sh verify` OK + SWEEP CLEAN.

## Test plan

- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` — 42 files, 1941 tests, all pass (14 new assertions).
- Live: 3 fixtures INTEG PASS (FP oracle) + xray detect/revert INTEG PASS (FN oracle).