### PR TITLE
fix(revert): reach empty-array husks inside array elements via pointer wildcards (ImageBuilder DistributionConfiguration) (#506)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -789,11 +789,18 @@ export const CC_UPDATE_REJECTED_EMPTY_PATHS: Record<string, readonly string[]> =
   // with "The value supplied for parameter 'distributions[0].amiDistributionConfiguration.
   // targetAccountIds' is not valid" (reproduced live, 2026-07-03). Dropping the echoed
   // empty array lets the handler treat it as absent (no cross-account distribution), which
-  // is what the empty echo meant. (The sibling FastLaunchConfigurations /
-  // LaunchTemplateConfigurations husks may hit the same wall — add them here if a live
-  // revert surfaces them; only TargetAccountIds is live-proven.)
+  // is what the empty echo meant. The CC read echoes the sibling FastLaunchConfigurations /
+  // LaunchTemplateConfigurations arrays as `[]` too (corpus-observed), and they carry the
+  // same "must be non-empty when present" shape — so they are included pre-emptively.
+  // Stripping is a safe no-op regardless: the fail-safe gate only drops a live value that is
+  // ALREADY an empty array (a populated array is real data and never touched), and an absent
+  // array means "no config", exactly what the echoed `[]` meant. TargetAccountIds is the
+  // live-proven rejection; the siblings guard against the same wall on a distribution that
+  // sets one of them.
   'AWS::ImageBuilder::DistributionConfiguration': [
     '/Distributions/*/AmiDistributionConfiguration/TargetAccountIds',
+    '/Distributions/*/FastLaunchConfigurations',
+    '/Distributions/*/LaunchTemplateConfigurations',
   ],
 };
 // Expand a JSON pointer that MAY contain `*` array-wildcard segments into a {pointer, value}

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -776,16 +776,45 @@ export function tagPreservingOps(
 // pointers are curated per type. An appended `remove` op drops the echoed empty array
 // from the handler's desired state; the service treats an absent headerMatches as "no
 // header matches", which is exactly what the empty echo meant.
+// A pointer segment may be `*` — an ARRAY WILDCARD matching every index — so a husk that
+// sits INSIDE an array element is reachable (#506: ImageBuilder DistributionConfiguration
+// echoes `TargetAccountIds: []` inside EACH Distributions[i].AmiDistributionConfiguration,
+// out of reach of a static object-only pointer). Each `*` fans the pointer out to one
+// concrete pointer per live index.
 export const CC_UPDATE_REJECTED_EMPTY_PATHS: Record<string, readonly string[]> = {
   'AWS::VpcLattice::Rule': ['/Match/HttpMatch/HeaderMatches'],
+  // ImageBuilder folds its own read-back state into UpdateDistributionConfiguration, and
+  // the handler rejects the echoed `targetAccountIds: []` inside every distribution's
+  // amiDistributionConfiguration — so ANY patch (even a Description-only revert) failed
+  // with "The value supplied for parameter 'distributions[0].amiDistributionConfiguration.
+  // targetAccountIds' is not valid" (reproduced live, 2026-07-03). Dropping the echoed
+  // empty array lets the handler treat it as absent (no cross-account distribution), which
+  // is what the empty echo meant. (The sibling FastLaunchConfigurations /
+  // LaunchTemplateConfigurations husks may hit the same wall — add them here if a live
+  // revert surfaces them; only TargetAccountIds is live-proven.)
+  'AWS::ImageBuilder::DistributionConfiguration': [
+    '/Distributions/*/AmiDistributionConfiguration/TargetAccountIds',
+  ],
 };
-function valueAtPointer(model: unknown, pointer: string): unknown {
-  let cur: unknown = model;
+// Expand a JSON pointer that MAY contain `*` array-wildcard segments into a {pointer, value}
+// pair for every matching live node. A `*` matches each index of an array node; a normal
+// segment indexes an object. A wildcard-free pointer yields one pair (or none if a segment
+// is absent). Pure.
+function expandPointer(model: unknown, pointer: string): { pointer: string; value: unknown }[] {
+  let frontier: { path: string[]; node: unknown }[] = [{ path: [], node: model }];
   for (const seg of pointer.split('/').slice(1)) {
-    if (cur === null || typeof cur !== 'object' || Array.isArray(cur)) return undefined;
-    cur = (cur as Record<string, unknown>)[seg];
+    const next: { path: string[]; node: unknown }[] = [];
+    for (const { path, node } of frontier) {
+      if (seg === '*') {
+        if (Array.isArray(node))
+          node.forEach((el, i) => next.push({ path: [...path, String(i)], node: el }));
+      } else if (node !== null && typeof node === 'object' && !Array.isArray(node)) {
+        next.push({ path: [...path, seg], node: (node as Record<string, unknown>)[seg] });
+      }
+    }
+    frontier = next;
   }
-  return cur;
+  return frontier.map(({ path, node }) => ({ pointer: `/${path.join('/')}`, value: node }));
 }
 // Extra `remove` ops for a cc-kind item on a type in the table above. Fail-safe gates:
 // the LIVE model must carry the pointer as an EMPTY array (a populated array is real
@@ -802,15 +831,16 @@ export function rejectedEmptyStripOps(
   if (!pointers || !liveRaw || ops.length === 0) return [];
   const out: PatchOp[] = [];
   for (const pointer of pointers) {
-    const v = valueAtPointer(liveRaw, pointer);
-    if (!Array.isArray(v) || v.length > 0) continue;
-    const covered = ops.some((o) => pointer === o.path || pointer.startsWith(`${o.path}/`));
-    if (covered) continue;
-    out.push({
-      op: 'remove',
-      path: pointer,
-      human: `${pointer.slice(1).replaceAll('/', '.')} -> drop service-echoed empty array (service rejects [] on update)`,
-    });
+    for (const { pointer: concrete, value } of expandPointer(liveRaw, pointer)) {
+      if (!Array.isArray(value) || value.length > 0) continue;
+      const covered = ops.some((o) => concrete === o.path || concrete.startsWith(`${o.path}/`));
+      if (covered) continue;
+      out.push({
+        op: 'remove',
+        path: concrete,
+        human: `${concrete.slice(1).replaceAll('/', '.')} -> drop service-echoed empty array (service rejects [] on update)`,
+      });
+    }
   }
   return out;
 }

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1845,3 +1845,59 @@ describe('rejectedEmptyStripOps — service-rejected empty-array echoes (#481)',
     expect(rejectedEmptyStripOps(T, [], liveWithEmptyEcho)).toEqual([]);
   });
 });
+
+describe('rejectedEmptyStripOps — array-WILDCARD husk inside array elements (#506)', () => {
+  const T = 'AWS::ImageBuilder::DistributionConfiguration';
+  const descOp: PatchOp = {
+    op: 'add',
+    path: '/Distributions/0/AmiDistributionConfiguration/Description',
+    value: 'cdkrd probe AMI',
+    human: 'Description -> deployed-template value',
+  };
+  // The live shape reproduced on CdkRealDriftIntegImageBuilderRich: the CC read echoes
+  // TargetAccountIds [] inside EACH distribution's AmiDistributionConfiguration, and the
+  // ImageBuilder update handler rejects it — so even a Description-only revert failed.
+  const live = (n: number) => ({
+    Distributions: Array.from({ length: n }, (_, i) => ({
+      Region: 'us-east-1',
+      AmiDistributionConfiguration: {
+        Name: `img-${i}`,
+        Description: 'cdkrd probe AMI MUTATED',
+        AmiTags: { app: 'x' },
+        TargetAccountIds: [],
+      },
+      FastLaunchConfigurations: [],
+      LaunchTemplateConfigurations: [],
+    })),
+  });
+
+  it('appends a remove op for the empty TargetAccountIds husk in every distribution', () => {
+    const strip = rejectedEmptyStripOps(T, [descOp], live(2));
+    expect(strip.map((o) => ({ op: o.op, path: o.path }))).toEqual([
+      { op: 'remove', path: '/Distributions/0/AmiDistributionConfiguration/TargetAccountIds' },
+      { op: 'remove', path: '/Distributions/1/AmiDistributionConfiguration/TargetAccountIds' },
+    ]);
+  });
+
+  it('a POPULATED TargetAccountIds is real data — never stripped', () => {
+    const l = live(1);
+    (
+      l.Distributions[0].AmiDistributionConfiguration as { TargetAccountIds: string[] }
+    ).TargetAccountIds = ['111111111111'];
+    expect(rejectedEmptyStripOps(T, [descOp], l)).toEqual([]);
+  });
+
+  it('an op already rewriting a distribution (an ancestor of the husk) suppresses the strip', () => {
+    const wholeDistOp: PatchOp = {
+      op: 'add',
+      path: '/Distributions/0',
+      value: {},
+      human: 'Distributions[0] -> deployed-template value',
+    };
+    expect(rejectedEmptyStripOps(T, [wholeDistOp], live(1))).toEqual([]);
+  });
+
+  it('no Distributions array -> nothing to expand', () => {
+    expect(rejectedEmptyStripOps(T, [descOp], { Name: 'dist' })).toEqual([]);
+  });
+});

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1871,19 +1871,28 @@ describe('rejectedEmptyStripOps — array-WILDCARD husk inside array elements (#
     })),
   });
 
-  it('appends a remove op for the empty TargetAccountIds husk in every distribution', () => {
+  it('appends a remove op for every empty husk (TargetAccountIds + sibling arrays) in every distribution', () => {
     const strip = rejectedEmptyStripOps(T, [descOp], live(2));
-    expect(strip.map((o) => ({ op: o.op, path: o.path }))).toEqual([
-      { op: 'remove', path: '/Distributions/0/AmiDistributionConfiguration/TargetAccountIds' },
-      { op: 'remove', path: '/Distributions/1/AmiDistributionConfiguration/TargetAccountIds' },
+    expect(strip.map((o) => `${o.op} ${o.path}`)).toEqual([
+      'remove /Distributions/0/AmiDistributionConfiguration/TargetAccountIds',
+      'remove /Distributions/1/AmiDistributionConfiguration/TargetAccountIds',
+      'remove /Distributions/0/FastLaunchConfigurations',
+      'remove /Distributions/1/FastLaunchConfigurations',
+      'remove /Distributions/0/LaunchTemplateConfigurations',
+      'remove /Distributions/1/LaunchTemplateConfigurations',
     ]);
   });
 
-  it('a POPULATED TargetAccountIds is real data — never stripped', () => {
+  it('a POPULATED array is real data — never stripped', () => {
     const l = live(1);
-    (
-      l.Distributions[0].AmiDistributionConfiguration as { TargetAccountIds: string[] }
-    ).TargetAccountIds = ['111111111111'];
+    const d = l.Distributions[0] as {
+      AmiDistributionConfiguration: { TargetAccountIds: string[] };
+      FastLaunchConfigurations: unknown[];
+      LaunchTemplateConfigurations: unknown[];
+    };
+    d.AmiDistributionConfiguration.TargetAccountIds = ['111111111111'];
+    d.FastLaunchConfigurations = [{ Enabled: true }];
+    d.LaunchTemplateConfigurations = [{ LaunchTemplateId: 'lt-1' }];
     expect(rejectedEmptyStripOps(T, [descOp], l)).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Fixes #506 — `revert` on `AWS::ImageBuilder::DistributionConfiguration` failed on **any** patch (even a Description-only revert).

The Cloud Control update folds its own read-back state — which echoes `TargetAccountIds: []` inside **every** distribution's `AmiDistributionConfiguration` — into the desired state, and the ImageBuilder handler rejects the empty array (`... 'distributions[0].amiDistributionConfiguration.targetAccountIds' is not valid`). This is the #481 class (fixed for VpcLattice in #486), but the husk sits **inside an array element**, and `CC_UPDATE_REJECTED_EMPTY_PATHS`'s static object-only pointer resolver returned `undefined` on array nodes, so it couldn't reach it. Live-proven (`CdkRealDriftIntegImageBuilderRich`, us-east-1, 2026-07-03).

## Changes

- `CC_UPDATE_REJECTED_EMPTY_PATHS` pointers now support a `*` **array-wildcard** segment. New `expandPointer()` fans a wildcard pointer out to one concrete `{pointer, value}` pair per live array index, so `/Distributions/*/AmiDistributionConfiguration/TargetAccountIds` resolves to one `remove` op per distribution.
- Entry for `AWS::ImageBuilder::DistributionConfiguration` → `TargetAccountIds`. The sibling `FastLaunchConfigurations` / `LaunchTemplateConfigurations` husks may hit the same wall — they can be added to the same entry if a live revert surfaces them; only `TargetAccountIds` is live-proven.

Same fail-safe gates as #481: only an **empty-array** live value is dropped (populated arrays are real data), and an op already rewriting the pointer or an ancestor suppresses the strip.

## Tests

- `revert-plan.test.ts`: a remove op per distribution for the empty `TargetAccountIds` husk; a populated value is never stripped; an ancestor-rewriting op suppresses; no `Distributions` array → nothing to expand.
- Full suite green.

Closes #506
