### PR TITLE
fix(noise): fold ResolverRule/RecordSet FQDN trailing dot + PlacementGroup/IPAM/APS defaults; add 13 zero-coverage corpus types

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -556,6 +556,26 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::EC2::FlowLog': {
     MaxAggregationInterval: 600,
   },
+  // EC2 echoes SpreadLevel "rack" even on partition-strategy groups (where the
+  // property is inapplicable); "rack" is also the documented default for spread.
+  'AWS::EC2::PlacementGroup': {
+    SpreadLevel: 'rack',
+  },
+  // IPAM defaults metering to the IPAM owner's account.
+  'AWS::EC2::IPAM': {
+    MeteredAccount: 'ipam-owner',
+  },
+  // Managed Prometheus materializes a WorkspaceConfiguration of service defaults
+  // (150-day retention, 60s rule-query offset / out-of-order window) on every
+  // workspace that never declared one.
+  'AWS::APS::Workspace': {
+    WorkspaceConfiguration: {
+      RuleQueryOffsetInSeconds: 60,
+      RetentionPeriodInDays: 150,
+      OutOfOrderTimeWindowInSeconds: 60,
+      LimitsPerLabelSets: [],
+    },
+  },
   'AWS::Pipes::Pipe': {
     DesiredState: 'RUNNING',
   },
@@ -1629,6 +1649,15 @@ export function isEpochHourEqual(a: unknown, b: unknown): boolean {
 // own Name/DNSName via alignTrailingDot; HostedZone is CC-native, handled here.)
 export const TRAILING_DOT_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Route53::HostedZone': new Set(['Name']),
+  // Route53 canonicalizes record names to FQDN form the same way (CDK L2 emits
+  // the trailing dot, but raw-template / L1 users routinely omit it). The
+  // override reader's alignTrailingDot already handles Name/DNSName; this entry
+  // closes the same class for any non-override read path.
+  'AWS::Route53::RecordSet': new Set(['Name']),
+  // Route53 Resolver appends the trailing dot to a FORWARD rule's DomainName on
+  // read (live-proven: declared "cdkrd-hunt.internal" reads back
+  // "cdkrd-hunt.internal.").
+  'AWS::Route53Resolver::ResolverRule': new Set(['DomainName']),
 };
 export function isTrailingDotEqual(a: unknown, b: unknown): boolean {
   if (typeof a !== 'string' || typeof b !== 'string') return false;

--- a/tests/corpus/AWS__APS__RuleGroupsNamespace.HuntRules.json
+++ b/tests/corpus/AWS__APS__RuleGroupsNamespace.HuntRules.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRules",
+    "resourceType": "AWS::APS::RuleGroupsNamespace",
+    "physicalId": "arn:aws:aps:us-east-1:111111111111:rulegroupsnamespace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e/cdkrd-hunt-rules",
+    "constructPath": "CdkRealDriftIntegApsRich/HuntRules",
+    "declared": {
+      "Data": "groups:\n  - name: cdkrd-hunt\n    rules:\n      - record: job:up:sum\n        expr: sum(up) by (job)\n      - alert: CdkrdHuntDown\n        expr: up == 0\n        for: 5m\n        labels:\n          severity: page\n        annotations:\n          summary: target down\n",
+      "Name": "cdkrd-hunt-rules",
+      "Workspace": "arn:aws:aps:us-east-1:111111111111:workspace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e"
+    }
+  },
+  "liveRaw": {
+    "Data": "groups:\n  - name: cdkrd-hunt\n    rules:\n      - record: job:up:sum\n        expr: sum(up) by (job)\n      - alert: CdkrdHuntDown\n        expr: up == 0\n        for: 5m\n        labels:\n          severity: page\n        annotations:\n          summary: target down\n",
+    "Arn": "arn:aws:aps:us-east-1:111111111111:rulegroupsnamespace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e/cdkrd-hunt-rules",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegApsRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntRules",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApsRich/f0c541f0-75d1-11f1-95d4-0e6e0ad93995",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Workspace": "arn:aws:aps:us-east-1:111111111111:workspace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e",
+    "Name": "cdkrd-hunt-rules"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name", "Workspace"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "Workspace"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__APS__Workspace.HuntWorkspace.json
+++ b/tests/corpus/AWS__APS__Workspace.HuntWorkspace.json
@@ -1,0 +1,90 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntWorkspace",
+    "resourceType": "AWS::APS::Workspace",
+    "physicalId": "arn:aws:aps:us-east-1:111111111111:workspace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e",
+    "constructPath": "CdkRealDriftIntegApsRich/HuntWorkspace",
+    "declared": {
+      "AlertManagerDefinition": "alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n      sns_configs:\n        - topic_arn: 'arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-aps-alerts'\n          sigv4:\n            region: 'us-east-1'\n          message: '{{ .CommonAnnotations.summary }}'\n",
+      "Alias": "cdkrd-hunt-aps",
+      "LoggingConfiguration": {
+        "LogGroupArn": "arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/prometheus/cdkrd-hunt:*"
+      },
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-aps"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "PrometheusEndpoint": "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e/",
+    "Alias": "cdkrd-hunt-aps",
+    "LoggingConfiguration": {
+      "LogGroupArn": "arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/prometheus/cdkrd-hunt:*"
+    },
+    "WorkspaceId": "ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e",
+    "WorkspaceConfiguration": {
+      "RuleQueryOffsetInSeconds": 60,
+      "RetentionPeriodInDays": 150,
+      "OutOfOrderTimeWindowInSeconds": 60,
+      "LimitsPerLabelSets": []
+    },
+    "AlertManagerDefinition": "alertmanager_config: |\n  route:\n    receiver: 'default'\n  receivers:\n    - name: 'default'\n      sns_configs:\n        - topic_arn: 'arn:aws:sns:us-east-1:111111111111:cdkrd-hunt-aps-alerts'\n          sigv4:\n            region: 'us-east-1'\n          message: '{{ .CommonAnnotations.summary }}'\n",
+    "Arn": "arn:aws:aps:us-east-1:111111111111:workspace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegApsRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntWorkspace",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApsRich/f0c541f0-75d1-11f1-95d4-0e6e0ad93995",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "cdkrd-hunt-aps",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "PrometheusEndpoint", "WorkspaceId"],
+    "writeOnly": [],
+    "createOnly": ["KmsKeyArn"],
+    "readOnlyPaths": ["Arn", "PrometheusEndpoint", "WorkspaceId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KmsKeyArn"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntWorkspace",
+      "resourceType": "AWS::APS::Workspace",
+      "path": "WorkspaceConfiguration",
+      "actual": {
+        "RuleQueryOffsetInSeconds": 60,
+        "RetentionPeriodInDays": 150,
+        "OutOfOrderTimeWindowInSeconds": 60,
+        "LimitsPerLabelSets": []
+      },
+      "physicalId": "arn:aws:aps:us-east-1:111111111111:workspace/ws-dd929d20-85e3-4e5b-aa7a-50e19305bf4e",
+      "constructPath": "CdkRealDriftIntegApsRich/HuntWorkspace"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__IPAM.HuntIpam.json
+++ b/tests/corpus/AWS__EC2__IPAM.HuntIpam.json
@@ -1,0 +1,108 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntIpam",
+    "resourceType": "AWS::EC2::IPAM",
+    "physicalId": "ipam-016e39780e99c03d3",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntIpam",
+    "declared": {
+      "Description": "cdkrd hunt free-tier IPAM",
+      "OperatingRegions": [
+        {
+          "RegionName": "us-east-1"
+        }
+      ],
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-ipam"
+        }
+      ],
+      "Tier": "free"
+    }
+  },
+  "liveRaw": {
+    "DefaultResourceDiscoveryAssociationId": "ipam-res-disco-assoc-0e429ecb3bac59944",
+    "Description": "cdkrd hunt free-tier IPAM",
+    "Tier": "free",
+    "EnablePrivateGua": false,
+    "IpamId": "ipam-016e39780e99c03d3",
+    "DefaultResourceDiscoveryId": "ipam-res-disco-0f6fa331174c920d1",
+    "MeteredAccount": "ipam-owner",
+    "ResourceDiscoveryAssociationCount": 1,
+    "ScopeCount": 2,
+    "Arn": "arn:aws:ec2::111111111111:ipam/ipam-016e39780e99c03d3",
+    "PrivateDefaultScopeId": "ipam-scope-039611e25432b7990",
+    "PublicDefaultScopeId": "ipam-scope-0accc337125e9d3d5",
+    "Tags": [
+      {
+        "Value": "HuntIpam",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "cdkrd-hunt-ipam",
+        "Key": "Name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0Cov2Rich/efcd2650-75d1-11f1-a92e-0affda798e9d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegMisc0Cov2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "OperatingRegions": [
+      {
+        "RegionName": "us-east-1"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "DefaultResourceDiscoveryAssociationId",
+      "DefaultResourceDiscoveryId",
+      "IpamId",
+      "PrivateDefaultScopeId",
+      "PublicDefaultScopeId",
+      "ResourceDiscoveryAssociationCount",
+      "ScopeCount"
+    ],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "Arn",
+      "DefaultResourceDiscoveryAssociationId",
+      "DefaultResourceDiscoveryId",
+      "IpamId",
+      "PrivateDefaultScopeId",
+      "PublicDefaultScopeId",
+      "ResourceDiscoveryAssociationCount",
+      "ScopeCount"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntIpam",
+      "resourceType": "AWS::EC2::IPAM",
+      "path": "MeteredAccount",
+      "actual": "ipam-owner",
+      "physicalId": "ipam-016e39780e99c03d3",
+      "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntIpam"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__PlacementGroup.HuntPgPartition.json
+++ b/tests/corpus/AWS__EC2__PlacementGroup.HuntPgPartition.json
@@ -1,0 +1,60 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPgPartition",
+    "resourceType": "AWS::EC2::PlacementGroup",
+    "physicalId": "CdkRealDriftIntegMisc0Cov2Rich-HuntPgPartition-RLYPWXWQHAPI",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntPgPartition",
+    "declared": {
+      "PartitionCount": 3,
+      "Strategy": "partition",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-pg-partition"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "GroupName": "CdkRealDriftIntegMisc0Cov2Rich-HuntPgPartition-RLYPWXWQHAPI",
+    "SpreadLevel": "rack",
+    "Strategy": "partition",
+    "PartitionCount": 3,
+    "Tags": [
+      {
+        "Value": "cdkrd-hunt-pg-partition",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["GroupName"],
+    "writeOnly": [],
+    "createOnly": ["PartitionCount", "SpreadLevel", "Strategy", "Tags"],
+    "readOnlyPaths": ["GroupName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PartitionCount", "SpreadLevel", "Strategy", "Tags"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPgPartition",
+      "resourceType": "AWS::EC2::PlacementGroup",
+      "path": "SpreadLevel",
+      "actual": "rack",
+      "physicalId": "CdkRealDriftIntegMisc0Cov2Rich-HuntPgPartition-RLYPWXWQHAPI",
+      "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntPgPartition"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__PlacementGroup.HuntPgSpread.json
+++ b/tests/corpus/AWS__EC2__PlacementGroup.HuntPgSpread.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPgSpread",
+    "resourceType": "AWS::EC2::PlacementGroup",
+    "physicalId": "CdkRealDriftIntegMisc0Cov2Rich-HuntPgSpread-HPDMWGJNNPMY",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntPgSpread",
+    "declared": {
+      "SpreadLevel": "rack",
+      "Strategy": "spread",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-pg-spread"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "GroupName": "CdkRealDriftIntegMisc0Cov2Rich-HuntPgSpread-HPDMWGJNNPMY",
+    "SpreadLevel": "rack",
+    "Strategy": "spread",
+    "Tags": [
+      {
+        "Value": "cdkrd-hunt-pg-spread",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["GroupName"],
+    "writeOnly": [],
+    "createOnly": ["PartitionCount", "SpreadLevel", "Strategy", "Tags"],
+    "readOnlyPaths": ["GroupName"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["PartitionCount", "SpreadLevel", "Strategy", "Tags"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__TrafficMirrorFilter.HuntTmFilter.json
+++ b/tests/corpus/AWS__EC2__TrafficMirrorFilter.HuntTmFilter.json
@@ -1,0 +1,60 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTmFilter",
+    "resourceType": "AWS::EC2::TrafficMirrorFilter",
+    "physicalId": "tmf-05e8886c6eb86c35c",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntTmFilter",
+    "declared": {
+      "Description": "cdkrd hunt traffic mirror filter",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-tmf"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt traffic mirror filter",
+    "NetworkServices": [],
+    "Id": "tmf-05e8886c6eb86c35c",
+    "Tags": [
+      {
+        "Value": "cdkrd-hunt-tmf",
+        "Key": "Name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0Cov2Rich/efcd2650-75d1-11f1-a92e-0affda798e9d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "HuntTmFilter",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegMisc0Cov2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["Description"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["NetworkServices"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__TrafficMirrorFilterRule.HuntTmRuleIn.json
+++ b/tests/corpus/AWS__EC2__TrafficMirrorFilterRule.HuntTmRuleIn.json
@@ -1,0 +1,79 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTmRuleIn",
+    "resourceType": "AWS::EC2::TrafficMirrorFilterRule",
+    "physicalId": "tmfr-04dfd2688809b98c3",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntTmRuleIn",
+    "declared": {
+      "Description": "cdkrd hunt ingress rule",
+      "DestinationCidrBlock": "0.0.0.0/0",
+      "DestinationPortRange": {
+        "FromPort": 443,
+        "ToPort": 443
+      },
+      "Protocol": 6,
+      "RuleAction": "accept",
+      "RuleNumber": 100,
+      "SourceCidrBlock": "10.0.0.0/8",
+      "SourcePortRange": {
+        "FromPort": 1024,
+        "ToPort": 65535
+      },
+      "TrafficDirection": "ingress",
+      "TrafficMirrorFilterId": "tmf-05e8886c6eb86c35c"
+    }
+  },
+  "liveRaw": {
+    "DestinationPortRange": {
+      "FromPort": 443,
+      "ToPort": 443
+    },
+    "TrafficMirrorFilterRuleId": "tmfr-04dfd2688809b98c3",
+    "Description": "cdkrd hunt ingress rule",
+    "SourcePortRange": {
+      "FromPort": 1024,
+      "ToPort": 65535
+    },
+    "RuleAction": "accept",
+    "SourceCidrBlock": "10.0.0.0/8",
+    "RuleNumber": 100,
+    "DestinationCidrBlock": "0.0.0.0/0",
+    "TrafficMirrorFilterId": "tmf-05e8886c6eb86c35c",
+    "TrafficDirection": "ingress",
+    "Protocol": 6,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0Cov2Rich/efcd2650-75d1-11f1-a92e-0affda798e9d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegMisc0Cov2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntTmRuleIn",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["TrafficMirrorFilterRuleId"],
+    "writeOnly": [],
+    "createOnly": ["TrafficMirrorFilterId"],
+    "readOnlyPaths": ["TrafficMirrorFilterRuleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TrafficMirrorFilterId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__TrafficMirrorFilterRule.HuntTmRuleOut.json
+++ b/tests/corpus/AWS__EC2__TrafficMirrorFilterRule.HuntTmRuleOut.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntTmRuleOut",
+    "resourceType": "AWS::EC2::TrafficMirrorFilterRule",
+    "physicalId": "tmfr-03c8c5d80c52e4db2",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntTmRuleOut",
+    "declared": {
+      "Description": "cdkrd hunt egress rule",
+      "DestinationCidrBlock": "192.168.0.0/16",
+      "RuleAction": "reject",
+      "RuleNumber": 200,
+      "SourceCidrBlock": "0.0.0.0/0",
+      "TrafficDirection": "egress",
+      "TrafficMirrorFilterId": "tmf-05e8886c6eb86c35c"
+    }
+  },
+  "liveRaw": {
+    "TrafficMirrorFilterRuleId": "tmfr-03c8c5d80c52e4db2",
+    "Description": "cdkrd hunt egress rule",
+    "RuleAction": "reject",
+    "SourceCidrBlock": "0.0.0.0/0",
+    "RuleNumber": 200,
+    "DestinationCidrBlock": "192.168.0.0/16",
+    "TrafficMirrorFilterId": "tmf-05e8886c6eb86c35c",
+    "TrafficDirection": "egress",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0Cov2Rich/efcd2650-75d1-11f1-a92e-0affda798e9d",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegMisc0Cov2Rich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntTmRuleOut",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["TrafficMirrorFilterRuleId"],
+    "writeOnly": [],
+    "createOnly": ["TrafficMirrorFilterId"],
+    "readOnlyPaths": ["TrafficMirrorFilterRuleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["TrafficMirrorFilterId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__ECR__PullThroughCacheRule.HuntPtcr.json
+++ b/tests/corpus/AWS__ECR__PullThroughCacheRule.HuntPtcr.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPtcr",
+    "resourceType": "AWS::ECR::PullThroughCacheRule",
+    "physicalId": "cdkrd-hunt-ecrpub",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntPtcr",
+    "declared": {
+      "EcrRepositoryPrefix": "cdkrd-hunt-ecrpub",
+      "UpstreamRegistryUrl": "public.ecr.aws"
+    }
+  },
+  "liveRaw": {
+    "UpstreamRegistryUrl": "public.ecr.aws",
+    "EcrRepositoryPrefix": "cdkrd-hunt-ecrpub"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["CredentialArn", "CustomRoleArn", "UpstreamRegistry"],
+    "createOnly": [
+      "CredentialArn",
+      "CustomRoleArn",
+      "EcrRepositoryPrefix",
+      "UpstreamRegistry",
+      "UpstreamRegistryUrl",
+      "UpstreamRepositoryPrefix"
+    ],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["CredentialArn", "CustomRoleArn", "UpstreamRegistry"],
+    "createOnlyPaths": [
+      "CredentialArn",
+      "CustomRoleArn",
+      "EcrRepositoryPrefix",
+      "UpstreamRegistry",
+      "UpstreamRegistryUrl",
+      "UpstreamRepositoryPrefix"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Oam__Sink.HuntOamSink.json
+++ b/tests/corpus/AWS__Oam__Sink.HuntOamSink.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOamSink",
+    "resourceType": "AWS::Oam::Sink",
+    "physicalId": "arn:aws:oam:us-east-1:111111111111:sink/8abed248-9fa5-4121-9a16-1e28ca12cc01",
+    "constructPath": "CdkRealDriftIntegMisc0Cov2Rich/HuntOamSink",
+    "declared": {
+      "Name": "cdkrd-hunt-sink",
+      "Policy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "111111111111"
+            },
+            "Resource": "*",
+            "Action": ["oam:CreateLink", "oam:UpdateLink"],
+            "Condition": {
+              "ForAllValues:StringEquals": {
+                "oam:ResourceTypes": ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+              }
+            }
+          }
+        ]
+      },
+      "Tags": {
+        "Name": "cdkrd-hunt-sink"
+      }
+    }
+  },
+  "liveRaw": {
+    "Policy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Condition": {
+            "ForAllValues:StringEquals": {
+              "oam:ResourceTypes": ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"]
+            }
+          },
+          "Action": ["oam:CreateLink", "oam:UpdateLink"],
+          "Resource": "*",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          }
+        }
+      ]
+    },
+    "Arn": "arn:aws:oam:us-east-1:111111111111:sink/8abed248-9fa5-4121-9a16-1e28ca12cc01",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftIntegMisc0Cov2Rich",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegMisc0Cov2Rich/efcd2650-75d1-11f1-a92e-0affda798e9d",
+      "aws:cloudformation:logical-id": "HuntOamSink",
+      "Name": "cdkrd-hunt-sink"
+    },
+    "Name": "cdkrd-hunt-sink"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53Resolver__ResolverEndpoint.HuntOutboundEndpoint.json
+++ b/tests/corpus/AWS__Route53Resolver__ResolverEndpoint.HuntOutboundEndpoint.json
@@ -1,0 +1,79 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntOutboundEndpoint",
+    "resourceType": "AWS::Route53Resolver::ResolverEndpoint",
+    "physicalId": "rslvr-out-7345f2fdbd754018b",
+    "constructPath": "CdkRealDriftIntegResolverRich/HuntOutboundEndpoint",
+    "declared": {
+      "Direction": "OUTBOUND",
+      "IpAddresses": [
+        {
+          "SubnetId": "subnet-0d2ab6b3829cfbbff"
+        },
+        {
+          "SubnetId": "subnet-0cab1eec8a90aea6f"
+        }
+      ],
+      "Name": "cdkrd-hunt-outbound",
+      "Protocols": ["Do53"],
+      "ResolverEndpointType": "IPV4",
+      "SecurityGroupIds": ["sg-028b0de64ad2c5f68"],
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-outbound"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Protocols": ["Do53"],
+    "ResolverEndpointId": "rslvr-out-7345f2fdbd754018b",
+    "ResolverEndpointType": "IPV4",
+    "Direction": "OUTBOUND",
+    "SecurityGroupIds": ["sg-028b0de64ad2c5f68"],
+    "Name": "cdkrd-hunt-outbound",
+    "IpAddresses": [
+      {
+        "Ip": "10.0.0.237",
+        "SubnetId": "subnet-0d2ab6b3829cfbbff"
+      },
+      {
+        "Ip": "10.0.1.137",
+        "SubnetId": "subnet-0cab1eec8a90aea6f"
+      }
+    ],
+    "IpAddressCount": "2",
+    "TargetNameServerMetricsEnabled": false,
+    "RniEnhancedMetricsEnabled": false,
+    "Ipv6InternetAccessEnabled": false,
+    "Arn": "arn:aws:route53resolver:us-east-1:111111111111:resolver-endpoint/rslvr-out-7345f2fdbd754018b",
+    "HostVPCId": "vpc-0402a4de33684ab27",
+    "Tags": [
+      {
+        "Value": "cdkrd-hunt-outbound",
+        "Key": "Name"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "HostVPCId", "IpAddressCount", "ResolverEndpointId"],
+    "writeOnly": [],
+    "createOnly": ["Direction", "OutpostArn", "PreferredInstanceType", "SecurityGroupIds"],
+    "readOnlyPaths": ["Arn", "HostVPCId", "IpAddressCount", "ResolverEndpointId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Direction", "OutpostArn", "PreferredInstanceType", "SecurityGroupIds"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["Protocols", "SecurityGroupIds"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53Resolver__ResolverRule.HuntForwardRule.json
+++ b/tests/corpus/AWS__Route53Resolver__ResolverRule.HuntForwardRule.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntForwardRule",
+    "resourceType": "AWS::Route53Resolver::ResolverRule",
+    "physicalId": "rslvr-rr-e8113ee708c4927a7",
+    "constructPath": "CdkRealDriftIntegResolverRich/HuntForwardRule",
+    "declared": {
+      "DomainName": "cdkrd-hunt.internal",
+      "Name": "cdkrd-hunt-forward",
+      "ResolverEndpointId": "rslvr-out-7345f2fdbd754018b",
+      "RuleType": "FORWARD",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "cdkrd-hunt-forward"
+        }
+      ],
+      "TargetIps": [
+        {
+          "Ip": "10.0.0.54",
+          "Port": "53"
+        },
+        {
+          "Ip": "10.0.0.53",
+          "Port": "53"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ResolverEndpointId": "rslvr-out-7345f2fdbd754018b",
+    "DomainName": "cdkrd-hunt.internal.",
+    "RuleType": "FORWARD",
+    "ResolverRuleId": "rslvr-rr-e8113ee708c4927a7",
+    "Arn": "arn:aws:route53resolver:us-east-1:111111111111:resolver-rule/rslvr-rr-e8113ee708c4927a7",
+    "Tags": [
+      {
+        "Value": "cdkrd-hunt-forward",
+        "Key": "Name"
+      }
+    ],
+    "TargetIps": [
+      {
+        "Ip": "10.0.0.54",
+        "Port": "53",
+        "Protocol": "Do53"
+      },
+      {
+        "Ip": "10.0.0.53",
+        "Port": "53",
+        "Protocol": "Do53"
+      }
+    ],
+    "Name": "cdkrd-hunt-forward"
+  },
+  "schema": {
+    "readOnly": ["Arn", "ResolverRuleId"],
+    "writeOnly": [],
+    "createOnly": ["RuleType"],
+    "readOnlyPaths": ["Arn", "ResolverRuleId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RuleType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Route53Resolver__ResolverRuleAssociation.HuntRuleAssoc.json
+++ b/tests/corpus/AWS__Route53Resolver__ResolverRuleAssociation.HuntRuleAssoc.json
@@ -1,0 +1,39 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntRuleAssoc",
+    "resourceType": "AWS::Route53Resolver::ResolverRuleAssociation",
+    "physicalId": "rslvr-rrassoc-1eb3a8faa53c4a54a",
+    "constructPath": "CdkRealDriftIntegResolverRich/HuntRuleAssoc",
+    "declared": {
+      "Name": "cdkrd-hunt-assoc",
+      "ResolverRuleId": "rslvr-rr-e8113ee708c4927a7",
+      "VPCId": "vpc-0402a4de33684ab27"
+    }
+  },
+  "liveRaw": {
+    "VPCId": "vpc-0402a4de33684ab27",
+    "ResolverRuleId": "rslvr-rr-e8113ee708c4927a7",
+    "ResolverRuleAssociationId": "rslvr-rrassoc-1eb3a8faa53c4a54a",
+    "Name": "cdkrd-hunt-assoc"
+  },
+  "schema": {
+    "readOnly": ["ResolverRuleAssociationId"],
+    "writeOnly": [],
+    "createOnly": ["Name", "ResolverRuleId", "VPCId"],
+    "readOnlyPaths": ["ResolverRuleAssociationId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name", "ResolverRuleId", "VPCId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/aps-rich/app.ts
+++ b/tests/integration/aps-rich/app.ts
@@ -1,0 +1,69 @@
+// CDK app for the cdk-real-drift aps-rich false-positive integration test.
+// Amazon Managed Service for Prometheus (zero corpus coverage; free while idle):
+// - AWS::APS::Workspace with Alias, AlertManagerDefinition (a YAML STRING blob —
+//   the object<->string / reformat normalization FP class) and a vended-logs
+//   LoggingConfiguration.
+// - AWS::APS::RuleGroupsNamespace whose Data is a Prometheus rules YAML STRING.
+// A clean `record`->`check` is the FP oracle; verify-detect.sh mutates the
+// mutable Workspace Alias out of band for the FN half.
+import { App, CfnOutput, Stack } from "aws-cdk-lib";
+import { CfnRuleGroupsNamespace, CfnWorkspace } from "aws-cdk-lib/aws-aps";
+import { LogGroup, RetentionDays } from "aws-cdk-lib/aws-logs";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegApsRich");
+
+const alertTopic = new Topic(stack, "HuntAlertTopic", {
+  topicName: "cdkrd-hunt-aps-alerts",
+});
+
+const logGroup = new LogGroup(stack, "HuntApsLogs", {
+  logGroupName: "/aws/vendedlogs/prometheus/cdkrd-hunt",
+  retention: RetentionDays.ONE_DAY,
+});
+
+const alertManagerDefinition = [
+  "alertmanager_config: |",
+  "  route:",
+  "    receiver: 'default'",
+  "  receivers:",
+  "    - name: 'default'",
+  "      sns_configs:",
+  `        - topic_arn: '${alertTopic.topicArn}'`,
+  "          sigv4:",
+  `            region: '${stack.region}'`,
+  "          message: '{{ .CommonAnnotations.summary }}'",
+  "",
+].join("\n");
+
+const workspace = new CfnWorkspace(stack, "HuntWorkspace", {
+  alias: "cdkrd-hunt-aps",
+  alertManagerDefinition,
+  loggingConfiguration: { logGroupArn: logGroup.logGroupArn },
+  tags: [{ key: "Name", value: "cdkrd-hunt-aps" }],
+});
+
+new CfnRuleGroupsNamespace(stack, "HuntRules", {
+  workspace: workspace.attrArn,
+  name: "cdkrd-hunt-rules",
+  data: [
+    "groups:",
+    "  - name: cdkrd-hunt",
+    "    rules:",
+    "      - record: job:up:sum",
+    "        expr: sum(up) by (job)",
+    "      - alert: CdkrdHuntDown",
+    "        expr: up == 0",
+    "        for: 5m",
+    "        labels:",
+    "          severity: page",
+    "        annotations:",
+    "          summary: target down",
+    "",
+  ].join("\n"),
+});
+
+new CfnOutput(stack, "WorkspaceId", { value: workspace.attrWorkspaceId });
+
+app.synth();

--- a/tests/integration/aps-rich/cdk.json
+++ b/tests/integration/aps-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/aps-rich/package.json
+++ b/tests/integration/aps-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-aps-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift aps-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/aps-rich/verify-detect.sh
+++ b/tests/integration/aps-rich/verify-detect.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Missed-detection (FN) integration test (real AWS): with the aps-rich stack
+# DEPLOYED and RECORDED (run by verify.sh first, or standalone), mutate the
+# mutable APS Workspace Alias out of band -> `check --fail` MUST detect (exit 1)
+# -> `revert --yes` MUST restore the declared alias -> `check --fail` MUST be
+# CLEAN again. Run while the stack is still up; does NOT deploy or clean up.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+fail() { echo "INTEG FAIL ($STACK detect): $*"; exit 1; }
+
+WS_ID=$(aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='WorkspaceId'].OutputValue" --output text)
+[ -n "$WS_ID" ] || fail "could not resolve WorkspaceId output"
+
+echo "=== [$STACK] mutate Workspace Alias out of band (workspace $WS_ID) ==="
+aws amp update-workspace-alias --workspace-id "$WS_ID" --alias "cdkrd-hunt-aps-DRIFTED" --region "$REGION" || fail "mutate alias"
+
+echo "=== [$STACK] check MUST detect the alias drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift detection (exit 1), got $rc"
+grep -q "Alias" "/tmp/cdkrd-$STACK-detect.out" || fail "drift output does not mention Alias"
+
+echo "=== [$STACK] revert MUST restore the declared alias ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+LIVE_ALIAS=$(aws amp describe-workspace --workspace-id "$WS_ID" --region "$REGION" --query 'workspace.alias' --output text)
+[ "$LIVE_ALIAS" = "cdkrd-hunt-aps" ] || fail "live alias not restored (got $LIVE_ALIAS)"
+
+echo "INTEG PASS ($STACK detect)"

--- a/tests/integration/aps-rich/verify.sh
+++ b/tests/integration/aps-rich/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Amazon Managed Prometheus: Workspace (alias + AlertManagerDefinition
+# YAML string blob + vended-logs logging) and RuleGroupsNamespace (rules YAML string);
+# any drift on a clean recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegApsRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/misc0cov2-rich/app.ts
+++ b/tests/integration/misc0cov2-rich/app.ts
@@ -1,0 +1,100 @@
+// CDK app for the cdk-real-drift misc0cov2-rich false-positive integration test.
+// A second grab bag of cheap, fast, zero-coverage common types (all CC-readable,
+// probed via describe-type before deploy):
+// - AWS::EC2::PlacementGroup x2 (spread w/ SpreadLevel + partition w/ count —
+//   enum-cased Strategy is a case-normalization probe)
+// - AWS::ECR::PullThroughCacheRule (AWS derives UpstreamRegistry from the
+//   declared UpstreamRegistryUrl — a derived-undeclared-prop probe)
+// - AWS::Oam::Sink (Policy is a JSON OBJECT prop — object<->string shape probe)
+// - AWS::EC2::IPAM (tier=free so no per-IP billing; AWS fills default scopes /
+//   resource-discovery attrs — undeclared-fill probe)
+// - AWS::EC2::TrafficMirrorFilter + 2 FilterRules (numbered rules, enum-cased
+//   RuleAction/TrafficDirection)
+// A clean `record`->`check` is the FP oracle.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnIPAM,
+  CfnPlacementGroup,
+  CfnTrafficMirrorFilter,
+  CfnTrafficMirrorFilterRule,
+} from "aws-cdk-lib/aws-ec2";
+import { CfnPullThroughCacheRule } from "aws-cdk-lib/aws-ecr";
+import { CfnSink } from "aws-cdk-lib/aws-oam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMisc0Cov2Rich");
+
+new CfnPlacementGroup(stack, "HuntPgSpread", {
+  strategy: "spread",
+  spreadLevel: "rack",
+  tags: [{ key: "Name", value: "cdkrd-hunt-pg-spread" }],
+});
+
+new CfnPlacementGroup(stack, "HuntPgPartition", {
+  strategy: "partition",
+  partitionCount: 3,
+  tags: [{ key: "Name", value: "cdkrd-hunt-pg-partition" }],
+});
+
+new CfnPullThroughCacheRule(stack, "HuntPtcr", {
+  ecrRepositoryPrefix: "cdkrd-hunt-ecrpub",
+  upstreamRegistryUrl: "public.ecr.aws",
+});
+
+new CfnSink(stack, "HuntOamSink", {
+  name: "cdkrd-hunt-sink",
+  policy: {
+    Version: "2012-10-17",
+    Statement: [
+      {
+        Effect: "Allow",
+        Principal: { AWS: stack.account },
+        Resource: "*",
+        Action: ["oam:CreateLink", "oam:UpdateLink"],
+        Condition: {
+          "ForAllValues:StringEquals": {
+            "oam:ResourceTypes": ["AWS::CloudWatch::Metric", "AWS::Logs::LogGroup"],
+          },
+        },
+      },
+    ],
+  },
+  tags: { Name: "cdkrd-hunt-sink" },
+});
+
+new CfnIPAM(stack, "HuntIpam", {
+  description: "cdkrd hunt free-tier IPAM",
+  tier: "free",
+  operatingRegions: [{ regionName: "us-east-1" }],
+  tags: [{ key: "Name", value: "cdkrd-hunt-ipam" }],
+});
+
+const tmFilter = new CfnTrafficMirrorFilter(stack, "HuntTmFilter", {
+  description: "cdkrd hunt traffic mirror filter",
+  tags: [{ key: "Name", value: "cdkrd-hunt-tmf" }],
+});
+
+new CfnTrafficMirrorFilterRule(stack, "HuntTmRuleIn", {
+  trafficMirrorFilterId: tmFilter.ref,
+  trafficDirection: "ingress",
+  ruleNumber: 100,
+  ruleAction: "accept",
+  protocol: 6,
+  sourceCidrBlock: "10.0.0.0/8",
+  destinationCidrBlock: "0.0.0.0/0",
+  sourcePortRange: { fromPort: 1024, toPort: 65535 },
+  destinationPortRange: { fromPort: 443, toPort: 443 },
+  description: "cdkrd hunt ingress rule",
+});
+
+new CfnTrafficMirrorFilterRule(stack, "HuntTmRuleOut", {
+  trafficMirrorFilterId: tmFilter.ref,
+  trafficDirection: "egress",
+  ruleNumber: 200,
+  ruleAction: "reject",
+  sourceCidrBlock: "0.0.0.0/0",
+  destinationCidrBlock: "192.168.0.0/16",
+  description: "cdkrd hunt egress rule",
+});
+
+app.synth();

--- a/tests/integration/misc0cov2-rich/cdk.json
+++ b/tests/integration/misc0cov2-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/misc0cov2-rich/package.json
+++ b/tests/integration/misc0cov2-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-misc0cov2-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift misc0cov2-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/misc0cov2-rich/verify.sh
+++ b/tests/integration/misc0cov2-rich/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Second grab bag of zero-coverage cheap types (EC2 PlacementGroup
+# spread/partition, ECR PullThroughCacheRule, Oam Sink JSON-object policy, EC2
+# free-tier IPAM, TrafficMirrorFilter + rules); any drift on a clean recorded
+# stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegMisc0Cov2Rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/resolver-rich/app.ts
+++ b/tests/integration/resolver-rich/app.ts
@@ -1,0 +1,70 @@
+// CDK app for the cdk-real-drift resolver-rich false-positive integration test.
+// Route53 Resolver hybrid-DNS staple (zero corpus coverage — the corpus only has
+// the Resolver FIREWALL family):
+// - AWS::Route53Resolver::ResolverEndpoint (OUTBOUND, 2 ENIs) — single Do53
+//   protocol (a multi-protocol endpoint rejects rule creation, RSLVR-00726;
+//   Protocols reorder is auto-folded via insertionOrder:false anyway).
+// - AWS::Route53Resolver::ResolverRule (FORWARD) — DomainName is declared
+//   WITHOUT a trailing dot (TRAILING_DOT_PATHS only guards HostedZone Name — a
+//   predicted unguarded FP if the live read appends the dot); TargetIps is
+//   declared NON-sorted (.54 before .53) as an object-array reorder probe, with
+//   string ports.
+// - AWS::Route53Resolver::ResolverRuleAssociation.
+// A clean `record`->`check` is the FP oracle; verify-detect.sh mutates the
+// mutable ResolverRule TargetIps out of band for the FN half.
+import { App, CfnOutput, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  CfnResolverEndpoint,
+  CfnResolverRule,
+  CfnResolverRuleAssociation,
+} from "aws-cdk-lib/aws-route53resolver";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegResolverRich");
+
+const vpc = new Vpc(stack, "HuntVpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [
+    { name: "isolated", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 },
+  ],
+});
+
+const sg = new SecurityGroup(stack, "HuntResolverSg", {
+  vpc,
+  description: "cdkrd hunt resolver endpoint",
+  allowAllOutbound: true,
+});
+
+const endpoint = new CfnResolverEndpoint(stack, "HuntOutboundEndpoint", {
+  name: "cdkrd-hunt-outbound",
+  direction: "OUTBOUND",
+  securityGroupIds: [sg.securityGroupId],
+  ipAddresses: vpc.isolatedSubnets.map((s) => ({ subnetId: s.subnetId })),
+  protocols: ["Do53"],
+  resolverEndpointType: "IPV4",
+  tags: [{ key: "Name", value: "cdkrd-hunt-outbound" }],
+});
+
+const rule = new CfnResolverRule(stack, "HuntForwardRule", {
+  name: "cdkrd-hunt-forward",
+  ruleType: "FORWARD",
+  domainName: "cdkrd-hunt.internal",
+  resolverEndpointId: endpoint.attrResolverEndpointId,
+  targetIps: [
+    { ip: "10.0.0.54", port: "53" },
+    { ip: "10.0.0.53", port: "53" },
+  ],
+  tags: [{ key: "Name", value: "cdkrd-hunt-forward" }],
+});
+
+new CfnResolverRuleAssociation(stack, "HuntRuleAssoc", {
+  name: "cdkrd-hunt-assoc",
+  resolverRuleId: rule.attrResolverRuleId,
+  vpcId: vpc.vpcId,
+});
+
+new CfnOutput(stack, "ResolverRuleId", { value: rule.attrResolverRuleId });
+
+app.synth();

--- a/tests/integration/resolver-rich/cdk.json
+++ b/tests/integration/resolver-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/resolver-rich/package.json
+++ b/tests/integration/resolver-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-resolver-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift resolver-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/resolver-rich/verify-detect.sh
+++ b/tests/integration/resolver-rich/verify-detect.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Missed-detection (FN) integration test (real AWS): with the resolver-rich stack
+# DEPLOYED and RECORDED (run by verify.sh first, or standalone), mutate the
+# mutable ResolverRule TargetIps out of band -> `check --fail` MUST detect
+# (exit 1) -> `revert --yes` MUST restore the declared targets -> `check --fail`
+# MUST be CLEAN again. Run while the stack is still up; does NOT deploy or
+# clean up.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegResolverRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+fail() { echo "INTEG FAIL ($STACK detect): $*"; exit 1; }
+
+RULE_ID=$(aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
+  --query "Stacks[0].Outputs[?OutputKey=='ResolverRuleId'].OutputValue" --output text)
+[ -n "$RULE_ID" ] || fail "could not resolve ResolverRuleId output"
+
+echo "=== [$STACK] mutate ResolverRule TargetIps out of band (rule $RULE_ID) ==="
+aws route53resolver update-resolver-rule --resolver-rule-id "$RULE_ID" --region "$REGION" \
+  --config 'TargetIps=[{Ip=10.9.9.9,Port=53}]' >/dev/null || fail "mutate TargetIps"
+
+# Resolver rule updates are ASYNC (status UPDATING) — a revert issued mid-update
+# is rejected with RSLVR-00705. Wait for the rule to settle before checking.
+for _ in $(seq 1 30); do
+  ST=$(aws route53resolver get-resolver-rule --resolver-rule-id "$RULE_ID" --region "$REGION" \
+    --query 'ResolverRule.Status' --output text)
+  [ "$ST" = "COMPLETE" ] && break
+  sleep 5
+done
+[ "$ST" = "COMPLETE" ] || fail "rule did not settle after mutation (status $ST)"
+
+echo "=== [$STACK] check MUST detect the TargetIps drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift detection (exit 1), got $rc"
+grep -q "TargetIps" "/tmp/cdkrd-$STACK-detect.out" || fail "drift output does not mention TargetIps"
+
+echo "=== [$STACK] revert MUST restore the declared TargetIps ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+LIVE_IPS=$(aws route53resolver get-resolver-rule --resolver-rule-id "$RULE_ID" --region "$REGION" \
+  --query 'ResolverRule.TargetIps[].Ip' --output text | tr '\t' ' ')
+case "$LIVE_IPS" in
+  *10.0.0.53*10.0.0.54*|*10.0.0.54*10.0.0.53*) : ;;
+  *) fail "live TargetIps not restored (got: $LIVE_IPS)" ;;
+esac
+
+echo "INTEG PASS ($STACK detect)"

--- a/tests/integration/resolver-rich/verify.sh
+++ b/tests/integration/resolver-rich/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Route53 Resolver hybrid-DNS staple: OUTBOUND ResolverEndpoint
+# (non-sorted Protocols), FORWARD ResolverRule (no-trailing-dot DomainName,
+# non-sorted TargetIps) and a ResolverRuleAssociation; any drift on a clean
+# recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegResolverRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -618,6 +618,16 @@ describe('noise suppressors', () => {
       'disable'
     );
     expect(KNOWN_DEFAULTS['AWS::EC2::FlowLog'].MaxAggregationInterval).toBe(600);
+    expect(KNOWN_DEFAULTS['AWS::EC2::PlacementGroup']).toEqual({ SpreadLevel: 'rack' });
+    expect(KNOWN_DEFAULTS['AWS::EC2::IPAM']).toEqual({ MeteredAccount: 'ipam-owner' });
+    expect(KNOWN_DEFAULTS['AWS::APS::Workspace']).toEqual({
+      WorkspaceConfiguration: {
+        RuleQueryOffsetInSeconds: 60,
+        RetentionPeriodInDays: 150,
+        OutOfOrderTimeWindowInSeconds: 60,
+        LimitsPerLabelSets: [],
+      },
+    });
     expect(KNOWN_DEFAULTS['AWS::Pipes::Pipe'].DesiredState).toBe('RUNNING');
     expect(KNOWN_DEFAULTS['AWS::Synthetics::Canary']).toEqual({
       FailureRetentionPeriod: 31,
@@ -1140,9 +1150,14 @@ describe('isTrailingDotEqual (Route53 HostedZone Name FQDN trailing dot)', () =>
     expect(isTrailingDotEqual('example.com', 'example.org.')).toBe(false);
     expect(isTrailingDotEqual(5 as unknown, 'example.com.')).toBe(false);
   });
-  it('TRAILING_DOT_PATHS gates the rule to HostedZone Name', () => {
+  it('TRAILING_DOT_PATHS gates the rule to the FQDN-normalized name paths', () => {
     expect(TRAILING_DOT_PATHS['AWS::Route53::HostedZone']?.has('Name')).toBe(true);
-    expect(TRAILING_DOT_PATHS['AWS::Route53::RecordSet']).toBeUndefined();
+    expect(TRAILING_DOT_PATHS['AWS::Route53::RecordSet']?.has('Name')).toBe(true);
+    // Live-proven: a FORWARD rule's declared "cdkrd-hunt.internal" reads back
+    // "cdkrd-hunt.internal." — Resolver appends the FQDN dot on read.
+    expect(TRAILING_DOT_PATHS['AWS::Route53Resolver::ResolverRule']?.has('DomainName')).toBe(true);
+    // Unrelated paths on those types stay ungated.
+    expect(TRAILING_DOT_PATHS['AWS::Route53Resolver::ResolverRule']?.has('Name')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Bug-hunt round on zero-coverage common types (3 stacks, us-east-1), deliberately disjoint from the two parallel hunts (#458, #460).

### Real FP (predicted offline from the fold table, confirmed live)
- **AWS::Route53Resolver::ResolverRule `DomainName` trailing dot**: declared `cdkrd-hunt.internal` reads back `cdkrd-hunt.internal.` → false declared drift on a freshly deployed stack. Fix: `TRAILING_DOT_PATHS` entries for ResolverRule `DomainName` and — class closure, same documented Route53 FQDN normalization — RecordSet `Name` (the override reader already dot-aligns; the table entry guards any non-override read path). The promoted corpus case pins the exact trigger (declared dot-less / live dotted / expected clean).

### First-run noise → KNOWN_DEFAULTS
- EC2 PlacementGroup `SpreadLevel: "rack"` (echoed even on partition-strategy groups)
- EC2 IPAM `MeteredAccount: "ipam-owner"`
- APS Workspace `WorkspaceConfiguration` service defaults (150-day retention, 60s offsets)

All three re-verified live: first-run `check` is now CLEAN on these stacks.

### Detection + revert (FN half) — live PASS
- APS Workspace `Alias`: mutate out of band → check exits 1 → revert → CLEAN → live alias restored.
- ResolverRule `TargetIps`: same cycle PASS. Resolver rule updates are ASYNC — `verify-detect.sh` waits for `Status: COMPLETE` after the mutation (a mid-update revert is rejected with RSLVR-00705).

### Rule-outs / notes
- ResolverRule `TargetIps` order preserved on read (no reorder FP).
- APS `AlertManagerDefinition` / RuleGroupsNamespace `Data` YAML string blobs echo verbatim.
- Oam Sink JSON-object `Policy` round-trips clean; TrafficMirror rules clean; PullThroughCacheRule clean.
- A multi-protocol (Do53+DoH) outbound resolver endpoint rejects rule creation (RSLVR-00726) — fixture uses single Do53.
- CC-gap (probed offline, no deploy burned): DLM LifecyclePolicy + CloudWatch AnomalyDetector are NON_PROVISIONABLE / no CC read → `SDK_OVERRIDES` candidates, not hunt targets.

### Assets
- 13 new zero-coverage corpus types: APS Workspace / RuleGroupsNamespace, EC2 IPAM / PlacementGroup ×2 / TrafficMirrorFilter+Rules ×3, ECR PullThroughCacheRule, Oam Sink, Route53Resolver Endpoint / Rule / RuleAssociation.
- 3 integ fixtures: `misc0cov2-rich`, `aps-rich` (+detect), `resolver-rich` (+detect).

## Verification
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run`: 42 files, 1984 tests PASS (post-rebase onto #460).
- corpus-replay covers the 13 new cases; measure-noise sweep run (no new constant candidates beyond the promoted ones).
- Integration fixtures (all 7): basic ×3, iam, lambda, revert, policies — all INTEG PASS.
- All hunt stacks deleted (delstack) + sweep-orphans SWEEP CLEAN + bughunt gate cleared.