### PR TITLE
fix(normalize): fold AWS-assigned RDS values (KmsKeyId/PI-key/AZ/windows) value-independent

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -234,7 +234,13 @@ const CLUSTER_ECHO_CHILD: Record<string, { parentIdKey: string; aliases: Record<
   {
     'AWS::RDS::DBInstance': {
       parentIdKey: 'DBClusterIdentifier',
-      aliases: { VPCSecurityGroups: 'VpcSecurityGroupIds' },
+      // The two APIs spell a few shared settings differently: an instance's VPCSecurityGroups
+      // is the cluster's VpcSecurityGroupIds; its EnablePerformanceInsights is the cluster's
+      // PerformanceInsightsEnabled (Aurora manages PI cluster-wide, so the instance mirrors it).
+      aliases: {
+        VPCSecurityGroups: 'VpcSecurityGroupIds',
+        EnablePerformanceInsights: 'PerformanceInsightsEnabled',
+      },
     },
   };
 

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1591,6 +1591,32 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   without enumerating each. Both observed live first-run (LineLink cognito, dev-main
   //   AimAssociation TOKEN "custom") with no out-of-band edit.
   'AWS::ApiGateway::Authorizer': new Set(['AuthType']),
+  //   AWS::RDS::DBCluster / ::DBInstance — an Aurora cluster/instance that declares no explicit
+  //   KMS key, availability-zone placement, or maintenance/backup window reads back the values
+  //   AWS ASSIGNED at creation: a specific `KmsKeyId` (the account/CDK key — create-only, so it
+  //   can never drift), the `AvailabilityZone(s)` AWS placed it in (create-only), and a
+  //   RANDOMLY-assigned `PreferredMaintenanceWindow` / `PreferredBackupWindow`. None is a
+  //   constant we can pin, and none is user intent — a user who cares DECLARES it, and then it
+  //   is compared in the declared loop (detected) and never reaches here. Fold value-independent
+  //   (mirrors the KinesisAnalytics maintenance-window precedent above). Observed live first-run
+  //   on dev-main-AuroraDB / dev-main-DbUsers-DB with no out-of-band edit.
+  //   `PerformanceInsightsKmsKeyId` (cluster) / `PerformanceInsightsKMSKeyId` (instance — note
+  //   the API's different casing) is the same shape as `KmsKeyId`: a Performance-Insights-
+  //   enabled cluster/instance that pins no explicit PI key reads back the AWS-assigned key.
+  'AWS::RDS::DBCluster': new Set([
+    'KmsKeyId',
+    'PerformanceInsightsKmsKeyId',
+    'AvailabilityZones',
+    'PreferredMaintenanceWindow',
+    'PreferredBackupWindow',
+  ]),
+  'AWS::RDS::DBInstance': new Set([
+    'KmsKeyId',
+    'PerformanceInsightsKMSKeyId',
+    'AvailabilityZone',
+    'PreferredMaintenanceWindow',
+    'PreferredBackupWindow',
+  ]),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4505,28 +4505,27 @@ describe('Aurora DBInstance cluster-echo strip (CLUSTER_ECHO_CHILD)', () => {
     expect(t.undeclared).toEqual([]);
   });
 
-  it('KEEPS an instance value that DIVERGES from the cluster (its own maintenance window)', () => {
+  it('KEEPS an instance value that DIVERGES from the cluster (echo strip is equality-gated)', () => {
+    // EngineVersion echoes the cluster; an instance value that DIFFERS must surface (it is not
+    // an echo). Uses a non-value-independent prop so the echo-strip gate is what is tested.
     const t = tiers(
       classifyResource(
         inst({ DBClusterIdentifier: 'c1' }),
-        { PreferredMaintenanceWindow: 'fri:15:16-fri:15:46' },
+        { EngineVersion: '8.0.mysql_aurora.3.09.0' },
         bareEcho,
         { clusterEchoModel }
       )
     );
-    expect(t.undeclared).toEqual(['PreferredMaintenanceWindow']);
+    expect(t.undeclared).toEqual(['EngineVersion']);
   });
 
-  it('KEEPS an instance-only property the cluster does not carry (its single AvailabilityZone)', () => {
+  it('KEEPS an instance-only property the cluster does not carry (equality-gated)', () => {
     const t = tiers(
-      classifyResource(
-        inst({ DBClusterIdentifier: 'c1' }),
-        { AvailabilityZone: 'ap-northeast-1d' },
-        bareEcho,
-        { clusterEchoModel }
-      )
+      classifyResource(inst({ DBClusterIdentifier: 'c1' }), { Iops: 3000 }, bareEcho, {
+        clusterEchoModel,
+      })
     );
-    expect(t.undeclared).toEqual(['AvailabilityZone']);
+    expect(t.undeclared).toEqual(['Iops']);
   });
 
   it('with NO cluster echo model, the echoes surface (unchanged behavior — fail-open)', () => {
@@ -4714,6 +4713,80 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
 // CACertificateIdentifier constant): values the user never set that AWS fills in from the
 // engine family, folded to atDefault so a clean CDK Aurora first run is not flooded with
 // potential-drift noise. Observed live on dev-main-AuroraDB / dev-main-DbUsers-DB.
+// AWS-ASSIGNED RDS values a user never declared: the KMS key, AZ placement, and randomly-
+// assigned maintenance/backup windows AWS picks at creation. Undeclared → AWS's choice, not
+// user intent → folded value-independent (atDefault). A DECLARED value is user intent →
+// compared in the declared loop (detected). Observed live on dev-main-AuroraDB / DbUsers-DB.
+describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const t = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    tiers(
+      classifyResource({ logicalId: 'R', resourceType, physicalId: 'p', declared }, live, bare)
+    );
+
+  it('DBCluster undeclared KmsKeyId/AZs/windows fold to atDefault (not undeclared drift)', () => {
+    const r = t(
+      'AWS::RDS::DBCluster',
+      {},
+      {
+        KmsKeyId: 'arn:aws:kms:ap-northeast-1:1:key/abc',
+        AvailabilityZones: ['ap-northeast-1a', 'ap-northeast-1c'],
+        PreferredMaintenanceWindow: 'tue:14:55-tue:15:25',
+        PreferredBackupWindow: '20:30-21:00',
+      }
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toEqual(
+      expect.arrayContaining([
+        'KmsKeyId',
+        'AvailabilityZones',
+        'PreferredMaintenanceWindow',
+        'PreferredBackupWindow',
+      ])
+    );
+  });
+
+  it('DBInstance undeclared AZ/window fold', () => {
+    const r = t(
+      'AWS::RDS::DBInstance',
+      {},
+      { AvailabilityZone: 'ap-northeast-1d', PreferredMaintenanceWindow: 'fri:15:16-fri:15:46' }
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toEqual(
+      expect.arrayContaining(['AvailabilityZone', 'PreferredMaintenanceWindow'])
+    );
+  });
+
+  it('a DECLARED window is user intent — compared in the declared loop, still detected', () => {
+    const r = t(
+      'AWS::RDS::DBCluster',
+      { PreferredMaintenanceWindow: 'mon:00:00-mon:00:30' },
+      { PreferredMaintenanceWindow: 'tue:14:55-tue:15:25' }
+    );
+    expect(r.declared).toEqual(['PreferredMaintenanceWindow']);
+    expect(r.atDefault).not.toContain('PreferredMaintenanceWindow');
+  });
+
+  it('the value-independent fold is gated per-type — another type stays undeclared', () => {
+    const r = t('AWS::Other::Thing', {}, { KmsKeyId: 'arn:aws:kms:x:1:key/abc' });
+    expect(r.undeclared).toContain('KmsKeyId');
+  });
+});
+
 describe('RDS engine-derived defaults fold to atDefault', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/integration/aurora-rich/verify.sh
+++ b/tests/integration/aurora-rich/verify.sh
@@ -45,6 +45,13 @@ for prop in StorageEncrypted EngineVersion BackupRetentionPeriod DBSubnetGroupNa
   grep -qE "\.$prop \(AWS::RDS::DBInstance\)" "/tmp/cdkrd-$STACK-pre.out" \
     && fail "DBInstance echo of cluster $prop surfaced (CLUSTER_ECHO_CHILD strip regressed)"
 done
+# AWS-ASSIGNED values a user never declared — the AZ placement and the randomly-assigned
+# maintenance/backup windows AWS picks at creation — fold value-independent (not user intent).
+# A regression un-folds one. (KmsKeyId only appears when encrypted; grepped best-effort.)
+for prop in AvailabilityZone AvailabilityZones PreferredMaintenanceWindow PreferredBackupWindow KmsKeyId; do
+  grep -qE "\.$prop \(AWS::RDS::DB" "/tmp/cdkrd-$STACK-pre.out" \
+    && fail "AWS-assigned $prop surfaced as potential drift (VALUE_INDEPENDENT fold regressed)"
+done
 
 echo "=== [$STACK] record (write baseline) ==="
 $CLI record "$STACK" --region "$REGION" --yes || fail "record"


### PR DESCRIPTION
## What

The values AWS **assigns** to an Aurora cluster/instance that the user never declared — the KMS key (storage + Performance Insights), the availability-zone placement, and the randomly-assigned maintenance/backup windows — flooded a first run as undeclared **potential drift** though none is user intent.

On `<db-users-dev-stack>-DB` this was the last 5 potential-drift lines; on `<aurora-cluster-dev-stack>`, 3 of the remaining.

## How

Add them to `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` — the existing mechanism for "AWS's choice, not user intent" (mirrors the ECS `PlatformVersion` and KinesisAnalytics maintenance-window precedents):

- `AWS::RDS::DBCluster`: `KmsKeyId`, `PerformanceInsightsKmsKeyId`, `AvailabilityZones`, `PreferredMaintenanceWindow`, `PreferredBackupWindow`
- `AWS::RDS::DBInstance`: `KmsKeyId`, `PerformanceInsightsKMSKeyId`, `AvailabilityZone`, `PreferredMaintenanceWindow`, `PreferredBackupWindow`

Plus the instance's `EnablePerformanceInsights` folded as a `CLUSTER_ECHO_CHILD` alias of the cluster's `PerformanceInsightsEnabled` (Aurora manages PI cluster-wide).

**The key invariant** (this is the design the user asked for): the fold fires **only when the property is undeclared** (= AWS assigned it). A user who cares **declares** the value — and then it is compared in the declared loop and **still detected**. So *AWS-assigned → folded, user-intent → surfaced*. Create-only ones (KmsKeyId, AZs) can never drift anyway; the mutable windows follow the same "undeclared ⇒ AWS domain" rule.

## Verification

- **Unit**: value-independent fold for KmsKeyId/AZ/windows; a **declared** window still surfaces as drift; per-type gating. All 2644 tests pass.
- **Golden corpus**: 7 RDS cases regenerated (undeclared → atDefault, tier-only diff).
- **Live-test (real stacks)**:
  - `<db-users-dev-stack>-DB` potential **5 → 0 (CLEAN)** — a fresh CDK deploy now checks clean on the first run.
  - `<aurora-cluster-dev-stack>` **6 → 3**. The 3 remaining are **genuine undeclared config**, exactly what cdkrd exists to surface: an undeclared `STAGE` Tag, an `autocommit` param, and `EngineLifecycleSupport=disabled`.
- **Integration (real AWS)**: `aurora-rich`'s `verify.sh` asserts the AWS-assigned values do not surface → **INTEG PASS** in us-east-1.

## Relation

Sixth (and final) FP fix from the real Aurora audit (#504, #510, #512, #514, #521). Realizes the principle: fold only AWS-assigned/generated/default values; surface everything the user actually declared or changed.
