### PR TITLE
fix(revert): pin Logs Transformer TransformerConfig order-significant so revert targets the raw live index (#529)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -66,6 +66,7 @@ import {
   isEpochHourEqual,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
+  ORDER_SIGNIFICANT_ARRAY_KEYS,
   READGAP_COLLECTION_PATHS,
   SCALAR_RETURNED_WHEN_SET,
   READ_NORMALIZED_DECLARED_PATHS,
@@ -788,8 +789,12 @@ function sortUnorderedSetProps(
     ...(UNORDERED_OBJECT_ARRAY_PROPS[resourceType] ?? []),
     ...schemaObjectArrayKeys,
   ]);
+  // A key whose ORDER is semantically significant (a Logs Transformer processor pipeline)
+  // must NOT be sorted even when the schema marks it insertionOrder:false — sorting the live
+  // side alone would re-skew the finding index vs the raw model the revert patches (#529).
+  const orderSig = ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType];
   for (const k of objKeys)
-    if (Array.isArray(model[k])) model[k] = sortUnorderedObjectArray(model[k]);
+    if (!orderSig?.has(k) && Array.isArray(model[k])) model[k] = sortUnorderedObjectArray(model[k]);
   for (const k of UNORDERED_ARRAY_PROPS[resourceType] ?? []) {
     const v = model[k];
     if (
@@ -1248,11 +1253,16 @@ export function classifyResource(
     // rule objects with no single identity field that AWS returns reordered. Sort BOTH
     // sides by canonical JSON before the positional diff so a reorder is not false
     // drift; a genuine rule change still differs after the sort.
+    // An ORDER-significant key (a Logs Transformer processor pipeline) is never sorted, even
+    // when its schema marks it insertionOrder:false — the raw order must be preserved so the
+    // finding index aligns with the live model the Cloud Control revert patches (#529).
+    const orderSignificant = ORDER_SIGNIFICANT_ARRAY_KEYS[resourceType]?.has(k) ?? false;
     const unorderedObjArray =
-      UNORDERED_OBJECT_ARRAY_PROPS[resourceType]?.has(k) ||
-      // schema-driven twin (#459): the schema marks this OBJECT array insertionOrder:false
-      // (and its items carry no identity field), so a reorder is never drift.
-      (schema.unorderedObjectArrayPaths?.includes(k) ?? false);
+      !orderSignificant &&
+      (UNORDERED_OBJECT_ARRAY_PROPS[resourceType]?.has(k) ||
+        // schema-driven twin (#459): the schema marks this OBJECT array insertionOrder:false
+        // (and its items carry no identity field), so a reorder is never drift.
+        (schema.unorderedObjectArrayPaths?.includes(k) ?? false));
     // Per-type NESTED unordered object-array paths under this key (Bedrock Guardrail
     // ContentPolicyConfig.FiltersConfig etc.): sort the reordered set on both sides so
     // a positional diff doesn't false-flag it.

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1910,6 +1910,15 @@ export function stripAsymmetricIdentityFields(declared: unknown, live: unknown):
 // is given this resourceType), so a same-named array on an unrelated type is unaffected.
 export const ORDER_SIGNIFICANT_ARRAY_KEYS: Record<string, ReadonlySet<string>> = {
   'AWS::CodePipeline::Pipeline': new Set(['Stages', 'Actions']),
+  // A Logs Transformer's `TransformerConfig` is an EXECUTION PIPELINE: processors run
+  // top-to-bottom (a `parseJson` must precede an `addKeys` that reads the parsed fields),
+  // and CloudWatch Logs returns them in declared order. Its CFn schema nonetheless marks it
+  // `insertionOrder: false` (→ `schema.unorderedObjectArrayPaths`), which would sort it as an
+  // unordered set: masking a genuine reorder AND — the #529 bug — skewing a drift finding's
+  // array index into the SORTED model while the Cloud Control `UpdateResource` revert patch
+  // addresses the RAW live model, so `revert` failed with `noSuchPath //TransformerConfig/0/...`.
+  // Pinning it order-significant keeps both compare sides in raw order so the index aligns.
+  'AWS::Logs::Transformer': new Set(['TransformerConfig']),
 };
 export function canonicalizeTagListsDeep(v: unknown, orderSig?: ReadonlySet<string>): unknown {
   return canonicalizeTagLists(v, orderSig, undefined);

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -8575,3 +8575,63 @@ describe('#535 AOSS / SAMLProvider / ENI first-run default folds', () => {
     ).not.toContain('SourceDestCheck');
   });
 });
+
+describe('#529 Logs Transformer order-significant pipeline (revert index skew)', () => {
+  // The Transformer schema marks TransformerConfig insertionOrder:false; the fix pins it
+  // order-significant so it is NOT sorted, keeping the finding index aligned with the raw
+  // live model the Cloud Control revert patches.
+  const schema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+    unorderedObjectArrayPaths: ['TransformerConfig'],
+  };
+  const declaredPipeline = [
+    { ParseJSON: {} },
+    { AddKeys: { Entries: [{ Key: 'app', OverwriteIfExists: true, Value: 'cdkrd' }] } },
+    { TrimString: { WithKeys: ['msg'] } },
+  ];
+  const res: DesiredResource = {
+    logicalId: 'Transformer',
+    resourceType: 'AWS::Logs::Transformer',
+    physicalId: '/cdkrd/opsmisc/app',
+    declared: { TransformerConfig: structuredClone(declaredPipeline) },
+  };
+
+  it('a clean pipeline (live == declared order, ParseJSON husk at index 0) is no drift', () => {
+    const t = tiers(
+      classifyResource(res, { TransformerConfig: structuredClone(declaredPipeline) }, schema)
+    );
+    expect(t.declared).toEqual([]);
+  });
+
+  it('an out-of-band AddKeys.Value edit reports the RAW index (1) and reverts to it', () => {
+    const live = structuredClone(declaredPipeline);
+    (live[1] as any).AddKeys.Entries[0].Value = 'cdkrd-MUTATED';
+    const findings = classifyResource(res, { TransformerConfig: live }, schema);
+    const declared = findings.filter((f) => f.tier === 'declared');
+    expect(declared).toHaveLength(1);
+    // index 1, NOT the sorted index 0 — the {ParseJSON:{}} husk stays at index 0.
+    expect(declared[0]?.path).toBe('TransformerConfig.1.AddKeys.Entries.0.Value');
+    const plan = buildRevertPlan(declared, undefined);
+    expect(plan.items[0]?.ops[0]?.path).toBe('/TransformerConfig/1/AddKeys/Entries/0/Value');
+    expect(plan.items[0]?.ops[0]?.value).toBe('cdkrd');
+    expect(plan.notRevertable).toEqual([]);
+  });
+
+  it('a genuine processor REORDER surfaces as drift (order is significant, not a set)', () => {
+    // Swap AddKeys and TrimString — a real semantic change to the pipeline.
+    const live = [declaredPipeline[0], declaredPipeline[2], declaredPipeline[1]];
+    const declared = classifyResource(
+      res,
+      { TransformerConfig: structuredClone(live) },
+      schema
+    ).filter((f) => f.tier === 'declared');
+    expect(declared.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/corpus/AWS__Logs__Transformer.Transformer.json
+++ b/tests/corpus/AWS__Logs__Transformer.Transformer.json
@@ -1,0 +1,87 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Transformer",
+    "resourceType": "AWS::Logs::Transformer",
+    "physicalId": "/cdkrd/opsmisc/app",
+    "constructPath": "CdkRealDriftIntegOpsMiscRich/Transformer",
+    "declared": {
+      "LogGroupIdentifier": "/cdkrd/opsmisc/app",
+      "TransformerConfig": [
+        {
+          "ParseJSON": {}
+        },
+        {
+          "AddKeys": {
+            "Entries": [
+              {
+                "Key": "app",
+                "OverwriteIfExists": true,
+                "Value": "cdkrd"
+              }
+            ]
+          }
+        },
+        {
+          "TrimString": {
+            "WithKeys": ["msg"]
+          }
+        },
+        {
+          "UpperCaseString": {
+            "WithKeys": ["level"]
+          }
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "TransformerConfig": [
+      {
+        "ParseJSON": {}
+      },
+      {
+        "AddKeys": {
+          "Entries": [
+            {
+              "OverwriteIfExists": true,
+              "Value": "cdkrd",
+              "Key": "app"
+            }
+          ]
+        }
+      },
+      {
+        "TrimString": {
+          "WithKeys": ["msg"]
+        }
+      },
+      {
+        "UpperCaseString": {
+          "WithKeys": ["level"]
+        }
+      }
+    ],
+    "LogGroupIdentifier": "/cdkrd/opsmisc/app"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["LogGroupIdentifier"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LogGroupIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["TransformerConfig"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}


### PR DESCRIPTION
Closes #529.

**Root cause** (differs from the issue's hypothesis — confirmed by live repro): `TransformerConfig`'s CFn schema marks it `insertionOrder:false`, so classify SORTS it as an unordered object-array. But a Logs Transformer is an ordered processor PIPELINE. Sorting skews the finding's array index into the sorted model while the Cloud Control revert patches the RAW live model → `revert` failed `noSuchPath //TransformerConfig/0/...`.

**Fix:** pin `AWS::Logs::Transformer` `TransformerConfig` order-significant (reuse `ORDER_SIGNIFICANT_ARRAY_KEYS`), excluding it from both the live-side (`sortUnorderedSetProps`) and declared-side sorts. A genuine processor reorder now also correctly surfaces as drift.

**Live-verified** (us-east-1): mutated `AddKeys.Value` out of band → `check` detects at raw index `.1.` → `revert` SUCCEEDS → live value restored → CLEAN. Unit test (classify→plan asserts index 1 + pointer) + corpus case added.
