### PR TITLE
fix(normalize): fold RDS EngineLifecycleSupport value-independent (+ regen drifted RDS corpus)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -551,7 +551,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     AutoMinorVersionUpgrade: true,
     BackupTarget: 'region',
     DatabaseInsightsMode: 'standard',
-    EngineLifecycleSupport: 'open-source-rds-extended-support',
+    // EngineLifecycleSupport is NOT a constant default — AWS changed the enrollment default over
+    // time (RDS Extended Support opt-in behavior changed 2024-02/03: newer resources default to
+    // `open-source-rds-extended-support` / auto-enroll, older ones read back
+    // `open-source-rds-extended-support-disabled`), so it varies by creation date. Folded
+    // value-independent via VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS instead (declared → detected).
     MonitoringInterval: 0,
     NetworkType: 'IPV4',
     StorageThroughput: 0,
@@ -576,7 +580,8 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::RDS::DBCluster': {
     AutoMinorVersionUpgrade: true,
     DatabaseInsightsMode: 'standard',
-    EngineLifecycleSupport: 'open-source-rds-extended-support',
+    // EngineLifecycleSupport folds value-independent (see the DBInstance note above) — its
+    // default varies by creation date, so it is not a constant KNOWN_DEFAULTS value.
     NetworkType: 'IPV4',
     EngineMode: 'provisioned', // default; serverless/parallelquery are explicit opt-ins
   },
@@ -1603,12 +1608,22 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   `PerformanceInsightsKmsKeyId` (cluster) / `PerformanceInsightsKMSKeyId` (instance — note
   //   the API's different casing) is the same shape as `KmsKeyId`: a Performance-Insights-
   //   enabled cluster/instance that pins no explicit PI key reads back the AWS-assigned key.
+  //   `EngineLifecycleSupport` — the RDS Extended Support enrollment default CHANGED over time
+  //   (opt-in behavior changed 2024-02/03: newer resources auto-enroll to
+  //   `open-source-rds-extended-support`, older ones read back
+  //   `open-source-rds-extended-support-disabled`). So the undeclared default varies by creation
+  //   date — AWS's choice, not user intent — and a constant KNOWN_DEFAULTS cannot fold both forms.
+  //   A user who cares about the enrollment (its billing / EOL implications) DECLARES it, and then
+  //   it is compared in the declared loop (detected). Observed live: fresh corpus deploys read
+  //   "open-source-rds-extended-support"; the older cdk-imported dev-main-AuroraDB reads
+  //   "open-source-rds-extended-support-disabled".
   'AWS::RDS::DBCluster': new Set([
     'KmsKeyId',
     'PerformanceInsightsKmsKeyId',
     'AvailabilityZones',
     'PreferredMaintenanceWindow',
     'PreferredBackupWindow',
+    'EngineLifecycleSupport',
   ]),
   'AWS::RDS::DBInstance': new Set([
     'KmsKeyId',
@@ -1616,6 +1631,7 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'AvailabilityZone',
     'PreferredMaintenanceWindow',
     'PreferredBackupWindow',
+    'EngineLifecycleSupport',
   ]),
 };
 

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4781,6 +4781,33 @@ describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)',
     expect(r.atDefault).not.toContain('PreferredMaintenanceWindow');
   });
 
+  it('EngineLifecycleSupport folds value-independent — BOTH the enabled and disabled defaults', () => {
+    // The default varies by creation date (RDS Extended Support opt-in changed 2024) — newer
+    // deploys read "…support", the older imported AuroraDB reads "…support-disabled". Both are
+    // AWS's choice, not user intent, so both fold.
+    for (const v of [
+      'open-source-rds-extended-support',
+      'open-source-rds-extended-support-disabled',
+    ]) {
+      expect(t('AWS::RDS::DBCluster', {}, { EngineLifecycleSupport: v }).atDefault).toContain(
+        'EngineLifecycleSupport'
+      );
+      expect(t('AWS::RDS::DBInstance', {}, { EngineLifecycleSupport: v }).atDefault).toContain(
+        'EngineLifecycleSupport'
+      );
+    }
+  });
+
+  it('a DECLARED EngineLifecycleSupport is user intent — still compared/detected', () => {
+    const r = t(
+      'AWS::RDS::DBCluster',
+      { EngineLifecycleSupport: 'open-source-rds-extended-support' },
+      { EngineLifecycleSupport: 'open-source-rds-extended-support-disabled' }
+    );
+    expect(r.declared).toEqual(['EngineLifecycleSupport']);
+    expect(r.atDefault).not.toContain('EngineLifecycleSupport');
+  });
+
   it('the value-independent fold is gated per-type — another type stays undeclared', () => {
     const r = t('AWS::Other::Thing', {}, { KmsKeyId: 'arn:aws:kms:x:1:key/abc' });
     expect(r.undeclared).toContain('KmsKeyId');

--- a/tests/integration/aurora-rich/verify.sh
+++ b/tests/integration/aurora-rich/verify.sh
@@ -45,10 +45,11 @@ for prop in StorageEncrypted EngineVersion BackupRetentionPeriod DBSubnetGroupNa
   grep -qE "\.$prop \(AWS::RDS::DBInstance\)" "/tmp/cdkrd-$STACK-pre.out" \
     && fail "DBInstance echo of cluster $prop surfaced (CLUSTER_ECHO_CHILD strip regressed)"
 done
-# AWS-ASSIGNED values a user never declared — the AZ placement and the randomly-assigned
-# maintenance/backup windows AWS picks at creation — fold value-independent (not user intent).
-# A regression un-folds one. (KmsKeyId only appears when encrypted; grepped best-effort.)
-for prop in AvailabilityZone AvailabilityZones PreferredMaintenanceWindow PreferredBackupWindow KmsKeyId; do
+# AWS-ASSIGNED values a user never declared — the AZ placement, the randomly-assigned
+# maintenance/backup windows, and the RDS Extended Support enrollment (EngineLifecycleSupport,
+# whose default varies by creation date) — fold value-independent (not user intent). A
+# regression un-folds one. (KmsKeyId only appears when encrypted; grepped best-effort.)
+for prop in AvailabilityZone AvailabilityZones PreferredMaintenanceWindow PreferredBackupWindow KmsKeyId EngineLifecycleSupport; do
   grep -qE "\.$prop \(AWS::RDS::DB" "/tmp/cdkrd-$STACK-pre.out" \
     && fail "AWS-assigned $prop surfaced as potential drift (VALUE_INDEPENDENT fold regressed)"
 done

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -641,7 +641,7 @@ describe('noise suppressors', () => {
       AutoMinorVersionUpgrade: true,
       BackupTarget: 'region',
       DatabaseInsightsMode: 'standard',
-      EngineLifecycleSupport: 'open-source-rds-extended-support',
+      // EngineLifecycleSupport moved to VALUE_INDEPENDENT (default varies by creation date).
       MonitoringInterval: 0,
       NetworkType: 'IPV4',
       StorageThroughput: 0,


### PR DESCRIPTION
## What

`EngineLifecycleSupport` (RDS Extended Support enrollment) was folded via a **constant** `KNOWN_DEFAULTS` value `open-source-rds-extended-support`. But the default **changed over time** — AWS's own announcement confirms the opt-in behavior changed **2024-02/03**: newer resources auto-enroll to `open-source-rds-extended-support`, while older ones read back `open-source-rds-extended-support-disabled`. So the undeclared default **varies by creation date**, and a single constant can't fold both forms — the older `cdk import`-ed `<aurora-cluster-dev-stack>` (which reads `…-disabled`) false-surfaced it.

## How

Move `EngineLifecycleSupport` from `KNOWN_DEFAULTS` (constant) to `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` for `AWS::RDS::DBCluster` + `AWS::RDS::DBInstance` — folded regardless of value **when undeclared** (AWS's choice, not user intent). A user who cares about the enrollment (billing / EOL implications) **declares** it → compared in the declared loop → still detected. Same pattern as ECS `PlatformVersion` ("varies by creation date").

## Also: fixes a corpus drift on `main`

While regenerating, found the 7 RDS golden-corpus cases were **out of sync with #533's code** on `main` — #533's `AvailabilityZones` / windows / `KmsKeyId` value-independent folds landed in `noise.ts`, but the corpus regen did not reach `main` (a parallel session's corpus reformat reverted the tiers), so `corpus-replay` was **red on main** (CI is billing-disabled, so it wasn't caught). This PR regenerates all 7, restoring consistency. **All 2655 tests pass.**

## Verification

- **Unit**: both `…support` and `…support-disabled` fold value-independent; a **declared** value still surfaces; per-type gating.
- **Sourced**: verified the default-changed-over-time claim against AWS docs ([opt-in-behavior-changing announcement](https://repost.aws/articles/ARHdQg4IelQS2uyXkNrINw-A/announcement-amazon-rds-extended-support-opt-in-behavior-is-changing-upgrade-your-amazon-rds-for-mysql-5-7-database-instances-before-february-29-2024-to-avoid-potential-increase-in-charges), [auto-enrollment blog](https://aws.amazon.com/blogs/aws/your-mysql-5-7-and-postgresql-11-databases-will-be-automatically-enrolled-into-amazon-rds-extended-support/)).
- **Live-test**: `<aurora-cluster-dev-stack>` potential **3 → 2** (`…-disabled` now folds). The 2 remaining are **genuine** — an `autocommit` param and an out-of-band `STAGE` Tag. `<db-users-dev-stack>-DB` stays **CLEAN**.
- **Integration (real AWS)**: `aurora-rich` asserts `EngineLifecycleSupport` does not surface → **INTEG PASS** in us-east-1.

## Relation

Follow-up to the Aurora audit series (#504/#510/#512/#514/#521/#533). Also verified separately that the folded RDS `KmsKeyId` is genuinely AWS-assigned: `KeyManager=AWS`, `alias/aws/rds` (the default RDS key), so #533's `KmsKeyId` fold is correct.
