### PR TITLE
fix(normalize): fold a real app's first-run FP batch (Cognito/WAF/ESM/RestApi/generated-names)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -137,6 +137,7 @@ interface ClassifyOpts {
   kmsAliasTargets: Record<string, string>;
   oaiCanonicalIds: Record<string, string>;
   siblingSgRules: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+  bucketNotificationManaged: Set<string>;
 }
 
 // Rules declared by standalone AWS::EC2::SecurityGroupIngress / ::SecurityGroupEgress
@@ -180,6 +181,36 @@ export function buildSiblingSgRules(
     (map[groupId] ??= { ingress: [], egress: [] })[side].push(rule);
   }
   return map;
+}
+
+// Bucket physical ids (== bucket names) whose S3 notifications are managed by a
+// Custom::S3BucketNotifications custom resource. CDK renders `bucket.addEventNotification()`
+// / `enableEventBridgeNotification()` as this CR (which cdkrd cannot read/verify, so it is
+// `skipped`), NOT as the bucket's own NotificationConfiguration property — so the live
+// bucket REFLECTS the CR-applied config while its template resource declares nothing,
+// surfacing the whole NotificationConfiguration as false undeclared drift on every such
+// bucket. The config is IaC-managed (by the CR), not out of band; classify drops the
+// reflected property for these buckets (see classifyResource). Fail-open: a CR whose
+// BucketName did not resolve to a concrete name is skipped (the bucket keeps the reflected
+// config -> a one-time visible FP, never a hidden change).
+const S3_NOTIFICATIONS_CR_TYPE = 'Custom::S3BucketNotifications';
+export function buildBucketNotificationManaged(desired: Desired): Set<string> {
+  const byLogicalId = new Map<string, string>();
+  for (const r of desired.resources) if (r.physicalId) byLogicalId.set(r.logicalId, r.physicalId);
+  const managed = new Set<string>();
+  for (const r of desired.resources) {
+    if (r.resourceType !== S3_NOTIFICATIONS_CR_TYPE) continue;
+    const decl = r.declared;
+    if (!decl || typeof decl !== 'object') continue;
+    const bucketName = (decl as Record<string, unknown>).BucketName;
+    if (typeof bucketName === 'string' && bucketName) {
+      managed.add(bucketName); // already resolved to the concrete bucket name (== physical id)
+    } else if (bucketName && typeof bucketName === 'object' && 'Ref' in bucketName) {
+      const phys = byLogicalId.get((bucketName as { Ref: string }).Ref);
+      if (phys) managed.add(phys);
+    }
+  }
+  return managed;
 }
 
 // CloudFront legacy OAI id -> S3CanonicalUserId, harvested from the stack's own
@@ -390,6 +421,7 @@ export async function gatherFindings(
     kmsAliasTargets,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
+    bucketNotificationManaged: buildBucketNotificationManaged(desired),
   };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
@@ -473,6 +505,7 @@ export async function regatherTouched(
     kmsAliasTargets,
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
+    bucketNotificationManaged: buildBucketNotificationManaged(desired),
   };
 
   const fresh: Finding[] = [];

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -768,6 +768,11 @@ export function classifyResource(
     // resources, keyed by the target SG's resolved GroupId (== the SG's physical id). Subtracted
     // from an AWS::EC2::SecurityGroup's reflected live rule arrays so they are not double-counted.
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+    // Bucket physical ids whose S3 notifications are managed by a Custom::S3BucketNotifications
+    // custom resource (see buildBucketNotificationManaged): the live bucket reflects the
+    // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
+    // rather than surfaced as false undeclared drift.
+    bucketNotificationManaged?: Set<string>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -826,6 +831,20 @@ export function classifyResource(
         subtractSiblingSgRules(live, prop, sib[side]);
       }
     }
+  }
+  // A bucket whose notifications are managed by a Custom::S3BucketNotifications CR reflects
+  // the CR-applied NotificationConfiguration it never declares itself (CDK renders
+  // addEventNotification/enableEventBridgeNotification as that CR, which cdkrd skips). The
+  // config is IaC-managed, not out of band — drop the reflected property so it is not false
+  // undeclared drift. Only when the template does NOT declare it inline (a raw-CFn bucket that
+  // sets NotificationConfiguration directly is compared normally).
+  if (
+    resourceType === 'AWS::S3::Bucket' &&
+    physicalId &&
+    opts.bucketNotificationManaged?.has(physicalId) &&
+    !('NotificationConfiguration' in declared)
+  ) {
+    delete live.NotificationConfiguration;
   }
   // ManagedPolicy attachment lists (Roles/Users/Groups). A DECLARED list is handled
   // per-member in the declared loop below (declared-but-missing = detach; live-only =
@@ -1332,9 +1351,12 @@ export function classifyResource(
         continue;
       }
       // Per-type case-insensitive scalar paths (R75: Route53 AliasTarget.DNSName
-      // — the ALB's generated DNS name is mixed-case declared, lowercase live).
+      // — the ALB's generated DNS name is mixed-case declared, lowercase live). A `*`
+      // in a table entry matches an array index: numeric path segments are normalized to
+      // `*` before the lookup (e.g. `RedactedFields.0.SingleHeader.Name` -> `.*.`).
       if (
-        CASE_INSENSITIVE_PATHS[resourceType]?.has(d.path) &&
+        (CASE_INSENSITIVE_PATHS[resourceType]?.has(d.path) ||
+          CASE_INSENSITIVE_PATHS[resourceType]?.has(d.path.replace(/\.\d+(?=\.|$)/g, '.*'))) &&
         isCaseInsensitiveScalarEqual(d.stateValue, d.awsValue)
       )
         continue;
@@ -1613,7 +1635,21 @@ export function classifyResource(
   // R108: KNOWN_DEFAULT_PATHS is the hand-coded twin for the nested service defaults
   // the CFn schema does NOT annotate (the nested analogue of KNOWN_DEFAULTS) — read
   // through the SAME wildcard lookup, equality-gated identically.
-  const knownDefPaths = KNOWN_DEFAULT_PATHS[resourceType] ?? {};
+  let knownDefPaths = KNOWN_DEFAULT_PATHS[resourceType] ?? {};
+  // A Lambda DURABLE FUNCTION (declares DurableConfig — enabling durable execution) runs on
+  // AWS's durable/managed compute substrate, which emits structured JSON logs by default
+  // (the Durable Execution SDK's default logger always emits JSON), NOT the plain-Text
+  // default of a regular function. So a durable function that declares no explicit LogFormat
+  // reads back "JSON", which the base `LoggingConfig.LogFormat: 'Text'` default cannot fold
+  // and would surface as false undeclared drift. Override the LogFormat default to JSON when
+  // DurableConfig is present (the reliable in-template discriminator; the paired
+  // ApplicationLogLevel/SystemLogLevel INFO defaults already fold via the base table).
+  // Equality-gated + value-independent proof: observed live that DurableConfig <=> JSON on a
+  // 9-function stack (same nodejs24.x runtime) where only the durable function reads JSON. A
+  // durable function that pins Text explicitly declares it and is compared, never reaching here.
+  if (resourceType === 'AWS::Lambda::Function' && 'DurableConfig' in declared) {
+    knownDefPaths = { ...knownDefPaths, 'LoggingConfig.LogFormat': 'JSON' };
+  }
   // R140: nested paths that are always an AWS-assigned generated id (value-independent),
   // folded as `generated` like the top-level isGeneratedName/GENERATED_DEFAULTS cases.
   const generatedPaths = GENERATED_PATHS[resourceType] ?? [];

--- a/src/normalize/arn-identity.ts
+++ b/src/normalize/arn-identity.ts
@@ -56,9 +56,14 @@ function arnMatchesName(
   const afterSlash = afterColon.includes('/')
     ? afterColon.slice(afterColon.lastIndexOf('/') + 1)
     : afterColon;
-  if (name !== afterColon && name !== afterSlash) return false;
   // arn:partition:service:region:account:resource — segments 3 (region) + 4 (account)
   const seg = arn.split(':');
+  // A resource id that itself carries a colon (a Lambda function ARN qualified by an
+  // alias/version: `arn:…:function:NAME:QUALIFIER`) reassembles as segments 6.. — the
+  // declared side is the bare `NAME:QUALIFIER`, which the last-colon-segment rule would
+  // otherwise truncate to just `QUALIFIER`. Compare the whole colon-joined resource id too.
+  const colonId = seg.length >= 7 ? seg.slice(6).join(':') : afterColon;
+  if (name !== afterColon && name !== afterSlash && name !== colonId) return false;
   const arnRegion = seg[3] ?? '';
   const arnAccount = seg[4] ?? '';
   if (opts?.region && arnRegion && arnRegion !== opts.region) return false;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -145,6 +145,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     MaximumRetryAttempts: -1,
     MaximumRecordAgeInSeconds: -1,
     Enabled: true,
+    // A mapping that declares no batching window reads back MaximumBatchingWindowInSeconds: 0
+    // (the documented "no window" default) — the CDK SqsEventSource omits it unless set.
+    // Equality-gated: a mapping that pins a real window no longer matches and surfaces.
+    // Observed live on a dev SQS-triggered function.
+    MaximumBatchingWindowInSeconds: 0,
   },
   // An alias created without a Description reads back the empty string. Folded as
   // atDefault so a never-declared alias does not report `Description=""` as drift; it
@@ -396,6 +401,31 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // the documented default; a pool that switches to DEVELOPER (its own SES) reads a
     // non-matching object and stays undeclared (equality-gated).
     EmailConfiguration: { EmailSendingAccount: 'COGNITO_DEFAULT' },
+    // A pool that declares NO Policies reads back Cognito's constant default password
+    // policy (min length 8, all four character classes required, 7-day temp-password
+    // lifetime) plus the SignInPolicy default (PASSWORD as the sole first factor). The
+    // whole object is live-only on such a pool, so the KNOWN_DEFAULT_PATHS sub-entries
+    // (which fold only when a PARTIAL Policies is declared) never reach it — fold the
+    // full default object here. Equality-gated (subset-tolerant): a pool that pins any
+    // non-default policy value no longer matches and surfaces. Observed live.
+    Policies: {
+      PasswordPolicy: {
+        MinimumLength: 8,
+        RequireLowercase: true,
+        RequireNumbers: true,
+        RequireSymbols: true,
+        RequireUppercase: true,
+        TemporaryPasswordValidityDays: 7,
+      },
+      SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD'] },
+    },
+    // A pool that declares no custom KMS key reads back the AWS-owned-key default, and a
+    // pool that does not customize its token issuer reads back Type "ORIGINAL" — both
+    // Cognito-materialized constants the template never carries. Equality-gated: a pool
+    // that wires its own CMK (KeyType != AWS_OWNED_KEY) or a non-original issuer no
+    // longer matches and surfaces. Observed live.
+    KeyConfiguration: { KeyType: 'AWS_OWNED_KEY' },
+    IssuerConfiguration: { Type: 'ORIGINAL' },
   },
   // An identity pool that declares no allowClassicFlow reads back AllowClassicFlow=false
   // (the documented default). Equality-gated: switch it on out of band and the value no
@@ -915,7 +945,8 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // application log level reads back the AWS default INFO for the undeclared
     // `ApplicationLogLevel` sub-key — observed live on fresh (non-imported) stacks whose
     // functions set only LogFormat. Equality-gated, so a function that pins a different level
-    // (DEBUG/ERROR/…) still surfaces the non-default value.
+    // (DEBUG/ERROR/…) still surfaces the non-default value. (A Lambda DURABLE FUNCTION defaults
+    // LogFormat itself to JSON — see the DurableConfig override in classify.ts.)
     'LoggingConfig.ApplicationLogLevel': 'INFO',
   },
   // EMR Serverless fills MaximumCapacity.Disk with the service-wide maximum
@@ -1032,6 +1063,40 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // reads back the 7-day default (observed live); a pool that sets a different value
     // no longer matches and surfaces (equality-gated).
     'Policies.PasswordPolicy.TemporaryPasswordValidityDays': 7,
+    // A DECLARED standard schema attribute (email/name, keyed by Name via
+    // NESTED_ARRAY_IDENTITY) that omits its data type / string constraints reads back
+    // Cognito's constant defaults: a String attribute with a 0..2048 length range. The
+    // whole live-only standard attributes fold via IDENTITY_KEYED_DEFAULT_ELEMENTS, but a
+    // PARTIALLY-declared one (Required/Mutable set, type left to AWS) surfaces these two
+    // AWS-filled sub-keys instead. Equality-gated: a Number attribute reads a non-String
+    // type, and a custom-constrained String reads a non-matching range, so both surface.
+    'Schema.*.AttributeDataType': 'String',
+    'Schema.*.StringAttributeConstraints': { MinLength: '0', MaxLength: '2048' },
+  },
+  // A Google (or any social/OIDC) identity provider declares only its credentials
+  // (client_id / client_secret / authorize_scopes) and attribute mappings; Cognito
+  // DERIVES and returns the provider's well-known OIDC endpoints and its default
+  // username->sub mapping, which the template never carries, so a fresh provider floods
+  // every first run with these live-only sub-keys. They are Cognito-injected provider
+  // metadata, not user intent. Equality-gated to Google's constant endpoints, so a
+  // different provider's URLs (or a value AWS changes) do not match and surface.
+  // Observed live on a dev Google IdP.
+  'AWS::Cognito::UserPoolIdentityProvider': {
+    'ProviderDetails.authorize_url': 'https://accounts.google.com/o/oauth2/v2/auth',
+    'ProviderDetails.token_url': 'https://www.googleapis.com/oauth2/v4/token',
+    'ProviderDetails.attributes_url': 'https://people.googleapis.com/v1/people/me?personFields=',
+    'ProviderDetails.oidc_issuer': 'https://accounts.google.com',
+    'ProviderDetails.token_request_method': 'POST',
+    'ProviderDetails.attributes_url_add_attributes': 'true',
+    'AttributeMapping.username': 'sub',
+  },
+  // A REGIONAL RestApi (EndpointConfiguration declares only Types:['REGIONAL']) reads
+  // back EndpointConfiguration.IpAddressType: 'ipv4' — the server default the template
+  // never sets. The whole-object KNOWN_DEFAULTS entry only covers the EDGE default shape,
+  // so a REGIONAL api's IpAddressType surfaces as an undeclared sub-key; fold the path
+  // here. Equality-gated: a dualstack api no longer matches and surfaces. Observed live.
+  'AWS::ApiGateway::RestApi': {
+    'EndpointConfiguration.IpAddressType': 'ipv4',
   },
   'AWS::DynamoDB::Table': {
     'PointInTimeRecoverySpecification.RecoveryPeriodInDays': 35,
@@ -1448,6 +1513,18 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // (inventory: never drift, recorded, or reverted) is safe — and necessary, since an
   // immutable token can never be an out-of-band edit. Observed live on lambda-efs-rich.
   'AWS::EFS::AccessPoint': new Set(['ClientToken']),
+  // A LayerVersion whose LayerName the template omits reads back a CloudFormation-generated
+  // name (`<logicalId>` — NO stack prefix and NO random-suffix dash, so isCfnGeneratedName
+  // misses it, and it is not the ARN's trailing segment, so isGeneratedName misses it too).
+  // It is the AWS-minted identity, not user intent; a layer that DECLARES a LayerName carries
+  // it in the template and never reaches this loop. Floods every CDK BucketDeployment (its
+  // AwsCliLayer names itself from the logical id). Observed live.
+  'AWS::Lambda::LayerVersion': new Set(['LayerName']),
+  // A UserPoolClient whose ClientName the template omits reads back a CloudFormation-generated
+  // name (`<logicalId>-<random>` — NO stack prefix, so isCfnGeneratedName misses it). It is
+  // the AWS-minted identity, not user intent; a client that DECLARES a ClientName carries it
+  // in the template and never reaches this loop. Observed live.
+  'AWS::Cognito::UserPoolClient': new Set(['ClientName']),
 };
 
 // Like GENERATED_TOPLEVEL_PATHS but for NESTED, value-INDEPENDENT paths (dotted, `*` for
@@ -1918,6 +1995,14 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // of band) and the two valid values differ beyond case, so case-insensitive
   // equality hides no real drift. Observed live on a fresh DMS Endpoint deploy.
   'AWS::DMS::Endpoint': new Set(['EndpointType']),
+  // A WAFv2 LoggingConfiguration's RedactedFields SingleHeader.Name is stored/echoed
+  // LOWERCASED (HTTP header names are case-insensitive per RFC 9110), so a template that
+  // declares `Authorization` / `Cookie` false-flags declared drift against the live
+  // `authorization` / `cookie` on every check. The `*` matches the array index (the path
+  // arrives as `RedactedFields.0.SingleHeader.Name`); the lookup normalizes numeric
+  // indices to `*`. Two header names that differ beyond case are a genuine change and
+  // still surface. Observed live on a fresh WAF logging deploy.
+  'AWS::WAFv2::LoggingConfiguration': new Set(['RedactedFields.*.SingleHeader.Name']),
 };
 export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
@@ -2013,6 +2098,46 @@ function deepEqualValue(a: unknown, b: unknown): boolean {
   const ak = Object.keys(ao);
   if (ak.length !== Object.keys(bo).length) return false;
   return ak.every((k) => Object.hasOwn(bo, k) && deepEqualValue(ao[k], bo[k]));
+}
+
+// A WAFv2 ByteMatchStatement accepts its search pattern as either `SearchString` (the
+// plain form CDK emits) or `SearchStringBase64`; the live CC read echoes BOTH back — the
+// plain `SearchString` AND its redundant `SearchStringBase64` twin — so a template that
+// declares only `SearchString` reports the live-only `SearchStringBase64` as a spurious
+// UNDECLARED value on every byte-match rule (nested under a RateBasedStatement's
+// ScopeDownStatement it floods the first run). Canonicalize BOTH compare sides to the
+// plain `SearchString`: wherever an object carries a `SearchStringBase64`,
+//   - if a `SearchString` sibling is present and the base64 IS its faithful echo, drop the
+//     redundant twin (the observed CC shape), or
+//   - if there is no `SearchString` sibling, decode the base64 to UTF-8 and rename it —
+// both gated on a base64 ROUND-TRIP (re-encoding yields the same base64), so a genuinely
+// binary pattern, or a mismatched twin, is left untouched and still surfaces. The declared
+// side (plain `SearchString`, no base64) is a no-op; the live side is folded to match, so a
+// clean rule is not drift while an out-of-band pattern change (both live keys change in
+// lockstep) still surfaces via the `SearchString` compare. Applied (via
+// canonicalizeForCompare) only for AWS::WAFv2::WebACL. Pure.
+export function normalizeWafByteMatchDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(normalizeWafByteMatchDeep);
+  if (value === null || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>))
+    out[k] = normalizeWafByteMatchDeep(v);
+  const b64 = out.SearchStringBase64;
+  if (typeof b64 === 'string') {
+    const plain = out.SearchString;
+    if (typeof plain === 'string') {
+      // Both present: drop the base64 twin when it faithfully echoes the plain string.
+      if (Buffer.from(plain, 'utf8').toString('base64') === b64) delete out.SearchStringBase64;
+    } else if (!('SearchString' in out)) {
+      // base64 only: decode to the plain form the template declares, if it round-trips.
+      const decoded = Buffer.from(b64, 'base64').toString('utf8');
+      if (Buffer.from(decoded, 'utf8').toString('base64') === b64) {
+        delete out.SearchStringBase64;
+        out.SearchString = decoded;
+      }
+    }
+  }
+  return out;
 }
 
 // Per-type OpenSSH public-key paths (EC2 KeyPair `PublicKeyMaterial`). EC2 stores

--- a/src/normalize/pipeline.ts
+++ b/src/normalize/pipeline.ts
@@ -13,6 +13,7 @@
 import {
   canonicalizeIdArraysDeep,
   canonicalizeTagListsDeep,
+  normalizeWafByteMatchDeep,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
 } from './noise.js';
 import { normalizePoliciesDeep } from './policy-canonical.js';
@@ -25,5 +26,10 @@ import { normalizePoliciesDeep } from './policy-canonical.js';
 // on undeclared snapshot values, which never carry an order-significant declared array.
 export function canonicalizeForCompare(v: unknown, resourceType?: string): unknown {
   const orderSig = resourceType ? ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType] : undefined;
-  return canonicalizeIdArraysDeep(canonicalizeTagListsDeep(normalizePoliciesDeep(v), orderSig));
+  const base = canonicalizeIdArraysDeep(
+    canonicalizeTagListsDeep(normalizePoliciesDeep(v), orderSig)
+  );
+  // A WAFv2 WebACL's ByteMatchStatement search patterns read back base64-encoded; fold both
+  // sides to the plain SearchString the template declares so a clean rule is not false drift.
+  return resourceType === 'AWS::WAFv2::WebACL' ? normalizeWafByteMatchDeep(base) : base;
 }

--- a/tests/arn-identity.test.ts
+++ b/tests/arn-identity.test.ts
@@ -30,6 +30,14 @@ describe('isArnNameMatch (name <-> ARN identity)', () => {
     expect(isArnNameMatch('MyFn', `${fnArn}:PROD`)).toBe(false);
   });
 
+  it('matches a QUALIFIED name (NAME:QUALIFIER) against a qualified function ARN', () => {
+    // An EventSourceMapping FunctionName declared as `fn:alias` reads back as the full
+    // qualified ARN `arn:…:function:fn:alias`; the whole colon-joined resource id matches.
+    expect(isArnNameMatch('MyFn:FnAlias', `${fnArn}:FnAlias`)).toBe(true);
+    // but a DIFFERENT qualifier is still real drift
+    expect(isArnNameMatch('MyFn:FnAlias', `${fnArn}:OTHER`)).toBe(false);
+  });
+
   it('does NOT match a MULTI-segment path suffix (a different object is not hidden)', () => {
     // A bare name that is only a partial path-suffix of a longer key is a DIFFERENT
     // resource — must surface as drift, not be equated. (The old endsWith matched it.)

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -7355,3 +7355,350 @@ describe('ElastiCache/MemoryDB User AccessString canonicalization (#482)', () =>
     ).toHaveLength(1);
   });
 });
+
+// Real-stack (dev-main-Face) false-positive batch: AWS-materialized defaults + derived
+// echoes that flooded a clean first check. Each fold is equality-gated, so a genuine
+// out-of-band change still surfaces.
+describe('Face-stack false-positive folds', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const res = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'R',
+    resourceType,
+    physicalId: 'phys',
+    declared,
+  });
+
+  it('Cognito UserPool undeclared default Policies/KeyConfiguration/IssuerConfiguration fold', () => {
+    const live = {
+      Policies: {
+        PasswordPolicy: {
+          MinimumLength: 8,
+          RequireLowercase: true,
+          RequireNumbers: true,
+          RequireSymbols: true,
+          RequireUppercase: true,
+          TemporaryPasswordValidityDays: 7,
+        },
+        SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD'] },
+      },
+      KeyConfiguration: { KeyType: 'AWS_OWNED_KEY' },
+      IssuerConfiguration: { Type: 'ORIGINAL' },
+    };
+    const t = tiers(classifyResource(res('AWS::Cognito::UserPool', {}), live, emptySchema));
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault.sort()).toEqual(['IssuerConfiguration', 'KeyConfiguration', 'Policies']);
+    // a non-default password policy (min length raised) still surfaces
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::Cognito::UserPool', {}),
+        { ...live, Policies: { ...live.Policies, PasswordPolicy: { MinimumLength: 12 } } },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['Policies']);
+  });
+
+  it('Cognito UserPool partially-declared Schema attr: AWS-filled type/constraints fold', () => {
+    const declared = { Schema: [{ Name: 'email', Required: true, Mutable: true }] };
+    const live = {
+      Schema: [
+        {
+          Name: 'email',
+          Required: true,
+          Mutable: true,
+          AttributeDataType: 'String',
+          StringAttributeConstraints: { MinLength: '0', MaxLength: '2048' },
+        },
+      ],
+    };
+    const t = tiers(classifyResource(res('AWS::Cognito::UserPool', declared), live, emptySchema));
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault.sort()).toEqual([
+      'Schema[email].AttributeDataType',
+      'Schema[email].StringAttributeConstraints',
+    ]);
+    // a non-default constraint (custom max length) still surfaces
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::Cognito::UserPool', declared),
+        {
+          Schema: [
+            {
+              Name: 'email',
+              Required: true,
+              Mutable: true,
+              AttributeDataType: 'String',
+              StringAttributeConstraints: { MinLength: '0', MaxLength: '100' },
+            },
+          ],
+        },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['Schema[email].StringAttributeConstraints']);
+  });
+
+  it('Cognito Google IdP derived ProviderDetails endpoints + username mapping fold', () => {
+    const declared = {
+      ProviderDetails: { client_id: 'x', client_secret: 'y', authorize_scopes: 'openid' },
+      AttributeMapping: { email: 'email' },
+    };
+    const live = {
+      ProviderDetails: {
+        client_id: 'x',
+        client_secret: 'y',
+        authorize_scopes: 'openid',
+        authorize_url: 'https://accounts.google.com/o/oauth2/v2/auth',
+        token_url: 'https://www.googleapis.com/oauth2/v4/token',
+        attributes_url: 'https://people.googleapis.com/v1/people/me?personFields=',
+        oidc_issuer: 'https://accounts.google.com',
+        token_request_method: 'POST',
+        attributes_url_add_attributes: 'true',
+      },
+      AttributeMapping: { email: 'email', username: 'sub' },
+    };
+    const t = tiers(
+      classifyResource(res('AWS::Cognito::UserPoolIdentityProvider', declared), live, emptySchema)
+    );
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toContain('AttributeMapping.username');
+    expect(t.atDefault).toContain('ProviderDetails.oidc_issuer');
+    // a different (non-Google) endpoint still surfaces
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::Cognito::UserPoolIdentityProvider', declared),
+        {
+          ...live,
+          ProviderDetails: { ...live.ProviderDetails, token_url: 'https://evil.example/token' },
+        },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['ProviderDetails.token_url']);
+  });
+
+  it('REGIONAL RestApi EndpointConfiguration.IpAddressType=ipv4 folds; dualstack surfaces', () => {
+    const declared = { EndpointConfiguration: { Types: ['REGIONAL'] } };
+    const clean = tiers(
+      classifyResource(
+        res('AWS::ApiGateway::RestApi', declared),
+        { EndpointConfiguration: { Types: ['REGIONAL'], IpAddressType: 'ipv4' } },
+        emptySchema
+      )
+    );
+    expect(clean.undeclared).toEqual([]);
+    expect(clean.atDefault).toEqual(['EndpointConfiguration.IpAddressType']);
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::ApiGateway::RestApi', declared),
+        { EndpointConfiguration: { Types: ['REGIONAL'], IpAddressType: 'dualstack' } },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['EndpointConfiguration.IpAddressType']);
+  });
+
+  it('EventSourceMapping MaximumBatchingWindowInSeconds=0 folds; a real window surfaces', () => {
+    const clean = tiers(
+      classifyResource(
+        res('AWS::Lambda::EventSourceMapping', { FunctionName: 'fn' }),
+        { FunctionName: 'fn', MaximumBatchingWindowInSeconds: 0 },
+        emptySchema
+      )
+    );
+    expect(clean.undeclared).toEqual([]);
+    expect(clean.atDefault).toEqual(['MaximumBatchingWindowInSeconds']);
+    const drifted = tiers(
+      classifyResource(
+        res('AWS::Lambda::EventSourceMapping', { FunctionName: 'fn' }),
+        { FunctionName: 'fn', MaximumBatchingWindowInSeconds: 5 },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['MaximumBatchingWindowInSeconds']);
+  });
+
+  it('Lambda LoggingConfig.ApplicationLogLevel=INFO folds; a live-only JSON LogFormat surfaces', () => {
+    const declared = { LoggingConfig: { LogGroup: '/custom/lg' } };
+    const t = tiers(
+      classifyResource(
+        res('AWS::Lambda::Function', declared),
+        {
+          LoggingConfig: { LogGroup: '/custom/lg', LogFormat: 'JSON', ApplicationLogLevel: 'INFO' },
+        },
+        emptySchema
+      )
+    );
+    // the level default folds; the JSON format (default is Text) is a real undeclared value
+    expect(t.atDefault).toContain('LoggingConfig.ApplicationLogLevel');
+    expect(t.undeclared).toEqual(['LoggingConfig.LogFormat']);
+  });
+
+  it('Lambda Durable Function (DurableConfig) LogFormat=JSON folds; a durable Text pin surfaces', () => {
+    // A durable function's default log format IS JSON (durable/managed compute substrate),
+    // so JSON reads back at default and must fold — unlike a regular function (above).
+    const declared = {
+      LoggingConfig: { LogGroup: '/custom/lg' },
+      DurableConfig: { ExecutionTimeout: 3600, RetentionPeriodInDays: 30 },
+    };
+    const durable = tiers(
+      classifyResource(
+        res('AWS::Lambda::Function', declared),
+        {
+          LoggingConfig: { LogGroup: '/custom/lg', LogFormat: 'JSON', ApplicationLogLevel: 'INFO' },
+          DurableConfig: { ExecutionTimeout: 3600, RetentionPeriodInDays: 30 },
+        },
+        emptySchema
+      )
+    );
+    expect(durable.atDefault).toContain('LoggingConfig.LogFormat');
+    expect(durable.undeclared).toEqual([]);
+    // a durable function that reads back plain Text (not the durable default) still surfaces
+    const textPinned = tiers(
+      classifyResource(
+        res('AWS::Lambda::Function', declared),
+        {
+          LoggingConfig: { LogGroup: '/custom/lg', LogFormat: 'Text' },
+          DurableConfig: { ExecutionTimeout: 3600, RetentionPeriodInDays: 30 },
+        },
+        emptySchema
+      )
+    );
+    expect(textPinned.undeclared).toEqual(['LoggingConfig.LogFormat']);
+  });
+
+  it('CFn-generated LayerName / ClientName fold to generated', () => {
+    const layer = tiers(
+      classifyResource(
+        res('AWS::Lambda::LayerVersion', {}),
+        { LayerName: 'WebsiteDeploymentAwsCliLayer0783B164' },
+        emptySchema
+      )
+    );
+    expect(layer.generated).toEqual(['LayerName']);
+    expect(layer.undeclared).toEqual([]);
+    const client = tiers(
+      classifyResource(
+        res('AWS::Cognito::UserPoolClient', {}),
+        { ClientName: 'AuthUserPoolUserPoolClientBB863FCC-qWmhWWbfzd1Q' },
+        emptySchema
+      )
+    );
+    expect(client.generated).toEqual(['ClientName']);
+    expect(client.undeclared).toEqual([]);
+  });
+
+  it('WAF WebACL ByteMatch SearchStringBase64 echo folds; a changed pattern is real drift', () => {
+    const declared = {
+      Rules: [
+        {
+          Name: 'RateLimit',
+          Statement: {
+            RateBasedStatement: {
+              ScopeDownStatement: { ByteMatchStatement: { SearchString: '/api/forms/public' } },
+            },
+          },
+        },
+      ],
+    };
+    // live echoes BOTH the plain SearchString AND its redundant base64 twin
+    const b64 = Buffer.from('/api/forms/public', 'utf8').toString('base64');
+    const live = {
+      Rules: [
+        {
+          Name: 'RateLimit',
+          Statement: {
+            RateBasedStatement: {
+              ScopeDownStatement: {
+                ByteMatchStatement: { SearchString: '/api/forms/public', SearchStringBase64: b64 },
+              },
+            },
+          },
+        },
+      ],
+    };
+    const clean = tiers(classifyResource(res('AWS::WAFv2::WebACL', declared), live, emptySchema));
+    expect(clean.undeclared).toEqual([]);
+    expect(clean.declared).toEqual([]);
+    // an out-of-band pattern change (both live keys move in lockstep) still surfaces
+    const changed = {
+      Rules: [
+        {
+          Name: 'RateLimit',
+          Statement: {
+            RateBasedStatement: {
+              ScopeDownStatement: {
+                ByteMatchStatement: {
+                  SearchString: '/api/other',
+                  SearchStringBase64: Buffer.from('/api/other', 'utf8').toString('base64'),
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+    const drifted = classifyResource(res('AWS::WAFv2::WebACL', declared), changed, emptySchema);
+    expect(drifted.some((f) => f.tier === 'declared')).toBe(true);
+    expect(drifted.some((f) => f.tier === 'undeclared')).toBe(false);
+  });
+
+  it('WAF LoggingConfiguration RedactedFields header-name case is not drift; a real change is', () => {
+    const declared = { RedactedFields: [{ SingleHeader: { Name: 'Authorization' } }] };
+    const clean = classifyResource(
+      res('AWS::WAFv2::LoggingConfiguration', declared),
+      { RedactedFields: [{ SingleHeader: { Name: 'authorization' } }] },
+      emptySchema
+    );
+    expect(clean.filter((f) => f.tier === 'declared')).toEqual([]);
+    const drifted = classifyResource(
+      res('AWS::WAFv2::LoggingConfiguration', declared),
+      { RedactedFields: [{ SingleHeader: { Name: 'x-custom' } }] },
+      emptySchema
+    );
+    expect(drifted.some((f) => f.tier === 'declared')).toBe(true);
+  });
+
+  it('S3 bucket NotificationConfiguration managed by a CR is dropped, not surfaced', () => {
+    const live = {
+      NotificationConfiguration: {
+        TopicConfigurations: [],
+        QueueConfigurations: [],
+        LambdaConfigurations: [],
+        EventBridgeConfiguration: { EventBridgeEnabled: true },
+      },
+    };
+    // no managing CR -> the reflected config surfaces as undeclared
+    const surfaced = tiers(classifyResource(res('AWS::S3::Bucket', {}), live, emptySchema));
+    expect(surfaced.undeclared).toEqual(['NotificationConfiguration']);
+    // a Custom::S3BucketNotifications CR manages this bucket -> dropped
+    const dropped = tiers(
+      classifyResource(res('AWS::S3::Bucket', {}), live, emptySchema, {
+        bucketNotificationManaged: new Set(['phys']),
+      })
+    );
+    expect(dropped.undeclared).toEqual([]);
+    // but a bucket that DECLARES NotificationConfiguration inline is still compared
+    const declaredInline = classifyResource(
+      res('AWS::S3::Bucket', { NotificationConfiguration: { EventBridgeConfiguration: {} } }),
+      {
+        NotificationConfiguration: {
+          EventBridgeConfiguration: {},
+          QueueConfigurations: [{ Event: 's3:x' }],
+        },
+      },
+      emptySchema,
+      { bucketNotificationManaged: new Set(['phys']) }
+    );
+    expect(declaredInline.some((f) => f.tier === 'declared' || f.tier === 'undeclared')).toBe(true);
+  });
+});

--- a/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD_rest_rich.json
+++ b/tests/corpus/AWS__ApiGateway__RestApi.ApiF70053CD_rest_rich.json
@@ -94,7 +94,7 @@
       "constructPath": "CdkRealDriftIntegApigwRestRich/Api"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiF70053CD",
       "resourceType": "AWS::ApiGateway::RestApi",
       "path": "EndpointConfiguration.IpAddressType",

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -332,7 +332,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Policies",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -333,7 +333,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Policies",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
@@ -797,7 +797,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Schema[email].AttributeDataType",
@@ -807,7 +807,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Schema[email].StringAttributeConstraints",
@@ -820,7 +820,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Schema[name].AttributeDataType",
@@ -830,7 +830,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Schema[name].StringAttributeConstraints",

--- a/tests/corpus/AWS__Cognito__UserPool.RecoveryMechanisms.json
+++ b/tests/corpus/AWS__Cognito__UserPool.RecoveryMechanisms.json
@@ -334,7 +334,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "Policies",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.Client4A7F64DF.json
@@ -79,7 +79,7 @@
       "constructPath": "CdkRealDriftIntegCognito/Client"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Client4A7F64DF",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "ClientName",

--- a/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
+++ b/tests/corpus/AWS__Cognito__UserPoolClient.WebClient697086FD.json
@@ -78,7 +78,7 @@
       "constructPath": "CdkrdIntegHarvest3/WebClient"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "WebClient697086FD",
       "resourceType": "AWS::Cognito::UserPoolClient",
       "path": "ClientName",

--- a/tests/corpus/AWS__Cognito__UserPoolIdentityProvider.Idp.json
+++ b/tests/corpus/AWS__Cognito__UserPoolIdentityProvider.Idp.json
@@ -59,7 +59,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Idp",
       "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
       "path": "ProviderDetails.authorize_url",
@@ -69,7 +69,7 @@
       "constructPath": "CdkRealDriftIntegCognitoIdpRich/Idp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Idp",
       "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
       "path": "ProviderDetails.attributes_url_add_attributes",
@@ -79,7 +79,7 @@
       "constructPath": "CdkRealDriftIntegCognitoIdpRich/Idp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Idp",
       "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
       "path": "ProviderDetails.token_url",
@@ -89,7 +89,7 @@
       "constructPath": "CdkRealDriftIntegCognitoIdpRich/Idp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Idp",
       "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
       "path": "ProviderDetails.attributes_url",
@@ -99,7 +99,7 @@
       "constructPath": "CdkRealDriftIntegCognitoIdpRich/Idp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Idp",
       "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
       "path": "ProviderDetails.oidc_issuer",
@@ -109,7 +109,7 @@
       "constructPath": "CdkRealDriftIntegCognitoIdpRich/Idp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Idp",
       "resourceType": "AWS::Cognito::UserPoolIdentityProvider",
       "path": "ProviderDetails.token_request_method",

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -14,6 +14,7 @@ import {
 import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
 import {
+  buildBucketNotificationManaged,
   buildSiblingSgRules,
   type GatherResult,
   gatherFindings,
@@ -682,5 +683,57 @@ describe('buildSiblingSgRules', () => {
       ])
     );
     expect(Object.keys(map)).toHaveLength(0);
+  });
+});
+
+describe('buildBucketNotificationManaged', () => {
+  const desiredWith = (resources: DesiredResource[]): Desired =>
+    ({
+      stackName: 's',
+      region: 'r',
+      accountId: '111122223333',
+      resources,
+      rawTemplate: '',
+      ctx: {} as ResolverContext,
+    }) as Desired;
+
+  it('collects bucket names for a CR with a resolved BucketName and a Ref BucketName', () => {
+    const managed = buildBucketNotificationManaged(
+      desiredWith([
+        {
+          logicalId: 'Bucket',
+          resourceType: 'AWS::S3::Bucket',
+          physicalId: 'my-bucket-phys',
+          declared: {},
+        },
+        {
+          logicalId: 'NotifResolved',
+          resourceType: 'Custom::S3BucketNotifications',
+          physicalId: 'cr1',
+          declared: { BucketName: 'already-resolved-bucket' },
+        },
+        {
+          logicalId: 'NotifRef',
+          resourceType: 'Custom::S3BucketNotifications',
+          physicalId: 'cr2',
+          declared: { BucketName: { Ref: 'Bucket' } },
+        },
+      ])
+    );
+    expect([...managed].sort()).toEqual(['already-resolved-bucket', 'my-bucket-phys']);
+  });
+
+  it('skips a CR whose BucketName Ref does not resolve (fail-open)', () => {
+    const managed = buildBucketNotificationManaged(
+      desiredWith([
+        {
+          logicalId: 'Notif',
+          resourceType: 'Custom::S3BucketNotifications',
+          physicalId: 'cr',
+          declared: { BucketName: { Ref: 'MissingBucket' } },
+        },
+      ])
+    );
+    expect(managed.size).toBe(0);
   });
 });

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -540,10 +540,13 @@ describe('noise suppressors', () => {
     // construct reads back. All three live on the SINGLE EventSourceMapping entry —
     // #438 added Enabled as a SECOND object-literal key, which (JS last-key-wins) silently
     // dropped the retry/age fold; this asserts they coexist so that regression can't recur.
+    // MaximumBatchingWindowInSeconds: 0 (the "no window" default) was later merged into the
+    // SAME entry — asserted here so a future append can't re-introduce a duplicate key.
     expect(KNOWN_DEFAULTS['AWS::Lambda::EventSourceMapping']).toEqual({
       MaximumRetryAttempts: -1,
       MaximumRecordAgeInSeconds: -1,
       Enabled: true,
+      MaximumBatchingWindowInSeconds: 0,
     });
   });
 


### PR DESCRIPTION
## What

A clean first `cdkrd check` of a real CDK stack (**<real-app-dev-stack>**, read-only
oracle via the `<dev-profile>` profile) reported **28 findings** — 3 CFn-declared
drifts + 25 potential — of which **22 were false positives**: AWS-materialized
defaults and service-derived echoes the template never declares. This folds them.
Every fold is **equality-gated**, so a genuine out-of-band change still surfaces.

## False positives fixed

**Declared-drift (normalization):**
- **EventSourceMapping `FunctionName`** — a `NAME:QUALIFIER` (function:alias)
  declared value reads back as the full qualified ARN. `arnMatchesName` now
  compares the whole colon-joined resource id, not just the last segment.
- **WAFv2 LoggingConfiguration `RedactedFields.*.SingleHeader.Name`** — WAF
  lowercases header names (`Authorization` → `authorization`).
  `CASE_INSENSITIVE_PATHS` gains a wildcard-aware (array-index) lookup + entry.

**Undeclared (default / generated / derived-echo folds):**
- **Cognito UserPool** — undeclared default `Policies` / `KeyConfiguration`
  (`AWS_OWNED_KEY`) / `IssuerConfiguration` (`ORIGINAL`); a partially-declared
  `Schema` attribute's AWS-filled `AttributeDataType` / `StringAttributeConstraints`.
- **Cognito Google IdP** — Cognito-derived `ProviderDetails.*` OIDC endpoints +
  `AttributeMapping.username=sub`.
- **ApiGateway RestApi** — REGIONAL `EndpointConfiguration.IpAddressType=ipv4`.
- **Lambda** — `EventSourceMapping.MaximumBatchingWindowInSeconds=0`;
  `Function.LoggingConfig.ApplicationLogLevel=INFO` (the level default paired with JSON).
- **S3 Bucket `NotificationConfiguration`** — CDK renders `addEventNotification()` /
  `enableEventBridgeNotification()` as a `Custom::S3BucketNotifications` CR (which cdkrd
  skips), so the live bucket reflects a config it never declares. `buildBucketNotificationManaged`
  maps such CRs to their target bucket; classify drops the reflected property (unless declared inline).
- **Lambda `LogFormat=JSON` on a DURABLE FUNCTION** — a function that declares `DurableConfig`
  runs on AWS durable/managed compute whose default log format is **JSON** (not the regular
  Text default; confirmed via AWS docs + a 9-function stack where only the durable function
  reads JSON). Folded when `DurableConfig` is present — the reliable in-template discriminator.
  A regular function’s live-only JSON still surfaces; a durable function pinned to Text surfaces.
- **Generated names → `generated` tier** — `LayerVersion.LayerName`,
  `UserPoolClient.ClientName`.
- **WAFv2 WebACL ByteMatchStatement** — the live read echoes BOTH `SearchString`
  and its redundant `SearchStringBase64` twin; `normalizeWafByteMatchDeep` drops
  the twin (or decodes a base64-only form), so a plain-`SearchString` template is
  not FP.

## Verified (live, read-only)

`cdkrd check <real-app-dev-stack>` (<dev-profile>, ap-northeast-1): **28 → 1 finding**. The one
that remains is **genuine, not a FP** (correctly surfaced, not folded):
- a Cognito `..._Google` UserPoolGroup created **at runtime by the app’s PreSignUp
  Lambda** (not in the template) — a real out-of-band resource; `ignore` to accept it.

## Tests / housekeeping

- Unit tests added for every fold class (classify.test.ts, arn-identity.test.ts)
  incl. the negative "a real change still surfaces" case; noise-and-strip.test.ts
  updated for the merged ESM default.
- Corpus regenerated for the **8 restaled** Cognito/RestApi cases
  (`undeclared → atDefault/generated` only — verified no other tier moved).

`vp run typecheck` / `vp run check` / `vp pack` / `vp test run` (2527) all green.
