### PR TITLE
fix(normalize): match SG sibling-rule ports across typed<->string + unresolved (Aurora ingress FP)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -246,8 +246,24 @@ const SG_RULE_REFLECTION: Record<string, 'ingress' | 'egress'> = {
   SecurityGroupEgress: 'egress',
 };
 
+// Match one sibling-declared rule field against the live element's value. The exact
+// deepEqual match is tried first (preserves every existing case), then two tolerances:
+//   - typed<->string scalar coercion: a rule port declared as `Fn::GetAtt <Cluster>.
+//     Endpoint.Port` resolves to the STRING "3306" (the DBCluster's live Endpoint.Port is
+//     a string), while the SG's reflected live rule carries the NUMBER 3306, so a strict
+//     deepEqual false-flags the whole declared ingress rule as undeclared drift on every
+//     CDK Aurora stack (`cluster.connections.allowFrom(...)` is the canonical shape).
+//   - UNRESOLVED wildcard: a declared field the intrinsic resolver could not evaluate is
+//     unknowable, so it must not BLOCK the match — the CidrIp/protocol/description identity
+//     still gates the subtraction. Consistent with the rest of the pipeline, which SKIPS an
+//     unresolved declared value rather than false-drifting on it.
+function siblingRuleFieldMatches(liveVal: unknown, sibVal: unknown): boolean {
+  if (sibVal === UNRESOLVED) return true;
+  return deepEqual(liveVal, sibVal) || isStringlyEqualScalar(liveVal, sibVal);
+}
+
 // Remove from `arr` the first element each sibling rule is a SUBSET of (every sibling key
-// deep-equals the live element's — the live element carries AWS-injected extras the sibling
+// matches the live element's — the live element carries AWS-injected extras the sibling
 // resource never declared, e.g. SourceSecurityGroupOwnerId on a self/peer-ref rule, so an
 // exact equality compare would miss the match). One removal per sibling rule preserves a
 // duplicate inline rule that legitimately repeats the shape.
@@ -265,7 +281,9 @@ function subtractSiblingSgRules(
       (el) =>
         el !== null &&
         typeof el === 'object' &&
-        Object.entries(sub).every(([k, v]) => deepEqual((el as Record<string, unknown>)[k], v))
+        Object.entries(sub).every(([k, v]) =>
+          siblingRuleFieldMatches((el as Record<string, unknown>)[k], v)
+        )
     );
     if (i >= 0) arr.splice(i, 1);
   }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6099,6 +6099,86 @@ describe('SecurityGroup sibling-rule reflection (subtraction)', () => {
     expect(t.declared).toEqual(['SecurityGroupIngress']);
   });
 
+  // The canonical CDK Aurora shape: `cluster.connections.allowFrom(...)` emits a standalone
+  // ingress whose FromPort/ToPort are `Fn::GetAtt <Cluster>.Endpoint.Port`. That GetAtt
+  // resolves against the DBCluster's live model, where Endpoint.Port is a STRING ("3306"),
+  // while the SG reflects the merged rule with a NUMBER port (3306) — a typed<->string
+  // mismatch that must NOT block the sibling subtraction. Observed live on dev-main-DbUsers-DB.
+  it('subtracts a sibling rule whose port is a STRING against a live NUMBER port (GetAtt Endpoint.Port)', () => {
+    const sgAurora: DesiredResource = {
+      logicalId: 'Sg',
+      resourceType: 'AWS::EC2::SecurityGroup',
+      physicalId: 'sg-1',
+      declared: {},
+    };
+    const liveAurora = {
+      SecurityGroupIngress: [
+        { CidrIp: '192.168.0.0/16', IpProtocol: 'tcp', FromPort: 3306, ToPort: 3306 },
+      ],
+    };
+    const siblings = {
+      'sg-1': {
+        ingress: [
+          { CidrIp: '192.168.0.0/16', IpProtocol: 'tcp', FromPort: '3306', ToPort: '3306' },
+        ],
+        egress: [] as unknown[],
+      },
+    };
+    const t = tiers(classifyResource(sgAurora, liveAurora, bare, { siblingSgRules: siblings }));
+    expect(t.undeclared).toEqual([]);
+  });
+
+  // A sibling field the resolver could not evaluate (UNRESOLVED) must act as a wildcard, not
+  // block the match — the CidrIp/protocol identity still gates the subtraction.
+  it('subtracts a sibling rule whose port is UNRESOLVED (wildcard on the unknowable field)', () => {
+    const sgAurora: DesiredResource = {
+      logicalId: 'Sg',
+      resourceType: 'AWS::EC2::SecurityGroup',
+      physicalId: 'sg-1',
+      declared: {},
+    };
+    const liveAurora = {
+      SecurityGroupIngress: [
+        { CidrIp: '192.168.0.0/16', IpProtocol: 'tcp', FromPort: 3306, ToPort: 3306 },
+      ],
+    };
+    const siblings = {
+      'sg-1': {
+        ingress: [
+          { CidrIp: '192.168.0.0/16', IpProtocol: 'tcp', FromPort: UNRESOLVED, ToPort: UNRESOLVED },
+        ],
+        egress: [] as unknown[],
+      },
+    };
+    const t = tiers(classifyResource(sgAurora, liveAurora, bare, { siblingSgRules: siblings }));
+    expect(t.undeclared).toEqual([]);
+  });
+
+  // The coercion is scoped: a genuinely different port still surfaces (no over-subtraction).
+  it('does NOT subtract when the port genuinely differs (string "3307" vs live 3306)', () => {
+    const sgAurora: DesiredResource = {
+      logicalId: 'Sg',
+      resourceType: 'AWS::EC2::SecurityGroup',
+      physicalId: 'sg-1',
+      declared: {},
+    };
+    const liveAurora = {
+      SecurityGroupIngress: [
+        { CidrIp: '192.168.0.0/16', IpProtocol: 'tcp', FromPort: 3306, ToPort: 3306 },
+      ],
+    };
+    const siblings = {
+      'sg-1': {
+        ingress: [
+          { CidrIp: '192.168.0.0/16', IpProtocol: 'tcp', FromPort: '3307', ToPort: '3307' },
+        ],
+        egress: [] as unknown[],
+      },
+    };
+    const t = tiers(classifyResource(sgAurora, liveAurora, bare, { siblingSgRules: siblings }));
+    expect(t.undeclared).toContain('SecurityGroupIngress');
+  });
+
   it('SecurityGroupIngress SourceSecurityGroupOwnerId folds to generated, not undeclared', () => {
     const ingress: DesiredResource = {
       logicalId: 'SgIn',

--- a/tests/integration/aurora-sg-sibling/app.ts
+++ b/tests/integration/aurora-sg-sibling/app.ts
@@ -1,0 +1,63 @@
+// CDK app for the cdk-real-drift Aurora SecurityGroup-sibling false-positive integration
+// test. The canonical CDK shape `cluster.connections.allowFrom(peer, Port.tcp(
+// cluster.clusterEndpoint.port))` references the cluster's OWN endpoint port (a deploy-time
+// GetAtt token) inside an ingress rule on the cluster's SG — a self-dependency CDK breaks by
+// emitting the rule as a STANDALONE `AWS::EC2::SecurityGroupIngress` resource whose
+// FromPort/ToPort are `Fn::GetAtt <Cluster>.Endpoint.Port` (the "{IndirectPort}" shape).
+//
+// The SG reflects that sibling rule into its live `SecurityGroupIngress` array with a NUMBER
+// port (3306), while the sibling's declared port resolves against the DBCluster's live model,
+// where Endpoint.Port is a STRING ("3306"). The strict deepEqual sibling-subtract then failed
+// on the typed<->string mismatch, so the DECLARED ingress rule false-flagged as UNDECLARED
+// potential drift on every CDK Aurora stack. This fixture is the real-AWS regression guard.
+//
+// A single writer instance on a small isolated VPC (no NAT) keeps the stack self-contained.
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import {
+  InstanceClass,
+  InstanceSize,
+  InstanceType,
+  Peer,
+  Port,
+  SubnetType,
+  Vpc,
+} from "aws-cdk-lib/aws-ec2";
+import {
+  AuroraMysqlEngineVersion,
+  ClusterInstance,
+  DatabaseCluster,
+  DatabaseClusterEngine,
+} from "aws-cdk-lib/aws-rds";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAuroraSgSibling");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "iso", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const engine = DatabaseClusterEngine.auroraMysql({
+  version: AuroraMysqlEngineVersion.of("8.0.mysql_aurora.3.10.4", "8.0"),
+});
+
+const cluster = new DatabaseCluster(stack, "Cluster", {
+  engine,
+  writer: ClusterInstance.provisioned("writer", {
+    instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.MEDIUM),
+  }),
+  vpc,
+  vpcSubnets: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+// The load-bearing line: the port is the cluster's OWN endpoint port token, so CDK emits a
+// standalone SecurityGroupIngress whose FromPort/ToPort are GetAtt <Cluster>.Endpoint.Port.
+cluster.connections.allowFrom(
+  Peer.ipv4("192.168.0.0/16"),
+  Port.tcp(cluster.clusterEndpoint.port),
+  "from 192.168.0.0/16"
+);
+
+app.synth();

--- a/tests/integration/aurora-sg-sibling/cdk.json
+++ b/tests/integration/aurora-sg-sibling/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/aurora-sg-sibling/package.json
+++ b/tests/integration/aurora-sg-sibling/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-aurora-sg-sibling",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/aurora-sg-sibling/verify.sh
+++ b/tests/integration/aurora-sg-sibling/verify.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# cdk-real-drift Aurora SecurityGroup-sibling false-positive integration test (real AWS).
+#
+# Deploys an Aurora cluster whose SG carries a STANDALONE AWS::EC2::SecurityGroupIngress
+# sibling (emitted by `cluster.connections.allowFrom(peer, Port.tcp(cluster.clusterEndpoint
+# .port))` — see app.ts). The sibling's FromPort/ToPort are GetAtt <Cluster>.Endpoint.Port,
+# which resolves to a STRING while the SG reflects the rule with a NUMBER port.
+#
+# The strong assertion: with NO baseline, `check` must NOT report the SG's
+# SecurityGroupIngress — the sibling subtract recognizes the reflected rule as declared. A
+# regression in siblingRuleFieldMatches (dropping the typed<->string / UNRESOLVED tolerance)
+# turns it back into a false undeclared potential-drift, which this grep catches. Then
+# record + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/aurora-sg-sibling && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAuroraSgSibling
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture (Aurora — allow ~15 min) ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check (no baseline) must NOT report the sibling-reflected SecurityGroupIngress ==="
+$CLI check "$STACK" --region "$REGION" | tee /tmp/cdkrd-aurora-sg-pre.out
+grep -q "SecurityGroupIngress" /tmp/cdkrd-aurora-sg-pre.out \
+  && fail "SG SecurityGroupIngress surfaced as drift — the sibling-rule subtract regressed (typed<->string / UNRESOLVED port)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## What

A standalone `AWS::EC2::SecurityGroupIngress` sibling — emitted by the **canonical CDK Aurora shape** `cluster.connections.allowFrom(peer, Port.tcp(cluster.clusterEndpoint.port))` — declares `FromPort`/`ToPort` as `Fn::GetAtt <Cluster>.Endpoint.Port`. That GetAtt resolves against the DBCluster's live model, where `Endpoint.Port` is a **STRING** (`"3306"`), while the SG reflects the merged rule with a **NUMBER** port (`3306`).

The strict `deepEqual` subset-match in `subtractSiblingSgRules` failed on the port field, so the sibling rule was never subtracted and the **declared** ingress rule false-flagged as **undeclared potential drift on every CDK Aurora stack**.

## Fix

`siblingRuleFieldMatches(liveVal, sibVal)` replaces the raw `deepEqual` in the subset match:
- exact `deepEqual` first (preserves every existing case),
- then typed↔string scalar coercion (`isStringlyEqualScalar`: `3306` vs `"3306"`),
- and an `UNRESOLVED` sibling field acts as a **wildcard** — an unknowable declared value must not block the match; the CidrIp/protocol/description identity still gates the subtraction.

A genuinely different port still surfaces (the coercion is value-scoped, not field-blind).

## Verification

- **Unit**: 3 cases added (string-vs-number subtraction, `UNRESOLVED` wildcard, negative `"3307"` vs `3306`).
- **Live-test (real stack)**: `<db-users-dev-stack>-DB` — `SecurityGroup.SecurityGroupIngress` potential drift → **0 occurrences**.
- **New integration fixture** `tests/integration/aurora-sg-sibling/` reproduces the exact `allowFrom(…clusterEndpoint.port)` shape (no existing fixture did — that's why the FP went undetected). Deployed real Aurora in us-east-1: **INTEG PASS** (SecurityGroupIngress not reported → record → check CLEAN → clean teardown).

## Relation

Independent of #504 (RDS identifier case + Lambda ApplicationLogLevel). Both are false positives found auditing real Aurora stacks.
