### PR TITLE
feat(revert): --wait to converge through a transient mid-update window in one command, + per-retry progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,24 +293,25 @@ CI (with `--yes`).
 
 ### Options
 
-| option                     | meaning                                                                                                                                         |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); else `env.region` per stack, else the `--profile`'s region                               |
-| `--profile <p>`            | AWS profile (or `$AWS_PROFILE`)                                                                                                                 |
-| `-a, --app <cmd\|cdk.out>` | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`); stack auto-discovery + construct paths                    |
-| `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                                      |
-| `--all`                    | target every stack the app defines (the default when no `<stack>` is named; overrides any positional names)                                     |
-| `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                                            |
-| `--fail`                   | (check) exit 1 on drift and never prompt; for scripts/CI. Without it, check reports drift but exits 0                                           |
-| `--strict`                 | (check) exit 1 when coverage is incomplete. A coverage gap is always surfaced loudly; `--strict` makes it CI-failing. Orthogonal to `--fail`    |
-| `--show-all`               | inventory mode: show all current undeclared state, ignoring the baseline                                                                        |
-| `--verbose` / `-v`         | (check) expand the `info:` footer tiers / (revert) expand the per-reason not-revertable summary to full lists                                   |
-| `--pre-deploy`             | (check) compare live vs the LOCAL synth template: the declared drift your next `cdk deploy` would silently overwrite                            |
-| `--undeclared-only`        | (check) undeclared drift only: pair cdkrd with `cdk drift` for the declared side                                                                |
-| `--declared-only`          | (check) declared drift vs the deployed template only (undeclared tier skipped; baseline untouched). Not `--pre-deploy`                          |
-| `--dry-run`                | (revert) print the plan; make no changes                                                                                                        |
-| `--remove-unrecorded`      | (revert) REMOVE unrecorded values + DELETE unrecorded added resources in a no-prompt run (`--yes`/CI); an interactive revert already lists them |
-| `--yes` / `-y`             | skip confirmations (revert apply; record records all without the multiselect)                                                                   |
+| option                     | meaning                                                                                                                                                                                    |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); else `env.region` per stack, else the `--profile`'s region                                                                          |
+| `--profile <p>`            | AWS profile (or `$AWS_PROFILE`)                                                                                                                                                            |
+| `-a, --app <cmd\|cdk.out>` | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`); stack auto-discovery + construct paths                                                               |
+| `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                                                                                 |
+| `--all`                    | target every stack the app defines (the default when no `<stack>` is named; overrides any positional names)                                                                                |
+| `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                                                                                       |
+| `--fail`                   | (check) exit 1 on drift and never prompt; for scripts/CI. Without it, check reports drift but exits 0                                                                                      |
+| `--strict`                 | (check) exit 1 when coverage is incomplete. A coverage gap is always surfaced loudly; `--strict` makes it CI-failing. Orthogonal to `--fail`                                               |
+| `--show-all`               | inventory mode: show all current undeclared state, ignoring the baseline                                                                                                                   |
+| `--verbose` / `-v`         | (check) expand the `info:` footer tiers / (revert) expand the per-reason not-revertable summary to full lists                                                                              |
+| `--pre-deploy`             | (check) compare live vs the LOCAL synth template: the declared drift your next `cdk deploy` would silently overwrite                                                                       |
+| `--undeclared-only`        | (check) undeclared drift only: pair cdkrd with `cdk drift` for the declared side                                                                                                           |
+| `--declared-only`          | (check) declared drift vs the deployed template only (undeclared tier skipped; baseline untouched). Not `--pre-deploy`                                                                     |
+| `--dry-run`                | (revert) print the plan; make no changes                                                                                                                                                   |
+| `--wait[=DURATION]`        | (revert) on a transient "resource is mid-update" error (e.g. Route53Resolver `RSLVR-00705`) keep retrying until it settles, up to DURATION (default `10m`; e.g. `--wait=5m`, `--wait=90s`) |
+| `--remove-unrecorded`      | (revert) REMOVE unrecorded values + DELETE unrecorded added resources in a no-prompt run (`--yes`/CI); an interactive revert already lists them                                            |
+| `--yes` / `-y`             | skip confirmations (revert apply; record records all without the multiselect)                                                                                                              |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
 the line) are errors (exit `2`): a typo'd flag never silently becomes a stack name.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -659,7 +659,19 @@ only when non-zero — unrecorded values are named as such, never folded into
   unconverged (exit stays 2). `classifyTransient` matches the error TEXT (Cloud
   Control surfaces async failures as a FAILED `StatusMessage`, not a thrown error), so
   `errorText` prepends the error name/`ErrorCode` for name-only signals like
-  `ThrottlingException`.
+  `ThrottlingException`. Each retry prints a `↻ <id>: <reason> — retry N (next in Ns)…`
+  progress line so the wait never looks frozen.
+  - **`revert --wait[=DURATION]`** turns the short default backoff (3 attempts) into a
+    DEADLINE-bounded retry (`retryTransient`'s `deadlineMs`): keep re-issuing the write
+    until the resource settles, up to DURATION (default 10m; `parseDurationMs` accepts
+    `90`, `30s`, `5m`, `1h`), so a minutes-long RSLVR-00705 window converges in ONE
+    command instead of stopping at the hint. It is GENERIC — retrying the write until it
+    succeeds needs no per-type "is it stable yet?" waiter (the write itself rejects with
+    the transient code until the resource is ready). Opt-in on purpose: the default stays
+    non-blocking + explanatory (issue #467's design call), and when `--wait` is off the
+    hint points at it (`… or re-run with --wait to block until it settles`). Backoff is
+    linear (3s, 6s, …) capped at `DEFAULT_MAX_DELAY_MS` (30s), and never sleeps past the
+    deadline.
 - **Write mechanism** (`plan.ts` chooses `kind`):
   - `kind: 'cc'` — generic Cloud Control `UpdateResource` RFC6902 PatchDocument,
     polled via `GetResourceRequestStatus` ([apply.ts](../src/revert/apply.ts)).

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,4 +1,5 @@
 // Tiny shared CLI arg parser (no dependency).
+import { DEFAULT_WAIT_MS, parseDurationMs } from './revert/transient.js';
 
 // The complete known-option surface. parseCommonArgs is shared by all three
 // verbs, so verb-specific flags (--dry-run) are recorded here and interpreted
@@ -59,6 +60,11 @@ export interface CommonArgs {
   strict: boolean;
   removeUnrecorded: boolean; // (revert) opt in to REMOVING undeclared drift on a stack with no baseline
   verbose: boolean; // (check) expand informational tiers / (revert) the NOT-revertable summary to full lists
+  // (revert) `--wait[=DURATION]`: block on a TRANSIENT "resource is mid-update" failure
+  // (RSLVR-00705 & friends), retrying until the resource settles instead of stopping at
+  // the short default backoff. undefined = not requested (default short backoff → hint);
+  // a number = the wait budget in ms (bare `--wait` = DEFAULT_WAIT_MS). Issue #467.
+  waitMs: number | undefined;
 }
 
 /**
@@ -76,6 +82,7 @@ export function parseCommonArgs(args: string[]): CommonArgs {
   const found = new Set<string>(); // boolean flags seen
   const stackNames: string[] = [];
   const context: Record<string, string> = {};
+  let waitMs: number | undefined; // (revert) --wait[=DURATION]; undefined = not requested
 
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
@@ -129,6 +136,14 @@ export function parseCommonArgs(args: string[]): CommonArgs {
       found.add(flag);
       continue;
     }
+    // `--wait` (revert): optional value, INLINE form only (`--wait` or `--wait=5m`). A
+    // following separate token is deliberately NOT consumed — `--wait 5m` would be
+    // ambiguous with a positional stack name, the exact misparse this parser guards
+    // against for an AWS-mutating verb.
+    if (flag === '--wait') {
+      waitMs = inlineValue === undefined ? DEFAULT_WAIT_MS : parseDurationMs(inlineValue);
+      continue;
+    }
     throw new Error(`unknown option "${a}" — see cdkrd --help`);
   }
 
@@ -158,5 +173,6 @@ export function parseCommonArgs(args: string[]): CommonArgs {
     declaredOnly: has('--declared-only'),
     removeUnrecorded: has('--remove-unrecorded'),
     verbose: has('--verbose') || has('-v'),
+    waitMs,
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,9 @@ OPTIONS
   --declared-only             (check) declared drift vs the DEPLOYED template only
                               (undeclared tier skipped; baseline untouched)
   --dry-run                   (revert) print the plan; make no changes
+  --wait[=DURATION]           (revert) on a transient "resource is mid-update" error
+                              (e.g. RSLVR-00705) keep retrying until it settles, up to
+                              DURATION (default 10m; e.g. --wait=5m, --wait=90s)
   --remove-unrecorded         (revert) REMOVE unrecorded values + DELETE unrecorded
                               added resources (never recorded; default: refuse —
                               record the ones that are right)

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -84,6 +84,7 @@ export async function runRevert(args: string[]): Promise<number> {
         removeUnrecorded: a.removeUnrecorded,
         verbose: a.verbose,
         interactive: isInteractive(),
+        ...(a.waitMs !== undefined && { waitMs: a.waitMs }),
       });
       worst = Math.max(worst, exit);
     } catch (e) {

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -35,7 +35,7 @@ import {
   tagPreservingOps,
   writeOnlyReincludeOps,
 } from '../revert/plan.js';
-import { errorText, retryTransient } from '../revert/transient.js';
+import { errorText, type RetryOptions, retryTransient } from '../revert/transient.js';
 import { resolveSdkWriter } from '../revert/writers.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
@@ -660,6 +660,14 @@ export interface RevertStackParams {
   // behind their API response — eventual consistency). Overridable so unit tests
   // don't sleep for real.
   convergeRetryDelayMs?: number;
+  // `revert --wait[=DURATION]` (issue #467): on a TRANSIENT "resource is mid-update"
+  // failure (RSLVR-00705 & friends), keep retrying the write until the resource settles
+  // (up to this many ms) instead of stopping at the short default backoff — so a
+  // minutes-long UPDATING window converges in one command. undefined = default backoff.
+  waitMs?: number;
+  // Injected clock/sleep for the wait path so deadline-mode unit tests don't sleep.
+  waitNow?: () => number;
+  waitSleep?: (ms: number) => Promise<void>;
 }
 
 const CONVERGE_RETRY_DELAY_MS = 3000;
@@ -713,6 +721,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     verbose,
     interactive,
     autoSelectAll,
+    waitMs,
+    waitNow,
+    waitSleep,
   } = p;
   let worst = 0;
   // R113: a standout undeclared value is surfaced to the user as [Potential Drift] (it is
@@ -827,11 +838,28 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     error?: string;
     hint?: string;
   }[] = [];
+  // Per-item transient-retry options (issue #467). `--wait` turns the short default
+  // backoff into a deadline-bounded wait so a minutes-long UPDATING window (RSLVR-00705)
+  // converges in one command; each item gets its OWN wait budget. `onRetry` prints a
+  // per-retry progress line so the wait never looks frozen (see #477's spinner ethos).
+  const clock = waitNow ?? Date.now;
+  const buildRetryOpts = (displayId: string): RetryOptions => ({
+    ...(waitMs !== undefined && { deadlineMs: clock() + waitMs }),
+    ...(waitNow && { now: waitNow }),
+    ...(waitSleep && { sleep: waitSleep }),
+    onRetry: ({ attempt, delayMs, hint }) => {
+      const reason = (hint ?? 'transient error').split(' — ')[0];
+      const secs = Math.max(1, Math.round(delayMs / 1000));
+      console.log(
+        style.infoTier(`    ↻ ${displayId}: ${reason} — retry ${attempt} (next in ${secs}s)…`)
+      );
+    },
+  });
   for (const item of plan.items) {
     let r: { ok: boolean; error?: string; hint?: string };
     if (item.kind === 'delete') {
       // physicalId IS the CC identifier (the composite the finding carried); delete it.
-      r = await applyRevertDelete(cc, item, item.physicalId);
+      r = await applyRevertDelete(cc, item, item.physicalId, buildRetryOpts(item.displayId));
       if (!r.ok) failedDeleteIds.add(item.logicalId);
     } else if (item.kind === 'sdk') {
       const res = byLogical.get(item.logicalId);
@@ -864,7 +892,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
         } catch (e) {
           return { ok: false, error: errorText(e) };
         }
-      });
+      }, buildRetryOpts(item.displayId));
     } else {
       const res = byLogical.get(item.logicalId);
       const identifier =
@@ -883,7 +911,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
         tagged
       );
       const ccItem = { ...item, ops: extra.length > 0 ? [...tagged, ...extra] : tagged };
-      r = await applyRevertItem(cc, ccItem, identifier);
+      r = await applyRevertItem(cc, ccItem, identifier, buildRetryOpts(item.displayId));
     }
     applied.push({
       logicalId: item.logicalId,
@@ -901,9 +929,14 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       console.log(style.ok(`  reverted: ${s.displayId}`));
     } else {
       console.log(style.fail(`  FAILED: ${s.displayId} — ${s.error}`));
-      // Transient "resource is mid-update" failure that survived bounded retries:
-      // add a targeted hint so the user knows this is retry-later, not a real failure.
-      if (s.hint) console.log(style.infoTier(`    ↳ ${s.hint}`));
+      // Transient "resource is mid-update" failure that survived the retries: add a
+      // targeted hint so the user knows this is retry-later, not a real failure. When we
+      // did NOT already wait (`--wait` off), point at it as the one-command settle path.
+      if (s.hint) {
+        const suffix =
+          waitMs === undefined ? ' (or re-run with --wait to block until it settles)' : '';
+        console.log(style.infoTier(`    ↳ ${s.hint}${suffix}`));
+      }
     }
   }
 

--- a/src/revert/transient.ts
+++ b/src/revert/transient.ts
@@ -92,41 +92,86 @@ export interface RetryableResult {
 }
 
 export interface RetryOptions {
-  // Total attempts including the first (default 3 → up to 2 retries).
+  // Total attempts including the first (default 3 → up to 2 retries). Ignored when
+  // `deadlineMs` is set (the `revert --wait` path retries until the deadline instead).
   maxAttempts?: number;
   // Linear backoff base: waits baseDelayMs * attempt between tries (3s, 6s, …).
   baseDelayMs?: number;
+  // Cap on a single backoff wait, so the deadline mode's linear growth stays bounded.
+  maxDelayMs?: number;
+  // `revert --wait` mode: keep retrying a transient failure until this wall-clock time
+  // (ms epoch), NOT a fixed attempt count — so a resource that stays UPDATING for
+  // minutes (RSLVR-00705) can converge in ONE command. `maxAttempts` is ignored.
+  deadlineMs?: number;
+  // Injectable clock (default Date.now) so deadline-mode tests don't wait for real time.
+  now?: () => number;
+  // Called before each backoff wait (a transient failure about to be retried) — the
+  // report layer uses it to print a per-retry progress line so a multi-minute `--wait`
+  // never looks frozen. `attempt` is the 1-based number of the attempt that just failed.
+  onRetry?: (info: { attempt: number; delayMs: number; hint?: string }) => void;
   // Injectable for tests (default real setTimeout).
   sleep?: (ms: number) => Promise<void>;
 }
 
 export const DEFAULT_MAX_ATTEMPTS = 3;
 export const DEFAULT_BASE_DELAY_MS = 3000;
+export const DEFAULT_MAX_DELAY_MS = 30_000;
+// `revert --wait` with no explicit duration: block for up to 10 minutes (a
+// Route53Resolver rule's UPDATING window is typically a few minutes).
+export const DEFAULT_WAIT_MS = 10 * 60 * 1000;
+
+// Parse a `--wait` duration: a bare number is SECONDS; a `s`/`m`/`h` suffix scales
+// (e.g. "300", "300s", "5m", "1h"). Returns ms. Throws on a malformed value so a
+// typo'd `--wait=5min` fails fast rather than silently defaulting.
+export function parseDurationMs(raw: string): number {
+  const m = /^(\d+)(s|m|h)?$/.exec(raw.trim());
+  if (!m) {
+    throw new Error(`invalid --wait duration "${raw}" — use e.g. 90, 30s, 5m, 1h`);
+  }
+  const n = Number(m[1]);
+  const unit = m[2] ?? 's';
+  const scale = unit === 'h' ? 3_600_000 : unit === 'm' ? 60_000 : 1000;
+  return n * scale;
+}
 
 const realSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 // Run `op` with bounded backoff, retrying ONLY while its failure classifies as
-// transient. A terminal failure returns immediately (no wasted waiting). When all
-// attempts are exhausted on a still-transient failure, the returned result carries
-// `transient: true` + the classifier's `hint` so the caller can show the targeted
-// message instead of a bare FAILED. `op` must be self-contained (catch its own throws
-// into `{ ok:false, error }`) — it is re-invoked verbatim each attempt.
+// transient. A terminal failure returns immediately (no wasted waiting). Two stop
+// conditions: the default fixed `maxAttempts`, or — when `deadlineMs` is set
+// (`revert --wait`) — a wall-clock deadline so a minutes-long UPDATING window can
+// converge in one command. When the retries are exhausted on a still-transient failure,
+// the returned result carries `transient: true` + the classifier's `hint` so the caller
+// can show the targeted message instead of a bare FAILED. `op` must be self-contained
+// (catch its own throws into `{ ok:false, error }`) — it is re-invoked verbatim each try.
 export async function retryTransient<T extends RetryableResult>(
   op: () => Promise<T>,
   opts: RetryOptions = {}
 ): Promise<T> {
   const max = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const base = opts.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const cap = opts.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
   const doSleep = opts.sleep ?? realSleep;
+  const clock = opts.now ?? Date.now;
+  const deadline = opts.deadlineMs;
   let result = await op();
-  for (let attempt = 1; !result.ok && attempt < max; attempt++) {
-    if (!classifyTransient(result.error).transient) return result; // terminal — stop
-    await doSleep(base * attempt);
-    result = await op();
-  }
-  if (!result.ok) {
+  let attempt = 1;
+  while (!result.ok) {
     const verdict = classifyTransient(result.error);
-    if (verdict.transient) return { ...result, transient: true, hint: verdict.hint };
+    if (!verdict.transient) return result; // terminal — stop, no annotation
+    // More tries allowed? deadline mode: only if there is time left to at least retry
+    // AFTER a (possibly shortened) wait; attempt mode: until maxAttempts.
+    const more = deadline !== undefined ? clock() < deadline : attempt < max;
+    if (!more) return { ...result, transient: true, hint: verdict.hint };
+    // In deadline mode, never sleep past the deadline (so the last wait doesn't overrun).
+    const wait =
+      deadline !== undefined
+        ? Math.max(0, Math.min(base * attempt, cap, deadline - clock()))
+        : Math.min(base * attempt, cap);
+    opts.onRetry?.({ attempt, delayMs: wait, ...(verdict.hint && { hint: verdict.hint }) });
+    await doSleep(wait);
+    attempt++;
+    result = await op();
   }
   return result;
 }

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -57,6 +57,25 @@ describe('parseCommonArgs', () => {
     expect(parseCommonArgs(['S', '--dry-run']).stackNames).toEqual(['S']);
   });
 
+  it('revert --wait: undefined by default, 10m bare, inline durations (issue #467)', () => {
+    expect(parseCommonArgs(['S']).waitMs).toBeUndefined();
+    expect(parseCommonArgs(['S', '--wait']).waitMs).toBe(10 * 60 * 1000);
+    expect(parseCommonArgs(['S', '--wait=5m']).waitMs).toBe(300_000);
+    expect(parseCommonArgs(['S', '--wait=90s']).waitMs).toBe(90_000);
+    expect(parseCommonArgs(['S', '--wait=1h']).waitMs).toBe(3_600_000);
+    expect(parseCommonArgs(['S', '--wait=45']).waitMs).toBe(45_000); // bare number = seconds
+  });
+
+  it('revert --wait consumes NO following token (inline form only — avoids stack misparse)', () => {
+    const a = parseCommonArgs(['revertMe', '--wait', '5m']);
+    expect(a.waitMs).toBe(10 * 60 * 1000); // bare --wait; "5m" is a positional
+    expect(a.stackNames).toEqual(['revertMe', '5m']);
+  });
+
+  it('revert --wait rejects a malformed inline duration', () => {
+    expect(() => parseCommonArgs(['S', '--wait=5min'])).toThrow(/invalid --wait duration/);
+  });
+
   it('-a is an alias for --app — value goes to app, never to stackNames', () => {
     const a = parseCommonArgs(['MyStack', '-a', 'cdk.out']);
     expect(a.app).toBe('cdk.out');

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -685,6 +685,63 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     expect(logs).toContain('could not be confirmed converged');
     expect(logs).toContain('could not be re-read to verify');
   });
+
+  // issue #467 — the `revert --wait` path.
+  const rslvrFailed = {
+    ProgressEvent: {
+      OperationStatus: 'FAILED' as const,
+      RequestToken: 't',
+      StatusMessage: "[RSLVR-00705] Cannot update Resolver Rule because it's currently updating.",
+    },
+  };
+  const runWith = async (extra: Record<string, unknown>) => {
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (s: unknown) => logs.push(String(s));
+    try {
+      const outcome = await revertStack({ ...params(), ...extra } as Parameters<
+        typeof revertStack
+      >[0]);
+      return { outcome, logs: logs.join('\n') };
+    } finally {
+      console.log = orig;
+    }
+  };
+
+  it('--wait retries a transient mid-update failure PAST the default attempts until it settles', async () => {
+    const cc = mockClient(CloudControlClient);
+    // Four RSLVR-00705 failures (past the 3-attempt default), then success.
+    cc.on(UpdateResourceCommand)
+      .resolvesOnce(rslvrFailed)
+      .resolvesOnce(rslvrFailed)
+      .resolvesOnce(rslvrFailed)
+      .resolvesOnce(rslvrFailed)
+      .resolves({ ProgressEvent: { OperationStatus: 'SUCCESS', RequestToken: 't' } });
+    cc.on(GetResourceCommand).resolves(liveRead('Enabled'));
+
+    const { outcome, logs } = await runWith({
+      waitMs: 600_000,
+      waitNow: () => 0, // constant clock < deadline → keep retrying (waitSleep is a no-op)
+      waitSleep: () => Promise.resolve(),
+    });
+    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(5); // 4 fails + 1 success
+    expect(logs).toMatch(/↻ .*retry 1/); // per-retry progress line printed
+    expect(logs).toContain('s: CLEAN after revert.');
+  });
+
+  it('without --wait, a persistent transient failure stops after the short backoff and suggests --wait', async () => {
+    const cc = mockClient(CloudControlClient);
+    cc.on(UpdateResourceCommand).resolves(rslvrFailed);
+    cc.on(GetResourceCommand).resolves(liveRead('Suspended')); // still drifted
+
+    const { outcome, logs } = await runWith({
+      waitSleep: () => Promise.resolve(), // no-op the DEFAULT backoff so the test is fast
+    });
+    expect(outcome.exit).toBe(2); // apply failed
+    expect(cc.commandCalls(UpdateResourceCommand).length).toBe(3); // default maxAttempts
+    expect(logs).toContain('or re-run with --wait to block until it settles');
+  });
 });
 
 describe('recordStack non-interactive refusal (R38)', () => {

--- a/tests/transient.test.ts
+++ b/tests/transient.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vite-plus/test';
 import {
   classifyTransient,
   errorText,
+  parseDurationMs,
   type RetryableResult,
   retryTransient,
 } from '../src/revert/transient.js';
@@ -151,5 +152,109 @@ describe('retryTransient — bounded backoff, then hint', () => {
       sleep: async (ms) => void waits.push(ms),
     });
     expect(waits).toEqual([1000, 2000]);
+  });
+
+  it('caps a single backoff wait at maxDelayMs', async () => {
+    const waits: number[] = [];
+    await retryTransient(async () => ({ ok: false, error: 'RSLVR-00705 currently updating' }), {
+      maxAttempts: 5,
+      baseDelayMs: 10_000,
+      maxDelayMs: 15_000,
+      sleep: async (ms) => void waits.push(ms),
+    });
+    // 10s, 20s→cap 15s, 30s→cap 15s, 40s→cap 15s
+    expect(waits).toEqual([10_000, 15_000, 15_000, 15_000]);
+  });
+});
+
+describe('retryTransient — deadline (--wait) mode', () => {
+  // A fake clock: each read advances by `step` ms so the loop terminates deterministically
+  // without real time. `sleep` is a no-op (the clock, not the sleep, drives the deadline).
+  const fakeClock = (step: number) => {
+    let t = 0;
+    return () => {
+      const now = t;
+      t += step;
+      return now;
+    };
+  };
+
+  it('retries past maxAttempts until the resource settles (one-command convergence)', async () => {
+    let calls = 0;
+    const r = await retryTransient(
+      async (): Promise<RetryableResult> => {
+        calls++;
+        return calls < 6 ? { ok: false, error: '[RSLVR-00705] currently updating' } : { ok: true };
+      },
+      {
+        maxAttempts: 3, // ignored in deadline mode
+        deadlineMs: 100_000,
+        now: fakeClock(1000), // advances slowly, deadline never hit before success
+        sleep: () => Promise.resolve(),
+      }
+    );
+    expect(r.ok).toBe(true);
+    expect(calls).toBe(6); // well past the 3-attempt default
+  });
+
+  it('gives up at the deadline and annotates the hint', async () => {
+    let calls = 0;
+    const r = await retryTransient(
+      async (): Promise<RetryableResult> => {
+        calls++;
+        return { ok: false, error: '[RSLVR-00705] currently updating' };
+      },
+      {
+        deadlineMs: 5000,
+        now: fakeClock(2000), // 0, 2000, 4000, 6000 → exceeds 5000 after a few tries
+        sleep: () => Promise.resolve(),
+      }
+    );
+    expect(r.ok).toBe(false);
+    expect(r.transient).toBe(true);
+    expect(r.hint).toContain('async propagation');
+    expect(calls).toBeGreaterThan(1);
+  });
+
+  it('invokes onRetry before each wait with the attempt number and delay', async () => {
+    const seen: { attempt: number; delayMs: number; hint?: string }[] = [];
+    await retryTransient(async () => ({ ok: false, error: 'RSLVR-00705 currently updating' }), {
+      maxAttempts: 3,
+      baseDelayMs: 1000,
+      sleep: () => Promise.resolve(),
+      onRetry: (info) => seen.push(info),
+    });
+    expect(seen.map((s) => s.attempt)).toEqual([1, 2]);
+    expect(seen[0]?.delayMs).toBe(1000);
+    expect(seen[0]?.hint).toContain('async propagation');
+  });
+
+  it('does NOT call onRetry for a terminal (non-transient) failure', async () => {
+    let called = 0;
+    await retryTransient(async () => ({ ok: false, error: 'ValidationException: bad' }), {
+      sleep: () => Promise.resolve(),
+      onRetry: () => called++,
+    });
+    expect(called).toBe(0);
+  });
+});
+
+describe('parseDurationMs', () => {
+  it('parses bare number as seconds', () => {
+    expect(parseDurationMs('90')).toBe(90_000);
+    expect(parseDurationMs('300')).toBe(300_000);
+  });
+  it('parses s/m/h suffixes', () => {
+    expect(parseDurationMs('30s')).toBe(30_000);
+    expect(parseDurationMs('5m')).toBe(300_000);
+    expect(parseDurationMs('1h')).toBe(3_600_000);
+  });
+  it('tolerates surrounding whitespace', () => {
+    expect(parseDurationMs('  5m ')).toBe(300_000);
+  });
+  it('throws on a malformed value', () => {
+    for (const bad of ['5min', 'abc', '', '5.5m', '-3s', 'm']) {
+      expect(() => parseDurationMs(bad)).toThrow(/invalid --wait duration/);
+    }
   });
 });


### PR DESCRIPTION
## What

Follow-up to #474 (issue #467). Adds an opt-in **`revert --wait[=DURATION]`** so a revert
can converge in ONE command when the target resource is still mid-async-update (a
Route53Resolver rule stays `Status: UPDATING` for minutes after an out-of-band change),
plus **per-retry progress messaging** so the wait never looks frozen.

Design (steered by the issue discussion): the **default stays non-blocking** — short
backoff → the targeted hint. `--wait` is the explicit path for one-command convergence.

## How

- **`transient.ts`** `retryTransient` gains:
  - `deadlineMs` — retry a transient failure until a wall-clock deadline (not a fixed
    attempt count), so a minutes-long UPDATING window converges. `now` is injectable.
  - `maxDelayMs` cap (30s) on the linear backoff; never sleeps past the deadline.
  - `onRetry(info)` callback → the report prints `↻ <id>: <reason> — retry N (next in Ns)…`.
  - `parseDurationMs` (`90` = seconds, `30s`, `5m`, `1h`).
- **`--wait[=DURATION]`** (revert): INLINE form only (`--wait` / `--wait=5m`) — a following
  token is deliberately not consumed (the AWS-mutating-verb stack-name misparse the parser
  guards against). Bare `--wait` = 10m. Threaded `cli-args → revert → RevertStackParams →`
  the `cc` / `sdk` / `delete` retry options.
- The default hint now points at it: `↳ … (or re-run with --wait to block until it settles)`.
  Exit semantics unchanged (a still-failing revert is exit 2).

## Tests

- `transient.test.ts` — deadline mode (retries past `maxAttempts` until settle / gives up
  at the deadline with the hint), `onRetry` firing (and NOT on terminal errors),
  `maxDelayMs` cap, `parseDurationMs` (valid + malformed).
- `cli-args.test.ts` — `--wait` default/inline/`no-following-token`/malformed.
- `stack-actions.test.ts` — `revert --wait` retries a mocked RSLVR-00705 past the default
  attempts until success (prints `↻`, lands CLEAN); without `--wait`, stops after the short
  backoff and suggests `--wait`.

## Live-tested (real AWS, resolver-rich, the issue's exact scenario)

```
revert --wait=5m   # issued mid-UPDATING
  ↻ …/HuntForwardRule: the resource is still applying a previous update … — retry 1 (next in 3s)…
  ↻ …  (retries 2-7, ~4 min through the UPDATING window)
  reverted: …/HuntForwardRule          # write landed once the rule settled
  → live TargetIps restored to the declared values
```

`--wait` converged in one command. The **full `/verify-pr` release integration set**
(basic ×3 / iam / lambda / revert / policies) also **passes** against this branch's dist.

> Note: the live-test also surfaced an **unrelated pre-existing** bug — a
> `ResolverEndpoint.IpAddresses` object-array reorder false-positive whose revert fails
> `RSLVR-00405`. Out of scope here; filed for a separate bug-hunt.
