### PR TITLE
fix(noise): drop the empty policy shell a service-attached log-group policy leaves after subtraction

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -374,6 +374,27 @@ function isSelfEchoTrivialEmpty(v: unknown, physicalId: string | undefined): boo
   return rest.length < entries.length && rest.every(([, val]) => isTrivialEmpty(val));
 }
 
+// A live-only policy DOCUMENT whose statements were ALL subtracted as AWS-managed
+// (canonicalizePolicy drops the delivery.logs `AWSLogDelivery*` statements a service
+// auto-attaches when vended logs are pointed at a log group — a CloudWatch Logs
+// Delivery, an APS Workspace LoggingConfiguration, VPC flow logs; issue #462 item 2,
+// APS instance per the #464 addendum). What survives is the bare policy-grammar
+// shell `{Version, Statement: []}` — Version is a non-empty constant string, so the
+// plain deep trivially-empty drop misses it and every vended-logs user saw one line
+// of first-run noise on the LOG GROUP. The shell carries no inventory value; drop it
+// as structural noise. Gated: `Statement` must be present and EMPTY (a doc with any
+// surviving statement — a real out-of-band policy, a foreign principal, a user grant
+// — is not a shell), and every other key must be the grammar boilerplate
+// (Version/Id strings). Pure.
+function isEmptyPolicyShell(v: unknown): boolean {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return false;
+  const o = v as Record<string, unknown>;
+  if (!Array.isArray(o.Statement) || o.Statement.length > 0) return false;
+  return Object.entries(o).every(
+    ([k, val]) => k === 'Statement' || ((k === 'Version' || k === 'Id') && typeof val === 'string')
+  );
+}
+
 // structuredClone rejects the UNRESOLVED Symbol a declared value may carry, so deep-clone
 // the declared model symbol-safe (symbols/primitives pass through by reference/value). Used
 // to clone the declared side before stripAsymmetricIdentityFields mutates it.
@@ -1357,7 +1378,8 @@ export function classifyResource(
     // and trivially-empty {}/[]. These carry no inventory value, so they are not folded.
     if (isAllAwsTags(v)) continue;
     if (physicalId !== undefined && v === physicalId) continue;
-    if (isTrivialEmpty(v) || isSelfEchoTrivialEmpty(v, physicalId)) continue;
+    if (isTrivialEmpty(v) || isSelfEchoTrivialEmpty(v, physicalId) || isEmptyPolicyShell(v))
+      continue;
     findings.push({ tier: 'undeclared', logicalId, resourceType, path: k, actual: v });
   }
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5519,6 +5519,81 @@ describe('issue #462 residual first-run noise folds', () => {
     defaultPaths: {},
   };
 
+  describe('service-attached log-group policy shell (item 2 + the #464 APS addendum)', () => {
+    const logGroup = (live: Record<string, unknown>) =>
+      classifyResource(
+        {
+          logicalId: 'HuntApsLogs',
+          resourceType: 'AWS::Logs::LogGroup',
+          physicalId: '/aws/vendedlogs/prometheus/cdkrd-hunt',
+          constructPath: 'Stack/HuntApsLogs',
+          declared: { LogGroupName: '/aws/vendedlogs/prometheus/cdkrd-hunt' },
+        },
+        { LogGroupName: '/aws/vendedlogs/prometheus/cdkrd-hunt', ...live },
+        bare462
+      ).find((f) => f.path === 'ResourcePolicyDocument');
+
+    // The REAL policy APS attaches to its vended-logs target group (harvested live
+    // from a fresh aps-rich deploy) — the CloudWatch Logs Delivery / VPC flow logs /
+    // CloudFront v2 auto-attach carries the same AWSLogDeliveryWrite* + delivery.logs
+    // shape. canonicalizePolicy subtracts the statement; the surviving grammar shell
+    // must then drop as structural noise, end to end.
+    const apsAutoAttached = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'AWSLogDeliveryWrite1',
+          Effect: 'Allow',
+          Principal: { Service: 'delivery.logs.amazonaws.com' },
+          Action: ['logs:CreateLogStream', 'logs:PutLogEvents'],
+          Resource:
+            'arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/prometheus/cdkrd-hunt:log-stream:*',
+          Condition: {
+            StringEquals: { 'aws:SourceAccount': '111111111111' },
+            ArnLike: { 'aws:SourceArn': 'arn:aws:logs:us-east-1:111111111111:*' },
+          },
+        },
+      ],
+    };
+
+    it('the live auto-attached policy (all statements AWS-managed) produces NO finding', () => {
+      expect(logGroup({ ResourcePolicyDocument: apsAutoAttached })).toBeUndefined();
+    });
+
+    it('a surviving USER statement keeps the document surfaced as undeclared', () => {
+      const withUserGrant = {
+        ...apsAutoAttached,
+        Statement: [
+          ...apsAutoAttached.Statement,
+          {
+            Sid: 'UserGrant',
+            Effect: 'Allow',
+            Principal: { AWS: 'arn:aws:iam::222222222222:root' },
+            Action: 'logs:PutLogEvents',
+            Resource: '*',
+          },
+        ],
+      };
+      expect(logGroup({ ResourcePolicyDocument: withUserGrant })?.tier).toBe('undeclared');
+    });
+
+    it('a delivery-shaped statement WITHOUT the AWSLogDelivery Sid is not subtracted and surfaces', () => {
+      const attackerShaped = {
+        Version: '2012-10-17',
+        Statement: [{ ...apsAutoAttached.Statement[0], Sid: 'LooksLikeDelivery' }],
+      };
+      expect(logGroup({ ResourcePolicyDocument: attackerShaped })?.tier).toBe('undeclared');
+    });
+
+    it('a shell carrying a non-boilerplate key is not dropped', () => {
+      expect(
+        logGroup({
+          ResourcePolicyDocument: { Version: '2012-10-17', Statement: [], Extra: { x: 1 } },
+        })?.tier
+      ).toBe('undeclared');
+    });
+  });
+
   describe('self-identity echo wrapper (DeliveryDestinationPolicy shape)', () => {
     const dest = (live: Record<string, unknown>) =>
       classifyResource(

--- a/tests/corpus/AWS__Logs__LogGroup.HuntApsLogsD100685A.json
+++ b/tests/corpus/AWS__Logs__LogGroup.HuntApsLogsD100685A.json
@@ -1,0 +1,115 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntApsLogsD100685A",
+    "resourceType": "AWS::Logs::LogGroup",
+    "physicalId": "/aws/vendedlogs/prometheus/cdkrd-hunt",
+    "constructPath": "CdkRealDriftIntegApsRich/HuntApsLogs",
+    "declared": {
+      "LogGroupName": "/aws/vendedlogs/prometheus/cdkrd-hunt",
+      "RetentionInDays": 1
+    }
+  },
+  "liveRaw": {
+    "FieldIndexPolicies": [],
+    "RetentionInDays": 1,
+    "BearerTokenAuthenticationEnabled": false,
+    "LogGroupClass": "STANDARD",
+    "ResourcePolicyDocument": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceAccount": "111111111111"
+            },
+            "ArnLike": {
+              "aws:SourceArn": "arn:aws:logs:us-east-1:111111111111:*"
+            }
+          },
+          "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+          "Resource": "arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/prometheus/cdkrd-hunt:log-stream:*",
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "delivery.logs.amazonaws.com"
+          },
+          "Sid": "AWSLogDeliveryWrite1"
+        }
+      ]
+    },
+    "LogGroupName": "/aws/vendedlogs/prometheus/cdkrd-hunt",
+    "Arn": "arn:aws:logs:us-east-1:111111111111:log-group:/aws/vendedlogs/prometheus/cdkrd-hunt:*",
+    "DeletionProtectionEnabled": false,
+    "Tags": [
+      {
+        "Value": "HuntApsLogsD100685A",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegApsRich/893d79d0-75f9-11f1-9e6b-0affc6e75353",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegApsRich",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "DataProtectionPolicy": {}
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["LogGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupName"],
+    "defaults": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    },
+    "defaultPaths": {
+      "LogGroupClass": "STANDARD",
+      "DeletionProtectionEnabled": false,
+      "BearerTokenAuthenticationEnabled": false
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntApsLogsD100685A",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "BearerTokenAuthenticationEnabled",
+      "actual": false,
+      "physicalId": "/aws/vendedlogs/prometheus/cdkrd-hunt",
+      "constructPath": "CdkRealDriftIntegApsRich/HuntApsLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntApsLogsD100685A",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "LogGroupClass",
+      "actual": "STANDARD",
+      "physicalId": "/aws/vendedlogs/prometheus/cdkrd-hunt",
+      "constructPath": "CdkRealDriftIntegApsRich/HuntApsLogs"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntApsLogsD100685A",
+      "resourceType": "AWS::Logs::LogGroup",
+      "path": "DeletionProtectionEnabled",
+      "actual": false,
+      "physicalId": "/aws/vendedlogs/prometheus/cdkrd-hunt",
+      "constructPath": "CdkRealDriftIntegApsRich/HuntApsLogs"
+    }
+  ]
+}


### PR DESCRIPTION
Closes the remaining item 2 of #462 (auto-attached LogGroup policy), **including the APS instance from the #464 addendum comment**.

## The class

Pointing vended logs at a log group (CloudWatch Logs Delivery, **APS Workspace `LoggingConfiguration`**, VPC flow logs, CloudFront v2) makes the service auto-attach an `AWSLogDeliveryWrite*` / `delivery.logs.amazonaws.com` policy to the group. Per-resource ARNs + account ids make it non-constant-foldable (equality-gated KNOWN_DEFAULTS can't close it) — exactly as the issue noted.

## What was already done vs what leaked

PR #465 already **subtracts the AWS-managed statements** in `canonicalizePolicy` (Sid `^AWSLogDelivery` AND the delivery.logs service principal, both required). But the surviving grammar shell `{Version, Statement: []}` is not trivially empty (`Version` is a non-empty constant string), so every vended-logs user still saw one first-run `[Potential Drift]` line on the LOG GROUP.

## Fix

New `isEmptyPolicyShell` structural-noise drop (undeclared loop): `Statement` must be present and EMPTY, every other key must be grammar boilerplate (`Version`/`Id` strings). Fail-closed guards, unit-tested:
- a surviving USER statement → still `undeclared`
- a delivery-shaped statement WITHOUT the `AWSLogDelivery` Sid (not subtracted by #465) → still `undeclared`
- a shell with a non-boilerplate extra key → still `undeclared`

## Verification

- **Live-proven** on a fresh `aps-rich` deploy (per the issue comment's repro): fresh no-baseline check went from `1 potential drift` (the shell) to **fully CLEAN** with the fixed binary. Stack deleted via delstack, `bughunt-track verify` OK (SWEEP CLEAN), gate cleared.
- The harvested REAL LogGroup read (with the actual APS-attached `AWSLogDeliveryWrite1` statement) is promoted as a corpus case — it pins the #465 subtraction AND this shell drop together, offline, forever.
- 2031 tests pass; typecheck/lint/build green; base on latest main.