### PR TITLE
fix(normalize): fold engine-derived RDS defaults (StorageType/Port/LicenseModel/groups/CA) to atDefault

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -46,6 +46,8 @@ import {
   TRAILING_DOT_PATHS,
   GENERATED_PATHS,
   CONTEXT_DEFAULTS,
+  DEFAULT_MANAGED_NAME_PATHS,
+  ENGINE_DEFAULTS,
   GENERATED_NESTED_PATHS,
   GENERATED_TOPLEVEL_PATHS,
   EPOCH_HOUR_PATHS,
@@ -1344,6 +1346,28 @@ export function classifyResource(
         findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
         continue;
       }
+    }
+    // A live value EQUAL to its ENGINE-DERIVED default — an RDS default whose VALUE depends on
+    // the resource's own live `Engine` (StorageType "aurora" for Aurora, Port 3306 for MySQL /
+    // 5432 for Postgres, …), which a constant KNOWN_DEFAULTS entry cannot express. Equality-
+    // gated with typed<->string coercion (a DBInstance echoes the port/storage as a string, a
+    // DBCluster as a number); an engine with no single default, or a value that differs, falls
+    // through to plain `undeclared` (recordable), never a wrong fold.
+    const engineDefault = ENGINE_DEFAULTS[resourceType]?.[k];
+    if (engineDefault !== undefined && typeof live.Engine === 'string') {
+      const def = engineDefault(live.Engine);
+      if (def !== undefined && (deepEqual(v, def) || isStringlyEqualScalar(v, def))) {
+        findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+        continue;
+      }
+    }
+    // A live value that is an AWS-MANAGED default resource NAME, recognized by its reserved
+    // `default.` / `default:` prefix (an RDS instance's default parameter/option group) rather
+    // than a constant — a CUSTOM group name never carries the prefix, so it still surfaces.
+    const namePattern = DEFAULT_MANAGED_NAME_PATHS[resourceType]?.[k];
+    if (namePattern !== undefined && typeof v === 'string' && namePattern.test(v)) {
+      findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+      continue;
     }
     // A live value EQUAL to the AWS/CDK-generated value for this resource (its minted
     // physical name, a default-named log group) is the `generated` tier: folded

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -524,8 +524,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     NetworkType: 'IPV4',
     StorageThroughput: 0,
     // Boolean feature flags off by default (observed unanimous across the corpus
-    // instances). NOT folded: per-resource/engine values (Port, EngineVersion,
-    // LicenseModel, MasterUsername, StorageType, *ParameterGroupName, CACertificateIdentifier).
+    // instances). Engine-DERIVED values (Port, LicenseModel, StorageType, AllocatedStorage)
+    // fold via ENGINE_DEFAULTS, and the default parameter/option groups via
+    // DEFAULT_MANAGED_NAME_PATHS; still NOT folded here: genuinely per-resource values
+    // (EngineVersion, MasterUsername).
     CopyTagsToSnapshot: false,
     DedicatedLogVolume: false,
     EnableIAMDatabaseAuthentication: false,
@@ -533,6 +535,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ManageMasterUserPassword: false,
     MultiAZ: false,
     StorageEncrypted: false,
+    // The current AWS default RDS server certificate authority — unanimous across every
+    // corpus DBInstance (aurora-mysql AND mysql) and both real Aurora dogfood stacks. A
+    // constant, not engine-derived. Equality-gated: AWS rotates the default CA over time, so
+    // a differing identifier (an older CA, or one the user pinned) still surfaces.
+    CACertificateIdentifier: 'rds-ca-rsa2048-g1',
   },
   'AWS::RDS::DBCluster': {
     AutoMinorVersionUpgrade: true,
@@ -1157,6 +1164,68 @@ export const GENERATED_PATHS: Record<string, string[]> = {
 // no SupportedRegions reads back `[<own region>]`.
 export const CONTEXT_DEFAULTS: Record<string, Record<string, 'region' | 'regionList'>> = {
   'AWS::EC2::VPCEndpointService': { SupportedRegions: 'regionList' },
+};
+
+// Top-level UNDECLARED keys whose service default VALUE is derived from the resource's own
+// live ENGINE (RDS) — the engine-conditional twin of CONTEXT_DEFAULTS (region-derived) and
+// KNOWN_DEFAULTS (constant). A single constant cannot express these because the default
+// differs per engine family (aurora-mysql `StorageType`="aurora" vs a provisioned MySQL's
+// "gp2", MySQL `Port`=3306 vs Postgres 5432), which is why the original KNOWN_DEFAULTS
+// comment left them unfolded — but that flooded every clean CDK Aurora first run with 4-7
+// potential-drift lines for values the user never set and (for the create-only ones) can
+// never change. Each entry maps the live `Engine` string to the default value, or `undefined`
+// when this engine has no single default (then the value stays `undeclared`, recordable).
+// Equality-gated with typed<->string coercion (a DBInstance echoes the port/storage as a
+// STRING "3306"/"1" while a DBCluster carries the NUMBER): a value that differs from the
+// engine default no longer matches and surfaces as real undeclared drift. Aurora is
+// create-only on StorageType, so its fold hides nothing revertable.
+export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => unknown>> = {
+  'AWS::RDS::DBInstance': {
+    StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : undefined),
+    AllocatedStorage: (e) => (e.startsWith('aurora') ? 1 : undefined),
+    Port: rdsDefaultPort,
+    LicenseModel: rdsDefaultLicense,
+  },
+  'AWS::RDS::DBCluster': {
+    StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : undefined),
+    AllocatedStorage: (e) => (e.startsWith('aurora') ? 1 : undefined),
+    Port: rdsDefaultPort,
+  },
+};
+
+// RDS engine-family default listener port. Only families with a single well-known default
+// are listed; an unknown engine returns undefined (no fold).
+function rdsDefaultPort(engine: string): number | undefined {
+  if (/mysql|maria/.test(engine)) return 3306;
+  if (/postgres/.test(engine)) return 5432;
+  if (/oracle/.test(engine)) return 1521;
+  if (/sqlserver/.test(engine)) return 1433;
+  return undefined;
+}
+
+// RDS engine-family default LicenseModel. MySQL/MariaDB/Aurora-MySQL read back
+// "general-public-license"; Postgres/Aurora-Postgres "postgresql-license". Oracle/SQLServer
+// carry BYOL/license-included with no single default, so they return undefined (no fold).
+function rdsDefaultLicense(engine: string): string | undefined {
+  if (/postgres/.test(engine)) return 'postgresql-license';
+  if (/mysql|maria/.test(engine)) return 'general-public-license';
+  return undefined;
+}
+
+// Top-level UNDECLARED keys whose value is an AWS-MANAGED default resource NAME, recognizable
+// by a `default`-family prefix rather than a constant. An RDS instance that pins no custom
+// parameter/option group reads back the engine's DEFAULT group — `DBParameterGroupName`
+// "default.aurora-mysql8.0" / "default.mysql8.0", `OptionGroupName` "default:aurora-mysql-8-0"
+// / "default:mysql-8-0". The `default.` / `default:` prefix is reserved by AWS for these
+// managed groups, so a CUSTOM group (whose name never starts with that prefix — observed in
+// the corpus, e.g. "cdkrealdriftintegaurorarich-instancepg…") still surfaces as real
+// undeclared inventory. Version-independent (matches any `default.<engine><ver>`), so it does
+// not go stale as KNOWN_DEFAULTS constants would.
+export const DEFAULT_MANAGED_NAME_PATHS: Record<string, Record<string, RegExp>> = {
+  'AWS::RDS::DBInstance': {
+    DBParameterGroupName: /^default\./,
+    OptionGroupName: /^default:/,
+  },
 };
 
 // Top-level UNDECLARED keys that are ALWAYS a service-minted, AWS-managed generated

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4065,6 +4065,156 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
   });
 });
 
+// Engine-derived RDS defaults (ENGINE_DEFAULTS + DEFAULT_MANAGED_NAME_PATHS + the
+// CACertificateIdentifier constant): values the user never set that AWS fills in from the
+// engine family, folded to atDefault so a clean CDK Aurora first run is not flooded with
+// potential-drift noise. Observed live on dev-main-AuroraDB / dev-main-DbUsers-DB.
+describe('RDS engine-derived defaults fold to atDefault', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const cls = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    tiers(
+      classifyResource({ logicalId: 'R', resourceType, physicalId: 'p', declared }, live, bare)
+    );
+
+  it('DBInstance StorageType "aurora" (Engine aurora-mysql) folds atDefault', () => {
+    const t = cls(
+      'AWS::RDS::DBInstance',
+      { Engine: 'aurora-mysql' },
+      { Engine: 'aurora-mysql', StorageType: 'aurora' }
+    );
+    expect(t.atDefault).toContain('StorageType');
+    expect(t.undeclared).not.toContain('StorageType');
+  });
+
+  it('DBInstance echoes Port/AllocatedStorage as STRINGS — typed<->string coercion folds them', () => {
+    const t = cls(
+      'AWS::RDS::DBInstance',
+      { Engine: 'aurora-mysql' },
+      { Engine: 'aurora-mysql', Port: '3306', AllocatedStorage: '1' }
+    );
+    expect(t.atDefault).toEqual(expect.arrayContaining(['Port', 'AllocatedStorage']));
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('DBCluster carries Port/AllocatedStorage as NUMBERS — both fold', () => {
+    const t = cls(
+      'AWS::RDS::DBCluster',
+      { Engine: 'aurora-mysql' },
+      { Engine: 'aurora-mysql', Port: 3306, AllocatedStorage: 1, StorageType: 'aurora' }
+    );
+    expect(t.atDefault).toEqual(
+      expect.arrayContaining(['Port', 'AllocatedStorage', 'StorageType'])
+    );
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('LicenseModel folds per engine family (mysql -> general-public-license, postgres -> postgresql-license)', () => {
+    expect(
+      cls(
+        'AWS::RDS::DBInstance',
+        { Engine: 'aurora-mysql' },
+        { Engine: 'aurora-mysql', LicenseModel: 'general-public-license' }
+      ).atDefault
+    ).toContain('LicenseModel');
+    expect(
+      cls(
+        'AWS::RDS::DBInstance',
+        { Engine: 'aurora-postgresql' },
+        { Engine: 'aurora-postgresql', LicenseModel: 'postgresql-license' }
+      ).atDefault
+    ).toContain('LicenseModel');
+  });
+
+  it('Postgres default Port 5432 folds; a MySQL 3306 on a Postgres engine still surfaces (equality-gated)', () => {
+    expect(
+      cls(
+        'AWS::RDS::DBInstance',
+        { Engine: 'aurora-postgresql' },
+        { Engine: 'aurora-postgresql', Port: '5432' }
+      ).atDefault
+    ).toContain('Port');
+    expect(
+      cls('AWS::RDS::DBInstance', { Engine: 'postgres' }, { Engine: 'postgres', Port: '3306' })
+        .undeclared
+    ).toContain('Port');
+  });
+
+  it('non-Aurora StorageType (gp2 on plain MySQL) does NOT fold — only the aurora constant does', () => {
+    const t = cls(
+      'AWS::RDS::DBInstance',
+      { Engine: 'mysql' },
+      { Engine: 'mysql', StorageType: 'gp2' }
+    );
+    expect(t.undeclared).toContain('StorageType');
+    expect(t.atDefault).not.toContain('StorageType');
+  });
+
+  it('default parameter/option groups fold by the reserved default. / default: prefix', () => {
+    const t = cls(
+      'AWS::RDS::DBInstance',
+      { Engine: 'aurora-mysql' },
+      {
+        Engine: 'aurora-mysql',
+        DBParameterGroupName: 'default.aurora-mysql8.0',
+        OptionGroupName: 'default:aurora-mysql-8-0',
+      }
+    );
+    expect(t.atDefault).toEqual(
+      expect.arrayContaining(['DBParameterGroupName', 'OptionGroupName'])
+    );
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('a CUSTOM parameter group (no default. prefix) still surfaces as undeclared', () => {
+    const t = cls(
+      'AWS::RDS::DBInstance',
+      { Engine: 'aurora-mysql' },
+      { Engine: 'aurora-mysql', DBParameterGroupName: 'mystack-instancepg-abc123' }
+    );
+    expect(t.undeclared).toContain('DBParameterGroupName');
+    expect(t.atDefault).not.toContain('DBParameterGroupName');
+  });
+
+  it('CACertificateIdentifier default rds-ca-rsa2048-g1 folds (constant); a pinned CA surfaces', () => {
+    expect(
+      cls(
+        'AWS::RDS::DBInstance',
+        { Engine: 'aurora-mysql' },
+        { Engine: 'aurora-mysql', CACertificateIdentifier: 'rds-ca-rsa2048-g1' }
+      ).atDefault
+    ).toContain('CACertificateIdentifier');
+    expect(
+      cls(
+        'AWS::RDS::DBInstance',
+        { Engine: 'aurora-mysql' },
+        { Engine: 'aurora-mysql', CACertificateIdentifier: 'rds-ca-2019' }
+      ).undeclared
+    ).toContain('CACertificateIdentifier');
+  });
+
+  it('the engine fold is gated to RDS types — the same key on another type is undeclared', () => {
+    const t = cls(
+      'AWS::Other::Thing',
+      { Engine: 'aurora-mysql' },
+      { Engine: 'aurora-mysql', StorageType: 'aurora' }
+    );
+    expect(t.undeclared).toContain('StorageType');
+  });
+});
+
 describe('partial-unresolved declared compare (WAVE20 F1 — a sibling drift is not hidden)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
@@ -215,7 +215,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "Port",
@@ -251,7 +251,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "StorageType",
@@ -287,7 +287,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "AllocatedStorage",

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
@@ -222,7 +222,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "Port",
@@ -258,7 +258,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "StorageType",
@@ -294,7 +294,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "AllocatedStorage",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
@@ -265,7 +265,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "Port",
@@ -310,7 +310,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageType",
@@ -328,7 +328,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
@@ -364,7 +364,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AllocatedStorage",
@@ -427,7 +427,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
@@ -454,7 +454,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
@@ -265,7 +265,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "Port",
@@ -310,7 +310,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageType",
@@ -328,7 +328,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
@@ -364,7 +364,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AllocatedStorage",
@@ -427,7 +427,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
@@ -454,7 +454,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
@@ -232,7 +232,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "Port",
@@ -259,7 +259,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DBParameterGroupName",
@@ -286,7 +286,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageType",
@@ -304,7 +304,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
@@ -340,7 +340,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AllocatedStorage",
@@ -403,7 +403,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
@@ -430,7 +430,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",

--- a/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
+++ b/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
@@ -293,7 +293,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "Port",
@@ -320,7 +320,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DBParameterGroupName",
@@ -347,7 +347,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
@@ -410,7 +410,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
@@ -437,7 +437,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",

--- a/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.logexports.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.logexports.json
@@ -292,7 +292,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "Port",
@@ -319,7 +319,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DBParameterGroupName",
@@ -337,7 +337,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
@@ -400,7 +400,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
@@ -427,7 +427,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",

--- a/tests/integration/aurora-rich/verify.sh
+++ b/tests/integration/aurora-rich/verify.sh
@@ -23,6 +23,18 @@ fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
 echo "=== [$STACK] deploy fixture ==="
 npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
 
+echo "=== [$STACK] check (NO baseline): engine-derived RDS defaults must NOT surface as potential drift ==="
+# ENGINE_DEFAULTS / DEFAULT_MANAGED_NAME_PATHS / the CACertificateIdentifier constant fold the
+# values AWS fills in from the engine family (StorageType "aurora", LicenseModel, the default
+# option group, the default CA) to atDefault, so a clean Aurora first run is not flooded with
+# them. A regression un-folds one and it reappears here. (DBParameterGroupName is NOT asserted
+# — this fixture pins a CUSTOM cluster/instance group, which correctly surfaces.)
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK-pre.out"
+for prop in StorageType LicenseModel CACertificateIdentifier OptionGroupName; do
+  grep -qE "\.$prop \(" "/tmp/cdkrd-$STACK-pre.out" \
+    && fail "engine-derived default $prop surfaced as potential drift (ENGINE_DEFAULTS fold regressed)"
+done
+
 echo "=== [$STACK] record (write baseline) ==="
 $CLI record "$STACK" --region "$REGION" --yes || fail "record"
 

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -623,6 +623,9 @@ describe('noise suppressors', () => {
       ManageMasterUserPassword: false,
       MultiAZ: false,
       StorageEncrypted: false,
+      // The current AWS default RDS server CA (constant; engine-derived RDS values fold via
+      // ENGINE_DEFAULTS / DEFAULT_MANAGED_NAME_PATHS instead).
+      CACertificateIdentifier: 'rds-ca-rsa2048-g1',
     });
     expect(KNOWN_DEFAULTS['AWS::RDS::DBCluster'].NetworkType).toBe('IPV4');
     expect(KNOWN_DEFAULTS['AWS::ElastiCache::ReplicationGroup']).toEqual({


### PR DESCRIPTION
## What

A clean CDK **Aurora** first run flooded `cdkrd check` with 7-9 **potential-drift** lines for values the user never set — `StorageType` "aurora", `Port` 3306, `AllocatedStorage` 1, `LicenseModel`, the default parameter/option groups, the default CA. These are AWS-filled engine defaults, not out-of-band changes, so surfacing them as potential drift is effectively noise (the user's report: *"showing drift on something I never touched is a bug"*).

The original `KNOWN_DEFAULTS` comment left them unfolded because a single **constant** cannot express an **engine-derived** value (aurora `StorageType` "aurora" vs a provisioned MySQL's "gp2"; MySQL `Port` 3306 vs Postgres 5432). This adds the engine-conditional machinery.

## How

Three mechanisms, all equality-gated (a value that differs still surfaces):

- **`ENGINE_DEFAULTS`** (new) — top-level RDS keys whose default derives from the resource's own live `Engine` (the engine twin of the region-derived `CONTEXT_DEFAULTS`). Covers `StorageType`, `Port`, `LicenseModel`, `AllocatedStorage`. Typed↔string coercion folds a DBInstance's string echo (`"3306"`/`"1"`) against a DBCluster's number.
- **`DEFAULT_MANAGED_NAME_PATHS`** (new) — the default parameter/option groups, recognized by the reserved `default.` / `default:` prefix. Version-independent; a **custom** group (no prefix) still surfaces as real undeclared inventory.
- **`CACertificateIdentifier: 'rds-ca-rsa2048-g1'`** — the current default CA, a constant unanimous across every corpus DBInstance and both real Aurora dogfood stacks → `KNOWN_DEFAULTS`.

Still **not** folded (genuinely per-resource, recordable): `EngineVersion`, `MasterUsername`, `KmsKeyId`, maintenance/backup windows, AZs.

## Verification

- **Unit**: 10 cases (per-engine port/license, aurora StorageType, string↔number coercion, default-group prefix, custom-group still surfaces, CA constant, type-gating, negatives).
- **Golden corpus**: the 7 RDS cases regenerated — **tier-only** diff (`undeclared` → `atDefault`), reviewed. All 2527 unit tests pass.
- **Live-test (real stack)**: `<db-users-dev-stack>-DB` potential drift **25 → 16** (9 engine defaults folded).
- **Integration (real AWS)**: `aurora-rich`'s `verify.sh` now asserts, pre-record, that the engine-derived defaults do **not** surface as potential drift → **INTEG PASS** in us-east-1.

## Relation

Third of three FP fixes from auditing real Aurora stacks (with #504 RDS identifier case + Lambda ApplicationLogLevel, and #510 SG sibling-rule port).
