### PR TITLE
fix(schema): strip NetworkManager GlobalNetwork lifecycle State/CreatedAt via SCHEMA_READONLY_SUPPLEMENTS

### DIFF
--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -73,6 +73,40 @@ export const OVERRIDE_READABLE_WRITEONLY: Record<string, readonly string[]> = {
   'AWS::MemoryDB::User': ['AccessString'],
 };
 
+// Curated readOnly SUPPLEMENTS: JSON-pointer property paths a type's CloudFormation
+// schema FORGETS to mark `readOnly`, so the readOnly strip leaves them in the live model
+// and they surface as first-run Potential Drift. This is the MIRROR of SDK_SUPPLEMENTS
+// (which patches writeOnly gaps the other direction, #482): here we patch a readOnly gap.
+// Applied on top of the fetched schema's readOnlyProperties BEFORE the strip runs, so the
+// property is stripped for EVERY tier (first-run noise, baseline, revert planning) — the
+// right treatment for a lifecycle/status attribute that can never be user intent and flaps
+// between values (so an equality-gated KNOWN_DEFAULTS fold would be wrong).
+//
+// AWS::NetworkManager::GlobalNetwork forgets readOnly on its lifecycle `State`
+// (AVAILABLE/UPDATING/DELETING) and `CreatedAt` timestamp — provably an AWS oversight:
+// the sibling AWS::NetworkManager::Site marks the SAME pair readOnly
+// (readOnlyProperties = [SiteId, SiteArn, State, CreatedAt]). GlobalNetwork's schema has
+// readOnly = [Id, Arn] only (#495). Keep this table CURATED/minimal — the corpus scan
+// found no other currently-leaking type, so do NOT add speculative entries.
+export const SCHEMA_READONLY_SUPPLEMENTS: Record<string, readonly string[]> = {
+  'AWS::NetworkManager::GlobalNetwork': ['/properties/State', '/properties/CreatedAt'],
+};
+
+// Merge a type's readOnly supplement paths into readOnly (top-level set) + readOnlyPaths
+// (nested strip), so the schema-strip layer removes them exactly as if the registry schema
+// had listed them in readOnlyProperties. Exported for unit testing without an AWS call.
+export function supplementReadOnly(info: SchemaInfo, resourceType: string): SchemaInfo {
+  const supplements = SCHEMA_READONLY_SUPPLEMENTS[resourceType];
+  if (!supplements?.length) return info;
+  const dotted = supplements.map(pointerToDotted);
+  const readOnlyPaths = [...new Set([...info.readOnlyPaths, ...dotted])];
+  return {
+    ...info,
+    readOnly: new Set([...info.readOnly, ...dotted.filter((p) => !p.includes('.'))]),
+    readOnlyPaths,
+  };
+}
+
 // The MIRROR of OVERRIDE_READABLE_WRITEONLY: nested paths an SDK_OVERRIDES reader
 // CANNOT read back even though the registry schema does not mark them writeOnly —
 // the type's Describe API simply never returns them. Appended to `writeOnlyPaths`
@@ -112,7 +146,10 @@ async function fetch(client: CloudFormationClient, resourceType: string): Promis
       new DescribeTypeCommand({ Type: 'RESOURCE', TypeName: resourceType })
     );
     return injectReaderGaps(
-      exemptOverrideReadable(parseSchema(r.Schema ?? '{}'), resourceType),
+      exemptOverrideReadable(
+        supplementReadOnly(parseSchema(r.Schema ?? '{}'), resourceType),
+        resourceType
+      ),
       resourceType
     );
   } catch {

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -32,6 +32,8 @@ import {
   injectReaderGaps,
   SDK_READER_GAP_PATHS,
   OVERRIDE_READABLE_WRITEONLY,
+  SCHEMA_READONLY_SUPPLEMENTS,
+  supplementReadOnly,
   parseSchema,
 } from '../src/schema/schema-strip.js';
 
@@ -908,6 +910,41 @@ describe('parseSchema', () => {
     expect(injectReaderGaps(raw, 'AWS::S3::Bucket')).toBe(raw);
     expect(SDK_READER_GAP_PATHS['AWS::CloudWatch::AnomalyDetector']).toEqual([
       'MetricMathAnomalyDetector.MetricDataQueries.*.Label',
+    ]);
+  });
+
+  it('supplementReadOnly patches a schema-forgotten readOnly gap (NetworkManager GlobalNetwork State/CreatedAt)', () => {
+    // GlobalNetwork's registry schema marks only [Id, Arn] readOnly and forgets its lifecycle
+    // State (AVAILABLE/UPDATING/DELETING) + CreatedAt — provably an AWS oversight (the sibling
+    // Site marks the same pair readOnly, #495). The supplement folds them into readOnly so a
+    // live model carrying State: "AVAILABLE" is stripped for every tier.
+    const raw = parseSchema(
+      JSON.stringify({
+        readOnlyProperties: ['/properties/Id', '/properties/Arn'],
+        properties: {
+          State: { type: 'string' },
+          CreatedAt: { type: 'string' },
+          Description: { type: 'string' },
+        },
+      })
+    );
+    // Before the supplement: schema has only Id/Arn readOnly; State/CreatedAt leak.
+    expect([...raw.readOnly].sort()).toEqual(['Arn', 'Id']);
+    expect(raw.readOnly.has('State')).toBe(false);
+    expect(raw.readOnly.has('CreatedAt')).toBe(false);
+
+    const info = supplementReadOnly(raw, 'AWS::NetworkManager::GlobalNetwork');
+    // After: both lifecycle attrs are readOnly (top-level set) AND readOnlyPaths (nested strip).
+    expect([...info.readOnly].sort()).toEqual(['Arn', 'CreatedAt', 'Id', 'State']);
+    expect(info.readOnlyPaths).toContain('State');
+    expect(info.readOnlyPaths).toContain('CreatedAt');
+    // Idempotent-ish: does not duplicate a path already present.
+    expect(info.readOnlyPaths.filter((p) => p === 'State')).toHaveLength(1);
+    // A type with no supplement is returned untouched.
+    expect(supplementReadOnly(raw, 'AWS::S3::Bucket')).toBe(raw);
+    expect(SCHEMA_READONLY_SUPPLEMENTS['AWS::NetworkManager::GlobalNetwork']).toEqual([
+      '/properties/State',
+      '/properties/CreatedAt',
     ]);
   });
 


### PR DESCRIPTION
## Summary

`AWS::NetworkManager::GlobalNetwork` leaks its lifecycle attribute `State = "AVAILABLE"` as first-run Potential Drift (and bakes it into the baseline) because the type's CloudFormation schema **forgets to mark `State`/`CreatedAt` as `readOnly`** — its `readOnlyProperties` lists only `[Id, Arn]`. The sibling `AWS::NetworkManager::Site` correctly marks the same pair readOnly (`readOnlyProperties = [SiteId, SiteArn, State, CreatedAt]`), confirming the omission is an AWS oversight, not semantics.

A lifecycle status can never be user intent, and it flaps (`UPDATING`/`DELETING`), so a KNOWN_DEFAULTS equality-fold would be wrong — it must be stripped for **every** tier (first-run noise, baseline, revert planning).

## Fix

Add a curated `SCHEMA_READONLY_SUPPLEMENTS` table in `src/schema/schema-strip.ts`:

```ts
{ 'AWS::NetworkManager::GlobalNetwork': ['/properties/State', '/properties/CreatedAt'] }
```

A new `supplementReadOnly(info, resourceType)` merges those pointer paths into `readOnly` (top-level set) + `readOnlyPaths` (nested strip), applied in `fetch()` on top of the fetched schema **before** the readOnly strip consumes it — the mirror of `SDK_SUPPLEMENTS`, which patches writeOnly gaps in the other direction (#482).

The table is kept curated/minimal: the corpus scan in #495 found no other currently-leaking type, so no speculative entries.

## Test

New unit test in `tests/noise-and-strip.test.ts` builds the documented shape (schema with readOnly `[Id, Arn]` + `State`/`CreatedAt` as plain props), asserts they leak before the supplement and are folded into `readOnly` + `readOnlyPaths` after, plus the no-op-for-unlisted-type and no-duplicate cases.

## Gates

typecheck / lint+format / build / 2518 unit tests all pass.

Closes #495
