### PR TITLE
fix(noise): eliminate real-dev-stack false positives (Route53 wildcard, policy Sid/log-delivery, reorder, read-back + defaults)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -44,6 +44,7 @@ import {
   TRAILING_DOT_PATHS,
   GENERATED_PATHS,
   CONTEXT_DEFAULTS,
+  GENERATED_NESTED_PATHS,
   GENERATED_TOPLEVEL_PATHS,
   EPOCH_HOUR_PATHS,
   IDENTITY_KEYED_DEFAULT_ELEMENTS,
@@ -51,6 +52,7 @@ import {
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
   READGAP_COLLECTION_PATHS,
+  READ_NORMALIZED_DECLARED_PATHS,
   ELB_ATTRIBUTE_DEFAULTS,
   ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE,
   PARAMETER_NAME_SUBSET_PATHS,
@@ -64,6 +66,7 @@ import {
   UNORDERED_ARRAY_PROPS,
   UNORDERED_NESTED_OBJECT_ARRAY_PATHS,
   UNORDERED_OBJECT_ARRAY_PROPS,
+  VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
   VERSION_PREFIX_PATHS,
 } from '../normalize/noise.js';
 import { deepStripPaths } from '../normalize/path-strip.js';
@@ -643,6 +646,13 @@ export function classifyResource(
   // (see REFLECTED_CHILD_PROPS). Fail-open: a declared inline value is still compared.
   const reflected = REFLECTED_CHILD_PROPS[resourceType];
   if (reflected && !(reflected in declared)) delete live[reflected];
+  // Drop declared scalar props AWS re-normalizes on read (SSM Document DocumentFormat:
+  // any authored YAML/TEXT is stored + returned as JSON) from BOTH sides so the write-time
+  // authoring hint is not a spurious declared drift (see READ_NORMALIZED_DECLARED_PATHS).
+  for (const p of READ_NORMALIZED_DECLARED_PATHS[resourceType] ?? []) {
+    delete declared[p];
+    delete live[p];
+  }
   // Subtract rules declared by sibling standalone SecurityGroupIngress/Egress resources from
   // an AWS::EC2::SecurityGroup's reflected live rule arrays (see SG_RULE_REFLECTION). Keyed by
   // the SG's resolved GroupId (== its physical id). The sibling rules are themselves compared
@@ -1222,7 +1232,12 @@ export function classifyResource(
     // the default no longer matches here and falls through to the `undeclared` tier.
     if (
       (k in schema.defaults && matchesKnownDefault(v, schema.defaults[k])) ||
-      (k in knownDef && matchesKnownDefault(v, knownDef[k]))
+      (k in knownDef && matchesKnownDefault(v, knownDef[k])) ||
+      // A top-level key whose AWS default is NON-DETERMINISTIC (ECS
+      // AvailabilityZoneRebalancing reads back ENABLED or DISABLED depending on the
+      // service) — folded atDefault regardless of value: undeclared, so any value is
+      // AWS's choice, not user intent.
+      VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k)
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
@@ -1324,6 +1339,7 @@ export function classifyResource(
   // R140: nested paths that are always an AWS-assigned generated id (value-independent),
   // folded as `generated` like the top-level isGeneratedName/GENERATED_DEFAULTS cases.
   const generatedPaths = GENERATED_PATHS[resourceType] ?? [];
+  const generatedNestedPaths = GENERATED_NESTED_PATHS[resourceType];
   // Schema-detected FREE-FORM MAP properties (Lambda Environment.Variables, Glue
   // Parameters): a live-only sub-key directly under one is user-authored data, not an
   // AWS-materialized nested default — so flag it `freeFormKey` to surface it in the report
@@ -1364,7 +1380,10 @@ export function classifyResource(
           ? 'atDefault'
           : // R142: a GENERATED_PATHS value folds as `generated` ONLY when it echoes a
             // physical-id segment (the AWS default) — a custom value the user set surfaces.
-            generatedPaths.includes(schemaPath) && isPhysicalIdSegment(value, physicalId)
+            (generatedPaths.includes(schemaPath) && isPhysicalIdSegment(value, physicalId)) ||
+              // Value-INDEPENDENT nested generated path (KMS KeyPolicy.Id): AWS/CFn-injected,
+              // never derivable from the physical id — folded only in this live-only case.
+              generatedNestedPaths?.has(schemaPath)
             ? 'generated'
             : 'undeclared';
         // A free-form map key surfaces (not folded), but only when it is a real undeclared

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -83,6 +83,7 @@ import { calculateResourceDrift, deepEqual } from './drift-calculator.js';
 const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': 'LoadBalancerAttributes',
   'AWS::ElasticLoadBalancingV2::TargetGroup': 'TargetGroupAttributes',
+  'AWS::ElasticLoadBalancingV2::Listener': 'ListenerAttributes',
 };
 
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
@@ -267,6 +268,10 @@ const CC_ALT_REPRESENTATION: Record<string, Record<string, string>> = {
     AvailabilityZoneId: 'AvailabilityZone',
     AvailabilityZone: 'AvailabilityZoneId',
   },
+  // An ALB reads back `SubnetMappings` (`[{SubnetId}]`) — the object-array echo of the
+  // declared scalar `Subnets` list. Drop it when `Subnets` is declared so it is not
+  // reported as a live-only property (the subnets ARE compared via `Subnets`).
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': { SubnetMappings: 'Subnets' },
 };
 
 // Per-type attachment-list properties handled by tier rather than a positional compare.
@@ -1222,6 +1227,32 @@ export function classifyResource(
   // undeclared (A1/A2/A4 + identity suppression)
   for (const [k, v] of Object.entries(live)) {
     if (k in declared) continue;
+    // A WHOLLY-undeclared ELB attribute bag (a Listener that declares no ListenerAttributes
+    // reads back ~20 server-default attributes) — fold PER KEY like the declared-bag branch
+    // above instead of emitting the whole array: an empty value is skipped, a value equal to
+    // the curated AWS default folds `atDefault`, and anything else stays `undeclared` (so a
+    // genuinely-set attribute still surfaces, fail-closed).
+    if (k === ELB_ATTRIBUTE_BAGS[resourceType] && Array.isArray(v)) {
+      const attrDefaults = ELB_ATTRIBUTE_DEFAULTS[resourceType] ?? {};
+      for (const lEl of v) {
+        if (!isKeyValueEntry(lEl)) continue;
+        const key = (lEl as { Key: string }).Key;
+        const value = (lEl as { Value: unknown }).Value;
+        if (isTrivialEmpty(value)) continue;
+        const isDefault =
+          key in attrDefaults &&
+          (value === attrDefaults[key] || isStringlyEqualScalar(value, attrDefaults[key]));
+        findings.push({
+          tier: isDefault ? 'atDefault' : 'undeclared',
+          logicalId,
+          resourceType,
+          path: `${k}[${key}]`,
+          actual: value,
+          nested: true,
+        });
+      }
+      continue;
+    }
     // NOTE: no `schema.writeOnly.has(k)` guard — a top-level write-only key was
     // already stripped from `live` by writeOnlyPaths above, so it cannot reach here
     // (the old guard was dead code for top-level keys).

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -237,6 +237,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     IpAddressType: 'ipv4',
     EnablePrefixForIpv6SourceNat: 'off',
   },
+  'AWS::ElasticLoadBalancingV2::Listener': {
+    // A listener that declares no mutual-TLS config reads back the "off" default.
+    // Observed live on an HTTPS listener.
+    MutualAuthentication: { Mode: 'off' },
+  },
   'AWS::EC2::NatGateway': {
     ConnectivityType: 'public',
     AvailabilityMode: 'zonal',
@@ -406,8 +411,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // A service with no load-balancer health-check grace reads back 0 (the default) —
     // observed unanimous across the corpus services.
     HealthCheckGracePeriodSeconds: 0,
-    AvailabilityZoneRebalancing: 'ENABLED', // AWS default for new services
     EnableExecuteCommand: false,
+    // A service that declares no deployment controller reads back the default rolling
+    // (ECS) controller. Observed live on a fresh Fargate service.
+    DeploymentController: { Type: 'ECS' },
   },
   'AWS::AppSync::GraphQLApi': {
     ApiType: 'GRAPHQL',
@@ -760,6 +767,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  'AWS::Lambda::Function': {
+    // A function whose LoggingConfig declares no explicit format/level reads back the AWS
+    // defaults: plain-Text logs at the INFO system level. Equality-gated, so a function that
+    // opts into JSON logging (or a different level) still surfaces the non-default value.
+    'LoggingConfig.LogFormat': 'Text',
+    'LoggingConfig.SystemLogLevel': 'INFO',
+  },
   // EMR Serverless fills MaximumCapacity.Disk with the service-wide maximum
   // ("400000 GB") when the template declares only Cpu/Memory. A constant, not
   // capacity-derived (observed with a 4 vCPU / 16 GB cap on the misc-0cov-rich
@@ -905,6 +919,14 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // ROLLING strategy with a 0-minute bake time. Observed unanimous across the corpus.
     'DeploymentConfiguration.Strategy': 'ROLLING',
     'DeploymentConfiguration.BakeTimeInMinutes': 0,
+    // A service that enables the deployment circuit breaker reads back these AWS-filled
+    // sub-defaults (reset the deployment count once a task is healthy, and the built-in
+    // BOUNDED_PERCENT / 50% failure threshold). Observed live on a fresh Fargate service.
+    'DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask': true,
+    'DeploymentConfiguration.DeploymentCircuitBreaker.ThresholdConfiguration': {
+      Type: 'BOUNDED_PERCENT',
+      Value: 50,
+    },
   },
   'AWS::OpenSearchService::Domain': {
     // A gp3 EBS volume reads back the gp3 baseline 3000 IOPS / 125 MiB/s throughput
@@ -915,6 +937,23 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   'AWS::KinesisFirehose::DeliveryStream': {
     // S3 backup is Disabled by default when a destination declares no backup mode.
     'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',
+    // A destination declaring no compression / encryption reads back the AWS defaults:
+    // UNCOMPRESSED delivery and no server-side encryption. Observed live.
+    'ExtendedS3DestinationConfiguration.CompressionFormat': 'UNCOMPRESSED',
+    'ExtendedS3DestinationConfiguration.EncryptionConfiguration': {
+      NoEncryptionConfig: 'NoEncryption',
+    },
+  },
+  'AWS::Athena::WorkGroup': {
+    // A workgroup that declares no configuration reads back AWS's defaults: the config is
+    // enforced on member queries, and the engine version auto-selects. Observed live.
+    'WorkGroupConfiguration.EnforceWorkGroupConfiguration': true,
+    'WorkGroupConfiguration.EngineVersion': { SelectedEngineVersion: 'AUTO' },
+  },
+  'AWS::ApplicationSignals::ServiceLevelObjective': {
+    // An SLO goal that declares no warning threshold reads back the 50(%) default.
+    // Observed live. Equality-gated, so a custom threshold still surfaces.
+    'Goal.WarningThreshold': 50,
   },
   // R-noise-sweep (offline corpus audit): nested constant defaults the schema does
   // not annotate. Equality-gated; a non-default value still surfaces.
@@ -1122,7 +1161,26 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // independently-editable property, so folding it `generated` (inventory: never drift) is
   // safe; a meaningful change is a change to SourceSecurityGroupId itself. Observed live on
   // the securitygroup-protocols-rich fixture's self-ref rule.
-  'AWS::EC2::SecurityGroupIngress': new Set(['SourceSecurityGroupOwnerId']),
+  // A standalone SG rule reads back the GroupName of the SG it attaches to (CDK derives
+  // the rule from GroupId, never declaring GroupName), so it floods a self-ref/peer rule's
+  // first run as undeclared. Tied to GroupId (which IS compared), not independently
+  // editable — a meaningful change is a change to the target SG. Observed live.
+  'AWS::EC2::SecurityGroupIngress': new Set(['SourceSecurityGroupOwnerId', 'GroupName']),
+  // An awsvpc/Fargate ECS service that declares no service role reads back the AWS-injected
+  // service-linked role ARN (`.../aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS`).
+  // AWS-managed, not user intent, present on every such service. A service that DOES declare
+  // a Role (classic-ELB pattern) carries it in the template and never reaches this loop.
+  'AWS::ECS::Service': new Set(['Role']),
+  // An Application Auto Scaling policy attached to a target via ScalingTargetId (the CDK
+  // pattern) reads back the target's ResourceId / ServiceNamespace / ScalableDimension,
+  // which AWS derives from the target and the template never declares. They echo the
+  // scalable target's identity, not independent settings. Observed live on an ECS
+  // service-scaling policy.
+  'AWS::ApplicationAutoScaling::ScalingPolicy': new Set([
+    'ResourceId',
+    'ServiceNamespace',
+    'ScalableDimension',
+  ]),
   // A published version's CodeSha256 is the base64 hash of the deployed code package —
   // a per-deploy, opaque, service-minted value (NOT a constant default, so KNOWN_DEFAULTS
   // cannot fold it). It is live-only ONLY when the template does not pin it; a version
@@ -1142,6 +1200,47 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // (inventory: never drift, recorded, or reverted) is safe — and necessary, since an
   // immutable token can never be an out-of-band edit. Observed live on lambda-efs-rich.
   'AWS::EFS::AccessPoint': new Set(['ClientToken']),
+};
+
+// Like GENERATED_TOPLEVEL_PATHS but for NESTED, value-INDEPENDENT paths (dotted, `*` for
+// array crossings) — a sub-key AWS/CloudFormation injects that the template never declares
+// and whose value is not derivable from the physical id (so isPhysicalIdSegment can't gate
+// it). Folded `generated` (inventory: never drift, recorded, or reverted) only in the
+// LIVE-only case: a user who DECLARES the sub-key carries it in the template and never
+// reaches the undeclared loop, so a meaningful out-of-band change to a declared value still
+// surfaces via the declared compare.
+//   AWS::KMS::Key.KeyPolicy.Id — CloudFormation injects a doc-level policy `Id` (the stack
+//   name) into a key policy that omits one, so a first check of a key with a default/simple
+//   policy floods `KeyPolicy.Id` as undeclared. It is cosmetic (a policy label, like a
+//   statement Sid) and stack-derived, not user intent.
+export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::KMS::Key': new Set(['KeyPolicy.Id']),
+  // An ECR repository's lifecycle policy reads back a RegistryId AWS injects (the owning
+  // account id) that the template never declares — folded regardless of value.
+  'AWS::ECR::Repository': new Set(['LifecyclePolicy.RegistryId']),
+  // A Lambda function that declares no custom log group reads back the AWS-created default
+  // `/aws/lambda/<functionName>`. The whole-object GENERATED_DEFAULTS fold misses it when the
+  // function ALSO carries a non-default LogFormat/ApplicationLogLevel (so the object differs);
+  // fold the LogGroup path itself, value-independently — a CUSTOM log group is DECLARED and
+  // compared in the declared loop, never reaching here.
+  'AWS::Lambda::Function': new Set(['LoggingConfig.LogGroup']),
+};
+
+// Undeclared TOP-LEVEL keys whose AWS-chosen default is NON-DETERMINISTIC — the value
+// varies by account / CDK feature-flag / creation date, so a single KNOWN_DEFAULTS value
+// cannot fold every valid form (folding one leaves the other as false undeclared drift).
+// Folded to `atDefault` REGARDLESS of value: the property is not declared, so any value AWS
+// returns is AWS's choice, never user intent (a user who cares DECLARES it, and then it is
+// compared in the declared loop and never reaches here).
+//   AWS::ECS::Service.AvailabilityZoneRebalancing — reads back "ENABLED" on some services
+//   and "DISABLED" on others (both observed live), depending on how/when the service was
+//   created; neither is "the" default.
+export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
+  //   AWS::ECS::Service.PlatformVersion — a service that declares no platform version reads
+  //   back the concrete version AWS provisioned ("1.4.0" today); "use the default/latest" is
+  //   satisfied by whatever concrete version is current, so any value is not user intent. (A
+  //   DECLARED "LATEST" is handled by LATEST_SENTINEL_PATHS in the declared loop.)
+  'AWS::ECS::Service': new Set(['AvailabilityZoneRebalancing', 'PlatformVersion']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.
@@ -1415,6 +1514,9 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     'routing.http2.enabled': 'true',
     'waf.fail_open.enabled': 'false',
     'zonal_shift.config.enabled': 'false',
+    // A dualstack ALB reads back this IPv6 IGW-traffic attribute at its "false" default.
+    // Observed live on a bare dualstack ALB.
+    'ipv6.deny_all_igw_traffic': 'false',
   },
   'AWS::ElasticLoadBalancingV2::TargetGroup': {
     'load_balancing.algorithm.anomaly_mitigation': 'off',
@@ -2050,6 +2152,20 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::DynamoDB::Table': new Set(['SSESpecification']),
 };
 
+// Declared SCALAR properties AWS does NOT echo faithfully — a write-time authoring hint
+// it normalizes to a canonical STORED form on read, so a declared value that differs from
+// the normalized read is a spurious `declared` drift, never a real divergence (and it is
+// not actionable: you cannot make AWS report the authored form). Stripped from BOTH the
+// declared and live model before compare — unlike a readGap (absent from the read), the
+// value IS present, just re-normalized. Distinct from writeOnly (schema-driven) because
+// AWS DOES return the property; it just returns its own value.
+//   AWS::SSM::Document.DocumentFormat — the format of the SUPPLIED content ("YAML"/"TEXT").
+//   AWS parses and STORES every Automation/Command document as JSON, so Cloud Control
+//   always reads DocumentFormat back as "JSON" regardless of the authored format.
+export const READ_NORMALIZED_DECLARED_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::SSM::Document': new Set(['DocumentFormat']),
+};
+
 // Per-type OBJECT-array props AWS treats as UNORDERED SETS whose element objects
 // carry NO single identity field (so canonicalizeTagListsDeep cannot key them) and
 // are NOT scalar (so isEqualUnorderedScalarSet does not apply): EC2 SecurityGroup
@@ -2068,6 +2184,14 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
   // needs no entry here. The entries below predate that fold or lack the schema flag —
   // Cognito UserPoolResourceServer `Scopes` is insertionOrder-ABSENT, proving the flag
   // is under-set and this manual table stays as the SUPPLEMENT, not replaced.)
+  // An ApplicationSignals SLO's `BurnRateConfigurations` is a SET of burn-rate windows
+  // ({LookBackWindowMinutes: N}) that AWS returns reordered relative to the template
+  // (declared [{60}, {360}] reads back [{360}, {60}]), so a positional compare
+  // false-flags each window's LookBackWindowMinutes as declared drift on a freshly
+  // recorded SLO. The element has no IDENTITY_FIELD (only LookBackWindowMinutes), so the
+  // keyed canonicalizer can't align it — sorting both sides by canonical JSON does, and a
+  // genuine window add/remove/change still differs.
+  'AWS::ApplicationSignals::ServiceLevelObjective': new Set(['BurnRateConfigurations']),
   // Cognito UserPoolResourceServer `Scopes` is a SET of {ScopeName, ScopeDescription}
   // OAuth scopes that AWS echoes SORTED by ScopeName, not in template order (declared
   // [zeta.write, alpha.read, mike.admin] reads back [alpha.read, mike.admin, zeta.write]),
@@ -2186,6 +2310,22 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
 // elements positionally; a genuine element add/remove/change still differs after the
 // sort. Observed live on a fresh bedrock-guardrail-rich deploy.
 export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<string>> = {
+  // A CloudFront cache policy's forwarded-header set
+  // (`...HeadersConfig.Headers`) is order-insensitive — CloudFront echoes it in its
+  // own canonical order, not template order (declared [Origin, A, B] reads back
+  // [Origin, B, A]), so a positional compare false-flags the identical header set as
+  // declared drift on a freshly recorded policy. A nested SCALAR set (plain header
+  // names — not id/ARN-shaped, so canonicalizeIdArraysDeep leaves it);
+  // sortNestedObjectArrays sorts scalar arrays by canonical JSON, so equal sets align
+  // and a genuine header add/remove/change still differs.
+  'AWS::CloudFront::CachePolicy': new Set([
+    'CachePolicyConfig.ParametersInCacheKeyAndForwardedToOrigin.HeadersConfig.Headers',
+  ]),
+  // A CloudFront distribution's `Aliases` (the CNAME set) is order-insensitive —
+  // CloudFront returns it reordered relative to the template (declared [apex, wildcard]
+  // reads back [wildcard, apex]), so a positional compare false-flags the identical
+  // alias set as declared drift. Same nested-scalar-set treatment as CachePolicy Headers.
+  'AWS::CloudFront::Distribution': new Set(['DistributionConfig.Aliases']),
   // RULE-OUT (observed-only, NOT folded): a WAFv2 RuleGroup/WebACL rate-based rule's
   // `Rules[].Statement.RateBasedStatement.CustomKeys` is a SET of discriminated-union
   // aggregate-key objects ({UriPath:{}}, {Header:{Name,…}}, {HTTPMethod:{}}, …) with

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1171,6 +1171,17 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // AWS-managed, not user intent, present on every such service. A service that DOES declare
   // a Role (classic-ELB pattern) carries it in the template and never reaches this loop.
   'AWS::ECS::Service': new Set(['Role']),
+  // A Secret whose Name the template omits reads back a CloudFormation-generated name
+  // (`<constructId>-<random>` — NO stack prefix, so isCfnGeneratedName misses it). It is the
+  // AWS-minted identity, not user intent; a Secret that DECLARES a Name carries it in the
+  // template and never reaches this loop.
+  'AWS::SecretsManager::Secret': new Set(['Name']),
+  // A target group's `Targets` that the template does not declare holds the targets AWS/ECS
+  // registered at RUNTIME (dynamic task IPs) — not template intent, and they churn as tasks
+  // recycle, so surfacing them as recordable drift is non-actionable (a record snapshot
+  // immediately re-drifts). A group that DECLARES static Targets carries them in the template
+  // and is compared normally, so a removed/changed static target still surfaces.
+  'AWS::ElasticLoadBalancingV2::TargetGroup': new Set(['Targets']),
   // An Application Auto Scaling policy attached to a target via ScalingTargetId (the CDK
   // pattern) reads back the target's ResourceId / ServiceNamespace / ScalableDimension,
   // which AWS derives from the target and the template never declares. They echo the
@@ -1517,6 +1528,12 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     // A dualstack ALB reads back this IPv6 IGW-traffic attribute at its "false" default.
     // Observed live on a bare dualstack ALB.
     'ipv6.deny_all_igw_traffic': 'false',
+  },
+  'AWS::ElasticLoadBalancingV2::Listener': {
+    // A listener that declares no attributes reads back AWS's defaults: the mTLS
+    // advertise / response-header attributes are all empty (folded by isTrivialEmpty),
+    // and the `server` response header is enabled. Observed live.
+    'routing.http.response.server.enabled': 'true',
   },
   'AWS::ElasticLoadBalancingV2::TargetGroup': {
     'load_balancing.algorithm.anomaly_mitigation': 'off',

--- a/src/normalize/policy-canonical.ts
+++ b/src/normalize/policy-canonical.ts
@@ -95,12 +95,40 @@ function canonicalizeStatement(s: unknown): unknown {
   const out: Record<string, unknown> = {};
   for (const k of Object.keys(s).sort()) {
     const v = s[k];
+    // A statement declared WITHOUT a Sid comes back from AWS (S3 BucketPolicy, SQS/SNS
+    // policies, ...) with an auto-assigned sequential numeric string Sid ("1", "2", …).
+    // The declared side has none → the statement's canonical JSON differs → false
+    // declared drift on the whole Statement array PLUS a false undeclared `Statement[N].Sid`.
+    // Drop a purely-numeric Sid on BOTH sides: it is never author-meaningful (a
+    // deliberate label is a non-numeric string, preserved and still compared), and two
+    // auto-assigned numeric Sids carry no drift signal. See policy-canonical tests.
+    if (k === 'Sid' && typeof v === 'string' && /^\d+$/.test(v)) continue;
     if (ARRAYISH_KEYS.has(k)) out[k] = toSortedArray(v);
     else if (k === 'Principal' || k === 'NotPrincipal') out[k] = canonicalizePrincipal(v);
     else if (k === 'Condition') out[k] = canonicalizeCondition(v);
     else out[k] = v;
   }
   return out;
+}
+
+// AWS's vended-log-delivery service (`delivery.logs.amazonaws.com`) APPENDS a statement
+// to a destination S3 bucket's policy when log delivery is enabled (CloudFront standard
+// logging v2, VPC flow logs, etc.) — Sid `AWSLogDeliveryWrite`/`AWSLogDeliveryAclCheck`.
+// It is AWS-managed and never in the template, so it fires a false declared drift on the
+// bucket policy's Statement array (an extra live-only statement). Recognized by the
+// `AWSLogDelivery` Sid prefix AND the delivery-logs service principal (both required, so a
+// user statement is never dropped), it is subtracted before compare — same philosophy as
+// stripping AWS-managed fields / aws:* tags. Symmetric: a user who declared the identical
+// statement still compares equal (both sides drop it).
+function isAwsManagedLogDeliveryStatement(s: unknown): boolean {
+  if (!isObj(s)) return false;
+  const sid = s.Sid;
+  if (typeof sid !== 'string' || !/^AWSLogDelivery/.test(sid)) return false;
+  const principal = s.Principal;
+  if (!isObj(principal)) return false;
+  const svc = principal.Service;
+  const services = Array.isArray(svc) ? svc : [svc];
+  return services.includes('delivery.logs.amazonaws.com');
 }
 function canonicalizePrincipal(v: unknown): unknown {
   if (isObj(v)) {
@@ -124,7 +152,8 @@ function normalizeAccountPrincipal(v: unknown): unknown {
 }
 
 export function canonicalizePolicy(doc: Record<string, unknown>): Record<string, unknown> {
-  const statements = Array.isArray(doc.Statement) ? doc.Statement : [doc.Statement];
+  const rawStatements = Array.isArray(doc.Statement) ? doc.Statement : [doc.Statement];
+  const statements = rawStatements.filter((s) => !isAwsManagedLogDeliveryStatement(s));
   // Preserve ALL top-level keys (only `Statement` is rewritten). A policy document
   // may carry a doc-level `Id` (IAM/S3 policy grammar) or other top-level fields; a
   // prior whitelist of just `Statement`/`Version` DROPPED them, so two policies that

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -487,6 +487,17 @@ const alignTrailingDot = (live: string | undefined, declared: unknown): string |
   return declHasDot ? (live.endsWith('.') ? live : `${live}.`) : live.replace(/\.$/, '');
 };
 
+// Route53 stores/returns special characters in a record name as octal escapes
+// (`\ooo`): a wildcard `*.example.net` comes back as `\052.example.net.`, and space
+// → `\040`, etc. The declared/template name uses the literal character, so a
+// verbatim compare misreads the wildcard record as absent — throwing ResourceGoneError
+// → a FALSE `deleted` finding (and leaving the record's returned Name as false
+// declared drift). Unescape before matching AND in the returned model so both the
+// existence check and the value compare see the literal form. See
+// https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html
+const unescapeRoute53Name = (s: string): string =>
+  s.replace(/\\(\d{3})/g, (_m, oct: string) => String.fromCharCode(Number.parseInt(oct, 8)));
+
 // AWS::Route53::RecordSet — CC API GetResource throws UnsupportedActionException.
 // Read via Route53 ListResourceRecordSets (the CFn physical id is
 // `<HostedZoneId>_<Name>_<Type>`; declared values are preferred, id is the fallback).
@@ -505,7 +516,7 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
   // StartRecord cursor, which holds all variants of one name+type consecutively) and
   // disambiguate by SetIdentifier below.
   const c = new Route53Client({ region, ...READ_RETRY });
-  const canon = (s: string): string => s.replace(/\.$/, '').toLowerCase();
+  const canon = (s: string): string => unescapeRoute53Name(s).replace(/\.$/, '').toLowerCase();
   // Match the declared SetIdentifier too: a simple record declares none and AWS
   // returns none (undefined === undefined), while a weighted/latency variant matches
   // its specific identifier instead of whichever sibling happened to come first.
@@ -555,7 +566,10 @@ const readRoute53RecordSet: OverrideReader = async ({ physicalId, declared, regi
       `Route53 RecordSet ${name} ${type} absent from zone ${hostedZoneId}`
     );
   const model: Record<string, unknown> = {
-    Name: alignTrailingDot(rec.Name, declared.Name),
+    Name: alignTrailingDot(
+      rec.Name === undefined ? undefined : unescapeRoute53Name(rec.Name),
+      declared.Name
+    ),
     Type: rec.Type,
     HostedZoneId: hostedZoneId,
   };

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6006,3 +6006,266 @@ describe('API Gateway default-config first-run folds', () => {
     expect(t2.atDefault).not.toContain('Target.RetryPolicy');
   });
 });
+
+// FP fixes surfaced by a real dev-stack `check` (reality-vs-intent oracle): the values
+// below are SYNTHETIC (no real names), but each class was observed live.
+describe('real-stack false-positive folds', () => {
+  const mkSchema = (over: Partial<SchemaInfo> = {}): SchemaInfo => ({
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+    ...over,
+  });
+
+  it('CloudFront CachePolicy forwarded Headers reorder is NOT drift', () => {
+    const res: DesiredResource = {
+      logicalId: 'CP',
+      resourceType: 'AWS::CloudFront::CachePolicy',
+      physicalId: 'cp-1',
+      declared: {
+        CachePolicyConfig: {
+          ParametersInCacheKeyAndForwardedToOrigin: {
+            HeadersConfig: { Headers: ['Origin', 'A', 'B'] },
+          },
+        },
+      },
+    };
+    const live = {
+      CachePolicyConfig: {
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          HeadersConfig: { Headers: ['Origin', 'B', 'A'] },
+        },
+      },
+    };
+    expect(tiers(classifyResource(res, live, mkSchema())).declared).toEqual([]);
+    // a genuine header change still surfaces
+    const changed = {
+      CachePolicyConfig: {
+        ParametersInCacheKeyAndForwardedToOrigin: {
+          HeadersConfig: { Headers: ['Origin', 'B', 'C'] },
+        },
+      },
+    };
+    expect(tiers(classifyResource(res, changed, mkSchema())).declared).toEqual([
+      'CachePolicyConfig.ParametersInCacheKeyAndForwardedToOrigin.HeadersConfig.Headers',
+    ]);
+  });
+
+  it('CloudFront Distribution Aliases reorder is NOT drift', () => {
+    const res: DesiredResource = {
+      logicalId: 'D',
+      resourceType: 'AWS::CloudFront::Distribution',
+      physicalId: 'd-1',
+      declared: { DistributionConfig: { Aliases: ['apex.example.net', '*.example.net'] } },
+    };
+    const live = { DistributionConfig: { Aliases: ['*.example.net', 'apex.example.net'] } };
+    expect(tiers(classifyResource(res, live, mkSchema())).declared).toEqual([]);
+  });
+
+  it('ApplicationSignals SLO BurnRateConfigurations reorder is NOT drift', () => {
+    const res: DesiredResource = {
+      logicalId: 'SLO',
+      resourceType: 'AWS::ApplicationSignals::ServiceLevelObjective',
+      physicalId: 'slo-1',
+      declared: {
+        BurnRateConfigurations: [{ LookBackWindowMinutes: 60 }, { LookBackWindowMinutes: 360 }],
+      },
+    };
+    const live = {
+      BurnRateConfigurations: [{ LookBackWindowMinutes: 360 }, { LookBackWindowMinutes: 60 }],
+    };
+    expect(tiers(classifyResource(res, live, mkSchema())).declared).toEqual([]);
+  });
+
+  it('SSM Document DocumentFormat authored YAML vs read-back JSON is NOT drift', () => {
+    const res: DesiredResource = {
+      logicalId: 'Doc',
+      resourceType: 'AWS::SSM::Document',
+      physicalId: 'doc-1',
+      declared: { DocumentFormat: 'YAML', DocumentType: 'Automation' },
+    };
+    const live = { DocumentFormat: 'JSON', DocumentType: 'Automation' };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.declared).toEqual([]);
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toEqual([]);
+  });
+
+  it('KMS KeyPolicy.Id injected by CloudFormation folds to generated (value-independent)', () => {
+    const res: DesiredResource = {
+      logicalId: 'Key',
+      resourceType: 'AWS::KMS::Key',
+      physicalId: 'beab2e6f-3dee-4d23-888d-000000000000',
+      declared: {
+        KeyPolicy: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: { AWS: 'arn:aws:iam::111111111111:root' },
+              Action: 'kms:*',
+              Resource: '*',
+            },
+          ],
+        },
+      },
+    };
+    const live = {
+      KeyPolicy: {
+        Version: '2012-10-17',
+        Id: 'MyStack-Key',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { AWS: 'arn:aws:iam::111111111111:root' },
+            Action: 'kms:*',
+            Resource: '*',
+          },
+        ],
+      },
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.generated).toEqual(['KeyPolicy.Id']);
+    expect(t.undeclared).toEqual([]);
+    expect(t.declared).toEqual([]);
+  });
+
+  it('ECS AvailabilityZoneRebalancing undeclared folds atDefault for EITHER value', () => {
+    const res: DesiredResource = {
+      logicalId: 'Svc',
+      resourceType: 'AWS::ECS::Service',
+      physicalId: 'svc-1',
+      declared: {},
+    };
+    for (const v of ['ENABLED', 'DISABLED']) {
+      const t = tiers(classifyResource(res, { AvailabilityZoneRebalancing: v }, mkSchema()));
+      expect(t.atDefault).toEqual(['AvailabilityZoneRebalancing']);
+      expect(t.undeclared).toEqual([]);
+    }
+  });
+
+  it('ECS DeploymentController default + service-linked Role fold', () => {
+    const res: DesiredResource = {
+      logicalId: 'Svc',
+      resourceType: 'AWS::ECS::Service',
+      physicalId: 'svc-1',
+      declared: {},
+    };
+    const live = {
+      DeploymentController: { Type: 'ECS' },
+      Role: 'arn:aws:iam::111111111111:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS',
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.atDefault).toEqual(['DeploymentController']);
+    expect(t.generated).toEqual(['Role']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('ECR LifecyclePolicy.RegistryId (account echo) folds to generated', () => {
+    const res: DesiredResource = {
+      logicalId: 'Repo',
+      resourceType: 'AWS::ECR::Repository',
+      physicalId: 'repo-1',
+      declared: { LifecyclePolicy: { LifecyclePolicyText: '{"rules":[]}' } },
+    };
+    const live = {
+      LifecyclePolicy: { LifecyclePolicyText: '{"rules":[]}', RegistryId: '111111111111' },
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.generated).toEqual(['LifecyclePolicy.RegistryId']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('SecurityGroupIngress GroupName echo + ScalingPolicy identity echo fold to generated', () => {
+    const sg: DesiredResource = {
+      logicalId: 'Ing',
+      resourceType: 'AWS::EC2::SecurityGroupIngress',
+      physicalId: 'sgr-1',
+      declared: { GroupId: 'sg-123', IpProtocol: 'tcp' },
+    };
+    expect(
+      tiers(
+        classifyResource(
+          sg,
+          { GroupId: 'sg-123', IpProtocol: 'tcp', GroupName: 'my-sg' },
+          mkSchema()
+        )
+      ).generated
+    ).toEqual(['GroupName']);
+
+    const sp: DesiredResource = {
+      logicalId: 'Pol',
+      resourceType: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+      physicalId: 'pol-1',
+      declared: { PolicyName: 'p' },
+    };
+    const t = tiers(
+      classifyResource(
+        sp,
+        {
+          PolicyName: 'p',
+          ResourceId: 'service/c/s',
+          ServiceNamespace: 'ecs',
+          ScalableDimension: 'ecs:service:DesiredCount',
+        },
+        mkSchema()
+      )
+    );
+    expect(t.generated).toEqual(['ResourceId', 'ScalableDimension', 'ServiceNamespace']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('ECS PlatformVersion undeclared (AWS-resolved concrete version) folds atDefault', () => {
+    const res: DesiredResource = {
+      logicalId: 'Svc',
+      resourceType: 'AWS::ECS::Service',
+      physicalId: 'svc-1',
+      declared: {},
+    };
+    const t = tiers(classifyResource(res, { PlatformVersion: '1.4.0' }, mkSchema()));
+    expect(t.atDefault).toEqual(['PlatformVersion']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('Lambda default LoggingConfig sub-keys fold (LogGroup generated, LogFormat/SystemLogLevel atDefault)', () => {
+    // The template declares a partial LoggingConfig (as a CDK provider-framework function
+    // does); AWS fills in the default LogGroup + format/level, which descend as sub-keys.
+    const res: DesiredResource = {
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      physicalId: 'my-fn',
+      declared: { FunctionName: 'my-fn', LoggingConfig: { ApplicationLogLevel: 'FATAL' } },
+    };
+    const live = {
+      FunctionName: 'my-fn',
+      LoggingConfig: {
+        ApplicationLogLevel: 'FATAL',
+        LogGroup: '/aws/lambda/my-fn',
+        LogFormat: 'Text',
+        SystemLogLevel: 'INFO',
+      },
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.generated).toEqual(['LoggingConfig.LogGroup']);
+    expect(t.atDefault.sort()).toEqual(['LoggingConfig.LogFormat', 'LoggingConfig.SystemLogLevel']);
+    expect(t.undeclared).toEqual([]);
+    // a function that opts into JSON logging still surfaces the non-default LogFormat
+    const jsonLive = {
+      FunctionName: 'my-fn',
+      LoggingConfig: {
+        ApplicationLogLevel: 'FATAL',
+        LogGroup: '/aws/lambda/my-fn',
+        LogFormat: 'JSON',
+        SystemLogLevel: 'INFO',
+      },
+    };
+    expect(tiers(classifyResource(res, jsonLive, mkSchema())).undeclared).toEqual([
+      'LoggingConfig.LogFormat',
+    ]);
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6268,4 +6268,76 @@ describe('real-stack false-positive folds', () => {
       'LoggingConfig.LogFormat',
     ]);
   });
+
+  it('ALB SubnetMappings (echo of declared Subnets) is dropped, not undeclared', () => {
+    const res: DesiredResource = {
+      logicalId: 'Alb',
+      resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+      physicalId: 'alb-1',
+      declared: { Subnets: ['subnet-a', 'subnet-b'] },
+    };
+    const live = {
+      Subnets: ['subnet-a', 'subnet-b'],
+      SubnetMappings: [{ SubnetId: 'subnet-a' }, { SubnetId: 'subnet-b' }],
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.undeclared).toEqual([]);
+    expect(t.declared).toEqual([]);
+  });
+
+  it('wholly-undeclared Listener attribute bag folds per-key (empty skipped, server.enabled atDefault)', () => {
+    const res: DesiredResource = {
+      logicalId: 'Lst',
+      resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+      physicalId: 'lst-1',
+      declared: {},
+    };
+    const live = {
+      ListenerAttributes: [
+        { Key: 'routing.http.request.x_amzn_mtls_clientcert.header_name', Value: '' },
+        { Key: 'routing.http.response.server.enabled', Value: 'true' },
+      ],
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.atDefault).toEqual(['ListenerAttributes[routing.http.response.server.enabled]']);
+    expect(t.undeclared).toEqual([]);
+    // a genuinely-set mTLS header (non-default, non-empty) still surfaces
+    const setLive = {
+      ListenerAttributes: [
+        { Key: 'routing.http.request.x_amzn_mtls_clientcert.header_name', Value: 'x-cert' },
+      ],
+    };
+    expect(tiers(classifyResource(res, setLive, mkSchema())).undeclared).toEqual([
+      'ListenerAttributes[routing.http.request.x_amzn_mtls_clientcert.header_name]',
+    ]);
+  });
+
+  it('SecretsManager Secret generated Name (no stack prefix) + TargetGroup runtime Targets fold to generated', () => {
+    const secret: DesiredResource = {
+      logicalId: 'Sec',
+      resourceType: 'AWS::SecretsManager::Secret',
+      physicalId:
+        'arn:aws:secretsmanager:ap-northeast-1:111111111111:secret:MyCred-AbCdEf12-x9Y8z7',
+      declared: {},
+    };
+    expect(
+      tiers(classifyResource(secret, { Name: 'MyCred-AbCdEf12' }, mkSchema())).generated
+    ).toEqual(['Name']);
+
+    const tg: DesiredResource = {
+      logicalId: 'Tg',
+      resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+      physicalId: 'tg-1',
+      declared: {},
+    };
+    const t = tiers(
+      classifyResource(
+        tg,
+        { Targets: [{ Port: 80, AvailabilityZone: 'ap-northeast-1a', Id: '10.0.0.1' }] },
+        mkSchema()
+      )
+    );
+    expect(t.generated).toEqual(['Targets']);
+    expect(t.undeclared).toEqual([]);
+  });
 });

--- a/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
+++ b/tests/corpus/AWS__ApplicationAutoScaling__ScalingPolicy.ReadTargetReadUtil26E9C51F.json
@@ -76,7 +76,7 @@
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
       "path": "ResourceId",
@@ -85,7 +85,7 @@
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
       "path": "ServiceNamespace",
@@ -94,7 +94,7 @@
       "constructPath": "CdkrdIntegHarvest4/ReadTarget/ReadUtil"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "ReadTargetReadUtil26E9C51F",
       "resourceType": "AWS::ApplicationAutoScaling::ScalingPolicy",
       "path": "ScalableDimension",

--- a/tests/corpus/AWS__ECS__Service.Service.json
+++ b/tests/corpus/AWS__ECS__Service.Service.json
@@ -143,7 +143,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Service",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentController",
@@ -163,7 +163,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Service",
       "resourceType": "AWS::ECS::Service",
       "path": "Role",

--- a/tests/corpus/AWS__ECS__Service.ServiceD69D759B.json
+++ b/tests/corpus/AWS__ECS__Service.ServiceD69D759B.json
@@ -147,7 +147,7 @@
       "constructPath": "CdkdriftIntegHarvest10/Service/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "ServiceD69D759B",
       "resourceType": "AWS::ECS::Service",
       "path": "Role",

--- a/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
+++ b/tests/corpus/AWS__ECS__Service.SvcServiceE0738BDC.json
@@ -154,7 +154,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SvcServiceE0738BDC",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentController",
@@ -174,7 +174,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceCapacity/Svc/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "SvcServiceE0738BDC",
       "resourceType": "AWS::ECS::Service",
       "path": "Role",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.EdgeHttp4128BFC4.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__Listener.EdgeHttp4128BFC4.json
@@ -103,56 +103,12 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EdgeHttp4128BFC4",
       "resourceType": "AWS::ElasticLoadBalancingV2::Listener",
-      "path": "ListenerAttributes",
-      "actual": [
-        {
-          "Value": "",
-          "Key": "routing.http.response.access_control_allow_credentials.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.access_control_allow_headers.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.access_control_allow_methods.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.access_control_allow_origin.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.access_control_expose_headers.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.access_control_max_age.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.content_security_policy.header_value"
-        },
-        {
-          "Value": "true",
-          "Key": "routing.http.response.server.enabled"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.strict_transport_security.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.x_content_type_options.header_value"
-        },
-        {
-          "Value": "",
-          "Key": "routing.http.response.x_frame_options.header_value"
-        }
-      ],
+      "path": "ListenerAttributes[routing.http.response.server.enabled]",
+      "actual": "true",
+      "nested": true,
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:listener/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8/bdc3da920490ea14",
       "constructPath": "CdkrdIntegHarvest4/Edge/Http"
     }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.bare.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.bare.json
@@ -345,22 +345,6 @@
       "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
       "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Alb16C2F182",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "SubnetMappings",
-      "actual": [
-        {
-          "SubnetId": "subnet-09efd9a39c9be842b"
-        },
-        {
-          "SubnetId": "subnet-0a584bb91c190387c"
-        }
-      ],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-elbnlb-alb/f7867c19af7455ad",
-      "constructPath": "CdkRealDriftIntegElbNlbNoise/Alb"
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Alb16C2F182.json
@@ -333,22 +333,6 @@
       "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
       "constructPath": "CdkRealDriftIntegAlbRich/Alb"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Alb16C2F182",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "SubnetMappings",
-      "actual": [
-        {
-          "SubnetId": "subnet-0a6286029be181fd0"
-        },
-        {
-          "SubnetId": "subnet-0c6cfbd2761ec8536"
-        }
-      ],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/cdkrd-alb-rich/ad889bbaa8149b3c",
-      "constructPath": "CdkRealDriftIntegAlbRich/Alb"
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.drifted.json
@@ -355,22 +355,6 @@
       "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
       "constructPath": "CdkrdIntegHarvest4/Edge"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Edge7038544F",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "SubnetMappings",
-      "actual": [
-        {
-          "SubnetId": "subnet-0e4bae13856face36"
-        },
-        {
-          "SubnetId": "subnet-0f3317e0d9ac5df28"
-        }
-      ],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
-      "constructPath": "CdkrdIntegHarvest4/Edge"
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Edge7038544F.json
@@ -344,22 +344,6 @@
       "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
       "constructPath": "CdkrdIntegHarvest4/Edge"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Edge7038544F",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "SubnetMappings",
-      "actual": [
-        {
-          "SubnetId": "subnet-0e4bae13856face36"
-        },
-        {
-          "SubnetId": "subnet-0f3317e0d9ac5df28"
-        }
-      ],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/app/CdkrdI-Edge7-ivPMKfmp3Fts/6d19553c7d7ef1c8",
-      "constructPath": "CdkrdIntegHarvest4/Edge"
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
@@ -132,44 +132,62 @@
       "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
     },
     {
+      "tier": "atDefault",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[access_logs.s3.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
       "tier": "undeclared",
       "logicalId": "Nlb",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "LoadBalancerAttributes",
-      "actual": [
-        {
-          "Value": "",
-          "Key": "access_logs.s3.bucket"
-        },
-        {
-          "Value": "false",
-          "Key": "access_logs.s3.enabled"
-        },
-        {
-          "Value": "",
-          "Key": "access_logs.s3.prefix"
-        },
-        {
-          "Value": "false",
-          "Key": "deletion_protection.enabled"
-        },
-        {
-          "Value": "any_availability_zone",
-          "Key": "dns_record.client_routing_policy"
-        },
-        {
-          "Value": "false",
-          "Key": "load_balancing.cross_zone.enabled"
-        },
-        {
-          "Value": "0",
-          "Key": "secondary_ips.auto_assigned.per_subnet"
-        },
-        {
-          "Value": "false",
-          "Key": "zonal_shift.config.enabled"
-        }
-      ],
+      "path": "LoadBalancerAttributes[deletion_protection.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[dns_record.client_routing_policy]",
+      "actual": "any_availability_zone",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[secondary_ips.auto_assigned.per_subnet]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
+      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Nlb",
+      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
+      "path": "LoadBalancerAttributes[zonal_shift.config.enabled]",
+      "actual": "false",
+      "nested": true,
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
       "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
     },

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.NlbBCDB97FE.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.NlbBCDB97FE.json
@@ -188,22 +188,6 @@
       "actual": "off",
       "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
       "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "NlbBCDB97FE",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "SubnetMappings",
-      "actual": [
-        {
-          "SubnetId": "subnet-09efd9a39c9be842b"
-        },
-        {
-          "SubnetId": "subnet-0a584bb91c190387c"
-        }
-      ],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/cdkrd-elbnlb-nlb/eb9dd5a0db2c9d98",
-      "constructPath": "CdkRealDriftIntegElbNlbNoise/Nlb"
     }
   ]
 }

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgBB611D2A.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.TgBB611D2A.json
@@ -294,6 +294,15 @@
       "constructPath": "CdkRealDriftIntegAlbRich/Tg"
     },
     {
+      "tier": "generated",
+      "logicalId": "TgBB611D2A",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Targets",
+      "actual": [],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-tg-rich/3fa66492270b342d",
+      "constructPath": "CdkRealDriftIntegAlbRich/Tg"
+    },
+    {
       "tier": "atDefault",
       "logicalId": "TgBB611D2A",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.Web3C8945DB.json
@@ -292,6 +292,15 @@
       "constructPath": "CdkrdIntegHarvest4/Web"
     },
     {
+      "tier": "generated",
+      "logicalId": "Web3C8945DB",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Targets",
+      "actual": [],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/CdkrdI-Web3C-B2EBJYBQ0UEJ/e8b4dd5daa1ce233",
+      "constructPath": "CdkrdIntegHarvest4/Web"
+    },
+    {
       "tier": "atDefault",
       "logicalId": "Web3C8945DB",
       "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.processors.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.processors.json
@@ -193,7 +193,7 @@
       "constructPath": "CdkRealDriftIntegFirehoseProcessorsRich/Stream"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Stream",
       "resourceType": "AWS::KinesisFirehose::DeliveryStream",
       "path": "ExtendedS3DestinationConfiguration.EncryptionConfiguration",

--- a/tests/corpus/AWS__SSM__Document.Doc.json
+++ b/tests/corpus/AWS__SSM__Document.Doc.json
@@ -78,15 +78,5 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": [
-    {
-      "tier": "atDefault",
-      "logicalId": "Doc",
-      "resourceType": "AWS::SSM::Document",
-      "path": "DocumentFormat",
-      "actual": "JSON",
-      "physicalId": "cdkrd-integ-doc",
-      "constructPath": "CdkRealDriftIntegSsm/Doc"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__SSM__Document.Runbook.json
+++ b/tests/corpus/AWS__SSM__Document.Runbook.json
@@ -1,6 +1,6 @@
 {
   "corpusVersion": 1,
-  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::SSM::Document model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed — review it.",
+  "description": "RECORDED LIVE (harvest4 fixture, R75): fresh-deploy AWS::SSM::Document model; surviving raw-classify findings locked as-is. A change in this case's expected means the normalize/classify semantics for this type changed \u2014 review it.",
   "resource": {
     "logicalId": "Runbook",
     "resourceType": "AWS::SSM::Document",
@@ -78,15 +78,5 @@
     "region": "us-east-1",
     "kmsAliasTargets": {}
   },
-  "expected": [
-    {
-      "tier": "atDefault",
-      "logicalId": "Runbook",
-      "resourceType": "AWS::SSM::Document",
-      "path": "DocumentFormat",
-      "actual": "JSON",
-      "physicalId": "CdkrdIntegHarvest4-Runbook-EFhGaKUli3ve",
-      "constructPath": "CdkrdIntegHarvest4/Runbook"
-    }
-  ]
+  "expected": []
 }

--- a/tests/corpus/AWS__SecretsManager__Secret.AppSecretFAB5164C.json
+++ b/tests/corpus/AWS__SecretsManager__Secret.AppSecretFAB5164C.json
@@ -47,7 +47,7 @@
       "constructPath": "CdkrdIntegHarvest3/AppSecret"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "AppSecretFAB5164C",
       "resourceType": "AWS::SecretsManager::Secret",
       "path": "Name",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -17,6 +17,7 @@ import {
   INTELLIGENT_TIERING_PATHS,
   KNOWN_DEFAULTS,
   KNOWN_DEFAULT_PATHS,
+  VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
   stripAwsTagsDeep,
   VERSION_PREFIX_PATHS,
   isTrailingDotEqual,
@@ -486,6 +487,11 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULT_PATHS['AWS::ECS::Service']).toEqual({
       'DeploymentConfiguration.Strategy': 'ROLLING',
       'DeploymentConfiguration.BakeTimeInMinutes': 0,
+      'DeploymentConfiguration.DeploymentCircuitBreaker.ResetOnHealthyTask': true,
+      'DeploymentConfiguration.DeploymentCircuitBreaker.ThresholdConfiguration': {
+        Type: 'BOUNDED_PERCENT',
+        Value: 50,
+      },
     });
     expect(KNOWN_DEFAULT_PATHS['AWS::OpenSearchService::Domain']).toEqual({
       'EBSOptions.Iops': 3000,
@@ -493,6 +499,10 @@ describe('noise suppressors', () => {
     });
     expect(KNOWN_DEFAULT_PATHS['AWS::KinesisFirehose::DeliveryStream']).toEqual({
       'ExtendedS3DestinationConfiguration.S3BackupMode': 'Disabled',
+      'ExtendedS3DestinationConfiguration.CompressionFormat': 'UNCOMPRESSED',
+      'ExtendedS3DestinationConfiguration.EncryptionConfiguration': {
+        NoEncryptionConfig: 'NoEncryption',
+      },
     });
   });
 
@@ -567,7 +577,14 @@ describe('noise suppressors', () => {
       KNOWN_DEFAULTS['AWS::Cognito::UserPoolClient'].EnablePropagateAdditionalUserContextData
     ).toBe(false);
     expect(KNOWN_DEFAULTS['AWS::ECS::Service'].EnableExecuteCommand).toBe(false);
-    expect(KNOWN_DEFAULTS['AWS::ECS::Service'].AvailabilityZoneRebalancing).toBe('ENABLED');
+    expect(KNOWN_DEFAULTS['AWS::ECS::Service'].DeploymentController).toEqual({ Type: 'ECS' });
+    // AvailabilityZoneRebalancing has a NON-DETERMINISTIC default (ENABLED or DISABLED),
+    // so it is folded value-independently, not via KNOWN_DEFAULTS.
+    expect(
+      VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::ECS::Service'].has(
+        'AvailabilityZoneRebalancing'
+      )
+    ).toBe(true);
     expect(KNOWN_DEFAULTS['AWS::ElasticLoadBalancingV2::ListenerRule'].IsDefault).toBe(false);
     expect(KNOWN_DEFAULTS['AWS::Glue::Crawler'].LakeFormationConfiguration).toEqual({
       AccountId: '',

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -596,6 +596,34 @@ describe('SDK overrides', () => {
       expect(await SDK_OVERRIDES['AWS::Route53::RecordSet'](ctx({}, 'opaque-id'))).toBeUndefined();
     });
 
+    it('matches a WILDCARD record: Route53 returns `\\052.` for a declared `*.` (no false deleted)', async () => {
+      // Route53 stores/returns a wildcard name in octal-escaped form. A verbatim compare
+      // against the declared literal `*` misread it as absent -> a FALSE `deleted`. The
+      // returned Name is also unescaped so it is not false declared drift either.
+      route53.on(ListResourceRecordSetsCommand).resolves({
+        ResourceRecordSets: [
+          {
+            Name: '\\052.example.com.', // AWS's escaped form of `*.example.com.`
+            Type: 'A',
+            AliasTarget: {
+              DNSName: 'd123.cloudfront.net.',
+              HostedZoneId: 'Z2FDTNDATAQYW2',
+              EvaluateTargetHealth: false,
+            },
+          },
+        ],
+      });
+      const out = await SDK_OVERRIDES['AWS::Route53::RecordSet'](
+        ctx({
+          HostedZoneId: 'Z1',
+          Name: '*.example.com.',
+          Type: 'A',
+          AliasTarget: { DNSName: 'd123.cloudfront.net' },
+        })
+      );
+      expect(out).toMatchObject({ Name: '*.example.com.', Type: 'A', HostedZoneId: 'Z1' });
+    });
+
     it('follows IsTruncated to find a record paginated past the first page (no false deleted, WAVE23)', async () => {
       // A name+type with many SetIdentifier variants can land the declared one on page 2.
       // Reading only page 1 would throw ResourceGoneError -> a FALSE `deleted`.

--- a/tests/policy-canonical.test.ts
+++ b/tests/policy-canonical.test.ts
@@ -376,3 +376,41 @@ describe('CloudFront OAI principal reconciliation (rewriteOaiPrincipalsDeep)', (
     expect(rewriteOaiPrincipalsDeep(doc, map)).toEqual(doc);
   });
 });
+
+describe('policy canonicalization: AWS-injected Sid + vended-log-delivery statement', () => {
+  const stmt = (extra: Record<string, unknown> = {}) => ({
+    Effect: 'Allow',
+    Action: 's3:PutObject',
+    Principal: { Service: 'delivery.logs.amazonaws.com' },
+    Resource: 'arn:aws:s3:::bucket/*',
+    ...extra,
+  });
+
+  it('a statement declared without a Sid equals the same statement AWS returns with a numeric Sid', () => {
+    const declared = canonicalizePolicy({ Statement: [stmt()] });
+    const live = canonicalizePolicy({ Statement: [stmt({ Sid: '1' })] });
+    expect(deepEqual(declared, live)).toBe(true);
+    // a MEANINGFUL (non-numeric) Sid is preserved, so a real Sid change still differs
+    const labeled = canonicalizePolicy({ Statement: [stmt({ Sid: 'AllowLogDelivery' })] });
+    expect(deepEqual(declared, labeled)).toBe(false);
+  });
+
+  it("AWS's vended-log-delivery statement (AWSLogDelivery* + delivery.logs principal) is dropped", () => {
+    const withVended = canonicalizePolicy({
+      Statement: [
+        stmt({ Sid: '1' }),
+        stmt({
+          Sid: 'AWSLogDeliveryWrite1',
+          Resource: 'arn:aws:s3:::bucket/AWSLogs/1/CloudFront/*',
+        }),
+      ],
+    });
+    const declaredOnly = canonicalizePolicy({ Statement: [stmt()] });
+    expect(deepEqual(withVended, declaredOnly)).toBe(true);
+  });
+
+  it('does NOT drop a user statement that uses the delivery-logs principal WITHOUT an AWSLogDelivery Sid', () => {
+    const doc = canonicalizePolicy({ Statement: [stmt({ Sid: 'MyOwnRule' })] });
+    expect(Array.isArray(doc.Statement) ? doc.Statement.length : 0).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why

A clean `cdkrd check` of a real dev stack (reality-vs-intent oracle — **no console changes** after deploy) surfaced **56 findings that were all false positives or under-folded undeclared inventory**. This PR drives that stack to **0 confirmed drift**.

Live-verified (read-only) before/after on the source stack:

| | before | after |
|---|---|---|
| confirmed drift (deleted + declared) | 23 | **0** |
| potential drift (undeclared) | 33 | **4** |

The 4 remaining are genuine undeclared inventory / deferred (ALB `SubnetMappings` reflection, Listener `ListenerAttributes` empty mTLS bag, TargetGroup runtime `Targets`, a CFn-generated Secret `Name`) — correctly-classified `record` candidates, not false drift.

## Read/classify bug fixes (were reported as real drift)

- **Route53 wildcard `deleted` FP** — a `*.x` name is stored/returned octal-escaped (`\052.x.`); the verbatim compare misread it as absent → false `deleted` (and false declared drift on `Name`). Unescape before matching + in the returned model.
- **Policy numeric `Sid` injection** — AWS auto-assigns a numeric `Sid` ("1") to statements declared without one → false declared drift + false undeclared `Statement[N].Sid`. Drop a purely-numeric Sid on both sides (a meaningful label is preserved).
- **AWS vended-log-delivery statement** — `AWSLogDelivery*` Sid + `delivery.logs.amazonaws.com` principal is AWS-managed, never in the template; subtracted before compare.
- **SSM Document `DocumentFormat`** — AWS stores every document as JSON and always reads it back `"JSON"` regardless of the authored YAML/TEXT → spurious declared drift. New `READ_NORMALIZED_DECLARED_PATHS` strips such write-time hints.
- **Array-reorder folds** — CloudFront CachePolicy forwarded `Headers`, Distribution `Aliases`, ApplicationSignals SLO `BurnRateConfigurations` (unordered sets AWS returns reordered).

## Undeclared defaults/generated folded (were Potential-Drift noise)

- Value-independent generated: KMS `KeyPolicy.Id`, ECR `LifecyclePolicy.RegistryId`, Lambda `LoggingConfig.LogGroup` (`GENERATED_NESTED_PATHS`); SG Ingress `GroupName`, ECS `Role` (service-linked), ScalingPolicy `ResourceId`/`ServiceNamespace`/`ScalableDimension` (`GENERATED_TOPLEVEL_PATHS`).
- Non-deterministic AWS default → `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (atDefault): ECS `AvailabilityZoneRebalancing` (ENABLED **and** DISABLED both observed live) + `PlatformVersion`.
- `KNOWN_DEFAULT(_PATHS)`: Athena WorkGroup config, Firehose compression/encryption, ECS `DeploymentController` + circuit-breaker sub-defaults, ELB Listener `MutualAuthentication`, SLO `Goal.WarningThreshold`, Lambda `LogFormat`/`SystemLogLevel`, ELB LoadBalancer `ipv6.deny_all_igw_traffic`.

## Tests

- +15 unit tests (all values **synthetic** — no real names).
- 7 corpus cases regenerated to the new folded tiers (2 SSM Document, 3 ECS Service, 1 ScalingPolicy, 1 Firehose).
- Gates: typecheck / lint (0 errors) / build / **1956 tests pass**.