### PR TITLE
fix(read): strip trailing-slash Prefix on ECR RepositoryCreationTemplate (false-deleted FP) (#502)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -41,6 +41,7 @@ import {
   isGeneratedName,
   isPhysicalIdSegment,
   isTrailingDotEqual,
+  isTrailingSlashEqual,
   isTrivialEmpty,
   isVersionPrefixMatch,
   isLatestSentinelMatch,
@@ -48,6 +49,7 @@ import {
   INTELLIGENT_TIERING_PATHS,
   LATEST_SENTINEL_PATHS,
   TRAILING_DOT_PATHS,
+  TRAILING_SLASH_PATHS,
   GENERATED_PATHS,
   CONTEXT_DEFAULTS,
   DEFAULT_MANAGED_NAME_PATHS,
@@ -1374,6 +1376,14 @@ export function classifyResource(
       if (
         TRAILING_DOT_PATHS[resourceType]?.has(d.path) &&
         isTrailingDotEqual(d.stateValue, d.awsValue)
+      )
+        continue;
+      // Per-type paths whose trailing `/` is optional (ECR RepositoryCreationTemplate
+      // Prefix: declared `cdkrd-hunt/`, service stores `cdkrd-hunt`) — equal once
+      // stripped; a genuine prefix change still differs.
+      if (
+        TRAILING_SLASH_PATHS[resourceType]?.has(d.path) &&
+        isTrailingSlashEqual(d.stateValue, d.awsValue)
       )
         continue;
       // Per-type version-track paths (R130: RDS DBInstance EngineVersion) — a declared

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2190,6 +2190,23 @@ export function isTrailingDotEqual(a: unknown, b: unknown): boolean {
   return strip(a) === strip(b);
 }
 
+// Per-type property paths whose trailing `/` is optional because the service
+// NORMALIZES it away on store while the declared/template form keeps it. Sibling of
+// TRAILING_DOT_PATHS (Route53 FQDN dots). Live-proven for ECR
+// RepositoryCreationTemplate `Prefix`: a template declares `Prefix: "cdkrd-hunt/"`
+// (S3-prefix habit — the trailing delimiter is conventional) but the service stores
+// `"cdkrd-hunt"`, so after the CC_IDENTIFIER_ADAPTERS read succeeds the residual
+// `Prefix` diff is pure trailing-delimiter noise, not drift. A genuine prefix change
+// still differs once both sides are stripped.
+export const TRAILING_SLASH_PATHS: Record<string, ReadonlySet<string>> = {
+  'AWS::ECR::RepositoryCreationTemplate': new Set(['Prefix']),
+};
+export function isTrailingSlashEqual(a: unknown, b: unknown): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const strip = (s: string): string => (s.endsWith('/') ? s.slice(0, -1) : s);
+  return strip(a) === strip(b);
+}
+
 // Per-type property paths where the declared `EngineVersion`/version track and the
 // live value differ only in PRECISION — one is a major/minor track, the other the
 // concrete patch version — so they name the same version and the difference is not

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -37,6 +37,17 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
     const tail = pid.startsWith('arn:') ? (pid.split('/').pop() ?? pid) : pid;
     return tail.replace(/:\d+$/, '');
   },
+  // ECR RepositoryCreationTemplate: the primaryIdentifier is the Prefix, but the
+  // service NORMALIZES a trailing `/` away (`cdkrd-hunt/` is stored as `cdkrd-hunt`)
+  // while CloudFormation keeps the user's declared form (with the slash) as the
+  // physical id. So CC GetResource on `cdkrd-hunt/` returns NotFound and the template
+  // is falsely reported `deleted` out of band (masking every declared prop on it, and
+  // a revert would plan a re-CREATE of a template that already exists). Strip the
+  // trailing slash to match the stored id. Verified live (misc0cov4 fixture,
+  // 2026-07-03): `cdkrd-hunt/` NotFounds, `cdkrd-hunt` reads. The literal `ROOT`
+  // prefix has no slash, so it passes through untouched. The residual declared
+  // `Prefix` diff (`cdkrd-hunt/` vs `cdkrd-hunt`) is folded by TRAILING_SLASH_PATHS.
+  'AWS::ECR::RepositoryCreationTemplate': (pid) => pid.replace(/\/$/, ''),
   // The rest are `[<parent ref>, <child id>]` composites: the CFn physical id is
   // only the child id; the parent id comes from the resolved declared Ref. CC's
   // composite-identifier separator is `|` (verified live — R74 Cognito, R76

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2165,6 +2165,38 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  // #502: ECR RepositoryCreationTemplate declares `Prefix: "cdkrd-hunt/"` (S3-prefix
+  // habit) but the service stores `"cdkrd-hunt"` — after the CC_IDENTIFIER_ADAPTERS
+  // read succeeds, the residual Prefix diff is pure trailing-slash noise.
+  describe('trailing-slash scalar path (ECR RepositoryCreationTemplate Prefix, #502)', () => {
+    const T = 'AWS::ECR::RepositoryCreationTemplate';
+
+    it('declared `cdkrd-hunt/` vs live `cdkrd-hunt` is NOT drift', () => {
+      expect(
+        classifyResource(res(T, { Prefix: 'cdkrd-hunt/' }), { Prefix: 'cdkrd-hunt' }, emptySchema)
+      ).toEqual([]);
+    });
+
+    it('a genuinely different prefix is still drift', () => {
+      expect(
+        tiers(classifyResource(res(T, { Prefix: 'cdkrd-hunt/' }), { Prefix: 'other' }, emptySchema))
+          .declared
+      ).toEqual(['Prefix']);
+    });
+
+    it('the rule is scoped per-type+path (other types stay strict)', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res('AWS::ECR::Repository', { RepositoryName: 'x/' }),
+            { RepositoryName: 'x' },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['RepositoryName']);
+    });
+  });
+
   // Found live by the batch-rich bug-hunt fixture: CDK's FargateComputeEnvironment
   // emits `Type: "managed"` (lowercase) but the Batch live read canonicalizes it to
   // `"MANAGED"` (uppercase), a case-only difference on a create-only enum.

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -126,6 +126,28 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('MyJobDef-abc');
   });
 
+  it('ECR RepositoryCreationTemplate: a trailing-slash Prefix physical id is stripped to the stored id (#502)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::ECR::RepositoryCreationTemplate', physicalId: 'cdkrd-hunt/' }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('cdkrd-hunt');
+  });
+
+  it('ECR RepositoryCreationTemplate: the literal ROOT prefix (no slash) passes through (#502)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::ECR::RepositoryCreationTemplate', physicalId: 'ROOT' }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('ROOT');
+  });
+
   it('Cognito UserPoolClient: builds the composite UserPoolId|ClientId identifier', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(


### PR DESCRIPTION
## Summary

Fixes #502 — a false `deleted out of band` on `AWS::ECR::RepositoryCreationTemplate` whose declared `Prefix` ends in `/`.

The service normalizes a trailing `/` away (`cdkrd-hunt/` → stored `cdkrd-hunt`), but CloudFormation keeps the declared form as the physical id. Cloud Control `GetResource` on `cdkrd-hunt/` returns `NotFound`, so cdkrd falsely reports the whole template deleted — masking every declared prop and making a `revert` plan a re-CREATE of a template that already exists. Live-proven on a fresh, untouched deploy (`CdkRealDriftHuntMisc0Cov4`, us-east-1, 2026-07-03).

## Changes

- `CC_IDENTIFIER_ADAPTERS['AWS::ECR::RepositoryCreationTemplate']` = strip the trailing slash to match the stored id (a normalization adapter, like the Batch JobDefinition ARN/`:revision` one). The literal `ROOT` prefix has no slash → passes through untouched.
- New `TRAILING_SLASH_PATHS` + `isTrailingSlashEqual` fold (sibling of `TRAILING_DOT_PATHS`) so the residual declared `Prefix` diff (`cdkrd-hunt/` vs `cdkrd-hunt`) is not reported; a genuine prefix change still differs.

## Tests

- `router.test.ts`: trailing-slash `Prefix` → stored id; `ROOT` passes through.
- `classify.test.ts`: `cdkrd-hunt/` vs `cdkrd-hunt` not drift; different prefix still drift; rule scoped per-type+path.
- Full suite: 2584 passing.

Closes #502