### PR TITLE
fix(normalize): scope Cognito ClientName generated-name fold (drop value-independent over-fold)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -57,8 +57,10 @@ import {
   CONTEXT_DEFAULTS,
   DEFAULT_MANAGED_NAME_PATHS,
   ENGINE_DEFAULTS,
+  GENERATED_LOGICALID_PREFIX_PATHS,
   GENERATED_NESTED_PATHS,
   GENERATED_TOPLEVEL_PATHS,
+  isLogicalIdPrefixedGeneratedName,
   EPOCH_HOUR_PATHS,
   IDENTITY_KEYED_DEFAULT_ELEMENTS,
   isEpochHourEqual,
@@ -1720,6 +1722,17 @@ export function classifyResource(
     // undeclared value (the differentiator): the value must start with THIS stack's name AND
     // end with CFn's random suffix — a user-chosen name realistically never matches both.
     if (isCfnGeneratedName(v, resource.constructPath, physicalId, logicalId)) {
+      findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
+      continue;
+    }
+    // A curated `<logicalId>-<random>` generated-name form (no `<stack>-` prefix) that the
+    // isCfnGeneratedName branches miss — scoped by type+path to avoid over-folding a short
+    // raw-CFn logical id's genuine undeclared names (GENERATED_LOGICALID_PREFIX_PATHS). Value-
+    // dependent: an undeclared user-SET name (no logical-id prefix) still surfaces as drift.
+    if (
+      GENERATED_LOGICALID_PREFIX_PATHS[resourceType]?.has(k) &&
+      isLogicalIdPrefixedGeneratedName(v, logicalId)
+    ) {
       findings.push({ tier: 'generated', logicalId, resourceType, path: k, actual: v });
       continue;
     }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1528,12 +1528,40 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
   // value-independent GENERATED_TOPLEVEL_PATHS entry would additionally fold an undeclared
   // user-set LayerName (e.g. "my-custom-layer") that is NOT the logical id, hiding real
   // undeclared drift — the exact differentiator cdkrd exists to surface.
-  // A UserPoolClient whose ClientName the template omits reads back a CloudFormation-generated
-  // name (`<logicalId>-<random>` — NO stack prefix, so isCfnGeneratedName misses it). It is
-  // the AWS-minted identity, not user intent; a client that DECLARES a ClientName carries it
-  // in the template and never reaches this loop. Observed live.
+  // NOTE: AWS::Cognito::UserPoolClient.ClientName is NOT folded here either. Its generated
+  // form is `<logicalId>-<random>` (no stack prefix), now folded value-DEPENDENTLY via
+  // GENERATED_LOGICALID_PREFIX_PATHS below. A value-independent entry would additionally
+  // fold an undeclared user-set ClientName that is NOT the logical-id form, hiding real
+  // undeclared drift.
+};
+
+// Value-DEPENDENT generated-name fold, scoped by type + top-level path. Folds a live value
+// to `generated` ONLY when it is the `<logicalId>-<random>` CFn auto-generated form — the
+// resource's logical id, a `-`, then CFn's 12+ char random suffix — for a type whose
+// no-explicit-name physical name takes that shape WITHOUT a `<stack>-` prefix (so the
+// isCfnGeneratedName stack-prefix branches miss it). UNLIKE the value-independent
+// GENERATED_TOPLEVEL_PATHS, an undeclared user-SET name (no logical-id prefix) does NOT match
+// and still surfaces as real drift. Deliberately NOT applied generically in
+// isCfnGeneratedName: a short raw-CFn logical id (e.g. a WAFv2 RegexPatternSet's `RegexSet`)
+// carries no construct hash, so `<logicalId>-<random>` would coincide with genuine undeclared
+// names and over-fold — this table gates it to the specific types/paths observed to need it.
+//   AWS::Cognito::UserPoolClient.ClientName — reads back `<logicalId>-<random>` when the
+//   template declares no ClientName (observed live).
+export const GENERATED_LOGICALID_PREFIX_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Cognito::UserPoolClient': new Set(['ClientName']),
 };
+
+// True when `value` is the `<logicalId>-<random>` CFn auto-generated-name form: the logical
+// id, a `-`, then CFn's random suffix. Consulted only for GENERATED_LOGICALID_PREFIX_PATHS
+// entries. Pure + exported for unit tests.
+const CFN_LOGICALID_RANDOM = /-[0-9A-Za-z]{12,}$/;
+export function isLogicalIdPrefixedGeneratedName(value: unknown, logicalId: string): boolean {
+  return (
+    typeof value === 'string' &&
+    value.startsWith(`${logicalId}-`) &&
+    CFN_LOGICALID_RANDOM.test(value)
+  );
+}
 
 // Like GENERATED_TOPLEVEL_PATHS but for NESTED, value-INDEPENDENT paths (dotted, `*` for
 // array crossings) — a sub-key AWS/CloudFormation injects that the template never declares

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -7983,15 +7983,32 @@ describe('Face-stack false-positive folds', () => {
     );
     expect(layer.generated).toEqual(['LayerName']);
     expect(layer.undeclared).toEqual([]);
+    // A UserPoolClient with no explicit ClientName reads back `<logicalId>-<random>` (no
+    // stack prefix); it folds via isCfnGeneratedName's `<logicalId>-<random>` branch — NOT a
+    // value-independent ClientName fold, which would also hide an undeclared user-set name.
+    const clientResource = {
+      logicalId: 'AuthUserPoolUserPoolClientBB863FCC',
+      resourceType: 'AWS::Cognito::UserPoolClient',
+      physicalId: '3n4b5c6d7e8f9g0h1i2j3k4l5m',
+      constructPath: 'Stack/Auth/UserPool/UserPoolClient',
+      declared: {},
+    };
     const client = tiers(
       classifyResource(
-        res('AWS::Cognito::UserPoolClient', {}),
+        clientResource,
         { ClientName: 'AuthUserPoolUserPoolClientBB863FCC-qWmhWWbfzd1Q' },
         emptySchema
       )
     );
     expect(client.generated).toEqual(['ClientName']);
     expect(client.undeclared).toEqual([]);
+    // A user-SET ClientName (no logical-id prefix) is NOT folded — it surfaces as real
+    // undeclared drift, the differentiator cdkrd exists to catch.
+    const userSet = tiers(
+      classifyResource(clientResource, { ClientName: 'my-app-web-client' }, emptySchema)
+    );
+    expect(userSet.undeclared).toEqual(['ClientName']);
+    expect(userSet.generated).toEqual([]);
   });
 
   it('WAF WebACL ByteMatch SearchStringBase64 echo folds; a changed pattern is real drift', () => {


### PR DESCRIPTION
## Problem

`GENERATED_TOPLEVEL_PATHS['AWS::Cognito::UserPoolClient'] = {'ClientName'}` folded
`ClientName` **value-independently** — any undeclared ClientName became `generated`,
hiding an undeclared **user-set** ClientName. Same over-fold class as the
LayerVersion `LayerName` entry removed in #525: it defeats the differentiator (a
console-set name is real undeclared drift).

The reason it was value-independent: the generated form is `<logicalId>-<random>`
(no `<stack>-` prefix), which `isCfnGeneratedName`'s existing branches
(`value === logicalId`, `<stack>-…-<random>`) don't reach.

## Fix — a *precise*, scoped fold

- New `GENERATED_LOGICALID_PREFIX_PATHS` (type → path set) + pure
  `isLogicalIdPrefixedGeneratedName(value, logicalId)`: folds a value to `generated`
  ONLY when it is the `<logicalId>-<random>` form (logical id, `-`, CFn's 12+ char
  random suffix). An undeclared **user-set** name (no logical-id prefix) no longer
  matches and surfaces as real drift.
- Consulted in classify's undeclared loop right after `isCfnGeneratedName`.
- Removed the value-independent `UserPoolClient.ClientName` entry.

### Why scoped, not a generic `isCfnGeneratedName` branch

I first tried a generic `<logicalId>-<random>` branch in `isCfnGeneratedName`. It
**over-folded 14 corpus cases** (WAFv2 RegexPatternSet `Name` = `RegexSet-CTQHtT5iegpr`,
RDS, …): a short **raw-CFn** logical id (`RegexSet`) carries no construct hash, so
`<logicalId>-<random>` collides with genuine undeclared names. Gating by type+path
(only where the shape is observed and safe — CDK logical ids there carry an 8-hex
construct hash) confines the fold.

## Verification

- `tests/classify.test.ts`: the generated `<logicalId>-<random>` ClientName folds to
  `generated`; a user-set `my-app-web-client` stays `undeclared` (new assertion).
- `vp run typecheck` / `vp check` (0 errors) / `vp pack` — pass.
- `vp test run` — 47 files, **2653 tests pass** (WAFv2/RDS corpus unaffected).
