### PR TITLE
fix(normalize): fold ResolverEndpoint IpAddresses reorder FP (identity-key by SubnetId)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -149,6 +149,20 @@ const IDENTITY_KEYED_SUBSET_ARRAYS: Record<string, Record<string, SubsetArraySpe
   // email) still surfaces. Exposed once UserPoolUser became CC-readable (router.ts adapter
   // above); observed live on a fresh cognito-userpooluser-rich deploy (sub injected).
   'AWS::Cognito::UserPoolUser': { UserAttributes: { idField: 'Name' } },
+  // A Route53Resolver ResolverEndpoint's `IpAddresses` is a SET keyed by SubnetId where
+  // the template declares only `{SubnetId}` (letting AWS assign the IP) but the live model
+  // is a SUPERSET: AWS fills in the assigned `Ip` (+ `IpId`/`Status`) per entry AND returns
+  // the entries in a NON-deterministic order. A positional compare then false-flags each
+  // shifted entry's `SubnetId` as declared drift on a freshly recorded endpoint — and the
+  // resulting phantom revert FAILS (writing the SubnetId-only entry back makes AWS re-pick
+  // an IP → `[RSLVR-00405] … not in subnet CIDR range or is reserved`). SubnetId is NOT one
+  // of the global IDENTITY_FIELDS, so only this per-type key aligns it. Aligning declared
+  // entries to live BY SubnetId neutralizes the reorder and subset-compares each declared
+  // `{SubnetId}` against its live twin (the assigned Ip/IpId are undeclared inventory,
+  // foldable/recordable); a genuinely changed subnet still surfaces. Assumes one IP per
+  // subnet (the hybrid-DNS norm — one endpoint IP per AZ); multiple IPs in one subnet would
+  // collapse on the key, an accepted edge case. Surfaced by the issue #467 --wait live-test.
+  'AWS::Route53Resolver::ResolverEndpoint': { IpAddresses: { idField: 'SubnetId' } },
 };
 // Nested object-arrays whose element identity is a NON-standard field (not Key/Id/
 // AttributeName/IndexName/Name). collectNestedUndeclared aligns identity-keyed arrays so a

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4822,6 +4822,53 @@ describe('EC2 Instance BlockDeviceMappings identity-keyed subset (found by ec2-i
   });
 });
 
+describe('Route53Resolver ResolverEndpoint IpAddresses identity-keyed subset (issue #467 --wait live-test)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const endpoint = (declared: Record<string, unknown>) => ({
+    logicalId: 'HuntOutboundEndpoint',
+    resourceType: 'AWS::Route53Resolver::ResolverEndpoint',
+    physicalId: 'rslvr-out-abc',
+    declared,
+  });
+  // The template declares SubnetId only (AWS assigns the IP).
+  const declaredA = { SubnetId: 'subnet-a' };
+  const declaredB = { SubnetId: 'subnet-b' };
+  // AWS enriches each live entry with the assigned Ip (+ IpId/Status) and returns them
+  // in a NON-deterministic order (here: b before a, the reverse of the declared order).
+  const liveA = { SubnetId: 'subnet-a', Ip: '10.0.0.53', IpId: 'rni-a', Status: 'ATTACHED' };
+  const liveB = { SubnetId: 'subnet-b', Ip: '10.0.0.106', IpId: 'rni-b', Status: 'ATTACHED' };
+
+  it('reordered + IP-enriched IpAddresses does NOT false-drift the SubnetId (the RSLVR-00405 FP)', () => {
+    const findings = classifyResource(
+      endpoint({ IpAddresses: [declaredA, declaredB] }),
+      { IpAddresses: [liveB, liveA] }, // reversed order + assigned Ip/IpId
+      bare
+    );
+    // no declared drift at all — the phantom SubnetId drift (that then failed to revert
+    // with RSLVR-00405) is gone; the assigned Ip/IpId are an undeclared superset, not a
+    // declared change, so aligning by SubnetId leaves the declared subset matching.
+    expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+  });
+
+  it('a declared subnet genuinely absent from live is still declared drift', () => {
+    const declaredDrift = classifyResource(
+      endpoint({ IpAddresses: [declaredA, declaredB] }),
+      { IpAddresses: [liveA] }, // subnet-b endpoint IP removed out of band
+      bare
+    ).filter((f) => f.tier === 'declared');
+    expect(declaredDrift).toHaveLength(1);
+  });
+});
+
 describe('EC2 Instance Volumes identity-keyed subset (found by ec2-instance-sets)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),


### PR DESCRIPTION
## What

Fixes a false-positive (and the failed revert it caused) on
`AWS::Route53Resolver::ResolverEndpoint` `IpAddresses`, discovered by the issue #467
`revert --wait` live-test.

The template declares each IP address as `{SubnetId}` only (AWS assigns the IP). The live
model is a **superset** — AWS fills in the assigned `Ip` (+ `IpId`/`Status`) — and returns
the entries in a **non-deterministic order**. A positional compare then false-flags each
shifted entry's `SubnetId` as declared drift on a freshly recorded endpoint, and the
resulting phantom revert **fails** (`[RSLVR-00405] … not in subnet CIDR range or is
reserved`, because writing the SubnetId-only entry back makes AWS re-pick an IP).

## How

One entry added to `IDENTITY_KEYED_SUBSET_ARRAYS` in `src/diff/classify.ts` — the same
mechanism EC2 Instance `BlockDeviceMappings` (keyed by `DeviceName`) already uses:

```
'AWS::Route53Resolver::ResolverEndpoint': { IpAddresses: { idField: 'SubnetId' } },
```

Declared entries align to live **by SubnetId**, so the reorder is neutralized and each
declared `{SubnetId}` subset-compares against its live twin (the assigned `Ip`/`IpId` are an
undeclared superset, not a declared change). A genuinely removed/changed subnet still
surfaces. Assumes one IP per subnet (the hybrid-DNS norm — one endpoint IP per AZ);
multiple IPs in one subnet would collapse on the key (documented edge case).

Fixing the detection FP also removes the phantom revert, so the RSLVR-00405 failure is gone.

## Tests

`tests/classify.test.ts` — reordered + IP-enriched `IpAddresses` produces **no** declared
drift; a declared subnet genuinely absent from live is still declared drift.

## Live-tested (real AWS, resolver-rich)

Fresh deploy → `record` → `check --fail` **×5** (the reorder is non-deterministic, so one
clean check isn't proof) — **5/5 CLEAN**, no `IpAddresses` / `HuntOutboundEndpoint` drift.
Stack torn down via `delstack`; `sweep-orphans` SWEEP CLEAN.
