### PR TITLE
fix(normalize): drop Aurora DBInstance properties that echo the parent DBCluster

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -138,6 +138,7 @@ interface ClassifyOpts {
   oaiCanonicalIds: Record<string, string>;
   siblingSgRules: Record<string, { ingress: unknown[]; egress: unknown[] }>;
   bucketNotificationManaged: Set<string>;
+  clusterEchoModel: Record<string, Record<string, unknown>>;
 }
 
 // Rules declared by standalone AWS::EC2::SecurityGroupIngress / ::SecurityGroupEgress
@@ -211,6 +212,31 @@ export function buildBucketNotificationManaged(desired: Desired): Set<string> {
     }
   }
   return managed;
+}
+
+// Per Aurora DBInstance physical id, the parent DBCluster's live model — the source for the
+// CLUSTER_ECHO_CHILD strip in classify (an instance's undeclared property that echoes its
+// cluster's cluster-level config). Resolved via the instance's declared DBClusterIdentifier
+// (a Ref that resolves to the cluster's physical id). Fail-open: an instance whose parent
+// cannot be resolved is simply not stripped (its echoes stay a one-time visible inventory,
+// never a hidden change).
+export function buildClusterEchoModels(desired: Desired): Record<string, Record<string, unknown>> {
+  const clusterByPhys: Record<string, Record<string, unknown>> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::RDS::DBCluster' || !r.physicalId) continue;
+    const live = desired.ctx.liveAttrs[r.logicalId];
+    if (live && typeof live === 'object')
+      clusterByPhys[r.physicalId] = live as Record<string, unknown>;
+  }
+  const map: Record<string, Record<string, unknown>> = {};
+  for (const r of desired.resources) {
+    if (r.resourceType !== 'AWS::RDS::DBInstance' || !r.physicalId) continue;
+    const clusterId = (r.declared as Record<string, unknown> | undefined)?.DBClusterIdentifier;
+    if (typeof clusterId !== 'string') continue;
+    const clusterLive = clusterByPhys[clusterId];
+    if (clusterLive) map[r.physicalId] = clusterLive;
+  }
+  return map;
 }
 
 // CloudFront legacy OAI id -> S3CanonicalUserId, harvested from the stack's own
@@ -422,6 +448,7 @@ export async function gatherFindings(
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
+    clusterEchoModel: buildClusterEchoModels(desired),
   };
 
   // Pass 2: classify (declared already re-resolved + override retries applied above).
@@ -506,6 +533,7 @@ export async function regatherTouched(
     oaiCanonicalIds,
     siblingSgRules: buildSiblingSgRules(desired),
     bucketNotificationManaged: buildBucketNotificationManaged(desired),
+    clusterEchoModel: buildClusterEchoModels(desired),
   };
 
   const fresh: Finding[] = [];

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -215,6 +215,23 @@ export const NESTED_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
   'AWS::ApiGateway::Stage': { MethodSettings: 'HttpMethod' },
 };
 
+// Child resources whose live model ECHOES their parent's cluster-level configuration. An
+// Aurora DBInstance reports the DBCluster's encryption / engine version / backup / security
+// groups / subnet group / master user / log exports — settings the CDK `ClusterInstance`
+// never declares on the instance, so they flood a first run as undeclared inventory that
+// merely mirrors the cluster (which cdkrd classifies independently). classify drops an
+// UNDECLARED instance property whose value EQUALS the parent cluster's value for the same
+// key; `aliases` maps the few keys the two APIs spell differently. The parent's own property
+// still carries detection, so no out-of-band change is hidden — and an instance value that
+// DIVERGES from the cluster (its own maintenance window, its single AZ) still surfaces.
+const CLUSTER_ECHO_CHILD: Record<string, { parentIdKey: string; aliases: Record<string, string> }> =
+  {
+    'AWS::RDS::DBInstance': {
+      parentIdKey: 'DBClusterIdentifier',
+      aliases: { VPCSecurityGroups: 'VpcSecurityGroupIds' },
+    },
+  };
+
 const isKeyValueEntry = (t: unknown): t is { Key: string; Value: unknown } =>
   !!t &&
   typeof t === 'object' &&
@@ -773,6 +790,9 @@ export function classifyResource(
     // CR-applied NotificationConfiguration the bucket resource never declares, so it is dropped
     // rather than surfaced as false undeclared drift.
     bucketNotificationManaged?: Set<string>;
+    // Per child physical id, the parent cluster's live model — for the CLUSTER_ECHO_CHILD
+    // strip (an Aurora DBInstance echoing its DBCluster's cluster-level config).
+    clusterEchoModel?: Record<string, Record<string, unknown>>;
   } = {}
 ): Finding[] {
   const { logicalId, resourceType, physicalId, declared: declaredIn } = resource;
@@ -845,6 +865,21 @@ export function classifyResource(
     !('NotificationConfiguration' in declared)
   ) {
     delete live.NotificationConfiguration;
+  }
+  // Drop an UNDECLARED property whose value ECHOES the parent cluster's value (an Aurora
+  // DBInstance mirroring its DBCluster's cluster-level config — see CLUSTER_ECHO_CHILD).
+  // Equality-gated: a declared property compares normally, and an instance value that
+  // DIVERGES from the cluster still surfaces. The parent's own property carries detection.
+  const echoSpec = CLUSTER_ECHO_CHILD[resourceType];
+  const echoModel = echoSpec && physicalId ? opts.clusterEchoModel?.[physicalId] : undefined;
+  if (echoSpec && echoModel) {
+    for (const k of Object.keys(live)) {
+      if (k in declared) continue;
+      const parentKey = echoSpec.aliases[k] ?? k;
+      if (!(parentKey in echoModel)) continue;
+      const pv = echoModel[parentKey];
+      if (deepEqual(live[k], pv) || isStringlyEqualDeep(live[k], pv)) delete live[k];
+    }
   }
   // ManagedPolicy attachment lists (Roles/Users/Groups). A DECLARED list is handled
   // per-member in the declared loop below (declared-but-missing = detach; live-only =

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4334,6 +4334,113 @@ describe('GENERATED_DEFAULTS — physical-id-derived auto values fold to `genera
 // TRUE/FALSE interchangeably; RDS canonicalizes a declared "ON"/"OFF" to "1"/"0" on read, so a
 // case that declares "ON" false-flags declared drift against the live "1". Observed live on
 // dev-main-AuroraDB.
+// An Aurora DBInstance's live model echoes its parent DBCluster's cluster-level config
+// (encryption, engine version, backup, security groups, subnet group, …) — undeclared on the
+// instance, mirroring the cluster (which cdkrd classifies independently). classify drops the
+// echo via opts.clusterEchoModel, equality-gated so an instance value that DIVERGES stays.
+describe('Aurora DBInstance cluster-echo strip (CLUSTER_ECHO_CHILD)', () => {
+  const bareEcho: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const inst = (declared: Record<string, unknown>): DesiredResource => ({
+    logicalId: 'Writer',
+    resourceType: 'AWS::RDS::DBInstance',
+    physicalId: 'inst-1',
+    declared,
+  });
+  const clusterEchoModel = {
+    'inst-1': {
+      StorageEncrypted: true,
+      EngineVersion: '8.0.mysql_aurora.3.08.0',
+      KmsKeyId: 'arn:aws:kms:ap-northeast-1:1:key/abc',
+      BackupRetentionPeriod: 14,
+      VpcSecurityGroupIds: ['sg-1'],
+      PreferredMaintenanceWindow: 'tue:14:55-tue:15:25',
+    },
+  };
+
+  it('drops undeclared instance props that ECHO the parent cluster (same key + value)', () => {
+    const t = tiers(
+      classifyResource(
+        inst({ DBClusterIdentifier: 'c1' }),
+        {
+          StorageEncrypted: true,
+          EngineVersion: '8.0.mysql_aurora.3.08.0',
+          KmsKeyId: 'arn:aws:kms:ap-northeast-1:1:key/abc',
+          BackupRetentionPeriod: 14,
+        },
+        bareEcho,
+        { clusterEchoModel }
+      )
+    );
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('drops VPCSecurityGroups via the VpcSecurityGroupIds alias', () => {
+    const t = tiers(
+      classifyResource(
+        inst({ DBClusterIdentifier: 'c1' }),
+        { VPCSecurityGroups: ['sg-1'] },
+        bareEcho,
+        { clusterEchoModel }
+      )
+    );
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('KEEPS an instance value that DIVERGES from the cluster (its own maintenance window)', () => {
+    const t = tiers(
+      classifyResource(
+        inst({ DBClusterIdentifier: 'c1' }),
+        { PreferredMaintenanceWindow: 'fri:15:16-fri:15:46' },
+        bareEcho,
+        { clusterEchoModel }
+      )
+    );
+    expect(t.undeclared).toEqual(['PreferredMaintenanceWindow']);
+  });
+
+  it('KEEPS an instance-only property the cluster does not carry (its single AvailabilityZone)', () => {
+    const t = tiers(
+      classifyResource(
+        inst({ DBClusterIdentifier: 'c1' }),
+        { AvailabilityZone: 'ap-northeast-1d' },
+        bareEcho,
+        { clusterEchoModel }
+      )
+    );
+    expect(t.undeclared).toEqual(['AvailabilityZone']);
+  });
+
+  it('with NO cluster echo model, the echoes surface (unchanged behavior — fail-open)', () => {
+    const t = tiers(
+      classifyResource(inst({ DBClusterIdentifier: 'c1' }), { StorageEncrypted: true }, bareEcho)
+    );
+    expect(t.undeclared).toEqual(['StorageEncrypted']);
+  });
+
+  it('a DECLARED instance property is compared normally, never echo-stripped', () => {
+    // declared StorageEncrypted:false but live true (== cluster) — a real declared drift the
+    // echo strip must NOT swallow.
+    const t = tiers(
+      classifyResource(
+        inst({ DBClusterIdentifier: 'c1', StorageEncrypted: false }),
+        { StorageEncrypted: true },
+        bareEcho,
+        { clusterEchoModel }
+      )
+    );
+    expect(t.declared).toEqual(['StorageEncrypted']);
+  });
+});
+
 describe('RDS parameter-group boolean tokens (ON≡1, OFF≡0)', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/integration/aurora-rich/verify.sh
+++ b/tests/integration/aurora-rich/verify.sh
@@ -38,6 +38,13 @@ done
 # on read — the ON≡1 boolean-token fold must keep it from false-flagging declared drift.
 grep -qE "Parameters\.slow_query_log" "/tmp/cdkrd-$STACK-pre.out" \
   && fail "MySQL boolean param slow_query_log (ON vs live 1) surfaced as drift (ON≡1 fold regressed)"
+# The DBInstance's live model ECHOES the DBCluster's cluster-level config (encryption, engine
+# version, backup, security groups, subnet group). The CLUSTER_ECHO_CHILD strip must drop
+# those from the instance — a regression re-floods them. Asserted per DBInstance line.
+for prop in StorageEncrypted EngineVersion BackupRetentionPeriod DBSubnetGroupName VPCSecurityGroups; do
+  grep -qE "\.$prop \(AWS::RDS::DBInstance\)" "/tmp/cdkrd-$STACK-pre.out" \
+    && fail "DBInstance echo of cluster $prop surfaced (CLUSTER_ECHO_CHILD strip regressed)"
+done
 
 echo "=== [$STACK] record (write baseline) ==="
 $CLI record "$STACK" --region "$REGION" --yes || fail "record"


### PR DESCRIPTION
## What

An Aurora `DBInstance`'s live model reports the parent `DBCluster`'s **cluster-level** configuration — `StorageEncrypted`, `EngineVersion`, `KmsKeyId`, `MasterUsername`, `BackupRetentionPeriod`, `VPCSecurityGroups`, `DBSubnetGroupName`, `EnableCloudwatchLogsExports`, `PreferredBackupWindow` — none of which the CDK `ClusterInstance` declares on the instance. They flood a first run as undeclared inventory that merely **mirrors the cluster** (which cdkrd already classifies independently): on `<db-users-dev-stack>-DB`, **9 of the 14** potential-drift lines were pure echoes of the cluster.

## How

`CLUSTER_ECHO_CHILD`: `gather` builds each `DBInstance`'s parent `DBCluster` live model (resolved via the declared `DBClusterIdentifier`); `classify` drops an **undeclared** instance property whose value **equals** the cluster's value for the same key (or the aliased `VPCSecurityGroups`→`VpcSecurityGroupIds`).

Equality-gated and **detection-preserving** — no false negative:
- an instance value that **diverges** from the cluster (its own maintenance window, its single AZ) still surfaces — those are genuine per-resource values;
- the cluster's **own** property is still classified, so an out-of-band change (a KMS re-key, a window change) surfaces on the cluster side — nothing is hidden;
- a **declared** instance property is compared normally, never echo-stripped (a real declared drift is never swallowed);
- **fail-open**: an instance whose parent can't be resolved keeps its echoes (visible, never hidden).

## Verification

- **Unit**: 6 cases (echo drop, alias, divergent value kept, cluster-absent key kept, no-model fail-open, declared compared normally).
- **Live-test (real stack)**: `<db-users-dev-stack>-DB` potential drift **14 → 5**. The 5 remaining are the genuine AWS-assigned per-resource values (cluster `KmsKeyId`/`AvailabilityZones`/maintenance-window + instance AZ/maintenance-window) — exactly the values `record` is for.
- **Integration (real AWS)**: `aurora-rich`'s `verify.sh` asserts the instance echoes (`StorageEncrypted`/`EngineVersion`/`BackupRetentionPeriod`/`DBSubnetGroupName`/`VPCSecurityGroups`) do **not** surface → **INTEG PASS** in us-east-1.

## Why this and not the residual

The residual 5 (KMS key, AZs, maintenance windows) are **not** noise to fold — they are independent settings whose out-of-band change is real drift cdkrd must detect. Surfacing them once (to establish the baseline via `record`) is the mechanism that makes that detection possible; folding them would be a false negative. This PR removes only the **redundant** cluster echoes.

## Relation

Fifth FP fix from the real Aurora audit (#504, #510, #512, #514). Together: `<db-users-dev-stack>-DB` declared 1→0, potential 26→5; `<aurora-cluster-dev-stack>` declared 5→0.
