### PR TITLE
test(corpus): regenerate stale RDS golden fixtures (fixes red main from #533)

### DIFF
--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.json
@@ -224,7 +224,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "PreferredBackupWindow",
@@ -260,7 +260,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "AvailabilityZones",
@@ -269,7 +269,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
+++ b/tests/corpus/AWS__RDS__DBCluster.ClusterEB0386A7.sv2.json
@@ -231,7 +231,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "PreferredBackupWindow",
@@ -267,7 +267,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "AvailabilityZones",
@@ -276,7 +276,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::RDS::DBCluster",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
@@ -319,7 +319,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
@@ -382,7 +382,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredBackupWindow",
@@ -436,7 +436,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
@@ -319,7 +319,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
@@ -382,7 +382,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredBackupWindow",
@@ -436,7 +436,7 @@
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
@@ -295,7 +295,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
@@ -358,7 +358,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredBackupWindow",
@@ -412,7 +412,7 @@
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
+++ b/tests/corpus/AWS__RDS__DBInstance.DatabaseB269D8BB.json
@@ -329,7 +329,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "KmsKeyId",
@@ -338,7 +338,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
@@ -374,7 +374,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredBackupWindow",
@@ -419,7 +419,7 @@
       "constructPath": "CdkdriftIntegHarvest13/Database"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DatabaseB269D8BB",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.logexports.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.logexports.json
@@ -328,7 +328,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
@@ -364,7 +364,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredBackupWindow",
@@ -409,7 +409,7 @@
       "constructPath": "CdkRealDriftIntegRdsLogexportsReorder/Db"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Db5D02A0A9",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",


### PR DESCRIPTION
## Problem

`main` (c321d8c) ships **7 failing golden-corpus cases** — the suite is red:

```
FAIL tests/corpus-replay.test.ts > AWS__RDS__DBInstance.DatabaseB269D8BB.json (+6 more RDS)
  expected 'atDefault' to deeply equal 'undeclared'
```

PR #533 added a value-independent fold for AWS-assigned RDS values (KmsKeyId / PI
key / AvailabilityZone / Preferred*Window) but did **not** regenerate the golden
fixtures that exercise those paths, so their `expected` still says `undeclared`
where the fold now (correctly) yields `atDefault`.

## Fix

Regenerated the 7 affected RDS fixtures by replaying `classifyResource` over their
recorded inputs (the golden-replay pipeline is pure). The diff is **exactly 22
`undeclared → atDefault` tier flips** on the folded AWS-assigned paths — no other
changes, no logic change. This just makes #533's intended behavior visible in the
golden corpus, which is where a fold's effect is meant to be reviewed.

## Verification

- `vp run typecheck` / `vp check` (0 errors) / `vp pack` — pass
- `vp test run` — 47 files, **2653 tests pass** (was 7 failing on main)