### PR TITLE
fix(normalize): fold RDS DB identifier case + Lambda ApplicationLogLevel default (Aurora FPs)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -911,6 +911,12 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // opts into JSON logging (or a different level) still surfaces the non-default value.
     'LoggingConfig.LogFormat': 'Text',
     'LoggingConfig.SystemLogLevel': 'INFO',
+    // A function that opts into JSON logs (`LogFormat: 'JSON'`, declared) but does not pin an
+    // application log level reads back the AWS default INFO for the undeclared
+    // `ApplicationLogLevel` sub-key — observed live on fresh (non-imported) stacks whose
+    // functions set only LogFormat. Equality-gated, so a function that pins a different level
+    // (DEBUG/ERROR/…) still surfaces the non-default value.
+    'LoggingConfig.ApplicationLogLevel': 'INFO',
   },
   // EMR Serverless fills MaximumCapacity.Disk with the service-wide maximum
   // ("400000 GB") when the template declares only Cpu/Memory. A constant, not
@@ -1894,6 +1900,16 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // the two valid values differ beyond case, so case-insensitive equality hides
   // no real drift. Observed live on a fresh misc-0cov-rich deploy.
   'AWS::EMRServerless::Application': new Set(['Type']),
+  // RDS lowercases DB instance / cluster identifiers on creation, so a template
+  // that declares a mixed-case `DBInstanceIdentifier` (e.g. CDK derives it from the
+  // construct id `dev-main-DbUsers-DB-writer`) reads back all-lowercase
+  // (`dev-main-dbusers-db-writer`) and a case-sensitive compare false-flags declared
+  // drift on every check. The lowercasing is unconditional and unenforceable — you
+  // can never actually have an uppercase identifier live — so case-insensitive
+  // equality hides no revertable drift; a genuine rename still differs beyond case.
+  // Observed live on fresh (non-imported) Aurora stacks in ap-northeast-1.
+  'AWS::RDS::DBInstance': new Set(['DBInstanceIdentifier']),
+  'AWS::RDS::DBCluster': new Set(['DBClusterIdentifier']),
 };
 export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2128,6 +2128,44 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  // Observed live on fresh (non-imported) Aurora stacks: RDS lowercases DB
+  // identifiers on creation, so a mixed-case declared identifier (CDK derives it
+  // from the construct id) reads back all-lowercase — a case-only, unenforceable
+  // difference.
+  describe('case-insensitive scalar path (RDS DB identifiers)', () => {
+    it('mixed-case declared DBInstanceIdentifier vs lowercase live is NOT drift', () => {
+      expect(
+        classifyResource(
+          res('AWS::RDS::DBInstance', { DBInstanceIdentifier: 'dev-main-DbUsers-DB-writer' }),
+          { DBInstanceIdentifier: 'dev-main-dbusers-db-writer' },
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('mixed-case declared DBClusterIdentifier vs lowercase live is NOT drift', () => {
+      expect(
+        classifyResource(
+          res('AWS::RDS::DBCluster', { DBClusterIdentifier: 'Dev-Main-Aurora' }),
+          { DBClusterIdentifier: 'dev-main-aurora' },
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a genuinely different DBInstanceIdentifier is still drift', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res('AWS::RDS::DBInstance', { DBInstanceIdentifier: 'dev-main-writer' }),
+            { DBInstanceIdentifier: 'dev-main-reader' },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['DBInstanceIdentifier']);
+    });
+  });
+
   // Found live by the xfer-sync hunt fixture (#494): the Cloud Control read handler
   // remaps DataBrew Recipe Steps[].Action.Parameters free-form map keys to PascalCase
   // (SourceColumn) while the template AND the DataBrew service carry camelCase


### PR DESCRIPTION
## What

Two false positives observed **live on fresh, non-imported** Aurora stacks (`<aurora-cluster-dev-stack>`, `<db-users-dev-stack>-DB/-Secrets`). Because they reproduce on a clean deploy — not just an imported one — they are confirmed cdkrd bugs, not import artifacts.

### 1. RDS DB identifier case (declared-drift FP)

RDS lowercases `DBInstanceIdentifier` / `DBClusterIdentifier` on creation. A template that declares a mixed-case identifier (CDK derives it from the construct id, e.g. `<db-users-dev-stack>-DB-writer`) reads back all-lowercase (`<db-users-dev-stack>-db-writer`), so a case-sensitive compare false-flagged **CFn-declared drift** on every check.

Fix: add both to `CASE_INSENSITIVE_PATHS`. The lowercasing is unconditional and unenforceable — you can never have an uppercase identifier live — so case-insensitive equality hides no revertable drift; a genuine rename still differs beyond case.

### 2. Lambda `LoggingConfig.ApplicationLogLevel` default (potential-drift FP)

A function that opts into JSON logs (`LogFormat: 'JSON'`, declared) but does not pin an application log level reads back the AWS default `INFO` for the undeclared `ApplicationLogLevel` sub-key, flooding first-run as potential drift.

Fix: add `LoggingConfig.ApplicationLogLevel: 'INFO'` to `KNOWN_DEFAULT_PATHS['AWS::Lambda::Function']`, alongside the existing `LogFormat`/`SystemLogLevel` defaults. Equality-gated, so a pinned level (DEBUG/ERROR/…) still surfaces.

## Live proof

| Stack | Before | After |
| --- | --- | --- |
| `<db-users-dev-stack>-DB` | 1 declared drift (DBInstanceIdentifier) + 26 potential | **0 declared** + 25 potential |
| `<db-users-dev-stack>-Secrets` | 1 potential (ApplicationLogLevel) | **CLEAN** |

## Tests

- `CASE_INSENSITIVE_PATHS` RDS entries: mixed-case identifier folds; genuine rename still drifts (new describe block in `classify.test.ts`).
- The new `KNOWN_DEFAULT_PATHS` Lambda entry is covered by the existing "EVERY entry FOLDS its exact nested default" sweep.

## Out of scope

The remaining potential drifts on these stacks are genuine undeclared values (KmsKeyId, EngineVersion, MasterUsername, maintenance/backup windows, …) — the differentiator feature working — plus RDS engine-family constants (`StorageType=aurora`, `LicenseModel`, default param/option groups, `CACertificateIdentifier`) that are deliberately not folded per the `noise.ts` comment. Also unaddressed: the `SecurityGroup.SecurityGroupIngress` sibling-reflection FP (the declared sibling `AWS::EC2::SecurityGroupIngress` fails to subtract because its `FromPort`/`ToPort` are unresolved `Fn::GetAtt Endpoint.Port`) — tracked for a follow-up since it touches the revert-side sibling merge.
