### PR TITLE
fix(normalize): fold service-injected defaults inside JSON-string props (CE CostCategory Rules) (#503)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -30,6 +30,7 @@ import {
   isEquivalentRateExpression,
   isJsonStringStructEqual,
   JSON_STRING_PROPS,
+  JSON_STRING_DEFAULT_FILLS,
   isPemEqual,
   isAccessStringEqual,
   isSshPublicKeyEqual,
@@ -453,6 +454,37 @@ const isNestedObject = (x: unknown): x is Record<string, unknown> =>
 // untruncated form is the branch above) — a user-chosen name realistically never matches
 // all of that. Pure.
 const CFN_RANDOM_SUFFIX = /-[0-9A-Za-z]{12,}$/;
+
+// #503: return a copy of a parsed JSON-string LIVE value with service-injected default
+// members subtracted, so the JSON_STRING_PROPS structural compare does not false-flag them.
+// A key is dropped from a live object only when it is a listed default, the DECLARED side
+// omits it, AND the live value equals the default (equality-gated — a member the template
+// set to a non-default value is kept and still compares). Runs per element when the parsed
+// value is a top-level array, at the root when it is an object; leaves anything else as-is.
+function stripInjectedJsonStringDefaults(
+  declared: unknown,
+  live: unknown,
+  defaults: Record<string, unknown>
+): unknown {
+  const stripObject = (d: unknown, l: unknown): unknown => {
+    if (l === null || typeof l !== 'object' || Array.isArray(l)) return l;
+    const dObj =
+      d !== null && typeof d === 'object' && !Array.isArray(d)
+        ? (d as Record<string, unknown>)
+        : {};
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(l as Record<string, unknown>)) {
+      if (key in defaults && !(key in dObj) && deepEqual(val, defaults[key])) continue;
+      out[key] = val;
+    }
+    return out;
+  };
+  if (Array.isArray(live)) {
+    const dArr = Array.isArray(declared) ? declared : [];
+    return live.map((l, i) => stripObject(dArr[i], l));
+  }
+  return stripObject(declared, live);
+}
 function isCfnGeneratedName(
   value: unknown,
   constructPath: string | undefined,
@@ -936,6 +968,30 @@ export function classifyResource(
         });
       }
       continue;
+    }
+    // #503: a JSON-STRING property into which the service INJECTS a constant default member
+    // the template never sent (CE CostCategory `Rules` gets `"Type":"REGULAR"` per rule).
+    // Both sides arrive as canonicalized JSON strings, so the plain string compare below
+    // false-flags the injected member as permanent declared drift (and revert can never
+    // converge — the re-read re-injects it). This prop is NOT in JSON_STRING_PROPS (its
+    // revert works via a plain Cloud Control whole-prop replace), so fold it HERE: parse
+    // both sides, subtract the service-injected defaults from live where the declared side
+    // omits them and the value equals the default, and skip if the remainder matches. A
+    // genuine change (a member set to a non-default value) does NOT match and falls through
+    // to the normal compare below, reported with the full live state.
+    const jsonFills = JSON_STRING_DEFAULT_FILLS[resourceType]?.[k];
+    if (jsonFills !== undefined && typeof v === 'string' && typeof live[k] === 'string') {
+      try {
+        const dvParsed = JSON.parse(v) as unknown;
+        const lvStripped = stripInjectedJsonStringDefaults(
+          dvParsed,
+          JSON.parse(live[k] as string),
+          jsonFills
+        );
+        if (deepEqual(dvParsed, lvStripped) || isStringlyEqualDeep(dvParsed, lvStripped)) continue;
+      } catch {
+        /* not JSON on one side — fall through to the normal compare */
+      }
     }
     // A CloudFormation JSON-STRING property (AWS::Config::ConfigRule InputParameters):
     // the schema types it as a string holding JSON, but CDK declares it as an object and

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1877,6 +1877,23 @@ export const JSON_STRING_PROPS: Record<string, ReadonlySet<string>> = {
   'AWS::Config::ConfigRule': new Set(['InputParameters']),
 };
 
+// Per-type JSON-STRING props whose service INJECTS a constant default MEMBER into the
+// parsed document that the template never sent — the same "service fills a default" class
+// as KNOWN_DEFAULT_PATHS / matchesKnownDefault, except the default lives INSIDE a parsed
+// JSON-string value, so those model-path-keyed tables can't reach it. Keyed
+// type -> prop -> a partial object of default KEY:VALUE pairs. Before the JSON_STRING_PROPS
+// structural compare, these are subtracted from the LIVE parsed side wherever the DECLARED
+// side omits the key AND the live value EQUALS the default (equality-gated: a member
+// declared with a non-default value still surfaces). If the parsed value is a top-level
+// ARRAY the subtraction runs per element; if an OBJECT, at its root.
+//   AWS::CE::CostCategory.Rules — the service injects `"Type":"REGULAR"` (the default
+//   rule type) into every rule, so a freshly deployed cost category reported permanent
+//   declared drift and revert could never converge (#503). A split-charge rule that sets a
+//   non-default Type is not omitted on the declared side, so it still compares.
+export const JSON_STRING_DEFAULT_FILLS: Record<string, Record<string, Record<string, unknown>>> = {
+  'AWS::CE::CostCategory': { Rules: { Type: 'REGULAR' } },
+};
+
 // Per-type property paths AWS compares CASE-INSENSITIVELY (R75: Route53
 // RecordSet AliasTarget.DNSName — an ALB's generated DNS name is mixed-case in
 // the template's GetAtt and all-lowercase in the live record; DNS hostnames are

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -203,6 +203,67 @@ describe('classifyResource (the heart)', () => {
     expect(asString.declared).toEqual([]);
   });
 
+  // #503: CE CostCategory Rules is a JSON-STRING prop; the service injects `"Type":"REGULAR"`
+  // (the default rule type) into every rule, so a clean deploy reported permanent declared
+  // drift. The values arrive as canonicalized JSON strings (normalize runs before classify).
+  it('JSON-string default-fill (CostCategory Rules Type:REGULAR): clean folds, non-default surfaces', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const res: DesiredResource = {
+      logicalId: 'CostCat',
+      resourceType: 'AWS::CE::CostCategory',
+      physicalId: 'arn:aws:ce::111111111111:costcategory/abc',
+      declared: {
+        Rules:
+          '[{"Rule":{"Dimensions":{"Key":"SERVICE_CODE","Values":["AmazonS3"]}},"Value":"storage"}]',
+      },
+    };
+    // Clean: live is identical except the service-injected Type:"REGULAR" per rule.
+    const clean = tiers(
+      classifyResource(
+        res,
+        {
+          Rules:
+            '[{"Rule":{"Dimensions":{"Key":"SERVICE_CODE","Values":["AmazonS3"]}},"Type":"REGULAR","Value":"storage"}]',
+        },
+        emptySchema
+      )
+    );
+    expect(clean.declared).toEqual([]);
+    // A rule whose Type is a NON-default value is not stripped -> still surfaces as drift.
+    const drifted = tiers(
+      classifyResource(
+        res,
+        {
+          Rules:
+            '[{"Rule":{"Dimensions":{"Key":"SERVICE_CODE","Values":["AmazonS3"]}},"Type":"INHERITED_VALUE","Value":"storage"}]',
+        },
+        emptySchema
+      )
+    );
+    expect(drifted.declared).toEqual(['Rules']);
+    // A genuine dimension change still surfaces even though Type:REGULAR is present.
+    const valueChange = tiers(
+      classifyResource(
+        res,
+        {
+          Rules:
+            '[{"Rule":{"Dimensions":{"Key":"SERVICE_CODE","Values":["AmazonEC2"]}},"Type":"REGULAR","Value":"storage"}]',
+        },
+        emptySchema
+      )
+    );
+    expect(valueChange.declared).toEqual(['Rules']);
+  });
+
   // First-run noise folds for a clean deploy: a Cognito user pool
   // ALWAYS returns the immutable OIDC standard attributes in Schema (fold to atDefault via
   // IDENTITY_KEYED_DEFAULT_ELEMENTS) and a Lambda Version's CodeSha256 is a per-deploy

--- a/tests/corpus/AWS__CE__CostCategory.CostCat.json
+++ b/tests/corpus/AWS__CE__CostCategory.CostCat.json
@@ -1,0 +1,57 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "CostCat",
+    "resourceType": "AWS::CE::CostCategory",
+    "physicalId": "arn:aws:ce::111111111111:costcategory/a0a6da6c-4258-4a6b-a417-452df2a37910",
+    "constructPath": "CdkRealDriftHuntMisc0Cov4/CostCat",
+    "declared": {
+      "DefaultValue": "other",
+      "Name": "cdkrd-hunt-costcat",
+      "RuleVersion": "CostCategoryExpression.v1",
+      "Rules": "[{\"Value\":\"storage\",\"Rule\":{\"Dimensions\":{\"Key\":\"SERVICE_CODE\",\"Values\":[\"AmazonS3\"]}}},{\"Value\":\"compute\",\"Rule\":{\"Dimensions\":{\"Key\":\"SERVICE_CODE\",\"Values\":[\"AmazonEC2\",\"AWSLambda\"]}}}]"
+    }
+  },
+  "liveRaw": {
+    "DefaultValue": "other",
+    "EffectiveStart": "2026-07-01T00:00:00Z",
+    "RuleVersion": "CostCategoryExpression.v1",
+    "Arn": "arn:aws:ce::111111111111:costcategory/a0a6da6c-4258-4a6b-a417-452df2a37910",
+    "Rules": "[ {\n  \"Value\" : \"storage\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"SERVICE_CODE\",\n      \"Values\" : [ \"AmazonS3\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n}, {\n  \"Value\" : \"compute\",\n  \"Rule\" : {\n    \"Dimensions\" : {\n      \"Key\" : \"SERVICE_CODE\",\n      \"Values\" : [ \"AmazonEC2\", \"AWSLambda\" ]\n    }\n  },\n  \"Type\" : \"REGULAR\"\n} ]",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHuntMisc0Cov4/64e887a0-76a8-11f1-aca8-121efa337807",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHuntMisc0Cov4",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "CostCat",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-hunt-costcat"
+  },
+  "schema": {
+    "readOnly": ["Arn", "EffectiveStart"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "EffectiveStart"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}


### PR DESCRIPTION
## Summary

Fixes #503 — a permanent declared-drift FP on `AWS::CE::CostCategory.Rules`, and the unrevertable-loop it caused.

`Rules` is a JSON-STRING property; the service injects `"Type":"REGULAR"` (the default rule type) into every rule inside the document, so a freshly deployed, untouched cost category reported declared drift forever and `revert` could never converge (the convergence re-read re-injected `Type` — the same shape as #494). Live-proven (`CdkRealDriftHuntMisc0Cov4`, us-east-1, 2026-07-03).

## Why existing folds missed it

`KNOWN_DEFAULT_PATHS` / `matchesKnownDefault` are keyed on resource **model** paths — they cannot reach a default that lives INSIDE a parsed JSON-string value.

## Fix

- New `JSON_STRING_DEFAULT_FILLS` table (`type -> prop -> default KEY:VALUE members`) + `stripInjectedJsonStringDefaults` helper. Before comparing a JSON-string prop, the listed default members are subtracted from the LIVE parsed side wherever the DECLARED side omits them AND the value equals the default. Equality-gated: a rule that sets a non-default `Type` (split-charge) is kept and still surfaces.
- Applied in the **normal declared loop**, deliberately NOT by adding `Rules` to `JSON_STRING_PROPS`: CostCategory Rules reverts fine via a plain Cloud Control whole-prop replace (the issue confirms "revert succeeds"), and routing it through `JSON_STRING_PROPS` would downgrade that working revert to "not revertable". A genuine change falls through to the normal compare.

## Tests

- Real hunt corpus case added as a golden-replay fixture (now replays clean).
- `classify.test.ts`: clean (injected `Type:REGULAR`) folds; a non-default `Type` surfaces; a genuine dimension change still surfaces.
- Full suite green.

Closes #503
