### PR TITLE
chore(gates): verify-stamp authorization for bughunt clear + orphan-sweep step in /verify-pr

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -296,8 +296,14 @@ enforced structurally rather than by discipline:
   non-empty** — so you physically cannot land the fix PR (or any commit) until the
   bug-hunt stacks are deleted and verified gone.
 - `bughunt-track.sh verify` asserts each tracked stack is GONE from CloudFormation
-  AND `sweep-orphans.sh` reports SWEEP CLEAN; `bughunt-track.sh clear` empties the
-  sentinel (releasing the gate) and is meant to be run ONLY after that passes.
+  AND `sweep-orphans.sh` reports SWEEP CLEAN, and on success STAMPS the verified
+  pending set; `bughunt-track.sh clear` empties the sentinel (releasing the gate)
+  and REFUSES without a stamp matching the current pending set — "verify passed
+  first" is enforced structurally, not by shell plumbing (a piped
+  `verify | tail && clear` once chained a clear onto a FAILED verify because the
+  pipeline's exit was tail's). Run `verify` and `clear` as separate, un-piped
+  commands from the SAME directory (the owner key is cwd-derived — a cwd that
+  drifted back to the main checkout arms/clears the WRONG owner).
 
 `delstack` only deletes stack MEMBERS. `sweep-orphans.sh` catches the
 stack-EXTERNAL orphans teardown leaves behind — auto-created `/aws/lambda/*` log

--- a/.claude/skills/hunt-bugs/bughunt-track.sh
+++ b/.claude/skills/hunt-bugs/bughunt-track.sh
@@ -15,8 +15,18 @@
 #   verify [--region R]         Assert each tracked stack is GONE from
 #                               CloudFormation AND sweep-orphans.sh is CLEAN.
 #                               Non-zero exit if anything remains. Does NOT clear.
+#                               On success, STAMPS the current pending set as
+#                               verified — the stamp is what authorizes `clear`.
 #   clear                       Empty THIS owner's pending list (releases the gate
-#                               for this owner). Run ONLY after verify passes.
+#                               for this owner). REFUSES unless the CURRENT pending
+#                               set carries a fresh `verify` stamp, so a chained
+#                               invocation whose verify FAILED can never release
+#                               the gate by accident (nearly happened live:
+#                               `verify 2>&1 | tail && clear` — the pipeline exit
+#                               is tail's 0, so && passed on a FAILED verify with
+#                               orphans remaining). A later `add` invalidates the
+#                               stamp. Escape hatch when a verify is IMPOSSIBLE
+#                               (e.g. no AWS credentials): CDKRD_BUGHUNT_FORCE_CLEAR=1.
 #   list [--all]                Print this owner's tracked stacks (--all: every
 #                               owner's, plus any legacy flat file).
 #
@@ -58,6 +68,20 @@ if [ -z "${owner_raw}" ]; then
 fi
 OWNER_KEY="$(printf '%s' "${owner_raw}" | sed 's#[^A-Za-z0-9._-]#_#g')"
 OWNER_FILE="${PENDING_DIR}/${OWNER_KEY}"
+# The verify stamp: a checksum of the pending set verify last PASSED on. `clear`
+# refuses when the stamp is missing or the pending set changed since (a later `add`).
+# Kept in a SIBLING dir, NOT inside PENDING_DIR: the bughunt-clean-gate hook counts
+# every non-empty file under PENDING_DIR as pending stacks, so a stamp there would
+# arm the gate forever.
+STAMP_DIR="${REPO_ROOT}/.markgate-bughunt-verified.d"
+STAMP_FILE="${STAMP_DIR}/${OWNER_KEY}"
+
+# Checksum of THIS owner's full pending state (owner file + the legacy flat file),
+# order-insensitive. Empty state hashes to the checksum of nothing — stable.
+pending_state_hash() {
+  { cat "${OWNER_FILE}" 2>/dev/null || true; cat "${LEGACY_SENTINEL}" 2>/dev/null || true; } |
+    sort | cksum
+}
 
 cmd="${1:-}"
 shift || true
@@ -75,6 +99,9 @@ case "${cmd}" in
         echo "${stack}" >>"${OWNER_FILE}"
       fi
     done
+    # New deploys invalidate any prior verify — the stamp hash would no longer
+    # match anyway; removing it keeps the failure message crisp ("run verify").
+    rm -f "${STAMP_FILE}"
     echo "tracked $# stack(s) for owner ${OWNER_KEY}; bughunt-clean gate is now ARMED"
     ;;
 
@@ -146,19 +173,40 @@ case "${cmd}" in
       echo "WARN: ${SWEEP} not found/executable — skipping orphan sweep" >&2
     fi
     if [ "${fail}" -ne 0 ]; then
+      # A failed verify revokes any prior stamp: the world changed under it.
+      rm -f "${STAMP_FILE}"
       echo "verify FAILED — delete the remaining stacks/orphans before clearing the gate" >&2
       exit 1
     fi
-    echo "verify OK — every tracked stack is gone and no orphans remain"
+    # Stamp the exact pending set this verify passed on; `clear` requires it.
+    mkdir -p "${STAMP_DIR}"
+    pending_state_hash >"${STAMP_FILE}"
+    echo "verify OK — every tracked stack is gone and no orphans remain (clear is now authorized)"
     ;;
 
   clear)
+    # A clear that would release actual pending stacks must be AUTHORIZED by a
+    # verify stamp matching the CURRENT pending set. Exit-code plumbing is not
+    # trusted here on purpose: `verify ... | tail && clear` once chained a clear
+    # onto a FAILED verify because the pipeline's exit was tail's. An empty pending
+    # state needs no stamp (nothing to release).
+    if [ -s "${OWNER_FILE}" ] || [ -s "${LEGACY_SENTINEL}" ]; then
+      if [ "${CDKRD_BUGHUNT_FORCE_CLEAR:-}" = "1" ]; then
+        echo "WARN: CDKRD_BUGHUNT_FORCE_CLEAR=1 — clearing WITHOUT a passing verify" >&2
+      elif [ ! -s "${STAMP_FILE}" ] || [ "$(cat "${STAMP_FILE}")" != "$(pending_state_hash)" ]; then
+        echo "REFUSED: the current pending set has no passing \`verify\` stamp — run" >&2
+        echo "  ${BASH_SOURCE[0]} verify" >&2
+        echo "first (or CDKRD_BUGHUNT_FORCE_CLEAR=1 if a verify is impossible)." >&2
+        exit 1
+      fi
+    fi
     # Remove ONLY this owner's file (+ the legacy flat file this owner may have
     # armed). NEVER `rm -rf` the whole dir — that would release a CONCURRENT owner's
     # still-pending stacks (the SPOF this design fixes).
-    rm -f "${OWNER_FILE}" "${LEGACY_SENTINEL}"
-    # Tidy the dir if this was the last owner (cosmetic; harmless if it is not empty).
+    rm -f "${OWNER_FILE}" "${LEGACY_SENTINEL}" "${STAMP_FILE}"
+    # Tidy the dirs if this was the last owner (cosmetic; harmless if not empty).
     rmdir "${PENDING_DIR}" 2>/dev/null || true
+    rmdir "${STAMP_DIR}" 2>/dev/null || true
     echo "cleared owner ${OWNER_KEY}; bughunt-clean gate is now RELEASED for this owner"
     ;;
 

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -87,6 +87,18 @@ Run each check and report pass/fail:
      up after themselves) — they need credentials and a bootstrapped account.
    - If credentials are absent, say so explicitly and DO NOT set the
      `verify-pr` marker — let the human run them or decide.
+   - **Sweep the orphans the fixtures ALWAYS leave.** The `basic`/`revert`
+     fixtures' S3 `autoDeleteObjects` custom-resource Lambdas auto-create
+     `/aws/lambda/*CustomS3AutoDeleteObjects*` log groups that stack deletion
+     does NOT remove — every core-fixture run leaves ~4 of them (observed on
+     three consecutive runs). After the fixtures pass, run:
+
+     ```bash
+     AWS_REGION=us-east-1 bash tests/integration/sweep-orphans.sh --delete
+     AWS_REGION=us-east-1 bash tests/integration/sweep-orphans.sh   # must print SWEEP CLEAN
+     ```
+
+     Do not set the `verify-pr` marker while the re-run reports orphans.
 
 8. **Retrospective + rules update**
    - Walk back over the session that produced this change. For each surprise,

--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ cdk.context.json
 
 # Node diagnostic reports (issue #402, --report-on-fatalerror)
 report.*.json
+.markgate-bughunt-verified.d/


### PR DESCRIPTION
## Summary

Two gate-integrity hardenings from the 2026-07-03 fix-session retrospective (the sessions that landed #485/#486/#488). Docs/tooling-only — no `src/**` in the diff.

### 1. `bughunt-track.sh`: `clear` now requires a passing-`verify` stamp

"Run `clear` ONLY after `verify` passes" was enforced by discipline + shell plumbing, and the plumbing failed live: `verify 2>&1 | tail && clear` chained a clear onto a **FAILED** verify (4 orphans remained) because the pipeline's exit code was `tail`'s 0. Now:

- `verify` on success stamps the exact pending set it passed on (`.markgate-bughunt-verified.d/<owner>`, gitignored — a **sibling** dir, because the `bughunt-clean-gate` hook counts every non-empty file under `.markgate-bughunt-pending.d/` as pending stacks).
- `clear` refuses without a stamp matching the current pending set; `add` and a failed `verify` both invalidate it. `CDKRD_BUGHUNT_FORCE_CLEAR=1` is the documented escape hatch for an impossible verify (no credentials).
- Flow tested live: `add` → `clear` REFUSED (rc 1) → `verify` OK (stamps, real CFn + sweep checks) → `clear` released (rc 0). `bash -n` clean.

### 2. `/verify-pr`: sweep the orphans the core fixtures always leave

The `basic`/`revert` fixtures' S3 `autoDeleteObjects` custom-resource Lambdas auto-create `/aws/lambda/*CustomS3AutoDeleteObjects*` log groups that stack deletion does not remove — ~4 per core-fixture run, observed on three consecutive runs yesterday. Step 7 now ends with `sweep-orphans.sh --delete` + a SWEEP CLEAN re-run, and forbids setting the `verify-pr` marker while orphans remain.

### 3. `/hunt-bugs` skill doc

Documents the new enforcement plus the two operational rules: never pipe `verify`/`clear`, and run both from the same directory (the owner key is cwd-derived; a cwd drifted back to the main checkout arms/clears the wrong owner — happened twice yesterday).
