### PR TITLE
fix(normalize): fold RDS parameter-group MySQL boolean tokens (ON≡1, OFF≡0)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -23,6 +23,8 @@ import {
   isCaseInsensitiveEqualScalarSet,
   isCaseInsensitiveKeyMapEqual,
   isCaseInsensitiveScalarEqual,
+  BOOLEAN_PARAM_MAP_PATHS,
+  isBooleanTokenEquivalent,
   isCfnTemplateNonAsciiMask,
   isEqualUnorderedScalarSet,
   isEquivalentRateExpression,
@@ -1299,6 +1301,16 @@ export function classifyResource(
       if (
         ACCESS_STRING_PATHS[resourceType]?.has(d.path) &&
         isAccessStringEqual(d.stateValue, d.awsValue)
+      )
+        continue;
+      // RDS parameter-group Parameters map: a MySQL boolean system variable declared as
+      // "ON"/"OFF" reads back as "1"/"0" (RDS canonicalizes on write). Fold only when both
+      // sides are boolean tokens of the SAME truthiness — a genuine flip (ON vs 0) and a
+      // non-boolean value still surface. Gated to the Parameters map's leaf paths.
+      if (
+        BOOLEAN_PARAM_MAP_PATHS[resourceType]?.has(d.path.split('.')[0] ?? '') &&
+        d.path.includes('.') &&
+        isBooleanTokenEquivalent(d.stateValue, d.awsValue)
       )
         continue;
       // CloudFormation's GetTemplate returns non-ASCII string literals with every

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1923,6 +1923,40 @@ export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
 }
 
+// Per-type property paths that hold an RDS engine PARAMETER map (`Parameters`) whose MySQL
+// boolean system variables accept ON/OFF, 1/0, and TRUE/FALSE interchangeably. RDS
+// canonicalizes a declared "ON"/"OFF" to "1"/"0" on read, so a template that writes
+// `slow_query_log: "ON"` false-flags declared drift against the live "1" on every check of a
+// MySQL / Aurora-MySQL cluster (observed live on dev-main-AuroraDB). Matched on the map's TOP
+// path segment; the per-key leaf compare applies isBooleanTokenEquivalent below.
+export const BOOLEAN_PARAM_MAP_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::RDS::DBClusterParameterGroup': new Set(['Parameters']),
+  'AWS::RDS::DBParameterGroup': new Set(['Parameters']),
+};
+const BOOL_TRUE_TOKENS = new Set(['on', '1', 'true']);
+const BOOL_FALSE_TOKENS = new Set(['off', '0', 'false']);
+// True when both values are boolean tokens (on/off, 1/0, true/false — any case) mapping to
+// the SAME truthiness. Scoped by the caller to boolean-capable param maps. A non-boolean
+// value (a numeric enum "2", a size "128M") is not a token, so it never matches — and a real
+// flip (declared "ON" true vs live "0" false) maps to different truthiness, so it still
+// surfaces as drift.
+export function isBooleanTokenEquivalent(a: unknown, b: unknown): boolean {
+  const tok = (v: unknown): 'true' | 'false' | undefined => {
+    const s =
+      typeof v === 'string'
+        ? v.toLowerCase()
+        : typeof v === 'number' || typeof v === 'boolean'
+          ? String(v)
+          : undefined;
+    if (s === undefined) return undefined;
+    if (BOOL_TRUE_TOKENS.has(s)) return 'true';
+    if (BOOL_FALSE_TOKENS.has(s)) return 'false';
+    return undefined;
+  };
+  const ta = tok(a);
+  return ta !== undefined && ta === tok(b);
+}
+
 // Per-type property paths that hold a FREE-FORM MAP whose KEYS the Cloud Control read
 // handler re-cases (#494). The map-KEY analogue of CASE_INSENSITIVE_PATHS (which folds a
 // VALUE case difference). On DataBrew Recipe `Steps[].Action.Parameters` the template AND

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4330,6 +4330,79 @@ describe('GENERATED_DEFAULTS — physical-id-derived auto values fold to `genera
 // R130: RDS DBInstance fresh-deploy false positives observed in harvest13 — a declared
 // EngineVersion track resolved to its full patch, and a MasterUsername declared as a
 // secretsmanager dynamic reference resolved to the live username. Neither is drift.
+// RDS parameter-group Parameters map: MySQL boolean system variables accept ON/OFF, 1/0,
+// TRUE/FALSE interchangeably; RDS canonicalizes a declared "ON"/"OFF" to "1"/"0" on read, so a
+// case that declares "ON" false-flags declared drift against the live "1". Observed live on
+// dev-main-AuroraDB.
+describe('RDS parameter-group boolean tokens (ON≡1, OFF≡0)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const declaredPaths = (declared: Record<string, unknown>, live: Record<string, unknown>) =>
+    classifyResource(
+      {
+        logicalId: 'R',
+        resourceType: 'AWS::RDS::DBClusterParameterGroup',
+        physicalId: 'p',
+        declared,
+      },
+      live,
+      bare
+    )
+      .filter((f) => f.tier === 'declared')
+      .map((f) => f.path);
+
+  it('declared "ON" vs live "1" (and "OFF" vs "0") is NOT drift', () => {
+    expect(
+      declaredPaths(
+        { Parameters: { slow_query_log: 'ON', general_log: 'OFF' } },
+        { Parameters: { slow_query_log: '1', general_log: '0' } }
+      )
+    ).toEqual([]);
+  });
+
+  it('a genuine flip (declared "ON" vs live "0") STILL surfaces as drift', () => {
+    expect(
+      declaredPaths(
+        { Parameters: { slow_query_log: 'ON' } },
+        { Parameters: { slow_query_log: '0' } }
+      )
+    ).toEqual(['Parameters.slow_query_log']);
+  });
+
+  it('a non-boolean param ("2" vs "1") still surfaces — the fold cannot mis-fire', () => {
+    expect(
+      declaredPaths(
+        { Parameters: { innodb_flush_log_at_trx_commit: '2' } },
+        { Parameters: { innodb_flush_log_at_trx_commit: '1' } }
+      )
+    ).toEqual(['Parameters.innodb_flush_log_at_trx_commit']);
+  });
+
+  it('the fold is gated to RDS param-group types — the same map shape elsewhere stays strict', () => {
+    const paths = classifyResource(
+      {
+        logicalId: 'R',
+        resourceType: 'AWS::Other::Thing',
+        physicalId: 'p',
+        declared: { Parameters: { flag: 'ON' } },
+      },
+      { Parameters: { flag: '1' } },
+      bare
+    )
+      .filter((f) => f.tier === 'declared')
+      .map((f) => f.path);
+    expect(paths).toEqual(['Parameters.flag']);
+  });
+});
+
 describe('classifyResource RDS version-track + dynamic-reference (R130)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/integration/aurora-rich/app.ts
+++ b/tests/integration/aurora-rich/app.ts
@@ -32,7 +32,10 @@ const engine = DatabaseClusterEngine.auroraMysql({
 
 const clusterPg = new ParameterGroup(stack, "ClusterPg", {
   engine,
-  parameters: { character_set_server: "utf8mb4" },
+  // `slow_query_log` is a MySQL boolean system variable declared "ON" — RDS canonicalizes it
+  // to "1" on read, so a case-sensitive compare false-flags declared drift. The verify.sh
+  // asserts it does NOT surface (the ON≡1 boolean-token fold).
+  parameters: { character_set_server: "utf8mb4", slow_query_log: "ON" },
 });
 const instancePg = new ParameterGroup(stack, "InstancePg", {
   engine,

--- a/tests/integration/aurora-rich/verify.sh
+++ b/tests/integration/aurora-rich/verify.sh
@@ -34,6 +34,10 @@ for prop in StorageType LicenseModel CACertificateIdentifier OptionGroupName; do
   grep -qE "\.$prop \(" "/tmp/cdkrd-$STACK-pre.out" \
     && fail "engine-derived default $prop surfaced as potential drift (ENGINE_DEFAULTS fold regressed)"
 done
+# The cluster parameter group declares `slow_query_log: "ON"`, which RDS canonicalizes to "1"
+# on read — the ON≡1 boolean-token fold must keep it from false-flagging declared drift.
+grep -qE "Parameters\.slow_query_log" "/tmp/cdkrd-$STACK-pre.out" \
+  && fail "MySQL boolean param slow_query_log (ON vs live 1) surfaced as drift (ON≡1 fold regressed)"
 
 echo "=== [$STACK] record (write baseline) ==="
 $CLI record "$STACK" --region "$REGION" --yes || fail "record"


### PR DESCRIPTION
## What

A MySQL / Aurora-MySQL `DBClusterParameterGroup` / `DBParameterGroup` declares boolean system variables as `"ON"`/`"OFF"` (e.g. `slow_query_log`, `innodb_file_per_table`, `innodb_print_all_deadlocks`, `log_queries_not_using_indexes`), but RDS canonicalizes them to `"1"`/`"0"` on read. A case-sensitive compare then false-flags **declared drift** on every check — **4 such params on the real `<aurora-cluster-dev-stack>` stack**.

## Fix

MySQL treats `ON`/`OFF`, `1`/`0`, and `TRUE`/`FALSE` as interchangeable for boolean sysvars. `isBooleanTokenEquivalent` folds a `Parameters`-map leaf **only when both sides are boolean tokens of the same truthiness**, gated to RDS parameter-group types via `BOOLEAN_PARAM_MAP_PATHS`.

Safety:
- A genuine flip — declared `"ON"` (true) vs live `"0"` (false) — maps to different truthiness and **still surfaces** as drift.
- A non-boolean value (a numeric enum `"2"`, a size `"128M"`) is not a token, so the fold **cannot mis-fire**.
- Gated per-type: the same map shape on another resource stays strict.

## Verification

- **Unit**: 4 cases (ON≡1 / OFF≡0 fold, genuine flip still drifts, non-boolean stays strict, type-gated).
- **Live-test (real stack)**: `<aurora-cluster-dev-stack>` declared drift **4 → 0** — the imported Aurora stack now has zero declared drift.
- **Integration (real AWS)**: `aurora-rich`'s cluster parameter group now declares `slow_query_log: "ON"`, and `verify.sh` asserts it does not surface as declared drift → **INTEG PASS** in us-east-1.

## Relation

Fourth and final FP fix from the real Aurora stack audit (#504 identifier case + Lambda ApplicationLogLevel, #510 SG sibling port, #512 ENGINE_DEFAULTS). Closes the last known declared-drift FP on `<aurora-cluster-dev-stack>`.
