### PR TITLE
fix(normalize): drop value-independent LayerVersion LayerName over-fold (fixes red main)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1529,13 +1529,12 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // (inventory: never drift, recorded, or reverted) is safe — and necessary, since an
   // immutable token can never be an out-of-band edit. Observed live on lambda-efs-rich.
   'AWS::EFS::AccessPoint': new Set(['ClientToken']),
-  // A LayerVersion whose LayerName the template omits reads back a CloudFormation-generated
-  // name (`<logicalId>` — NO stack prefix and NO random-suffix dash, so isCfnGeneratedName
-  // misses it, and it is not the ARN's trailing segment, so isGeneratedName misses it too).
-  // It is the AWS-minted identity, not user intent; a layer that DECLARES a LayerName carries
-  // it in the template and never reaches this loop. Floods every CDK BucketDeployment (its
-  // AwsCliLayer names itself from the logical id). Observed live.
-  'AWS::Lambda::LayerVersion': new Set(['LayerName']),
+  // NOTE: AWS::Lambda::LayerVersion.LayerName is NOT folded here. The flood case — a CDK
+  // BucketDeployment's AwsCliLayer reads back its own logical id verbatim — is handled
+  // PRECISELY by isCfnGeneratedName's `value === logicalId` echo (classify.ts). A
+  // value-independent GENERATED_TOPLEVEL_PATHS entry would additionally fold an undeclared
+  // user-set LayerName (e.g. "my-custom-layer") that is NOT the logical id, hiding real
+  // undeclared drift — the exact differentiator cdkrd exists to surface.
   // A UserPoolClient whose ClientName the template omits reads back a CloudFormation-generated
   // name (`<logicalId>-<random>` — NO stack prefix, so isCfnGeneratedName misses it). It is
   // the AWS-minted identity, not user intent; a client that DECLARES a ClientName carries it

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -7883,9 +7883,20 @@ describe('Face-stack false-positive folds', () => {
   });
 
   it('CFn-generated LayerName / ClientName fold to generated', () => {
+    // A BucketDeployment's AwsCliLayer reads its LayerName back as its OWN logical id
+    // verbatim (the real flood); it folds via isCfnGeneratedName's `value === logicalId`
+    // echo — NOT a value-independent LayerName fold, which would also hide an undeclared
+    // user-set LayerName (see the "merely SIMILAR" case above).
     const layer = tiers(
       classifyResource(
-        res('AWS::Lambda::LayerVersion', {}),
+        {
+          logicalId: 'WebsiteDeploymentAwsCliLayer0783B164',
+          resourceType: 'AWS::Lambda::LayerVersion',
+          physicalId:
+            'arn:aws:lambda:us-east-1:111111111111:layer:WebsiteDeploymentAwsCliLayer0783B164:1',
+          constructPath: 'Stack/WebsiteDeployment/AwsCliLayer',
+          declared: {},
+        },
         { LayerName: 'WebsiteDeploymentAwsCliLayer0783B164' },
         emptySchema
       )


### PR DESCRIPTION
## Problem

`main` (3d892ea) ships a **failing unit test** — the suite is currently red:

```
× CFn auto-generated name folding > an undeclared value merely SIMILAR to the logical id (not exact) stays undeclared
  AssertionError: expected 'generated' to be 'undeclared'
```

PR #517 added two things in one commit:

1. `isCfnGeneratedName`'s precise `value === logicalId` echo (classify.ts) — the
   **correct** fix for the AwsCliLayer flood (a BucketDeployment's `AwsCliLayer`
   reads its `LayerName` back as its own logical id verbatim).
2. A **value-independent** `GENERATED_TOPLEVEL_PATHS['AWS::Lambda::LayerVersion'] =
   {'LayerName'}` entry — which folds **any** undeclared `LayerName` to `generated`.

(2) is redundant with (1) for the real flood, and **over-broad**: it hides an
undeclared, user-set `LayerName` (e.g. `my-custom-layer`) — exactly the
undeclared-property drift cdkrd exists to surface. #517 also shipped a
**self-contradictory test pair**: one asserts a non-echo `LayerName` stays
`undeclared`, the other (unrealistically, with `logicalId: 'R'`) asserts a
generated-looking `LayerName` folds. Only one can pass — hence the red main.

## Fix

- Remove the value-independent `LayerVersion.LayerName` entry from
  `GENERATED_TOPLEVEL_PATHS`. The real flood still folds via the precise
  `value === logicalId` echo.
- Make the `CFn-generated LayerName` test **realistic**: `LayerName == logicalId`
  (with a `constructPath`), matching how the AwsCliLayer flood actually reads back,
  so it folds via the echo rather than the removed value-independent entry.

`Cognito::UserPoolClient.ClientName` is intentionally left as a value-independent
fold — its generated form is `<logicalId>-<random>` (not an exact logical-id echo),
so the precise echo cannot reach it.

## Verification

- `vp run typecheck` — pass
- `vp check` (lint + format) — 0 errors
- `vp pack` — pass
- `vp test run` — 46 files, **2629 tests pass** (was 1 failing on main)
