### PR TITLE
fix(diff): detect a declared scalar cleared out of band on returned-when-set paths (#507)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -60,6 +60,7 @@ import {
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
   READGAP_COLLECTION_PATHS,
+  SCALAR_RETURNED_WHEN_SET,
   READ_NORMALIZED_DECLARED_PATHS,
   ELB_ATTRIBUTE_DEFAULTS,
   ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE,
@@ -917,7 +918,21 @@ export function classifyResource(
       const isNonEmptyCollection =
         (Array.isArray(v) && v.length > 0) ||
         (v !== null && typeof v === 'object' && Object.keys(v as object).length > 0);
-      if (isNonEmptyCollection && !READGAP_COLLECTION_PATHS[resourceType]?.has(k)) {
+      // #507: a declared SCALAR on a curated SCALAR_RETURNED_WHEN_SET path — proven to
+      // be echoed by the live read when set — that is absent from live was cleared out
+      // of band (replace-omit update semantics). Detect it like a removed collection
+      // (whole-property `add` on revert). A non-empty string / boolean / number counts
+      // as "set"; a declared empty string stays readGap (declared `""` vs absent is not
+      // drift).
+      const isClearedAllowlistedScalar =
+        SCALAR_RETURNED_WHEN_SET[resourceType]?.has(k) === true &&
+        ((typeof v === 'string' && v.length > 0) ||
+          typeof v === 'number' ||
+          typeof v === 'boolean');
+      if (
+        (isNonEmptyCollection && !READGAP_COLLECTION_PATHS[resourceType]?.has(k)) ||
+        isClearedAllowlistedScalar
+      ) {
         findings.push({
           tier: 'declared',
           logicalId,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2596,6 +2596,27 @@ export const READGAP_COLLECTION_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::DynamoDB::Table': new Set(['SSESpecification']),
 };
 
+// SCALAR_RETURNED_WHEN_SET is the ALLOWLIST inverse of the collection default in the
+// `else if (!(k in live))` branch (#416): a declared SCALAR absent from the live read
+// normally stays an informational `readGap` ("AWS may legitimately not echo a scalar"),
+// which is the right FP-cautious default — but it means every service with replace-omit
+// update semantics has silently clearable declared scalars (a real console/CLI slip that
+// `check` then reports CLEAN). For the paths listed here — scalars OBSERVED to be ALWAYS
+// returned by the live read when set (provable with a fresh deploy: zero readGap on a
+// clean check) — an absent-from-live declared scalar is DECLARED drift (whole-property
+// emit; revert re-adds it via a top-level `add`, same shape as the collection case).
+// FP-safety mirrors #416 exactly: a wrongly-listed path surfaces as a VISIBLE, removable
+// false positive, never a silent FN. Curated per-path; do NOT broaden to whole types.
+//   AWS::NetworkFirewall::RuleGroup.Description — live-proven (#507): a fresh deploy
+//   returns Description (zero readGap), and `update-rule-group` WITHOUT --description
+//   CLEARS it (replace-omit semantics), which was a silent FN.
+//   AWS::NetworkFirewall::FirewallPolicy.Description — same service, same update-replace
+//   semantics.
+export const SCALAR_RETURNED_WHEN_SET: Record<string, ReadonlySet<string>> = {
+  'AWS::NetworkFirewall::RuleGroup': new Set(['Description']),
+  'AWS::NetworkFirewall::FirewallPolicy': new Set(['Description']),
+};
+
 // Declared SCALAR properties AWS does NOT echo faithfully — a write-time authoring hint
 // it normalizes to a canonical STORED form on read, so a declared value that differs from
 // the normalized read is a spurious `declared` drift, never a real divergence (and it is

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6133,6 +6133,67 @@ describe('absent declared collection → declared drift by default (readGap only
     expect(findings.some((f) => f.tier === 'declared' && f.path === 'Port')).toBe(false);
   });
 
+  it('allowlist (#507): a cleared declared scalar on a SCALAR_RETURNED_WHEN_SET path -> whole-property declared drift', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'SuricataGroup',
+        resourceType: 'AWS::NetworkFirewall::RuleGroup',
+        physicalId: 'rg-1',
+        declared: { RuleGroupName: 'rg-1', Description: 'cdkrd suricata blob probe' },
+      },
+      { RuleGroupName: 'rg-1' }, // live omits Description (cleared out of band)
+      sgSchema
+    );
+    const decl = findings.filter((f) => f.tier === 'declared');
+    expect(decl.map((f) => f.path)).toEqual(['Description']);
+    expect(decl[0].desired).toBe('cdkrd suricata blob probe');
+    expect(decl[0].actual).toBeUndefined();
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'Description')).toBe(false);
+  });
+
+  it('allowlist (#507): scoped per-type+path — the same scalar path on an unlisted type stays readGap', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'T',
+        resourceType: 'AWS::SomeOther::Type',
+        physicalId: 'p',
+        declared: { Description: 'x' },
+      },
+      {},
+      sgSchema
+    );
+    expect(findings.some((f) => f.tier === 'readGap' && f.path === 'Description')).toBe(true);
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'Description')).toBe(false);
+  });
+
+  it('allowlist (#507): a still-set Description compares normally (no false drift)', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'SuricataGroup',
+        resourceType: 'AWS::NetworkFirewall::RuleGroup',
+        physicalId: 'rg-1',
+        declared: { RuleGroupName: 'rg-1', Description: 'same' },
+      },
+      { RuleGroupName: 'rg-1', Description: 'same' },
+      sgSchema
+    );
+    expect(findings.filter((f) => f.tier === 'declared')).toHaveLength(0);
+  });
+
+  it('allowlist (#507): an empty declared Description stays readGap (declared "" vs absent is not drift)', () => {
+    const findings = classifyResource(
+      {
+        logicalId: 'SuricataGroup',
+        resourceType: 'AWS::NetworkFirewall::RuleGroup',
+        physicalId: 'rg-1',
+        declared: { RuleGroupName: 'rg-1', Description: '' },
+      },
+      { RuleGroupName: 'rg-1' },
+      sgSchema
+    );
+    expect(findings.some((f) => f.tier === 'declared' && f.path === 'Description')).toBe(false);
+  });
+
   it('exception (empty collection): an absent EMPTY declared collection is not drift', () => {
     const findings = classifyResource(
       {


### PR DESCRIPTION
## Summary

Fixes #507 — a declared **scalar** cleared out of band is a silent false negative.

`classify` files a declared-key-absent-from-live SCALAR as `readGap` (#416 boundary: collections detect, scalars stay readGap) — the right FP-cautious default, but it means every service with replace-omit update semantics has silently clearable declared scalars. Live-proven on `AWS::NetworkFirewall::RuleGroup.Description` (us-east-1, 2026-07-03): a fresh deploy returns `Description` with **zero readGap**, and `update-rule-group` **without** `--description` CLEARS it — cdkrd reported `CLEAN`.

## Changes

- New `SCALAR_RETURNED_WHEN_SET` allowlist (noise.ts) — the curated inverse of the #416 collection default. For listed scalar paths, absent-from-live ⇒ **declared** drift (whole-property emit; revert re-adds via a top-level `add`, same shape as the removed-collection case).
- Wired into the `else if (!(k in live))` branch in `classify.ts`. A non-empty string / number / boolean counts as "set"; a declared empty string stays `readGap` (declared `""` vs absent is not drift).
- Seed entries: `AWS::NetworkFirewall::RuleGroup` + `AWS::NetworkFirewall::FirewallPolicy` → `Description`.

FP-safety mirrors #416 exactly: a wrongly-listed path surfaces as a **visible, removable** false positive, never a silent FN.

## Tests

- `classify.test.ts`: cleared allowlisted scalar → whole-property declared drift (desired set, actual undefined); scoped per-type+path (unlisted type stays readGap); still-set compares clean; empty declared string stays readGap.
- Full suite: 2589 passing.

## Note

The revert half re-uses the existing removed-collection shape (declared finding, `actual: undefined`, top-level path → CC `add`), so no revert code change was needed; a live mutate→revert on this path is worth a spot-check when convenient.

Closes #507