### PR TITLE
chore(noise): fold Managed Flink app defaults + Lambda LayerVersion logical-id echo (#509)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -463,6 +463,14 @@ function isCfnGeneratedName(
   // — never fold it into a `generated` finding here, or a resource whose physical id IS its
   // CFn-generated name gains a phantom finding.
   if (typeof value !== 'string' || !constructPath || value === physicalId) return false;
+  // A bare LOGICAL-ID echo: for some types CloudFormation mints an auto-generated physical
+  // name equal to the resource's LOGICAL ID verbatim — no `<stack>-` prefix, no extra random
+  // suffix beyond the CDK hash already baked into the logical id (a BucketDeployment's
+  // AwsCliLayer LayerName reads back "CaDeployAwsCliLayer58606CDE", its own logical id; #509).
+  // The strict `<stack>-…-<suffix>` shapes below never match that form. A CDK logical id
+  // already carries an 8-hex-char construct hash, so a user-chosen value coinciding is
+  // effectively impossible — fold it. (aws-s3-deployment is a very common construct.)
+  if (logicalId && value === logicalId) return true;
   const stackName = constructPath.split('/')[0];
   if (!stackName || !CFN_RANDOM_SUFFIX.test(value)) return false;
   if (value.startsWith(`${stackName}-`)) return true;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -9,6 +9,12 @@
 // entries were all OBSERVED on real default-config stacks during dogfooding.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
+  // A Managed Service for Apache Flink application that declares no ApplicationMode
+  // reads back STREAMING — the constant service default for Flink runtimes (the only
+  // other value, INTERACTIVE, requires a Zeppelin/Studio runtime, a different declared
+  // config; ApplicationMode is createOnly so it cannot drift). Equality-gated. Observed
+  // live on a fresh READY Flink app (streaming-rich fixture, 2026-07-03; #509).
+  'AWS::KinesisAnalyticsV2::Application': { ApplicationMode: 'STREAMING' },
   // S3 versioning can never return to the never-enabled state — a revert "remove"
   // lands on Suspended, which IS the off state. Without this entry an undeclared
   // {Status:"Suspended"} re-reports forever and revert can never converge (R46).
@@ -905,6 +911,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A Managed Service for Apache Flink application that declares no encryption config
+  // reads back the AWS-owned-key default. Constant (a customer CMK is set explicitly).
+  // Equality-gated: an out-of-band switch to a customer key no longer matches. Observed
+  // live on a fresh READY Flink app (streaming-rich fixture, 2026-07-03; #509).
+  'AWS::KinesisAnalyticsV2::Application': {
+    'ApplicationConfiguration.ApplicationEncryptionConfiguration': { KeyType: 'AWS_OWNED_KEY' },
+  },
   'AWS::Lambda::Function': {
     // A function whose LoggingConfig declares no explicit format/level reads back the AWS
     // defaults: plain-Text logs at the INFO system level. Equality-gated, so a function that
@@ -1489,6 +1502,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   satisfied by whatever concrete version is current, so any value is not user intent. (A
   //   DECLARED "LATEST" is handled by LATEST_SENTINEL_PATHS in the declared loop.)
   'AWS::ECS::Service': new Set(['AvailabilityZoneRebalancing', 'PlatformVersion']),
+  //   AWS::KinesisAnalyticsV2::Application.ApplicationMaintenanceConfiguration — a Flink
+  //   app that declares no maintenance window reads back a service-ASSIGNED window
+  //   ({ApplicationMaintenanceWindowStartTime}). The window is not a constant we can pin
+  //   (AWS may assign it per app/region — constancy unverified live), so fold it
+  //   value-independent: undeclared, so whatever window AWS chose is its default, not user
+  //   intent. A DECLARED window goes through the declared loop (compared), unaffected.
+  'AWS::KinesisAnalyticsV2::Application': new Set(['ApplicationMaintenanceConfiguration']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -6526,6 +6526,37 @@ describe('CFn auto-generated name folding (generated tier)', () => {
     );
     expect(f?.tier).toBe('undeclared');
   });
+
+  // #509: a BucketDeployment's AwsCliLayer LayerName reads back its bare LOGICAL ID
+  // ("CaDeployAwsCliLayer58606CDE") — no `<stack>-` prefix, no extra random suffix — so the
+  // strict/truncated shapes above don't match; the logical-id-echo branch folds it.
+  it('an undeclared value equal to the resource logical id (bare CFn-generated name) folds as generated', () => {
+    const layer: DesiredResource = {
+      logicalId: 'CaDeployAwsCliLayer58606CDE',
+      resourceType: 'AWS::Lambda::LayerVersion',
+      physicalId: 'arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1',
+      constructPath: 'CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer',
+      declared: {},
+    };
+    const f = classifyResource(layer, { LayerName: 'CaDeployAwsCliLayer58606CDE' }, bare).find(
+      (x) => x.path === 'LayerName'
+    );
+    expect(f?.tier).toBe('generated');
+  });
+
+  it('an undeclared value merely SIMILAR to the logical id (not exact) stays undeclared', () => {
+    const layer: DesiredResource = {
+      logicalId: 'CaDeployAwsCliLayer58606CDE',
+      resourceType: 'AWS::Lambda::LayerVersion',
+      physicalId: 'arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1',
+      constructPath: 'CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer',
+      declared: {},
+    };
+    const f = classifyResource(layer, { LayerName: 'my-custom-layer' }, bare).find(
+      (x) => x.path === 'LayerName'
+    );
+    expect(f?.tier).toBe('undeclared');
+  });
 });
 
 describe('Cloud Control field mis-echo / alternative-representation folds (VPC noise)', () => {

--- a/tests/corpus/AWS__KinesisAnalyticsV2__Application.FlinkApp.json
+++ b/tests/corpus/AWS__KinesisAnalyticsV2__Application.FlinkApp.json
@@ -1,0 +1,177 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "FlinkApp",
+    "resourceType": "AWS::KinesisAnalyticsV2::Application",
+    "physicalId": "cdkrd-flink-app",
+    "constructPath": "CdkRealDriftIntegStreamingRich/FlinkApp",
+    "declared": {
+      "ApplicationConfiguration": {
+        "ApplicationCodeConfiguration": {
+          "CodeContent": {
+            "S3ContentLocation": {
+              "BucketARN": "arn:aws:s3:::cdk-hnb659fds-assets-111111111111-us-east-1",
+              "FileKey": "f927eca46b25fa23904c3e9d8c30fbc94e121d5cc81370f4f18e6d8016a0a1ad.jar"
+            }
+          },
+          "CodeContentType": "ZIPFILE"
+        },
+        "ApplicationSnapshotConfiguration": {
+          "SnapshotsEnabled": false
+        },
+        "EnvironmentProperties": {
+          "PropertyGroups": [
+            {
+              "PropertyGroupId": "cdkrdGroup",
+              "PropertyMap": {
+                "alpha": "1",
+                "beta": "two",
+                "gamma": "3.0"
+              }
+            }
+          ]
+        },
+        "FlinkApplicationConfiguration": {
+          "CheckpointConfiguration": {
+            "CheckpointInterval": 60000,
+            "CheckpointingEnabled": true,
+            "ConfigurationType": "CUSTOM",
+            "MinPauseBetweenCheckpoints": 5000
+          },
+          "MonitoringConfiguration": {
+            "ConfigurationType": "CUSTOM",
+            "LogLevel": "INFO",
+            "MetricsLevel": "APPLICATION"
+          },
+          "ParallelismConfiguration": {
+            "AutoScalingEnabled": false,
+            "ConfigurationType": "CUSTOM",
+            "Parallelism": 1,
+            "ParallelismPerKPU": 1
+          }
+        }
+      },
+      "ApplicationDescription": "cdkrd probe app (never started)",
+      "ApplicationName": "cdkrd-flink-app",
+      "RuntimeEnvironment": "FLINK-1_19",
+      "ServiceExecutionRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegStreamingRich-FlinkRoleDDDF0AE3-qeQDm28BcTw3"
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "cdkrd-flink-app",
+    "RuntimeEnvironment": "FLINK-1_19",
+    "ApplicationMode": "STREAMING",
+    "ApplicationMaintenanceConfiguration": {
+      "ApplicationMaintenanceWindowStartTime": "03:00"
+    },
+    "ApplicationConfiguration": {
+      "ApplicationCodeConfiguration": {
+        "CodeContentType": "ZIPFILE",
+        "CodeContent": {
+          "S3ContentLocation": {
+            "BucketARN": "arn:aws:s3:::cdk-hnb659fds-assets-111111111111-us-east-1",
+            "FileKey": "f927eca46b25fa23904c3e9d8c30fbc94e121d5cc81370f4f18e6d8016a0a1ad.jar"
+          }
+        }
+      },
+      "ApplicationEncryptionConfiguration": {
+        "KeyType": "AWS_OWNED_KEY"
+      },
+      "FlinkApplicationConfiguration": {
+        "CheckpointConfiguration": {
+          "ConfigurationType": "CUSTOM",
+          "CheckpointInterval": 60000,
+          "MinPauseBetweenCheckpoints": 5000,
+          "CheckpointingEnabled": true
+        },
+        "ParallelismConfiguration": {
+          "ConfigurationType": "CUSTOM",
+          "ParallelismPerKPU": 1,
+          "AutoScalingEnabled": false,
+          "Parallelism": 1
+        },
+        "MonitoringConfiguration": {
+          "ConfigurationType": "CUSTOM",
+          "MetricsLevel": "APPLICATION",
+          "LogLevel": "INFO"
+        }
+      },
+      "ApplicationSnapshotConfiguration": {
+        "SnapshotsEnabled": false
+      },
+      "ApplicationSystemRollbackConfiguration": {
+        "RollbackEnabled": false
+      }
+    },
+    "ApplicationDescription": "cdkrd probe app (never started)",
+    "ServiceExecutionRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegStreamingRich-FlinkRoleDDDF0AE3-qeQDm28BcTw3"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["RunConfiguration"],
+    "createOnly": ["ApplicationMode", "ApplicationName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [
+      "ApplicationConfiguration.ApplicationCodeConfiguration.CodeContent.ZipFileContent",
+      "ApplicationConfiguration.EnvironmentProperties",
+      "RunConfiguration"
+    ],
+    "createOnlyPaths": ["ApplicationMode", "ApplicationName"],
+    "defaults": {
+      "ApplicationDescription": ""
+    },
+    "defaultPaths": {
+      "ApplicationDescription": ""
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [
+      "ApplicationConfiguration.EnvironmentProperties.PropertyGroups",
+      "ApplicationConfiguration.SqlApplicationConfiguration.Inputs",
+      "ApplicationConfiguration.VpcConfigurations",
+      "ApplicationConfiguration.ZeppelinApplicationConfiguration.CustomArtifactsConfiguration"
+    ],
+    "freeFormMapPaths": [
+      "ApplicationConfiguration.EnvironmentProperties.PropertyGroups.*.PropertyMap"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "FlinkApp",
+      "resourceType": "AWS::KinesisAnalyticsV2::Application",
+      "path": "ApplicationMode",
+      "actual": "STREAMING",
+      "physicalId": "cdkrd-flink-app",
+      "constructPath": "CdkRealDriftIntegStreamingRich/FlinkApp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FlinkApp",
+      "resourceType": "AWS::KinesisAnalyticsV2::Application",
+      "path": "ApplicationMaintenanceConfiguration",
+      "actual": {
+        "ApplicationMaintenanceWindowStartTime": "03:00"
+      },
+      "physicalId": "cdkrd-flink-app",
+      "constructPath": "CdkRealDriftIntegStreamingRich/FlinkApp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "FlinkApp",
+      "resourceType": "AWS::KinesisAnalyticsV2::Application",
+      "path": "ApplicationConfiguration.ApplicationEncryptionConfiguration",
+      "actual": {
+        "KeyType": "AWS_OWNED_KEY"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-flink-app",
+      "constructPath": "CdkRealDriftIntegStreamingRich/FlinkApp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lambda__LayerVersion.CaDeployAwsCliLayer58606CDE.json
+++ b/tests/corpus/AWS__Lambda__LayerVersion.CaDeployAwsCliLayer58606CDE.json
@@ -1,0 +1,76 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CaDeployAwsCliLayer58606CDE",
+    "resourceType": "AWS::Lambda::LayerVersion",
+    "physicalId": "arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1",
+    "constructPath": "CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer",
+    "declared": {
+      "Content": {
+        "S3Bucket": "cdk-hnb659fds-assets-111111111111-us-east-1",
+        "S3Key": "a72522445441e9b66c2f16956c54d4786af8c61c156b80c48a6e7c32fcc49023.zip"
+      },
+      "Description": "/opt/awscli/aws"
+    }
+  },
+  "liveRaw": {
+    "CompatibleRuntimes": [],
+    "Description": "/opt/awscli/aws",
+    "LayerName": "CaDeployAwsCliLayer58606CDE",
+    "LayerVersionArn": "arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1",
+    "CompatibleArchitectures": []
+  },
+  "schema": {
+    "readOnly": ["LayerVersionArn"],
+    "writeOnly": ["Content"],
+    "createOnly": [
+      "CompatibleArchitectures",
+      "CompatibleRuntimes",
+      "Content",
+      "Description",
+      "LayerName",
+      "LicenseInfo"
+    ],
+    "readOnlyPaths": ["LayerVersionArn"],
+    "writeOnlyPaths": ["Content"],
+    "createOnlyPaths": [
+      "CompatibleArchitectures",
+      "CompatibleRuntimes",
+      "Content",
+      "Description",
+      "LayerName",
+      "LicenseInfo"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["CompatibleArchitectures", "CompatibleRuntimes"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "CaDeployAwsCliLayer58606CDE",
+      "resourceType": "AWS::Lambda::LayerVersion",
+      "path": "Content",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1",
+      "constructPath": "CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "CaDeployAwsCliLayer58606CDE",
+      "resourceType": "AWS::Lambda::LayerVersion",
+      "path": "LayerName",
+      "actual": "CaDeployAwsCliLayer58606CDE",
+      "physicalId": "arn:aws:lambda:us-east-1:111111111111:layer:CaDeployAwsCliLayer58606CDE:1",
+      "constructPath": "CdkRealDriftIntegS3LensMiscRich/CaDeploy/AwsCliLayer"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #509 — first-run `[Potential Drift]` noise from the 2026-07-03 round D hunt (Managed Flink app + a `aws-s3-deployment` layer echo). The round was otherwise quiet (all 6 ImageBuilder types, 2 NetworkFirewall types, S3 StorageLens/Group, TrustStore, SageMaker Pipeline/ModelPackageGroup produced zero first-run noise).

## Changes

**`AWS::KinesisAnalyticsV2::Application`** (fresh READY Flink app, none of these declared):
- `ApplicationMode` `"STREAMING"` → `KNOWN_DEFAULTS` (constant Flink-runtime default; `INTERACTIVE` needs a Zeppelin/Studio runtime; createOnly so it can't drift). Equality-gated.
- `ApplicationConfiguration.ApplicationEncryptionConfiguration` `{KeyType:AWS_OWNED_KEY}` → `KNOWN_DEFAULT_PATHS` (constant until a customer CMK is set). Equality-gated.
- `ApplicationMaintenanceConfiguration` → `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`. The maintenance-window start is **service-assigned** and its constancy was **not verified live** this session, so it is folded value-independent (undeclared ⇒ whatever window AWS chose is its default, not user intent). A **declared** window still compares normally in the declared loop.

**`AWS::Lambda::LayerVersion.LayerName`** — a `BucketDeployment`'s `AwsCliLayer` declares no `LayerName`; CloudFormation mints it as the **bare logical id** (`CaDeployAwsCliLayer58606CDE`) — no `<stack>-` prefix, no extra random suffix — so the strict/truncated `isCfnGeneratedName` shapes missed it and it surfaced on every stack using `aws-s3-deployment`. Extended `isCfnGeneratedName` with the bare logical-id-echo case (`value === logicalId → generated`); the CDK logical id already carries an 8-hex-char construct hash so a user value coinciding is effectively impossible.

## Tests

- Two real hunt corpus cases added as golden-replay fixtures (`AWS__KinesisAnalyticsV2__Application.FlinkApp.json`, `AWS__Lambda__LayerVersion.CaDeployAwsCliLayer58606CDE.json`) — the Flink findings now replay as `atDefault`, the LayerName as `generated`.
- Focused `classify.test.ts` cases for the logical-id-echo fold (exact match folds; a similar-but-not-exact value stays `undeclared`).
- Full suite green.

Closes #509
