### PR TITLE
feat(check): show a spinner while reading live state so a run never looks frozen

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -6,6 +6,7 @@
 // exits 0 (a hint names --fail); with --fail drift exits 1 and prompts are
 // suppressed. Errors always exit 2. The exit is the worst across all checked
 // stacks.
+import { spinner } from '@clack/prompts';
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
@@ -26,7 +27,7 @@ import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
 import { resolveStacks } from './resolve-stacks.js';
-import { gatherFindings } from './gather.js';
+import { gatherFindings, type GatherResult } from './gather.js';
 import { resolveInteractively } from './interactive-resolve.js';
 
 // --pre-deploy reports declared-side drift the next deploy would clobber; the
@@ -159,6 +160,33 @@ export function finalCheckExit(code: number, fail: boolean): number {
   return fail || code !== 1 ? code : 0;
 }
 
+// A stack's live read + drift computation (gatherFindings) runs SILENTLY and can take
+// many seconds on a large stack — long enough that a run looks frozen before the first
+// report, and (in a multi-stack run) in the gap between one stack's interactive prompt
+// and the next stack's report, where the user has no cue anything is happening. Show a
+// spinner while it runs so it is clear cdkrd is working, not hung. TTY + text mode only:
+// a spinner would corrupt --json's machine stdout and is noise in a non-TTY/CI pipe, so
+// the caller passes `show=false` there and this is a plain pass-through. The spinner is
+// stopped on BOTH success (`stop`) and error (`error`, which renders the failure symbol)
+// so a throw still tears the animation down before the outer catch prints its message.
+export async function gatherWithProgress(
+  show: boolean,
+  label: string,
+  run: () => Promise<GatherResult>
+): Promise<GatherResult> {
+  if (!show) return run();
+  const s = spinner();
+  s.start(`${label}: reading live AWS state & computing drift…`);
+  try {
+    const gathered = await run();
+    s.stop(`${label}: live state read`);
+    return gathered;
+  } catch (e) {
+    s.error(`${label}: read failed`);
+    throw e;
+  }
+}
+
 export async function runCheck(args: string[]): Promise<number> {
   const a = parseCommonArgs(args);
   if (a.profile) process.env.AWS_PROFILE = a.profile; // honored by SDK clients + synth subprocess
@@ -216,7 +244,9 @@ export async function runCheck(args: string[]): Promise<number> {
   // R37: one blank line between consecutive stack reports (text mode only) — done
   // here at the call site so a single-stack run never gets a stray leading blank.
   const separate = stackSeparator();
-  for (const { stackName, region, template } of stacks) {
+  // The gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
+  const showProgress = !a.json && isInteractive();
+  for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
       console.error(
         `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
@@ -233,7 +263,14 @@ export async function runCheck(args: string[]): Promise<number> {
       // The stack's synth template (always carried by resolveStacks) is the non-ASCII
       // RECOVERY source for the deployed-template path — loadDesired ignores it under
       // --pre-deploy (where synthTemplates is already the declared override).
-      const gathered = await gatherFindings(stackName, region, synthTemplates?.get(sKey), template);
+      // Progress counter only when there is more than one stack to check (a lone
+      // "[1/1]" is noise). The spinner is suppressed under --json / non-TTY.
+      const progressPrefix = stacks.length > 1 ? `[${idx + 1}/${stacks.length}] ` : '';
+      const gathered = await gatherWithProgress(
+        showProgress,
+        `${progressPrefix}${stackName} (${region})`,
+        () => gatherFindings(stackName, region, synthTemplates?.get(sKey), template)
+      );
       const { desired, schemas, liveByLogical } = gathered;
       let findings = gathered.findings;
 

--- a/tests/gather-progress.test.ts
+++ b/tests/gather-progress.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// A stub spinner so we can assert start/stop are (or are not) driven by
+// gatherWithProgress without a real TTY animation.
+const start = vi.fn();
+const stop = vi.fn();
+const error = vi.fn();
+vi.mock('@clack/prompts', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, spinner: () => ({ start, stop, error, message: vi.fn() }) };
+});
+
+import { gatherWithProgress } from '../src/commands/check.js';
+import type { GatherResult } from '../src/commands/gather.js';
+
+// A minimal GatherResult — gatherWithProgress only forwards it, never inspects it.
+const RESULT = {
+  desired: {},
+  findings: [],
+  schemas: new Map(),
+  liveByLogical: new Map(),
+} as unknown as GatherResult;
+
+describe('gatherWithProgress', () => {
+  beforeEach(() => {
+    start.mockClear();
+    stop.mockClear();
+    error.mockClear();
+  });
+
+  it('is a plain pass-through when show=false (no spinner)', async () => {
+    const run = vi.fn().mockResolvedValue(RESULT);
+    const out = await gatherWithProgress(false, 'S (r)', run);
+    expect(out).toBe(RESULT);
+    expect(run).toHaveBeenCalledOnce();
+    expect(start).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('starts and stops the spinner around the run when show=true', async () => {
+    const run = vi.fn().mockResolvedValue(RESULT);
+    const out = await gatherWithProgress(true, 'S (r)', run);
+    expect(out).toBe(RESULT);
+    expect(start).toHaveBeenCalledOnce();
+    // success path: stop (not error), carrying the stack label.
+    expect(stop).toHaveBeenCalledOnce();
+    expect(stop.mock.calls[0]![0]).toContain('S (r)');
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('tears the spinner down via error() and rethrows on failure', async () => {
+    const boom = new Error('read blew up');
+    const run = vi.fn().mockRejectedValue(boom);
+    await expect(gatherWithProgress(true, 'S (r)', run)).rejects.toThrow('read blew up');
+    // failure symbol shown, success stop NOT called, so the outer catch prints cleanly.
+    expect(error).toHaveBeenCalledOnce();
+    expect(error.mock.calls[0]![0]).toContain('S (r)');
+    expect(stop).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Why

Between finishing one stack's interactive prompt and the next stack's report — and before the very first report — `check` runs `gatherFindings` (a live read of every resource via Cloud Control / SDK overrides, then the diff) completely **silently**. On a large or multi-stack run this silent gap is long enough that the CLI looks frozen, with no cue that anything is happening.

## What

Wrap each stack's `gatherFindings` in a `gatherWithProgress` helper that shows a `@clack/prompts` spinner while the read + diff runs:

- `[2/3] <stack> (<region>): reading live AWS state & computing drift…` while running, then `: live state read` on completion (the report prints right after).
- Progress counter `[N/M]` only shown for multi-stack runs (a lone `[1/1]` is noise).
- TTY + text mode only (`!--json && isInteractive()`): suppressed under `--json` (would corrupt machine stdout) and in non-TTY / CI, where it is a plain pass-through.
- On error the spinner is torn down via `spinner().error(...)` before the outer catch prints, so a failed read still renders cleanly.

## Tests

`tests/gather-progress.test.ts` covers the three paths: pass-through when `show=false` (no spinner), start+stop around a successful run, and `error()` teardown + rethrow on failure.

Note: the spinner is TTY-gated, so it is only visually observable in a real terminal — confirmed here via unit tests; eyeball in a TTY with `node dist/cli.js check ...`.
