### PR TITLE
fix(normalize): fold CodePipeline V2 Git trigger filter set reorder (branch/path/tag globs)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1573,6 +1573,10 @@ export function classifyResource(
       // table needed, FN-safe).
       if (
         (UNORDERED_ARRAY_PROPS[resourceType]?.has(d.path) ||
+          // A `*` in a table entry matches an array index: numeric path segments are
+          // normalized to `*` before the lookup (e.g. a CodePipeline trigger filter
+          // `Triggers.0.GitConfiguration.Push.0.Branches.Includes` -> `Triggers.*.…Push.*.…`).
+          UNORDERED_ARRAY_PROPS[resourceType]?.has(d.path.replace(/\.\d+(?=\.|$)/g, '.*')) ||
           schema.unorderedScalarPaths?.includes(d.path)) &&
         isEqualUnorderedScalarSet(d.stateValue, d.awsValue)
       )

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2835,6 +2835,29 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
   'AWS::RDS::DBCluster': new Set(['EnableCloudwatchLogsExports']),
   'AWS::Neptune::DBCluster': new Set(['EnableCloudwatchLogsExports']),
   'AWS::DocDB::DBCluster': new Set(['EnableCloudwatchLogsExports']),
+  // Live-observed on a fresh codepipeline-triggers deploy: a V2 pipeline's Git trigger
+  // filter lists — the Branches / FilePaths / Tags Includes/Excludes glob sets and the
+  // PullRequest Events enum set — are declared in the CFn schema as `uniqueItems: true`
+  // arrays WITHOUT `insertionOrder: false`, so the schema-driven `unorderedScalarPaths`
+  // fold does NOT cover them. CodePipeline stores them as SETS: an out-of-band reorder of
+  // an identical branch/path/tag list (or a console edit that re-canonicalizes them) reads
+  // back in a different order, which a positional compare false-drifts (declared `Includes`
+  // [release/*, main, develop] vs live [develop, release/*, main]). A genuine glob
+  // add/remove still changes the multiset. Keyed with `*` wildcards (Triggers[] and Push[]/
+  // PullRequest[] are arrays); the classify lookup normalizes numeric segments to `*`.
+  'AWS::CodePipeline::Pipeline': new Set([
+    'Triggers.*.GitConfiguration.Push.*.Branches.Includes',
+    'Triggers.*.GitConfiguration.Push.*.Branches.Excludes',
+    'Triggers.*.GitConfiguration.Push.*.FilePaths.Includes',
+    'Triggers.*.GitConfiguration.Push.*.FilePaths.Excludes',
+    'Triggers.*.GitConfiguration.Push.*.Tags.Includes',
+    'Triggers.*.GitConfiguration.Push.*.Tags.Excludes',
+    'Triggers.*.GitConfiguration.PullRequest.*.Branches.Includes',
+    'Triggers.*.GitConfiguration.PullRequest.*.Branches.Excludes',
+    'Triggers.*.GitConfiguration.PullRequest.*.FilePaths.Includes',
+    'Triggers.*.GitConfiguration.PullRequest.*.FilePaths.Excludes',
+    'Triggers.*.GitConfiguration.PullRequest.*.Events',
+  ]),
 };
 
 // True when both values are scalar arrays containing the same multiset of

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1179,6 +1179,48 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['AutoRollbackConfiguration.Events']);
     });
 
+    // Live-observed FP (codepipeline-triggers fixture): a V2 pipeline's Git trigger
+    // filter lists (Branches/FilePaths Includes/Excludes) are `uniqueItems: true` sets the
+    // CFn schema does NOT mark insertionOrder:false, so they need a per-type UNORDERED entry.
+    // The path is under TWO array indices (Triggers[] and Push[]), so this also pins the
+    // numeric-index -> `*` wildcard normalization in the classify lookup.
+    it('UNORDERED_ARRAY_PROPS: CodePipeline trigger Branches.Includes reorder (nested under array indices) is NOT drift', () => {
+      const pipe = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Pipeline',
+        resourceType: 'AWS::CodePipeline::Pipeline',
+        physicalId: 'cdkrd-triggers-pipeline',
+        declared,
+      });
+      const withBranches = (includes: string[]): Record<string, unknown> => ({
+        Triggers: [
+          {
+            GitConfiguration: {
+              SourceActionName: 'GitHubSource',
+              Push: [{ Branches: { Includes: includes, Excludes: ['hotfix/*'] } }],
+            },
+          },
+        ],
+      });
+      // same branch-glob set, reordered (CodePipeline stores it as a set) -> no drift
+      expect(
+        classifyResource(
+          pipe(withBranches(['release/*', 'main', 'develop'])),
+          withBranches(['develop', 'release/*', 'main']),
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine glob add/remove still changes the multiset -> reports the nested path
+      expect(
+        tiers(
+          classifyResource(
+            pipe(withBranches(['release/*', 'main', 'develop'])),
+            withBranches(['release/*', 'main']),
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['Triggers.0.GitConfiguration.Push.0.Branches.Includes']);
+    });
+
     // Schema-driven fold (insertionOrder:false): ECS marks RequiresCompatibilities
     // insertionOrder:false, so the launch-type set AWS sorts alphabetically (declared
     // [FARGATE, EC2] read back [EC2, FARGATE]) folds from the schema — no per-type entry.

--- a/tests/corpus/AWS__CodeBuild__Project.Proj26959B7F.envcache.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Proj26959B7F.envcache.json
@@ -1,0 +1,173 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Proj26959B7F",
+    "resourceType": "AWS::CodeBuild::Project",
+    "physicalId": "cdkrd-envcache-build",
+    "constructPath": "CdkRealDriftIntegCodeBuildEnvCache/Proj",
+    "declared": {
+      "Artifacts": {
+        "Location": "cdkrealdriftintegcodebuildenvcache-bucket83908e77-yntppdvl8gqc",
+        "Name": "out",
+        "NamespaceType": "NONE",
+        "Packaging": "NONE",
+        "Type": "S3"
+      },
+      "Cache": {
+        "Modes": ["LOCAL_SOURCE_CACHE", "LOCAL_DOCKER_LAYER_CACHE", "LOCAL_CUSTOM_CACHE"],
+        "Type": "LOCAL"
+      },
+      "EncryptionKey": "alias/aws/s3",
+      "Environment": {
+        "ComputeType": "BUILD_GENERAL1_SMALL",
+        "EnvironmentVariables": [
+          {
+            "Name": "ZED",
+            "Type": "PLAINTEXT",
+            "Value": "z-value"
+          },
+          {
+            "Name": "ALPHA",
+            "Type": "PLAINTEXT",
+            "Value": "a-value"
+          },
+          {
+            "Name": "MID",
+            "Type": "PLAINTEXT",
+            "Value": "m-value"
+          }
+        ],
+        "Image": "aws/codebuild/standard:7.0",
+        "ImagePullCredentialsType": "CODEBUILD",
+        "PrivilegedMode": false,
+        "Type": "LINUX_CONTAINER"
+      },
+      "Name": "cdkrd-envcache-build",
+      "ServiceRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodeBuildEnvCache-ProjRoleA26DD2F4-unkl0GS79b8Q",
+      "Source": {
+        "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"echo hi\"\n      ]\n    }\n  }\n}",
+        "Location": "cdkrealdriftintegcodebuildenvcache-bucket83908e77-yntppdvl8gqc/source.zip",
+        "Type": "S3"
+      }
+    }
+  },
+  "liveRaw": {
+    "Name": "cdkrd-envcache-build",
+    "ServiceRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodeBuildEnvCache-ProjRoleA26DD2F4-unkl0GS79b8Q",
+    "TimeoutInMinutes": 60,
+    "QueuedTimeoutInMinutes": 480,
+    "EncryptionKey": "arn:aws:kms:us-east-1:111111111111:alias/aws/s3",
+    "Source": {
+      "Type": "S3",
+      "Location": "cdkrealdriftintegcodebuildenvcache-bucket83908e77-yntppdvl8gqc/source.zip",
+      "BuildSpec": "{\n  \"version\": \"0.2\",\n  \"phases\": {\n    \"build\": {\n      \"commands\": [\n        \"echo hi\"\n      ]\n    }\n  }\n}",
+      "InsecureSsl": false
+    },
+    "Artifacts": {
+      "Type": "S3",
+      "Location": "cdkrealdriftintegcodebuildenvcache-bucket83908e77-yntppdvl8gqc",
+      "Name": "out",
+      "NamespaceType": "NONE",
+      "Packaging": "NONE",
+      "EncryptionDisabled": false
+    },
+    "Environment": {
+      "Type": "LINUX_CONTAINER",
+      "ComputeType": "BUILD_GENERAL1_SMALL",
+      "Image": "aws/codebuild/standard:7.0",
+      "PrivilegedMode": false,
+      "ImagePullCredentialsType": "CODEBUILD",
+      "EnvironmentVariables": [
+        {
+          "Name": "ZED",
+          "Value": "z-value",
+          "Type": "PLAINTEXT"
+        },
+        {
+          "Name": "ALPHA",
+          "Value": "a-value",
+          "Type": "PLAINTEXT"
+        },
+        {
+          "Name": "MID",
+          "Value": "m-value",
+          "Type": "PLAINTEXT"
+        }
+      ]
+    },
+    "Visibility": "PRIVATE",
+    "BadgeEnabled": false,
+    "Cache": {
+      "Type": "LOCAL",
+      "Modes": ["LOCAL_SOURCE_CACHE", "LOCAL_DOCKER_LAYER_CACHE", "LOCAL_CUSTOM_CACHE"]
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Proj26959B7F",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "TimeoutInMinutes",
+      "actual": 60,
+      "physicalId": "cdkrd-envcache-build",
+      "constructPath": "CdkRealDriftIntegCodeBuildEnvCache/Proj"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Proj26959B7F",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "QueuedTimeoutInMinutes",
+      "actual": 480,
+      "physicalId": "cdkrd-envcache-build",
+      "constructPath": "CdkRealDriftIntegCodeBuildEnvCache/Proj"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Proj26959B7F",
+      "resourceType": "AWS::CodeBuild::Project",
+      "path": "Visibility",
+      "actual": "PRIVATE",
+      "physicalId": "cdkrd-envcache-build",
+      "constructPath": "CdkRealDriftIntegCodeBuildEnvCache/Proj"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodePipeline__Pipeline.PipelineC660917D.triggers.json
+++ b/tests/corpus/AWS__CodePipeline__Pipeline.PipelineC660917D.triggers.json
@@ -1,0 +1,244 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PipelineC660917D",
+    "resourceType": "AWS::CodePipeline::Pipeline",
+    "physicalId": "cdkrd-triggers-pipeline",
+    "constructPath": "CdkRealDriftIntegCodepipelineTriggers/Pipeline",
+    "declared": {
+      "ArtifactStore": {
+        "Location": "cdkrealdriftintegcodepipelinetri-artifacts82dd59a1-1ajvvnudpqcf",
+        "Type": "S3"
+      },
+      "Name": "cdkrd-triggers-pipeline",
+      "PipelineType": "V2",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipelineT-PipelineRoleD68726F7-eIOQaULO9eUx",
+      "Stages": [
+        {
+          "Actions": [
+            {
+              "ActionTypeId": {
+                "Category": "Source",
+                "Owner": "AWS",
+                "Provider": "CodeStarSourceConnection",
+                "Version": "1"
+              },
+              "Configuration": {
+                "ConnectionArn": "arn:aws:codeconnections:us-east-1:111111111111:connection/34793d66-518b-4b87-bd4d-e90e9ff99666",
+                "FullRepositoryId": "cdkrd-hunt-owner/cdkrd-hunt-repo",
+                "BranchName": "main",
+                "DetectChanges": false
+              },
+              "Name": "GitHubSource",
+              "OutputArtifacts": [
+                {
+                  "Name": "Artifact_Source_GitHubSource"
+                }
+              ],
+              "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineSourceGitHubSourc-jiQV75tmDcnk",
+              "RunOrder": 1
+            }
+          ],
+          "Name": "Source"
+        },
+        {
+          "Actions": [
+            {
+              "ActionTypeId": {
+                "Category": "Build",
+                "Owner": "AWS",
+                "Provider": "CodeBuild",
+                "Version": "1"
+              },
+              "Configuration": {
+                "ProjectName": "cdkrd-triggers-build"
+              },
+              "InputArtifacts": [
+                {
+                  "Name": "Artifact_Source_GitHubSource"
+                }
+              ],
+              "Name": "Build",
+              "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineBuildCodePipeline-1isE19wjhBY4",
+              "RunOrder": 1
+            }
+          ],
+          "Name": "Build"
+        }
+      ],
+      "Triggers": [
+        {
+          "GitConfiguration": {
+            "Push": [
+              {
+                "Branches": {
+                  "Excludes": ["experimental/*", "hotfix/*"],
+                  "Includes": ["release/*", "main", "develop"]
+                },
+                "FilePaths": {
+                  "Excludes": ["docs/**", "README.md"],
+                  "Includes": ["src/**", "package.json", "lib/**"]
+                }
+              }
+            ],
+            "SourceActionName": "GitHubSource"
+          },
+          "ProviderType": "CodeStarSourceConnection"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "ArtifactStores": [],
+    "DisableInboundStageTransitions": [],
+    "Stages": [
+      {
+        "Blockers": [],
+        "Actions": [
+          {
+            "ActionTypeId": {
+              "Owner": "AWS",
+              "Category": "Source",
+              "Version": "1",
+              "Provider": "CodeStarSourceConnection"
+            },
+            "Configuration": {
+              "DetectChanges": "false",
+              "ConnectionArn": "arn:aws:codeconnections:us-east-1:111111111111:connection/34793d66-518b-4b87-bd4d-e90e9ff99666",
+              "BranchName": "main",
+              "FullRepositoryId": "cdkrd-hunt-owner/cdkrd-hunt-repo"
+            },
+            "InputArtifacts": [],
+            "OutputArtifacts": [
+              {
+                "Files": [],
+                "Name": "Artifact_Source_GitHubSource"
+              }
+            ],
+            "Commands": [],
+            "OutputVariables": [],
+            "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineSourceGitHubSourc-jiQV75tmDcnk",
+            "RunOrder": 1,
+            "Name": "GitHubSource"
+          }
+        ],
+        "Name": "Source"
+      },
+      {
+        "Blockers": [],
+        "Actions": [
+          {
+            "ActionTypeId": {
+              "Owner": "AWS",
+              "Category": "Build",
+              "Version": "1",
+              "Provider": "CodeBuild"
+            },
+            "Configuration": {
+              "ProjectName": "cdkrd-triggers-build"
+            },
+            "InputArtifacts": [
+              {
+                "Name": "Artifact_Source_GitHubSource"
+              }
+            ],
+            "OutputArtifacts": [],
+            "Commands": [],
+            "OutputVariables": [],
+            "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipe-PipelineBuildCodePipeline-1isE19wjhBY4",
+            "RunOrder": 1,
+            "Name": "Build"
+          }
+        ],
+        "Name": "Build"
+      }
+    ],
+    "ExecutionMode": "SUPERSEDED",
+    "Triggers": [
+      {
+        "GitConfiguration": {
+          "PullRequest": [],
+          "Push": [
+            {
+              "FilePaths": {
+                "Includes": ["lib/**", "src/**", "package.json"],
+                "Excludes": ["README.md", "docs/**"]
+              },
+              "Branches": {
+                "Includes": ["develop", "release/*", "main"],
+                "Excludes": ["hotfix/*", "experimental/*"]
+              }
+            }
+          ],
+          "SourceActionName": "GitHubSource"
+        },
+        "ProviderType": "CodeStarSourceConnection"
+      }
+    ],
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCodepipelineT-PipelineRoleD68726F7-eIOQaULO9eUx",
+    "Name": "cdkrd-triggers-pipeline",
+    "Variables": [],
+    "Version": "1",
+    "ArtifactStore": {
+      "Type": "S3",
+      "Location": "cdkrealdriftintegcodepipelinetri-artifacts82dd59a1-1ajvvnudpqcf"
+    },
+    "PipelineType": "V2",
+    "Arn": "arn:aws:codepipeline:us-east-1:111111111111:cdkrd-triggers-pipeline",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "Version"],
+    "writeOnly": ["RestartExecutionOnUpdate"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Version"],
+    "writeOnlyPaths": ["RestartExecutionOnUpdate"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {
+      "ExecutionMode": "SUPERSEDED"
+    },
+    "defaultPaths": {
+      "ExecutionMode": "SUPERSEDED"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "PipelineC660917D",
+      "resourceType": "AWS::CodePipeline::Pipeline",
+      "path": "ExecutionMode",
+      "actual": "SUPERSEDED",
+      "physicalId": "cdkrd-triggers-pipeline",
+      "constructPath": "CdkRealDriftIntegCodepipelineTriggers/Pipeline"
+    }
+  ]
+}

--- a/tests/integration/codebuild-envcache/app.ts
+++ b/tests/integration/codebuild-envcache/app.ts
@@ -1,0 +1,49 @@
+// CDK app for the cdk-real-drift codebuild-envcache false-positive + coverage integration
+// test. AWS::CodeBuild::Project is Cloud-Control NON_PROVISIONABLE, so cdkrd reads it via
+// the BatchGetProjects SDK override. This fixture probes areas that reader had NOT exercised:
+//   - Environment.EnvironmentVariables with MULTIPLE entries declared in a deliberately
+//     NON-alphabetical order (ZED, ALPHA, MID) — the reader maps them in SDK order; if the
+//     SDK returns them reordered, the declared compare would flag a false `declared` drift
+//     (an env-var-list reorder FP, the CodeBuild analogue of the pipeline trigger-filter set).
+//   - Cache LOCAL with multiple Modes (a set-like array) declared non-sorted.
+// An S3 source keeps it connection-free (no GitHub webhook). A clean `record`->`check` is
+// the FP oracle for the env-var and cache-mode nested shapes.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  Artifacts,
+  BuildSpec,
+  Cache,
+  BuildEnvironmentVariableType,
+  LocalCacheMode,
+  Project,
+  Source,
+} from "aws-cdk-lib/aws-codebuild";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCodeBuildEnvCache");
+const bucket = new Bucket(stack, "Bucket");
+
+new Project(stack, "Proj", {
+  projectName: "cdkrd-envcache-build",
+  source: Source.s3({ bucket, path: "source.zip" }),
+  artifacts: Artifacts.s3({ bucket, name: "out", includeBuildId: false, packageZip: false }),
+  buildSpec: BuildSpec.fromObject({
+    version: "0.2",
+    phases: { build: { commands: ["echo hi"] } },
+  }),
+  // Multiple env vars in a deliberately non-alphabetical declared order.
+  environmentVariables: {
+    ZED: { value: "z-value", type: BuildEnvironmentVariableType.PLAINTEXT },
+    ALPHA: { value: "a-value", type: BuildEnvironmentVariableType.PLAINTEXT },
+    MID: { value: "m-value", type: BuildEnvironmentVariableType.PLAINTEXT },
+  },
+  // LOCAL cache with multiple modes (a set-like array), declared non-sorted.
+  cache: Cache.local(
+    LocalCacheMode.SOURCE,
+    LocalCacheMode.DOCKER_LAYER,
+    LocalCacheMode.CUSTOM,
+  ),
+});
+
+app.synth();

--- a/tests/integration/codebuild-envcache/cdk.json
+++ b/tests/integration/codebuild-envcache/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codebuild-envcache/package.json
+++ b/tests/integration/codebuild-envcache/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-codebuild-envcache",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift codebuild-envcache false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/codebuild-envcache/verify.sh
+++ b/tests/integration/codebuild-envcache/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy a CodeBuild project with multiple
+# env vars (non-alphabetical) and a LOCAL cache with multiple modes -> record -> check
+# MUST be CLEAN. Probes an env-var-list / cache-mode reorder FP in the BatchGetProjects
+# override reader.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodeBuildEnvCache
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] harvest corpus (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-$STACK" $CLI check "$STACK" --region "$REGION" --verbose \
+  | tee "/tmp/cdkrd-$STACK.pre.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/codepipeline-triggers/app.ts
+++ b/tests/integration/codepipeline-triggers/app.ts
@@ -1,0 +1,101 @@
+// CDK app for the cdk-real-drift codepipeline-triggers false-positive integration test.
+// A V2 CodePipeline whose source is a CodeStar (CodeConnections) GitHub action driving
+// a `Triggers` GitConfiguration block: push filters with Branches Includes/Excludes and
+// FilePaths Includes/Excludes globs. Those filter lists are declared in the CFn schema as
+// `uniqueItems: true` arrays WITHOUT `insertionOrder: false`, so cdkrd's schema-driven
+// unordered fold does NOT cover them — if AWS re-orders a set-like filter list on read,
+// the declared compare would flag a false `declared` drift. This is exactly the "branch
+// trigger filter" reorder-FP class this fixture probes. Declared here in a deliberately
+// NON-sorted order (release/* , main, develop / src, package.json, lib) so any AWS-side
+// reordering surfaces as a mismatch. A clean `record`->`check` is the FP oracle.
+//
+// The connection ARN is passed via -c connectionArn=... (a PENDING connection is fine:
+// the pipeline creates and stores its trigger config without the connection being
+// authorized — we never actually run the pipeline).
+import { App, RemovalPolicy, Stack } from "aws-cdk-lib";
+import { BuildSpec, PipelineProject } from "aws-cdk-lib/aws-codebuild";
+import {
+  Artifact,
+  Pipeline,
+  PipelineType,
+  ProviderType,
+} from "aws-cdk-lib/aws-codepipeline";
+import {
+  CodeBuildAction,
+  CodeStarConnectionsSourceAction,
+} from "aws-cdk-lib/aws-codepipeline-actions";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCodepipelineTriggers");
+
+const connectionArn =
+  (stack.node.tryGetContext("connectionArn") as string | undefined) ??
+  "arn:aws:codeconnections:us-east-1:000000000000:connection/00000000-0000-0000-0000-000000000000";
+
+const bucket = new Bucket(stack, "Artifacts", {
+  removalPolicy: RemovalPolicy.DESTROY,
+  autoDeleteObjects: true,
+});
+
+const project = new PipelineProject(stack, "Build", {
+  projectName: "cdkrd-triggers-build",
+  buildSpec: BuildSpec.fromObject({
+    version: "0.2",
+    phases: { build: { commands: ["echo hello"] } },
+  }),
+});
+
+const sourceOutput = new Artifact();
+const sourceAction = new CodeStarConnectionsSourceAction({
+  actionName: "GitHubSource",
+  owner: "cdkrd-hunt-owner",
+  repo: "cdkrd-hunt-repo",
+  branch: "main",
+  connectionArn,
+  output: sourceOutput,
+  // V2 pipeline: let the Triggers block drive starts, not the action's own push flag.
+  triggerOnPush: false,
+});
+
+new Pipeline(stack, "Pipeline", {
+  pipelineName: "cdkrd-triggers-pipeline",
+  artifactBucket: bucket,
+  pipelineType: PipelineType.V2,
+  stages: [
+    {
+      stageName: "Source",
+      actions: [sourceAction],
+    },
+    {
+      stageName: "Build",
+      actions: [
+        new CodeBuildAction({
+          actionName: "Build",
+          project,
+          input: sourceOutput,
+        }),
+      ],
+    },
+  ],
+  triggers: [
+    {
+      providerType: ProviderType.CODE_STAR_SOURCE_CONNECTION,
+      gitConfiguration: {
+        sourceAction,
+        pushFilter: [
+          {
+            // Deliberately NON-sorted, multi-element set-like lists to expose any
+            // AWS-side reordering as a declared mismatch.
+            branchesIncludes: ["release/*", "main", "develop"],
+            branchesExcludes: ["experimental/*", "hotfix/*"],
+            filePathsIncludes: ["src/**", "package.json", "lib/**"],
+            filePathsExcludes: ["docs/**", "README.md"],
+          },
+        ],
+      },
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/codepipeline-triggers/cdk.json
+++ b/tests/integration/codepipeline-triggers/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/codepipeline-triggers/package.json
+++ b/tests/integration/codepipeline-triggers/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-codepipeline-triggers",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift codepipeline-triggers false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/codepipeline-triggers/verify.sh
+++ b/tests/integration/codepipeline-triggers/verify.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Integration test (real AWS) for the CodePipeline V2 Git trigger-filter reorder FP.
+# A V2 pipeline with a CodeStar (CodeConnections) GitHub source and a Triggers
+# GitConfiguration (push filters: Branches Includes/Excludes, FilePaths Includes/Excludes)
+# whose filter lists are `uniqueItems: true` schema arrays WITHOUT `insertionOrder: false`.
+# CodePipeline stores them as SETS, so an out-of-band reorder of an identical list reads
+# back in a different order — which a positional compare false-drifted before the
+# UNORDERED_ARRAY_PROPS fold for these trigger paths.
+#
+# Asserts, end to end:
+#   1. deploy -> record -> check is CLEAN (baseline FP oracle),
+#   2. out-of-band REORDER of Branches.Includes (same set) -> check STILL CLEAN (FP guard),
+#   3. out-of-band REMOVE of a branch (real change) -> check DETECTS declared drift (FN guard).
+#
+# Self-provisions a PENDING CodeConnections GitHub connection (fine: the pipeline stores
+# its trigger config without the connection being authorized — we never run the pipeline)
+# and deletes it on cleanup. Set CDKRD_CONNECTION_ARN to reuse an existing connection.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCodepipelineTriggers
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+PIPELINE=cdkrd-triggers-pipeline
+OWN_CONN=""
+
+CONN="${CDKRD_CONNECTION_ARN:-}"
+if [ -z "$CONN" ]; then
+  CONN="$(aws codeconnections create-connection --provider-type GitHub \
+    --connection-name "cdkrd-triggers-$RANDOM" --region "$REGION" \
+    --query ConnectionArn --output text)" || { echo "INTEG FAIL ($STACK): create-connection"; exit 1; }
+  OWN_CONN="$CONN"
+fi
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  [ -n "$OWN_CONN" ] && aws codeconnections delete-connection --connection-arn "$OWN_CONN" --region "$REGION" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never -c "connectionArn=$CONN" || fail "deploy"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes -c "connectionArn=$CONN" || fail "record"
+
+echo "=== [$STACK] (1) check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail -c "connectionArn=$CONN" || fail "expected CLEAN after record"
+
+echo "=== [$STACK] (2) out-of-band REORDER of Branches.Includes (same set) -> STILL CLEAN ==="
+aws codepipeline get-pipeline --name "$PIPELINE" --region "$REGION" --query pipeline > /tmp/cpt-pl.json || fail "get-pipeline"
+python3 - <<'PY'
+import json
+p=json.load(open('/tmp/cpt-pl.json'))
+b=p['triggers'][0]['gitConfiguration']['push'][0]['branches']
+b['includes']=list(reversed(b['includes']))  # reorder only (semantic no-op for a set)
+json.dump({'pipeline':p},open('/tmp/cpt-reorder.json','w'))
+PY
+aws codepipeline update-pipeline --cli-input-json file:///tmp/cpt-reorder.json --region "$REGION" >/dev/null || fail "update reorder"
+$CLI check "$STACK" --region "$REGION" --fail -c "connectionArn=$CONN" \
+  || fail "FALSE POSITIVE: a set-reorder of Branches.Includes was reported as drift"
+
+echo "=== [$STACK] (3) out-of-band REMOVE a branch (real change) -> MUST DETECT ==="
+python3 - <<'PY'
+import json
+p=json.load(open('/tmp/cpt-pl.json'))
+b=p['triggers'][0]['gitConfiguration']['push'][0]['branches']
+b['includes']=b['includes'][:-1]  # drop one branch (real multiset change)
+json.dump({'pipeline':p},open('/tmp/cpt-remove.json','w'))
+PY
+aws codepipeline update-pipeline --cli-input-json file:///tmp/cpt-remove.json --region "$REGION" >/dev/null || fail "update remove"
+$CLI check "$STACK" --region "$REGION" --fail -c "connectionArn=$CONN"
+rc=$?
+[ "$rc" -eq 1 ] || fail "FALSE NEGATIVE: removing a branch was not detected (exit $rc, expected 1)"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A V2 CodePipeline's Git **trigger filter** lists — `Branches` / `FilePaths` / `Tags`
Includes/Excludes glob sets and the `PullRequest` `Events` enum set — are declared in
the CFn schema as `uniqueItems: true` arrays **without** `insertionOrder: false`, so the
schema-driven `unorderedScalarPaths` fold did not cover them. CodePipeline stores them as
**sets**: an out-of-band reorder of an identical list (or a console edit that
re-canonicalizes it) reads back in a different order, which a positional compare
**false-drifted**:

```
Pipeline.Triggers.0.GitConfiguration.Push.0.Branches.Includes
    desired=["release/*","main","develop"]
    actual =["develop","release/*","main"]   ← same set, reordered → FALSE declared drift
```

## Fix

- Add the trigger-filter paths to `UNORDERED_ARRAY_PROPS['AWS::CodePipeline::Pipeline']`,
  keyed with `*` wildcards (they sit under two array indices — `Triggers[]` and
  `Push[]`/`PullRequest[]`).
- Teach the classify set-fold lookup to normalize numeric path segments to `*` before the
  match (`Triggers.0.…Push.0.…` → `Triggers.*.…Push.*.…`) — the same normalization already
  used for `CASE_INSENSITIVE_PATHS`.

The fold is equality-gated on the multiset, so a genuine glob **add/remove still surfaces**
as declared drift (no false negative).

## Evidence (live, us-east-1)

End-to-end on a fresh `codepipeline-triggers` deploy:
1. deploy → record → `check` **CLEAN**
2. out-of-band **reorder** of `Branches.Includes` (same set) → `check` **still CLEAN** (FP fixed)
3. out-of-band **remove** a branch (real change) → `check` **detects** declared drift (FN guard)

Also confirmed CodePipeline `Version` (readOnly-stripped) and the AWS-added
`PullRequest: []` (folded via `isTrivialEmpty`) produce no FP. `codebuild-envcache`
(multi env-var / cache-mode order) checks CLEAN — CodeBuild's `BatchGetProjects` override
preserves order.

## Tests

- `classify.test.ts`: reorder → no drift, add/remove → declared drift (pins the nested
  wildcard normalization).
- Two golden corpus cases — the pipeline case carries a **reordered** live read so
  `corpus-replay` actively exercises the fold.
- `codepipeline-triggers` + `codebuild-envcache` regression fixtures.

🤖 Found via `/hunt-bugs` (CodePipeline / CodeBuild territory).
