### PR TITLE
fix(noise): truncated CFn-generated names + per-LB-type ELB defaults + S3Express/S3Tables/vended-logs folds

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -51,6 +51,7 @@ import {
   KNOWN_DEFAULTS,
   READGAP_COLLECTION_PATHS,
   ELB_ATTRIBUTE_DEFAULTS,
+  ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE,
   PARAMETER_NAME_SUBSET_PATHS,
   alignParameterNameSubset,
   RATE_EXPRESSION_PATHS,
@@ -308,19 +309,44 @@ const isNestedObject = (x: unknown): x is Record<string, unknown> =>
 // CFn mints `<stackName>-<logicalId>-<random>` (the stack name is the FIRST segment of the
 // CDK construct path). DELIBERATELY strict — it must start with this stack's name AND end
 // with CFn's ~12+ char alphanumeric random suffix — so a user-chosen name is not folded away
-// (that would hide a real undeclared value, defeating the differentiator). Pure.
+// (that would hide a real undeclared value, defeating the differentiator). For SHORT-name
+// resource types (an ELBv2 load balancer / target group name is capped at 32 chars) CFn
+// TRUNCATES both segments — stack `CdkRealDriftIntegIotVpces` + logical id `NlbBC…` mints
+// `CdkRea-NlbBC-Rz5FCsQXIO7E` — so the full-prefix test misses and every auto-named
+// NLB/ALB/target group was first-run noise (observed live). The truncated branch stays
+// tightly gated: BOTH halves must be prefixes of this stack's name and this resource's own
+// logical id, with the stack half a STRICT prefix (truncation actually happened — the
+// untruncated form is the branch above) — a user-chosen name realistically never matches
+// all of that. Pure.
 const CFN_RANDOM_SUFFIX = /-[0-9A-Za-z]{12,}$/;
 function isCfnGeneratedName(
   value: unknown,
   constructPath: string | undefined,
-  physicalId: string | undefined
+  physicalId: string | undefined,
+  logicalId?: string
 ): boolean {
   // The bare physical-id echo (value === physicalId) is a STRUCTURAL drop handled separately
   // — never fold it into a `generated` finding here, or a resource whose physical id IS its
   // CFn-generated name gains a phantom finding.
   if (typeof value !== 'string' || !constructPath || value === physicalId) return false;
   const stackName = constructPath.split('/')[0];
-  return !!stackName && value.startsWith(`${stackName}-`) && CFN_RANDOM_SUFFIX.test(value);
+  if (!stackName || !CFN_RANDOM_SUFFIX.test(value)) return false;
+  if (value.startsWith(`${stackName}-`)) return true;
+  if (!logicalId) return false;
+  // Truncated short-name form: `<stackPrefix>-<logicalIdPrefix>-<random>`. Logical ids are
+  // alphanumeric (never '-'), so the LAST '-' in the de-suffixed base splits the two halves
+  // even when the stack name itself contains dashes.
+  const base = value.replace(CFN_RANDOM_SUFFIX, '');
+  const sep = base.lastIndexOf('-');
+  if (sep <= 0) return false;
+  const stackPart = base.slice(0, sep);
+  const logicalPart = base.slice(sep + 1);
+  return (
+    stackPart.length < stackName.length &&
+    stackName.startsWith(stackPart) &&
+    logicalPart.length > 0 &&
+    logicalId.startsWith(logicalPart)
+  );
 }
 
 // structuredClone rejects the UNRESOLVED Symbol a declared value may carry, so deep-clone
@@ -832,7 +858,17 @@ export function classifyResource(
       const declaredKeys = new Set(
         v.filter(isKeyValueEntry).map((e) => (e as { Key: string }).Key)
       );
-      const attrDefaults = ELB_ATTRIBUTE_DEFAULTS[resourceType] ?? {};
+      // A LoadBalancer's per-type defaults (NLB/GWLB cross_zone "false") override the
+      // shared table — the live `Type` is authoritative (readable, createOnly), with
+      // the omitted-Type default `application` as the fallback.
+      const lbType =
+        resourceType === 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+          ? String(live.Type ?? declared.Type ?? 'application')
+          : undefined;
+      const attrDefaults = {
+        ...(ELB_ATTRIBUTE_DEFAULTS[resourceType] ?? {}),
+        ...(lbType === undefined ? {} : (ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE[lbType] ?? {})),
+      };
       for (const lEl of liveBag) {
         if (!isKeyValueEntry(lEl)) continue;
         const key = (lEl as { Key: string }).Key;
@@ -1176,7 +1212,7 @@ export function classifyResource(
     // so an auto-named resource is not first-run noise. Tightly gated to avoid hiding a REAL
     // undeclared value (the differentiator): the value must start with THIS stack's name AND
     // end with CFn's random suffix — a user-chosen name realistically never matches both.
-    if (isCfnGeneratedName(v, resource.constructPath, physicalId)) {
+    if (isCfnGeneratedName(v, resource.constructPath, physicalId, logicalId)) {
       findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
       continue;
     }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -42,6 +42,77 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       ],
     },
   },
+  // S3 Express directory buckets are always encrypted; a never-declared bucket
+  // reads back SSE-S3 with the bucket key ON (unlike general-purpose buckets,
+  // which read BucketKeyEnabled:false and a BlockedEncryptionTypes field).
+  // Observed live on a fresh s3express-s3tables-rich deploy.
+  'AWS::S3Express::DirectoryBucket': {
+    BucketEncryption: {
+      ServerSideEncryptionConfiguration: [
+        {
+          BucketKeyEnabled: true,
+          ServerSideEncryptionByDefault: { SSEAlgorithm: 'AES256' },
+        },
+      ],
+    },
+  },
+  // S3 Tables table buckets materialize three constant service defaults on read:
+  // Standard storage class, table-level metrics off, and SSE-S3 encryption.
+  // Observed live on a fresh s3express-s3tables-rich deploy; equality-gated like
+  // every KNOWN_DEFAULTS entry, so moving any of them off the default (e.g. KMS
+  // encryption set out of band) re-surfaces as real undeclared drift.
+  'AWS::S3Tables::TableBucket': {
+    StorageClassConfiguration: { StorageClass: 'STANDARD' },
+    MetricsConfiguration: { Status: 'Disabled' },
+    EncryptionConfiguration: { SSEAlgorithm: 'AES256' },
+  },
+  // Vended-logs v2 (CloudWatch Logs Delivery family). DeliveryDestinationType is
+  // DERIVED from the declared DestinationResourceArn (a log-group destination always
+  // reads back "CWL") — observed-only like the ApiGateway Authorizer AuthType fold; an
+  // S3/FH/XRay destination's value simply doesn't match and surfaces once, recordable.
+  'AWS::Logs::DeliveryDestination': { DeliveryDestinationType: 'CWL' },
+  // A Delivery that declares no RecordFields materializes the source's FULL default
+  // field list on read. This is the CloudFront ACCESS_LOGS default (the most common
+  // vended source) — equality-gated, so a field added/removed/reordered out of band no
+  // longer matches and surfaces as real undeclared drift; other sources' lists simply
+  // don't fold. Observed live on a fresh cloudfront-kvs-logs-delivery deploy.
+  'AWS::Logs::Delivery': {
+    RecordFields: [
+      'date',
+      'time',
+      'x-edge-location',
+      'sc-bytes',
+      'c-ip',
+      'cs-method',
+      'cs(Host)',
+      'cs-uri-stem',
+      'sc-status',
+      'cs(Referer)',
+      'cs(User-Agent)',
+      'cs-uri-query',
+      'cs(Cookie)',
+      'x-edge-result-type',
+      'x-edge-request-id',
+      'x-host-header',
+      'cs-protocol',
+      'cs-bytes',
+      'time-taken',
+      'x-forwarded-for',
+      'ssl-protocol',
+      'ssl-cipher',
+      'x-edge-response-result-type',
+      'cs-protocol-version',
+      'fle-status',
+      'fle-encrypted-fields',
+      'c-port',
+      'time-to-first-byte',
+      'x-edge-detailed-result-type',
+      'sc-content-type',
+      'sc-content-len',
+      'sc-range-start',
+      'sc-range-end',
+    ],
+  },
   // R66 (dogfood-observed service defaults):
   'AWS::Lambda::Function': {
     TracingConfig: { Mode: 'PassThrough' },
@@ -1278,10 +1349,10 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     // idleTimeout). NLB has no idle_timeout attribute, so no cross-type conflict.
     'idle_timeout.timeout_seconds': '60',
     // ALB cross-zone load balancing is always on and not configurable -> AWS always
-    // returns "true". NB: an NLB's cross_zone default is "false" — the OPPOSITE — and
-    // this table is keyed only by resourceType (shared ALB/NLB), so the two cannot both
-    // fold; the ALB value wins and an NLB's cross_zone stays `undeclared` (a known minor
-    // residual; the equality gate keeps it correct, never mis-folding).
+    // returns "true". An NLB's / GWLB's default is "false" — the OPPOSITE — so those
+    // two override this entry via ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE below (the shared
+    // ALB value here previously mis-folded an out-of-band NLB cross_zone ENABLE as
+    // atDefault — a real undeclared change `record` then never snapshotted).
     'load_balancing.cross_zone.enabled': 'true',
     // NLB-only attribute keys (an ALB never returns them, so no conflict) — observed live
     // on a bare internal NLB.
@@ -1311,6 +1382,19 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     'target_group_health.unhealthy_state_routing.minimum_healthy_targets.count': '1',
     'target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage': 'off',
   },
+};
+
+// Load-balancer attribute defaults that differ BY LB TYPE (the LoadBalancer `Type`
+// property: application | network | gateway; omitted = application). Merged OVER the
+// shared ELB_ATTRIBUTE_DEFAULTS entry in classify, keyed by the live Type. cross_zone
+// is the one known split: an ALB is always-on ("true"), while an NLB / GWLB defaults
+// OFF ("false"). One shared entry could not fold the NLB first-run "false" AND
+// mis-folded an out-of-band NLB cross-zone ENABLE ("true" matched the shared ALB
+// default → atDefault, so `record` never snapshotted a real undeclared change and a
+// later flip could hide). Observed live on a fresh internal NLB (iot-vpces-rich).
+export const ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE: Record<string, Record<string, string>> = {
+  network: { 'load_balancing.cross_zone.enabled': 'false' },
+  gateway: { 'load_balancing.cross_zone.enabled': 'false' },
 };
 
 // (R95) The generic `projectLiveToDeclaredSubset` was REMOVED. It projected the live

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -805,6 +805,62 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ]);
   });
 
+  it('hunt-lowcov first-run folds: S3Express DirectoryBucket / S3Tables TableBucket / Logs Delivery family', () => {
+    // Constant service defaults observed live on fresh s3express-s3tables-rich and
+    // cloudfront-kvs-logs-delivery deploys with NO out-of-band edit — first-run noise
+    // that must fold to atDefault, while a real change to each surfaces (equality-gated).
+    const t = (rt: string, live: Record<string, unknown>) =>
+      tiers(classifyResource(bare(rt), live, emptySchema));
+
+    // Directory buckets are always encrypted: SSE-S3 with the bucket key ON.
+    const dirEnc = (algo: string) => ({
+      BucketEncryption: {
+        ServerSideEncryptionConfiguration: [
+          { BucketKeyEnabled: true, ServerSideEncryptionByDefault: { SSEAlgorithm: algo } },
+        ],
+      },
+    });
+    expect(t('AWS::S3Express::DirectoryBucket', dirEnc('AES256')).atDefault).toEqual([
+      'BucketEncryption',
+    ]);
+    expect(t('AWS::S3Express::DirectoryBucket', dirEnc('aws:kms')).undeclared).toEqual([
+      'BucketEncryption',
+    ]);
+
+    // Table buckets materialize three constant defaults; a KMS switch surfaces.
+    expect(
+      t('AWS::S3Tables::TableBucket', {
+        StorageClassConfiguration: { StorageClass: 'STANDARD' },
+        MetricsConfiguration: { Status: 'Disabled' },
+        EncryptionConfiguration: { SSEAlgorithm: 'AES256' },
+      }).atDefault.sort()
+    ).toEqual(['EncryptionConfiguration', 'MetricsConfiguration', 'StorageClassConfiguration']);
+    expect(
+      t('AWS::S3Tables::TableBucket', { EncryptionConfiguration: { SSEAlgorithm: 'aws:kms' } })
+        .undeclared
+    ).toEqual(['EncryptionConfiguration']);
+
+    // Vended logs v2: a log-group destination derives DeliveryDestinationType "CWL";
+    // an S3 destination's value doesn't match the fold and surfaces (recordable).
+    expect(
+      t('AWS::Logs::DeliveryDestination', { DeliveryDestinationType: 'CWL' }).atDefault
+    ).toEqual(['DeliveryDestinationType']);
+    expect(
+      t('AWS::Logs::DeliveryDestination', { DeliveryDestinationType: 'S3' }).undeclared
+    ).toEqual(['DeliveryDestinationType']);
+
+    // A Delivery with no declared RecordFields reads back the source's FULL default
+    // field list (CloudFront ACCESS_LOGS here); a trimmed selection surfaces.
+    const cfFields = KNOWN_DEFAULTS['AWS::Logs::Delivery'].RecordFields as string[];
+    expect(cfFields.length).toBeGreaterThan(30);
+    expect(t('AWS::Logs::Delivery', { RecordFields: cfFields }).atDefault).toEqual([
+      'RecordFields',
+    ]);
+    expect(t('AWS::Logs::Delivery', { RecordFields: cfFields.slice(0, 5) }).undeclared).toEqual([
+      'RecordFields',
+    ]);
+  });
+
   it('R104: StateMachineType STANDARD folds, EXPRESS stays undeclared (equality-gated curation)', () => {
     const t = (v: string) =>
       tiers(
@@ -1327,18 +1383,42 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       ]);
     });
 
-    it("an NLB's cross_zone default (false) does NOT fold (the ALB-keyed table holds true) and stays undeclared", () => {
-      // The table is keyed only by resourceType, and ALB cross_zone default "true" wins;
-      // an NLB's "false" must NOT mis-fold against "true" — the equality gate keeps it
-      // `undeclared` (recorded, fail-closed), a known minor residual noise on NLBs.
+    it("an NLB's cross_zone default (false) folds to atDefault via the per-LB-type override", () => {
+      // ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE keys on the live Type: an NLB's cross_zone
+      // default is "false" (the OPPOSITE of the shared ALB entry), so a fresh NLB is no
+      // longer first-run noise (observed live on iot-vpces-rich).
+      const nlbLive = (crossZone: string) => ({
+        Type: 'network',
+        LoadBalancerAttributes: [
+          { Key: 'deletion_protection.enabled', Value: 'false' },
+          { Key: 'load_balancing.cross_zone.enabled', Value: crossZone },
+        ],
+      });
+      const nlbDeclared = {
+        Type: 'network',
+        LoadBalancerAttributes: [{ Key: 'deletion_protection.enabled', Value: 'false' }],
+      };
+      const atDefault = classifyResource(res(T, nlbDeclared), nlbLive('false'), emptySchema).filter(
+        (f) => f.tier === 'atDefault'
+      );
+      expect(atDefault.map((f) => f.path)).toEqual([
+        'LoadBalancerAttributes[load_balancing.cross_zone.enabled]',
+      ]);
+    });
+
+    it("an NLB's out-of-band cross_zone ENABLE (true) stays undeclared — the shared ALB default must NOT mis-fold it", () => {
+      // Before the per-type override, "true" matched the shared ALB entry -> atDefault,
+      // so `record` never snapshotted a REAL undeclared change (an FN, not just noise).
       const undeclared = classifyResource(
         res(T, {
+          Type: 'network',
           LoadBalancerAttributes: [{ Key: 'deletion_protection.enabled', Value: 'false' }],
         }),
         {
+          Type: 'network',
           LoadBalancerAttributes: [
             { Key: 'deletion_protection.enabled', Value: 'false' },
-            { Key: 'load_balancing.cross_zone.enabled', Value: 'false' },
+            { Key: 'load_balancing.cross_zone.enabled', Value: 'true' },
           ],
         },
         emptySchema
@@ -1346,6 +1426,29 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       expect(undeclared.map((f) => f.path)).toEqual([
         'LoadBalancerAttributes[load_balancing.cross_zone.enabled]',
       ]);
+    });
+
+    it("an ALB (no Type declared or read = application) keeps the shared cross_zone default: 'true' folds, 'false' surfaces", () => {
+      const albLive = (crossZone: string) => ({
+        LoadBalancerAttributes: [
+          { Key: 'deletion_protection.enabled', Value: 'false' },
+          { Key: 'load_balancing.cross_zone.enabled', Value: crossZone },
+        ],
+      });
+      const albDeclared = {
+        LoadBalancerAttributes: [{ Key: 'deletion_protection.enabled', Value: 'false' }],
+      };
+      const path = 'LoadBalancerAttributes[load_balancing.cross_zone.enabled]';
+      expect(
+        classifyResource(res(T, albDeclared), albLive('true'), emptySchema).find(
+          (f) => f.path === path
+        )?.tier
+      ).toBe('atDefault');
+      expect(
+        classifyResource(res(T, albDeclared), albLive('false'), emptySchema).find(
+          (f) => f.path === path
+        )?.tier
+      ).toBe('undeclared');
     });
 
     it('a genuine change to a DECLARED attribute still surfaces, named by Key (R78)', () => {
@@ -5279,6 +5382,49 @@ describe('CFn auto-generated name folding (generated tier)', () => {
     expect(tierOf({ GroupName: 'other-stack-name-8qZ9xcu9LOZR' }, 'GroupName')).toBe('undeclared');
     // right prefix but no random suffix (a real human-meaningful name)
     expect(tierOf({ GroupName: 'CdkRealDriftIntegSg-web-tier' }, 'GroupName')).toBe('undeclared');
+  });
+
+  it('a TRUNCATED CFn-generated short name (<stackPrefix>-<logicalIdPrefix>-<random>) folds as generated', () => {
+    // ELBv2 names are capped at 32 chars, so CFn truncates BOTH segments: stack
+    // `CdkRealDriftIntegIotVpces` + logical id `NlbBC02D1613` mints
+    // `CdkRea-NlbBC-Rz5FCsQXIO7E` (observed live on a fresh auto-named internal NLB).
+    const nlb: DesiredResource = {
+      logicalId: 'NlbBC02D1613',
+      resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+      physicalId:
+        'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/CdkRea-NlbBC-Rz5FCsQXIO7E/abc',
+      constructPath: 'CdkRealDriftIntegIotVpces/Nlb',
+      declared: {},
+    };
+    const f = classifyResource(nlb, { Name: 'CdkRea-NlbBC-Rz5FCsQXIO7E' }, bare).find(
+      (x) => x.path === 'Name'
+    );
+    expect(f?.tier).toBe('generated');
+  });
+
+  it('the truncated branch stays gated: both halves must be prefixes of THIS stack + logical id', () => {
+    const nlb = (name: string): [DesiredResource, Record<string, unknown>] => [
+      {
+        logicalId: 'NlbBC02D1613',
+        resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+        physicalId: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/net/x/abc',
+        constructPath: 'CdkRealDriftIntegIotVpces/Nlb',
+        declared: {},
+      },
+      { Name: name },
+    ];
+    const tier = (name: string) => {
+      const [r, live] = nlb(name);
+      return classifyResource(r, live, bare).find((x) => x.path === 'Name')?.tier;
+    };
+    // stack half is not a prefix of the stack name -> a user-chosen name, surfaces
+    expect(tier('MyProd-NlbBC-Rz5FCsQXIO7E')).toBe('undeclared');
+    // logical-id half is not a prefix of this resource's logical id -> surfaces
+    expect(tier('CdkRea-WebLb-Rz5FCsQXIO7E')).toBe('undeclared');
+    // no random suffix -> a human-meaningful name, surfaces
+    expect(tier('CdkRea-NlbBC-internal')).toBe('undeclared');
+    // stack half must be a STRICT prefix (untruncated names take the strict branch)
+    expect(tier('CdkRealDriftIntegIotVpces-NlbBC02D1613-Rz5FCsQXIO7E')).toBe('generated');
   });
 
   it('no constructPath -> cannot derive the stack name -> never folds (safe)', () => {

--- a/tests/corpus/AWS__CloudFront__Function.Fn9270CBC0.json
+++ b/tests/corpus/AWS__CloudFront__Function.Fn9270CBC0.json
@@ -1,0 +1,71 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Fn9270CBC0",
+    "resourceType": "AWS::CloudFront::Function",
+    "physicalId": "arn:aws:cloudfront::111111111111:function/cdkrd-hunt-kvs-fn",
+    "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Fn",
+    "declared": {
+      "AutoPublish": true,
+      "FunctionCode": "function handler(event) { return event.request; }",
+      "FunctionConfig": {
+        "Comment": "cdkrd hunt fixture function with a KVS association",
+        "KeyValueStoreAssociations": [
+          {
+            "KeyValueStoreARN": "arn:aws:cloudfront::111111111111:key-value-store/3fbbe012-5594-4bd7-88fc-a6094b4928ad"
+          }
+        ],
+        "Runtime": "cloudfront-js-2.0"
+      },
+      "Name": "cdkrd-hunt-kvs-fn"
+    }
+  },
+  "liveRaw": {
+    "FunctionConfig": {
+      "Comment": "cdkrd hunt fixture function with a KVS association",
+      "Runtime": "cloudfront-js-2.0",
+      "KeyValueStoreAssociations": [
+        {
+          "KeyValueStoreARN": "arn:aws:cloudfront::111111111111:key-value-store/3fbbe012-5594-4bd7-88fc-a6094b4928ad"
+        }
+      ]
+    },
+    "FunctionARN": "arn:aws:cloudfront::111111111111:function/cdkrd-hunt-kvs-fn",
+    "FunctionMetadata": {
+      "FunctionARN": "arn:aws:cloudfront::111111111111:function/cdkrd-hunt-kvs-fn"
+    },
+    "FunctionCode": "function handler(event) { return event.request; }",
+    "Stage": "LIVE",
+    "Tags": [],
+    "Name": "cdkrd-hunt-kvs-fn"
+  },
+  "schema": {
+    "readOnly": ["FunctionARN", "Stage"],
+    "writeOnly": ["AutoPublish"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["FunctionARN", "FunctionMetadata.FunctionARN", "Stage"],
+    "writeOnlyPaths": ["AutoPublish"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Fn9270CBC0",
+      "resourceType": "AWS::CloudFront::Function",
+      "path": "AutoPublish",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:cloudfront::111111111111:function/cdkrd-hunt-kvs-fn",
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Fn"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CloudFront__KeyValueStore.KvsB102E7FA.json
+++ b/tests/corpus/AWS__CloudFront__KeyValueStore.KvsB102E7FA.json
@@ -1,0 +1,40 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "KvsB102E7FA",
+    "resourceType": "AWS::CloudFront::KeyValueStore",
+    "physicalId": "cdkrd-hunt-kvs",
+    "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Kvs",
+    "declared": {
+      "Comment": "cdkrd hunt fixture key-value store",
+      "Name": "cdkrd-hunt-kvs"
+    }
+  },
+  "liveRaw": {
+    "Status": "READY",
+    "Comment": "cdkrd hunt fixture key-value store",
+    "Id": "3fbbe012-5594-4bd7-88fc-a6094b4928ad",
+    "Arn": "arn:aws:cloudfront::111111111111:key-value-store/3fbbe012-5594-4bd7-88fc-a6094b4928ad",
+    "Tags": [],
+    "Name": "cdkrd-hunt-kvs"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id", "Status"],
+    "writeOnly": ["ImportSource"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id", "Status"],
+    "writeOnlyPaths": ["ImportSource"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__PlacementGroup.Spread.json
+++ b/tests/corpus/AWS__EC2__PlacementGroup.Spread.json
@@ -1,0 +1,38 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Spread",
+    "resourceType": "AWS::EC2::PlacementGroup",
+    "physicalId": "CdkRealDriftIntegS3ExpressTables-Spread-PK9XWRK2PRG7",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/Spread",
+    "declared": {
+      "SpreadLevel": "rack",
+      "Strategy": "spread"
+    }
+  },
+  "liveRaw": {
+    "GroupName": "CdkRealDriftIntegS3ExpressTables-Spread-PK9XWRK2PRG7",
+    "SpreadLevel": "rack",
+    "Strategy": "spread",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["GroupName"],
+    "writeOnly": [],
+    "createOnly": ["PartitionCount", "SpreadLevel", "Strategy", "Tags"],
+    "readOnlyPaths": ["GroupName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PartitionCount", "SpreadLevel", "Strategy", "Tags"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPCEndpointService.EndpointService.json
+++ b/tests/corpus/AWS__EC2__VPCEndpointService.EndpointService.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EndpointService",
+    "resourceType": "AWS::EC2::VPCEndpointService",
+    "physicalId": "vpce-svc-0cc5642a6bca215f9",
+    "constructPath": "CdkRealDriftIntegIotVpces/EndpointService",
+    "declared": {
+      "AcceptanceRequired": true,
+      "NetworkLoadBalancerArns": [
+        "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRea-NlbBC-Rz5FCsQXIO7E/001bc53fc064a60c"
+      ],
+      "SupportedIpAddressTypes": ["ipv4"]
+    }
+  },
+  "liveRaw": {
+    "NetworkLoadBalancerArns": [
+      "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRea-NlbBC-Rz5FCsQXIO7E/001bc53fc064a60c"
+    ],
+    "AcceptanceRequired": true,
+    "SupportedIpAddressTypes": ["ipv4"],
+    "GatewayLoadBalancerArns": [],
+    "SupportedRegions": ["us-east-1"],
+    "Tags": [],
+    "ServiceId": "vpce-svc-0cc5642a6bca215f9"
+  },
+  "schema": {
+    "readOnly": ["ServiceId"],
+    "writeOnly": ["ContributorInsightsEnabled"],
+    "createOnly": [],
+    "readOnlyPaths": ["ServiceId"],
+    "writeOnlyPaths": ["ContributorInsightsEnabled"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SupportedIpAddressTypes", "SupportedRegions"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EndpointService",
+      "resourceType": "AWS::EC2::VPCEndpointService",
+      "path": "SupportedRegions",
+      "actual": ["us-east-1"],
+      "physicalId": "vpce-svc-0cc5642a6bca215f9",
+      "constructPath": "CdkRealDriftIntegIotVpces/EndpointService"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECR__PullThroughCacheRule.EcrPublicPtc.json
+++ b/tests/corpus/AWS__ECR__PullThroughCacheRule.EcrPublicPtc.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EcrPublicPtc",
+    "resourceType": "AWS::ECR::PullThroughCacheRule",
+    "physicalId": "cdkrd-hunt-ecrpub",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/EcrPublicPtc",
+    "declared": {
+      "EcrRepositoryPrefix": "cdkrd-hunt-ecrpub",
+      "UpstreamRegistryUrl": "public.ecr.aws"
+    }
+  },
+  "liveRaw": {
+    "UpstreamRegistryUrl": "public.ecr.aws",
+    "EcrRepositoryPrefix": "cdkrd-hunt-ecrpub"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["CredentialArn", "CustomRoleArn", "UpstreamRegistry"],
+    "createOnly": [
+      "CredentialArn",
+      "CustomRoleArn",
+      "EcrRepositoryPrefix",
+      "UpstreamRegistry",
+      "UpstreamRegistryUrl",
+      "UpstreamRepositoryPrefix"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["CredentialArn", "CustomRoleArn", "UpstreamRegistry"],
+    "createOnlyPaths": [
+      "CredentialArn",
+      "CustomRoleArn",
+      "EcrRepositoryPrefix",
+      "UpstreamRegistry",
+      "UpstreamRegistryUrl",
+      "UpstreamRepositoryPrefix"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
@@ -339,7 +339,7 @@
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "Name",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
@@ -328,7 +328,7 @@
       "constructPath": "CdkrdIntegHarvest4/Edge"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Edge7038544F",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "Name",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
@@ -174,7 +174,7 @@
       "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Nlb",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "Name",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.NlbBCDB97FE.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.NlbBCDB97FE.json
@@ -142,7 +142,7 @@
       "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "NlbBCDB97FE",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
@@ -328,7 +328,7 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
       "path": "Name",

--- a/tests/corpus/AWS__IoT__Policy.DevicePolicy.json
+++ b/tests/corpus/AWS__IoT__Policy.DevicePolicy.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DevicePolicy",
+    "resourceType": "AWS::IoT::Policy",
+    "physicalId": "cdkrd-hunt-iot-policy",
+    "constructPath": "CdkRealDriftIntegIotVpces/DevicePolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["iot:Connect"],
+            "Resource": ["arn:aws:iot:us-east-1:111111111111:client/cdkrd-hunt-*"]
+          },
+          {
+            "Effect": "Allow",
+            "Action": ["iot:Publish"],
+            "Resource": ["arn:aws:iot:us-east-1:111111111111:topic/cdkrd/hunt/*"]
+          }
+        ]
+      },
+      "PolicyName": "cdkrd-hunt-iot-policy"
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "cdkrd-hunt-iot-policy",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["iot:Connect"],
+          "Resource": ["arn:aws:iot:us-east-1:111111111111:client/cdkrd-hunt-*"],
+          "Effect": "Allow"
+        },
+        {
+          "Action": ["iot:Publish"],
+          "Resource": ["arn:aws:iot:us-east-1:111111111111:topic/cdkrd/hunt/*"],
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Id": "cdkrd-hunt-iot-policy",
+    "Arn": "arn:aws:iot:us-east-1:111111111111:policy/cdkrd-hunt-iot-policy",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["PolicyName"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PolicyName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IoT__Thing.Thing.json
+++ b/tests/corpus/AWS__IoT__Thing.Thing.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Thing",
+    "resourceType": "AWS::IoT::Thing",
+    "physicalId": "cdkrd-hunt-thing",
+    "constructPath": "CdkRealDriftIntegIotVpces/Thing",
+    "declared": {
+      "AttributePayload": {
+        "Attributes": {
+          "env": "hunt",
+          "owner": "cdkrd"
+        }
+      },
+      "ThingName": "cdkrd-hunt-thing"
+    }
+  },
+  "liveRaw": {
+    "AttributePayload": {
+      "Attributes": {
+        "owner": "cdkrd",
+        "env": "hunt"
+      }
+    },
+    "Id": "162515c1-d1b3-4c99-bd83-82a3ed0ebd63",
+    "ThingName": "cdkrd-hunt-thing",
+    "Arn": "arn:aws:iot:us-east-1:111111111111:thing/cdkrd-hunt-thing"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["ThingName"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ThingName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": ["AttributePayload.Attributes"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IoT__TopicRule.Rule.json
+++ b/tests/corpus/AWS__IoT__TopicRule.Rule.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Rule",
+    "resourceType": "AWS::IoT::TopicRule",
+    "physicalId": "cdkrd_hunt_rule",
+    "constructPath": "CdkRealDriftIntegIotVpces/Rule",
+    "declared": {
+      "RuleName": "cdkrd_hunt_rule",
+      "TopicRulePayload": {
+        "Actions": [
+          {
+            "CloudwatchLogs": {
+              "LogGroupName": "CdkRealDriftIntegIotVpces-RuleLogs58570289-D2ZfvFblIoBv",
+              "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegIotVpces-RuleRole85A02A56-0XGvSudoAhcL"
+            }
+          }
+        ],
+        "AwsIotSqlVersion": "2016-03-23",
+        "Description": "cdkrd hunt fixture rule (FN target: RuleDisabled)",
+        "RuleDisabled": false,
+        "Sql": "SELECT temperature, deviceId FROM 'cdkrd/hunt/telemetry' WHERE temperature > 20"
+      }
+    }
+  },
+  "liveRaw": {
+    "TopicRulePayload": {
+      "RuleDisabled": false,
+      "Description": "cdkrd hunt fixture rule (FN target: RuleDisabled)",
+      "AwsIotSqlVersion": "2016-03-23",
+      "Actions": [
+        {
+          "CloudwatchLogs": {
+            "LogGroupName": "CdkRealDriftIntegIotVpces-RuleLogs58570289-D2ZfvFblIoBv",
+            "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegIotVpces-RuleRole85A02A56-0XGvSudoAhcL"
+          }
+        }
+      ],
+      "Sql": "SELECT temperature, deviceId FROM 'cdkrd/hunt/telemetry' WHERE temperature > 20"
+    },
+    "Arn": "arn:aws:iot:us-east-1:111111111111:rule/cdkrd_hunt_rule",
+    "RuleName": "cdkrd_hunt_rule",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["RuleName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RuleName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": [
+      "TopicRulePayload.Actions.*.Kafka.ClientProperties",
+      "TopicRulePayload.ErrorAction.Kafka.ClientProperties"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Logs__Delivery.Delivery.json
+++ b/tests/corpus/AWS__Logs__Delivery.Delivery.json
@@ -1,0 +1,134 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Delivery",
+    "resourceType": "AWS::Logs::Delivery",
+    "physicalId": "QoiN3vrTYs9CIX3u",
+    "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Delivery",
+    "declared": {
+      "DeliveryDestinationArn": "arn:aws:logs:us-east-1:111111111111:delivery-destination:cdkrd-hunt-cf-dest",
+      "DeliverySourceName": "cdkrd-hunt-cf-access"
+    }
+  },
+  "liveRaw": {
+    "DeliveryId": "QoiN3vrTYs9CIX3u",
+    "S3EnableHiveCompatiblePath": false,
+    "DeliveryDestinationArn": "arn:aws:logs:us-east-1:111111111111:delivery-destination:cdkrd-hunt-cf-dest",
+    "DeliverySourceName": "cdkrd-hunt-cf-access",
+    "RecordFields": [
+      "date",
+      "time",
+      "x-edge-location",
+      "sc-bytes",
+      "c-ip",
+      "cs-method",
+      "cs(Host)",
+      "cs-uri-stem",
+      "sc-status",
+      "cs(Referer)",
+      "cs(User-Agent)",
+      "cs-uri-query",
+      "cs(Cookie)",
+      "x-edge-result-type",
+      "x-edge-request-id",
+      "x-host-header",
+      "cs-protocol",
+      "cs-bytes",
+      "time-taken",
+      "x-forwarded-for",
+      "ssl-protocol",
+      "ssl-cipher",
+      "x-edge-response-result-type",
+      "cs-protocol-version",
+      "fle-status",
+      "fle-encrypted-fields",
+      "c-port",
+      "time-to-first-byte",
+      "x-edge-detailed-result-type",
+      "sc-content-type",
+      "sc-content-len",
+      "sc-range-start",
+      "sc-range-end"
+    ],
+    "S3SuffixPath": "",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:delivery:QoiN3vrTYs9CIX3u",
+    "DeliveryDestinationType": "CWL",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCfKvsLogsDel/467ad090-75cf-11f1-85ee-0ef9777f977d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegCfKvsLogsDel",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Delivery",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "DeliveryDestinationType", "DeliveryId"],
+    "writeOnly": [],
+    "createOnly": ["DeliveryDestinationArn", "DeliverySourceName"],
+    "readOnlyPaths": ["Arn", "DeliveryDestinationType", "DeliveryId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DeliveryDestinationArn", "DeliverySourceName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Delivery",
+      "resourceType": "AWS::Logs::Delivery",
+      "path": "RecordFields",
+      "actual": [
+        "date",
+        "time",
+        "x-edge-location",
+        "sc-bytes",
+        "c-ip",
+        "cs-method",
+        "cs(Host)",
+        "cs-uri-stem",
+        "sc-status",
+        "cs(Referer)",
+        "cs(User-Agent)",
+        "cs-uri-query",
+        "cs(Cookie)",
+        "x-edge-result-type",
+        "x-edge-request-id",
+        "x-host-header",
+        "cs-protocol",
+        "cs-bytes",
+        "time-taken",
+        "x-forwarded-for",
+        "ssl-protocol",
+        "ssl-cipher",
+        "x-edge-response-result-type",
+        "cs-protocol-version",
+        "fle-status",
+        "fle-encrypted-fields",
+        "c-port",
+        "time-to-first-byte",
+        "x-edge-detailed-result-type",
+        "sc-content-type",
+        "sc-content-len",
+        "sc-range-start",
+        "sc-range-end"
+      ],
+      "physicalId": "QoiN3vrTYs9CIX3u",
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/Delivery"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__DeliveryDestination.DeliveryDest.json
+++ b/tests/corpus/AWS__Logs__DeliveryDestination.DeliveryDest.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DeliveryDest",
+    "resourceType": "AWS::Logs::DeliveryDestination",
+    "physicalId": "cdkrd-hunt-cf-dest",
+    "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliveryDest",
+    "declared": {
+      "DestinationResourceArn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkRealDriftIntegCfKvsLogsDel-AccessLogs8B620ECA-rs0hNgn9n0pi:*",
+      "Name": "cdkrd-hunt-cf-dest",
+      "OutputFormat": "json"
+    }
+  },
+  "liveRaw": {
+    "DestinationResourceArn": "arn:aws:logs:us-east-1:111111111111:log-group:CdkRealDriftIntegCfKvsLogsDel-AccessLogs8B620ECA-rs0hNgn9n0pi:*",
+    "OutputFormat": "json",
+    "DeliveryDestinationPolicy": {
+      "DeliveryDestinationName": "cdkrd-hunt-cf-dest",
+      "DeliveryDestinationPolicy": {}
+    },
+    "Arn": "arn:aws:logs:us-east-1:111111111111:delivery-destination:cdkrd-hunt-cf-dest",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCfKvsLogsDel/467ad090-75cf-11f1-85ee-0ef9777f977d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegCfKvsLogsDel",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "DeliveryDest",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "DeliveryDestinationType": "CWL",
+    "Name": "cdkrd-hunt-cf-dest"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["DeliveryDestinationType", "DestinationResourceArn", "Name", "OutputFormat"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "DeliveryDestinationType",
+      "DestinationResourceArn",
+      "Name",
+      "OutputFormat"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "DeliveryDest",
+      "resourceType": "AWS::Logs::DeliveryDestination",
+      "path": "DeliveryDestinationPolicy",
+      "actual": {
+        "DeliveryDestinationName": "cdkrd-hunt-cf-dest",
+        "DeliveryDestinationPolicy": {}
+      },
+      "physicalId": "cdkrd-hunt-cf-dest",
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliveryDest"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "DeliveryDest",
+      "resourceType": "AWS::Logs::DeliveryDestination",
+      "path": "DeliveryDestinationType",
+      "actual": "CWL",
+      "physicalId": "cdkrd-hunt-cf-dest",
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliveryDest"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__DeliverySource.DeliverySource.json
+++ b/tests/corpus/AWS__Logs__DeliverySource.DeliverySource.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DeliverySource",
+    "resourceType": "AWS::Logs::DeliverySource",
+    "physicalId": "cdkrd-hunt-cf-access",
+    "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliverySource",
+    "declared": {
+      "LogType": "ACCESS_LOGS",
+      "Name": "cdkrd-hunt-cf-access",
+      "ResourceArn": "arn:aws:cloudfront::111111111111:distribution/E35M9GMDFB6LAP"
+    }
+  },
+  "liveRaw": {
+    "LogType": "ACCESS_LOGS",
+    "Service": "cloudfront",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:delivery-source:cdkrd-hunt-cf-access",
+    "ResourceArns": ["arn:aws:cloudfront::111111111111:distribution/E35M9GMDFB6LAP"],
+    "Tags": [
+      {
+        "Value": "DeliverySource",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCfKvsLogsDel/467ad090-75cf-11f1-85ee-0ef9777f977d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegCfKvsLogsDel",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "cdkrd-hunt-cf-access"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ResourceArns", "Service", "Status", "StatusReason"],
+    "writeOnly": ["ResourceArn"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "ResourceArns", "Service", "Status", "StatusReason"],
+    "writeOnlyPaths": ["ResourceArn"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["ResourceArns"],
+    "freeFormMapPaths": ["DeliverySourceConfiguration"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "DeliverySource",
+      "resourceType": "AWS::Logs::DeliverySource",
+      "path": "ResourceArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-hunt-cf-access",
+      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliverySource"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Logs__LogAnomalyDetector.AnomalyDetector.json
+++ b/tests/corpus/AWS__Logs__LogAnomalyDetector.AnomalyDetector.json
@@ -1,0 +1,58 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AnomalyDetector",
+    "resourceType": "AWS::Logs::LogAnomalyDetector",
+    "physicalId": "arn:aws:logs:us-east-1:111111111111:anomaly-detector:ac5f5ca2-b19a-48c0-97ef-7a12a5526f65",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/AnomalyDetector",
+    "declared": {
+      "AnomalyVisibilityTime": 14,
+      "DetectorName": "cdkrd-hunt-anomaly",
+      "EvaluationFrequency": "ONE_HOUR",
+      "LogGroupArnList": [
+        "arn:aws:logs:us-east-1:111111111111:log-group:CdkRealDriftIntegS3ExpressTables-AnomalyLg0E01DA92-t2aNM2AlkO9W"
+      ]
+    }
+  },
+  "liveRaw": {
+    "AnomalyVisibilityTime": 14,
+    "LogGroupArnList": [
+      "arn:aws:logs:us-east-1:111111111111:log-group:CdkRealDriftIntegS3ExpressTables-AnomalyLg0E01DA92-t2aNM2AlkO9W"
+    ],
+    "CreationTimeStamp": 1782966875230,
+    "AnomalyDetectorStatus": "TRAINING",
+    "EvaluationFrequency": "ONE_HOUR",
+    "AnomalyDetectorArn": "arn:aws:logs:us-east-1:111111111111:anomaly-detector:ac5f5ca2-b19a-48c0-97ef-7a12a5526f65",
+    "DetectorName": "cdkrd-hunt-anomaly",
+    "LastModifiedTimeStamp": 1782966875374
+  },
+  "schema": {
+    "readOnly": [
+      "AnomalyDetectorArn",
+      "AnomalyDetectorStatus",
+      "CreationTimeStamp",
+      "LastModifiedTimeStamp"
+    ],
+    "writeOnly": ["AccountId"],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "AnomalyDetectorArn",
+      "AnomalyDetectorStatus",
+      "CreationTimeStamp",
+      "LastModifiedTimeStamp"
+    ],
+    "writeOnlyPaths": ["AccountId"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LogGroupArnList"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3Express__BucketPolicy.DirBucketPolicy.json
+++ b/tests/corpus/AWS__S3Express__BucketPolicy.DirBucketPolicy.json
@@ -1,0 +1,68 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DirBucketPolicy",
+    "resourceType": "AWS::S3Express::BucketPolicy",
+    "physicalId": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/DirBucketPolicy",
+    "declared": {
+      "Bucket": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "DenyInsecureTransport",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3express:*",
+            "Resource": "arn:aws:s3express:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov--use1-az4--x-s3",
+            "Condition": {
+              "Bool": {
+                "aws:SecureTransport": "false"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Bucket": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "false"
+            }
+          },
+          "Action": "s3express:*",
+          "Resource": "arn:aws:s3express:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov--use1-az4--x-s3",
+          "Effect": "Deny",
+          "Principal": "*",
+          "Sid": "DenyInsecureTransport"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Bucket"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Bucket"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3Express__DirectoryBucket.DirBucket.json
+++ b/tests/corpus/AWS__S3Express__DirectoryBucket.DirBucket.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DirBucket",
+    "resourceType": "AWS::S3Express::DirectoryBucket",
+    "physicalId": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/DirBucket",
+    "declared": {
+      "BucketName": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+      "DataRedundancy": "SingleAvailabilityZone",
+      "LocationName": "use1-az4"
+    }
+  },
+  "liveRaw": {
+    "InventoryConfigurations": [],
+    "BucketName": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+    "BucketEncryption": {
+      "ServerSideEncryptionConfiguration": [
+        {
+          "BucketKeyEnabled": true,
+          "ServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+          }
+        }
+      ]
+    },
+    "AvailabilityZoneName": "us-east-1c",
+    "DataRedundancy": "SingleAvailabilityZone",
+    "Arn": "arn:aws:s3express:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov--use1-az4--x-s3",
+    "MetricsConfigurations": [],
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegS3ExpressTables",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "DirBucket",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegS3ExpressTables/477f9660-75cf-11f1-8815-0e2eacb1cb8f",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "LocationName": "use1-az4"
+  },
+  "schema": {
+    "readOnly": ["Arn", "AvailabilityZoneName"],
+    "writeOnly": [],
+    "createOnly": ["BucketName", "DataRedundancy", "LocationName"],
+    "readOnlyPaths": ["Arn", "AvailabilityZoneName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["BucketName", "DataRedundancy", "LocationName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "DirBucket",
+      "resourceType": "AWS::S3Express::DirectoryBucket",
+      "path": "BucketEncryption",
+      "actual": {
+        "ServerSideEncryptionConfiguration": [
+          {
+            "BucketKeyEnabled": true,
+            "ServerSideEncryptionByDefault": {
+              "SSEAlgorithm": "AES256"
+            }
+          }
+        ]
+      },
+      "physicalId": "cdkrd-hunt-lowcov--use1-az4--x-s3",
+      "constructPath": "CdkRealDriftIntegS3ExpressTables/DirBucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3Tables__TableBucket.TableBucket.json
+++ b/tests/corpus/AWS__S3Tables__TableBucket.TableBucket.json
@@ -1,0 +1,91 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TableBucket",
+    "resourceType": "AWS::S3Tables::TableBucket",
+    "physicalId": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/TableBucket",
+    "declared": {
+      "TableBucketName": "cdkrd-hunt-lowcov-tables",
+      "UnreferencedFileRemoval": {
+        "NoncurrentDays": 5,
+        "Status": "Enabled",
+        "UnreferencedDays": 10
+      }
+    }
+  },
+  "liveRaw": {
+    "TableBucketName": "cdkrd-hunt-lowcov-tables",
+    "TableBucketARN": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+    "StorageClassConfiguration": {
+      "StorageClass": "STANDARD"
+    },
+    "MetricsConfiguration": {
+      "Status": "Disabled"
+    },
+    "EncryptionConfiguration": {
+      "SSEAlgorithm": "AES256"
+    },
+    "UnreferencedFileRemoval": {
+      "Status": "Enabled",
+      "NoncurrentDays": 5,
+      "UnreferencedDays": 10
+    },
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["TableBucketARN"],
+    "writeOnly": [],
+    "createOnly": ["TableBucketName"],
+    "readOnlyPaths": ["TableBucketARN"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TableBucketName"],
+    "defaults": {},
+    "defaultPaths": {
+      "MetricsConfiguration.Status": "Disabled"
+    },
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TableBucket",
+      "resourceType": "AWS::S3Tables::TableBucket",
+      "path": "StorageClassConfiguration",
+      "actual": {
+        "StorageClass": "STANDARD"
+      },
+      "physicalId": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+      "constructPath": "CdkRealDriftIntegS3ExpressTables/TableBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TableBucket",
+      "resourceType": "AWS::S3Tables::TableBucket",
+      "path": "MetricsConfiguration",
+      "actual": {
+        "Status": "Disabled"
+      },
+      "physicalId": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+      "constructPath": "CdkRealDriftIntegS3ExpressTables/TableBucket"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "TableBucket",
+      "resourceType": "AWS::S3Tables::TableBucket",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "SSEAlgorithm": "AES256"
+      },
+      "physicalId": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+      "constructPath": "CdkRealDriftIntegS3ExpressTables/TableBucket"
+    }
+  ]
+}

--- a/tests/corpus/AWS__S3Tables__TableBucketPolicy.TableBucketPolicy.json
+++ b/tests/corpus/AWS__S3Tables__TableBucketPolicy.TableBucketPolicy.json
@@ -1,0 +1,62 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TableBucketPolicy",
+    "resourceType": "AWS::S3Tables::TableBucketPolicy",
+    "physicalId": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+    "constructPath": "CdkRealDriftIntegS3ExpressTables/TableBucketPolicy",
+    "declared": {
+      "ResourcePolicy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "AllowOwnerRead",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Action": ["s3tables:GetTableBucket"],
+            "Resource": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables"
+          }
+        ]
+      },
+      "TableBucketARN": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables"
+    }
+  },
+  "liveRaw": {
+    "TableBucketARN": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+    "ResourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "s3tables:GetTableBucket",
+          "Resource": "arn:aws:s3tables:us-east-1:111111111111:bucket/cdkrd-hunt-lowcov-tables",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Sid": "AllowOwnerRead"
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["TableBucketARN"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TableBucketARN"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/cloudfront-kvs-logs-delivery/app.ts
+++ b/tests/integration/cloudfront-kvs-logs-delivery/app.ts
@@ -1,0 +1,82 @@
+// CDK app for the cdk-real-drift CloudFront KeyValueStore + vended-logs-v2
+// false-positive test. Two 0-coverage families ride one distribution:
+// - AWS::CloudFront::KeyValueStore, associated to a cloudfront-js-2.0 Function
+//   (the Function type is covered; the KVS + its association are not).
+// - The CloudWatch Logs vended-logs v2 delivery triple (AWS::Logs::DeliverySource
+//   / DeliveryDestination / Delivery) wiring CloudFront access logs into a log
+//   group — an increasingly common replacement for legacy S3 access logs.
+// A freshly deployed + recorded stack with NO out-of-band change MUST report
+// CLEAN; any drift here is a normalization / default-folding FP on these shapes.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  Distribution,
+  Function as CfFunction,
+  FunctionCode,
+  FunctionEventType,
+  FunctionRuntime,
+  KeyValueStore,
+  PriceClass,
+} from "aws-cdk-lib/aws-cloudfront";
+import { HttpOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
+import {
+  CfnDelivery,
+  CfnDeliveryDestination,
+  CfnDeliverySource,
+  LogGroup,
+  RetentionDays,
+} from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCfKvsLogsDel");
+
+const kvs = new KeyValueStore(stack, "Kvs", {
+  keyValueStoreName: "cdkrd-hunt-kvs",
+  comment: "cdkrd hunt fixture key-value store",
+});
+
+const fn = new CfFunction(stack, "Fn", {
+  functionName: "cdkrd-hunt-kvs-fn",
+  runtime: FunctionRuntime.JS_2_0,
+  keyValueStore: kvs,
+  comment: "cdkrd hunt fixture function with a KVS association",
+  code: FunctionCode.fromInline(
+    "function handler(event) { return event.request; }",
+  ),
+});
+
+const distribution = new Distribution(stack, "Dist", {
+  comment: "cdkrd hunt fixture distribution (KVS + vended access logs)",
+  priceClass: PriceClass.PRICE_CLASS_100,
+  defaultBehavior: {
+    origin: new HttpOrigin("example.com"),
+    functionAssociations: [
+      { function: fn, eventType: FunctionEventType.VIEWER_REQUEST },
+    ],
+  },
+});
+
+const logGroup = new LogGroup(stack, "AccessLogs", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+// CloudFront standard logging v2: distribution ARN as the delivery source.
+const source = new CfnDeliverySource(stack, "DeliverySource", {
+  name: "cdkrd-hunt-cf-access",
+  logType: "ACCESS_LOGS",
+  resourceArn: `arn:aws:cloudfront::${stack.account}:distribution/${distribution.distributionId}`,
+});
+
+const destination = new CfnDeliveryDestination(stack, "DeliveryDest", {
+  name: "cdkrd-hunt-cf-dest",
+  outputFormat: "json",
+  destinationResourceArn: logGroup.logGroupArn,
+});
+
+const delivery = new CfnDelivery(stack, "Delivery", {
+  deliverySourceName: source.name,
+  deliveryDestinationArn: destination.attrArn,
+});
+delivery.addDependency(source);
+
+app.synth();

--- a/tests/integration/cloudfront-kvs-logs-delivery/cdk.json
+++ b/tests/integration/cloudfront-kvs-logs-delivery/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudfront-kvs-logs-delivery/package.json
+++ b/tests/integration/cloudfront-kvs-logs-delivery/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudfront-kvs-logs-delivery",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift cloudfront-kvs-logs-delivery false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudfront-kvs-logs-delivery/verify.sh
+++ b/tests/integration/cloudfront-kvs-logs-delivery/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded CloudFront KeyValueStore (with a
+# function association) and vended-logs-v2 delivery triple (DeliverySource /
+# DeliveryDestination / Delivery) with NO out-of-band change must report no
+# drift; any drift here is a normalization / default-folding FP on those shapes.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCfKvsLogsDel
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (pre-record fresh check) ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-/tmp/corpus-cf-kvs-logs}" $CLI check "$STACK" --region "$REGION" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/iot-vpces-rich/app.ts
+++ b/tests/integration/iot-vpces-rich/app.ts
@@ -1,0 +1,102 @@
+// CDK app for the cdk-real-drift IoT Core + VPC endpoint service false-positive
+// and missed-detection test. IoT has ZERO corpus coverage despite being a very
+// common device-fleet stack; the PrivateLink provider side is also uncovered:
+// - AWS::IoT::Thing (attribute payload), AWS::IoT::Policy (policy document),
+//   AWS::IoT::TopicRule (SQL + CloudWatch Logs action) — the TopicRule also
+//   drives the FN half: verify.sh disables the rule out of band and asserts
+//   check detects the declared RuleDisabled drift, then reverts it.
+// - AWS::EC2::VPCEndpointService fronting an internal NLB (PrivateLink provider).
+// A freshly deployed + recorded stack with NO out-of-band change MUST report
+// CLEAN; any drift here is a normalization / default-folding FP.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnVPCEndpointService, IpAddresses, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { NetworkLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import { PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnPolicy, CfnThing, CfnTopicRule } from "aws-cdk-lib/aws-iot";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegIotVpces");
+
+new CfnThing(stack, "Thing", {
+  thingName: "cdkrd-hunt-thing",
+  attributePayload: {
+    attributes: { env: "hunt", owner: "cdkrd" },
+  },
+});
+
+new CfnPolicy(stack, "DevicePolicy", {
+  policyName: "cdkrd-hunt-iot-policy",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: ["iot:Connect"],
+        Resource: [`arn:aws:iot:${stack.region}:${stack.account}:client/cdkrd-hunt-*`],
+      },
+      {
+        Effect: "Allow",
+        Action: ["iot:Publish"],
+        Resource: [`arn:aws:iot:${stack.region}:${stack.account}:topic/cdkrd/hunt/*`],
+      },
+    ],
+  },
+});
+
+const ruleLogs = new LogGroup(stack, "RuleLogs", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const ruleRole = new Role(stack, "RuleRole", {
+  assumedBy: new ServicePrincipal("iot.amazonaws.com"),
+});
+ruleRole.addToPolicy(
+  new PolicyStatement({
+    actions: ["logs:CreateLogStream", "logs:DescribeLogStreams", "logs:PutLogEvents"],
+    resources: [ruleLogs.logGroupArn],
+  }),
+);
+
+new CfnTopicRule(stack, "Rule", {
+  ruleName: "cdkrd_hunt_rule",
+  topicRulePayload: {
+    sql: "SELECT temperature, deviceId FROM 'cdkrd/hunt/telemetry' WHERE temperature > 20",
+    awsIotSqlVersion: "2016-03-23",
+    ruleDisabled: false,
+    description: "cdkrd hunt fixture rule (FN target: RuleDisabled)",
+    actions: [
+      {
+        cloudwatchLogs: {
+          logGroupName: ruleLogs.logGroupName,
+          roleArn: ruleRole.roleArn,
+        },
+      },
+    ],
+  },
+});
+
+// PrivateLink provider side: internal NLB + VPC endpoint service.
+const vpc = new Vpc(stack, "Vpc", {
+  ipAddresses: IpAddresses.cidr("10.61.0.0/24"),
+  natGateways: 0,
+  maxAzs: 2,
+  subnetConfiguration: [
+    { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 26 },
+  ],
+});
+
+const nlb = new NetworkLoadBalancer(stack, "Nlb", {
+  vpc,
+  internetFacing: false,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+});
+
+new CfnVPCEndpointService(stack, "EndpointService", {
+  networkLoadBalancerArns: [nlb.loadBalancerArn],
+  acceptanceRequired: true,
+  supportedIpAddressTypes: ["ipv4"],
+});
+
+app.synth();

--- a/tests/integration/iot-vpces-rich/cdk.json
+++ b/tests/integration/iot-vpces-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/iot-vpces-rich/package.json
+++ b/tests/integration/iot-vpces-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-iot-vpces-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift iot-vpces-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/iot-vpces-rich/verify.sh
+++ b/tests/integration/iot-vpces-rich/verify.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# False-positive AND missed-detection integration test (real AWS) for the IoT
+# Core family (Thing / Policy / TopicRule) + EC2 VPCEndpointService:
+#   1. deploy -> record -> check MUST be CLEAN (FP half).
+#   2. disable the topic rule out of band (aws iot disable-topic-rule) ->
+#      check MUST detect the declared RuleDisabled drift (exit 1) ->
+#      revert -> check CLEAN again and the live rule is re-enabled (FN half).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIotVpces
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+RULE=cdkrd_hunt_rule
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (pre-record fresh check) ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-/tmp/corpus-iot-vpces}" $CLI check "$STACK" --region "$REGION" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "=== [$STACK] FN half: disable the topic rule out of band ==="
+aws iot disable-topic-rule --rule-name "$RULE" --region "$REGION" || fail "disable-topic-rule"
+
+echo "=== [$STACK] check MUST DETECT the RuleDisabled drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || { echo "--- MISSED DETECTION: out-of-band disable-topic-rule not reported ---"; fail "expected drift (exit 1), got $rc"; }
+grep -q "RuleDisabled" "/tmp/cdkrd-$STACK-detect.out" || fail "drift report does not mention RuleDisabled"
+
+echo "=== [$STACK] revert the drift ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+echo "=== [$STACK] live rule MUST be re-enabled ==="
+disabled="$(aws iot get-topic-rule --rule-name "$RULE" --region "$REGION" --query 'rule.ruleDisabled' --output text)"
+[ "$disabled" = "False" ] || fail "live rule still disabled after revert (ruleDisabled=$disabled)"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3express-s3tables-rich/app.ts
+++ b/tests/integration/s3express-s3tables-rich/app.ts
@@ -1,0 +1,99 @@
+// CDK app for the cdk-real-drift S3 Express One Zone + S3 Tables false-positive
+// test, plus three cheap 0-coverage riders. Every type here is CC-readable but
+// absent from the golden corpus:
+// - AWS::S3Express::DirectoryBucket + AWS::S3Express::BucketPolicy (S3 Express
+//   One Zone directory buckets — fast-growing usage, zonal naming suffix).
+// - AWS::S3Tables::TableBucket + AWS::S3Tables::TableBucketPolicy (Iceberg table
+//   buckets with an explicit non-default UnreferencedFileRemoval config).
+// - AWS::ECR::PullThroughCacheRule (public.ecr.aws upstream, no credentials).
+// - AWS::Logs::LogAnomalyDetector (log anomaly detection on a log group).
+// - AWS::EC2::PlacementGroup (spread/rack).
+// A freshly deployed + recorded stack with NO out-of-band change MUST report
+// CLEAN; any drift here is a normalization / default-folding FP.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { CfnPlacementGroup } from "aws-cdk-lib/aws-ec2";
+import { CfnPullThroughCacheRule } from "aws-cdk-lib/aws-ecr";
+import { CfnLogAnomalyDetector, LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { CfnBucketPolicy, CfnDirectoryBucket } from "aws-cdk-lib/aws-s3express";
+import { CfnTableBucket, CfnTableBucketPolicy } from "aws-cdk-lib/aws-s3tables";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3ExpressTables");
+
+// Directory bucket names embed the availability-zone id: <base>--<az-id>--x-s3.
+const dirBucketName = "cdkrd-hunt-lowcov--use1-az4--x-s3";
+const dirBucket = new CfnDirectoryBucket(stack, "DirBucket", {
+  bucketName: dirBucketName,
+  locationName: "use1-az4",
+  dataRedundancy: "SingleAvailabilityZone",
+});
+
+new CfnBucketPolicy(stack, "DirBucketPolicy", {
+  bucket: dirBucket.ref,
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "DenyInsecureTransport",
+        Effect: "Deny",
+        Principal: "*",
+        Action: "s3express:*",
+        Resource: `arn:aws:s3express:${stack.region}:${stack.account}:bucket/${dirBucketName}`,
+        Condition: { Bool: { "aws:SecureTransport": "false" } },
+      },
+    ],
+  },
+});
+
+const tableBucket = new CfnTableBucket(stack, "TableBucket", {
+  tableBucketName: "cdkrd-hunt-lowcov-tables",
+  // Non-default maintenance config to exercise the nested round-trip.
+  unreferencedFileRemoval: {
+    status: "Enabled",
+    unreferencedDays: 10,
+    noncurrentDays: 5,
+  },
+});
+
+new CfnTableBucketPolicy(stack, "TableBucketPolicy", {
+  tableBucketArn: tableBucket.attrTableBucketArn,
+  resourcePolicy: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Sid: "AllowOwnerRead",
+        Effect: "Allow",
+        Principal: { AWS: `arn:aws:iam::${stack.account}:root` },
+        Action: ["s3tables:GetTableBucket"],
+        Resource: tableBucket.attrTableBucketArn,
+      },
+    ],
+  },
+});
+
+new CfnPullThroughCacheRule(stack, "EcrPublicPtc", {
+  ecrRepositoryPrefix: "cdkrd-hunt-ecrpub",
+  upstreamRegistryUrl: "public.ecr.aws",
+});
+
+const logGroup = new LogGroup(stack, "AnomalyLg", {
+  retention: RetentionDays.ONE_WEEK,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+new CfnLogAnomalyDetector(stack, "AnomalyDetector", {
+  detectorName: "cdkrd-hunt-anomaly",
+  // LogGroup.logGroupArn ends in ":*" — build the plain log-group ARN instead.
+  logGroupArnList: [
+    `arn:aws:logs:${stack.region}:${stack.account}:log-group:${logGroup.logGroupName}`,
+  ],
+  anomalyVisibilityTime: 14,
+  evaluationFrequency: "ONE_HOUR",
+});
+
+new CfnPlacementGroup(stack, "Spread", {
+  strategy: "spread",
+  spreadLevel: "rack",
+});
+
+app.synth();

--- a/tests/integration/s3express-s3tables-rich/cdk.json
+++ b/tests/integration/s3express-s3tables-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3express-s3tables-rich/package.json
+++ b/tests/integration/s3express-s3tables-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3express-s3tables-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3express-s3tables-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3express-s3tables-rich/verify.sh
+++ b/tests/integration/s3express-s3tables-rich/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded S3 Express directory bucket (+
+# bucket policy), S3 Tables table bucket (+ policy, non-default maintenance
+# config), ECR pull-through-cache rule, log anomaly detector, and placement
+# group with NO out-of-band change must report no drift; any drift here is a
+# normalization / default-folding FP on those shapes.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3ExpressTables
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (pre-record fresh check) ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-/tmp/corpus-s3express-tables}" $CLI check "$STACK" --region "$REGION" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug-hunt round (zero-coverage common types)

Deployed 3 real stacks against genuinely uncovered, high-frequency types — coordinated to be disjoint from the parallel #457 hunt. **All 3 FP-clean after record; IoT TopicRule FN cycle (out-of-band `disable-topic-rule` → detect → CC revert → CLEAN → live re-enabled) proven live.**

| stack | new types exercised |
|---|---|
| cloudfront-kvs-logs-delivery | CloudFront KeyValueStore (+ Function association), Logs DeliverySource / DeliveryDestination / Delivery (vended logs v2) |
| s3express-s3tables-rich | S3Express DirectoryBucket + BucketPolicy, S3Tables TableBucket + Policy, ECR PullThroughCacheRule, Logs LogAnomalyDetector, EC2 PlacementGroup |
| iot-vpces-rich | IoT Thing / Policy / TopicRule (IoT had ZERO corpus coverage), EC2 VPCEndpointService (internal NLB) |

## Fixes

1. **Truncated CFn-generated name FP class** — short-name types (ELBv2's 32-char cap) make CFn truncate BOTH segments (`CdkRea-NlbBC-Rz5FCsQXIO7E`), so the strict `isCfnGeneratedName` (#417) missed and **every auto-named NLB/ALB/target group was first-run noise** (observed live). The truncated branch stays tightly gated: stack half must be a STRICT prefix of this stack's name, logical half a prefix of this resource's logical id, plus the random suffix.
2. **NLB cross_zone mis-fold FN** — `ELB_ATTRIBUTE_DEFAULTS` is keyed by resourceType only, so the shared ALB `cross_zone=true` entry mis-folded an out-of-band **NLB cross-zone ENABLE** to atDefault (never recorded → permanently hidden). New `ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE` discriminates on the live `Type` (network/gateway override `false`): folds the NLB first-run default AND surfaces a real enable.
3. **KNOWN_DEFAULTS** — S3Express DirectoryBucket (SSE-S3 with bucket key ON), S3Tables TableBucket (StorageClass/Metrics/Encryption), Logs DeliveryDestinationType (derived `CWL`), Logs Delivery RecordFields (CloudFront ACCESS_LOGS default field list). All equality-gated.

## Assets

- **16 new golden-corpus cases** (all types above) + 5 ELB cases regenerated for the new folds — replayed offline by `corpus-replay`.
- 3 committed integ fixtures (FP half + IoT FN half in `iot-vpces-rich/verify.sh`).
- Noted offline: `AWS::CloudWatch::AnomalyDetector` is NON_PROVISIONABLE (CC-gap) → `SDK_OVERRIDES` candidate, not huntable.
- Residual (deliberate, recordable 1-liners): `DeliveryDestinationPolicy` empty wrapper, auto-attached LogGroup `ResourcePolicyDocument`, VPCEndpointService `SupportedRegions`.

## Verification

- typecheck / lint / build / unit **1962 pass** (incl. new classify tests that fail without each fix)
- Live: 3 deploys, record→check CLEAN ×3, FN detect→revert→CLEAN ×1; harvested real NLB read replayed through the fixed classifier (Name→generated, cross_zone→atDefault)
- Cleanup: `bughunt-track verify` OK (all stacks GONE + SWEEP CLEAN), gate cleared