### PR TITLE
fix(read): add CC_IDENTIFIER_ADAPTERS for SSM MaintenanceWindowTarget/Task (WindowId composite) (#528)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -237,6 +237,16 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // log stream). Verified live: `<LogGroupName>|<LogStreamName>` reads, the reverse
   // ResourceNotFoundExceptions.
   'AWS::Logs::LogStream': compositeWith('LogGroupName'),
+  // SSM MaintenanceWindowTarget / MaintenanceWindowTask primaryIdentifier is
+  // [WindowId, WindowTargetId] / [WindowId, WindowTaskId] (parent-first), but the CFn
+  // physical id (Ref) is the bare child UUID — so CC GetResource ValidationException-skips
+  // both on every check (silent read-gap on any patch-window automation). WindowId is a
+  // required create prop (a Ref to the window) so it is always a resolved declared value.
+  // Verified live (opsmisc-rich): `<WindowId>|<childId>` reads both; the bare child id is
+  // rejected. (The sibling Athena PreparedStatement needs NO adapter — its CFn Ref is
+  // already the `<StatementName>|<WorkGroup>` composite.)
+  'AWS::SSM::MaintenanceWindowTarget': compositeWith('WindowId'),
+  'AWS::SSM::MaintenanceWindowTask': compositeWith('WindowId'),
   // TransitGatewayRouteTablePropagation primaryIdentifier is [TransitGatewayRouteTableId,
   // TransitGatewayAttachmentId], but its CFn physical id (Ref) is the AWS console id
   // format `${attachmentId}_${routeTableId}` (underscore, ATTACHMENT first) — NOT the CC

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -462,6 +462,37 @@ describe('readLive (CC identifier adapters, R74)', () => {
   });
 
   for (const t of [
+    'AWS::SSM::MaintenanceWindowTarget',
+    'AWS::SSM::MaintenanceWindowTask',
+  ] as const) {
+    it(`${t}: builds the WindowId|<childId> composite — PARENT first (#528)`, async () => {
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({
+          resourceType: t,
+          physicalId: '2e28d55f-197f-458f-8cc5-1883bfb37fea',
+          declared: { WindowId: 'mw-084705ae45cc003ec' },
+        }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('mw-084705ae45cc003ec|2e28d55f-197f-458f-8cc5-1883bfb37fea');
+    });
+
+    it(`${t}: an unresolved WindowId falls back to the raw physical id`, async () => {
+      cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+      await readLive(
+        cc as unknown as CloudControlClient,
+        res({ resourceType: t, physicalId: 'child-uuid', declared: {} }),
+        'us-east-1',
+        '1'
+      );
+      expect(sent()).toBe('child-uuid');
+    });
+  }
+
+  for (const t of [
     'AWS::Cognito::UserPoolDomain',
     'AWS::Cognito::UserPoolResourceServer',
     'AWS::Cognito::UserPoolIdentityProvider',


### PR DESCRIPTION
Closes #528.

`AWS::SSM::MaintenanceWindowTarget` / `MaintenanceWindowTask` have a COMPOSITE primaryIdentifier (`[WindowId, WindowTargetId]` / `[WindowId, WindowTaskId]`) but their CFn physical id is the bare child UUID → silently `skipped` (CC ValidationException) on every check. Add `CC_IDENTIFIER_ADAPTERS` entries (`compositeWith('WindowId')` → `WindowId|<childId>`, parent-first).

**Live-verified** (us-east-1): both types now READ (no ValidationException skip); the auto-created SSM service-role surfaces as record-worthy undeclared, no FP. Router unit tests added.
