### PR TITLE
feat(record,ignore,revert): share the check gather-phase spinner across all four verbs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -290,6 +290,7 @@ checked.
     `applicableActions` / `cycleAction` / `setAllToAction` / `groupByAction` are pure +
     unit-tested.
   - **gather.ts** — shared read+classify pipeline (the 2-pass GetAtt resolution lives here).
+  - **progress.ts** — the gather-phase spinner shared by all four verbs (`gatherWithProgress` / `progressLabel`): the live read + diff runs silently for seconds, so a spinner shows it is working, not hung. TTY + text mode only — `--json` / non-TTY is an untouched pass-through.
   - **resolve-stacks.ts** — synth-discover the app, then turn args into `{stackName, region}[]` (all / exact / glob).
   - **glob-match.ts** — pure `*`/`?` matcher (`isGlob` / `globToRegExp` / `matchesGlob`).
   - **bulk-multiselect.ts** — the record/revert multiselect, built on `@clack/core`'s `MultiSelectPrompt` so it can bind bulk keys the high-level wrapper hides (space = toggle, → = all, ← = none, enter = confirm; mirrors cdk-local's target picker, R116). `bulkSelectValues` / `bulkSelectHint` are pure + unit-tested.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -6,7 +6,6 @@
 // exits 0 (a hint names --fail); with --fail drift exits 1 and prompts are
 // suppressed. Errors always exit 2. The exit is the worst across all checked
 // stacks.
-import { spinner } from '@clack/prompts';
 import { isStackNotDeployed, StackNotCheckableError } from '../aws-errors.js';
 import {
   applyBaseline,
@@ -27,7 +26,8 @@ import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
 import { resolveStacks } from './resolve-stacks.js';
-import { gatherFindings, type GatherResult } from './gather.js';
+import { gatherFindings } from './gather.js';
+import { gatherWithProgress, progressLabel } from './progress.js';
 import { resolveInteractively } from './interactive-resolve.js';
 
 // --pre-deploy reports declared-side drift the next deploy would clobber; the
@@ -160,33 +160,6 @@ export function finalCheckExit(code: number, fail: boolean): number {
   return fail || code !== 1 ? code : 0;
 }
 
-// A stack's live read + drift computation (gatherFindings) runs SILENTLY and can take
-// many seconds on a large stack — long enough that a run looks frozen before the first
-// report, and (in a multi-stack run) in the gap between one stack's interactive prompt
-// and the next stack's report, where the user has no cue anything is happening. Show a
-// spinner while it runs so it is clear cdkrd is working, not hung. TTY + text mode only:
-// a spinner would corrupt --json's machine stdout and is noise in a non-TTY/CI pipe, so
-// the caller passes `show=false` there and this is a plain pass-through. The spinner is
-// stopped on BOTH success (`stop`) and error (`error`, which renders the failure symbol)
-// so a throw still tears the animation down before the outer catch prints its message.
-export async function gatherWithProgress(
-  show: boolean,
-  label: string,
-  run: () => Promise<GatherResult>
-): Promise<GatherResult> {
-  if (!show) return run();
-  const s = spinner();
-  s.start(`${label}: reading live AWS state & computing drift…`);
-  try {
-    const gathered = await run();
-    s.stop(`${label}: live state read`);
-    return gathered;
-  } catch (e) {
-    s.error(`${label}: read failed`);
-    throw e;
-  }
-}
-
 export async function runCheck(args: string[]): Promise<number> {
   const a = parseCommonArgs(args);
   if (a.profile) process.env.AWS_PROFILE = a.profile; // honored by SDK clients + synth subprocess
@@ -263,12 +236,9 @@ export async function runCheck(args: string[]): Promise<number> {
       // The stack's synth template (always carried by resolveStacks) is the non-ASCII
       // RECOVERY source for the deployed-template path — loadDesired ignores it under
       // --pre-deploy (where synthTemplates is already the declared override).
-      // Progress counter only when there is more than one stack to check (a lone
-      // "[1/1]" is noise). The spinner is suppressed under --json / non-TTY.
-      const progressPrefix = stacks.length > 1 ? `[${idx + 1}/${stacks.length}] ` : '';
       const gathered = await gatherWithProgress(
         showProgress,
-        `${progressPrefix}${stackName} (${region})`,
+        progressLabel(idx, stacks.length, stackName, region),
         () => gatherFindings(stackName, region, synthTemplates?.get(sKey), template)
       );
       const { desired, schemas, liveByLogical } = gathered;

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -15,6 +15,7 @@ import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
+import { gatherWithProgress, progressLabel } from './progress.js';
 import { ignoreStack } from './stack-actions.js';
 
 export async function runIgnore(args: string[]): Promise<number> {
@@ -43,7 +44,9 @@ export async function runIgnore(args: string[]): Promise<number> {
 
   let worst = 0;
   let wroteAny = false;
-  for (const { stackName, region, template } of stacks) {
+  // gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
+  const showProgress = !a.json && isInteractive();
+  for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
       console.error(
         `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
@@ -52,7 +55,11 @@ export async function runIgnore(args: string[]): Promise<number> {
       continue;
     }
     try {
-      const { desired, findings } = await gatherFindings(stackName, region, undefined, template);
+      const { desired, findings } = await gatherWithProgress(
+        showProgress,
+        progressLabel(idx, stacks.length, stackName, region),
+        () => gatherFindings(stackName, region, undefined, template)
+      );
       // Reconcile exactly as check does so the offered drift matches what the user saw:
       // suppress already-recorded baseline entries, then re-tag config-ignored findings
       // out (they are already `ignored`, so ignoreStack never re-offers them).

--- a/src/commands/progress.ts
+++ b/src/commands/progress.ts
@@ -1,0 +1,45 @@
+// Shared gather-phase progress spinner for the four verbs (check / record / ignore /
+// revert). Each of them reads a stack's full live state + computes the diff via
+// `gatherFindings`, which runs SILENTLY and can take many seconds on a large stack —
+// long enough that a run looks frozen before the first output, and (in a multi-stack
+// run) in the gap between one stack's interactive prompt and the next stack's turn,
+// where the user has no cue anything is happening. Show a spinner while it runs so it is
+// clear cdkrd is working, not hung.
+import { spinner } from '@clack/prompts';
+
+// TTY + text mode only: a spinner would corrupt --json's machine stdout and is noise in
+// a non-TTY / CI pipe, so callers pass `show=false` there and this is a plain
+// pass-through. Stopped on BOTH success (`stop`) and error (`error`, which renders the
+// failure symbol) so a throw still tears the animation down before the caller's catch
+// prints its message. Generic in the gather result so every verb (which unpacks the
+// result differently) can wrap its own `gatherFindings` call unchanged.
+export async function gatherWithProgress<T>(
+  show: boolean,
+  label: string,
+  run: () => Promise<T>
+): Promise<T> {
+  if (!show) return run();
+  const s = spinner();
+  s.start(`${label}: reading live AWS state & computing drift…`);
+  try {
+    const gathered = await run();
+    s.stop(`${label}: live state read`);
+    return gathered;
+  } catch (e) {
+    s.error(`${label}: read failed`);
+    throw e;
+  }
+}
+
+// The per-stack spinner label: `[2/3] Stack (region)` in a multi-stack run, or just
+// `Stack (region)` for a lone stack (a bare `[1/1]` is noise). `idx` is the 0-based
+// position, `total` the number of stacks being processed.
+export function progressLabel(
+  idx: number,
+  total: number,
+  stackName: string,
+  region: string
+): string {
+  const prefix = total > 1 ? `[${idx + 1}/${total}] ` : '';
+  return `${prefix}${stackName} (${region})`;
+}

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -7,6 +7,7 @@ import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
+import { gatherWithProgress, progressLabel } from './progress.js';
 import { recordStack } from './stack-actions.js';
 
 export async function runRecord(args: string[]): Promise<number> {
@@ -34,7 +35,9 @@ export async function runRecord(args: string[]): Promise<number> {
   }
 
   let worst = 0;
-  for (const { stackName, region, template } of stacks) {
+  // gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
+  const showProgress = !a.json && isInteractive();
+  for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
       console.error(
         `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
@@ -46,7 +49,11 @@ export async function runRecord(args: string[]): Promise<number> {
       // gather FIRST: the baseline filename embeds the accountId, which only the
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
       // `template` (synth) recovers GetTemplate's `?`-masked non-ASCII literals.
-      const { desired, findings } = await gatherFindings(stackName, region, undefined, template);
+      const { desired, findings } = await gatherWithProgress(
+        showProgress,
+        progressLabel(idx, stacks.length, stackName, region),
+        () => gatherFindings(stackName, region, undefined, template)
+      );
       // ignore rules re-tag matching undeclared findings out of the record set, so an
       // externally-managed property is never recorded (and never re-detected).
       const result = await recordStack({

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -14,6 +14,7 @@ import {
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { loadConfig } from '../config/config-file.js';
 import { gatherFindings } from './gather.js';
+import { gatherWithProgress, progressLabel } from './progress.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { revertStack } from './stack-actions.js';
 
@@ -43,7 +44,10 @@ export async function runRevert(args: string[]): Promise<number> {
   }
 
   let worst = 0;
-  for (const { stackName, region, template } of stacks) {
+  // gather-phase spinner (see gatherWithProgress) — text mode + TTY only. The revert
+  // confirm prompt fires AFTER the gather, so the spinner never overlaps it.
+  const showProgress = !a.json && isInteractive();
+  for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
       console.error(
         `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
@@ -56,7 +60,11 @@ export async function runRevert(args: string[]): Promise<number> {
       // gather (DescribeStackResources) resolves. (R21 — was load-then-gather.)
       // `template` (synth) recovers GetTemplate's `?`-masked non-ASCII literals so a
       // revert writes the REAL declared value, never a `?????` mask.
-      const gathered = await gatherFindings(stackName, region, undefined, template);
+      const gathered = await gatherWithProgress(
+        showProgress,
+        progressLabel(idx, stacks.length, stackName, region),
+        () => gatherFindings(stackName, region, undefined, template)
+      );
       const baseline: BaselineFile | undefined = await loadBaseline(
         stackName,
         gathered.desired.accountId,

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -10,16 +10,11 @@ vi.mock('@clack/prompts', async (importOriginal) => {
   return { ...actual, spinner: () => ({ start, stop, error, message: vi.fn() }) };
 });
 
-import { gatherWithProgress } from '../src/commands/check.js';
-import type { GatherResult } from '../src/commands/gather.js';
+import { gatherWithProgress, progressLabel } from '../src/commands/progress.js';
 
-// A minimal GatherResult — gatherWithProgress only forwards it, never inspects it.
-const RESULT = {
-  desired: {},
-  findings: [],
-  schemas: new Map(),
-  liveByLogical: new Map(),
-} as unknown as GatherResult;
+// gatherWithProgress is generic and only forwards its run() result — a sentinel object
+// is enough to assert pass-through.
+const RESULT = { sentinel: true };
 
 describe('gatherWithProgress', () => {
   beforeEach(() => {
@@ -57,5 +52,16 @@ describe('gatherWithProgress', () => {
     expect(error).toHaveBeenCalledOnce();
     expect(error.mock.calls[0]![0]).toContain('S (r)');
     expect(stop).not.toHaveBeenCalled();
+  });
+});
+
+describe('progressLabel', () => {
+  it('omits the counter for a lone stack (a bare [1/1] is noise)', () => {
+    expect(progressLabel(0, 1, 'MyStack', 'us-east-1')).toBe('MyStack (us-east-1)');
+  });
+
+  it('prefixes a 1-based [idx/total] counter in a multi-stack run', () => {
+    expect(progressLabel(0, 3, 'A', 'ap-northeast-1')).toBe('[1/3] A (ap-northeast-1)');
+    expect(progressLabel(2, 3, 'C', 'ap-northeast-1')).toBe('[3/3] C (ap-northeast-1)');
   });
 });


### PR DESCRIPTION
## Why

PR #477 added a gather-phase spinner to `check` so a run never looks frozen during the silent live-read + diff. But `record`, `ignore`, and `revert` share the exact same `gatherFindings` call and had the identical silent gap — when a human runs `cdkrd revert` (or `record` / `ignore`) interactively, the CLI still looked hung while reading live state. This extends the same spinner to all four verbs so the behavior is consistent.

## What

- Extract the spinner helper out of `check.ts` into a shared `src/commands/progress.ts`:
  - `gatherWithProgress<T>(show, label, run)` — now generic, so each verb can wrap its own `gatherFindings` call unchanged. TTY + text mode only; `--json` / non-TTY is a plain pass-through. Torn down via `spinner().error(...)` on failure.
  - `progressLabel(idx, total, stackName, region)` — the shared `[N/M] Stack (region)` label (counter omitted for a lone stack), so the four call sites don't each re-derive it.
- Wire `gatherWithProgress` + `progressLabel` into `record`, `ignore`, and `revert` (each gated on `!--json && isInteractive()`). For `revert` the spinner runs before the confirm prompt, so it never overlaps it.
- `check.ts` now imports the shared helper instead of defining it locally (no behavior change).

## Tests

`tests/progress.test.ts` (renamed from `gather-progress.test.ts`) keeps the three `gatherWithProgress` paths (pass-through / success / error) and adds `progressLabel` coverage (lone stack omits the counter; multi-stack prefixes a 1-based `[idx/total]`).

Docs: `docs/ARCHITECTURE.md` commands/ list gains a `progress.ts` entry at the existing granularity.

Note: the spinner is TTY-gated, so it is only visually observable in a real terminal — confirmed here via unit tests.
