### PR TITLE
fix(noise): drop self-identity echo wrappers + context-derived region defaults

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -43,6 +43,7 @@ import {
   LATEST_SENTINEL_PATHS,
   TRAILING_DOT_PATHS,
   GENERATED_PATHS,
+  CONTEXT_DEFAULTS,
   GENERATED_TOPLEVEL_PATHS,
   EPOCH_HOUR_PATHS,
   IDENTITY_KEYED_DEFAULT_ELEMENTS,
@@ -347,6 +348,22 @@ function isCfnGeneratedName(
     logicalPart.length > 0 &&
     logicalId.startsWith(logicalPart)
   );
+}
+
+// A live-only OBJECT that is a SELF-IDENTITY ECHO WRAPPER: some CC read handlers
+// (AWS::Logs::DeliveryDestination's DeliveryDestinationPolicy) return
+// `{ <IdentityField>: <own physical id>, <Payload>: {} }` when the payload was never
+// set — semantically "nothing configured", but the id echo defeats the plain deep
+// trivially-empty drop. Ignore FIRST-LEVEL entries equal to the resource's own
+// physical id (at least one must match, so ordinary objects never take this path),
+// then apply the same deep trivially-empty test. A REAL payload (an actually
+// attached policy) is not trivially empty and still surfaces. Pure.
+function isSelfEchoTrivialEmpty(v: unknown, physicalId: string | undefined): boolean {
+  if (physicalId === undefined || v === null || typeof v !== 'object' || Array.isArray(v))
+    return false;
+  const entries = Object.entries(v as Record<string, unknown>);
+  const rest = entries.filter(([, val]) => val !== physicalId);
+  return rest.length < entries.length && rest.every(([, val]) => isTrivialEmpty(val));
 }
 
 // structuredClone rejects the UNRESOLVED Symbol a declared value may carry, so deep-clone
@@ -1210,6 +1227,19 @@ export function classifyResource(
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
     }
+    // A live value equal to its CONTEXT-DERIVED default — a default whose VALUE is
+    // this resource's own read context (region), which a constant KNOWN_DEFAULTS
+    // entry cannot express (a VPCEndpointService's SupportedRegions defaults to
+    // [own region]). Equality-gated like every default fold; with no resolved
+    // region it falls through to plain `undeclared` (recordable), never a wrong fold.
+    const ctxKind = CONTEXT_DEFAULTS[resourceType]?.[k];
+    if (ctxKind !== undefined && opts.region !== undefined) {
+      const ctxDefault = ctxKind === 'region' ? opts.region : [opts.region];
+      if (deepEqual(v, ctxDefault)) {
+        findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+        continue;
+      }
+    }
     // A live value EQUAL to the AWS/CDK-generated value for this resource (its minted
     // physical name, a default-named log group) is the `generated` tier: folded
     // inventory like atDefault, never drift, never recorded. Equality-gated against
@@ -1269,7 +1299,7 @@ export function classifyResource(
     // and trivially-empty {}/[]. These carry no inventory value, so they are not folded.
     if (isAllAwsTags(v)) continue;
     if (physicalId !== undefined && v === physicalId) continue;
-    if (isTrivialEmpty(v)) continue;
+    if (isTrivialEmpty(v) || isSelfEchoTrivialEmpty(v, physicalId)) continue;
     findings.push({ tier: 'undeclared', logicalId, resourceType, path: k, actual: v });
   }
 

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1087,6 +1087,19 @@ export const GENERATED_PATHS: Record<string, string[]> = {
   'AWS::XRay::SamplingRule': ['SamplingRule.RuleARN'],
 };
 
+// Top-level UNDECLARED keys whose service default VALUE is derived from the READ
+// CONTEXT (the resource's own region), which a constant KNOWN_DEFAULTS entry cannot
+// express. Kinds: 'region' (the scalar region), 'regionList' (a single-element list
+// of the own region). Equality-gated against the resolved context like every default
+// fold — a value that differs (extra regions added out of band) no longer matches
+// and surfaces as real undeclared drift; with NO resolved region the value simply
+// stays `undeclared` (recordable), never a wrong fold. First case (observed live on
+// a fresh iot-vpces-rich deploy, issue #462): a VPC endpoint service that declares
+// no SupportedRegions reads back `[<own region>]`.
+export const CONTEXT_DEFAULTS: Record<string, Record<string, 'region' | 'regionList'>> = {
+  'AWS::EC2::VPCEndpointService': { SupportedRegions: 'regionList' },
+};
+
 // Top-level UNDECLARED keys that are ALWAYS a service-minted, AWS-managed generated
 // id — value-INDEPENDENT (unlike GENERATED_PATHS/isPhysicalIdSegment, the value is an
 // opaque churning id, not derivable from the physical id). An ApiGatewayV2 Stage with

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5507,6 +5507,100 @@ describe('nested removed collection → declared drift (issue #421 TASK 1 regres
   });
 });
 
+describe('issue #462 residual first-run noise folds', () => {
+  const bare462: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  describe('self-identity echo wrapper (DeliveryDestinationPolicy shape)', () => {
+    const dest = (live: Record<string, unknown>) =>
+      classifyResource(
+        {
+          logicalId: 'DeliveryDest',
+          resourceType: 'AWS::Logs::DeliveryDestination',
+          physicalId: 'cdkrd-dest',
+          constructPath: 'Stack/DeliveryDest',
+          declared: {},
+        },
+        live,
+        bare462
+      ).find((f) => f.path === 'DeliveryDestinationPolicy');
+
+    it('an empty-policy wrapper carrying only the self-name echo is dropped (structural noise)', () => {
+      expect(
+        dest({
+          DeliveryDestinationPolicy: {
+            DeliveryDestinationName: 'cdkrd-dest',
+            DeliveryDestinationPolicy: {},
+          },
+        })
+      ).toBeUndefined();
+    });
+
+    it('a REAL attached policy still surfaces (payload is not trivially empty)', () => {
+      expect(
+        dest({
+          DeliveryDestinationPolicy: {
+            DeliveryDestinationName: 'cdkrd-dest',
+            DeliveryDestinationPolicy: {
+              Version: '2012-10-17',
+              Statement: [{ Effect: 'Allow', Principal: '*', Action: 'logs:PutLogEvents' }],
+            },
+          },
+        })?.tier
+      ).toBe('undeclared');
+    });
+
+    it('an echo of a DIFFERENT resource (not the own physical id) still surfaces', () => {
+      expect(
+        dest({
+          DeliveryDestinationPolicy: {
+            DeliveryDestinationName: 'someone-elses-dest',
+            DeliveryDestinationPolicy: {},
+          },
+        })?.tier
+      ).toBe('undeclared');
+    });
+  });
+
+  describe('context-derived defaults (CONTEXT_DEFAULTS)', () => {
+    const vpces = (live: Record<string, unknown>, region?: string) =>
+      classifyResource(
+        {
+          logicalId: 'EndpointService',
+          resourceType: 'AWS::EC2::VPCEndpointService',
+          physicalId: 'vpce-svc-0123456789abcdef0',
+          constructPath: 'Stack/EndpointService',
+          declared: {},
+        },
+        live,
+        bare462,
+        region === undefined ? {} : { region }
+      ).find((f) => f.path === 'SupportedRegions');
+
+    it('SupportedRegions equal to [own region] folds to atDefault', () => {
+      expect(vpces({ SupportedRegions: ['us-east-1'] }, 'us-east-1')?.tier).toBe('atDefault');
+    });
+
+    it('extra regions added out of band no longer match and surface as undeclared', () => {
+      expect(vpces({ SupportedRegions: ['us-east-1', 'eu-west-1'] }, 'us-east-1')?.tier).toBe(
+        'undeclared'
+      );
+    });
+
+    it('with no resolved region the value stays undeclared (never a wrong fold)', () => {
+      expect(vpces({ SupportedRegions: ['us-east-1'] })?.tier).toBe('undeclared');
+    });
+  });
+});
+
 describe('CFn auto-generated name folding (generated tier)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/corpus/AWS__EC2__VPCEndpointService.EndpointService.json
+++ b/tests/corpus/AWS__EC2__VPCEndpointService.EndpointService.json
@@ -44,7 +44,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EndpointService",
       "resourceType": "AWS::EC2::VPCEndpointService",
       "path": "SupportedRegions",

--- a/tests/corpus/AWS__Lambda__EventSourceMapping.Esm.json
+++ b/tests/corpus/AWS__Lambda__EventSourceMapping.Esm.json
@@ -135,17 +135,6 @@
       "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "Esm",
-      "resourceType": "AWS::Lambda::EventSourceMapping",
-      "path": "SelfManagedKafkaEventSourceConfig",
-      "actual": {
-        "ConsumerGroupId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec"
-      },
-      "physicalId": "81c7f62a-08ec-42fe-8709-1690fbcf48ec",
-      "constructPath": "CdkRealDriftIntegEsmSourceaccessRich/Esm"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "Esm",
       "resourceType": "AWS::Lambda::EventSourceMapping",

--- a/tests/corpus/AWS__Logs__DeliveryDestination.DeliveryDest.json
+++ b/tests/corpus/AWS__Logs__DeliveryDestination.DeliveryDest.json
@@ -61,18 +61,6 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
-      "logicalId": "DeliveryDest",
-      "resourceType": "AWS::Logs::DeliveryDestination",
-      "path": "DeliveryDestinationPolicy",
-      "actual": {
-        "DeliveryDestinationName": "cdkrd-hunt-cf-dest",
-        "DeliveryDestinationPolicy": {}
-      },
-      "physicalId": "cdkrd-hunt-cf-dest",
-      "constructPath": "CdkRealDriftIntegCfKvsLogsDel/DeliveryDest"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "DeliveryDest",
       "resourceType": "AWS::Logs::DeliveryDestination",


### PR DESCRIPTION
Closes #462 (items 1 and 3; item 2 is a documented won't-fold — see below).

## 1. Self-identity echo wrapper drop (`isSelfEchoTrivialEmpty`)

Some CC read handlers return `{ <IdentityField>: <own physical id>, <Payload>: {} }` when the payload was never configured — semantically "nothing set", but the id echo defeats the deep trivially-empty drop, so it surfaced as `[Potential Drift]` on every first run. Now: ignore first-level entries equal to the resource's OWN physical id (at least one must match), then apply the same deep trivially-empty test.

- Observed live: `AWS::Logs::DeliveryDestination.DeliveryDestinationPolicy` (every vended-logs-v2 user).
- **Corpus replay proved the class generalizes**: `AWS::Lambda::EventSourceMapping.SelfManagedKafkaEventSourceConfig` (`{ConsumerGroupId: <own ESM UUID>}` — AWS defaults the Kafka consumer group to the ESM's own id) folds by the same rule. Both props are effectively unset defaults; a user-set value lives in the template and never reaches the undeclared loop.
- Guards: a REAL attached policy is not trivially empty → surfaces; an echo of a DIFFERENT resource's id → surfaces.

## 2. `CONTEXT_DEFAULTS` — context-derived service defaults

A default whose VALUE is the resource's own read context can't be expressed by a constant KNOWN_DEFAULTS entry. New small table (kinds `region` / `regionList`), equality-gated against `opts.region`; with no resolved region the value stays `undeclared` (never a wrong fold). First case: `AWS::EC2::VPCEndpointService.SupportedRegions` = `[own region]`.

## 3. NOT folded (deliberate)

`AWS::Logs::LogGroup.ResourcePolicyDocument` auto-attached by a CWL-destination Delivery stays surfaced: per-resource ARNs, security-relevant — record once is the correct treatment.

## Verification

- 6 new unit tests (fail without each fix); 1993 pass total.
- The two motivating corpus cases are REAL live reads harvested in the #458 hunt — regenerated expected shows the transitions (`undeclared` → dropped / `atDefault`), replayed offline by corpus-replay.
- typecheck / lint / build green; markers set.