### PR TITLE
feat(report): annotate Application Signals / Lambda Insights footprint with an origin hint

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -98,7 +98,12 @@ NEW (cdkd does NOT have these):
   rules scoped on `{ path, stack?, account?, region? }` (declared, undeclared, OR
   an out-of-band `added` resource) that re-tag findings to `ignored` and STOP
   watching (the `.driftignore` / `ignore_changes` analogue)
-- **report** — tiered text + JSON
+- **report** — tiered text + JSON. A finding whose live value has a recognizable
+  external origin also carries a non-classifying `hint` (diff/hints.ts) — e.g. the
+  CloudWatch Application Signals / Lambda Insights auto-instrumentation footprint
+  (an added Insights layer + tracer execution policy). A hint NEVER folds or
+  re-tiers the finding (an unexpected account-wide enablement stays visible as
+  real drift); it only names the likely source in a dim trailing line.
 - **golden corpus** — recorded real pipeline inputs+findings, replayed offline in CI (R63)
 
 ## Roadmap (private until Phase 4)

--- a/README.md
+++ b/README.md
@@ -451,6 +451,12 @@ info:
   `result:` points you at `cdkrd record` to accept them (or `revert` to remove).
   Once a resource is fully snapshotted, a value that _appears_ later is real drift
   (`appeared since record`).
+- **`↳` origin hint**: when a finding's live value has a recognizable external
+  source — e.g. the CloudWatch Application Signals / Lambda Insights
+  auto-instrumentation footprint (an added Insights layer + tracer execution
+  policy, typically enabled account-wide, not per-resource) — a dim `↳` line names
+  the likely source. It's an explanation only: the finding is still real drift and
+  still drives the exit, so an unexpected account-wide enablement is never hidden.
 - **`info:` footer** folds the informational tiers to per-reason counts
   (`--verbose` expands them):
 

--- a/src/diff/hints.ts
+++ b/src/diff/hints.ts
@@ -1,0 +1,70 @@
+// Non-classifying, human-facing HINTS for findings whose live value has a recognizable
+// external origin. A hint NEVER folds or re-tiers a finding — the divergence is still
+// reported as real drift (an account-wide enablement the user did not expect must stay
+// visible). It only annotates the finding with WHERE the value likely came from, so a
+// puzzling "I never touched this" finding is self-explaining.
+//
+// The first (and currently only) recognized footprint is CloudWatch Application Signals /
+// Lambda Insights auto-instrumentation. When enabled at the ACCOUNT/REGION level (a
+// CloudWatch setting, not a per-resource console edit), AWS uniformly:
+//   - adds the AWS-owned Lambda Insights extension LAYER to every function
+//     (`arn:aws:lambda:<region>:<aws-owned-acct>:layer:LambdaInsightsExtension[-Arm64]:N`), and
+//   - attaches a tracer / insights execution POLICY to each function's role
+//     (`AWSLambdaTracerAccessExecutionRole-<uuid>` or `CloudWatchLambdaInsightsExecutionRolePolicy`).
+// Neither is a CDK-declared intent, so cdkrd surfaces them (Layers = undeclared, the extra
+// ManagedPolicyArns entry = declared drift) — correctly. This hint just names the source.
+import type { Finding } from '../types.js';
+
+const APP_SIGNALS_HINT =
+  'looks like CloudWatch Application Signals / Lambda Insights auto-instrumentation — ' +
+  'typically enabled at the account/region level (a CloudWatch setting), not a per-resource ' +
+  'edit; declare it in CDK to make it intent, or record/ignore to accept it';
+
+// The AWS-owned Lambda Insights extension layer name is constant across regions (only the
+// publisher account and version vary), so match on the layer-name segment.
+const INSIGHTS_LAYER = /:layer:LambdaInsightsExtension(-Arm64)?:/;
+
+// The two managed policies Application Signals / Lambda Insights attach to a function's
+// execution role. The tracer policy carries a random UUID suffix, so match the stable stem.
+const INSIGHTS_POLICY =
+  /(AWSLambdaTracerAccessExecutionRole|CloudWatchLambdaInsightsExecutionRolePolicy)/;
+
+/** All string leaves of a value (scalar, array, or nested) — flattened. Pure. */
+function strings(v: unknown): string[] {
+  if (typeof v === 'string') return [v];
+  if (Array.isArray(v)) return v.flatMap(strings);
+  return [];
+}
+
+/**
+ * The hint for a single finding, or undefined if none applies. Pure + exported for tests.
+ * Path is matched leniently (bare `Layers`, an indexed `Layers[0]`, or a nested
+ * `...ManagedPolicyArns`) so the same detector fires whether the property surfaced whole or
+ * per-element. For the role policy — a DECLARED drift carrying both sides — only the
+ * LIVE-ONLY entries (actual minus desired) are inspected, so a hint fires on the ADDED
+ * policy, never on one the template already declared.
+ */
+export function findingHint(f: Finding): string | undefined {
+  if (f.resourceType === 'AWS::Lambda::Function' && /(^|\.)Layers(\[|$)/.test(f.path)) {
+    if (strings(f.actual).some((s) => INSIGHTS_LAYER.test(s))) return APP_SIGNALS_HINT;
+  }
+  if (f.resourceType === 'AWS::IAM::Role' && /(^|\.)ManagedPolicyArns(\[|$)/.test(f.path)) {
+    const declared = new Set(strings(f.desired));
+    const liveOnly = strings(f.actual).filter((s) => !declared.has(s));
+    if (liveOnly.some((s) => INSIGHTS_POLICY.test(s))) return APP_SIGNALS_HINT;
+  }
+  return undefined;
+}
+
+/**
+ * Return a copy of `findings` with a `hint` set on any finding whose live value has a
+ * recognized external origin. Non-mutating; leaves an already-set hint untouched. Applied
+ * just before the report so both the text and --json outputs carry it.
+ */
+export function annotateHints(findings: Finding[]): Finding[] {
+  return findings.map((f) => {
+    if (f.hint !== undefined) return f;
+    const hint = findingHint(f);
+    return hint === undefined ? f : { ...f, hint };
+  });
+}

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -18,6 +18,7 @@
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
 import { deepEqual } from '../diff/drift-calculator.js';
+import { annotateHints } from '../diff/hints.js';
 import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
 
@@ -131,6 +132,9 @@ export function formatFinding(f: Finding): string {
     s += formatArrayDelta(f.arrayDelta);
   else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
     s += ` = ${style.actual(j(f.actual))}`;
+  // A non-classifying origin hint (diff/hints.ts) — the finding is still real drift; this
+  // just names where the live value likely came from. Dim trailing line, below the values.
+  if (f.hint) s += `\n      ${style.infoTier(`↳ ${f.hint}`)}`;
   return s;
 }
 
@@ -240,8 +244,12 @@ function groupReasons(items: Finding[]): string {
     .join(', ');
 }
 
-export function report(findings: Finding[], header: string, opts: ReportOptions = {}): number {
+export function report(rawFindings: Finding[], header: string, opts: ReportOptions = {}): number {
   const log = opts.log ?? console.log;
+  // Annotate origin hints (diff/hints.ts) here, at the single render chokepoint, so the
+  // text report, the --json payload, and the --pre-deploy report all carry them. A hint is
+  // display-only — it never changes a tier — so the `drifted` verdict below is unaffected.
+  const findings = annotateHints(rawFindings);
   // unrecorded findings (R60/R62): an inventory awaiting a baseline decision,
   // not drift — they never count toward the verdict or the exit.
   const isDriftHere = (f: Finding): boolean => DRIFT_TIERS.includes(f.tier) && !f.unrecorded;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,14 @@ export interface Finding {
   desired?: unknown;
   actual?: unknown;
   note?: string;
+  // A non-classifying, human-facing EXPLANATION for a finding whose live value has a
+  // recognizable external origin — e.g. the CloudWatch Application Signals / Lambda
+  // Insights auto-instrumentation footprint (see diff/hints.ts, annotateHints). Unlike a
+  // fold, it does NOT change the tier: the finding is still reported as real drift, the
+  // hint only tells the user WHERE it likely came from ("enabled at the account/region
+  // level, not per-resource"), so an unexpected account-wide enablement is never hidden.
+  // Rendered as a dim trailing line in the text report and carried through --json.
+  hint?: string;
   // undeclared tier only (R62): the value has NO baseline entry and its resource
   // was never snapshot-complete — the user has not decided on it yet, so it is an
   // UNRECORDED inventory item, not drift. Set by applyBaseline; excluded from the

--- a/tests/hints.test.ts
+++ b/tests/hints.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { annotateHints, findingHint } from '../src/diff/hints.js';
+import { report } from '../src/report/report.js';
+import type { Finding } from '../src/types.js';
+
+const INSIGHTS_LAYER =
+  'arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:80';
+const TRACER_POLICY =
+  'arn:aws:iam::123456789012:policy/service-role/AWSLambdaTracerAccessExecutionRole-c63e7091-06fb-4d95-be6a-fcc3de761556';
+const BASIC = 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole';
+
+const HINT = 'CloudWatch Application Signals / Lambda Insights';
+
+describe('findingHint — Application Signals / Lambda Insights footprint', () => {
+  it('flags an undeclared Lambda Insights extension layer (whole-array path)', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Layers',
+      actual: [INSIGHTS_LAYER],
+    };
+    expect(findingHint(f)).toContain(HINT);
+  });
+
+  it('flags the Arm64 insights layer and an indexed Layers path', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Layers[0]',
+      actual: 'arn:aws:lambda:us-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:20',
+    };
+    expect(findingHint(f)).toContain(HINT);
+  });
+
+  it('does NOT flag an ordinary user layer', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Layers',
+      actual: ['arn:aws:lambda:us-east-1:111111111111:layer:my-shared-deps:3'],
+    };
+    expect(findingHint(f)).toBeUndefined();
+  });
+
+  it('flags the tracer policy added to a role (declared drift — only the LIVE-ONLY entry)', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'ManagedPolicyArns',
+      desired: [BASIC],
+      actual: [TRACER_POLICY, BASIC],
+    };
+    expect(findingHint(f)).toContain(HINT);
+  });
+
+  it('flags the CloudWatchLambdaInsightsExecutionRolePolicy variant', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'ManagedPolicyArns',
+      desired: [BASIC],
+      actual: [BASIC, 'arn:aws:iam::aws:policy/CloudWatchLambdaInsightsExecutionRolePolicy'],
+    };
+    expect(findingHint(f)).toContain(HINT);
+  });
+
+  it('does NOT flag when the tracer policy was ALREADY declared (no live-only add)', () => {
+    // If the template already declares it, it is intent — not an out-of-band footprint.
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'ManagedPolicyArns',
+      desired: [BASIC, TRACER_POLICY],
+      actual: [BASIC],
+    };
+    expect(findingHint(f)).toBeUndefined();
+  });
+
+  it('does NOT flag an unrelated role managed-policy drift', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'ManagedPolicyArns',
+      desired: [BASIC],
+      actual: [BASIC, 'arn:aws:iam::aws:policy/AdministratorAccess'],
+    };
+    expect(findingHint(f)).toBeUndefined();
+  });
+});
+
+describe('annotateHints', () => {
+  it('sets hint on matching findings, leaves others and never mutates the input', () => {
+    const layer: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Layers',
+      actual: [INSIGHTS_LAYER],
+    };
+    const other: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Timeout',
+      actual: 30,
+    };
+    const out = annotateHints([layer, other]);
+    expect(out[0]?.hint).toContain(HINT);
+    expect(out[1]?.hint).toBeUndefined();
+    expect(layer.hint).toBeUndefined(); // input not mutated
+  });
+});
+
+describe('report renders the hint (still real drift, just annotated)', () => {
+  it('shows a dim trailing hint line under the finding — tier unchanged, counted as drift', () => {
+    const lines: string[] = [];
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Role',
+      resourceType: 'AWS::IAM::Role',
+      path: 'ManagedPolicyArns',
+      desired: [BASIC],
+      actual: [TRACER_POLICY, BASIC],
+    };
+    const code = report([f], 'stack (ap-northeast-1)', { log: (s) => lines.push(s) });
+    const text = lines.join('\n');
+    expect(text).toContain(`↳ looks like ${HINT}`);
+    expect(text).toContain('CFn-Declared Drift'); // still classified & counted as real drift
+    expect(code).toBe(1);
+  });
+});


### PR DESCRIPTION
## Motivation

On a real dev stack, `cdkrd check` surfaced two findings the user "never touched":

- `ServiceRole.ManagedPolicyArns` gained `AWSLambdaTracerAccessExecutionRole-<uuid>`
  (declared drift)
- the function's `Layers` gained `LambdaInsightsExtension:80` (Potential Drift)

Both are correct — they are genuinely absent from the deployed template — but they
are the footprint of **CloudWatch Application Signals / Lambda Insights
auto-instrumentation**, typically enabled at the **account/region level** (a
CloudWatch setting), not a per-resource edit. So the user is confused ("I didn't
touch this"), even though cdkrd is doing exactly its job.

We deliberately do **not** fold this: it adds real cost (Insights billing) and real
permissions (an execution-role policy), so hiding it would be a false negative —
the opposite of the differentiator. Instead we **annotate** it.

## What this adds

- `src/diff/hints.ts` — a pure `findingHint` / `annotateHints` that recognizes the
  Application Signals / Lambda Insights footprint:
  - `AWS::Lambda::Function` `Layers` containing `:layer:LambdaInsightsExtension[-Arm64]:`
  - `AWS::IAM::Role` `ManagedPolicyArns` whose **live-only** entry matches
    `AWSLambdaTracerAccessExecutionRole` or `CloudWatchLambdaInsightsExecutionRolePolicy`
    (only the added entry is inspected — a declared one is intent, not a footprint)
- A new display-only `hint?: string` on `Finding`; rendered as a dim `↳` trailing
  line and carried through `--json`.
- Applied once inside `report()` (the single render chokepoint), so text, `--json`,
  and `--pre-deploy` all get parity. **A hint never changes a tier** — the finding
  stays real drift and still drives the `--fail` exit.

Example:

```
[CFn-Declared Drift: 1] ...
  .../ServiceRole.ManagedPolicyArns (AWS::IAM::Role)
      desired=[...AWSLambdaBasicExecutionRole]
      actual =[...AWSLambdaTracerAccessExecutionRole-c63e...,...BasicExecutionRole]
      ↳ looks like CloudWatch Application Signals / Lambda Insights auto-instrumentation — typically enabled at the account/region level (a CloudWatch setting), not a per-resource edit; declare it in CDK to make it intent, or record/ignore to accept it
```

## Verification

- New `tests/hints.test.ts` — 8 detector cases (layer, Arm64 layer, indexed path,
  tracer policy, insights-policy variant, already-declared → no hint, unrelated
  policy → no hint) + `annotateHints` non-mutation + a report-render test asserting
  the `↳` line shows and the finding is still counted as drift (`code === 1`).
- Docs: DESIGN.md `report` stage + README.md "how to read the report" updated.
- `vp run typecheck` / `vp check` / `vp pack` — pass.
- `vp test run` — 47 files, **2649 tests pass**.
