### PR TITLE
chore(noise): fold EKS Cluster/Addon/AccessEntry + Athena WorkGroup first-run defaults (#531)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -172,7 +172,33 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // GENERATED_TOPLEVEL_PATHS instead.
   'AWS::Lambda::Version': { RuntimePolicy: { UpdateRuntimeOn: 'Auto' } },
   'AWS::Events::Rule': { EventBusName: 'default' },
-  'AWS::Athena::WorkGroup': { State: 'ENABLED' },
+  'AWS::Athena::WorkGroup': {
+    State: 'ENABLED',
+    // A workgroup that declares ONLY Name/Description reads back AWS's whole default
+    // WorkGroupConfiguration (the existing WorkGroupConfiguration.* nested paths only fire
+    // when the object is PARTIALLY declared and thus descended; a fully-undeclared object is
+    // reported whole, so it needs this top-level fold). EngineVersion's read-only
+    // EffectiveEngineVersion is schema-stripped, leaving SelectedEngineVersion:AUTO. Observed
+    // live (hunt 2026-07-03 round E). Equality-gated: any enforced non-default surfaces.
+    WorkGroupConfiguration: {
+      EnforceWorkGroupConfiguration: true,
+      EngineVersion: { SelectedEngineVersion: 'AUTO' },
+      PublishCloudWatchMetricsEnabled: true,
+      RequesterPaysEnabled: false,
+    },
+  },
+  // A fresh EKS cluster reads back several whole-object service defaults the template never
+  // declares. Constants (equality-gated) — an out-of-band change to any surfaces. The
+  // per-deploy-variable bits (KubernetesNetworkConfig.ServiceIpv4Cidr is 10.100 OR 172.20,
+  // Version tracks the service default) are deliberately NOT folded — they stay record-worthy.
+  // Observed live (hunt 2026-07-03 round E).
+  'AWS::EKS::Cluster': {
+    ControlPlaneScalingConfig: { Tier: 'standard' },
+    UpgradePolicy: { SupportType: 'EXTENDED' },
+  },
+  // A vpc-cni (and other) addon reads back the kube-system namespace it installs into when
+  // the template declares no NamespaceConfig. AddonVersion is per-cluster-version → record-worthy.
+  'AWS::EKS::Addon': { NamespaceConfig: { Namespace: 'kube-system' } },
   // A WebACL that declares no on-source DDoS protection reads back AWS's default
   // OnSourceDDoSProtectionConfig — ALBLowReputationMode=ACTIVE_UNDER_DDOS (the first
   // enum value / documented default), so the live read reports it as undeclared
@@ -1181,6 +1207,14 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'WorkGroupConfiguration.EnforceWorkGroupConfiguration': true,
     'WorkGroupConfiguration.EngineVersion': { SelectedEngineVersion: 'AUTO' },
   },
+  'AWS::EKS::Cluster': {
+    // A cluster that declares SubnetIds (partially declaring ResourcesVpcConfig, so it is
+    // descended) reads back AWS's endpoint defaults on the sibling sub-keys. Constants,
+    // equality-gated. Observed live (hunt 2026-07-03 round E).
+    'ResourcesVpcConfig.EndpointPublicAccess': true,
+    'ResourcesVpcConfig.PublicAccessCidrs': ['0.0.0.0/0'],
+    'ResourcesVpcConfig.ControlPlaneEgressMode': 'AWS_MANAGED',
+  },
   'AWS::ApplicationSignals::ServiceLevelObjective': {
     // An SLO goal that declares no warning threshold reads back the 50(%) default.
     // Observed live. Equality-gated, so a custom threshold still surfaces.
@@ -1645,6 +1679,13 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
     'PreferredMaintenanceWindow',
     'PreferredBackupWindow',
   ]),
+  //   AWS::EKS::AccessEntry.Username — an access entry that declares no explicit Username reads
+  //   back the value EKS DERIVES from the declared PrincipalArn
+  //   ("arn:aws:sts::<acct>:assumed-role/<role>/{{SessionName}}" for an IAM role). It can never
+  //   be a constant we pin (it embeds the per-resource role name), and it is never user intent
+  //   when undeclared — a user who sets a custom Username declares it (compared in the declared
+  //   loop). Fold value-independent. Observed live first-run (hunt 2026-07-03 round E).
+  'AWS::EKS::AccessEntry': new Set(['Username']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -8220,3 +8220,171 @@ describe('MSK Configuration ServerProperties properties-file compare (#508)', ()
     expect(findings[0]?.path).toBe('ServerProperties');
   });
 });
+
+describe('#531 EKS + Athena first-run default folds', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  it('EKS Cluster: constant service defaults fold; ServiceIpv4Cidr + Version stay record-worthy', () => {
+    const res: DesiredResource = {
+      logicalId: 'Cluster',
+      resourceType: 'AWS::EKS::Cluster',
+      physicalId: 'cdkrd-eks',
+      declared: {
+        Name: 'cdkrd-eks',
+        RoleArn: 'arn:aws:iam::111111111111:role/ClusterRole',
+        ResourcesVpcConfig: { SubnetIds: ['subnet-a', 'subnet-b'] },
+      },
+    };
+    const live = {
+      Name: 'cdkrd-eks',
+      RoleArn: 'arn:aws:iam::111111111111:role/ClusterRole',
+      ResourcesVpcConfig: {
+        SubnetIds: ['subnet-a', 'subnet-b'],
+        EndpointPublicAccess: true,
+        PublicAccessCidrs: ['0.0.0.0/0'],
+        ControlPlaneEgressMode: 'AWS_MANAGED',
+        EndpointPrivateAccess: false,
+        SecurityGroupIds: [],
+      },
+      ControlPlaneScalingConfig: { Tier: 'standard' },
+      UpgradePolicy: { SupportType: 'EXTENDED' },
+      KubernetesNetworkConfig: {
+        ServiceIpv4Cidr: '172.20.0.0/16',
+        IpFamily: 'ipv4',
+        ElasticLoadBalancing: { Enabled: false },
+      },
+      Version: '1.36',
+    };
+    const t = tiers(classifyResource(res, live, emptySchema));
+    expect(t.atDefault).toEqual([
+      'ControlPlaneScalingConfig',
+      'ResourcesVpcConfig.ControlPlaneEgressMode',
+      'ResourcesVpcConfig.EndpointPublicAccess',
+      'ResourcesVpcConfig.PublicAccessCidrs',
+      'UpgradePolicy',
+    ]);
+    // The per-deploy-variable bits are deliberately still surfaced (record-worthy).
+    expect(t.undeclared).toEqual(['KubernetesNetworkConfig', 'Version']);
+  });
+
+  it('EKS Cluster: an out-of-band-narrowed PublicAccessCidrs still surfaces (equality-gated)', () => {
+    const res: DesiredResource = {
+      logicalId: 'Cluster',
+      resourceType: 'AWS::EKS::Cluster',
+      physicalId: 'cdkrd-eks',
+      declared: { ResourcesVpcConfig: { SubnetIds: ['subnet-a'] } },
+    };
+    const t = tiers(
+      classifyResource(
+        res,
+        { ResourcesVpcConfig: { SubnetIds: ['subnet-a'], PublicAccessCidrs: ['10.0.0.0/8'] } },
+        emptySchema
+      )
+    );
+    expect(t.undeclared).toEqual(['ResourcesVpcConfig.PublicAccessCidrs']);
+    expect(t.atDefault).toEqual([]);
+  });
+
+  it('EKS Addon: kube-system NamespaceConfig folds; AddonVersion stays record-worthy', () => {
+    const res: DesiredResource = {
+      logicalId: 'Addon',
+      resourceType: 'AWS::EKS::Addon',
+      physicalId: 'cdkrd-eks/vpc-cni',
+      declared: { AddonName: 'vpc-cni', ClusterName: 'cdkrd-eks' },
+    };
+    const t = tiers(
+      classifyResource(
+        res,
+        {
+          AddonName: 'vpc-cni',
+          ClusterName: 'cdkrd-eks',
+          NamespaceConfig: { Namespace: 'kube-system' },
+          AddonVersion: 'v1.21.2-eksbuild.2',
+        },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['NamespaceConfig']);
+    expect(t.undeclared).toEqual(['AddonVersion']);
+  });
+
+  it('EKS AccessEntry: derived Username folds value-independent; a declared Username is compared', () => {
+    const res: DesiredResource = {
+      logicalId: 'Entry',
+      resourceType: 'AWS::EKS::AccessEntry',
+      physicalId: 'entry-phys',
+      declared: {
+        ClusterName: 'cdkrd-eks',
+        PrincipalArn: 'arn:aws:iam::111111111111:role/EntryRole',
+      },
+    };
+    // Undeclared: whatever derived Username AWS returns folds (value-independent).
+    const t = tiers(
+      classifyResource(
+        res,
+        {
+          ClusterName: 'cdkrd-eks',
+          PrincipalArn: 'arn:aws:iam::111111111111:role/EntryRole',
+          Username: 'arn:aws:sts::111111111111:assumed-role/EntryRole/{{SessionName}}',
+        },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['Username']);
+    expect(t.undeclared).toEqual([]);
+    // Declared: a user-set Username that drifts surfaces in the declared loop.
+    const withDeclared: DesiredResource = {
+      ...res,
+      declared: { ...res.declared, Username: 'my-user' },
+    };
+    const t2 = tiers(
+      classifyResource(
+        withDeclared,
+        {
+          ClusterName: 'cdkrd-eks',
+          PrincipalArn: 'arn:aws:iam::111111111111:role/EntryRole',
+          Username: 'changed-out-of-band',
+        },
+        emptySchema
+      )
+    );
+    expect(t2.declared).toEqual(['Username']);
+  });
+
+  it('Athena WorkGroup: a Name/Description-only workgroup folds its whole default WorkGroupConfiguration', () => {
+    const res: DesiredResource = {
+      logicalId: 'Wg',
+      resourceType: 'AWS::Athena::WorkGroup',
+      physicalId: 'cdkrd-wg',
+      declared: { Name: 'cdkrd-wg', Description: 'probe' },
+    };
+    const t = tiers(
+      classifyResource(
+        res,
+        {
+          Name: 'cdkrd-wg',
+          Description: 'probe',
+          State: 'ENABLED',
+          WorkGroupConfiguration: {
+            EnforceWorkGroupConfiguration: true,
+            EngineVersion: { SelectedEngineVersion: 'AUTO' },
+            PublishCloudWatchMetricsEnabled: true,
+            RequesterPaysEnabled: false,
+          },
+        },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual(['State', 'WorkGroupConfiguration']);
+    expect(t.undeclared).toEqual([]);
+  });
+});

--- a/tests/corpus/AWS__Athena__WorkGroup.Queries.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.Queries.json
@@ -74,7 +74,7 @@
       "constructPath": "CdkrdIntegHarvest/Queries"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Queries",
       "resourceType": "AWS::Athena::WorkGroup",
       "path": "WorkGroupConfiguration",

--- a/tests/corpus/AWS__Athena__WorkGroup.WgOpsMisc.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.WgOpsMisc.json
@@ -1,0 +1,97 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Wg",
+    "resourceType": "AWS::Athena::WorkGroup",
+    "physicalId": "cdkrd-wg-e",
+    "constructPath": "CdkRealDriftIntegOpsMiscRich/Wg",
+    "declared": {
+      "Description": "cdkrd probe workgroup",
+      "Name": "cdkrd-wg-e"
+    }
+  },
+  "liveRaw": {
+    "WorkGroupConfiguration": {
+      "EnforceWorkGroupConfiguration": true,
+      "EngineVersion": {
+        "SelectedEngineVersion": "AUTO",
+        "EffectiveEngineVersion": "Athena engine version 3"
+      },
+      "PublishCloudWatchMetricsEnabled": true,
+      "RequesterPaysEnabled": false
+    },
+    "Description": "cdkrd probe workgroup",
+    "State": "ENABLED",
+    "CreationTime": "1783077542",
+    "Tags": [],
+    "Name": "cdkrd-wg-e"
+  },
+  "schema": {
+    "readOnly": ["CreationTime"],
+    "writeOnly": ["RecursiveDeleteOption", "WorkGroupConfigurationUpdates"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "CreationTime",
+      "WorkGroupConfiguration.EngineVersion.EffectiveEngineVersion",
+      "WorkGroupConfigurationUpdates.EngineVersion.EffectiveEngineVersion"
+    ],
+    "writeOnlyPaths": [
+      "RecursiveDeleteOption",
+      "WorkGroupConfiguration.AdditionalConfiguration",
+      "WorkGroupConfiguration.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfiguration.EngineConfiguration.CoordinatorDpuSize",
+      "WorkGroupConfiguration.EngineConfiguration.DefaultExecutorDpuSize",
+      "WorkGroupConfiguration.EngineConfiguration.MaxConcurrentDpus",
+      "WorkGroupConfiguration.EngineConfiguration.SparkProperties",
+      "WorkGroupConfigurationUpdates"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "WorkGroupConfiguration.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfiguration.EngineConfiguration.Classifications.*.Properties",
+      "WorkGroupConfiguration.EngineConfiguration.SparkProperties",
+      "WorkGroupConfiguration.MonitoringConfiguration.CloudWatchLoggingConfiguration.LogTypes",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.Classifications.*.Properties",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.SparkProperties",
+      "WorkGroupConfigurationUpdates.MonitoringConfiguration.CloudWatchLoggingConfiguration.LogTypes"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Wg",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration",
+      "actual": {
+        "EnforceWorkGroupConfiguration": true,
+        "EngineVersion": {
+          "SelectedEngineVersion": "AUTO"
+        },
+        "PublishCloudWatchMetricsEnabled": true,
+        "RequesterPaysEnabled": false
+      },
+      "physicalId": "cdkrd-wg-e",
+      "constructPath": "CdkRealDriftIntegOpsMiscRich/Wg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Wg",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "State",
+      "actual": "ENABLED",
+      "physicalId": "cdkrd-wg-e",
+      "constructPath": "CdkRealDriftIntegOpsMiscRich/Wg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EKS__AccessEntry.EntryEksRich.json
+++ b/tests/corpus/AWS__EKS__AccessEntry.EntryEksRich.json
@@ -1,0 +1,84 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Entry",
+    "resourceType": "AWS::EKS::AccessEntry",
+    "physicalId": "arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg|cdkrd-eks",
+    "constructPath": "CdkRealDriftIntegEksRich/Entry",
+    "declared": {
+      "AccessPolicies": [
+        {
+          "AccessScope": {
+            "Type": "cluster"
+          },
+          "PolicyArn": "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+        }
+      ],
+      "ClusterName": "cdkrd-eks",
+      "KubernetesGroups": ["cdkrd-viewers"],
+      "PrincipalArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg",
+      "Type": "STANDARD"
+    }
+  },
+  "liveRaw": {
+    "Type": "STANDARD",
+    "PrincipalArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg",
+    "KubernetesGroups": ["cdkrd-viewers"],
+    "Username": "arn:aws:sts::111111111111:assumed-role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg/{{SessionName}}",
+    "ClusterName": "cdkrd-eks",
+    "AccessEntryArn": "arn:aws:eks:us-east-1:111111111111:access-entry/cdkrd-eks/role/111111111111/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg/aecf93db-31e2-bd9b-777c-b70761a1f919",
+    "AccessPolicies": [
+      {
+        "PolicyArn": "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy",
+        "AccessScope": {
+          "Namespaces": [],
+          "Type": "cluster"
+        }
+      }
+    ],
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegEksRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEksRich/21580dd0-76d0-11f1-b35a-0affd8210315",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "Entry",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AccessEntryArn"],
+    "writeOnly": [],
+    "createOnly": ["ClusterName", "PrincipalArn", "Type"],
+    "readOnlyPaths": ["AccessEntryArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ClusterName", "PrincipalArn", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["KubernetesGroups"],
+    "unorderedObjectArrayPaths": ["AccessPolicies"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Entry",
+      "resourceType": "AWS::EKS::AccessEntry",
+      "path": "Username",
+      "actual": "arn:aws:sts::111111111111:assumed-role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg/{{SessionName}}",
+      "physicalId": "arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-EntryRole30BEEDCC-dB5Ek4PlmWNg|cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Entry"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EKS__Addon.AddonEksRich.json
+++ b/tests/corpus/AWS__EKS__Addon.AddonEksRich.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Addon",
+    "resourceType": "AWS::EKS::Addon",
+    "physicalId": "cdkrd-eks|vpc-cni",
+    "constructPath": "CdkRealDriftIntegEksRich/Addon",
+    "declared": {
+      "AddonName": "vpc-cni",
+      "ClusterName": "cdkrd-eks",
+      "ConfigurationValues": "{\"env\":{\"ENABLE_PREFIX_DELEGATION\":\"true\"}}",
+      "ResolveConflicts": "OVERWRITE"
+    }
+  },
+  "liveRaw": {
+    "NamespaceConfig": {
+      "Namespace": "kube-system"
+    },
+    "AddonVersion": "v1.21.2-eksbuild.2",
+    "ClusterName": "cdkrd-eks",
+    "AddonName": "vpc-cni",
+    "Arn": "arn:aws:eks:us-east-1:111111111111:addon/cdkrd-eks/vpc-cni/c8cf93db-310b-cd6f-a379-7eecc3e26f74",
+    "Tags": [
+      {
+        "Value": "Addon",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEksRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEksRich/21580dd0-76d0-11f1-b35a-0affd8210315",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "ConfigurationValues": "{\"env\":{\"ENABLE_PREFIX_DELEGATION\":\"true\"}}"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["PodIdentityAssociations", "PreserveOnDelete", "ResolveConflicts"],
+    "createOnly": ["AddonName", "ClusterName", "NamespaceConfig"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["PodIdentityAssociations", "PreserveOnDelete", "ResolveConflicts"],
+    "createOnlyPaths": ["AddonName", "ClusterName", "NamespaceConfig"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["PodIdentityAssociations"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Addon",
+      "resourceType": "AWS::EKS::Addon",
+      "path": "ResolveConflicts",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-eks|vpc-cni",
+      "constructPath": "CdkRealDriftIntegEksRich/Addon"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Addon",
+      "resourceType": "AWS::EKS::Addon",
+      "path": "NamespaceConfig",
+      "actual": {
+        "Namespace": "kube-system"
+      },
+      "physicalId": "cdkrd-eks|vpc-cni",
+      "constructPath": "CdkRealDriftIntegEksRich/Addon"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Addon",
+      "resourceType": "AWS::EKS::Addon",
+      "path": "AddonVersion",
+      "actual": "v1.21.2-eksbuild.2",
+      "physicalId": "cdkrd-eks|vpc-cni",
+      "constructPath": "CdkRealDriftIntegEksRich/Addon"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EKS__Cluster.Cluster.json
+++ b/tests/corpus/AWS__EKS__Cluster.Cluster.json
@@ -162,7 +162,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "UpgradePolicy",
@@ -173,7 +173,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "ControlPlaneScalingConfig",
@@ -184,7 +184,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "ResourcesVpcConfig.ControlPlaneEgressMode",
@@ -194,7 +194,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodEks/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "ResourcesVpcConfig.PublicAccessCidrs",

--- a/tests/corpus/AWS__EKS__Cluster.ClusterEksRich.json
+++ b/tests/corpus/AWS__EKS__Cluster.ClusterEksRich.json
@@ -1,0 +1,252 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cluster",
+    "resourceType": "AWS::EKS::Cluster",
+    "physicalId": "cdkrd-eks",
+    "constructPath": "CdkRealDriftIntegEksRich/Cluster",
+    "declared": {
+      "AccessConfig": {
+        "AuthenticationMode": "API_AND_CONFIG_MAP"
+      },
+      "Logging": {
+        "ClusterLogging": {
+          "EnabledTypes": [
+            {
+              "Type": "api"
+            },
+            {
+              "Type": "audit"
+            }
+          ]
+        }
+      },
+      "Name": "cdkrd-eks",
+      "ResourcesVpcConfig": {
+        "SubnetIds": [
+          "subnet-009fa2e0b8cca055d",
+          "subnet-0e9e19d9507df130e",
+          "subnet-0df8652e0fa4970aa",
+          "subnet-09ce4dfdf112af53c"
+        ]
+      },
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-ClusterRoleD9CA7471-eGoUJWSUITF9"
+    }
+  },
+  "liveRaw": {
+    "Logging": {
+      "ClusterLogging": {
+        "EnabledTypes": [
+          {
+            "Type": "api"
+          },
+          {
+            "Type": "audit"
+          }
+        ]
+      }
+    },
+    "DeletionProtection": false,
+    "AccessConfig": {
+      "AuthenticationMode": "API_AND_CONFIG_MAP"
+    },
+    "CertificateAuthorityData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURCVENDQWUyZ0F3SUJBZ0lJWFk5dzJZV0xuQzh3RFFZSktvWklodmNOQVFFTEJRQXdGVEVUTUJFR0ExVUUKQXhNS2EzVmlaWEp1WlhSbGN6QWVGdzB5TmpBM01ETXhNVEUwTURCYUZ3MHpOakEyTXpBeE1URTVNREJhTUJVeApFekFSQmdOVkJBTVRDbXQxWW1WeWJtVjBaWE13Z2dFaU1BMEdDU3FHU0liM0RRRUJBUVVBQTRJQkR3QXdnZ0VLCkFvSUJBUURyZVZKeWltMlQ2SDRZbVFXV213QUFPWXBxaHZ3TFBLTlFUUkpGRjNZaUNTWWJtOEFGWHNMTTZRQUgKNCtJV2JYUGpTVDBrbGo2UlFNV3Y1QU9lbTBTWG9JSGViNjU4RXhGQkNKNUpLU0tzTnNlL053aVR1OHZTOFFpVwpjUk5Eellld0Z6V0JWbjRvSGZRZng5MHhpRlB0b200alRkQ1o1SWEvNEZSUDc1Mm1pZlFQdVRFSFR4ejRIZWVyClpibnZ4aVVGSFBNQTBFa1Y5aUVMSTFJdllQbk00Mnc4Q1UzamJ1cTFIWXdGWTZrZGpSVHBwUU5mMVIzVGd0M04KbmkrUkVzdXp5UTJVQXJDbUlnc0FiMW00ckpFR1dmcEZWcVRabkpYdkNFeXlSZmdOV1FvaUp5VndaRlcyQjZ3bQo3RUozTE92a0hvWklvbFB3UW9rY055Zjcrd0oxQWdNQkFBR2pXVEJYTUE0R0ExVWREd0VCL3dRRUF3SUNwREFQCkJnTlZIUk1CQWY4RUJUQURBUUgvTUIwR0ExVWREZ1FXQkJUdy8reEptV3JkSUhoc2NQYktqR2lNYjBYRWZ6QVYKQmdOVkhSRUVEakFNZ2dwcmRXSmxjbTVsZEdWek1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRRFBFZGpkSUdkcQpDbmZEeXhkRDYxbSsxaXBYL1NiUDc4clZrUVVWRDVnMUFOV0Irck5LQ0M1MXBqWFJURy9mTXN4VWpkelJXN1dCClhvUkEyMm0venZJWmQ4Tll2VkMrK1FFNUtkcE14eUZISk95MmRqbjVycE0wTXNtWm1oTVd3NTBldkEzemZSbFEKWVErRGtZUDVvTklwcTJxNitWN0drcE1OWWJXanlQTkU0bXZMb2dHNG0zVkFJcXlaS2R0MDRJTHBDdGFEaDVTTQo1ZWFqd1F4UG9IczdlRERNQkFsQUp3QlRrS1g1ak15UjFkNTZtclZtM1l1RUhBZU1iektHTTZ0dUJ0Mzh5dDJVCk9MNC9GOW1wRUszaEt0aktMYnNYRDJ1MVJvbC9RZUszY3ZOYkdrUlNWMFdWbWc5Q25UR1pQeUlSWUZBdm9VK1YKMlRWUG5PUWdBbWk1Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
+    "EncryptionConfig": [],
+    "KubernetesNetworkConfig": {
+      "ServiceIpv4Cidr": "172.20.0.0/16",
+      "IpFamily": "ipv4",
+      "ElasticLoadBalancing": {
+        "Enabled": false
+      }
+    },
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegEksRich-ClusterRoleD9CA7471-eGoUJWSUITF9",
+    "Name": "cdkrd-eks",
+    "UpgradePolicy": {
+      "SupportType": "EXTENDED"
+    },
+    "Endpoint": "https://600D650FD28CFB3F9E60D272E34D3415.gr7.us-east-1.eks.amazonaws.com",
+    "Version": "1.36",
+    "ControlPlaneScalingConfig": {
+      "Tier": "standard"
+    },
+    "ClusterSecurityGroupId": "sg-09ac0591a9d27e1c6",
+    "Arn": "arn:aws:eks:us-east-1:111111111111:cluster/cdkrd-eks",
+    "ResourcesVpcConfig": {
+      "EndpointPublicAccess": true,
+      "ControlPlaneEgressMode": "AWS_MANAGED",
+      "PublicAccessCidrs": ["0.0.0.0/0"],
+      "EndpointPrivateAccess": false,
+      "SecurityGroupIds": [],
+      "SubnetIds": [
+        "subnet-009fa2e0b8cca055d",
+        "subnet-0e9e19d9507df130e",
+        "subnet-0df8652e0fa4970aa",
+        "subnet-09ce4dfdf112af53c"
+      ]
+    },
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegEksRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Cluster",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEksRich/21580dd0-76d0-11f1-b35a-0affd8210315",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "OpenIdConnectIssuerUrl": "https://oidc.eks.us-east-1.amazonaws.com/id/600D650FD28CFB3F9E60D272E34D3415"
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CertificateAuthorityData",
+      "ClusterSecurityGroupId",
+      "EncryptionConfigKeyArn",
+      "Endpoint",
+      "Id",
+      "OpenIdConnectIssuerUrl"
+    ],
+    "writeOnly": ["BootstrapSelfManagedAddons", "Force", "RollbackConfig"],
+    "createOnly": [
+      "BootstrapSelfManagedAddons",
+      "EncryptionConfig",
+      "Name",
+      "OutpostConfig",
+      "RoleArn"
+    ],
+    "readOnlyPaths": [
+      "Arn",
+      "CertificateAuthorityData",
+      "ClusterSecurityGroupId",
+      "EncryptionConfigKeyArn",
+      "Endpoint",
+      "Id",
+      "KubernetesNetworkConfig.ServiceIpv6Cidr",
+      "OpenIdConnectIssuerUrl"
+    ],
+    "writeOnlyPaths": [
+      "AccessConfig.BootstrapClusterCreatorAdminPermissions",
+      "BootstrapSelfManagedAddons",
+      "Force",
+      "RollbackConfig"
+    ],
+    "createOnlyPaths": [
+      "AccessConfig.BootstrapClusterCreatorAdminPermissions",
+      "BootstrapSelfManagedAddons",
+      "EncryptionConfig",
+      "KubernetesNetworkConfig.IpFamily",
+      "KubernetesNetworkConfig.ServiceIpv4Cidr",
+      "Name",
+      "OutpostConfig",
+      "RoleArn"
+    ],
+    "defaults": {
+      "Force": false
+    },
+    "defaultPaths": {
+      "Force": false
+    },
+    "unorderedScalarPaths": [
+      "ComputeConfig.NodePools",
+      "OutpostConfig.OutpostArns",
+      "ResourcesVpcConfig.PublicAccessCidrs",
+      "ResourcesVpcConfig.SecurityGroupIds",
+      "ResourcesVpcConfig.SubnetIds"
+    ],
+    "unorderedObjectArrayPaths": [
+      "EncryptionConfig",
+      "Logging.ClusterLogging.EnabledTypes",
+      "RemoteNetworkConfig.RemoteNodeNetworks",
+      "RemoteNetworkConfig.RemotePodNetworks"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "KubernetesNetworkConfig",
+      "actual": {
+        "ServiceIpv4Cidr": "172.20.0.0/16",
+        "IpFamily": "ipv4",
+        "ElasticLoadBalancing": {
+          "Enabled": false
+        }
+      },
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "UpgradePolicy",
+      "actual": {
+        "SupportType": "EXTENDED"
+      },
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "Version",
+      "actual": "1.36",
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ControlPlaneScalingConfig",
+      "actual": {
+        "Tier": "standard"
+      },
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ResourcesVpcConfig.EndpointPublicAccess",
+      "actual": true,
+      "nested": true,
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ResourcesVpcConfig.ControlPlaneEgressMode",
+      "actual": "AWS_MANAGED",
+      "nested": true,
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::EKS::Cluster",
+      "path": "ResourcesVpcConfig.PublicAccessCidrs",
+      "actual": ["0.0.0.0/0"],
+      "nested": true,
+      "physicalId": "cdkrd-eks",
+      "constructPath": "CdkRealDriftIntegEksRich/Cluster"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #531.

First-run `[At AWS Default]` folds for a fresh EKS cluster + an Athena WorkGroup that declares only Name/Description.

**Folds (all equality-gated — a real out-of-band change still surfaces):**
- `AWS::EKS::Cluster`: `ControlPlaneScalingConfig={Tier:standard}`, `UpgradePolicy={SupportType:EXTENDED}` (KNOWN_DEFAULTS); `ResourcesVpcConfig.EndpointPublicAccess/PublicAccessCidrs/ControlPlaneEgressMode` (KNOWN_DEFAULT_PATHS). `KubernetesNetworkConfig` (ServiceIpv4Cidr varies 10.100/172.20) + `Version` stay record-worthy.
- `AWS::EKS::Addon`: `NamespaceConfig={Namespace:kube-system}`.
- `AWS::EKS::AccessEntry`: `Username` (derived from PrincipalArn) → VALUE_INDEPENDENT fold (undeclared only).
- `AWS::Athena::WorkGroup`: whole `WorkGroupConfiguration` default-fill (a fully-undeclared object is reported whole, so the existing nested paths didn't fire).

**Live-verified** (us-east-1): a fresh Athena WorkGroup reads back `WorkGroupConfiguration` → folds to atDefault, `check` CLEAN. Corpus cases + unit tests added; `corpus-replay` regenerated for the affected EKS/Athena cases (tier flips visible in the diff).
