### PR TITLE
fix(read): CC_IDENTIFIER_ADAPTERS for ElasticBeanstalk ConfigurationTemplate + OptionSettings default-fill guard

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -315,6 +315,91 @@ const IAM_ATTACHMENT_SUBSET: Record<string, ReadonlySet<string>> = {
   'AWS::IAM::ManagedPolicy': new Set(['Roles', 'Users', 'Groups']),
 };
 
+// #493: identity-keyed object-array SUBSET folds where the identity is a COMPOSITE of
+// several fields AND live entries carry extra service-injected fields the template never
+// declares. This is a stricter cousin of noise.ts NAME_VALUE_SUBSET_PATHS (RDS OptionGroup
+// #480/#485) — that helper folds only PURE `{name,value}` pairs keyed by a single field, so
+// it disqualifies (returns null) the moment an element carries any other key. Elastic
+// Beanstalk's ConfigurationTemplate `OptionSettings` needs the composite variant:
+//   - the template declares a SUBSET (~3 entries); once the composite-identifier adapter
+//     (router.ts) makes the template CC-readable, CC returns the FULLY RESOLVED set (~58
+//     entries) the service default-fills — a whole-array `declared` FP on every fresh deploy;
+//   - each entry's identity is `Namespace` + `OptionName` together (neither alone is unique);
+//   - live entries carry an extra `ResourceName` field the template never declares, which is
+//     STRIPPED before the value compare (it is not part of the declared intent).
+// When every declared entry is present in live with an equal value (declared ⊆ live), the
+// whole-array `declared` diff is suppressed and the live-only (service-filled) entries surface
+// as nested undeclared inventory (recorded; a later change still surfaces). A genuine declared
+// entry change (missing key or differing value) returns null and the finding is kept.
+interface CompositeSubsetSpec {
+  re: RegExp;
+  keyFields: string[];
+  ignoreFields: ReadonlySet<string>;
+}
+const COMPOSITE_KEY_SUBSET_PATHS: Record<string, CompositeSubsetSpec> = {
+  'AWS::ElasticBeanstalk::ConfigurationTemplate': {
+    re: /(^|\.)OptionSettings$/,
+    keyFields: ['Namespace', 'OptionName'],
+    ignoreFields: new Set(['ResourceName']),
+  },
+};
+
+// Align a declared object array to a live one BY a composite identity key, ignoring the
+// spec's live-only fields in the value compare. Returns the live-only entries (server-
+// injected / out-of-band entries the template never declared) when every DECLARED entry is
+// present in live and deep-equal on its declared (non-ignored) fields (declared ⊆ live,
+// reorder-insensitive). Returns null when a declared entry is MISSING from live or a declared
+// field differs (a genuine declared drift the caller must keep), or when either side is not a
+// pure object array or an element is missing a key field (disqualify rather than risk muting).
+function alignCompositeKeySubset(
+  declared: unknown,
+  live: unknown,
+  spec: CompositeSubsetSpec
+): unknown[] | null {
+  if (!Array.isArray(declared) || !Array.isArray(live)) return null;
+  const keyOf = (e: unknown): string | null => {
+    if (!e || typeof e !== 'object' || Array.isArray(e)) return null;
+    const r = e as Record<string, unknown>;
+    const parts: string[] = [];
+    for (const f of spec.keyFields) {
+      if (typeof r[f] !== 'string') return null;
+      parts.push(r[f] as string);
+    }
+    return JSON.stringify(parts);
+  };
+  // A declared entry deep-equals a live entry once BOTH sides drop the ignored (live-only)
+  // fields — the declared side never carries them, but strip symmetrically to be safe.
+  const stripIgnored = (e: Record<string, unknown>): Record<string, unknown> => {
+    if (spec.ignoreFields.size === 0) return e;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(e)) if (!spec.ignoreFields.has(k)) out[k] = v;
+    return out;
+  };
+  const lm = new Map<string, unknown>();
+  for (const e of live) {
+    const k = keyOf(e);
+    if (k === null) return null;
+    lm.set(k, e);
+  }
+  const declaredKeys = new Set<string>();
+  for (const d of declared) {
+    const k = keyOf(d);
+    if (k === null || !lm.has(k)) return null;
+    if (
+      !deepEqual(
+        stripIgnored(d as Record<string, unknown>),
+        stripIgnored(lm.get(k) as Record<string, unknown>)
+      )
+    )
+      return null;
+    declaredKeys.add(k);
+  }
+  return live.filter((e) => {
+    const k = keyOf(e);
+    return k !== null && !declaredKeys.has(k);
+  });
+}
+
 // R96/R98: recurse the declared and live sides of a property and emit each LIVE-only
 // nested key — a sub-key present in live but never declared, at any depth.
 //   - Plain objects (R96): walk every live key; recurse where declared, emit otherwise.
@@ -1104,6 +1189,31 @@ export function classifyResource(
               logicalId,
               resourceType,
               path: `${d.path}[${String((lo as Record<string, unknown>)[nvSubsetSpec.nameField])}]`,
+              actual: lo,
+              nested: true,
+            });
+          }
+          continue;
+        }
+      }
+      // #493: composite-identity object-array subset (ElasticBeanstalk ConfigurationTemplate
+      // `OptionSettings`): the template declares ~3 entries but CC returns the fully resolved
+      // ~58, keyed by Namespace+OptionName with a live-only ResourceName field. Same fold as
+      // the name/value subset above but with a composite key + ignored live-only fields. When
+      // every declared entry is a subset of live, suppress the whole-array `declared` FP and
+      // surface the service-filled extras as nested undeclared inventory.
+      const ckSubsetSpec = COMPOSITE_KEY_SUBSET_PATHS[resourceType];
+      if (ckSubsetSpec?.re.test(d.path)) {
+        const liveOnly = alignCompositeKeySubset(d.stateValue, d.awsValue, ckSubsetSpec);
+        if (liveOnly) {
+          for (const lo of liveOnly) {
+            const r = lo as Record<string, unknown>;
+            const key = ckSubsetSpec.keyFields.map((f) => String(r[f])).join('|');
+            findings.push({
+              tier: 'undeclared',
+              logicalId,
+              resourceType,
+              path: `${d.path}[${key}]`,
               actual: lo,
               nested: true,
             });

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -136,6 +136,22 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // Verified live (codedeploy-deploymentgroup-readgap): `ApplicationName|DeploymentGroupName`
   // reads; the reverse order returns NotFound ("No application found for name").
   'AWS::CodeDeploy::DeploymentGroup': compositeWith('ApplicationName'),
+  // ElasticBeanstalk ConfigurationTemplate primaryIdentifier is [ApplicationName,
+  // TemplateName] — parent-first. The CFn physical id is the bare TemplateName; the
+  // ApplicationName comes from the resolved declared Ref. Without this a declared
+  // configuration template is a CC ValidationException skip on every check (read-gap),
+  // so both undeclared drift on it AND an out-of-band change to a declared property
+  // (OptionSettings, SolutionStackName, …) are invisible. Verified live (#493,
+  // CdkRealDriftHuntEbElbVpn, us-east-1): `ApplicationName|TemplateName` reads; the
+  // reverse order (`TemplateName|ApplicationName`) returns NotFound.
+  'AWS::ElasticBeanstalk::ConfigurationTemplate': compositeWith('ApplicationName'),
+  // ElasticBeanstalk ApplicationVersion primaryIdentifier is [ApplicationName, Id] —
+  // parent-first, the same shape as its ConfigurationTemplate sibling above. The CFn
+  // physical id is the bare version label; the ApplicationName comes from the resolved
+  // declared Ref, so it almost certainly shares the same composite read-gap. Added
+  // BY ANALOGY with the live-proven ConfigurationTemplate (#493) — not separately
+  // live-verified this round.
+  'AWS::ElasticBeanstalk::ApplicationVersion': compositeWith('ApplicationName'),
   // AutoScaling ScheduledAction primaryIdentifier is [ScheduledActionName,
   // AutoScalingGroupName] — CHILD-first, the REVERSE of its sibling LifecycleHook
   // (parent-first). The CFn physical id is the bare ScheduledActionName; the ASG name

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1870,6 +1870,133 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  describe('ElasticBeanstalk ConfigurationTemplate OptionSettings subset (composite Namespace+OptionName key + live-only ResourceName, #493)', () => {
+    const T = 'AWS::ElasticBeanstalk::ConfigurationTemplate';
+    // The template declares a handful of settings; each is keyed by Namespace+OptionName.
+    const declared = {
+      ApplicationName: 'cdkrd-hunt-ebapp',
+      TemplateName: 'MyStack-EbTemplate-1CZ1zQUn5g9T',
+      SolutionStackName: '64bit Amazon Linux 2 v3.5.0 running Docker',
+      OptionSettings: [
+        {
+          Namespace: 'aws:autoscaling:asg',
+          OptionName: 'MinSize',
+          Value: '1',
+        },
+        {
+          Namespace: 'aws:autoscaling:asg',
+          OptionName: 'MaxSize',
+          Value: '2',
+        },
+        {
+          Namespace: 'aws:elasticbeanstalk:environment',
+          OptionName: 'EnvironmentType',
+          Value: 'LoadBalanced',
+        },
+      ],
+    };
+    // The live shape observed once the composite-identifier adapter makes the template
+    // CC-readable: the service reorders the settings, materializes the fully resolved set
+    // (here truncated for the test but representative of the ~58 live entries), AND injects
+    // a `ResourceName` field on many entries that the template never declares.
+    const liveModel = (settings: unknown[]) => ({
+      ApplicationName: 'cdkrd-hunt-ebapp',
+      TemplateName: 'MyStack-EbTemplate-1CZ1zQUn5g9T',
+      SolutionStackName: '64bit Amazon Linux 2 v3.5.0 running Docker',
+      // PlatformArn is a service-echoed top-level default the template never declares.
+      PlatformArn:
+        'arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2/3.5.0',
+      OptionSettings: settings,
+    });
+    const liveDefaultFilled = [
+      // declared entries, reordered + carrying a live-only ResourceName
+      {
+        ResourceName: 'AWSEBAutoScalingGroup',
+        Value: 'LoadBalanced',
+        Namespace: 'aws:elasticbeanstalk:environment',
+        OptionName: 'EnvironmentType',
+      },
+      {
+        ResourceName: 'AWSEBAutoScalingGroup',
+        Value: '2',
+        Namespace: 'aws:autoscaling:asg',
+        OptionName: 'MaxSize',
+      },
+      {
+        ResourceName: 'AWSEBAutoScalingGroup',
+        Value: '1',
+        Namespace: 'aws:autoscaling:asg',
+        OptionName: 'MinSize',
+      },
+      // service-filled extras the template never declared
+      {
+        ResourceName: 'AWSEBAutoScalingGroup',
+        Value: 'Any',
+        Namespace: 'aws:autoscaling:asg',
+        OptionName: 'Availability Zones',
+      },
+      {
+        Value: '30',
+        Namespace: 'aws:autoscaling:asg',
+        OptionName: 'Cooldown',
+      },
+      {
+        Value: 'tcp',
+        Namespace: 'aws:elb:healthcheck',
+        OptionName: 'HealthyThreshold',
+      },
+    ];
+
+    it('a reordered + default-filled OptionSettings (with live-only ResourceName) is NOT declared drift; live-only settings surface as undeclared', () => {
+      const findings = classifyResource(
+        res(T, declared),
+        liveModel(liveDefaultFilled),
+        emptySchema
+      );
+      expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+      const undeclared = findings.filter((f) => f.tier === 'undeclared');
+      // the three service-filled extras surface (composite-key path), plus the top-level
+      // PlatformArn echo (undeclared inventory, recordable — NOT a declared drift).
+      expect(undeclared.map((f) => f.path).sort()).toEqual([
+        'OptionSettings[aws:autoscaling:asg|Availability Zones]',
+        'OptionSettings[aws:autoscaling:asg|Cooldown]',
+        'OptionSettings[aws:elb:healthcheck|HealthyThreshold]',
+        'PlatformArn',
+      ]);
+      // the OptionSettings extras are nested inventory
+      expect(
+        undeclared
+          .filter((f) => f.path.startsWith('OptionSettings'))
+          .every((f) => f.nested === true)
+      ).toBe(true);
+    });
+
+    it('a genuine change to a DECLARED setting value still surfaces as declared drift (fail-closed)', () => {
+      const mutated = liveDefaultFilled.map((s) =>
+        (s as { OptionName: string }).OptionName === 'MaxSize'
+          ? { ...(s as object), Value: '9' }
+          : s
+      );
+      const declaredF = classifyResource(res(T, declared), liveModel(mutated), emptySchema).filter(
+        (f) => f.tier === 'declared'
+      );
+      expect(declaredF).toHaveLength(1);
+      expect(declaredF[0]?.path).toBe('OptionSettings');
+    });
+
+    it('a declared setting MISSING from live is declared drift, not silently dropped', () => {
+      const withoutDeclared = liveDefaultFilled.filter(
+        (s) => (s as { OptionName: string }).OptionName !== 'MinSize'
+      );
+      const declaredF = classifyResource(
+        res(T, declared),
+        liveModel(withoutDeclared),
+        emptySchema
+      ).filter((f) => f.tier === 'declared');
+      expect(declaredF).toHaveLength(1);
+    });
+  });
+
   describe('VpcLattice ServiceNetwork SharingConfig service default (#483)', () => {
     const T = 'AWS::VpcLattice::ServiceNetwork';
 

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -444,6 +444,55 @@ describe('readLive (CC identifier adapters, R74)', () => {
     });
   }
 
+  // #493: ElasticBeanstalk ConfigurationTemplate [ApplicationName, TemplateName] —
+  // parent-first. CFn physical id is the bare TemplateName; without the adapter it is a
+  // CC ValidationException skip. Verified live: ApplicationName|TemplateName reads, reverse 404s.
+  it('ElasticBeanstalk ConfigurationTemplate: builds the ApplicationName|TemplateName composite — PARENT first', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ElasticBeanstalk::ConfigurationTemplate',
+        physicalId: 'MyStack-EbTemplate-1CZ1zQUn5g9T',
+        declared: { ApplicationName: 'cdkrd-hunt-ebapp' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('cdkrd-hunt-ebapp|MyStack-EbTemplate-1CZ1zQUn5g9T');
+  });
+
+  it('ElasticBeanstalk ConfigurationTemplate: an unresolved ApplicationName falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ElasticBeanstalk::ConfigurationTemplate',
+        physicalId: 'MyStack-EbTemplate-1CZ1zQUn5g9T',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('MyStack-EbTemplate-1CZ1zQUn5g9T');
+  });
+
+  // #493 (by analogy): ApplicationVersion [ApplicationName, Id] — parent-first, same shape.
+  it('ElasticBeanstalk ApplicationVersion: builds the ApplicationName|Id composite — PARENT first', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ElasticBeanstalk::ApplicationVersion',
+        physicalId: 'v-1a2b3c',
+        declared: { ApplicationName: 'cdkrd-hunt-ebapp' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('cdkrd-hunt-ebapp|v-1a2b3c');
+  });
+
   it('ApiGateway Model: an unresolved RestApiId falls back to the raw physical id', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(


### PR DESCRIPTION
Closes #493.

## Problem
`AWS::ElasticBeanstalk::ConfigurationTemplate` was silently `skipped` on every check (CC `ValidationException`): its composite `primaryIdentifier = [ApplicationName, TemplateName]` is parent-first, but the CFn physical id is only the bare `TemplateName`. So both declared and undeclared drift on it were invisible.

## Fix
1. **Read adapter** (`src/read/router.ts`): `CC_IDENTIFIER_ADAPTERS['AWS::ElasticBeanstalk::ConfigurationTemplate'] = compositeWith('ApplicationName')` — CC now reads `ApplicationName|TemplateName` (live-proven in #493; reverse order 404s). Added the sibling `AWS::ElasticBeanstalk::ApplicationVersion` (`[ApplicationName, Id]`) **by analogy** (commented as not separately live-verified this round).

2. **Default-fill guard** (`src/diff/classify.ts`): making the template readable exposes the RDS OptionGroup default-fill FP class (#480/#485) — the template declares ~3 `OptionSettings` but CC returns the fully-resolved ~58. This case is stricter than the existing `NAME_VALUE_SUBSET_PATHS` helper (which lives in `noise.ts`, out of this PR's scope, and only folds *pure* single-field `{name,value}` pairs): EB entries are keyed by a **composite** `Namespace` + `OptionName` and carry an extra live-only `ResourceName` field. Added a classify-local `COMPOSITE_KEY_SUBSET_PATHS` table + `alignCompositeKeySubset()` that:
   - aligns declared → live by the composite key,
   - strips the live-only `ResourceName` before the value compare,
   - suppresses the whole-array `declared` FP when declared ⊆ live and surfaces the service-filled extras as nested `undeclared` inventory,
   - keeps a genuine declared-value change / missing declared entry as `declared` drift (fail-closed).

## Tests
- `tests/router.test.ts`: ConfigurationTemplate + ApplicationVersion form the `App|Child` composite; unresolved parent falls back to the raw physical id.
- `tests/classify.test.ts`: 3 declared vs 6 live (composite-keyed, live-only `ResourceName`) → no declared drift, extras fold to `undeclared`; a mutated declared value and a missing declared entry still surface as `declared`.

Full suite: 45 files / 2523 tests pass; typecheck + lint/format + build clean.

## Caveat / deferred
The `PlatformArn` top-level echo the service adds is currently reported as `undeclared` inventory (recordable, **not** a `[Potential Drift]` false positive — behavior is correct). Folding it to `atDefault` would require a `KNOWN_DEFAULTS` entry in `src/normalize/noise.ts`, which is owned by another agent this round, so it is **left as a follow-up**. No live re-verification of the ApplicationVersion sibling was done (adapter added by analogy).
