### PR TITLE
chore(corpus): normalize ElastiCache/MemoryDB golden fixtures to canonical format

### DIFF
--- a/tests/corpus/AWS__ElastiCache__User.HuntEcDefaultUser.json
+++ b/tests/corpus/AWS__ElastiCache__User.HuntEcDefaultUser.json
@@ -23,32 +23,12 @@
     "AccessString": "off ~* -@all"
   },
   "schema": {
-    "readOnly": [
-      "Arn",
-      "Status"
-    ],
-    "writeOnly": [
-      "AuthenticationMode",
-      "NoPasswordRequired",
-      "Passwords"
-    ],
-    "createOnly": [
-      "UserId",
-      "UserName"
-    ],
-    "readOnlyPaths": [
-      "Arn",
-      "Status"
-    ],
-    "writeOnlyPaths": [
-      "AuthenticationMode",
-      "NoPasswordRequired",
-      "Passwords"
-    ],
-    "createOnlyPaths": [
-      "UserId",
-      "UserName"
-    ],
+    "readOnly": ["Arn", "Status"],
+    "writeOnly": ["AuthenticationMode", "NoPasswordRequired", "Passwords"],
+    "createOnly": ["UserId", "UserName"],
+    "readOnlyPaths": ["Arn", "Status"],
+    "writeOnlyPaths": ["AuthenticationMode", "NoPasswordRequired", "Passwords"],
+    "createOnlyPaths": ["UserId", "UserName"],
     "defaults": {},
     "defaultPaths": {},
     "unorderedScalarPaths": [],

--- a/tests/corpus/AWS__ElastiCache__User.HuntEcReaderUser.json
+++ b/tests/corpus/AWS__ElastiCache__User.HuntEcReaderUser.json
@@ -8,9 +8,7 @@
     "declared": {
       "AccessString": "on ~app:* +@read",
       "Engine": "redis",
-      "Passwords": [
-        "cdkrd-hunt-Passw0rd-123456"
-      ],
+      "Passwords": ["cdkrd-hunt-Passw0rd-123456"],
       "UserId": "cdkrd-hunt-reader",
       "UserName": "cdkrd-hunt-reader"
     }
@@ -25,32 +23,12 @@
     "AccessString": "on ~app:* -@all +@read"
   },
   "schema": {
-    "readOnly": [
-      "Arn",
-      "Status"
-    ],
-    "writeOnly": [
-      "AuthenticationMode",
-      "NoPasswordRequired",
-      "Passwords"
-    ],
-    "createOnly": [
-      "UserId",
-      "UserName"
-    ],
-    "readOnlyPaths": [
-      "Arn",
-      "Status"
-    ],
-    "writeOnlyPaths": [
-      "AuthenticationMode",
-      "NoPasswordRequired",
-      "Passwords"
-    ],
-    "createOnlyPaths": [
-      "UserId",
-      "UserName"
-    ],
+    "readOnly": ["Arn", "Status"],
+    "writeOnly": ["AuthenticationMode", "NoPasswordRequired", "Passwords"],
+    "createOnly": ["UserId", "UserName"],
+    "readOnlyPaths": ["Arn", "Status"],
+    "writeOnlyPaths": ["AuthenticationMode", "NoPasswordRequired", "Passwords"],
+    "createOnlyPaths": ["UserId", "UserName"],
     "defaults": {},
     "defaultPaths": {},
     "unorderedScalarPaths": [],

--- a/tests/corpus/AWS__ElastiCache__UserGroup.HuntEcUserGroup.json
+++ b/tests/corpus/AWS__ElastiCache__UserGroup.HuntEcUserGroup.json
@@ -8,10 +8,7 @@
     "declared": {
       "Engine": "redis",
       "UserGroupId": "cdkrd-hunt-group",
-      "UserIds": [
-        "cdkrd-hunt-reader",
-        "cdkrd-hunt-default"
-      ]
+      "UserIds": ["cdkrd-hunt-reader", "cdkrd-hunt-default"]
     }
   },
   "liveRaw": {
@@ -19,34 +16,19 @@
     "UserGroupId": "cdkrd-hunt-group",
     "Arn": "arn:aws:elasticache:us-east-1:111111111111:usergroup:cdkrd-hunt-group",
     "Engine": "redis",
-    "UserIds": [
-      "cdkrd-hunt-reader",
-      "cdkrd-hunt-default"
-    ],
+    "UserIds": ["cdkrd-hunt-reader", "cdkrd-hunt-default"],
     "Tags": []
   },
   "schema": {
-    "readOnly": [
-      "Arn",
-      "Status"
-    ],
+    "readOnly": ["Arn", "Status"],
     "writeOnly": [],
-    "createOnly": [
-      "UserGroupId"
-    ],
-    "readOnlyPaths": [
-      "Arn",
-      "Status"
-    ],
+    "createOnly": ["UserGroupId"],
+    "readOnlyPaths": ["Arn", "Status"],
     "writeOnlyPaths": [],
-    "createOnlyPaths": [
-      "UserGroupId"
-    ],
+    "createOnlyPaths": ["UserGroupId"],
     "defaults": {},
     "defaultPaths": {},
-    "unorderedScalarPaths": [
-      "UserIds"
-    ],
+    "unorderedScalarPaths": ["UserIds"],
     "unorderedObjectArrayPaths": [],
     "freeFormMapPaths": []
   },

--- a/tests/corpus/AWS__MemoryDB__ACL.HuntMdbAcl.json
+++ b/tests/corpus/AWS__MemoryDB__ACL.HuntMdbAcl.json
@@ -7,37 +7,23 @@
     "constructPath": "CdkRealDriftIntegCacheUsers/HuntMdbAcl",
     "declared": {
       "ACLName": "cdkrd-hunt-mdb-acl",
-      "UserNames": [
-        "cdkrd-hunt-mdb-user"
-      ]
+      "UserNames": ["cdkrd-hunt-mdb-user"]
     }
   },
   "liveRaw": {
     "Status": "active",
     "ACLName": "cdkrd-hunt-mdb-acl",
-    "UserNames": [
-      "cdkrd-hunt-mdb-user"
-    ],
+    "UserNames": ["cdkrd-hunt-mdb-user"],
     "Arn": "arn:aws:memorydb:us-east-1:111111111111:acl/cdkrd-hunt-mdb-acl",
     "Tags": []
   },
   "schema": {
-    "readOnly": [
-      "Arn",
-      "Status"
-    ],
+    "readOnly": ["Arn", "Status"],
     "writeOnly": [],
-    "createOnly": [
-      "ACLName"
-    ],
-    "readOnlyPaths": [
-      "Arn",
-      "Status"
-    ],
+    "createOnly": ["ACLName"],
+    "readOnlyPaths": ["Arn", "Status"],
     "writeOnlyPaths": [],
-    "createOnlyPaths": [
-      "ACLName"
-    ],
+    "createOnlyPaths": ["ACLName"],
     "defaults": {},
     "defaultPaths": {},
     "unorderedScalarPaths": [],

--- a/tests/corpus/AWS__MemoryDB__User.HuntMdbUser.json
+++ b/tests/corpus/AWS__MemoryDB__User.HuntMdbUser.json
@@ -21,26 +21,12 @@
     "AccessString": "on ~* &* -@all +@read"
   },
   "schema": {
-    "readOnly": [
-      "Arn",
-      "Status"
-    ],
-    "writeOnly": [
-      "AuthenticationMode"
-    ],
-    "createOnly": [
-      "UserName"
-    ],
-    "readOnlyPaths": [
-      "Arn",
-      "Status"
-    ],
-    "writeOnlyPaths": [
-      "AuthenticationMode"
-    ],
-    "createOnlyPaths": [
-      "UserName"
-    ],
+    "readOnly": ["Arn", "Status"],
+    "writeOnly": ["AuthenticationMode"],
+    "createOnly": ["UserName"],
+    "readOnlyPaths": ["Arn", "Status"],
+    "writeOnlyPaths": ["AuthenticationMode"],
+    "createOnlyPaths": ["UserName"],
     "defaults": {},
     "defaultPaths": {},
     "unorderedScalarPaths": [],


### PR DESCRIPTION
Format-only normalization of 5 `tests/corpus` fixtures (ElastiCache User/UserGroup, MemoryDB ACL/User) added by #488 with expanded multi-line arrays that `vp check` flags — so `vp run check` has been failing on them on every branch since (unnoticed while CI is billing-off), and every worktree had to `git checkout` them back to avoid the reformat leaking into an unrelated PR.

**Format-only**: canonical JSON content (sort_keys) is byte-identical for all 5, so corpus-replay is unaffected. Ends the recurring revert foot-gun and makes `vp run check` clean. No `src/**` → verify-pr-gate exempt.

`vp run typecheck` / `vp run check` / `vp test run` (2599) all green.