### PR TITLE
feat(check): surface multi-stack progress [i/N] in report header + interactive prompt, announce total up front

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -27,7 +27,12 @@ import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
-import { gatherWithProgress, progressLabel } from './progress.js';
+import {
+  gatherWithProgress,
+  positionPrefix,
+  progressLabel,
+  stackCountAnnouncement,
+} from './progress.js';
 import { resolveInteractively } from './interactive-resolve.js';
 
 // --pre-deploy reports declared-side drift the next deploy would clobber; the
@@ -186,6 +191,16 @@ export async function runCheck(args: string[]): Promise<number> {
     return 0;
   }
 
+  // Announce the total up front (issue #539): in a multi-stack run each stack prints its
+  // report + interactive prompt one at a time, so without this the count only ever shows
+  // embedded in the scrolled-away `[i/N]` spinner line. To stderr (never pollutes --json
+  // stdout) and suppressed under --json; a lone stack gets nothing (stackCountAnnouncement
+  // returns null — consistent with the `[1/1]`-is-noise rule).
+  if (!a.json) {
+    const announce = stackCountAnnouncement(stacks.map((s) => s.stackName));
+    if (announce) console.error(announce);
+  }
+
   // --pre-deploy: synth the local app once and use each stack's synth template as
   // the declared source, so check reports the declared drift the next deploy would
   // overwrite (clobber) rather than comparing against the already-deployed template.
@@ -227,6 +242,11 @@ export async function runCheck(args: string[]): Promise<number> {
       worst = Math.max(worst, 2);
       continue;
     }
+    // The `[i/N] ` position cue (issue #539) — same gating as the spinner label: only in
+    // a multi-stack text run, '' for a lone stack or --json. Threaded into the report
+    // header and the interactive prompt so the cue is present where the user reads/decides,
+    // not only on the scrolled-away spinner line.
+    const posPrefix = a.json ? '' : positionPrefix(idx, stacks.length);
     try {
       const sKey = synthKey(stackName, region);
       if (synthTemplates && !synthTemplates.has(sKey)) {
@@ -302,7 +322,7 @@ export async function runCheck(args: string[]): Promise<number> {
         if (!a.json) separate();
         const preDeployCode = report(
           applyIgnores(declaredOnly, { stackName, accountId: desired.accountId, region }, config),
-          `${stackName} (${region})`,
+          `${posPrefix}${stackName} (${region})`,
           {
             json: a.json,
             verbose: a.verbose,
@@ -365,7 +385,7 @@ export async function runCheck(args: string[]): Promise<number> {
         config
       );
       if (!a.json) separate();
-      let code = report(reconciled, `${stackName} (${region})`, {
+      let code = report(reconciled, `${posPrefix}${stackName} (${region})`, {
         json: a.json,
         verbose: a.verbose,
         // --show-all is inventory mode: list every undeclared value, including the
@@ -405,6 +425,7 @@ export async function runCheck(args: string[]): Promise<number> {
           yes: a.yes,
           removeUnrecorded: a.removeUnrecorded,
           verbose: a.verbose,
+          positionPrefix: posPrefix,
         });
       } else if (!baseline && !hasUnrecorded && !a.json && !a.showAll && !a.preDeploy) {
         // R142: no interactive establish prompt could fire (non-TTY, or --fail) and there is

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -53,6 +53,7 @@ export interface ResolveParams {
   yes: boolean;
   removeUnrecorded: boolean;
   verbose: boolean;
+  positionPrefix?: string; // `[2/3] ` in a multi-stack run, '' otherwise (issue #539)
 }
 
 /**
@@ -279,13 +280,19 @@ export function buildResolveOptions(
 }
 
 /** The top-menu prompt, worded by the remaining exit state (drift vs unrecorded-only vs
- *  R141 no-baseline establish). Pure + exported. */
-export function resolveMenuMessage(stackName: string, code: number, establishOnly = false): string {
+ *  R141 no-baseline establish). `prefix` carries the `[2/3] ` multi-stack position cue
+ *  (issue #539) — empty for a lone stack. Pure + exported. */
+export function resolveMenuMessage(
+  stackName: string,
+  code: number,
+  establishOnly = false,
+  prefix = ''
+): string {
   if (establishOnly)
-    return `${stackName}: no .cdkrd baseline yet — record the current state as your baseline?`;
+    return `${prefix}${stackName}: no .cdkrd baseline yet — record the current state as your baseline?`;
   return code === 1
-    ? `${stackName}: drift found — what do you want to do?`
-    : `${stackName}: potential drift found (live-only, no baseline yet) — what do you want to do?`;
+    ? `${prefix}${stackName}: drift found — what do you want to do?`
+    : `${prefix}${stackName}: potential drift found (live-only, no baseline yet) — what do you want to do?`;
 }
 
 export async function resolveInteractively(p: ResolveParams): Promise<number> {
@@ -331,7 +338,7 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
     const options = buildResolveOptions(actions, decidable.length, recordLabel);
 
     const choice = await select({
-      message: resolveMenuMessage(p.stackName, code, establishOnly),
+      message: resolveMenuMessage(p.stackName, code, establishOnly, p.positionPrefix ?? ''),
       options,
       initialValue: 'nothing',
     });

--- a/src/commands/progress.ts
+++ b/src/commands/progress.ts
@@ -31,15 +31,32 @@ export async function gatherWithProgress<T>(
   }
 }
 
+// The `[2/3] ` position cue shared by the spinner label, the report header, and the
+// interactive resolve prompt (issue #539) so all three agree on "which stack of how
+// many". Empty for a lone stack (a bare `[1/1]` is noise). `idx` is the 0-based
+// position, `total` the number of stacks being processed. Pure + exported for tests.
+export function positionPrefix(idx: number, total: number): string {
+  return total > 1 ? `[${idx + 1}/${total}] ` : '';
+}
+
 // The per-stack spinner label: `[2/3] Stack (region)` in a multi-stack run, or just
-// `Stack (region)` for a lone stack (a bare `[1/1]` is noise). `idx` is the 0-based
-// position, `total` the number of stacks being processed.
+// `Stack (region)` for a lone stack. `idx` is the 0-based position, `total` the number
+// of stacks being processed.
 export function progressLabel(
   idx: number,
   total: number,
   stackName: string,
   region: string
 ): string {
-  const prefix = total > 1 ? `[${idx + 1}/${total}] ` : '';
-  return `${prefix}${stackName} (${region})`;
+  return `${positionPrefix(idx, total)}${stackName} (${region})`;
+}
+
+// The up-front "checking N stacks" announcement (issue #539): emitted once before the
+// per-stack loop so the user knows the total (and which stacks) at the start, not only
+// embedded inside the scrolled-away `[i/N]` spinner line. Only meaningful with >1 stack
+// — a lone stack returns null (consistent with the `[1/1]`-is-noise rule). Pure +
+// exported for tests; the caller gates on `--json` (stderr must not pollute JSON stdout).
+export function stackCountAnnouncement(stackNames: string[]): string | null {
+  if (stackNames.length <= 1) return null;
+  return `note: checking ${stackNames.length} stack(s): ${stackNames.join(', ')}`;
 }

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -182,6 +182,22 @@ describe('resolveMenuMessage (R133 — worded by remaining exit state)', () => {
   it('R141: establishOnly says "no .cdkrd baseline yet"', () => {
     expect(resolveMenuMessage('S', 0, true)).toContain('no .cdkrd baseline yet');
   });
+
+  // issue #539: the multi-stack [i/N] position cue is carried into the interactive prompt.
+  it('prefixes the [i/N] position cue before the stack name (drift)', () => {
+    expect(resolveMenuMessage('S', 1, false, '[2/3] ')).toBe(
+      '[2/3] S: drift found — what do you want to do?'
+    );
+  });
+  it('prefixes the [i/N] cue for the potential-drift and establish wordings too', () => {
+    expect(resolveMenuMessage('S', 0, false, '[2/3] ')).toMatch(
+      /^\[2\/3\] S: potential drift found/
+    );
+    expect(resolveMenuMessage('S', 0, true, '[2/3] ')).toMatch(/^\[2\/3\] S: no \.cdkrd baseline/);
+  });
+  it('adds nothing when the prefix is empty (lone stack — default)', () => {
+    expect(resolveMenuMessage('S', 1)).toBe('S: drift found — what do you want to do?');
+  });
 });
 
 describe('finalCheckExit (R53 — report-only by default, --fail opts into exit 1)', () => {

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -10,7 +10,12 @@ vi.mock('@clack/prompts', async (importOriginal) => {
   return { ...actual, spinner: () => ({ start, stop, error, message: vi.fn() }) };
 });
 
-import { gatherWithProgress, progressLabel } from '../src/commands/progress.js';
+import {
+  gatherWithProgress,
+  positionPrefix,
+  progressLabel,
+  stackCountAnnouncement,
+} from '../src/commands/progress.js';
 
 // gatherWithProgress is generic and only forwards its run() result — a sentinel object
 // is enough to assert pass-through.
@@ -63,5 +68,35 @@ describe('progressLabel', () => {
   it('prefixes a 1-based [idx/total] counter in a multi-stack run', () => {
     expect(progressLabel(0, 3, 'A', 'ap-northeast-1')).toBe('[1/3] A (ap-northeast-1)');
     expect(progressLabel(2, 3, 'C', 'ap-northeast-1')).toBe('[3/3] C (ap-northeast-1)');
+  });
+});
+
+describe('positionPrefix (issue #539 — the [i/N] cue shared by spinner/header/prompt)', () => {
+  it('is empty for a lone stack (a bare [1/1] is noise)', () => {
+    expect(positionPrefix(0, 1)).toBe('');
+  });
+
+  it('is a 1-based [idx/total] with a trailing space in a multi-stack run', () => {
+    expect(positionPrefix(0, 3)).toBe('[1/3] ');
+    expect(positionPrefix(1, 3)).toBe('[2/3] ');
+    expect(positionPrefix(2, 3)).toBe('[3/3] ');
+  });
+
+  it('agrees with the spinner label prefix (all three cues stay consistent)', () => {
+    expect(`${positionPrefix(1, 3)}S (r)`).toBe(progressLabel(1, 3, 'S', 'r'));
+  });
+});
+
+describe('stackCountAnnouncement (issue #539 — up-front total)', () => {
+  it('is null for a lone stack (nothing to announce)', () => {
+    expect(stackCountAnnouncement(['Only'])).toBeNull();
+  });
+
+  it('is null for zero stacks', () => {
+    expect(stackCountAnnouncement([])).toBeNull();
+  });
+
+  it('lists the count and names for a multi-stack run', () => {
+    expect(stackCountAnnouncement(['A', 'B', 'C'])).toBe('note: checking 3 stack(s): A, B, C');
   });
 });


### PR DESCRIPTION
## Summary

Closes #539. In a multi-stack `check` run cdkrd processes stacks one at a time — each prints its report then opens the interactive resolve prompt before moving on — so the "which stack of how many" cue lived **only** on the gather-phase spinner line, scrolled away by the time the user is reading a report or deciding at the menu. There was also no up-front total-count announcement.

## Changes

- **`positionPrefix(idx, total)`** (`src/commands/progress.ts`) — extracted the shared `[i/N] ` cue out of `progressLabel`, so the spinner label, report header, and interactive prompt all agree. Empty for a lone stack (a bare `[1/1]` is noise).
- **`stackCountAnnouncement(names)`** — a one-line `note: checking N stack(s): A, B, C` emitted once before the per-stack loop (stderr, suppressed under `--json`, `null`/nothing for a single stack).
- **Report header** now carries the prefix — `[2/3] MyStack (us-east-1)` — on both the normal and `--pre-deploy` `report(...)` calls. Never prefixed under `--json` (`posPrefix` is forced to `''`), so machine stdout is unchanged.
- **`resolveMenuMessage`** gains an optional `prefix` param → `[2/3] MyStack: drift found — what do you want to do?`, threaded via a new optional `ResolveParams.positionPrefix`.

## Acceptance

- ✅ A 3-stack TTY run prints `checking 3 stack(s): …` up front, and every report header + interactive prompt shows `[i/3]`.
- ✅ A single-stack run shows none of the above (no count line, no `[1/1]` prefix) — `positionPrefix` returns `''`, `stackCountAnnouncement` returns `null`. The single-stack README example stays accurate (change is a no-op there).
- ✅ `--json` unchanged: no prefix on the header, no stderr count line pollutes stdout.
- ✅ Unit tests: `positionPrefix` gating + spinner-consistency, `stackCountAnnouncement` (0/1/N), and the prefixed `resolveMenuMessage` wordings (drift / potential-drift / establish).

## Checks

typecheck ✅ · lint+format ✅ · build ✅ · unit tests 2664 ✅
