### PR TITLE
fix(read): AnomalyDetector follow-ups — metric-math listing, CFn Range pattern, Label read-gap, AccountId echo

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -418,8 +418,11 @@ const readEc2Eip: OverrideReader = async ({ physicalId, region }) => {
 // Dimensions); the live model is emitted in the SAME style the template used so the
 // compare is shape-stable. Field mapping: the CW API spells the timezone
 // `MetricTimezone` while CFn spells it `MetricTimeZone`; ExcludedTimeRanges come back
-// as Date objects and are projected as ISO strings only when present (FP-safe: an
-// unset Configuration stays absent on both sides).
+// as Date objects and are projected in the CFn Range pattern — the registry schema
+// enforces `YYYY-MM-DDTHH:MM:SS` (zone-less UTC; a trailing `Z` is REJECTED at deploy,
+// live-proven), so a full-ISO projection would false-flag every declared range
+// (`desired="…T00:00:00" actual="…T00:00:00.000Z"`). Only projected when present
+// (FP-safe: an unset Configuration stays absent on both sides).
 const dimSetEqual = (a: unknown, b: unknown): boolean => {
   const norm = (v: unknown): string =>
     JSON.stringify(
@@ -429,6 +432,9 @@ const dimSetEqual = (a: unknown, b: unknown): boolean => {
     );
   return norm(a) === norm(b);
 };
+// CFn Range pattern: `YYYY-MM-DDTHH:MM:SS` in UTC (the schema rejects a zone suffix).
+const cfnRangeTime = (v: unknown): unknown =>
+  v instanceof Date ? v.toISOString().slice(0, 19) : v;
 const readCloudWatchAnomalyDetector: OverrideReader = async ({ declared, region }) => {
   const singleDecl = declared.SingleMetricAnomalyDetector as Record<string, unknown> | undefined;
   const mathDecl = declared.MetricMathAnomalyDetector as Record<string, unknown> | undefined;
@@ -439,9 +445,15 @@ const readCloudWatchAnomalyDetector: OverrideReader = async ({ declared, region 
   if (!mathDecl && (!ns || !metric || !stat)) return undefined; // unresolved identity -> skipped
 
   const c = new CloudWatchClient({ region, ...READ_RETRY });
-  // Namespace/MetricName filters match only single-metric detectors, so a math
-  // detector needs the unfiltered listing.
-  const filters = mathDecl ? {} : { Namespace: ns, MetricName: metric };
+  // Namespace/MetricName filters match only single-metric detectors. A math
+  // detector MUST request AnomalyDetectorTypes=METRIC_MATH explicitly: the API
+  // DEFAULTS to SINGLE_METRIC when the field is omitted, so an "unfiltered"
+  // listing never returns math detectors — every metric-math detector then
+  // false-reported "deleted out of band" on a fresh stack (live-caught; the
+  // unit-test mock returned detectors regardless of the filter, masking it).
+  const filters = mathDecl
+    ? { AnomalyDetectorTypes: ['METRIC_MATH' as const] }
+    : { Namespace: ns, MetricName: metric };
   const detectors: AnomalyDetector[] = [];
   let nextToken: string | undefined;
   do {
@@ -477,6 +489,11 @@ const readCloudWatchAnomalyDetector: OverrideReader = async ({ declared, region 
   } else if (singleDecl) {
     const s = found.SingleMetricAnomalyDetector;
     model.SingleMetricAnomalyDetector = {
+      // AccountId is projected ONLY when the template declares it (cross-account
+      // monitoring): the API echoes the OWN account id on every detector, which would
+      // otherwise surface as undeclared first-run noise.
+      ...(str(singleDecl.AccountId) !== undefined &&
+        str(s?.AccountId) !== undefined && { AccountId: s?.AccountId }),
       Namespace: s?.Namespace ?? found.Namespace,
       MetricName: s?.MetricName ?? found.MetricName,
       Stat: s?.Stat ?? found.Stat,
@@ -497,8 +514,8 @@ const readCloudWatchAnomalyDetector: OverrideReader = async ({ declared, region 
     if (str(cfg.MetricTimezone)) out.MetricTimeZone = cfg.MetricTimezone;
     if ((cfg.ExcludedTimeRanges ?? []).length > 0)
       out.ExcludedTimeRanges = (cfg.ExcludedTimeRanges ?? []).map((rng) => ({
-        StartTime: rng.StartTime instanceof Date ? rng.StartTime.toISOString() : rng.StartTime,
-        EndTime: rng.EndTime instanceof Date ? rng.EndTime.toISOString() : rng.EndTime,
+        StartTime: cfnRangeTime(rng.StartTime),
+        EndTime: cfnRangeTime(rng.EndTime),
       }));
     if (Object.keys(out).length > 0) model.Configuration = out;
   }

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -839,8 +839,15 @@ const writeCloudWatchAnomalyDetector: SdkWriter = async (ctx, ops) => {
         ExcludedTimeRanges?: { StartTime?: unknown; EndTime?: unknown }[];
       }
     | undefined;
+  // The CFn Range pattern is ZONE-LESS UTC (`YYYY-MM-DDTHH:MM:SS`) — a bare
+  // `new Date(s)` would parse that as LOCAL time and shift every range by the
+  // machine's UTC offset on revert. Pin zone-less strings to UTC explicitly.
   const toDate = (v: unknown): Date | undefined =>
-    typeof v === 'string' ? new Date(v) : v instanceof Date ? v : undefined;
+    typeof v === 'string'
+      ? new Date(/Z$|[+-]\d\d:\d\d$/.test(v) ? v : `${v}Z`)
+      : v instanceof Date
+        ? v
+        : undefined;
   const configuration = {
     ...(str(cfg?.MetricTimeZone) && { MetricTimezone: cfg?.MetricTimeZone as string }),
     ...((cfg?.ExcludedTimeRanges ?? []).length > 0 && {

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -65,6 +65,25 @@ export const OVERRIDE_READABLE_WRITEONLY: Record<string, readonly string[]> = {
   'AWS::ECS::Service': ['ServiceConnectConfiguration', 'VolumeConfigurations'],
 };
 
+// The MIRROR of OVERRIDE_READABLE_WRITEONLY: nested paths an SDK_OVERRIDES reader
+// CANNOT read back even though the registry schema does not mark them writeOnly —
+// the type's Describe API simply never returns them. Appended to `writeOnlyPaths`
+// so BOTH sides strip the path (readGap semantics): without this, a declared value
+// at such a path false-flags as declared drift against the reader's live model
+// (found live on AnomalyDetector: DescribeAnomalyDetectors never echoes a metric-math
+// query's cosmetic `Label`, so a declared label reported `desired="…" actual=undefined`).
+export const SDK_READER_GAP_PATHS: Record<string, readonly string[]> = {
+  'AWS::CloudWatch::AnomalyDetector': ['MetricMathAnomalyDetector.MetricDataQueries.*.Label'],
+};
+
+// Append a type's SDK-reader gap paths to writeOnlyPaths (strip from both sides).
+// Exported for unit testing without an AWS call.
+export function injectReaderGaps(info: SchemaInfo, resourceType: string): SchemaInfo {
+  const gaps = SDK_READER_GAP_PATHS[resourceType];
+  if (!gaps?.length) return info;
+  return { ...info, writeOnlyPaths: [...info.writeOnlyPaths, ...gaps] };
+}
+
 // Remove the override-readable writeOnly props from a type's writeOnly sets so the
 // classify pipeline compares (not strips/readGaps) the value the override now supplies.
 // Exported for unit testing without an AWS call.
@@ -84,7 +103,10 @@ async function fetch(client: CloudFormationClient, resourceType: string): Promis
     const r = await client.send(
       new DescribeTypeCommand({ Type: 'RESOURCE', TypeName: resourceType })
     );
-    return exemptOverrideReadable(parseSchema(r.Schema ?? '{}'), resourceType);
+    return injectReaderGaps(
+      exemptOverrideReadable(parseSchema(r.Schema ?? '{}'), resourceType),
+      resourceType
+    );
   } catch {
     return EMPTY;
   }

--- a/tests/corpus/AWS__CloudWatch__AnomalyDetector.Detector.json
+++ b/tests/corpus/AWS__CloudWatch__AnomalyDetector.Detector.json
@@ -3,10 +3,16 @@
   "resource": {
     "logicalId": "Detector",
     "resourceType": "AWS::CloudWatch::AnomalyDetector",
-    "physicalId": "Detector-hBQuGyRQLp3R",
+    "physicalId": "Detector-5YH1QJhaeEW2",
     "constructPath": "CdkRealDriftIntegCwAnomaly/Detector",
     "declared": {
       "Configuration": {
+        "ExcludedTimeRanges": [
+          {
+            "EndTime": "2026-12-26T00:00:00",
+            "StartTime": "2026-12-24T00:00:00"
+          }
+        ],
         "MetricTimeZone": "Asia/Tokyo"
       },
       "SingleMetricAnomalyDetector": {
@@ -35,7 +41,13 @@
       ]
     },
     "Configuration": {
-      "MetricTimeZone": "Asia/Tokyo"
+      "MetricTimeZone": "Asia/Tokyo",
+      "ExcludedTimeRanges": [
+        {
+          "StartTime": "2026-12-24T00:00:00",
+          "EndTime": "2026-12-26T00:00:00"
+        }
+      ]
     }
   },
   "schema": {
@@ -51,7 +63,7 @@
       "Stat"
     ],
     "readOnlyPaths": ["Id"],
-    "writeOnlyPaths": [],
+    "writeOnlyPaths": ["MetricMathAnomalyDetector.MetricDataQueries.*.Label"],
     "createOnlyPaths": [
       "Dimensions",
       "MetricCharacteristics",

--- a/tests/corpus/AWS__CloudWatch__AnomalyDetector.MetricMath.json
+++ b/tests/corpus/AWS__CloudWatch__AnomalyDetector.MetricMath.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "MetricMath",
+    "resourceType": "AWS::CloudWatch::AnomalyDetector",
+    "physicalId": "MetricMath-4qw3U8Fiyqcw",
+    "constructPath": "CdkRealDriftIntegCwAnomaly/MetricMath",
+    "declared": {
+      "MetricMathAnomalyDetector": {
+        "MetricDataQueries": [
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "QueueName",
+                    "Value": "cdkrd-integ-anomaly-q"
+                  }
+                ],
+                "MetricName": "NumberOfMessagesSent",
+                "Namespace": "AWS/SQS"
+              },
+              "Period": 300,
+              "Stat": "Sum"
+            },
+            "ReturnData": false
+          },
+          {
+            "Expression": "m1/300",
+            "Id": "e1",
+            "Label": "send rate",
+            "ReturnData": true
+          }
+        ]
+      }
+    }
+  },
+  "liveRaw": {
+    "MetricMathAnomalyDetector": {
+      "MetricDataQueries": [
+        {
+          "Id": "m1",
+          "MetricStat": {
+            "Metric": {
+              "Namespace": "AWS/SQS",
+              "MetricName": "NumberOfMessagesSent",
+              "Dimensions": [
+                {
+                  "Name": "QueueName",
+                  "Value": "cdkrd-integ-anomaly-q"
+                }
+              ]
+            },
+            "Period": 300,
+            "Stat": "Sum"
+          },
+          "ReturnData": false
+        },
+        {
+          "Id": "e1",
+          "Expression": "m1/300",
+          "ReturnData": true
+        }
+      ]
+    }
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": [
+      "Dimensions",
+      "MetricCharacteristics",
+      "MetricMathAnomalyDetector",
+      "MetricName",
+      "Namespace",
+      "SingleMetricAnomalyDetector",
+      "Stat"
+    ],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": ["MetricMathAnomalyDetector.MetricDataQueries.*.Label"],
+    "createOnlyPaths": [
+      "Dimensions",
+      "MetricCharacteristics",
+      "MetricMathAnomalyDetector",
+      "MetricName",
+      "Namespace",
+      "SingleMetricAnomalyDetector",
+      "Stat"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/cloudwatch-anomalydetector-readgap/app.ts
+++ b/tests/integration/cloudwatch-anomalydetector-readgap/app.ts
@@ -21,6 +21,36 @@ new CfnAnomalyDetector(stack, "Detector", {
   },
   configuration: {
     metricTimeZone: "Asia/Tokyo",
+    // Declared in the CFn Range pattern (zone-less UTC — the schema REJECTS a
+    // trailing Z at deploy). The reader must project the API's Date objects in the
+    // SAME pattern or every declared range false-flags on a clean stack.
+    excludedTimeRanges: [
+      { startTime: "2026-12-24T00:00:00", endTime: "2026-12-26T00:00:00" },
+    ],
+  },
+});
+
+// Metric-math detector with a query Label: DescribeAnomalyDetectors never echoes
+// the cosmetic Label back, so without the SDK_READER_GAP_PATHS strip a declared
+// label false-flags `desired="send rate" actual=undefined` on a clean stack.
+new CfnAnomalyDetector(stack, "MetricMath", {
+  metricMathAnomalyDetector: {
+    metricDataQueries: [
+      {
+        id: "m1",
+        metricStat: {
+          metric: {
+            namespace: "AWS/SQS",
+            metricName: "NumberOfMessagesSent",
+            dimensions: [{ name: "QueueName", value: "cdkrd-integ-anomaly-q" }],
+          },
+          period: 300,
+          stat: "Sum",
+        },
+        returnData: false,
+      },
+      { id: "e1", expression: "m1/300", label: "send rate", returnData: true },
+    ],
   },
 });
 

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -28,6 +28,8 @@ import {
 import { canonicalizeForCompare } from '../src/normalize/pipeline.js';
 import {
   exemptOverrideReadable,
+  injectReaderGaps,
+  SDK_READER_GAP_PATHS,
   OVERRIDE_READABLE_WRITEONLY,
   parseSchema,
 } from '../src/schema/schema-strip.js';
@@ -892,6 +894,20 @@ describe('parseSchema', () => {
     expect(info.readOnlyPaths).toContain('Lifecycle.Rules.*.X');
     expect([...info.writeOnly]).toEqual(['AccessControl']);
     expect(info.defaults).toEqual({ Path: '/' });
+  });
+
+  it('injectReaderGaps appends SDK-reader-unreadable nested paths as writeOnly strips (AnomalyDetector Label)', () => {
+    // DescribeAnomalyDetectors never echoes a metric-math query's cosmetic Label, so a
+    // declared label would false-flag as declared drift against the override reader's
+    // live model — the gap path strips it from BOTH sides (readGap semantics).
+    const raw = parseSchema(JSON.stringify({ properties: { Namespace: { type: 'string' } } }));
+    const info = injectReaderGaps(raw, 'AWS::CloudWatch::AnomalyDetector');
+    expect(info.writeOnlyPaths).toContain('MetricMathAnomalyDetector.MetricDataQueries.*.Label');
+    // a type with no reader gaps is returned untouched
+    expect(injectReaderGaps(raw, 'AWS::S3::Bucket')).toBe(raw);
+    expect(SDK_READER_GAP_PATHS['AWS::CloudWatch::AnomalyDetector']).toEqual([
+      'MetricMathAnomalyDetector.MetricDataQueries.*.Label',
+    ]);
   });
 
   it('exemptOverrideReadable un-marks a writeOnly prop an SDK override can read (EC2 LaunchTemplate)', () => {

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -1010,6 +1010,70 @@ describe('SDK overrides', () => {
       ).toBeUndefined();
     });
 
+    it('ExcludedTimeRanges project in the CFn Range pattern (zone-less UTC — the schema rejects a trailing Z)', async () => {
+      cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({
+        AnomalyDetectors: [
+          {
+            ...liveSingle,
+            Configuration: {
+              MetricTimezone: 'UTC',
+              ExcludedTimeRanges: [
+                {
+                  StartTime: new Date('2026-12-24T00:00:00Z'),
+                  EndTime: new Date('2026-12-26T00:00:00Z'),
+                },
+              ],
+            },
+          },
+        ],
+      } as never);
+      const out = (await SDK_OVERRIDES['AWS::CloudWatch::AnomalyDetector'](
+        ctx({
+          SingleMetricAnomalyDetector: {
+            Namespace: 'AWS/Lambda',
+            MetricName: 'Errors',
+            Stat: 'Sum',
+            Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+          },
+        })
+      )) as Record<string, unknown>;
+      // a declared range MUST be `YYYY-MM-DDTHH:MM:SS` (deploy rejects `Z`), so the
+      // projection uses the same shape or every declared range would false-flag.
+      expect(out.Configuration).toEqual({
+        MetricTimeZone: 'UTC',
+        ExcludedTimeRanges: [{ StartTime: '2026-12-24T00:00:00', EndTime: '2026-12-26T00:00:00' }],
+      });
+    });
+
+    it('the own-account AccountId echo is projected ONLY when the template declares it', async () => {
+      const withAccount = {
+        ...liveSingle,
+        SingleMetricAnomalyDetector: {
+          ...liveSingle.SingleMetricAnomalyDetector,
+          AccountId: '123456789012',
+        },
+      };
+      cloudwatch
+        .on(DescribeAnomalyDetectorsCommand)
+        .resolves({ AnomalyDetectors: [withAccount] } as never);
+      const decl = {
+        Namespace: 'AWS/Lambda',
+        MetricName: 'Errors',
+        Stat: 'Sum',
+        Dimensions: [{ Name: 'FunctionName', Value: 'fn' }],
+      };
+      // undeclared -> suppressed (first-run noise: the API echoes the own account)
+      const out = (await SDK_OVERRIDES['AWS::CloudWatch::AnomalyDetector'](
+        ctx({ SingleMetricAnomalyDetector: decl })
+      )) as { SingleMetricAnomalyDetector: Record<string, unknown> };
+      expect(out.SingleMetricAnomalyDetector).not.toHaveProperty('AccountId');
+      // declared (cross-account monitoring) -> compared like any prop
+      const out2 = (await SDK_OVERRIDES['AWS::CloudWatch::AnomalyDetector'](
+        ctx({ SingleMetricAnomalyDetector: { ...decl, AccountId: '123456789012' } })
+      )) as { SingleMetricAnomalyDetector: Record<string, unknown> };
+      expect(out2.SingleMetricAnomalyDetector.AccountId).toBe('123456789012');
+    });
+
     it('metric-math style: lists unfiltered and matches by query-id set', async () => {
       const mathDetector = {
         MetricMathAnomalyDetector: {
@@ -1031,9 +1095,14 @@ describe('SDK overrides', () => {
         })
       )) as Record<string, unknown>;
       expect(out.MetricMathAnomalyDetector).toEqual(mathDetector.MetricMathAnomalyDetector);
-      // no Namespace/MetricName filter for math detectors
+      // no Namespace/MetricName filter for math detectors — but the type MUST be
+      // requested explicitly: the API defaults to SINGLE_METRIC when omitted, so an
+      // unfiltered listing never returns math detectors (live-caught deleted-FP).
       const call = cloudwatch.commandCalls(DescribeAnomalyDetectorsCommand)[0]!;
-      expect(call.args[0].input).toEqual({ NextToken: undefined });
+      expect(call.args[0].input).toEqual({
+        AnomalyDetectorTypes: ['METRIC_MATH'],
+        NextToken: undefined,
+      });
     });
   });
 

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -254,6 +254,56 @@ describe('CloudWatch AnomalyDetector writer (PutAnomalyDetector upsert, issue #4
     expect(input.Configuration).toEqual({});
   });
 
+  it('zone-less CFn range strings are parsed as UTC, not local time', async () => {
+    cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({
+      AnomalyDetectors: [
+        {
+          SingleMetricAnomalyDetector: {
+            Namespace: 'AWS/Lambda',
+            MetricName: 'Errors',
+            Stat: 'Sum',
+          },
+          Configuration: {
+            MetricTimezone: 'UTC',
+            ExcludedTimeRanges: [
+              {
+                StartTime: new Date('2026-12-24T06:00:00Z'), // drifted out of band
+                EndTime: new Date('2026-12-26T00:00:00Z'),
+              },
+            ],
+          },
+        },
+      ],
+    });
+    cloudwatch.on(PutAnomalyDetectorCommand).resolves({});
+    await SDK_WRITERS['AWS::CloudWatch::AnomalyDetector'](
+      ctx({
+        physicalId: 'abc-generated-id',
+        declared: {
+          SingleMetricAnomalyDetector: {
+            Namespace: 'AWS/Lambda',
+            MetricName: 'Errors',
+            Stat: 'Sum',
+          },
+        },
+      }),
+      [
+        {
+          op: 'add',
+          // the declared value is in the CFn Range pattern: zone-less, meaning UTC —
+          // a bare new Date() would shift it by the machine's local offset.
+          path: '/Configuration/ExcludedTimeRanges/0/StartTime',
+          value: '2026-12-24T00:00:00',
+          human: 'Configuration.ExcludedTimeRanges.0.StartTime -> deployed-template value',
+        },
+      ]
+    );
+    const input = cloudwatch.commandCalls(PutAnomalyDetectorCommand)[0]!.args[0].input;
+    expect(input.Configuration?.ExcludedTimeRanges?.[0]?.StartTime).toEqual(
+      new Date('2026-12-24T00:00:00Z')
+    );
+  });
+
   it('throws when no detector identity can be resolved', async () => {
     cloudwatch.on(DescribeAnomalyDetectorsCommand).resolves({ AnomalyDetectors: [] });
     await expect(


### PR DESCRIPTION
Follow-up to #469 (the #461 SDK reader/writer). This session live-tested the same feature in parallel with a richer fixture and found four issues — each live-proven on a fresh deploy of the extended `cloudwatch-anomalydetector-readgap` fixture (INTEG PASS end-to-end):

## 1. Metric-math lookup was broken (deleted-FP)
`DescribeAnomalyDetectors` **defaults to SINGLE_METRIC** when `AnomalyDetectorTypes` is omitted, so #469's "unfiltered" math listing never returned metric-math detectors — every metric-math detector false-reported **"deleted out of band"** on a fresh stack. The unit test's mock returned detectors regardless of the filter, masking it; a real deploy caught it immediately. Fix: request `METRIC_MATH` explicitly.

## 2. CFn Range pattern (declared-range FP)
The registry schema enforces zone-less UTC (`YYYY-MM-DDTHH:MM:SS`) and **rejects a trailing `Z` at deploy**, so the reader's `toISOString()` projection false-flagged every declared `ExcludedTimeRange` (`desired="…T00:00:00" actual="…T00:00:00.000Z"`). Reader now projects the CFn pattern; the writer pins zone-less strings to UTC on re-parse (a bare `new Date()` shifts by the machine's local offset — 9h here).

## 3. NEW `SDK_READER_GAP_PATHS` (Label read-gap)
Mirror of `OVERRIDE_READABLE_WRITEONLY`: nested paths an override reader **cannot** read back are appended to `writeOnlyPaths` (stripped both sides, readGap semantics). First entry: the API never echoes a metric-math query's cosmetic `Label` → a declared label false-flagged `desired="send rate" actual=undefined`.

## 4. AccountId echo (first-run noise)
The own-account `AccountId` in `SingleMetricAnomalyDetector` is projected only when the template declares it (cross-account monitoring).

## Live verification
Extended fixture (declared ranges + a metric-math detector with a Label): fresh check fully CLEAN → record → CLEAN → out-of-band config flip detected (**2 drifts**: timezone + the dropped ranges) → revert restores BOTH → CLEAN → live timezone restored. Stack deleted, `bughunt-track verify` = SWEEP CLEAN.

Gates: /check + /check-docs + /verify-pr (42 files / 2025 tests).