### PR TITLE
fix(normalize): fold DynamoDB classic Table on-demand baseline WarmThroughput (12000/4000)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -352,18 +352,21 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Visibility: 'PRIVATE', // the default; folds to atDefault so a never-declared project is not first-run noise — flipping to PUBLIC_READ no longer matches and surfaces
     Cache: { Type: 'NO_CACHE' }, // BatchGetProjects always returns cache; the unconfigured default folds to atDefault so a never-declared cache is not first-run noise — switching to S3/LOCAL no longer matches and surfaces
   },
+  // A PAY_PER_REQUEST (on-demand) DynamoDB table reads back a baseline WarmThroughput
+  // that AWS assigns to every fresh table (12000 read / 4000 write units) even though the
+  // template never declares it — observed live on a dev LineLink stack (GlobalTable /
+  // TableV2) and a dev reco-MailQueues stack (classic AWS::DynamoDB::Table), neither with
+  // an out-of-band edit. The service default is identical for both CFn types, so both fold.
+  // Equality-gated: a table that has WARMED UP to a higher value under traffic no longer
+  // matches and surfaces as a real undeclared value (the warm throughput auto-ratchets and
+  // never decreases), and an explicitly declared WarmThroughput compares as declared
+  // instead. Top-level WarmThroughput only — the GSI-nested `*.WarmThroughput` stays
+  // surfaced (see KNOWN_DEFAULT_PATHS note below).
   'AWS::DynamoDB::Table': {
     BillingMode: 'PROVISIONED',
     DeletionProtectionEnabled: false,
+    WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
   },
-  // A PAY_PER_REQUEST (on-demand) TableV2 reads back a baseline WarmThroughput that
-  // AWS assigns to every fresh table (12000 read / 4000 write units) even though the
-  // template never declares it — observed live on a dev LineLink stack with no
-  // out-of-band edit. Equality-gated: a table that has WARMED UP to a higher value
-  // under traffic no longer matches and surfaces as a real undeclared value (the warm
-  // throughput auto-ratchets and never decreases), and an explicitly declared
-  // WarmThroughput compares as declared instead. Top-level WarmThroughput only — the
-  // GSI-nested `*.WarmThroughput` stays surfaced (see KNOWN_DEFAULT_PATHS note below).
   'AWS::DynamoDB::GlobalTable': {
     WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
   },

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -789,6 +789,20 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       }).undeclared
     ).toEqual(['WarmThroughput']);
 
+    // The classic AWS::DynamoDB::Table (L1) reads back the SAME baseline warm throughput
+    // when on-demand — observed live on a dev reco-MailQueues stack — so it folds too;
+    // a warmed-up table still surfaces (equality-gated).
+    expect(
+      t('AWS::DynamoDB::Table', {
+        WarmThroughput: { ReadUnitsPerSecond: 12000, WriteUnitsPerSecond: 4000 },
+      }).atDefault
+    ).toEqual(['WarmThroughput']);
+    expect(
+      t('AWS::DynamoDB::Table', {
+        WarmThroughput: { ReadUnitsPerSecond: 24000, WriteUnitsPerSecond: 8000 },
+      }).undeclared
+    ).toEqual(['WarmThroughput']);
+
     // ESM created enabled → folds. (Enabled:false is dropped upstream as trivially-empty,
     // like the KMS Key Enabled case — neither undeclared nor atDefault.)
     expect(t('AWS::Lambda::EventSourceMapping', { Enabled: true }).atDefault).toEqual(['Enabled']);

--- a/tests/corpus/AWS__DynamoDB__Table.Classic397C6F85.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Classic397C6F85.json
@@ -182,7 +182,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Classic397C6F85",
       "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Data666C94C7.json
@@ -171,7 +171,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
+++ b/tests/corpus/AWS__DynamoDB__Table.OrdersA9B65338.json
@@ -160,7 +160,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OrdersA9B65338",
       "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Sessions8896A56D.json
@@ -88,7 +88,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Sessions8896A56D",
       "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__Table.Table.json
+++ b/tests/corpus/AWS__DynamoDB__Table.Table.json
@@ -136,7 +136,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Table",
       "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",

--- a/tests/corpus/AWS__DynamoDB__Table.TableCD117FA1.json
+++ b/tests/corpus/AWS__DynamoDB__Table.TableCD117FA1.json
@@ -117,7 +117,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "TableCD117FA1",
       "resourceType": "AWS::DynamoDB::Table",
       "path": "WarmThroughput",


### PR DESCRIPTION
## What

`cdkrd check` reported a first-run **false positive** on a classic
`AWS::DynamoDB::Table` (on-demand / `PAY_PER_REQUEST`):

```
[Potential Drift: 1]
  <stack>/QueueLockTable.WarmThroughput (AWS::DynamoDB::Table)
    = {"ReadUnitsPerSecond":12000,"WriteUnitsPerSecond":4000}
```

`12000` read / `4000` write is the **baseline WarmThroughput AWS assigns to
every fresh on-demand DynamoDB table** — the template never declares it, and no
out-of-band change was made.

## Why it slipped through

The 12000/4000 default fold already existed in `KNOWN_DEFAULTS`, but **only under
`AWS::DynamoDB::GlobalTable` (TableV2)**. The classic L1 `AWS::DynamoDB::Table`
reads back the identical service default and had no fold, so it surfaced as
`undeclared` potential drift.

## Fix

Add the same equality-gated `WarmThroughput` default to the existing
`AWS::DynamoDB::Table` `KNOWN_DEFAULTS` entry. Equality-gated, so a table that has
warmed up to a higher value (auto-ratchets, never decreases) still surfaces, and
the GSI-nested `*.WarmThroughput` stays surfaced as before.

## Tests

- `tests/classify.test.ts`: assert 12000/4000 folds to `atDefault` for
  `AWS::DynamoDB::Table` and a warmed-up 24000/8000 still surfaces as `undeclared`.
- Regenerated 6 `AWS__DynamoDB__Table.*` golden corpus cases — top-level
  `WarmThroughput` now `atDefault`; GSI-nested `*.WarmThroughput` unchanged.
