### PR TITLE
fix(noise): apply per-LB-type ELB defaults to wholly-undeclared attribute bags + fold deletion_protection default

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1233,7 +1233,19 @@ export function classifyResource(
     // the curated AWS default folds `atDefault`, and anything else stays `undeclared` (so a
     // genuinely-set attribute still surfaces, fail-closed).
     if (k === ELB_ATTRIBUTE_BAGS[resourceType] && Array.isArray(v)) {
-      const attrDefaults = ELB_ATTRIBUTE_DEFAULTS[resourceType] ?? {};
+      // Same per-LB-type default resolution as the declared-bag branch above: an NLB/GWLB
+      // whose LoadBalancerAttributes is WHOLLY undeclared reads back its type-specific
+      // defaults (cross_zone "false", deletion_protection "false"), which the shared
+      // application-oriented table does not carry — merge the BY_LB_TYPE overrides so they
+      // fold `atDefault` instead of surfacing as false undeclared drift.
+      const lbType =
+        resourceType === 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+          ? String(live.Type ?? declared.Type ?? 'application')
+          : undefined;
+      const attrDefaults = {
+        ...(ELB_ATTRIBUTE_DEFAULTS[resourceType] ?? {}),
+        ...(lbType === undefined ? {} : (ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE[lbType] ?? {})),
+      };
       for (const lEl of v) {
         if (!isKeyValueEntry(lEl)) continue;
         const key = (lEl as { Key: string }).Key;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1500,6 +1500,9 @@ function canonicalizeTagLists(
 export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': {
     'access_logs.s3.enabled': 'false',
+    // Deletion protection is off by default on every LB type (ALB/NLB/GWLB). Equality-gated,
+    // so a load balancer that enables it still surfaces the non-default "true".
+    'deletion_protection.enabled': 'false',
     'client_keep_alive.seconds': '3600',
     'connection_logs.s3.enabled': 'false',
     'health_check_logs.s3.enabled': 'false',

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6312,6 +6312,29 @@ describe('real-stack false-positive folds', () => {
     ]);
   });
 
+  it('wholly-undeclared NLB LoadBalancerAttributes folds per-LB-type defaults (cross_zone/deletion_protection)', () => {
+    const res: DesiredResource = {
+      logicalId: 'Nlb',
+      resourceType: 'AWS::ElasticLoadBalancingV2::LoadBalancer',
+      physicalId: 'nlb-1',
+      declared: { Type: 'network' },
+    };
+    const live = {
+      Type: 'network',
+      LoadBalancerAttributes: [
+        { Key: 'load_balancing.cross_zone.enabled', Value: 'false' }, // NLB default (BY_LB_TYPE)
+        { Key: 'deletion_protection.enabled', Value: 'false' }, // shared default
+        { Key: 'access_logs.s3.enabled', Value: 'true' }, // NON-default -> still surfaces
+      ],
+    };
+    const t = tiers(classifyResource(res, live, mkSchema()));
+    expect(t.atDefault.sort()).toEqual([
+      'LoadBalancerAttributes[deletion_protection.enabled]',
+      'LoadBalancerAttributes[load_balancing.cross_zone.enabled]',
+    ]);
+    expect(t.undeclared).toEqual(['LoadBalancerAttributes[access_logs.s3.enabled]']);
+  });
+
   it('SecretsManager Secret generated Name (no stack prefix) + TargetGroup runtime Targets fold to generated', () => {
     const secret: DesiredResource = {
       logicalId: 'Sec',

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
@@ -142,7 +142,7 @@
       "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Nlb",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "LoadBalancerAttributes[deletion_protection.enabled]",
@@ -162,7 +162,7 @@
       "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Nlb",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
       "path": "LoadBalancerAttributes[load_balancing.cross_zone.enabled]",


### PR DESCRIPTION
## Why

Follow-up to #465. That PR added a fold for a **wholly-undeclared** ELB attribute bag (undeclared loop) but consulted only the flat `ELB_ATTRIBUTE_DEFAULTS` — **not** the per-LB-type `ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE` (#458) that the *declared*-bag branch already uses. So an NLB/GWLB whose `LoadBalancerAttributes` is wholly undeclared surfaced its type-specific defaults (`load_balancing.cross_zone.enabled=false`) as **false undeclared drift**.

## What

- Derive `lbType` (live `Type` → declared `Type` → `"application"` fallback) and merge the `BY_LB_TYPE` overrides in the undeclared-bag branch — identical resolution to the declared branch.
- Fold `deletion_protection.enabled=false` (off by default on every LB type; was in neither table) via the shared `ELB_ATTRIBUTE_DEFAULTS`. Equality-gated — an LB that enables it still surfaces `"true"`.

## Tests

- +1 unit test (wholly-undeclared NLB bag: `cross_zone`/`deletion_protection` fold `atDefault`, a non-default `access_logs.s3.enabled=true` still surfaces `undeclared`).
- `Nlb.subnetmappings` corpus case regenerated (2 attrs: undeclared → atDefault).
- Gates: typecheck / lint (0 errors) / build / **2021 tests pass**.