### PR TITLE
fix(revert): strip service-echoed empty arrays the service rejects on CC update (VpcLattice Rule HeaderMatches)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,7 +129,14 @@ TransitGatewayAttachmentId]` composite is built from TWO declared props (its
    them (cdkd #812 — reverting any prop on an ECS Service with a managed EBS volume
    lost the write-only `VolumeConfigurations` and UpdateService hard-failed). The
    revert now re-includes every fully-resolved declared write-only top-level prop the
-   patch does not already touch (`writeOnlyReincludeOps` in plan.ts).
+   patch does not already touch (`writeOnlyReincludeOps` in plan.ts). A second
+   edge (#481): a service can REJECT its own read-back — the CC read of a
+   VpcLattice Rule echoes `Match.HttpMatch.HeaderMatches: []`, and the update
+   handler re-sends it to an UpdateRule that requires >= 1 members, so ANY
+   patch on such a rule failed. The revert appends a `remove` op for curated
+   per-type pointers when the live model carries them as an EMPTY array
+   (`CC_UPDATE_REJECTED_EMPTY_PATHS` + `rejectedEmptyStripOps` in plan.ts —
+   live-gated, populated arrays are never dropped).
 
 If these six bets are right, the tool is right. The rest of this document is how each
 is realized in code.

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -30,6 +30,7 @@ import { CC_IDENTIFIER_ADAPTERS } from '../read/router.js';
 import { applyRevertDelete, applyRevertItem } from '../revert/apply.js';
 import {
   buildRevertPlan,
+  rejectedEmptyStripOps,
   type RevertItem,
   type RevertPlan,
   tagPreservingOps,
@@ -910,7 +911,15 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
         gathered.schemas.get(item.resourceType),
         tagged
       );
-      const ccItem = { ...item, ops: extra.length > 0 ? [...tagged, ...extra] : tagged };
+      // Drop service-echoed empty arrays the service itself rejects on update
+      // (#481 — VpcLattice Rule HeaderMatches []). Live-gated + ancestor-aware.
+      const strip = rejectedEmptyStripOps(
+        item.resourceType,
+        [...tagged, ...extra],
+        gathered.liveByLogical.get(item.logicalId)
+      );
+      const combined = [...tagged, ...extra, ...strip];
+      const ccItem = { ...item, ops: combined.length > tagged.length ? combined : tagged };
       r = await applyRevertItem(cc, ccItem, identifier, buildRetryOpts(item.displayId));
     }
     applied.push({

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -765,6 +765,56 @@ export function tagPreservingOps(
   });
 }
 
+// Service-echoed EMPTY sub-arrays that the service itself REJECTS when a Cloud Control
+// UpdateResource re-sends them (#481): the CC read of a VpcLattice Rule echoes
+// `Match.HttpMatch.HeaderMatches: []` for a rule declared with only a path match (the
+// common shape), and the CC update handler folds its own read-back state into
+// `UpdateRule` — which requires headerMatches to have >= 1 members. So ANY patch on such
+// a rule, even a Priority-only revert, failed with "Value '[]' at
+// 'match.httpMatch.headerMatches' failed to satisfy constraint" (reproduced live). The
+// CFn schema does not annotate the constraint (no minItems on HeaderMatches), so the
+// pointers are curated per type. An appended `remove` op drops the echoed empty array
+// from the handler's desired state; the service treats an absent headerMatches as "no
+// header matches", which is exactly what the empty echo meant.
+export const CC_UPDATE_REJECTED_EMPTY_PATHS: Record<string, readonly string[]> = {
+  'AWS::VpcLattice::Rule': ['/Match/HttpMatch/HeaderMatches'],
+};
+function valueAtPointer(model: unknown, pointer: string): unknown {
+  let cur: unknown = model;
+  for (const seg of pointer.split('/').slice(1)) {
+    if (cur === null || typeof cur !== 'object' || Array.isArray(cur)) return undefined;
+    cur = (cur as Record<string, unknown>)[seg];
+  }
+  return cur;
+}
+// Extra `remove` ops for a cc-kind item on a type in the table above. Fail-safe gates:
+// the LIVE model must carry the pointer as an EMPTY array (a populated array is real
+// data and is never dropped; an absent pointer needs no strip and a `remove` on it
+// would itself fail), and no planned op may already rewrite the pointer or an ANCESTOR
+// of it (such a rewrite replaces what lives there, so a trailing remove would target a
+// path the patch may have just dropped).
+export function rejectedEmptyStripOps(
+  resourceType: string,
+  ops: PatchOp[],
+  liveRaw: Record<string, unknown> | undefined
+): PatchOp[] {
+  const pointers = CC_UPDATE_REJECTED_EMPTY_PATHS[resourceType];
+  if (!pointers || !liveRaw || ops.length === 0) return [];
+  const out: PatchOp[] = [];
+  for (const pointer of pointers) {
+    const v = valueAtPointer(liveRaw, pointer);
+    if (!Array.isArray(v) || v.length > 0) continue;
+    const covered = ops.some((o) => pointer === o.path || pointer.startsWith(`${o.path}/`));
+    if (covered) continue;
+    out.push({
+      op: 'remove',
+      path: pointer,
+      human: `${pointer.slice(1).replaceAll('/', '.')} -> drop service-echoed empty array (service rejects [] on update)`,
+    });
+  }
+  return out;
+}
+
 /** Serialize a RevertItem's ops to an RFC6902 PatchDocument string for Cloud Control. */
 export function toPatchDocument(item: RevertItem): string {
   return JSON.stringify(

--- a/tests/integration/vpclattice-listener/verify-detect.sh
+++ b/tests/integration/vpclattice-listener/verify-detect.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Missed-detection + revert integration test (real AWS): deploy -> record -> mutate a
+# declared MUTABLE prop out of band (Rule Priority via update-rule) -> check MUST
+# detect (exit 1) -> revert MUST succeed (#481: the CC update used to fail on the
+# service-echoed empty Match.HttpMatch.HeaderMatches) -> check MUST be CLEAN and the
+# live priority restored.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLatticeListener
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+if [ -z "${CDKRD_KEEP_STACK:-}" ]; then trap cleanup EXIT; fi
+fail() { echo "INTEG FAIL ($STACK detect): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+SVC=$(aws vpc-lattice list-services --region "$REGION" --query "items[?name=='cdkrd-hunt-svc'].id" --output text)
+LIS=$(aws vpc-lattice list-listeners --service-identifier "$SVC" --region "$REGION" --query "items[0].id" --output text)
+RULE=$(aws vpc-lattice list-rules --service-identifier "$SVC" --listener-identifier "$LIS" --region "$REGION" --query "items[?name=='cdkrd-hunt-rule'].id" --output text)
+[ -n "$RULE" ] || fail "rule id lookup"
+
+echo "=== [$STACK] mutate out of band: Rule Priority 10 -> 20 ==="
+aws vpc-lattice update-rule --service-identifier "$SVC" --listener-identifier "$LIS" \
+  --rule-identifier "$RULE" --priority 20 --region "$REGION" >/dev/null || fail "update-rule"
+
+echo "=== [$STACK] check MUST detect (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected detect exit 1, got $rc"
+grep -q "Priority" "/tmp/cdkrd-$STACK-detect.out" || fail "Priority not in findings"
+
+echo "=== [$STACK] revert MUST succeed (#481 strip of the empty HeaderMatches echo) ==="
+$CLI revert "$STACK" --region "$REGION" --yes | tee "/tmp/cdkrd-$STACK-revert.out"
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "revert"
+grep -q "FAILED" "/tmp/cdkrd-$STACK-revert.out" && fail "revert reported a FAILED item"
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "post-revert check not clean"
+
+LIVEP=$(aws vpc-lattice get-rule --service-identifier "$SVC" --listener-identifier "$LIS" \
+  --rule-identifier "$RULE" --region "$REGION" --query priority --output text)
+[ "$LIVEP" = "10" ] || fail "live priority not restored: $LIVEP"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -8,6 +8,7 @@ import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import {
   buildRevertPlan,
   type PatchOp,
+  rejectedEmptyStripOps,
   tagPreservingOps,
   toPatchDocument,
   writeOnlyReincludeOps,
@@ -1760,5 +1761,87 @@ describe('removed declared collection reverts via Cloud Control add /Prop (issue
         value: f.desired,
       }),
     ]);
+  });
+});
+
+describe('rejectedEmptyStripOps — service-rejected empty-array echoes (#481)', () => {
+  const T = 'AWS::VpcLattice::Rule';
+  const priorityOp: PatchOp = {
+    op: 'add',
+    path: '/Priority',
+    value: 10,
+    human: 'Priority -> deployed-template value',
+  };
+  const liveWithEmptyEcho = {
+    Priority: 20,
+    Match: {
+      HttpMatch: {
+        HeaderMatches: [],
+        PathMatch: { Match: { Prefix: '/api' }, CaseSensitive: false },
+      },
+    },
+  };
+
+  it('appends a remove op for a live EMPTY HeaderMatches echo on a Priority-only revert', () => {
+    // The live shape reproduced on CdkRealDriftIntegLatticeListener: the CC read echoes
+    // Match.HttpMatch.HeaderMatches [] the template never declared, and the CC update
+    // handler re-sends it to UpdateRule which requires >= 1 members — so the
+    // Priority-only revert failed. The strip op drops the echo from the patched state.
+    const strip = rejectedEmptyStripOps(T, [priorityOp], liveWithEmptyEcho);
+    expect(strip).toHaveLength(1);
+    expect(strip[0]).toMatchObject({ op: 'remove', path: '/Match/HttpMatch/HeaderMatches' });
+    // serialized without a value (RFC6902 remove)
+    expect(
+      toPatchDocument({
+        logicalId: 'HuntRule',
+        displayId: 'HuntRule',
+        resourceType: T,
+        physicalId: 'arn:rule',
+        kind: 'cc',
+        ops: [priorityOp, ...strip],
+      })
+    ).toBe(
+      JSON.stringify([
+        { op: 'add', path: '/Priority', value: 10 },
+        { op: 'remove', path: '/Match/HttpMatch/HeaderMatches' },
+      ])
+    );
+  });
+
+  it('a POPULATED live HeaderMatches is real data — never stripped', () => {
+    const live = structuredClone(liveWithEmptyEcho);
+    live.Match.HttpMatch.HeaderMatches = [
+      { Name: 'x-tenant', Match: { Exact: 'a' } },
+    ] as unknown as never[];
+    expect(rejectedEmptyStripOps(T, [priorityOp], live)).toEqual([]);
+  });
+
+  it('an ABSENT pointer needs no strip (a remove on it would itself fail)', () => {
+    expect(rejectedEmptyStripOps(T, [priorityOp], { Priority: 20 })).toEqual([]);
+    expect(
+      rejectedEmptyStripOps(T, [priorityOp], { Priority: 20, Match: { HttpMatch: {} } })
+    ).toEqual([]);
+  });
+
+  it('an op already rewriting the pointer or an ancestor suppresses the strip', () => {
+    const matchOp: PatchOp = {
+      op: 'add',
+      path: '/Match',
+      value: { HttpMatch: { PathMatch: { Match: { Prefix: '/api' } } } },
+      human: 'Match -> deployed-template value',
+    };
+    expect(rejectedEmptyStripOps(T, [matchOp], liveWithEmptyEcho)).toEqual([]);
+    const exactOp: PatchOp = {
+      op: 'remove',
+      path: '/Match/HttpMatch/HeaderMatches',
+      human: 'already handled',
+    };
+    expect(rejectedEmptyStripOps(T, [exactOp], liveWithEmptyEcho)).toEqual([]);
+  });
+
+  it('unknown types and missing live models are untouched', () => {
+    expect(rejectedEmptyStripOps('AWS::SQS::Queue', [priorityOp], liveWithEmptyEcho)).toEqual([]);
+    expect(rejectedEmptyStripOps(T, [priorityOp], undefined)).toEqual([]);
+    expect(rejectedEmptyStripOps(T, [], liveWithEmptyEcho)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #481. Any `AWS::VpcLattice::Rule` with a path match (the common shape) was un-revertable: the Cloud Control read echoes `Match.HttpMatch.HeaderMatches: []`, and the CC update handler folds its own read-back into `UpdateRule`, which requires `headerMatches` length >= 1 — so even a Priority-only revert failed with a validation error.

## Fix

`CC_UPDATE_REJECTED_EMPTY_PATHS` (curated per-type RFC6902 pointers — the CFn schema carries no `minItems` for HeaderMatches, so this cannot be schema-driven) + `rejectedEmptyStripOps` in `src/revert/plan.ts`, hooked into the cc-kind apply path alongside `tagPreservingOps` / `writeOnlyReincludeOps`. The appended `remove` op drops the echoed empty array from the handler's desired state.

Fail-safe gates:
- live-gated: the strip applies only when the LIVE model carries the pointer as an EMPTY array — a populated `HeaderMatches` is real data and is never dropped; an absent pointer needs no strip (a `remove` on it would itself fail);
- ancestor-aware: suppressed when a planned op already rewrites the pointer or an ancestor of it.

## Verification

- Unit: 45 files / 2499 tests green; new `rejectedEmptyStripOps` describes (strip + populated/absent/covered guards + RFC6902 serialization).
- Live: `vpclattice-listener/verify-detect.sh` (new, committed as the regression integ) — deploy → record → `update-rule` priority 10→20 out of band → `check` detects (exit 1) → `revert --yes` **succeeds** → `check` CLEAN → live priority restored. INTEG PASS; stack deleted, sweep clean.
- `/verify-pr`: the 7 core integ fixtures (basic ×3, iam, lambda, revert, policies) all INTEG PASS (re-run on this branch since the revert path changed).

`AWS::VpcLattice::Listener` default-action echoes were not observed to trip the same constraint this round; if a sibling case surfaces, it is a one-line pointer addition to the same table.
