### PR TITLE
fix(normalize): fold ApiGateway Authorizer AuthType value-independently (TOKEN/REQUEST 'custom' FP)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -295,16 +295,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ApiGateway::DomainName': {
     SecurityPolicy: 'TLS_1_2',
   },
-  // A Cognito authorizer declares only Type: COGNITO_USER_POOLS; AWS derives and
-  // returns AuthType "cognito_user_pools" (the lowercase form), which the template
-  // never carries, so the live read reports it as undeclared on every first run —
-  // observed live on a dev LineLink stack with no out-of-band edit. AuthType is purely
-  // derived from Type and cannot be set independently, so only this Cognito value is
-  // folded; a TOKEN/REQUEST authorizer's "custom" AuthType is unobserved and left to
-  // surface (observed-only discipline). Equality-gated like every other entry.
-  'AWS::ApiGateway::Authorizer': {
-    AuthType: 'cognito_user_pools',
-  },
+  // NOTE: AWS::ApiGateway::Authorizer.AuthType is NOT a KNOWN_DEFAULTS entry — it is
+  // folded value-independently via VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS below
+  // (AuthType is a derived, non-declarable read-back of the declared Type).
   // A VPC is in nearly every CDK stack. AWS reports these two constant defaults on
   // every first run when the template does not declare them (raw CfnVPC, or an L2 Vpc
   // that sets only DNS hostnames): InstanceTenancy "default" (vs dedicated/host) and
@@ -1588,6 +1581,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   value-independent: undeclared, so whatever window AWS chose is its default, not user
   //   intent. A DECLARED window goes through the declared loop (compared), unaffected.
   'AWS::KinesisAnalyticsV2::Application': new Set(['ApplicationMaintenanceConfiguration']),
+  //   AWS::ApiGateway::Authorizer.AuthType — a REST-API authorizer's schema carries NO
+  //   `AuthType` property (the template declares `Type`: TOKEN / REQUEST /
+  //   COGNITO_USER_POOLS); AWS DERIVES and reads back AuthType from it ("custom" for
+  //   TOKEN/REQUEST, "cognito_user_pools" for COGNITO_USER_POOLS). Since AuthType can
+  //   never be declared, any value AWS returns is a pure reflection of the declared Type,
+  //   not user intent — and a real change to Type surfaces in the declared loop on `Type`
+  //   itself. Fold value-independent so both derived forms (and any future enum) fold
+  //   without enumerating each. Both observed live first-run (LineLink cognito, dev-main
+  //   AimAssociation TOKEN "custom") with no out-of-band edit.
+  'AWS::ApiGateway::Authorizer': new Set(['AuthType']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -871,13 +871,16 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(disabled.undeclared).toEqual([]);
     expect(disabled.atDefault).toEqual([]);
 
-    // Cognito-derived AuthType folds; a different (e.g. custom) AuthType surfaces.
+    // AuthType is a derived, non-declarable read-back of the declared Type, so BOTH the
+    // Cognito ("cognito_user_pools") and TOKEN/REQUEST ("custom", observed live on a
+    // dev-main AimAssociation TOKEN authorizer) forms fold value-independently.
     expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'cognito_user_pools' }).atDefault).toEqual([
       'AuthType',
     ]);
-    expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'custom' }).undeclared).toEqual([
+    expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'custom' }).atDefault).toEqual([
       'AuthType',
     ]);
+    expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'custom' }).undeclared).toEqual([]);
   });
 
   it('hunt-lowcov first-run folds: S3Express DirectoryBucket / S3Tables TableBucket / Logs Delivery family', () => {

--- a/tests/corpus/AWS__ApiGateway__Authorizer.AuthorizerBD825682.json
+++ b/tests/corpus/AWS__ApiGateway__Authorizer.AuthorizerBD825682.json
@@ -43,7 +43,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AuthorizerBD825682",
       "resourceType": "AWS::ApiGateway::Authorizer",
       "path": "AuthType",


### PR DESCRIPTION
## Problem

On a real dev stack (`<real-app-dev-stack>`, `ap-northeast-1`) with **no
out-of-band console edit**, `cdkrd check` reported a false Potential Drift:

```
<real-app-dev-stack>/Api/Authorizer.AuthType (AWS::ApiGateway::Authorizer) = "custom"
```

`AWS::ApiGateway::Authorizer` has **no `AuthType` property** in its CFn schema —
the template declares `Type` (TOKEN / REQUEST / COGNITO_USER_POOLS), and AWS
**derives** and reads back `AuthType` from it (`"custom"` for TOKEN/REQUEST,
`"cognito_user_pools"` for COGNITO_USER_POOLS). Since `AuthType` can never be
declared, any value AWS returns is a pure reflection of the declared `Type` — not
user intent — and a real change to `Type` surfaces in the declared loop on `Type`
itself.

Previously only the Cognito form was folded (via `KNOWN_DEFAULTS`), with the
TOKEN/REQUEST `"custom"` form deliberately left to surface under observed-only
discipline (it hadn't been seen live). It has now been observed live.

## Fix

- Remove the single-value `KNOWN_DEFAULTS['AWS::ApiGateway::Authorizer'].AuthType`
  entry.
- Fold `AuthType` **value-independently** via
  `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` — the same mechanism used for other
  derived, non-declarable read-backs (ECS `PlatformVersion`,
  KinesisAnalyticsV2 maintenance window). Both derived forms (and any future enum)
  fold without enumerating each; a genuine `Type` change still surfaces on `Type`.

## Verification

- Unit test updated: both `cognito_user_pools` and `custom` fold to `atDefault`.
- Golden corpus fixture `AWS__ApiGateway__Authorizer.AuthorizerBD825682.json`
  (harvested from the `CdkRealDriftIntegRestApiAuthorizerRich` integ, a real TOKEN
  authorizer with `AuthType: "custom"`) reclassified `undeclared → atDefault` —
  the exact real-world FP this fixes.
- `vp run typecheck` / `vp check` / `vp pack` — pass.
- `vp test run` — 46 files, **2640 tests pass**.
