### PR TITLE
feat(revert): classify stateful-DB mid-modify 'not in available state' faults as transient

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -652,7 +652,10 @@ only when non-zero — unrecorded values are named as such, never folded into
   stays `Status: UPDATING` for minutes after an out-of-band change while it
   propagates to endpoint ENIs, so a revert in that window honestly failed and only a
   later retry succeeded), plus the cross-service concurrent-modification / operation-
-  in-progress / throttling class. A terminal ValidationException/AccessDenied returns
+  in-progress / throttling class and the stateful-DB "not in the available state" faults
+  (RDS/Aurora/DocDB/Neptune/ElastiCache/Redshift reject a modify while `modifying` —
+  `InvalidDBInstanceState` & friends — so a revert of a just-modified BackupRetention /
+  node type retries until it settles). A terminal ValidationException/AccessDenied returns
   on the first attempt (no wasted waiting). When retries are exhausted on a still-
   transient failure, the `FAILED:` line gains a targeted `↳ retry in a few minutes`
   hint instead of a bare provider error, and the drift correctly still shows as

--- a/src/revert/transient.ts
+++ b/src/revert/transient.ts
@@ -52,6 +52,19 @@ const TRANSIENT_PATTERNS: readonly { pattern: RegExp; hint: string }[] = [
       /another (operation|update|change|request)[^.]*in progress|operation[^.]*(already )?in progress|update[^.]*in progress|modification[^.]*in progress|currently being (created|updated|modified|deleted|provisioned)|is not in a stable state|resource is in use|please try again|try again (later|in a few)/i,
     hint: RETRY_HINT,
   },
+  // Stateful resources (RDS / Aurora / DocDB / Neptune / ElastiCache / Redshift) reject
+  // a modify while the resource is mid-change with an "invalid state" fault whose message
+  // says it is "not in the available state". This is the SAME mid-update-retry-later class
+  // as RSLVR-00705 for the DB reverts cdkrd already supports (RDS/DocDB BackupRetention,
+  // DBInstanceClass, ElastiCache node type, …): an out-of-band `modify-*` leaves the
+  // resource `modifying`/`rebooting` for minutes, so an immediate revert fails and only a
+  // later retry succeeds. Matched by the service state-fault codes plus AWS's shared
+  // "not in the available state" / "not in available state" phrasing.
+  {
+    pattern:
+      /InvalidDBInstanceState|InvalidDBClusterState|InvalidClusterState|InvalidReplicationGroupState|InvalidCacheClusterState|InvalidGlobalClusterState|is not (currently )?in (the |an? )?available state/i,
+    hint: RETRY_HINT,
+  },
   // Throttling / rate limiting — retryable, but a distinct hint.
   {
     pattern:

--- a/tests/transient.test.ts
+++ b/tests/transient.test.ts
@@ -39,6 +39,33 @@ describe('classifyTransient — transient (retry-later) error class', () => {
     }
   });
 
+  it('classifies stateful-DB mid-modify "not in available state" faults (RDS/ElastiCache/Redshift)', () => {
+    for (const msg of [
+      'InvalidDBInstanceState: The instance mydb is not in the available state.',
+      'InvalidDBClusterStateFault: Cluster is not in available state',
+      'InvalidClusterState: cluster is not in the available state', // Redshift
+      'InvalidReplicationGroupState: Replication group is not in available state', // ElastiCache
+      'InvalidCacheClusterState: not currently in the available state',
+      'The DB instance is not in the available state',
+    ]) {
+      const v = classifyTransient(msg);
+      expect(v.transient).toBe(true);
+      expect(v.hint).toBe(
+        'the resource is still applying a previous update — retry in a few minutes'
+      );
+    }
+  });
+
+  it('does NOT misclassify a terminal DB error as the mid-modify state fault', () => {
+    for (const msg of [
+      'DBInstanceNotFound: DBInstance mydb not found',
+      'InvalidParameterValue: Invalid backup retention period',
+      'InvalidParameterCombination: bad combo',
+    ]) {
+      expect(classifyTransient(msg).transient).toBe(false);
+    }
+  });
+
   it('classifies throttling with the throttle-specific hint', () => {
     for (const msg of [
       'ThrottlingException: Rate exceeded',


### PR DESCRIPTION
## What

Follow-up to #474 / #479 (issue #467). Broadens the transient-error classifier so the
retry-then-hint (and `--wait`) treatment also covers **stateful-DB mid-modify faults**.

cdkrd already reverts mutable DB properties (RDS/DocDB `BackupRetentionPeriod`,
`DBInstanceClass`, ElastiCache node type, …). An out-of-band `modify-*` leaves the
resource `modifying` for minutes; an immediate revert then fails with an "invalid state"
fault (`InvalidDBInstanceState: … is not in the available state`). That is the SAME
mid-update-retry-later class as the Route53Resolver `RSLVR-00705` case — previously it
surfaced as a bare `FAILED` with no retry and no hint.

## How

One entry added to `TRANSIENT_PATTERNS` in `src/revert/transient.ts`:

```
InvalidDBInstanceState | InvalidDBClusterState | InvalidClusterState |
InvalidReplicationGroupState | InvalidCacheClusterState | InvalidGlobalClusterState |
is not (currently )?in (the|an?)? available state
```

(RDS / Aurora / DocDB / Neptune / ElastiCache / Redshift). Kept conservative — only the
unambiguous mid-modify state faults, matched by both the service state-fault codes and
AWS's shared "not in the available state" phrasing. A terminal DB error
(`DBInstanceNotFound`, `InvalidParameterValue`) is NOT matched.

## Tests

`tests/transient.test.ts` — the six state faults classify transient (with the generic
retry hint); three terminal DB errors do not.

## Verification

Pure classifier addition (no behaviour change beyond classification):
- All 2471 unit tests pass; typecheck + lint clean.
- Minimal runtime repro (`node --experimental-strip-types` importing `classifyTransient`)
  confirms the DB state faults → transient and `DBInstanceNotFound` → terminal.
- It cannot regress the integration fixtures (none exercise a mid-modify DB revert), so
  #479's full green release-integ run carries.
