### PR TITLE
fix(noise): fold AccessAnalyzer ArchiveRules reorder; WarmPool/CapacityProvider defaults

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -582,6 +582,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     HealthCheckType: 'EC2',
     HealthCheckGracePeriod: 0,
   },
+  // A warm pool that declares no MinSize reads back MinSize:0 — the documented
+  // constant default ("minimum 0 warmed instances"). Observed undeclared on a fresh
+  // ecs-capacityprovider-rich deploy. Equality-gated: raise it out of band and it
+  // no longer matches, so it surfaces as real undeclared drift.
+  'AWS::AutoScaling::WarmPool': {
+    MinSize: 0,
+  },
   'AWS::DocDB::DBCluster': {
     Port: 27017, // DocDB's fixed default port
   },
@@ -739,6 +746,14 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   // fixture). Equality-gated: a real disk cap no longer matches and surfaces.
   'AWS::EMRServerless::Application': {
     'MaximumCapacity.Disk': '400000 GB',
+  },
+  // ECS materializes ManagedDraining:"ENABLED" (the documented constant default) into
+  // AutoScalingGroupProvider when the template omits it — CDK's AsgCapacityProvider
+  // doesn't render it unless set, so every ECS-on-EC2 first run reports it as
+  // undeclared. Equality-gated: disable draining out of band and it surfaces.
+  // Observed live on a fresh ecs-capacityprovider-rich deploy.
+  'AWS::ECS::CapacityProvider': {
+    'AutoScalingGroupProvider.ManagedDraining': 'ENABLED',
   },
   // AWS Backup materializes these defaults into each live BackupPlanRule (keyed by RuleName
   // — descended via NESTED_ARRAY_IDENTITY). Folding them keeps a clean plan clean; an
@@ -2005,6 +2020,19 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
 // canonical JSON before the positional diff — a genuine rule change still differs.
 export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   'AWS::EC2::SecurityGroup': new Set(['SecurityGroupIngress', 'SecurityGroupEgress']),
+  // An Access Analyzer's `ArchiveRules` is a SET of {RuleName, Filter} rules that AWS
+  // echoes SORTED by RuleName, not in template order (declared [ArchiveNonPublic,
+  // ArchiveKnownPrincipal] reads back [ArchiveKnownPrincipal, ArchiveNonPublic]), so a
+  // positional compare false-flags every shifted rule's RuleName AND whole Filter array
+  // as declared drift on a freshly recorded analyzer. `RuleName` is NOT one of
+  // canonicalizeTagListsDeep's IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name),
+  // so that keyed canonicalizer can't align it — hence the per-type opt-in. The schema
+  // marks ArchiveRules insertionOrder:false, but the schema-driven unorderedScalarPaths
+  // fold is scalar-items-only, so this OBJECT array needs the manual entry. Sorting both
+  // sides by canonical JSON aligns equal rules; a genuine rule add/remove/filter change
+  // still differs. Observed live on a fresh accessanalyzer-iot-rich deploy (4 false
+  // declared drifts on a 2-rule analyzer).
+  'AWS::AccessAnalyzer::Analyzer': new Set(['ArchiveRules']),
   // Cognito UserPoolResourceServer `Scopes` is a SET of {ScopeName, ScopeDescription}
   // OAuth scopes that AWS echoes SORTED by ScopeName, not in template order (declared
   // [zeta.write, alpha.read, mike.admin] reads back [alpha.read, mike.admin, zeta.write]),

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2178,6 +2178,54 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  // An Access Analyzer's `ArchiveRules` is a SET of {RuleName, Filter} AWS echoes
+  // SORTED by RuleName, not in template order (found by accessanalyzer-iot-rich:
+  // declared [ArchiveNonPublic, ArchiveKnownPrincipal] read back alphabetical —
+  // 4 false declared drifts on a 2-rule analyzer). RuleName is NOT an
+  // IDENTITY_FIELD and ArchiveRules is an OBJECT array, so the schema's
+  // insertionOrder:false (scalar-only fold) can't align it — only the per-type fold.
+  describe('AccessAnalyzer Analyzer ArchiveRules (RuleName-keyed reordered set, found by accessanalyzer-iot-rich)', () => {
+    const T = 'AWS::AccessAnalyzer::Analyzer';
+    const declared = {
+      Type: 'ACCOUNT',
+      ArchiveRules: [
+        { RuleName: 'ArchiveNonPublic', Filter: [{ Property: 'isPublic', Eq: ['false'] }] },
+        {
+          RuleName: 'ArchiveKnownPrincipal',
+          Filter: [
+            { Property: 'principal.AWS', Contains: ['999988887777'] },
+            { Property: 'resourceType', Eq: ['AWS::S3::Bucket'] },
+          ],
+        },
+      ],
+    };
+
+    it('AWS returning the ArchiveRules sorted by RuleName is NOT drift', () => {
+      const live = {
+        Type: 'ACCOUNT',
+        ArchiveRules: [declared.ArchiveRules[1], declared.ArchiveRules[0]],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine rule change (an edited Filter value) still surfaces', () => {
+      const live = {
+        Type: 'ACCOUNT',
+        ArchiveRules: [
+          {
+            RuleName: 'ArchiveKnownPrincipal',
+            Filter: [
+              { Property: 'principal.AWS', Contains: ['111122223333'] }, // account edited
+              { Property: 'resourceType', Eq: ['AWS::S3::Bucket'] },
+            ],
+          },
+          declared.ArchiveRules[0],
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   // An IAM principal's inline `Policies` is a SET of {PolicyName, PolicyDocument}
   // AWS returns SORTED by PolicyName, not in template order (found by
   // iam-permboundary-rich: declared [readObjects, describeOnly] read back

--- a/tests/corpus/AWS__AccessAnalyzer__Analyzer.Analyzer.json
+++ b/tests/corpus/AWS__AccessAnalyzer__Analyzer.Analyzer.json
@@ -1,0 +1,99 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Analyzer",
+    "resourceType": "AWS::AccessAnalyzer::Analyzer",
+    "physicalId": "arn:aws:access-analyzer:us-east-1:111111111111:analyzer/cdkrd-hunt-analyzer",
+    "constructPath": "CdkRealDriftIntegAnalyzerIot/Analyzer",
+    "declared": {
+      "AnalyzerName": "cdkrd-hunt-analyzer",
+      "ArchiveRules": [
+        {
+          "Filter": [
+            {
+              "Eq": ["false"],
+              "Property": "isPublic"
+            }
+          ],
+          "RuleName": "ArchiveNonPublic"
+        },
+        {
+          "Filter": [
+            {
+              "Contains": ["999988887777"],
+              "Property": "principal.AWS"
+            },
+            {
+              "Eq": ["AWS::S3::Bucket"],
+              "Property": "resourceType"
+            }
+          ],
+          "RuleName": "ArchiveKnownPrincipal"
+        }
+      ],
+      "Type": "ACCOUNT"
+    }
+  },
+  "liveRaw": {
+    "ArchiveRules": [
+      {
+        "Filter": [
+          {
+            "Contains": ["999988887777"],
+            "Property": "principal.AWS"
+          },
+          {
+            "Eq": ["AWS::S3::Bucket"],
+            "Property": "resourceType"
+          }
+        ],
+        "RuleName": "ArchiveKnownPrincipal"
+      },
+      {
+        "Filter": [
+          {
+            "Eq": ["false"],
+            "Property": "isPublic"
+          }
+        ],
+        "RuleName": "ArchiveNonPublic"
+      }
+    ],
+    "Type": "ACCOUNT",
+    "AnalyzerName": "cdkrd-hunt-analyzer",
+    "Arn": "arn:aws:access-analyzer:us-east-1:111111111111:analyzer/cdkrd-hunt-analyzer",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAnalyzerIot/4cd8a5b0-75d0-11f1-b9d0-0e73b11ab369",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAnalyzerIot",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Analyzer",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["AnalyzerName", "Type"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AnalyzerName", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ApiGatewayV2__VpcLink.Link1234EF21.json
+++ b/tests/corpus/AWS__ApiGatewayV2__VpcLink.Link1234EF21.json
@@ -1,0 +1,44 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Link1234EF21",
+    "resourceType": "AWS::ApiGatewayV2::VpcLink",
+    "physicalId": "aiy2m2",
+    "constructPath": "CdkRealDriftIntegVpcLinkEndpointSvc/Link",
+    "declared": {
+      "Name": "cdkrd-hunt-vpclink",
+      "SecurityGroupIds": ["sg-09fc7234dffd50693", "sg-0b47c3521ea43939e"],
+      "SubnetIds": ["subnet-0e480d6adfbcab461", "subnet-02a3be4d32aed38c6"]
+    }
+  },
+  "liveRaw": {
+    "VpcLinkId": "aiy2m2",
+    "SubnetIds": ["subnet-0e480d6adfbcab461", "subnet-02a3be4d32aed38c6"],
+    "SecurityGroupIds": ["sg-09fc7234dffd50693", "sg-0b47c3521ea43939e"],
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegVpcLinkEndpointSvc",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcLinkEndpointSvc/4c41bce0-75d0-11f1-9173-12e6c1f74983",
+      "aws:cloudformation:logical-id": "Link1234EF21"
+    },
+    "Name": "cdkrd-hunt-vpclink"
+  },
+  "schema": {
+    "readOnly": ["VpcLinkId"],
+    "writeOnly": [],
+    "createOnly": ["SecurityGroupIds", "SubnetIds"],
+    "readOnlyPaths": ["VpcLinkId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["SecurityGroupIds", "SubnetIds"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["SecurityGroupIds", "SubnetIds"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AutoScaling__WarmPool.AsgWarmPool18E7ECCA.json
+++ b/tests/corpus/AWS__AutoScaling__WarmPool.AsgWarmPool18E7ECCA.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AsgWarmPool18E7ECCA",
+    "resourceType": "AWS::AutoScaling::WarmPool",
+    "physicalId": "CdkRealDriftIntegEcsCapacityProvider-AsgASGD1D7B4E2-jR1Tyi7kHDEe",
+    "constructPath": "CdkRealDriftIntegEcsCapacityProvider/Asg/WarmPool",
+    "declared": {
+      "AutoScalingGroupName": "CdkRealDriftIntegEcsCapacityProvider-AsgASGD1D7B4E2-jR1Tyi7kHDEe",
+      "InstanceReusePolicy": {
+        "ReuseOnScaleIn": false
+      },
+      "MaxGroupPreparedCapacity": 0,
+      "PoolState": "Stopped"
+    }
+  },
+  "liveRaw": {
+    "MinSize": 0,
+    "MaxGroupPreparedCapacity": 0,
+    "AutoScalingGroupName": "CdkRealDriftIntegEcsCapacityProvider-AsgASGD1D7B4E2-jR1Tyi7kHDEe",
+    "PoolState": "Stopped",
+    "InstanceReusePolicy": {
+      "ReuseOnScaleIn": false
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["AutoScalingGroupName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AutoScalingGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AsgWarmPool18E7ECCA",
+      "resourceType": "AWS::AutoScaling::WarmPool",
+      "path": "MinSize",
+      "actual": 0,
+      "physicalId": "CdkRealDriftIntegEcsCapacityProvider-AsgASGD1D7B4E2-jR1Tyi7kHDEe",
+      "constructPath": "CdkRealDriftIntegEcsCapacityProvider/Asg/WarmPool"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__CapacityProvider.CpADC102F4.json
+++ b/tests/corpus/AWS__ECS__CapacityProvider.CpADC102F4.json
@@ -1,0 +1,87 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CpADC102F4",
+    "resourceType": "AWS::ECS::CapacityProvider",
+    "physicalId": "cdkrd-hunt-cp",
+    "constructPath": "CdkRealDriftIntegEcsCapacityProvider/Cp/Cp",
+    "declared": {
+      "AutoScalingGroupProvider": {
+        "AutoScalingGroupArn": "CdkRealDriftIntegEcsCapacityProvider-AsgASGD1D7B4E2-jR1Tyi7kHDEe",
+        "ManagedScaling": {
+          "InstanceWarmupPeriod": 120,
+          "MaximumScalingStepSize": 5,
+          "MinimumScalingStepSize": 1,
+          "Status": "ENABLED",
+          "TargetCapacity": 80
+        },
+        "ManagedTerminationProtection": "DISABLED"
+      },
+      "Name": "cdkrd-hunt-cp"
+    }
+  },
+  "liveRaw": {
+    "AutoScalingGroupProvider": {
+      "ManagedScaling": {
+        "Status": "ENABLED",
+        "MinimumScalingStepSize": 1,
+        "InstanceWarmupPeriod": 120,
+        "TargetCapacity": 80,
+        "MaximumScalingStepSize": 5
+      },
+      "AutoScalingGroupArn": "CdkRealDriftIntegEcsCapacityProvider-AsgASGD1D7B4E2-jR1Tyi7kHDEe",
+      "ManagedTerminationProtection": "DISABLED",
+      "ManagedDraining": "ENABLED"
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEcsCapacityProvider/4b3b4960-75d0-11f1-8bf3-0affc63b653f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEcsCapacityProvider",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CpADC102F4",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-hunt-cp"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ClusterName", "Name"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "AutoScalingGroupProvider.AutoScalingGroupArn",
+      "ClusterName",
+      "ManagedInstancesProvider.InstanceLaunchTemplate.FipsEnabled",
+      "Name"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "CpADC102F4",
+      "resourceType": "AWS::ECS::CapacityProvider",
+      "path": "AutoScalingGroupProvider.ManagedDraining",
+      "actual": "ENABLED",
+      "nested": true,
+      "physicalId": "cdkrd-hunt-cp",
+      "constructPath": "CdkRealDriftIntegEcsCapacityProvider/Cp/Cp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ECS__ClusterCapacityProviderAssociations.Cluster3DA9CCBA.json
+++ b/tests/corpus/AWS__ECS__ClusterCapacityProviderAssociations.Cluster3DA9CCBA.json
@@ -1,0 +1,38 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cluster3DA9CCBA",
+    "resourceType": "AWS::ECS::ClusterCapacityProviderAssociations",
+    "physicalId": "CdkRealDriftIntegEcsCapacityProvider-ClusterEB0386A7-9d4xKYE58fcq",
+    "constructPath": "CdkRealDriftIntegEcsCapacityProvider/Cluster/Cluster",
+    "declared": {
+      "CapacityProviders": ["FARGATE", "FARGATE_SPOT", "cdkrd-hunt-cp"],
+      "Cluster": "CdkRealDriftIntegEcsCapacityProvider-ClusterEB0386A7-9d4xKYE58fcq",
+      "DefaultCapacityProviderStrategy": []
+    }
+  },
+  "liveRaw": {
+    "DefaultCapacityProviderStrategy": [],
+    "CapacityProviders": ["FARGATE", "FARGATE_SPOT", "cdkrd-hunt-cp"],
+    "Cluster": "CdkRealDriftIntegEcsCapacityProvider-ClusterEB0386A7-9d4xKYE58fcq"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["Cluster"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Cluster"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__IoT__Policy.IotPolicy.json
+++ b/tests/corpus/AWS__IoT__Policy.IotPolicy.json
@@ -1,0 +1,67 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "IotPolicy",
+    "resourceType": "AWS::IoT::Policy",
+    "physicalId": "cdkrd-hunt-iot-policy",
+    "constructPath": "CdkRealDriftIntegAnalyzerIot/IotPolicy",
+    "declared": {
+      "PolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["iot:Connect"],
+            "Resource": ["arn:aws:iot:us-east-1:111111111111:client/cdkrd-hunt-*"]
+          },
+          {
+            "Effect": "Allow",
+            "Action": ["iot:Publish", "iot:Subscribe"],
+            "Resource": ["arn:aws:iot:us-east-1:111111111111:topic/cdkrd/hunt"]
+          }
+        ]
+      },
+      "PolicyName": "cdkrd-hunt-iot-policy"
+    }
+  },
+  "liveRaw": {
+    "PolicyName": "cdkrd-hunt-iot-policy",
+    "PolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": ["iot:Connect"],
+          "Resource": ["arn:aws:iot:us-east-1:111111111111:client/cdkrd-hunt-*"],
+          "Effect": "Allow"
+        },
+        {
+          "Action": ["iot:Publish", "iot:Subscribe"],
+          "Resource": ["arn:aws:iot:us-east-1:111111111111:topic/cdkrd/hunt"],
+          "Effect": "Allow"
+        }
+      ]
+    },
+    "Id": "cdkrd-hunt-iot-policy",
+    "Arn": "arn:aws:iot:us-east-1:111111111111:policy/cdkrd-hunt-iot-policy",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["PolicyName"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PolicyName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/accessanalyzer-iot-rich/app.ts
+++ b/tests/integration/accessanalyzer-iot-rich/app.ts
@@ -1,0 +1,80 @@
+// CDK app for the cdk-real-drift accessanalyzer-iot-rich false-positive integration
+// test. Exercises three free/instant types cdkrd has never read live:
+//   - AWS::AccessAnalyzer::Analyzer — ACCOUNT external-access analyzer with two
+//     ArchiveRules: a RuleName-keyed object array whose Filter elements carry
+//     property/eq/contains shapes AWS may reorder or re-case.
+//   - AWS::IoT::TopicRule — TopicRulePayload nests Sql/AwsIotSqlVersion/Actions;
+//     RuleDisabled is the mutable knob the detect path can flip via
+//     iot:DisableTopicRule. Action is a discriminated-union-ish object (Sns).
+//   - AWS::IoT::Policy — a non-IAM policy document (iot:* actions, client ARNs):
+//     runs the policy canonicalization path on an IoT-shaped document.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAnalyzer } from "aws-cdk-lib/aws-accessanalyzer";
+import { Effect, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnPolicy, CfnTopicRule } from "aws-cdk-lib/aws-iot";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAnalyzerIot");
+
+new CfnAnalyzer(stack, "Analyzer", {
+  type: "ACCOUNT",
+  analyzerName: "cdkrd-hunt-analyzer",
+  archiveRules: [
+    {
+      ruleName: "ArchiveNonPublic",
+      filter: [{ property: "isPublic", eq: ["false"] }],
+    },
+    {
+      ruleName: "ArchiveKnownPrincipal",
+      filter: [
+        { property: "principal.AWS", contains: ["999988887777"] },
+        { property: "resourceType", eq: ["AWS::S3::Bucket"] },
+      ],
+    },
+  ],
+});
+
+const topic = new Topic(stack, "AlertTopic");
+const role = new Role(stack, "IotRole", {
+  assumedBy: new ServicePrincipal("iot.amazonaws.com"),
+});
+role.addToPolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ["sns:Publish"],
+    resources: [topic.topicArn],
+  }),
+);
+
+new CfnTopicRule(stack, "Rule", {
+  ruleName: "cdkrd_hunt_rule",
+  topicRulePayload: {
+    sql: "SELECT * FROM 'cdkrd/hunt'",
+    awsIotSqlVersion: "2016-03-23",
+    ruleDisabled: false,
+    description: "cdkrd hunt fixture rule",
+    actions: [{ sns: { targetArn: topic.topicArn, roleArn: role.roleArn, messageFormat: "RAW" } }],
+  },
+});
+
+new CfnPolicy(stack, "IotPolicy", {
+  policyName: "cdkrd-hunt-iot-policy",
+  policyDocument: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Action: ["iot:Connect"],
+        Resource: [`arn:aws:iot:${stack.region}:${stack.account}:client/cdkrd-hunt-*`],
+      },
+      {
+        Effect: "Allow",
+        Action: ["iot:Publish", "iot:Subscribe"],
+        Resource: [`arn:aws:iot:${stack.region}:${stack.account}:topic/cdkrd/hunt`],
+      },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/accessanalyzer-iot-rich/cdk.json
+++ b/tests/integration/accessanalyzer-iot-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/accessanalyzer-iot-rich/package.json
+++ b/tests/integration/accessanalyzer-iot-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-accessanalyzer-iot-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift accessanalyzer-iot-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/accessanalyzer-iot-rich/verify.sh
+++ b/tests/integration/accessanalyzer-iot-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded Access Analyzer (2 ArchiveRules),
+# IoT TopicRule (SNS action payload) and IoT Policy (non-IAM policy document)
+# with NO out-of-band change must report no drift.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAnalyzerIot
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/ecs-capacityprovider-rich/app.ts
+++ b/tests/integration/ecs-capacityprovider-rich/app.ts
@@ -1,0 +1,88 @@
+// CDK app for the cdk-real-drift ecs-capacityprovider-rich false-positive integration
+// test. Exercises three types cdkrd has never read live:
+//   - AWS::ECS::CapacityProvider — an ASG-backed capacity provider with a rich
+//     ManagedScaling block (TargetCapacity/step sizes/InstanceWarmupPeriod). AWS
+//     materializes defaults for the ManagedScaling knobs left undeclared, so this is
+//     prime KNOWN_DEFAULTS territory.
+//   - AWS::ECS::ClusterCapacityProviderAssociations — the CapacityProviders list mixes
+//     FARGATE / FARGATE_SPOT / the custom provider: a set-like scalar array that AWS may
+//     echo in its own order (reorder-FP probe), plus a DefaultCapacityProviderStrategy
+//     object array with no Key/Id/Name identity field.
+//   - AWS::AutoScaling::WarmPool — attached to the same ASG with explicit zeros so no
+//     instance ever launches; AWS fills PoolState/ReuseOnScaleIn style defaults.
+// The ASG is min/max/desired 0-0-... (min 0, max 1, desired defaults to min) so the
+// stack never runs an instance — deploy/delete is fast and free.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  AutoScalingGroup,
+  PoolState,
+} from "aws-cdk-lib/aws-autoscaling";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  LaunchTemplate,
+  SubnetType,
+  UserData,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import { AsgCapacityProvider, Cluster, EcsOptimizedImage } from "aws-cdk-lib/aws-ecs";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEcsCapacityProvider");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "p", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+const cluster = new Cluster(stack, "Cluster", {
+  vpc,
+  enableFargateCapacityProviders: true, // FARGATE + FARGATE_SPOT join the associations set
+});
+
+const lt = new LaunchTemplate(stack, "Lt", {
+  instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MICRO),
+  machineImage: EcsOptimizedImage.amazonLinux2023(),
+  userData: UserData.forLinux(),
+  requireImdsv2: true,
+  // addAsgCapacityProvider wires ECS cluster config into the instance role's
+  // userdata, so the launch template must define one.
+  role: new Role(stack, "InstanceRole", {
+    assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  }),
+});
+
+const asg = new AutoScalingGroup(stack, "Asg", {
+  vpc,
+  launchTemplate: lt,
+  minCapacity: 0,
+  maxCapacity: 1,
+  vpcSubnets: { subnetType: SubnetType.PUBLIC },
+});
+
+// Zero-sized warm pool: the resource exists (and AWS fills its defaults) but no
+// instance is ever prepared.
+asg.addWarmPool({
+  minGroupSize: 0,
+  maxGroupPreparedCapacity: 0,
+  poolState: PoolState.STOPPED,
+  reuseOnScaleIn: false,
+});
+
+const cp = new AsgCapacityProvider(stack, "Cp", {
+  capacityProviderName: "cdkrd-hunt-cp",
+  autoScalingGroup: asg,
+  enableManagedScaling: true,
+  // Termination protection must stay OFF so teardown never blocks on protected instances.
+  enableManagedTerminationProtection: false,
+  targetCapacityPercent: 80,
+  minimumScalingStepSize: 1,
+  maximumScalingStepSize: 5,
+  instanceWarmupPeriod: 120,
+});
+cluster.addAsgCapacityProvider(cp);
+
+app.synth();

--- a/tests/integration/ecs-capacityprovider-rich/cdk.json
+++ b/tests/integration/ecs-capacityprovider-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ecs-capacityprovider-rich/package.json
+++ b/tests/integration/ecs-capacityprovider-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ecs-capacityprovider-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ecs-capacityprovider-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ecs-capacityprovider-rich/verify-detect.sh
+++ b/tests/integration/ecs-capacityprovider-rich/verify-detect.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Detect + revert integration test (real AWS): the "someone changed it in the
+# console" scenario for an ECS capacity provider. Deploy -> record -> lower
+# ManagedScaling.TargetCapacity out of band (80 -> 50) -> check MUST DETECT the
+# declared drift (exit 1) -> revert -> check MUST be CLEAN and the live value
+# MUST be 80 again. TargetCapacity is declared and FULLY_MUTABLE, so the whole
+# detect -> revert -> clean cycle must close.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsCapacityProvider
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+CP_NAME=cdkrd-hunt-cp
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: ManagedScaling TargetCapacity 80 -> 50 (console-edit) ==="
+aws ecs update-capacity-provider --name "$CP_NAME" --region "$REGION" \
+  --auto-scaling-group-provider 'managedScaling={targetCapacity=50}' >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "TargetCapacity" "/tmp/cdkrd-$STACK-detect.out" || fail "TargetCapacity drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+LIVE="$(aws ecs describe-capacity-providers --capacity-providers "$CP_NAME" --region "$REGION" \
+  --query 'capacityProviders[0].autoScalingGroupProvider.managedScaling.targetCapacity' --output text)"
+[ "$LIVE" = "80" ] || fail "live TargetCapacity not restored (got $LIVE)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/ecs-capacityprovider-rich/verify.sh
+++ b/tests/integration/ecs-capacityprovider-rich/verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded ECS capacity provider (rich
+# ManagedScaling), ClusterCapacityProviderAssociations (FARGATE/FARGATE_SPOT/custom
+# set) and zero-sized WarmPool with NO out-of-band change must report no drift.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEcsCapacityProvider
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/vpclink-endpointservice-rich/app.ts
+++ b/tests/integration/vpclink-endpointservice-rich/app.ts
@@ -1,0 +1,49 @@
+// CDK app for the cdk-real-drift vpclink-endpointservice-rich false-positive
+// integration test. Exercises two PrivateLink-adjacent types cdkrd has never read:
+//   - AWS::EC2::VPCEndpointService — the provider side of PrivateLink, backed by an
+//     internal NLB. AcceptanceRequired is declared true (and is the mutable knob the
+//     detect script flips); SupportedIpAddressTypes is a declared scalar set.
+//   - AWS::ApiGatewayV2::VpcLink — SubnetIds (2 AZs) and SecurityGroupIds (two SGs,
+//     declared in non-sorted order) are set-like scalar arrays AWS may echo in its own
+//     order: a reorder-FP probe.
+// Isolated subnets, no NAT, internal NLB with no listener/targets — nothing runs, so
+// deploy/delete is fast and cheap (NLB hourly is the only cost for the test window).
+import { App, Stack } from "aws-cdk-lib";
+import { VpcLink } from "aws-cdk-lib/aws-apigatewayv2";
+import { CfnVPCEndpointService, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { NetworkLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancingv2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegVpcLinkEndpointSvc");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "iso", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const nlb = new NetworkLoadBalancer(stack, "Nlb", {
+  vpc,
+  internetFacing: false,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+});
+
+new CfnVPCEndpointService(stack, "EndpointService", {
+  networkLoadBalancerArns: [nlb.loadBalancerArn],
+  acceptanceRequired: true,
+  supportedIpAddressTypes: ["ipv4"],
+});
+
+// Two SGs declared z-before-a so any live-side sort of SecurityGroupIds surfaces
+// as a positional mismatch instead of hiding behind an already-sorted declaration.
+const sgZ = new SecurityGroup(stack, "SgZ", { vpc, description: "cdkrd hunt vpclink z" });
+const sgA = new SecurityGroup(stack, "SgA", { vpc, description: "cdkrd hunt vpclink a" });
+
+new VpcLink(stack, "Link", {
+  vpc,
+  vpcLinkName: "cdkrd-hunt-vpclink",
+  subnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  securityGroups: [sgZ, sgA],
+});
+
+app.synth();

--- a/tests/integration/vpclink-endpointservice-rich/cdk.json
+++ b/tests/integration/vpclink-endpointservice-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/vpclink-endpointservice-rich/package.json
+++ b/tests/integration/vpclink-endpointservice-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-vpclink-endpointservice-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift vpclink-endpointservice-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/vpclink-endpointservice-rich/verify-detect.sh
+++ b/tests/integration/vpclink-endpointservice-rich/verify-detect.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Detect + revert integration test (real AWS): flip a VPCEndpointService's
+# AcceptanceRequired out of band (true -> false, the classic "quietly opened up a
+# PrivateLink service" console change). check MUST DETECT the declared drift
+# (exit 1) -> revert -> check MUST be CLEAN and the live flag restored to true.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegVpcLinkEndpointSvc
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+SVC="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::EC2::VPCEndpointService'].PhysicalResourceId" --output text)"
+[ -n "$SVC" ] || fail "could not resolve endpoint service physical id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: AcceptanceRequired true -> false (console-edit) ==="
+aws ec2 modify-vpc-endpoint-service-configuration --service-id "$SVC" --region "$REGION" \
+  --no-acceptance-required >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "AcceptanceRequired" "/tmp/cdkrd-$STACK-detect.out" || fail "AcceptanceRequired drift not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+LIVE="$(aws ec2 describe-vpc-endpoint-service-configurations --service-ids "$SVC" --region "$REGION" \
+  --query 'ServiceConfigurations[0].AcceptanceRequired' --output text)"
+[ "$LIVE" = "True" ] || fail "live AcceptanceRequired not restored (got $LIVE)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/vpclink-endpointservice-rich/verify.sh
+++ b/tests/integration/vpclink-endpointservice-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A freshly deployed + recorded VPCEndpointService (internal NLB,
+# AcceptanceRequired) and ApiGatewayV2 VpcLink (2 subnets + 2 SGs in non-sorted
+# declared order) with NO out-of-band change must report no drift; any drift here
+# is a normalization / set-reorder / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegVpcLinkEndpointSvc
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -408,6 +408,18 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('WarmPool + ECS CapacityProvider known defaults present (bug-hunt: ecs-capacityprovider-rich)', () => {
+    // Constant service defaults a fresh ECS-on-EC2 deploy reports as first-run
+    // undeclared inventory; equality-gated, so a value set away from the default
+    // still surfaces. Exercised by the AWS__AutoScaling__WarmPool and
+    // AWS__ECS__CapacityProvider corpus cases. Per-resource values (the WarmPool's
+    // MaxGroupPreparedCapacity, the provider's ASG ARN) are deliberately NOT folded.
+    expect(KNOWN_DEFAULTS['AWS::AutoScaling::WarmPool']).toEqual({ MinSize: 0 });
+    expect(KNOWN_DEFAULT_PATHS['AWS::ECS::CapacityProvider']).toEqual({
+      'AutoScalingGroupProvider.ManagedDraining': 'ENABLED',
+    });
+  });
+
   it('AppSync + Logs SubscriptionFilter known defaults present (bug-hunt: appsync-resolver-rich / logs-subscriptionfilter-rich)', () => {
     // Constant service defaults a fresh deploy reports as first-run undeclared
     // inventory; equality-gated, so a value set away from the default still surfaces.


### PR DESCRIPTION
## Bug-hunt round (disjoint from the parallel hunt-0cov / hunt-lowcov sessions)

3 stacks deployed live in us-east-1, FP+FN verified, all deleted + sweep-verified (the one sweep hit was the parallel hunt's LIVE ApsRich stack member — untouched).

### Real FP fixed
**`AWS::AccessAnalyzer::Analyzer` `ArchiveRules` reorder** — AWS echoes the {RuleName, Filter} SET sorted by RuleName, not in template order → 4 false declared drifts on a freshly recorded 2-rule analyzer. RuleName ∉ IDENTITY_FIELDS and the schema's `insertionOrder:false` only drives the SCALAR-array fold, so the object array needed the per-type `UNORDERED_OBJECT_ARRAY_PROPS` entry. Live-proven CLEAN after the fix; a genuine filter edit still surfaces (unit-tested both ways). Follow-up #459 filed to generalize the schema fold to object arrays.

### First-run noise folds (measure-noise CANDIDATEs, live-proven 16→14 potential / 24→26 atDefault)
- `AWS::AutoScaling::WarmPool` `MinSize: 0` → KNOWN_DEFAULTS
- `AWS::ECS::CapacityProvider` `AutoScalingGroupProvider.ManagedDraining: ENABLED` → KNOWN_DEFAULT_PATHS

### FN half — all pass via plain Cloud Control
detect → revert → CLEAN → live value restored, for:
- ECS CapacityProvider `ManagedScaling.TargetCapacity` (80→50 via `update-capacity-provider`)
- EC2 VPCEndpointService `AcceptanceRequired` (true→false via `modify-vpc-endpoint-service-configuration`)
- IoT TopicRule `TopicRulePayload.RuleDisabled` (via `disable-topic-rule`)

### Rule-outs / confirmations
- ApiGatewayV2 VpcLink `SubnetIds`/`SecurityGroupIds` (declared non-sorted): covered by the schema-driven `insertionOrder:false` scalar fold — live CLEAN.
- ECS ClusterCapacityProviderAssociations `CapacityProviders` (FARGATE/FARGATE_SPOT/custom set): order echoed as declared — no FP.
- CloudWatch::AnomalyDetector probed offline: NON_PROVISIONABLE / no CC read → SDK_OVERRIDES candidate, deploy skipped.

### Assets
- 6 new golden-corpus types: AccessAnalyzer Analyzer, IoT Policy, ECS CapacityProvider / ClusterCapacityProviderAssociations, AutoScaling WarmPool, ApiGatewayV2 VpcLink (VPCEndpointService + IoT TopicRule near-identical harvests landed first via #458 — dropped here in rebase).
- 3 integ fixtures (`ecs-capacityprovider-rich`, `vpclink-endpointservice-rich`, `accessanalyzer-iot-rich`) with verify.sh + 2 verify-detect.sh.

Gates: /check (42 files / 1971 tests), /check-docs (no docs-visible surface), /verify-pr (this round's real-AWS deploy→FP→FN→revert cycle is the live-test).