### PR TITLE
feat(read): SDK_OVERRIDES reader + writer for AWS::CloudWatch::AnomalyDetector

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,10 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   (the SES inbound receipt-rule family — `ReceiptRuleSet` / `ReceiptRule` /
   `ReceiptFilter` — has no Cloud Control handlers),
   `glue:GetTable`, `logs:DescribeMetricFilters`, `scheduler:GetSchedule`,
+  `cloudwatch:DescribeAnomalyDetectors` (reads an `AWS::CloudWatch::AnomalyDetector` —
+  the type is NON_PROVISIONABLE in the registry, so Cloud Control cannot read it;
+  the detector is located from its declared metric/math identity, not the guid
+  physical id),
   `ssm:DescribeParameters` (supplements the Cloud Control read of an
   `AWS::SSM::Parameter` with its writeOnly `Description` / `AllowedPattern`),
   `elasticache:DescribeReplicationGroups` + `elasticache:DescribeCacheClusters`
@@ -530,6 +534,8 @@ is refused, never overwritten, so the un-read credential is never cleared),
 `logs:PutMetricFilter`, `route53:ChangeResourceRecordSets`,
 `ses:UpdateReceiptRule` (reverts an `AWS::SES::ReceiptRule` — the whole rule is
 re-supplied in place, since Cloud Control has no handler for the type),
+`cloudwatch:PutAnomalyDetector` (reverts an `AWS::CloudWatch::AnomalyDetector` —
+a whole-config create-or-update on the detector's metric/math identity),
 `docdb:ModifyDBCluster` / `ModifyDBInstance`,
 `config:DescribeConfigRules` / `config:PutConfigRule`,
 `ecs:UpdateService` (reverts an `AWS::ECS::Service` `ServiceConnectConfiguration` /

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@aws-sdk/client-cloudcontrol": "^3.1065.0",
     "@aws-sdk/client-cloudformation": "^3.1065.0",
     "@aws-sdk/client-cloudfront": "^3.1073.0",
+    "@aws-sdk/client-cloudwatch": "3.1066.0",
     "@aws-sdk/client-cloudwatch-logs": "^3.1066.0",
     "@aws-sdk/client-codebuild": "^3.1068.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1069.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@aws-sdk/client-cloudfront':
         specifier: ^3.1073.0
         version: 3.1073.0
+      '@aws-sdk/client-cloudwatch':
+        specifier: 3.1066.0
+        version: 3.1066.0
       '@aws-sdk/client-cloudwatch-logs':
         specifier: ^3.1066.0
         version: 3.1066.0
@@ -314,6 +317,10 @@ packages:
 
   '@aws-sdk/client-cloudwatch-logs@3.1066.0':
     resolution: {integrity: sha512-yJEixTEkz3JoDLbalcjmPcki3+M1gARBr+/bxmp5RfudI1t1S8l+180MG3C5qHOUgG5cx1sv7yWBJtQ7lsdRNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cloudwatch@3.1066.0':
+    resolution: {integrity: sha512-XbMPM+hk0oapGlUBSAvLwxOGDyFMIoAMGk+CLsQkcQiEjKRyDVUjEadNqApfeaMQc67YG0z/cSH2GWzglQ08Jg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-codebuild@3.1068.0':
@@ -1461,6 +1468,10 @@ packages:
     resolution: {integrity: sha512-N/LoLG8pZ1zv5cIWpdF6vmSjtZtXKK9G0OqT5yYCOZU+CzPq1+nYA95VoKJBGWRScs7YbMugZ7lZx8Fj1vdHoA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.0':
+    resolution: {integrity: sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.8':
     resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
     engines: {node: '>=18.0.0'}
@@ -1480,6 +1491,10 @@ packages:
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
+
+  '@smithy/middleware-compression@4.5.5':
+    resolution: {integrity: sha512-YbEND0YHxzTmvwqX89vrdXjWdsegA6rg7uy6Ef7iFIxCzTR81BXV7wbvJtOTmQJGZLiZcN+XwVJnebd7F6Zgdg==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-endpoint@4.5.6':
     resolution: {integrity: sha512-zdG5bJZOiM2PRgL2lwcgui6uwZ+s5y6Qsk/rk05Q69sZJT6oi1x+v8Kn++V/q9VY94EgOtEe5kivpu+eGau0wQ==}
@@ -2242,6 +2257,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.1:
+    resolution: {integrity: sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -3756,7 +3774,7 @@ snapshots:
   '@aws-crypto/crc32c@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/types': 3.973.14
       tslib: 2.8.1
 
   '@aws-crypto/sha1-browser@5.2.0':
@@ -3933,6 +3951,20 @@ snapshots:
       '@smithy/core': 3.24.6
       '@smithy/fetch-http-handler': 5.4.6
       '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-cloudwatch@3.1066.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.24
+      '@aws-sdk/credential-provider-node': 3.972.59
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/middleware-compression': 4.5.5
+      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4594,28 +4626,28 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.53':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.54':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-login@3.972.55':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4949,12 +4981,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4962,12 +4994,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4975,12 +5007,12 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
-      '@smithy/fetch-http-handler': 5.4.6
-      '@smithy/node-http-handler': 4.7.7
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
+      '@smithy/fetch-http-handler': 5.6.1
+      '@smithy/node-http-handler': 4.9.1
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5020,37 +5052,37 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1066.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.20
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1069.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.21
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1071.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.22
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1074.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
+      '@aws-sdk/core': 3.974.24
       '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.24.6
+      '@aws-sdk/types': 3.973.14
+      '@smithy/core': 3.28.0
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5684,6 +5716,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.29.0':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.8':
     dependencies:
       '@smithy/core': 3.24.6
@@ -5710,6 +5747,13 @@ snapshots:
 
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-compression@4.5.5':
+    dependencies:
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      fflate: 0.8.1
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@4.5.6':
@@ -6383,6 +6427,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.1: {}
 
   figures@2.0.0:
     dependencies:

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -9,6 +9,11 @@
 import { AppSyncClient, ListApiKeysCommand } from '@aws-sdk/client-appsync';
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import {
+  type AnomalyDetector,
+  CloudWatchClient,
+  DescribeAnomalyDetectorsCommand,
+} from '@aws-sdk/client-cloudwatch';
 import { CognitoSyncClient, GetCognitoEventsCommand } from '@aws-sdk/client-cognito-sync';
 import { BatchGetProjectsCommand, CodeBuildClient } from '@aws-sdk/client-codebuild';
 import { DescribeServicesCommand, ECSClient } from '@aws-sdk/client-ecs';
@@ -842,6 +847,187 @@ const readMetricFilter: OverrideReader = async ({ physicalId, declared, region }
 // "group/name", "group|name", and the full ARN were all tried against CC).
 // Read via Scheduler GetSchedule with the declared GroupName instead. The CFn
 // physical id IS the schedule name.
+// AWS::CloudWatch::AnomalyDetector — NON_PROVISIONABLE in the registry with no Cloud
+// Control read handler, so every declared anomaly detector came back `skipped` (found
+// offline in the 2026-07-02 hunts, #461). Read via CloudWatch DescribeAnomalyDetectors.
+// The CFn physical id is a generated guid no API can look up, so the detector is
+// located from the resolved DECLARED identity:
+//   - single-metric: Namespace/MetricName/Stat/Dimensions — accepted in BOTH template
+//     shapes (legacy top-level props, or the SingleMetricAnomalyDetector wrapper).
+//     Namespace/MetricName/Dimensions filter server-side; Stat + the exact dimension
+//     set disambiguate (one metric can carry one detector per Stat).
+//   - metric-math: listed with AnomalyDetectorTypes=METRIC_MATH and matched by the
+//     MetricDataQueries identity (sorted by Id, comparing Id/Expression/MetricStat —
+//     Label/ReturnData are display knobs, not identity).
+// The live model is projected into the SAME shape the template declared (top-level vs
+// wrapper) so the subset compare aligns, mapping the SDK's `MetricTimezone` back to
+// CFn's `MetricTimeZone` and Date ranges back to the CFn Range pattern — the schema
+// enforces `YYYY-MM-DDTHH:MM:SS` (UTC, NO zone suffix, no millis; a trailing `Z` is
+// rejected at deploy), so the projection uses the same shape a template must declare.
+// StateValue is AWS-managed noise. A detector
+// absent from the listing was deleted out of band → ResourceGoneError → `deleted`.
+type CwDims = { Name?: unknown; Value?: unknown }[];
+const dimKey = (dims: unknown): string =>
+  (Array.isArray(dims) ? (dims as CwDims) : [])
+    .map((d) => `${str(d?.Name) ?? ''}=${str(d?.Value) ?? ''}`)
+    .sort()
+    .join(',');
+// CFn Range pattern: `YYYY-MM-DDTHH:MM:SS` in UTC — the schema REJECTS a zone suffix.
+const cfnRangeTime = (d: Date | undefined): string | undefined =>
+  d === undefined ? undefined : d.toISOString().slice(0, 19);
+const cfnAnomalyConfiguration = (
+  c: AnomalyDetector['Configuration']
+): Record<string, unknown> | undefined => {
+  if (!c) return undefined;
+  const out: Record<string, unknown> = {};
+  if (c.ExcludedTimeRanges !== undefined)
+    out.ExcludedTimeRanges = c.ExcludedTimeRanges.map((r) => ({
+      ...(cfnRangeTime(r.StartTime) !== undefined && { StartTime: cfnRangeTime(r.StartTime) }),
+      ...(cfnRangeTime(r.EndTime) !== undefined && { EndTime: cfnRangeTime(r.EndTime) }),
+    }));
+  if (c.MetricTimezone !== undefined) out.MetricTimeZone = c.MetricTimezone;
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+// identity of one metric-math query set: Id/Expression/MetricStat (dimension-order
+// insensitive), sorted by Id — Label/ReturnData/Period-at-query-level are not identity.
+const mathQueriesKey = (queries: unknown): string => {
+  const qs = Array.isArray(queries) ? queries : [];
+  const canon = qs
+    .map((q) => {
+      const query = (q ?? {}) as Record<string, unknown>;
+      const ms = (query.MetricStat ?? undefined) as Record<string, unknown> | undefined;
+      const metric = (ms?.Metric ?? undefined) as Record<string, unknown> | undefined;
+      return {
+        Id: str(query.Id) ?? '',
+        Expression: str(query.Expression) ?? '',
+        MetricStat: ms
+          ? {
+              Namespace: str(metric?.Namespace) ?? '',
+              MetricName: str(metric?.MetricName) ?? '',
+              Dimensions: dimKey(metric?.Dimensions),
+              Stat: str(ms.Stat) ?? '',
+            }
+          : undefined,
+      };
+    })
+    .sort((a, b) => (a.Id < b.Id ? -1 : 1));
+  return JSON.stringify(canon);
+};
+const readCloudWatchAnomalyDetector: OverrideReader = async ({ declared, region }) => {
+  const single = (declared.SingleMetricAnomalyDetector ?? undefined) as
+    | Record<string, unknown>
+    | undefined;
+  const math = (declared.MetricMathAnomalyDetector ?? undefined) as
+    | Record<string, unknown>
+    | undefined;
+  const namespace = str(single?.Namespace) ?? str(declared.Namespace);
+  const metricName = str(single?.MetricName) ?? str(declared.MetricName);
+  const stat = str(single?.Stat) ?? str(declared.Stat);
+  const declaredDims = single?.Dimensions ?? declared.Dimensions;
+  if (!math && (!namespace || !metricName || !stat)) return undefined; // unresolvable -> skipped
+  const c = new CloudWatchClient({ region, ...READ_RETRY });
+
+  let found: AnomalyDetector | undefined;
+  let nextToken: string | undefined;
+  do {
+    const r = await c.send(
+      new DescribeAnomalyDetectorsCommand(
+        math
+          ? { AnomalyDetectorTypes: ['METRIC_MATH'], ...(nextToken && { NextToken: nextToken }) }
+          : {
+              Namespace: namespace,
+              MetricName: metricName,
+              AnomalyDetectorTypes: ['SINGLE_METRIC'],
+              ...(nextToken && { NextToken: nextToken }),
+            }
+      )
+    );
+    found = (r.AnomalyDetectors ?? []).find((d) => {
+      if (math)
+        return (
+          mathQueriesKey(d.MetricMathAnomalyDetector?.MetricDataQueries) ===
+          mathQueriesKey(math.MetricDataQueries)
+        );
+      const liveSingle = d.SingleMetricAnomalyDetector;
+      return (
+        (str(liveSingle?.Stat) ?? str(d.Stat)) === stat &&
+        dimKey(liveSingle?.Dimensions ?? d.Dimensions) === dimKey(declaredDims)
+      );
+    });
+    nextToken = r.NextToken;
+  } while (!found && nextToken);
+  if (!found)
+    throw new ResourceGoneError(
+      `AnomalyDetector ${math ? 'METRIC_MATH' : `${namespace}/${metricName}/${stat}`} not found`
+    );
+
+  const model: Record<string, unknown> = {};
+  const cfg = cfnAnomalyConfiguration(found.Configuration);
+  if (cfg !== undefined) model.Configuration = cfg;
+  if (found.MetricCharacteristics?.PeriodicSpikes !== undefined)
+    model.MetricCharacteristics = { PeriodicSpikes: found.MetricCharacteristics.PeriodicSpikes };
+  if (math) {
+    const queries = found.MetricMathAnomalyDetector?.MetricDataQueries ?? [];
+    model.MetricMathAnomalyDetector = {
+      MetricDataQueries: queries.map((q) => ({
+        Id: q.Id,
+        ...(q.Expression !== undefined && { Expression: q.Expression }),
+        ...(q.Label !== undefined && { Label: q.Label }),
+        ...(q.ReturnData !== undefined && { ReturnData: q.ReturnData }),
+        ...(q.Period !== undefined && { Period: q.Period }),
+        ...(q.AccountId !== undefined && { AccountId: q.AccountId }),
+        ...(q.MetricStat !== undefined && {
+          MetricStat: {
+            ...(q.MetricStat.Metric !== undefined && {
+              Metric: {
+                ...(q.MetricStat.Metric.Namespace !== undefined && {
+                  Namespace: q.MetricStat.Metric.Namespace,
+                }),
+                ...(q.MetricStat.Metric.MetricName !== undefined && {
+                  MetricName: q.MetricStat.Metric.MetricName,
+                }),
+                ...(q.MetricStat.Metric.Dimensions !== undefined && {
+                  Dimensions: q.MetricStat.Metric.Dimensions,
+                }),
+              },
+            }),
+            ...(q.MetricStat.Period !== undefined && { Period: q.MetricStat.Period }),
+            ...(q.MetricStat.Stat !== undefined && { Stat: q.MetricStat.Stat }),
+            ...(q.MetricStat.Unit !== undefined && { Unit: q.MetricStat.Unit }),
+          },
+        }),
+      })),
+    };
+    return model;
+  }
+  const liveSingle = found.SingleMetricAnomalyDetector;
+  const liveNamespace = str(liveSingle?.Namespace) ?? str(found.Namespace);
+  const liveMetric = str(liveSingle?.MetricName) ?? str(found.MetricName);
+  const liveStat = str(liveSingle?.Stat) ?? str(found.Stat);
+  const liveDims = liveSingle?.Dimensions ?? found.Dimensions;
+  if (single) {
+    // project into the wrapper shape the template declared. AccountId is projected
+    // ONLY when the template declares it (cross-account monitoring): the API echoes
+    // the OWN account id on every detector, which would otherwise surface as
+    // undeclared first-run noise — and an out-of-band "account change" is not a
+    // real mutation (the account is the detector's identity).
+    model.SingleMetricAnomalyDetector = {
+      ...(str(single.AccountId) !== undefined &&
+        str(liveSingle?.AccountId) !== undefined && { AccountId: liveSingle?.AccountId }),
+      ...(liveNamespace !== undefined && { Namespace: liveNamespace }),
+      ...(liveMetric !== undefined && { MetricName: liveMetric }),
+      ...(liveDims !== undefined && { Dimensions: liveDims }),
+      ...(liveStat !== undefined && { Stat: liveStat }),
+    };
+    return model;
+  }
+  if (liveNamespace !== undefined) model.Namespace = liveNamespace;
+  if (liveMetric !== undefined) model.MetricName = liveMetric;
+  if (liveStat !== undefined) model.Stat = liveStat;
+  if (liveDims !== undefined) model.Dimensions = liveDims;
+  return model;
+};
+
 const readSchedulerSchedule: OverrideReader = async ({ physicalId, declared, region }) => {
   const name = str(physicalId) ?? str(declared.Name);
   if (!name) return undefined;
@@ -1353,6 +1539,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::Glue::Connection': readGlueConnection,
   'AWS::Logs::MetricFilter': readMetricFilter,
   'AWS::Scheduler::Schedule': readSchedulerSchedule,
+  'AWS::CloudWatch::AnomalyDetector': readCloudWatchAnomalyDetector,
 };
 
 // ---------------------------------------------------------------------------

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -39,6 +39,11 @@ import {
   UpdateDistributionCommand,
 } from '@aws-sdk/client-cloudfront';
 import {
+  CloudWatchClient,
+  PutAnomalyDetectorCommand,
+  type PutAnomalyDetectorCommandInput,
+} from '@aws-sdk/client-cloudwatch';
+import {
   CloudWatchLogsClient,
   PutBearerTokenAuthenticationCommand,
   PutMetricFilterCommand,
@@ -1253,6 +1258,61 @@ const writeEcsServiceWriteOnlyProps: SdkWriter = async (ctx, ops) => {
   await c.send(new UpdateServiceCommand(input));
 };
 
+// AWS::CloudWatch::AnomalyDetector (#461) — NON_PROVISIONABLE, so Cloud Control can
+// neither read nor write it. Revert = read the current model back via the override
+// READER (already projected into the declared template shape), apply the revert ops,
+// and PutAnomalyDetector the reconstructed desired detector — Put is a whole-config
+// create-or-update on the detector identified by its metric/math identity, so
+// re-supplying the full desired model converges Configuration/MetricCharacteristics
+// edits. Maps CFn's `MetricTimeZone` back to the SDK's `MetricTimezone` and ISO range
+// strings back to Dates.
+const rangeUtc = (s: string): Date => new Date(/Z$|[+-]\d\d:\d\d$/.test(s) ? s : `${s}Z`);
+const writeCloudWatchAnomalyDetector: SdkWriter = async (ctx, ops) => {
+  const m = await desiredModel('AWS::CloudWatch::AnomalyDetector', ctx, ops);
+  const cfg = (m.Configuration ?? undefined) as Record<string, unknown> | undefined;
+  const ranges = Array.isArray(cfg?.ExcludedTimeRanges)
+    ? (cfg.ExcludedTimeRanges as Record<string, unknown>[])
+    : undefined;
+  const input: PutAnomalyDetectorCommandInput = {
+    ...(m.Namespace !== undefined && { Namespace: m.Namespace as string }),
+    ...(m.MetricName !== undefined && { MetricName: m.MetricName as string }),
+    ...(m.Stat !== undefined && { Stat: m.Stat as string }),
+    ...(m.Dimensions !== undefined && {
+      Dimensions: m.Dimensions as PutAnomalyDetectorCommandInput['Dimensions'],
+    }),
+    ...(m.SingleMetricAnomalyDetector !== undefined && {
+      SingleMetricAnomalyDetector:
+        m.SingleMetricAnomalyDetector as PutAnomalyDetectorCommandInput['SingleMetricAnomalyDetector'],
+    }),
+    ...(m.MetricMathAnomalyDetector !== undefined && {
+      MetricMathAnomalyDetector:
+        m.MetricMathAnomalyDetector as PutAnomalyDetectorCommandInput['MetricMathAnomalyDetector'],
+    }),
+    ...(m.MetricCharacteristics !== undefined && {
+      MetricCharacteristics:
+        m.MetricCharacteristics as PutAnomalyDetectorCommandInput['MetricCharacteristics'],
+    }),
+    ...(cfg !== undefined && {
+      Configuration: {
+        ...(str(cfg.MetricTimeZone) !== undefined && {
+          MetricTimezone: cfg.MetricTimeZone as string,
+        }),
+        ...(ranges !== undefined && {
+          // a range always carries both bounds (CFn Range requires them). The CFn
+          // pattern is zone-less UTC (`YYYY-MM-DDTHH:MM:SS`) — bare `new Date` would
+          // parse that as LOCAL time, so pin it to UTC explicitly.
+          ExcludedTimeRanges: ranges.map((r) => ({
+            StartTime: rangeUtc(String(r.StartTime)),
+            EndTime: rangeUtc(String(r.EndTime)),
+          })),
+        }),
+      },
+    }),
+  };
+  const c = new CloudWatchClient({ region: ctx.region });
+  await c.send(new PutAnomalyDetectorCommand(input));
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::OpenSearchService::Domain': writeOpenSearchDomain,
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
@@ -1274,6 +1334,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::Events::EventBusPolicy': writeEventBusPolicy,
   'AWS::IAM::Policy': writeIamPolicy,
   'AWS::IAM::ManagedPolicy': writeIamManagedPolicy,
+  'AWS::CloudWatch::AnomalyDetector': writeCloudWatchAnomalyDetector,
 };
 
 // Property-scoped SDK writers: CC-writable types where ONE property must be

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -65,6 +65,25 @@ export const OVERRIDE_READABLE_WRITEONLY: Record<string, readonly string[]> = {
   'AWS::ECS::Service': ['ServiceConnectConfiguration', 'VolumeConfigurations'],
 };
 
+// The MIRROR of OVERRIDE_READABLE_WRITEONLY: nested paths an SDK_OVERRIDES reader
+// CANNOT read back even though the registry schema does not mark them writeOnly —
+// the type's Describe API simply never returns them. Appended to `writeOnlyPaths`
+// so BOTH sides strip the path (readGap semantics): without this, a declared value
+// at such a path false-flags as declared drift against the reader's live model
+// (found live on AnomalyDetector: DescribeAnomalyDetectors never echoes a metric-math
+// query's cosmetic `Label`, so a declared label reported `desired="…" actual=undefined`).
+export const SDK_READER_GAP_PATHS: Record<string, readonly string[]> = {
+  'AWS::CloudWatch::AnomalyDetector': ['MetricMathAnomalyDetector.MetricDataQueries.*.Label'],
+};
+
+// Append a type's SDK-reader gap paths to writeOnlyPaths (strip from both sides).
+// Exported for unit testing without an AWS call.
+export function injectReaderGaps(info: SchemaInfo, resourceType: string): SchemaInfo {
+  const gaps = SDK_READER_GAP_PATHS[resourceType];
+  if (!gaps?.length) return info;
+  return { ...info, writeOnlyPaths: [...info.writeOnlyPaths, ...gaps] };
+}
+
 // Remove the override-readable writeOnly props from a type's writeOnly sets so the
 // classify pipeline compares (not strips/readGaps) the value the override now supplies.
 // Exported for unit testing without an AWS call.
@@ -84,7 +103,10 @@ async function fetch(client: CloudFormationClient, resourceType: string): Promis
     const r = await client.send(
       new DescribeTypeCommand({ Type: 'RESOURCE', TypeName: resourceType })
     );
-    return exemptOverrideReadable(parseSchema(r.Schema ?? '{}'), resourceType);
+    return injectReaderGaps(
+      exemptOverrideReadable(parseSchema(r.Schema ?? '{}'), resourceType),
+      resourceType
+    );
   } catch {
     return EMPTY;
   }

--- a/tests/corpus/AWS__CloudWatch__AnomalyDetector.MetricMath.json
+++ b/tests/corpus/AWS__CloudWatch__AnomalyDetector.MetricMath.json
@@ -1,0 +1,107 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MetricMath",
+    "resourceType": "AWS::CloudWatch::AnomalyDetector",
+    "physicalId": "MetricMath-EC349Nswzn2M",
+    "constructPath": "CdkRealDriftIntegAnomalyDetector/MetricMath",
+    "declared": {
+      "MetricMathAnomalyDetector": {
+        "MetricDataQueries": [
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "QueueName",
+                    "Value": "cdkrd-hunt-anomaly-q"
+                  }
+                ],
+                "MetricName": "NumberOfMessagesSent",
+                "Namespace": "AWS/SQS"
+              },
+              "Period": 300,
+              "Stat": "Sum"
+            },
+            "ReturnData": false
+          },
+          {
+            "Expression": "m1/300",
+            "Id": "e1",
+            "Label": "send rate",
+            "ReturnData": true
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "Configuration": {
+      "ExcludedTimeRanges": []
+    },
+    "MetricMathAnomalyDetector": {
+      "MetricDataQueries": [
+        {
+          "Id": "m1",
+          "ReturnData": false,
+          "MetricStat": {
+            "Metric": {
+              "Namespace": "AWS/SQS",
+              "MetricName": "NumberOfMessagesSent",
+              "Dimensions": [
+                {
+                  "Name": "QueueName",
+                  "Value": "cdkrd-hunt-anomaly-q"
+                }
+              ]
+            },
+            "Period": 300,
+            "Stat": "Sum"
+          }
+        },
+        {
+          "Id": "e1",
+          "Expression": "m1/300",
+          "ReturnData": true
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "Dimensions",
+      "MetricCharacteristics",
+      "MetricMathAnomalyDetector",
+      "MetricName",
+      "Namespace",
+      "SingleMetricAnomalyDetector",
+      "Stat"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["MetricMathAnomalyDetector.MetricDataQueries.*.Label"],
+    "createOnlyPaths": [
+      "Dimensions",
+      "MetricCharacteristics",
+      "MetricMathAnomalyDetector",
+      "MetricName",
+      "Namespace",
+      "SingleMetricAnomalyDetector",
+      "Stat"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__CloudWatch__AnomalyDetector.SingleMetric.json
+++ b/tests/corpus/AWS__CloudWatch__AnomalyDetector.SingleMetric.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SingleMetric",
+    "resourceType": "AWS::CloudWatch::AnomalyDetector",
+    "physicalId": "SingleMetric-dJ1GPQgXdK4y",
+    "constructPath": "CdkRealDriftIntegAnomalyDetector/SingleMetric",
+    "declared": {
+      "Configuration": {
+        "ExcludedTimeRanges": [
+          {
+            "EndTime": "2026-12-26T00:00:00",
+            "StartTime": "2026-12-24T00:00:00"
+          }
+        ],
+        "MetricTimeZone": "UTC"
+      },
+      "SingleMetricAnomalyDetector": {
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "cdkrd-hunt-anomaly-fn"
+          }
+        ],
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Stat": "Sum"
+      }
+    }
+  },
+  "liveRaw": {
+    "Configuration": {
+      "ExcludedTimeRanges": [
+        {
+          "StartTime": "2026-12-24T00:00:00",
+          "EndTime": "2026-12-26T00:00:00"
+        }
+      ],
+      "MetricTimeZone": "UTC"
+    },
+    "SingleMetricAnomalyDetector": {
+      "Namespace": "AWS/Lambda",
+      "MetricName": "Errors",
+      "Dimensions": [
+        {
+          "Name": "FunctionName",
+          "Value": "cdkrd-hunt-anomaly-fn"
+        }
+      ],
+      "Stat": "Sum"
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "Dimensions",
+      "MetricCharacteristics",
+      "MetricMathAnomalyDetector",
+      "MetricName",
+      "Namespace",
+      "SingleMetricAnomalyDetector",
+      "Stat"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["MetricMathAnomalyDetector.MetricDataQueries.*.Label"],
+    "createOnlyPaths": [
+      "Dimensions",
+      "MetricCharacteristics",
+      "MetricMathAnomalyDetector",
+      "MetricName",
+      "Namespace",
+      "SingleMetricAnomalyDetector",
+      "Stat"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/anomalydetector-rich/app.ts
+++ b/tests/integration/anomalydetector-rich/app.ts
@@ -1,0 +1,54 @@
+// CDK app for the cdk-real-drift anomalydetector-rich integration test (#461).
+// AWS::CloudWatch::AnomalyDetector is NON_PROVISIONABLE in the registry (no Cloud
+// Control read handler), so before the SDK_OVERRIDES reader every declared detector
+// came back `skipped`. Two detectors exercise both identity shapes the reader
+// resolves from the declared model:
+//   - single-metric via the SingleMetricAnomalyDetector wrapper, with a rich
+//     Configuration (MetricTimeZone + ExcludedTimeRanges — the mutable knobs the
+//     detect script flips out of band);
+//   - metric-math via MetricMathAnomalyDetector (matched by its MetricDataQueries
+//     identity, not by any physical id — the CFn physical id is a guid no API takes).
+// Anomaly detectors are free; deploy/delete is instant.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnAnomalyDetector } from "aws-cdk-lib/aws-cloudwatch";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAnomalyDetector");
+
+new CfnAnomalyDetector(stack, "SingleMetric", {
+  singleMetricAnomalyDetector: {
+    namespace: "AWS/Lambda",
+    metricName: "Errors",
+    dimensions: [{ name: "FunctionName", value: "cdkrd-hunt-anomaly-fn" }],
+    stat: "Sum",
+  },
+  configuration: {
+    metricTimeZone: "UTC",
+    excludedTimeRanges: [
+      { startTime: "2026-12-24T00:00:00", endTime: "2026-12-26T00:00:00" },
+    ],
+  },
+});
+
+new CfnAnomalyDetector(stack, "MetricMath", {
+  metricMathAnomalyDetector: {
+    metricDataQueries: [
+      {
+        id: "m1",
+        metricStat: {
+          metric: {
+            namespace: "AWS/SQS",
+            metricName: "NumberOfMessagesSent",
+            dimensions: [{ name: "QueueName", value: "cdkrd-hunt-anomaly-q" }],
+          },
+          period: 300,
+          stat: "Sum",
+        },
+        returnData: false,
+      },
+      { id: "e1", expression: "m1/300", label: "send rate", returnData: true },
+    ],
+  },
+});
+
+app.synth();

--- a/tests/integration/anomalydetector-rich/cdk.json
+++ b/tests/integration/anomalydetector-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/anomalydetector-rich/package.json
+++ b/tests/integration/anomalydetector-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-anomalydetector-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift anomalydetector-rich integration test (#461). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/anomalydetector-rich/verify-detect.sh
+++ b/tests/integration/anomalydetector-rich/verify-detect.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Detect + revert integration test (real AWS): flip the single-metric detector's
+# Configuration out of band (MetricTimezone UTC -> America/New_York, the "someone
+# edited the anomaly model in the console" scenario). check MUST DETECT the declared
+# drift (exit 1) -> revert (PutAnomalyDetector) -> check MUST be CLEAN and the live
+# timezone restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAnomalyDetector
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+SMAD='{"Namespace":"AWS/Lambda","MetricName":"Errors","Dimensions":[{"Name":"FunctionName","Value":"cdkrd-hunt-anomaly-fn"}],"Stat":"Sum"}'
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: Configuration MetricTimezone UTC -> America/New_York ==="
+aws cloudwatch put-anomaly-detector --region "$REGION" \
+  --single-metric-anomaly-detector "$SMAD" \
+  --configuration '{"MetricTimezone":"America/New_York","ExcludedTimeRanges":[{"StartTime":"2026-12-24T00:00:00","EndTime":"2026-12-26T00:00:00"}]}' \
+  || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -q "MetricTimeZone" "/tmp/cdkrd-$STACK-detect.out" || fail "MetricTimeZone drift not reported"
+
+echo "=== revert (PutAnomalyDetector writes declared config back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+LIVE="$(aws cloudwatch describe-anomaly-detectors --region "$REGION" \
+  --namespace AWS/Lambda --metric-name Errors \
+  --query 'AnomalyDetectors[0].Configuration.MetricTimezone' --output text)"
+[ "$LIVE" = "UTC" ] || fail "live MetricTimezone not restored (got $LIVE)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/anomalydetector-rich/verify.sh
+++ b/tests/integration/anomalydetector-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN, and neither detector may be skipped (the SDK_OVERRIDES reader for
+# the NON_PROVISIONABLE AWS::CloudWatch::AnomalyDetector must read both the
+# single-metric and the metric-math detector).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAnomalyDetector
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN with no skipped detectors ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+grep -q "skipped=" "/tmp/cdkrd-$STACK.out" && fail "detector(s) still skipped — the SDK override reader did not engage"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -27,6 +27,8 @@ import {
 import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
 import {
   exemptOverrideReadable,
+  injectReaderGaps,
+  SDK_READER_GAP_PATHS,
   OVERRIDE_READABLE_WRITEONLY,
   parseSchema,
 } from '../src/schema/schema-strip.js';
@@ -875,6 +877,20 @@ describe('parseSchema', () => {
     expect(info.readOnlyPaths).toContain('Lifecycle.Rules.*.X');
     expect([...info.writeOnly]).toEqual(['AccessControl']);
     expect(info.defaults).toEqual({ Path: '/' });
+  });
+
+  it('injectReaderGaps appends SDK-reader-unreadable nested paths as writeOnly strips (AnomalyDetector Label, #461)', () => {
+    // DescribeAnomalyDetectors never echoes a metric-math query's cosmetic Label, so a
+    // declared label would false-flag as declared drift against the override reader's
+    // live model — the gap path strips it from BOTH sides (readGap semantics).
+    const raw = parseSchema(JSON.stringify({ properties: { Namespace: { type: 'string' } } }));
+    const info = injectReaderGaps(raw, 'AWS::CloudWatch::AnomalyDetector');
+    expect(info.writeOnlyPaths).toContain('MetricMathAnomalyDetector.MetricDataQueries.*.Label');
+    // a type with no reader gaps is returned untouched
+    expect(injectReaderGaps(raw, 'AWS::S3::Bucket')).toBe(raw);
+    expect(SDK_READER_GAP_PATHS['AWS::CloudWatch::AnomalyDetector']).toEqual([
+      'MetricMathAnomalyDetector.MetricDataQueries.*.Label',
+    ]);
   });
 
   it('exemptOverrideReadable un-marks a writeOnly prop an SDK override can read (EC2 LaunchTemplate)', () => {

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -27,6 +27,7 @@ import {
 } from '@aws-sdk/client-iam';
 import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
+import { CloudWatchClient, DescribeAnomalyDetectorsCommand } from '@aws-sdk/client-cloudwatch';
 import { GetBucketPolicyCommand, S3Client } from '@aws-sdk/client-s3';
 import { GetScheduleCommand, SchedulerClient } from '@aws-sdk/client-scheduler';
 import {
@@ -64,6 +65,7 @@ const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
 const ec2 = mockClient(EC2Client);
 const ses = mockClient(SESClient);
+const cloudwatch = mockClient(CloudWatchClient);
 
 const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
   physicalId,
@@ -92,6 +94,7 @@ beforeEach(() => {
     appsync,
     ec2,
     ses,
+    cloudwatch,
   ])
     m.reset();
 });
@@ -475,6 +478,130 @@ describe('SDK overrides', () => {
     });
     const input = budgets.commandCalls(DescribeBudgetCommand).at(-1)!.args[0].input;
     expect(input.BudgetName).toBe('CfnBudget-us-east-1-123-abc');
+  });
+
+  describe('CloudWatch AnomalyDetector (#461, NON_PROVISIONABLE)', () => {
+    const read = SDK_OVERRIDES['AWS::CloudWatch::AnomalyDetector'];
+    const liveSingle = {
+      SingleMetricAnomalyDetector: {
+        Namespace: 'AWS/Lambda',
+        MetricName: 'Errors',
+        Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+        Stat: 'Sum',
+      },
+      Configuration: {
+        MetricTimezone: 'UTC',
+        ExcludedTimeRanges: [
+          {
+            StartTime: new Date('2026-01-01T00:00:00Z'),
+            EndTime: new Date('2026-01-02T00:00:00Z'),
+          },
+        ],
+      },
+      StateValue: 'TRAINED' as const,
+    };
+
+    it('single-metric via the wrapper shape: matched by Stat + dimension set, projected into the declared shape', async () => {
+      cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({
+        AnomalyDetectors: [
+          {
+            SingleMetricAnomalyDetector: {
+              ...liveSingle.SingleMetricAnomalyDetector,
+              Stat: 'Average',
+            },
+          },
+          liveSingle,
+        ],
+      });
+      const model = await read(
+        ctx({
+          SingleMetricAnomalyDetector: {
+            Namespace: 'AWS/Lambda',
+            MetricName: 'Errors',
+            Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+            Stat: 'Sum',
+          },
+        })
+      );
+      expect(model).toEqual({
+        SingleMetricAnomalyDetector: {
+          Namespace: 'AWS/Lambda',
+          MetricName: 'Errors',
+          Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+          Stat: 'Sum',
+        },
+        Configuration: {
+          MetricTimeZone: 'UTC', // SDK MetricTimezone -> CFn MetricTimeZone
+          ExcludedTimeRanges: [
+            // projected in the CFn Range pattern: zone-less UTC (the schema rejects `Z`)
+            { StartTime: '2026-01-01T00:00:00', EndTime: '2026-01-02T00:00:00' },
+          ],
+        },
+      });
+      // StateValue (AWS-managed) is never projected
+      expect(model).not.toHaveProperty('StateValue');
+    });
+
+    it('single-metric via LEGACY top-level props projects top-level (declared-shape mirror)', async () => {
+      cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({ AnomalyDetectors: [liveSingle] });
+      const model = await read(
+        ctx({
+          Namespace: 'AWS/Lambda',
+          MetricName: 'Errors',
+          Stat: 'Sum',
+          Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+        })
+      );
+      expect(model?.Namespace).toBe('AWS/Lambda');
+      expect(model?.Stat).toBe('Sum');
+      expect(model).not.toHaveProperty('SingleMetricAnomalyDetector');
+    });
+
+    it('metric-math: matched by the MetricDataQueries identity across pagination', async () => {
+      const queries = [
+        {
+          Id: 'm1',
+          MetricStat: {
+            Metric: {
+              Namespace: 'AWS/SQS',
+              MetricName: 'NumberOfMessagesSent',
+              Dimensions: [{ Name: 'QueueName', Value: 'q' }],
+            },
+            Period: 300,
+            Stat: 'Sum',
+          },
+          ReturnData: true,
+        },
+        { Id: 'e1', Expression: 'm1/300', Label: 'rate' },
+      ];
+      cloudwatch
+        .on(DescribeAnomalyDetectorsCommand)
+        .resolvesOnce({
+          AnomalyDetectors: [
+            {
+              MetricMathAnomalyDetector: { MetricDataQueries: [{ Id: 'other', Expression: 'x' }] },
+            },
+          ],
+          NextToken: 't1',
+        })
+        .resolvesOnce({
+          AnomalyDetectors: [{ MetricMathAnomalyDetector: { MetricDataQueries: queries } }],
+        });
+      const model = await read(ctx({ MetricMathAnomalyDetector: { MetricDataQueries: queries } }));
+      const math = (model ?? {}).MetricMathAnomalyDetector as { MetricDataQueries: unknown[] };
+      expect(math.MetricDataQueries).toHaveLength(2);
+    });
+
+    it('an out-of-band-deleted detector throws ResourceGoneError (-> deleted tier)', async () => {
+      cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({ AnomalyDetectors: [] });
+      await expect(
+        read(ctx({ Namespace: 'AWS/Lambda', MetricName: 'Errors', Stat: 'Sum' }))
+      ).rejects.toThrow(ResourceGoneError);
+    });
+
+    it('an unresolvable identity (no Namespace/MetricName/Stat) returns undefined -> skipped', async () => {
+      expect(await read(ctx({ Namespace: 'AWS/Lambda' }))).toBeUndefined();
+    });
   });
 
   describe('Route53 RecordSet', () => {

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -4,6 +4,11 @@ import {
   UpdateIntegrationResponseCommand,
   UpdateMethodResponseCommand,
 } from '@aws-sdk/client-api-gateway';
+import {
+  CloudWatchClient,
+  DescribeAnomalyDetectorsCommand,
+  PutAnomalyDetectorCommand,
+} from '@aws-sdk/client-cloudwatch';
 import { ECSClient, UpdateServiceCommand } from '@aws-sdk/client-ecs';
 import {
   CloudFrontClient,
@@ -130,6 +135,7 @@ const eventbridge = mockClient(EventBridgeClient);
 const apigw = mockClient(APIGatewayClient);
 const ecs = mockClient(ECSClient);
 const cloudcontrol = mockClient(CloudControlClient);
+const cloudwatch = mockClient(CloudWatchClient);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -177,6 +183,7 @@ beforeEach(() => {
   apigw.reset();
   ecs.reset();
   cloudcontrol.reset();
+  cloudwatch.reset();
 });
 
 describe('ECS ServiceConnect writer (re-supplies the whole writeOnly config via UpdateService)', () => {
@@ -829,6 +836,71 @@ describe('Logs MetricFilter writer (CC GetResource ValidationException on compos
         patternOp('"x"'),
       ])
     ).rejects.toThrow(/metric filter target/);
+  });
+});
+
+describe('CloudWatch AnomalyDetector writer (#461, NON_PROVISIONABLE: PutAnomalyDetector overwrite)', () => {
+  it('reverts a Configuration edit: reader shape mapped back to the SDK shape (MetricTimeZone -> MetricTimezone, ISO -> Date)', async () => {
+    // the override READER lists detectors; the current (drifted) config has TZ moved
+    cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({
+      AnomalyDetectors: [
+        {
+          SingleMetricAnomalyDetector: {
+            Namespace: 'AWS/Lambda',
+            MetricName: 'Errors',
+            Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+            Stat: 'Sum',
+          },
+          Configuration: {
+            MetricTimezone: 'America/New_York', // drifted out of band
+            ExcludedTimeRanges: [
+              {
+                StartTime: new Date('2026-01-01T00:00:00Z'),
+                EndTime: new Date('2026-01-02T00:00:00Z'),
+              },
+            ],
+          },
+        },
+      ],
+    });
+    cloudwatch.on(PutAnomalyDetectorCommand).resolves({});
+    await SDK_WRITERS['AWS::CloudWatch::AnomalyDetector'](
+      {
+        physicalId: 'guid-1234',
+        declared: {
+          SingleMetricAnomalyDetector: {
+            Namespace: 'AWS/Lambda',
+            MetricName: 'Errors',
+            Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+            Stat: 'Sum',
+          },
+        },
+        region: 'us-east-1',
+        accountId: '123456789012',
+      },
+      [
+        {
+          op: 'add',
+          path: '/Configuration/MetricTimeZone',
+          value: 'UTC',
+          human: 'Configuration.MetricTimeZone -> deployed-template value',
+        },
+      ]
+    );
+    const calls = cloudwatch.commandCalls(PutAnomalyDetectorCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input;
+    expect(input.SingleMetricAnomalyDetector).toEqual({
+      Namespace: 'AWS/Lambda',
+      MetricName: 'Errors',
+      Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+      Stat: 'Sum',
+    });
+    // reverted TZ, mapped back to the SDK field name; range strings back to Dates
+    expect(input.Configuration?.MetricTimezone).toBe('UTC');
+    expect(input.Configuration?.ExcludedTimeRanges?.[0]?.StartTime).toEqual(
+      new Date('2026-01-01T00:00:00Z')
+    );
   });
 });
 


### PR DESCRIPTION
Closes #461.

`AWS::CloudWatch::AnomalyDetector` is NON_PROVISIONABLE in the registry (no CC read handler) — every declared detector came back `skipped`, so a standard CloudWatch anomaly-alarm pattern was invisible to detect and revert.

## Reader (`cloudwatch:DescribeAnomalyDetectors`)
- The CFn physical id is a generated guid no API accepts → the detector is located from the resolved **declared identity**: single-metric via Namespace/MetricName/Stat/Dimensions (legacy top-level AND the `SingleMetricAnomalyDetector` wrapper shape), metric-math via a MetricDataQueries identity match (sorted by Id; Id/Expression/MetricStat) across pagination.
- Live model projected into the SAME shape the template declared; `MetricTimezone` → `MetricTimeZone`; range Dates formatted in the CFn Range pattern (**zone-less UTC** — the schema rejects a trailing `Z` at deploy, live-proven the hard way).
- Own-account `AccountId` echo projected only when declared (else first-run noise). Unmatched → `ResourceGoneError` → `deleted`.

## NEW mechanism: `SDK_READER_GAP_PATHS`
Mirror of `OVERRIDE_READABLE_WRITEONLY` — nested paths an override reader **cannot** read back are appended to `writeOnlyPaths` (stripped both sides, readGap semantics). First entry: `DescribeAnomalyDetectors` never echoes a metric-math query's cosmetic `Label`; without it a declared label false-flagged `desired="send rate" actual=undefined` (caught live).

## Writer (`cloudwatch:PutAnomalyDetector`)
Whole-config create-or-update on the detector's metric/math identity via the reader-backed `desiredModel`.

## Live verification (stack deployed → deleted, sentinel verified + cleared)
Fresh 2-detector stack (single-metric + metric-math): fresh `check` fully CLEAN → `record` → CLEAN → out-of-band `MetricTimezone` UTC→America/New_York **detected** → `revert` → CLEAN → live restored to UTC. Fixture (`anomalydetector-rich` verify.sh + verify-detect.sh) + 2 golden-corpus cases committed.

## Notes
- `@aws-sdk/client-cloudwatch` pinned to the sibling version `3.1066.0`: a caret add re-resolved 585 lockfile lines and flipped type-aware lint diagnostics; the pin keeps the lock diff a 264-line pure addition.
- Leftover account orphans (5 `/aws/lambda/CdkRealDriftIntegRevert-*`/`CdkdriftIntegBasic-*` autoDeleteObjects log groups from EARLIER integ runs, no live stacks) were flagged by sweep but their deletion was denied by the session's permission classifier — left for a manual `sweep-orphans.sh --delete`.

Gates: /check + /check-docs + /verify-pr (42 files / 1996 tests; live-test above).