### PR TITLE
fix(revert): retry transient mid-update errors (RSLVR-00705 & friends) with bounded backoff, then a targeted hint

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -311,7 +311,7 @@ checked.
   - **drift-calculator.ts** — pure structural diff (`calculateResourceDrift`), copied from cdkd.
 - **baseline/baseline-file.ts** — git-committed baseline I/O (machine-generated DATA → JSON, `.cdkrd/baselines/<stack>.<accountId>.<region>.json`), `applyBaseline`, `writeBaseline`.
 - **config/config-file.ts** — git-committed ignore-rule file (hand-edited POLICY → YAML so it can carry `#` comments, `.cdkrd/ignore.yaml`): `loadConfig` + `applyIgnores` (R32 path-level ignore rules → `ignored` tier; rule shape `{ path, stack?, account?, region? }`) + `addIgnoreRules` (comment-preserving, append-only).
-- **revert/** — the write path (section 7): **plan.ts** (incl. a `delete`-kind item for an out-of-band `added` resource, and `REVERT_SET_DEFAULT_PATHS` — properties whose undeclared "appeared since record" revert must WRITE the known `KNOWN_DEFAULTS` default explicitly (an `add`) instead of an RFC6902 `remove`, because the provider leaves the value UNCHANGED when it is merely absent so a bare `remove` is a silent no-op: IAM Role `MaxSessionDuration` is the proven case — `UpdateRole` ignores an omitted value, so reverting an out-of-band 7200 back toward the 3600 default never converged; Lambda Alias `Description` is the same shape — `UpdateAlias` ignores an omitted description, so revert writes the empty-string default to clear it; Cognito IdentityPool `AllowClassicFlow` likewise — `UpdateIdentityPool` ignores an omitted flag, so a bare `remove` of an out-of-band `true` is a no-op and the `false` default is written explicitly (all proven live). Curated, not "every `KNOWN_DEFAULTS` entry": most properties already converge via `remove` (S3 `DeleteBucketOwnershipControls` re-defaults), and `KNOWN_DEFAULTS` holds read-side COMPARE shapes some of which are not valid CC write inputs), **apply.ts** (CC UpdateResource / DeleteResource + poll), **apply-ops.ts** (pure RFC6902 apply), **writers.ts** (SDK writers).
+- **revert/** — the write path (section 7): **plan.ts** (incl. a `delete`-kind item for an out-of-band `added` resource, and `REVERT_SET_DEFAULT_PATHS` — properties whose undeclared "appeared since record" revert must WRITE the known `KNOWN_DEFAULTS` default explicitly (an `add`) instead of an RFC6902 `remove`, because the provider leaves the value UNCHANGED when it is merely absent so a bare `remove` is a silent no-op: IAM Role `MaxSessionDuration` is the proven case — `UpdateRole` ignores an omitted value, so reverting an out-of-band 7200 back toward the 3600 default never converged; Lambda Alias `Description` is the same shape — `UpdateAlias` ignores an omitted description, so revert writes the empty-string default to clear it; Cognito IdentityPool `AllowClassicFlow` likewise — `UpdateIdentityPool` ignores an omitted flag, so a bare `remove` of an out-of-band `true` is a no-op and the `false` default is written explicitly (all proven live). Curated, not "every `KNOWN_DEFAULTS` entry": most properties already converge via `remove` (S3 `DeleteBucketOwnershipControls` re-defaults), and `KNOWN_DEFAULTS` holds read-side COMPARE shapes some of which are not valid CC write inputs), **apply.ts** (CC UpdateResource / DeleteResource + poll), **apply-ops.ts** (pure RFC6902 apply), **writers.ts** (SDK writers), **transient.ts** (`classifyTransient` + `retryTransient` — bounded backoff on transient "resource is mid-update" errors like RSLVR-00705, then a targeted retry-later hint; issue #467).
 - **synth/** — **synth.ts** (`@aws-cdk/toolkit-lib` synth + `discoverStacks`), **resolve-app.ts**, **io-host.ts** (`QuietIoHost`).
 - **report/report.ts** — tiered text + JSON + exit code. **report/style.ts** —
   TTY-only semantic colors (R43). **aws-errors.ts** — `isStackNotDeployed` etc.
@@ -644,6 +644,21 @@ only when non-zero — unrecorded values are named as such, never folded into
   endorses the live value (it stops being drift entirely — record is never a step
   toward reverting that same value), while `--remove-unrecorded` removes it. When
   the guard fires, the plan leads with a note spelling out that fork.
+- **Transient-error retry then hint (issue #467)**: every mutating write (`cc`,
+  `sdk`, and the `added`-resource `delete`) is wrapped in a bounded backoff that
+  retries ONLY failures classified as transient "resource is mid-operation" by
+  [transient.ts](../src/revert/transient.ts) — RSLVR-00705 (a Route53Resolver rule
+  stays `Status: UPDATING` for minutes after an out-of-band change while it
+  propagates to endpoint ENIs, so a revert in that window honestly failed and only a
+  later retry succeeded), plus the cross-service concurrent-modification / operation-
+  in-progress / throttling class. A terminal ValidationException/AccessDenied returns
+  on the first attempt (no wasted waiting). When retries are exhausted on a still-
+  transient failure, the `FAILED:` line gains a targeted `↳ retry in a few minutes`
+  hint instead of a bare provider error, and the drift correctly still shows as
+  unconverged (exit stays 2). `classifyTransient` matches the error TEXT (Cloud
+  Control surfaces async failures as a FAILED `StatusMessage`, not a thrown error), so
+  `errorText` prepends the error name/`ErrorCode` for name-only signals like
+  `ThrottlingException`.
 - **Write mechanism** (`plan.ts` chooses `kind`):
   - `kind: 'cc'` — generic Cloud Control `UpdateResource` RFC6902 PatchDocument,
     polled via `GetResourceRequestStatus` ([apply.ts](../src/revert/apply.ts)).

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -35,6 +35,7 @@ import {
   tagPreservingOps,
   writeOnlyReincludeOps,
 } from '../revert/plan.js';
+import { errorText, retryTransient } from '../revert/transient.js';
 import { resolveSdkWriter } from '../revert/writers.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
@@ -587,21 +588,42 @@ export function formatPlan(
  *  fully reverted resource never prints twice and a partial failure is never shown as a
  *  plain success. Insertion order (first item per resource) is preserved. */
 export function summarizeRevertResults(
-  applied: readonly { logicalId: string; displayId: string; ok: boolean; error?: string }[]
-): { displayId: string; ok: boolean; error?: string }[] {
-  const byResource = new Map<string, { displayId: string; ok: boolean; errors: string[] }>();
+  applied: readonly {
+    logicalId: string;
+    displayId: string;
+    ok: boolean;
+    error?: string;
+    hint?: string;
+  }[]
+): { displayId: string; ok: boolean; error?: string; hint?: string }[] {
+  const byResource = new Map<
+    string,
+    { displayId: string; ok: boolean; errors: string[]; hints: string[] }
+  >();
   for (const a of applied) {
-    const g = byResource.get(a.logicalId) ?? { displayId: a.displayId, ok: true, errors: [] };
+    const g = byResource.get(a.logicalId) ?? {
+      displayId: a.displayId,
+      ok: true,
+      errors: [],
+      hints: [],
+    };
     if (!a.ok) {
       g.ok = false;
       if (a.error) g.errors.push(a.error);
+      // Collapse duplicate hints (a cc + sdk split can both fail transiently) to one line.
+      if (a.hint && !g.hints.includes(a.hint)) g.hints.push(a.hint);
     }
     byResource.set(a.logicalId, g);
   }
   return [...byResource.values()].map((g) =>
     g.ok
       ? { displayId: g.displayId, ok: true }
-      : { displayId: g.displayId, ok: false, error: g.errors.join('; ') }
+      : {
+          displayId: g.displayId,
+          ok: false,
+          error: g.errors.join('; '),
+          ...(g.hints.length > 0 && { hint: g.hints.join('; ') }),
+        }
   );
 }
 
@@ -798,40 +820,51 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // correctly vanishes from `post`, but a FAILED one would vanish too (reading as CLEAN).
   // Track the failed ones and re-add their findings so they still count as drift.
   const failedDeleteIds = new Set<string>();
-  const applied: { logicalId: string; displayId: string; ok: boolean; error?: string }[] = [];
+  const applied: {
+    logicalId: string;
+    displayId: string;
+    ok: boolean;
+    error?: string;
+    hint?: string;
+  }[] = [];
   for (const item of plan.items) {
-    let r: { ok: boolean; error?: string };
+    let r: { ok: boolean; error?: string; hint?: string };
     if (item.kind === 'delete') {
       // physicalId IS the CC identifier (the composite the finding carried); delete it.
       r = await applyRevertDelete(cc, item, item.physicalId);
       if (!r.ok) failedDeleteIds.add(item.logicalId);
     } else if (item.kind === 'sdk') {
       const res = byLogical.get(item.logicalId);
-      try {
-        const writer = resolveSdkWriter(item.resourceType, item.ops);
-        if (!writer) throw new Error(`no SDK writer for ${item.resourceType}`);
-        // A Cloud-Control-routed nested writer addresses the resource by the composite CC
-        // identifier (e.g. AWS::ApiGateway::Stage `RestApiId|StageName`) the READ path
-        // resolves — pass it so its GetResource/UpdateResource doesn't ValidationException
-        // on the bare physical id. Falls back to the physical id when no adapter applies.
-        const identifier =
-          CC_IDENTIFIER_ADAPTERS[item.resourceType]?.(item.physicalId, res?.declared ?? {}) ??
-          item.physicalId;
-        await writer(
-          {
-            physicalId: item.physicalId,
-            identifier,
-            declared: res?.declared ?? {},
-            region,
-            accountId: gathered.desired.accountId,
-            resourceType: item.resourceType,
-          },
-          item.ops
-        );
-        r = { ok: true };
-      } catch (e) {
-        r = { ok: false, error: (e as Error).message };
-      }
+      // Same transient-retry wrapper as the Cloud Control path (issue #467): an SDK
+      // writer can also throw a "resource is currently updating" error that settles on
+      // a retry, and exhausted retries carry the targeted hint.
+      r = await retryTransient(async () => {
+        try {
+          const writer = resolveSdkWriter(item.resourceType, item.ops);
+          if (!writer) throw new Error(`no SDK writer for ${item.resourceType}`);
+          // A Cloud-Control-routed nested writer addresses the resource by the composite CC
+          // identifier (e.g. AWS::ApiGateway::Stage `RestApiId|StageName`) the READ path
+          // resolves — pass it so its GetResource/UpdateResource doesn't ValidationException
+          // on the bare physical id. Falls back to the physical id when no adapter applies.
+          const identifier =
+            CC_IDENTIFIER_ADAPTERS[item.resourceType]?.(item.physicalId, res?.declared ?? {}) ??
+            item.physicalId;
+          await writer(
+            {
+              physicalId: item.physicalId,
+              identifier,
+              declared: res?.declared ?? {},
+              region,
+              accountId: gathered.desired.accountId,
+              resourceType: item.resourceType,
+            },
+            item.ops
+          );
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: errorText(e) };
+        }
+      });
     } else {
       const res = byLogical.get(item.logicalId);
       const identifier =
@@ -857,17 +890,21 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       displayId: item.displayId,
       ok: r.ok,
       ...(r.error !== undefined && { error: r.error }),
+      ...(r.hint !== undefined && { hint: r.hint }),
     });
     if (!r.ok) worst = Math.max(worst, 2);
   }
   // Print ONE outcome per resource (a resource that split into a `cc` + `sdk` item
   // produced two results) so a fully reverted resource never prints `reverted:` twice.
   for (const s of summarizeRevertResults(applied)) {
-    console.log(
-      s.ok
-        ? style.ok(`  reverted: ${s.displayId}`)
-        : style.fail(`  FAILED: ${s.displayId} — ${s.error}`)
-    );
+    if (s.ok) {
+      console.log(style.ok(`  reverted: ${s.displayId}`));
+    } else {
+      console.log(style.fail(`  FAILED: ${s.displayId} — ${s.error}`));
+      // Transient "resource is mid-update" failure that survived bounded retries:
+      // add a targeted hint so the user knows this is retry-later, not a real failure.
+      if (s.hint) console.log(style.infoTier(`    ↳ ${s.hint}`));
+    }
   }
 
   // Re-check convergence — scoped to the resources the revert just touched (R44).

--- a/src/revert/apply.ts
+++ b/src/revert/apply.ts
@@ -9,10 +9,15 @@ import {
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
 import { type RevertItem, toPatchDocument } from './plan.js';
+import { errorText, type RetryOptions, retryTransient } from './transient.js';
 
 export interface ApplyResult {
   ok: boolean;
   error?: string;
+  // Set when the FINAL failure (after bounded retries) is a transient "resource is
+  // mid-update" class — carries a targeted hint for the report layer (issue #467).
+  transient?: boolean;
+  hint?: string;
 }
 
 const POLL_INTERVAL_MS = 2000;
@@ -53,7 +58,11 @@ async function pollToCompletion(
     const status = event?.OperationStatus;
     if (status === 'SUCCESS') return { ok: true };
     if (status === 'FAILED' || status === 'CANCEL_COMPLETE') {
-      return { ok: false, error: event?.StatusMessage ?? status };
+      // StatusMessage carries the service code (e.g. RSLVR-00705) for transient
+      // classification; ErrorCode is a coarser CC enum, appended when present.
+      const msg = event?.StatusMessage ?? status;
+      const code = event?.ErrorCode;
+      return { ok: false, error: code && !msg.includes(code) ? `${code}: ${msg}` : msg };
     }
     await sleep(POLL_INTERVAL_MS);
     const polled = await cc.send(new GetResourceRequestStatusCommand({ RequestToken: token }));
@@ -69,20 +78,26 @@ export async function applyRevertItem(
   // composite-identifier types (e.g. AWS::ECS::Service = `${ServiceArn}|${Cluster}`)
   // need the same adapted identifier the READ path uses — the caller resolves it via
   // CC_IDENTIFIER_ADAPTERS and passes it here, else UpdateResource ValidationExceptions.
-  identifier: string = item.physicalId
+  identifier: string = item.physicalId,
+  // Bounded-backoff retry knobs (issue #467) — tests inject a no-op sleep.
+  retry: RetryOptions = {}
 ): Promise<ApplyResult> {
-  try {
-    const res = await cc.send(
-      new UpdateResourceCommand({
-        TypeName: item.resourceType,
-        Identifier: identifier,
-        PatchDocument: toPatchDocument(item),
-      })
-    );
-    return await pollToCompletion(cc, res.ProgressEvent);
-  } catch (e) {
-    return { ok: false, error: (e as Error).message };
-  }
+  // Retry ONLY transient "resource is mid-update" failures (RSLVR-00705 & friends);
+  // a terminal ValidationException returns on the first attempt.
+  return retryTransient(async () => {
+    try {
+      const res = await cc.send(
+        new UpdateResourceCommand({
+          TypeName: item.resourceType,
+          Identifier: identifier,
+          PatchDocument: toPatchDocument(item),
+        })
+      );
+      return await pollToCompletion(cc, res.ProgressEvent);
+    } catch (e) {
+      return { ok: false, error: errorText(e) };
+    }
+  }, retry);
 }
 
 // DELETE an `added` (out-of-band) resource via Cloud Control DeleteResource. The
@@ -91,19 +106,24 @@ export async function applyRevertItem(
 export async function applyRevertDelete(
   cc: CloudControlClient,
   item: RevertItem,
-  identifier: string = item.physicalId
+  identifier: string = item.physicalId,
+  retry: RetryOptions = {}
 ): Promise<ApplyResult> {
-  try {
-    const res = await cc.send(
-      new DeleteResourceCommand({ TypeName: item.resourceType, Identifier: identifier })
-    );
-    const result = await pollToCompletion(cc, res.ProgressEvent);
-    // already-gone surfaced as a FAILED event (vs a thrown error, handled below)
-    if (!result.ok && isAlreadyGone({ message: result.error })) return { ok: true };
-    return result;
-  } catch (e) {
-    const err = e as { name?: string; message?: string };
-    if (isAlreadyGone(err)) return { ok: true };
-    return { ok: false, error: err.message ?? String(e) };
-  }
+  // Same transient-retry wrapper as the update path: a DeleteResource can also hit a
+  // "resource is currently updating / in use" window and settle on a retry.
+  return retryTransient(async () => {
+    try {
+      const res = await cc.send(
+        new DeleteResourceCommand({ TypeName: item.resourceType, Identifier: identifier })
+      );
+      const result = await pollToCompletion(cc, res.ProgressEvent);
+      // already-gone surfaced as a FAILED event (vs a thrown error, handled below)
+      if (!result.ok && isAlreadyGone({ message: result.error })) return { ok: true };
+      return result;
+    } catch (e) {
+      const err = e as { name?: string; message?: string };
+      if (isAlreadyGone(err)) return { ok: true };
+      return { ok: false, error: errorText(e) };
+    }
+  }, retry);
 }

--- a/src/revert/transient.ts
+++ b/src/revert/transient.ts
@@ -1,0 +1,132 @@
+// Cross-service classification of TRANSIENT "the resource is mid-operation, retry
+// later" revert failures — as opposed to terminal validation/permission/state errors.
+//
+// The motivating case (issue #467): after an out-of-band `route53resolver
+// update-resolver-rule`, the rule stays `Status: UPDATING` for minutes (async
+// propagation to endpoint ENIs). A `cdkrd revert` issued in that window fails with
+//   [RSLVR-00705] Cannot update Resolver Rule because it's currently updating.
+// That is not a real failure — a later revert succeeds. The whole class (concurrent
+// modification, throttling, "another operation in progress") is retry-then-hint
+// material, not generic-FAILED material.
+//
+// We only have the error TEXT to work with (Cloud Control surfaces async failures as a
+// FAILED ProgressEvent StatusMessage; thrown SDK errors are caught to a message string).
+// `errorText` prepends the error `name`/`code` so name-only signals (e.g.
+// `ThrottlingException`) survive into the string the classifier matches on.
+
+// Verdict for a single error string.
+export interface TransientVerdict {
+  transient: boolean;
+  // A short human-facing explanation, shown once retries are exhausted (hybrid UX:
+  // bounded backoff first, then this hint instead of a bare `FAILED: … — <raw error>`).
+  hint?: string;
+}
+
+const RETRY_HINT = 'the resource is still applying a previous update — retry in a few minutes';
+const THROTTLE_HINT = 'AWS throttled the request — retry shortly';
+
+// First match wins. Patterns match against `errorText` (case-insensitive). Keep this
+// focused on the genuinely-transient class: a false positive here turns a permanent
+// failure into wasted backoff + a misleading "retry later" hint, so err toward
+// specificity (service codes, unambiguous phrases) over broad substrings.
+const TRANSIENT_PATTERNS: readonly { pattern: RegExp; hint: string }[] = [
+  // Route53Resolver rule/endpoint mid-update (async ENI propagation).
+  {
+    pattern: /RSLVR-00705|currently updating/i,
+    hint:
+      'the resource is still applying a previous update (async propagation) — ' +
+      'retry in a few minutes',
+  },
+  // Generic concurrent-modification / operation-in-progress across services
+  // (e.g. ConcurrentModificationException, OperationInProgressException,
+  // ResourceConflictException/ConflictException) plus Cloud Control's bare
+  // HandlerErrorCode forms (ResourceConflict, NetworkFailure, InternalFailure,
+  // ServiceInternalError) surfaced on a FAILED ProgressEvent.
+  {
+    pattern:
+      /ConcurrentModificationException|OperationInProgressException|OperationAbortedException|ResourceConflictException|ConflictException|\bResourceConflict\b|\bNetworkFailure\b|\bInternalFailure\b|\bServiceInternalError\b/i,
+    hint: RETRY_HINT,
+  },
+  {
+    pattern:
+      /another (operation|update|change|request)[^.]*in progress|operation[^.]*(already )?in progress|update[^.]*in progress|modification[^.]*in progress|currently being (created|updated|modified|deleted|provisioned)|is not in a stable state|resource is in use|please try again|try again (later|in a few)/i,
+    hint: RETRY_HINT,
+  },
+  // Throttling / rate limiting — retryable, but a distinct hint.
+  {
+    pattern:
+      /ThrottlingException|ThrottledException|TooManyRequestsException|RequestThrottled|RequestLimitExceeded|ServiceUnavailable|\bThrottling\b|rate exceeded/i,
+    hint: THROTTLE_HINT,
+  },
+];
+
+// Best-effort text extraction: `name: message` when the name adds signal the message
+// lacks, else the message alone. Accepts already-stringified errors too.
+export function errorText(e: unknown): string {
+  if (typeof e === 'string') return e;
+  const o = (e ?? {}) as { name?: unknown; code?: unknown; message?: unknown };
+  const name = typeof o.name === 'string' ? o.name : typeof o.code === 'string' ? o.code : '';
+  const message = typeof o.message === 'string' ? o.message : '';
+  if (name && (!message || !message.includes(name))) {
+    return message ? `${name}: ${message}` : name;
+  }
+  return message || String(e);
+}
+
+export function classifyTransient(error: string | undefined): TransientVerdict {
+  if (!error) return { transient: false };
+  for (const { pattern, hint } of TRANSIENT_PATTERNS) {
+    if (pattern.test(error)) return { transient: true, hint };
+  }
+  return { transient: false };
+}
+
+// The shape a retryable revert step returns. `applyRevertItem` / `applyRevertDelete`
+// and the SDK-writer path all normalize to this (ok + error string); on exhaustion the
+// retry annotates it with `transient` + `hint` for the report layer.
+export interface RetryableResult {
+  ok: boolean;
+  error?: string;
+  transient?: boolean;
+  hint?: string;
+}
+
+export interface RetryOptions {
+  // Total attempts including the first (default 3 → up to 2 retries).
+  maxAttempts?: number;
+  // Linear backoff base: waits baseDelayMs * attempt between tries (3s, 6s, …).
+  baseDelayMs?: number;
+  // Injectable for tests (default real setTimeout).
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export const DEFAULT_MAX_ATTEMPTS = 3;
+export const DEFAULT_BASE_DELAY_MS = 3000;
+
+const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// Run `op` with bounded backoff, retrying ONLY while its failure classifies as
+// transient. A terminal failure returns immediately (no wasted waiting). When all
+// attempts are exhausted on a still-transient failure, the returned result carries
+// `transient: true` + the classifier's `hint` so the caller can show the targeted
+// message instead of a bare FAILED. `op` must be self-contained (catch its own throws
+// into `{ ok:false, error }`) — it is re-invoked verbatim each attempt.
+export async function retryTransient<T extends RetryableResult>(
+  op: () => Promise<T>,
+  opts: RetryOptions = {}
+): Promise<T> {
+  const max = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const base = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const doSleep = opts.sleep ?? realSleep;
+  let result = await op();
+  for (let attempt = 1; !result.ok && attempt < max; attempt++) {
+    if (!classifyTransient(result.error).transient) return result; // terminal — stop
+    await doSleep(base * attempt);
+    result = await op();
+  }
+  if (!result.ok) {
+    const verdict = classifyTransient(result.error);
+    if (verdict.transient) return { ...result, transient: true, hint: verdict.hint };
+  }
+  return result;
+}

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -1,11 +1,18 @@
-import { CloudControlClient, DeleteResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import {
+  CloudControlClient,
+  DeleteResourceCommand,
+  UpdateResourceCommand,
+} from '@aws-sdk/client-cloudcontrol';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
-import { applyRevertDelete, isAlreadyGone } from '../src/revert/apply.js';
+import { applyRevertDelete, applyRevertItem, isAlreadyGone } from '../src/revert/apply.js';
 import type { RevertItem } from '../src/revert/plan.js';
 
 const cc = mockClient(CloudControlClient);
 beforeEach(() => cc.reset());
+
+// No real backoff waiting in tests.
+const noNap = { sleep: () => Promise.resolve() };
 
 const deleteItem = (): RevertItem => ({
   logicalId: 'Child',
@@ -15,6 +22,19 @@ const deleteItem = (): RevertItem => ({
   kind: 'delete',
   ops: [],
 });
+
+const updateItem = (): RevertItem => ({
+  logicalId: 'RR',
+  displayId: 'Stack/ResolverRule',
+  resourceType: 'AWS::Route53Resolver::ResolverRule',
+  physicalId: 'rslvr-rr-abc',
+  kind: 'cc',
+  ops: [
+    { op: 'add', path: '/DomainName', value: 'example.internal.', human: 'DomainName -> default' },
+  ],
+});
+
+const RSLVR_UPDATING = "[RSLVR-00705] Cannot update Resolver Rule because it's currently updating.";
 
 describe('isAlreadyGone', () => {
   it('true for not-found error names', () => {
@@ -50,5 +70,105 @@ describe('applyRevertDelete — already-gone tolerance', () => {
     const r = await applyRevertDelete(cc as unknown as CloudControlClient, deleteItem());
     expect(r.ok).toBe(false);
     expect(r.error).toContain('not authorized');
+  });
+});
+
+describe('applyRevertItem — transient retry then hint (issue #467)', () => {
+  it('retries an RSLVR-00705 mid-update FAILED event and succeeds on a later attempt', async () => {
+    cc.on(UpdateResourceCommand)
+      .resolvesOnce({
+        ProgressEvent: {
+          RequestToken: 't1',
+          OperationStatus: 'FAILED',
+          StatusMessage: RSLVR_UPDATING,
+        },
+      })
+      .resolves({ ProgressEvent: { RequestToken: 't2', OperationStatus: 'SUCCESS' } });
+    const r = await applyRevertItem(
+      cc as unknown as CloudControlClient,
+      updateItem(),
+      undefined,
+      noNap
+    );
+    expect(r.ok).toBe(true);
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(2);
+  });
+
+  it('exhausts retries on a persistent mid-update failure and returns a transient hint', async () => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: {
+        RequestToken: 't1',
+        OperationStatus: 'FAILED',
+        StatusMessage: RSLVR_UPDATING,
+      },
+    });
+    const r = await applyRevertItem(cc as unknown as CloudControlClient, updateItem(), undefined, {
+      maxAttempts: 3,
+      sleep: () => Promise.resolve(),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.transient).toBe(true);
+    expect(r.hint).toContain('async propagation');
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(3);
+  });
+
+  it('does NOT retry a terminal ValidationException (fails on first attempt)', async () => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: {
+        RequestToken: 't1',
+        OperationStatus: 'FAILED',
+        StatusMessage: 'Invalid property DomainName',
+        ErrorCode: 'InvalidRequest',
+      },
+    });
+    const r = await applyRevertItem(
+      cc as unknown as CloudControlClient,
+      updateItem(),
+      undefined,
+      noNap
+    );
+    expect(r.ok).toBe(false);
+    expect(r.transient).toBeUndefined();
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(1);
+  });
+
+  it('surfaces the Cloud Control ErrorCode alongside the message for classification', async () => {
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: {
+        RequestToken: 't1',
+        OperationStatus: 'FAILED',
+        StatusMessage: 'Rate exceeded',
+        ErrorCode: 'Throttling',
+      },
+    });
+    const r = await applyRevertItem(cc as unknown as CloudControlClient, updateItem(), undefined, {
+      maxAttempts: 2,
+      sleep: () => Promise.resolve(),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('Throttling');
+    expect(r.transient).toBe(true);
+  });
+});
+
+describe('applyRevertDelete — transient retry', () => {
+  it('retries a mid-update DeleteResource failure and succeeds', async () => {
+    cc.on(DeleteResourceCommand)
+      .resolvesOnce({
+        ProgressEvent: {
+          RequestToken: 't1',
+          OperationStatus: 'FAILED',
+          StatusMessage: 'ConcurrentModificationException: another operation is in progress',
+        },
+      })
+      .resolves({ ProgressEvent: { RequestToken: 't2', OperationStatus: 'SUCCESS' } });
+    const r = await applyRevertDelete(
+      cc as unknown as CloudControlClient,
+      deleteItem(),
+      undefined,
+      noNap
+    );
+    expect(r.ok).toBe(true);
+    expect(cc.commandCalls(DeleteResourceCommand).length).toBe(2);
   });
 });

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -357,6 +357,44 @@ describe('summarizeRevertResults (one outcome per resource even when it split in
       { displayId: 'Stack/A', ok: false, error: 'e1; e2' },
     ]);
   });
+
+  it('carries a transient hint through on a failed entry (issue #467)', () => {
+    const out = summarizeRevertResults([
+      {
+        logicalId: 'RR',
+        displayId: 'Stack/ResolverRule',
+        ok: false,
+        error: '[RSLVR-00705] currently updating',
+        hint: 'retry in a few minutes',
+      },
+    ]);
+    expect(out).toEqual([
+      {
+        displayId: 'Stack/ResolverRule',
+        ok: false,
+        error: '[RSLVR-00705] currently updating',
+        hint: 'retry in a few minutes',
+      },
+    ]);
+  });
+
+  it('deduplicates identical hints from a cc+sdk split into one', () => {
+    const out = summarizeRevertResults([
+      { logicalId: 'X', displayId: 'Stack/X', ok: false, error: 'e1', hint: 'retry later' },
+      { logicalId: 'X', displayId: 'Stack/X', ok: false, error: 'e2', hint: 'retry later' },
+    ]);
+    expect(out).toEqual([
+      { displayId: 'Stack/X', ok: false, error: 'e1; e2', hint: 'retry later' },
+    ]);
+  });
+
+  it('omits the hint entirely for a plain (non-transient) failure', () => {
+    const out = summarizeRevertResults([
+      { logicalId: 'Y', displayId: 'Stack/Y', ok: false, error: 'AccessDenied' },
+    ]);
+    expect(out).toEqual([{ displayId: 'Stack/Y', ok: false, error: 'AccessDenied' }]);
+    expect(out[0]).not.toHaveProperty('hint');
+  });
 });
 
 describe('revertSelectOptions / filterRevertPlan distinguish ELB attribute-bag ops', () => {

--- a/tests/transient.test.ts
+++ b/tests/transient.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  classifyTransient,
+  errorText,
+  type RetryableResult,
+  retryTransient,
+} from '../src/revert/transient.js';
+
+describe('classifyTransient — transient (retry-later) error class', () => {
+  it('classifies the Route53Resolver mid-update code (issue #467)', () => {
+    const v = classifyTransient(
+      "[RSLVR-00705] Cannot update Resolver Rule because it's currently updating."
+    );
+    expect(v.transient).toBe(true);
+    expect(v.hint).toContain('async propagation');
+  });
+
+  it('classifies generic concurrent-modification / in-progress errors', () => {
+    for (const msg of [
+      'ConcurrentModificationException: Cannot update while a change is applied',
+      'OperationInProgressException: try again',
+      'ResourceConflictException: The operation cannot be performed',
+      'ConflictException: resource is being modified',
+      'Another operation is currently in progress for this resource',
+      'An update is in progress; please try again',
+      'The resource is currently being updated',
+      'Please try again later',
+    ]) {
+      const v = classifyTransient(msg);
+      expect(v.transient).toBe(true);
+      expect(v.hint).toBeTruthy();
+    }
+  });
+
+  it('classifies Cloud Control bare HandlerErrorCode transient forms', () => {
+    for (const code of ['ResourceConflict', 'NetworkFailure', 'InternalFailure', 'Throttling']) {
+      expect(classifyTransient(`${code}: something happened`).transient).toBe(true);
+    }
+  });
+
+  it('classifies throttling with the throttle-specific hint', () => {
+    for (const msg of [
+      'ThrottlingException: Rate exceeded',
+      'TooManyRequestsException',
+      'Rate exceeded',
+    ]) {
+      const v = classifyTransient(msg);
+      expect(v.transient).toBe(true);
+      expect(v.hint).toContain('throttled');
+    }
+  });
+
+  it('does NOT classify terminal validation / permission / not-found errors', () => {
+    for (const msg of [
+      'ValidationException: Invalid property FooBar',
+      'AccessDeniedException: not authorized to perform cloudcontrolapi:UpdateResource',
+      'ResourceNotFoundException: the resource was not found',
+      'InvalidRequest: property is createOnly and cannot be updated',
+      'A ServiceLimitExceeded error occurred', // limit != transient in-progress
+      undefined,
+      '',
+    ]) {
+      expect(classifyTransient(msg).transient).toBe(false);
+    }
+  });
+});
+
+describe('errorText — best-effort name + message extraction', () => {
+  it('prepends the error name when it adds signal', () => {
+    const e = Object.assign(new Error("it's currently updating"), { name: 'RSLVR-00705' });
+    expect(errorText(e)).toBe("RSLVR-00705: it's currently updating");
+  });
+  it('does not duplicate a name already present in the message', () => {
+    const e = Object.assign(new Error('ThrottlingException: Rate exceeded'), {
+      name: 'ThrottlingException',
+    });
+    expect(errorText(e)).toBe('ThrottlingException: Rate exceeded');
+  });
+  it('uses the SDK `code` field when there is no `name`', () => {
+    expect(errorText({ code: 'Throttling', message: 'slow down' })).toBe('Throttling: slow down');
+  });
+  it('passes a plain string through unchanged', () => {
+    expect(errorText('plain error')).toBe('plain error');
+  });
+});
+
+describe('retryTransient — bounded backoff, then hint', () => {
+  const nap = () => Promise.resolve(); // no real waiting in tests
+
+  it('returns immediately on first success (no retry)', async () => {
+    let calls = 0;
+    const r = await retryTransient(
+      async () => {
+        calls++;
+        return { ok: true } as RetryableResult;
+      },
+      { sleep: nap }
+    );
+    expect(r.ok).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it('retries a transient failure and succeeds on a later attempt', async () => {
+    let calls = 0;
+    const r = await retryTransient(
+      async () => {
+        calls++;
+        return calls < 3 ? { ok: false, error: '[RSLVR-00705] currently updating' } : { ok: true };
+      },
+      { sleep: nap }
+    );
+    expect(r.ok).toBe(true);
+    expect(calls).toBe(3);
+  });
+
+  it('does NOT retry a terminal failure (returns on first attempt)', async () => {
+    let calls = 0;
+    const r = await retryTransient(
+      async (): Promise<RetryableResult> => {
+        calls++;
+        return { ok: false, error: 'ValidationException: bad property' };
+      },
+      { sleep: nap }
+    );
+    expect(r.ok).toBe(false);
+    expect(calls).toBe(1);
+    expect(r.transient).toBeUndefined();
+    expect(r.hint).toBeUndefined();
+  });
+
+  it('exhausts retries on a persistent transient failure and annotates the hint', async () => {
+    let calls = 0;
+    const r = await retryTransient(
+      async (): Promise<RetryableResult> => {
+        calls++;
+        return { ok: false, error: '[RSLVR-00705] currently updating' };
+      },
+      { maxAttempts: 3, sleep: nap }
+    );
+    expect(r.ok).toBe(false);
+    expect(calls).toBe(3); // first + 2 retries
+    expect(r.transient).toBe(true);
+    expect(r.hint).toContain('async propagation');
+  });
+
+  it('waits with linear backoff (baseDelayMs * attempt) between tries', async () => {
+    const waits: number[] = [];
+    await retryTransient(async () => ({ ok: false, error: 'ThrottlingException: Rate exceeded' }), {
+      maxAttempts: 3,
+      baseDelayMs: 1000,
+      sleep: async (ms) => void waits.push(ms),
+    });
+    expect(waits).toEqual([1000, 2000]);
+  });
+});


### PR DESCRIPTION
## What

Closes #467. Improve the revert UX when the target resource is **mid-async-update**
(e.g. a Route53Resolver rule that stays `Status: UPDATING` for minutes after an
out-of-band change while it propagates to endpoint ENIs). Previously a revert in that
window failed with a bare generic `FAILED: … [RSLVR-00705] … currently updating`.

**Hybrid UX** (chosen over retry-only / hint-only): bounded backoff retry **then** a
targeted retry-later hint.

## How

- New **`src/revert/transient.ts`**:
  - `classifyTransient(errorText) → { transient, hint }` over a cross-service pattern
    table — RSLVR-00705 / "currently updating"; the concurrent-modification /
    operation-in-progress class (`ConcurrentModificationException`,
    `OperationInProgressException`, `ResourceConflictException`/`ConflictException` +
    Cloud Control bare `HandlerErrorCode`s `ResourceConflict`/`NetworkFailure`/
    `InternalFailure`); and throttling (distinct hint). Conservative on purpose — a
    false positive would waste backoff and mislead.
  - `retryTransient(op, { maxAttempts=3, baseDelayMs=3000, sleep })` — retries **only**
    transient failures (linear 3s/6s), returns terminal failures on the first attempt,
    and on exhaustion annotates `{ transient, hint }`.
  - `errorText(e)` prepends the error `name`/`code` (and the CC `ErrorCode` in
    `pollToCompletion`) so name-only signals like `ThrottlingException` survive into the
    matched string.
- Wired into `applyRevertItem` / `applyRevertDelete` and the SDK-writer branch of
  `revertStack`. The hint is plumbed through `applied[]` → `summarizeRevertResults`
  (dedups a cc+sdk split) → an indented `↳ <hint>` line under `FAILED:`.
- **Exit semantics unchanged**: a transient FAILED still bumps exit to 2 and the
  convergence re-check still honestly reports the drift as remaining — this is purely a
  friendlier surface, not a silent swallow.

## Tests

- `tests/transient.test.ts` — the classification table (transient vs terminal, per-hint),
  `errorText`, and `retryTransient` (no-retry success, retry-then-succeed,
  no-retry-on-terminal, exhaust-then-hint, linear backoff).
- `tests/apply.test.ts` — `applyRevertItem` retries an RSLVR-00705 FAILED event then
  succeeds / exhausts to a hint / does not retry a ValidationException / surfaces the CC
  `ErrorCode`; `applyRevertDelete` retries a mid-update delete.
- `tests/stack-actions.test.ts` — `summarizeRevertResults` carries + dedups the hint,
  and omits it for plain failures.

## Live-tested (real AWS, `tests/integration/resolver-rich`, the issue's exact scenario)

```
# mutate TargetIps out of band → immediate revert (mid-UPDATING)
FAILED: …/HuntForwardRule — InvalidRequest: [RSLVR-00705] … currently updating …
  ↳ the resource is still applying a previous update (async propagation) — retry in a few minutes
CdkRealDriftIntegResolverRich: 1 drift(s) remain.   (exit 2)

# after Status=COMPLETE → revert again
reverted: …/HuntForwardRule
CdkRealDriftIntegResolverRich: CLEAN after revert.   (exit 0, live TargetIps restored)
```

Stack torn down via `delstack`; `sweep-orphans` reports SWEEP CLEAN.
