### PR TITLE
feat(read): add SDK_OVERRIDES readers for EC2 ClientVPN + DAX families (#534)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@aws-sdk/client-cognito-sync": "^3.1075.0",
     "@aws-sdk/client-config-service": "^3.1075.0",
     "@aws-sdk/client-database-migration-service": "^3.1079.0",
+    "@aws-sdk/client-dax": "^3.1079.0",
     "@aws-sdk/client-dlm": "^3.1078.0",
     "@aws-sdk/client-docdb": "^3.1073.0",
     "@aws-sdk/client-ec2": "^3.1066.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       '@aws-sdk/client-database-migration-service':
         specifier: ^3.1079.0
         version: 3.1079.0
+      '@aws-sdk/client-dax':
+        specifier: ^3.1079.0
+        version: 3.1079.0
       '@aws-sdk/client-dlm':
         specifier: ^3.1078.0
         version: 3.1078.0
@@ -363,6 +366,10 @@ packages:
 
   '@aws-sdk/client-database-migration-service@3.1079.0':
     resolution: {integrity: sha512-ty9OA2Ypn4uFJ4KwbkEgoP6+rdMsJsAIbF9+7SI8ZY78okiKStfk1p22khUP1PEvuvxjh3mLS2fV1DwmD2r2Qg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-dax@3.1079.0':
+    resolution: {integrity: sha512-8cdaRlfUDnlLA+6rSCZO61xEaiDlHunxvZxgbD8rCSBUz7+l75duaNGDDWFRTVYCGCZv0ooa5BHx5QlLt7FWqA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-dlm@3.1078.0':
@@ -3958,6 +3965,17 @@ snapshots:
       tslib: 2.8.1
 
   '@aws-sdk/client-database-migration-service@3.1079.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.27
+      '@aws-sdk/credential-provider-node': 3.972.62
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-dax@3.1079.0':
     dependencies:
       '@aws-sdk/core': 3.974.27
       '@aws-sdk/credential-provider-node': 3.972.62

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -886,11 +886,13 @@ const readEc2ClientVpnEndpoint: OverrideReader = async ({ physicalId, region }) 
   if (typeof e.SessionTimeoutHours === 'number') model.SessionTimeoutHours = e.SessionTimeoutHours;
   if (typeof e.DisconnectOnSessionTimeout === 'boolean')
     model.DisconnectOnSessionTimeout = e.DisconnectOnSessionTimeout;
-  // SelfServicePortal: the API returns SelfServicePortalUrl (a non-empty URL when the portal
-  // is enabled), NOT the CFn enabled/disabled enum. Derive the CFn value from presence of the
-  // URL. This derived mapping is validated live.
-  if (str(e.SelfServicePortalUrl) !== undefined) model.SelfServicePortal = 'enabled';
-  else model.SelfServicePortal = 'disabled';
+  // SelfServicePortal is NOT projected: the API returns a `SelfServicePortalUrl` for EVERY
+  // endpoint regardless of whether the CFn `SelfServicePortal` is enabled or disabled
+  // (live-verified: an endpoint that declares no SelfServicePortal — i.e. the "disabled"
+  // default — still returns a URL). So URL presence cannot distinguish enabled from disabled,
+  // and deriving "enabled" from it would false-drift against a declared "disabled". There is
+  // no reliable read-back signal, so the field is left unread (a declared value becomes a
+  // readGap — honest — rather than a false positive).
   // ConnectionLogOptions: API ConnectionLogResponseOptions carries the SAME CFn field names
   // (Enabled/CloudwatchLogGroup/CloudwatchLogStream). Project the sub-fields that are present.
   if (e.ConnectionLogOptions) {
@@ -957,6 +959,10 @@ const readEc2ClientVpnAuthorizationRule: OverrideReader = async ({ declared, reg
       `ClientVpnAuthorizationRule cidr=${cidr} group=${groupId} absent from endpoint ${endpointId}`
     );
   const model: Record<string, unknown> = {};
+  // Echo the parent endpoint id (the declared, resolved value) so a declared
+  // ClientVpnEndpointId compares rather than read-gapping (the describe call is scoped
+  // to it, so it is authoritative).
+  model.ClientVpnEndpointId = endpointId;
   if (str(rule.DestinationCidr)) model.TargetNetworkCidr = rule.DestinationCidr;
   if (str(rule.GroupId)) model.AccessGroupId = rule.GroupId;
   if (str(rule.Description)) model.Description = rule.Description;

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -28,10 +28,20 @@ import {
 } from '@aws-sdk/client-cloudwatch-logs';
 import {
   DescribeAddressesCommand,
+  DescribeClientVpnAuthorizationRulesCommand,
+  DescribeClientVpnEndpointsCommand,
+  DescribeClientVpnTargetNetworksCommand,
   DescribeLaunchTemplateVersionsCommand,
   DescribeNetworkAclsCommand,
   EC2Client,
 } from '@aws-sdk/client-ec2';
+import {
+  DAXClient,
+  DescribeClustersCommand,
+  DescribeParameterGroupsCommand,
+  DescribeParametersCommand as DescribeDaxParametersCommand,
+  DescribeSubnetGroupsCommand,
+} from '@aws-sdk/client-dax';
 import {
   GetClassifierCommand,
   GetConnectionCommand,
@@ -842,6 +852,229 @@ const readEc2LaunchTemplate: OverrideReader = async ({ physicalId, region }) => 
   if (str(v.LaunchTemplateName)) model.LaunchTemplateName = v.LaunchTemplateName;
   if (v.LaunchTemplateData !== undefined)
     model.LaunchTemplateData = v.LaunchTemplateData as Record<string, unknown>;
+  return model;
+};
+
+// AWS::EC2::ClientVpnEndpoint — NON_PROVISIONABLE (no Cloud Control read handler; issue #534).
+// The CFn physical id (Ref) IS the ClientVpnEndpointId, which
+// ec2:DescribeClientVpnEndpoints accepts directly. Project the CFn-declarable props; drop the
+// computed/managed fields (Status/CreationTime/DeletionTime/DnsName/VpnProtocol/
+// AssociatedTargetNetworks/ClientConnectOptions/ClientLoginBannerOptions/
+// ClientRouteEnforcementOptions/EndpointIpAddressType/Tags). Read-ONLY. A deleted endpoint
+// yields an empty result -> ResourceGoneError so the router maps it to `deleted`.
+const readEc2ClientVpnEndpoint: OverrideReader = async ({ physicalId, region }) => {
+  const id = str(physicalId);
+  if (!id) return undefined;
+  const c = new EC2Client({ region, ...READ_RETRY });
+  const r = await c.send(new DescribeClientVpnEndpointsCommand({ ClientVpnEndpointIds: [id] }));
+  const e = r.ClientVpnEndpoints?.[0];
+  if (!e) throw new ResourceGoneError(`ClientVpnEndpoint ${id} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(e.Description)) model.Description = e.Description;
+  if (str(e.ClientCidrBlock)) model.ClientCidrBlock = e.ClientCidrBlock;
+  const dnsServers = (e.DnsServers ?? []).filter((v): v is string => str(v) !== undefined);
+  if (dnsServers.length > 0) model.DnsServers = dnsServers;
+  if (typeof e.SplitTunnel === 'boolean') model.SplitTunnel = e.SplitTunnel;
+  if (str(e.TransportProtocol)) model.TransportProtocol = e.TransportProtocol;
+  if (typeof e.VpnPort === 'number') model.VpnPort = e.VpnPort;
+  if (str(e.ServerCertificateArn)) model.ServerCertificateArn = e.ServerCertificateArn;
+  const securityGroupIds = (e.SecurityGroupIds ?? []).filter(
+    (v): v is string => str(v) !== undefined
+  );
+  if (securityGroupIds.length > 0) model.SecurityGroupIds = securityGroupIds;
+  if (str(e.VpcId)) model.VpcId = e.VpcId;
+  if (typeof e.SessionTimeoutHours === 'number') model.SessionTimeoutHours = e.SessionTimeoutHours;
+  if (typeof e.DisconnectOnSessionTimeout === 'boolean')
+    model.DisconnectOnSessionTimeout = e.DisconnectOnSessionTimeout;
+  // SelfServicePortal: the API returns SelfServicePortalUrl (a non-empty URL when the portal
+  // is enabled), NOT the CFn enabled/disabled enum. Derive the CFn value from presence of the
+  // URL. This derived mapping is validated live.
+  if (str(e.SelfServicePortalUrl) !== undefined) model.SelfServicePortal = 'enabled';
+  else model.SelfServicePortal = 'disabled';
+  // ConnectionLogOptions: API ConnectionLogResponseOptions carries the SAME CFn field names
+  // (Enabled/CloudwatchLogGroup/CloudwatchLogStream). Project the sub-fields that are present.
+  if (e.ConnectionLogOptions) {
+    const clo: Record<string, unknown> = {};
+    if (typeof e.ConnectionLogOptions.Enabled === 'boolean')
+      clo.Enabled = e.ConnectionLogOptions.Enabled;
+    if (str(e.ConnectionLogOptions.CloudwatchLogGroup))
+      clo.CloudwatchLogGroup = e.ConnectionLogOptions.CloudwatchLogGroup;
+    if (str(e.ConnectionLogOptions.CloudwatchLogStream))
+      clo.CloudwatchLogStream = e.ConnectionLogOptions.CloudwatchLogStream;
+    if (Object.keys(clo).length > 0) model.ConnectionLogOptions = clo;
+  }
+  // AuthenticationOptions: API ClientVpnAuthentication[] -> CFn ClientAuthenticationRequest[].
+  // The CFn sub-field names DIFFER from the API: MutualAuthentication.ClientRootCertificateChain
+  // (API) -> ClientRootCertificateChainArn (CFn); FederatedAuthentication.SamlProviderArn (API)
+  // -> SAMLProviderArn (CFn); SelfServiceSamlProviderArn (API) -> SelfServiceSAMLProviderArn
+  // (CFn). These CFn names are validated live. Project each sub-object only when present.
+  if (Array.isArray(e.AuthenticationOptions) && e.AuthenticationOptions.length > 0) {
+    const auth = e.AuthenticationOptions.map((a) => {
+      const item: Record<string, unknown> = {};
+      if (str(a.Type)) item.Type = a.Type;
+      if (a.ActiveDirectory && str(a.ActiveDirectory.DirectoryId))
+        item.ActiveDirectory = { DirectoryId: a.ActiveDirectory.DirectoryId };
+      if (a.MutualAuthentication && str(a.MutualAuthentication.ClientRootCertificateChain))
+        item.MutualAuthentication = {
+          ClientRootCertificateChainArn: a.MutualAuthentication.ClientRootCertificateChain,
+        };
+      if (a.FederatedAuthentication) {
+        const fed: Record<string, unknown> = {};
+        if (str(a.FederatedAuthentication.SamlProviderArn))
+          fed.SAMLProviderArn = a.FederatedAuthentication.SamlProviderArn;
+        if (str(a.FederatedAuthentication.SelfServiceSamlProviderArn))
+          fed.SelfServiceSAMLProviderArn = a.FederatedAuthentication.SelfServiceSamlProviderArn;
+        if (Object.keys(fed).length > 0) item.FederatedAuthentication = fed;
+      }
+      return item;
+    });
+    model.AuthenticationOptions = auth;
+  }
+  return model;
+};
+
+// AWS::EC2::ClientVpnAuthorizationRule — NON_PROVISIONABLE (issue #534). The CFn Ref is an
+// opaque generated id, so the reader resolves the PARENT ClientVpnEndpointId from the declared
+// props and MATCHES the specific rule by its declared identity (TargetNetworkCidr === live
+// DestinationCidr, and — when declared — AccessGroupId === live GroupId). Read-ONLY. No matching
+// rule -> ResourceGoneError (deleted out of band); unresolved parent -> undefined (skipped).
+const readEc2ClientVpnAuthorizationRule: OverrideReader = async ({ declared, region }) => {
+  const endpointId = str(declared.ClientVpnEndpointId);
+  if (!endpointId) return undefined;
+  const cidr = str(declared.TargetNetworkCidr);
+  const groupId = str(declared.AccessGroupId);
+  const c = new EC2Client({ region, ...READ_RETRY });
+  const r = await c.send(
+    new DescribeClientVpnAuthorizationRulesCommand({ ClientVpnEndpointId: endpointId })
+  );
+  const rule = (r.AuthorizationRules ?? []).find(
+    (a) =>
+      (cidr === undefined || a.DestinationCidr === cidr) &&
+      (groupId === undefined || a.GroupId === groupId)
+  );
+  if (!rule)
+    throw new ResourceGoneError(
+      `ClientVpnAuthorizationRule cidr=${cidr} group=${groupId} absent from endpoint ${endpointId}`
+    );
+  const model: Record<string, unknown> = {};
+  if (str(rule.DestinationCidr)) model.TargetNetworkCidr = rule.DestinationCidr;
+  if (str(rule.GroupId)) model.AccessGroupId = rule.GroupId;
+  if (str(rule.Description)) model.Description = rule.Description;
+  if (typeof rule.AccessAll === 'boolean') model.AuthorizeAllGroups = rule.AccessAll;
+  return model;
+};
+
+// AWS::EC2::ClientVpnTargetNetworkAssociation — NON_PROVISIONABLE (issue #534). The CFn physical
+// id (Ref) IS the AssociationId; ec2:DescribeClientVpnTargetNetworks requires the parent
+// ClientVpnEndpointId (resolved from declared) plus the AssociationId. Read-ONLY. Empty result ->
+// ResourceGoneError (deleted out of band); unresolved parent -> undefined (skipped).
+const readEc2ClientVpnTargetNetworkAssociation: OverrideReader = async ({
+  physicalId,
+  declared,
+  region,
+}) => {
+  const id = str(physicalId);
+  const endpointId = str(declared.ClientVpnEndpointId);
+  if (!endpointId || !id) return undefined;
+  const c = new EC2Client({ region, ...READ_RETRY });
+  const r = await c.send(
+    new DescribeClientVpnTargetNetworksCommand({
+      ClientVpnEndpointId: endpointId,
+      AssociationIds: [id],
+    })
+  );
+  const n = r.ClientVpnTargetNetworks?.[0];
+  if (!n) throw new ResourceGoneError(`ClientVpnTargetNetworkAssociation ${id} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(n.ClientVpnEndpointId)) model.ClientVpnEndpointId = n.ClientVpnEndpointId;
+  if (str(n.TargetNetworkId)) model.SubnetId = n.TargetNetworkId;
+  return model;
+};
+
+// AWS::DAX::Cluster — NON_PROVISIONABLE (no Cloud Control read handler; issue #534). The CFn
+// physical id (Ref) IS the ClusterName, which dax:DescribeClusters accepts via ClusterNames.
+// Project the CFn-declarable props; drop the computed/managed fields (ClusterArn/TotalNodes/
+// ActiveNodes/Status/ClusterDiscoveryEndpoint/NodeIdsToRemove/Nodes/NetworkType). Note the CFn
+// casing IAMRoleARN (from API IamRoleArn) and the nested field extractions (SubnetGroupName from
+// SubnetGroup, SecurityGroupIds from SecurityGroups[].SecurityGroupIdentifier, ParameterGroupName
+// from ParameterGroup.ParameterGroupName, NotificationTopicARN from
+// NotificationConfiguration.TopicArn, SSESpecification from SSEDescription.Status). Read-ONLY.
+// Empty result -> ResourceGoneError so the router maps it to `deleted`.
+const readDaxCluster: OverrideReader = async ({ physicalId, region }) => {
+  const name = str(physicalId);
+  if (!name) return undefined;
+  const c = new DAXClient({ region, ...READ_RETRY });
+  const cl = (await c.send(new DescribeClustersCommand({ ClusterNames: [name] }))).Clusters?.[0];
+  if (!cl) throw new ResourceGoneError(`DAX Cluster ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(cl.ClusterName)) model.ClusterName = cl.ClusterName;
+  if (str(cl.Description)) model.Description = cl.Description;
+  if (str(cl.NodeType)) model.NodeType = cl.NodeType;
+  if (str(cl.IamRoleArn)) model.IAMRoleARN = cl.IamRoleArn;
+  if (str(cl.PreferredMaintenanceWindow))
+    model.PreferredMaintenanceWindow = cl.PreferredMaintenanceWindow;
+  if (str(cl.SubnetGroup)) model.SubnetGroupName = cl.SubnetGroup;
+  if (str(cl.ClusterEndpointEncryptionType))
+    model.ClusterEndpointEncryptionType = cl.ClusterEndpointEncryptionType;
+  const securityGroupIds = (cl.SecurityGroups ?? [])
+    .map((s) => str(s.SecurityGroupIdentifier))
+    .filter((v): v is string => v !== undefined);
+  if (securityGroupIds.length > 0) model.SecurityGroupIds = securityGroupIds;
+  if (cl.ParameterGroup && str(cl.ParameterGroup.ParameterGroupName))
+    model.ParameterGroupName = cl.ParameterGroup.ParameterGroupName;
+  if (cl.NotificationConfiguration && str(cl.NotificationConfiguration.TopicArn))
+    model.NotificationTopicARN = cl.NotificationConfiguration.TopicArn;
+  if (cl.SSEDescription?.Status === 'ENABLED') model.SSESpecification = { SSEEnabled: true };
+  return model;
+};
+
+// AWS::DAX::ParameterGroup — NON_PROVISIONABLE (issue #534). The CFn physical id (Ref) IS the
+// ParameterGroupName. DescribeParameterGroups yields the name + description;
+// DescribeParameters yields the parameter values, projected as the CFn free-form map
+// ParameterNameValues { name -> value }. Only user-settable parameters (IsModifiable !== 'FALSE')
+// are projected — DAX returns many system-fixed defaults that the user never declared. Read-ONLY.
+// Empty result -> ResourceGoneError so the router maps it to `deleted`.
+const readDaxParameterGroup: OverrideReader = async ({ physicalId, region }) => {
+  const name = str(physicalId);
+  if (!name) return undefined;
+  const c = new DAXClient({ region, ...READ_RETRY });
+  const g = (await c.send(new DescribeParameterGroupsCommand({ ParameterGroupNames: [name] })))
+    .ParameterGroups?.[0];
+  if (!g) throw new ResourceGoneError(`DAX ParameterGroup ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(g.ParameterGroupName)) model.ParameterGroupName = g.ParameterGroupName;
+  if (str(g.Description)) model.Description = g.Description;
+  const p = await c.send(new DescribeDaxParametersCommand({ ParameterGroupName: name }));
+  const values: Record<string, string> = {};
+  for (const param of p.Parameters ?? []) {
+    // Skip system-fixed parameters (IsModifiable === 'FALSE') — they are not user-declarable.
+    if (param.IsModifiable === 'FALSE') continue;
+    const pName = str(param.ParameterName);
+    const pValue = param.ParameterValue;
+    if (pName !== undefined && typeof pValue === 'string') values[pName] = pValue;
+  }
+  if (Object.keys(values).length > 0) model.ParameterNameValues = values;
+  return model;
+};
+
+// AWS::DAX::SubnetGroup — NON_PROVISIONABLE (issue #534). The CFn physical id (Ref) IS the
+// SubnetGroupName. Project SubnetGroupName/Description and flatten Subnets[].SubnetIdentifier to
+// the CFn SubnetIds list. Drop the computed/managed fields (VpcId/SupportedNetworkTypes).
+// Read-ONLY. Empty result -> ResourceGoneError so the router maps it to `deleted`.
+const readDaxSubnetGroup: OverrideReader = async ({ physicalId, region }) => {
+  const name = str(physicalId);
+  if (!name) return undefined;
+  const c = new DAXClient({ region, ...READ_RETRY });
+  const g = (await c.send(new DescribeSubnetGroupsCommand({ SubnetGroupNames: [name] })))
+    .SubnetGroups?.[0];
+  if (!g) throw new ResourceGoneError(`DAX SubnetGroup ${name} absent`);
+  const model: Record<string, unknown> = {};
+  if (str(g.SubnetGroupName)) model.SubnetGroupName = g.SubnetGroupName;
+  if (str(g.Description)) model.Description = g.Description;
+  const subnetIds = (g.Subnets ?? [])
+    .map((s) => str(s.SubnetIdentifier))
+    .filter((v): v is string => v !== undefined);
+  if (subnetIds.length > 0) model.SubnetIds = subnetIds;
   return model;
 };
 
@@ -1728,6 +1961,12 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::EC2::EIP': readEc2Eip,
   'AWS::EC2::LaunchTemplate': readEc2LaunchTemplate,
   'AWS::EC2::NetworkAclEntry': readEc2NetworkAclEntry,
+  'AWS::EC2::ClientVpnEndpoint': readEc2ClientVpnEndpoint,
+  'AWS::EC2::ClientVpnAuthorizationRule': readEc2ClientVpnAuthorizationRule,
+  'AWS::EC2::ClientVpnTargetNetworkAssociation': readEc2ClientVpnTargetNetworkAssociation,
+  'AWS::DAX::Cluster': readDaxCluster,
+  'AWS::DAX::ParameterGroup': readDaxParameterGroup,
+  'AWS::DAX::SubnetGroup': readDaxSubnetGroup,
   'AWS::CloudWatch::AnomalyDetector': readCloudWatchAnomalyDetector,
   'AWS::CodeBuild::ReportGroup': readCodeBuildReportGroup,
   'AWS::DLM::LifecyclePolicy': readDlmLifecyclePolicy,

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -17,7 +17,20 @@ import {
   BatchGetReportGroupsCommand,
   CodeBuildClient,
 } from '@aws-sdk/client-codebuild';
-import { DescribeNetworkAclsCommand, EC2Client } from '@aws-sdk/client-ec2';
+import {
+  DescribeClientVpnAuthorizationRulesCommand,
+  DescribeClientVpnEndpointsCommand,
+  DescribeClientVpnTargetNetworksCommand,
+  DescribeNetworkAclsCommand,
+  EC2Client,
+} from '@aws-sdk/client-ec2';
+import {
+  DAXClient,
+  DescribeClustersCommand,
+  DescribeParameterGroupsCommand,
+  DescribeParametersCommand as DescribeDaxParametersCommand,
+  DescribeSubnetGroupsCommand,
+} from '@aws-sdk/client-dax';
 import {
   DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
@@ -84,6 +97,7 @@ const cloudwatch = mockClient(CloudWatchClient);
 const dlm = mockClient(DLMClient);
 const dms = mockClient(DatabaseMigrationServiceClient);
 const mediaconvert = mockClient(MediaConvertClient);
+const dax = mockClient(DAXClient);
 
 const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
   physicalId,
@@ -116,6 +130,7 @@ beforeEach(() => {
     dlm,
     dms,
     mediaconvert,
+    dax,
   ])
     m.reset();
 });
@@ -2426,5 +2441,368 @@ describe('SES inbound receipt-rule family (Cloud Control read-gap: no handlers)'
 
   it('ReceiptFilter: undefined (skipped) when neither physical id nor declared name resolves', async () => {
     expect(await SDK_OVERRIDES['AWS::SES::ReceiptFilter'](ctx({}))).toBeUndefined();
+  });
+});
+
+describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
+  describe('ClientVpnEndpoint', () => {
+    it('projects the CFn-declarable props + derives SelfServicePortal from the URL', async () => {
+      ec2.on(DescribeClientVpnEndpointsCommand).resolves({
+        ClientVpnEndpoints: [
+          {
+            ClientVpnEndpointId: 'cvpn-endpoint-abc',
+            Description: 'my vpn',
+            ClientCidrBlock: '10.0.0.0/22',
+            DnsServers: ['8.8.8.8'],
+            SplitTunnel: true,
+            TransportProtocol: 'udp',
+            VpnPort: 443,
+            ServerCertificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/srv',
+            SecurityGroupIds: ['sg-123'],
+            VpcId: 'vpc-123',
+            SessionTimeoutHours: 12,
+            DisconnectOnSessionTimeout: false,
+            SelfServicePortalUrl: 'https://self-service.clientvpn.amazonaws.com/endpoints/cvpn',
+            ConnectionLogOptions: {
+              Enabled: true,
+              CloudwatchLogGroup: '/aws/vpn',
+              CloudwatchLogStream: 'conn',
+            },
+            AuthenticationOptions: [
+              {
+                Type: 'certificate-authentication',
+                MutualAuthentication: { ClientRootCertificateChain: 'arn:aws:acm:...:ca' },
+              },
+              {
+                Type: 'federated-authentication',
+                FederatedAuthentication: {
+                  SamlProviderArn: 'arn:aws:iam::123456789012:saml-provider/idp',
+                  SelfServiceSamlProviderArn: 'arn:aws:iam::123456789012:saml-provider/self',
+                },
+              },
+              {
+                Type: 'directory-service-authentication',
+                ActiveDirectory: { DirectoryId: 'd-123' },
+              },
+            ],
+            // computed/managed fields the projection must drop
+            Status: { Code: 'available' },
+            CreationTime: '2026-01-01',
+            DnsName: '*.cvpn.prod.clientvpn.us-east-1.amazonaws.com',
+            VpnProtocol: 'openvpn',
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnEndpoint'](ctx({}, 'cvpn-endpoint-abc'));
+      expect(out).toEqual({
+        Description: 'my vpn',
+        ClientCidrBlock: '10.0.0.0/22',
+        DnsServers: ['8.8.8.8'],
+        SplitTunnel: true,
+        TransportProtocol: 'udp',
+        VpnPort: 443,
+        ServerCertificateArn: 'arn:aws:acm:us-east-1:123456789012:certificate/srv',
+        SecurityGroupIds: ['sg-123'],
+        VpcId: 'vpc-123',
+        SessionTimeoutHours: 12,
+        DisconnectOnSessionTimeout: false,
+        SelfServicePortal: 'enabled',
+        ConnectionLogOptions: {
+          Enabled: true,
+          CloudwatchLogGroup: '/aws/vpn',
+          CloudwatchLogStream: 'conn',
+        },
+        AuthenticationOptions: [
+          {
+            Type: 'certificate-authentication',
+            MutualAuthentication: { ClientRootCertificateChainArn: 'arn:aws:acm:...:ca' },
+          },
+          {
+            Type: 'federated-authentication',
+            FederatedAuthentication: {
+              SAMLProviderArn: 'arn:aws:iam::123456789012:saml-provider/idp',
+              SelfServiceSAMLProviderArn: 'arn:aws:iam::123456789012:saml-provider/self',
+            },
+          },
+          {
+            Type: 'directory-service-authentication',
+            ActiveDirectory: { DirectoryId: 'd-123' },
+          },
+        ],
+      });
+      const call = ec2.commandCalls(DescribeClientVpnEndpointsCommand)[0]!;
+      expect(call.args[0].input).toEqual({ ClientVpnEndpointIds: ['cvpn-endpoint-abc'] });
+    });
+
+    it('SelfServicePortal is disabled when no SelfServicePortalUrl is returned', async () => {
+      ec2.on(DescribeClientVpnEndpointsCommand).resolves({
+        ClientVpnEndpoints: [{ ClientVpnEndpointId: 'cvpn-endpoint-abc', Description: 'x' }],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnEndpoint'](ctx({}, 'cvpn-endpoint-abc'));
+      expect(out).toEqual({ Description: 'x', SelfServicePortal: 'disabled' });
+    });
+
+    it('the endpoint is absent -> ResourceGoneError (deleted out of band)', async () => {
+      ec2.on(DescribeClientVpnEndpointsCommand).resolves({ ClientVpnEndpoints: [] } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::EC2::ClientVpnEndpoint'](ctx({}, 'cvpn-endpoint-abc'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('no physical id -> undefined (skipped)', async () => {
+      expect(await SDK_OVERRIDES['AWS::EC2::ClientVpnEndpoint'](ctx({}, ''))).toBeUndefined();
+    });
+  });
+
+  describe('ClientVpnAuthorizationRule', () => {
+    it('matches the rule by TargetNetworkCidr + AccessGroupId and projects the CFn shape', async () => {
+      ec2.on(DescribeClientVpnAuthorizationRulesCommand).resolves({
+        AuthorizationRules: [
+          { DestinationCidr: '10.0.0.0/16', GroupId: 'other', AccessAll: false },
+          {
+            DestinationCidr: '192.168.0.0/16',
+            GroupId: 'grp-1',
+            Description: 'admins',
+            AccessAll: false,
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnAuthorizationRule'](
+        ctx({
+          ClientVpnEndpointId: 'cvpn-endpoint-abc',
+          TargetNetworkCidr: '192.168.0.0/16',
+          AccessGroupId: 'grp-1',
+        })
+      );
+      expect(out).toEqual({
+        TargetNetworkCidr: '192.168.0.0/16',
+        AccessGroupId: 'grp-1',
+        Description: 'admins',
+        AuthorizeAllGroups: false,
+      });
+      const call = ec2.commandCalls(DescribeClientVpnAuthorizationRulesCommand)[0]!;
+      expect(call.args[0].input).toEqual({ ClientVpnEndpointId: 'cvpn-endpoint-abc' });
+    });
+
+    it('matches an all-groups rule when no AccessGroupId is declared', async () => {
+      ec2.on(DescribeClientVpnAuthorizationRulesCommand).resolves({
+        AuthorizationRules: [{ DestinationCidr: '0.0.0.0/0', AccessAll: true }],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnAuthorizationRule'](
+        ctx({ ClientVpnEndpointId: 'cvpn-endpoint-abc', TargetNetworkCidr: '0.0.0.0/0' })
+      );
+      expect(out).toEqual({ TargetNetworkCidr: '0.0.0.0/0', AuthorizeAllGroups: true });
+    });
+
+    it('no matching rule -> ResourceGoneError (deleted out of band)', async () => {
+      ec2.on(DescribeClientVpnAuthorizationRulesCommand).resolves({
+        AuthorizationRules: [{ DestinationCidr: '10.0.0.0/16' }],
+      } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::EC2::ClientVpnAuthorizationRule'](
+          ctx({ ClientVpnEndpointId: 'cvpn-endpoint-abc', TargetNetworkCidr: '192.168.0.0/16' })
+        )
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('no declared parent endpoint -> undefined (skipped)', async () => {
+      expect(
+        await SDK_OVERRIDES['AWS::EC2::ClientVpnAuthorizationRule'](
+          ctx({ TargetNetworkCidr: '192.168.0.0/16' })
+        )
+      ).toBeUndefined();
+    });
+  });
+
+  describe('ClientVpnTargetNetworkAssociation', () => {
+    it('projects ClientVpnEndpointId + SubnetId (from TargetNetworkId)', async () => {
+      ec2.on(DescribeClientVpnTargetNetworksCommand).resolves({
+        ClientVpnTargetNetworks: [
+          {
+            AssociationId: 'cvpn-assoc-123',
+            ClientVpnEndpointId: 'cvpn-endpoint-abc',
+            TargetNetworkId: 'subnet-123',
+            Status: { Code: 'associated' },
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnTargetNetworkAssociation'](
+        ctx({ ClientVpnEndpointId: 'cvpn-endpoint-abc' }, 'cvpn-assoc-123')
+      );
+      expect(out).toEqual({
+        ClientVpnEndpointId: 'cvpn-endpoint-abc',
+        SubnetId: 'subnet-123',
+      });
+      const call = ec2.commandCalls(DescribeClientVpnTargetNetworksCommand)[0]!;
+      expect(call.args[0].input).toEqual({
+        ClientVpnEndpointId: 'cvpn-endpoint-abc',
+        AssociationIds: ['cvpn-assoc-123'],
+      });
+    });
+
+    it('the association is absent -> ResourceGoneError (deleted out of band)', async () => {
+      ec2
+        .on(DescribeClientVpnTargetNetworksCommand)
+        .resolves({ ClientVpnTargetNetworks: [] } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::EC2::ClientVpnTargetNetworkAssociation'](
+          ctx({ ClientVpnEndpointId: 'cvpn-endpoint-abc' }, 'cvpn-assoc-123')
+        )
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('no declared parent endpoint -> undefined (skipped)', async () => {
+      expect(
+        await SDK_OVERRIDES['AWS::EC2::ClientVpnTargetNetworkAssociation'](
+          ctx({}, 'cvpn-assoc-123')
+        )
+      ).toBeUndefined();
+    });
+  });
+});
+
+describe('DAX family (NON_PROVISIONABLE, issue #534)', () => {
+  describe('Cluster', () => {
+    it('projects the CFn-declarable props with correct casing + nested extractions', async () => {
+      dax.on(DescribeClustersCommand).resolves({
+        Clusters: [
+          {
+            ClusterName: 'my-dax',
+            Description: 'cache cluster',
+            NodeType: 'dax.r5.large',
+            IamRoleArn: 'arn:aws:iam::123456789012:role/dax',
+            PreferredMaintenanceWindow: 'sun:01:00-sun:09:00',
+            SubnetGroup: 'my-subnet-grp',
+            ClusterEndpointEncryptionType: 'TLS',
+            SecurityGroups: [
+              { SecurityGroupIdentifier: 'sg-aaa', Status: 'active' },
+              { SecurityGroupIdentifier: 'sg-bbb', Status: 'active' },
+            ],
+            ParameterGroup: { ParameterGroupName: 'my-pg', ParameterApplyStatus: 'in-sync' },
+            NotificationConfiguration: {
+              TopicArn: 'arn:aws:sns:us-east-1:123456789012:dax-events',
+              TopicStatus: 'active',
+            },
+            SSEDescription: { Status: 'ENABLED' },
+            // computed/managed fields the projection must drop
+            ClusterArn: 'arn:aws:dax:us-east-1:123456789012:cache/my-dax',
+            TotalNodes: 3,
+            ActiveNodes: 3,
+            Status: 'available',
+            NetworkType: 'ipv4',
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DAX::Cluster'](ctx({}, 'my-dax'));
+      expect(out).toEqual({
+        ClusterName: 'my-dax',
+        Description: 'cache cluster',
+        NodeType: 'dax.r5.large',
+        IAMRoleARN: 'arn:aws:iam::123456789012:role/dax',
+        PreferredMaintenanceWindow: 'sun:01:00-sun:09:00',
+        SubnetGroupName: 'my-subnet-grp',
+        ClusterEndpointEncryptionType: 'TLS',
+        SecurityGroupIds: ['sg-aaa', 'sg-bbb'],
+        ParameterGroupName: 'my-pg',
+        NotificationTopicARN: 'arn:aws:sns:us-east-1:123456789012:dax-events',
+        SSESpecification: { SSEEnabled: true },
+      });
+      const call = dax.commandCalls(DescribeClustersCommand)[0]!;
+      expect(call.args[0].input).toEqual({ ClusterNames: ['my-dax'] });
+    });
+
+    it('omits SSESpecification when SSE is not ENABLED', async () => {
+      dax.on(DescribeClustersCommand).resolves({
+        Clusters: [{ ClusterName: 'my-dax', SSEDescription: { Status: 'DISABLED' } }],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DAX::Cluster'](ctx({}, 'my-dax'));
+      expect(out).toEqual({ ClusterName: 'my-dax' });
+    });
+
+    it('the cluster is absent -> ResourceGoneError (deleted out of band)', async () => {
+      dax.on(DescribeClustersCommand).resolves({ Clusters: [] } as never);
+      await expect(SDK_OVERRIDES['AWS::DAX::Cluster'](ctx({}, 'my-dax'))).rejects.toBeInstanceOf(
+        ResourceGoneError
+      );
+    });
+
+    it('no physical id -> undefined (skipped)', async () => {
+      expect(await SDK_OVERRIDES['AWS::DAX::Cluster'](ctx({}, ''))).toBeUndefined();
+    });
+  });
+
+  describe('ParameterGroup', () => {
+    it('projects name/description + user-settable ParameterNameValues (skips IsModifiable FALSE)', async () => {
+      dax.on(DescribeParameterGroupsCommand).resolves({
+        ParameterGroups: [{ ParameterGroupName: 'my-pg', Description: 'tuned' }],
+      } as never);
+      dax.on(DescribeDaxParametersCommand).resolves({
+        Parameters: [
+          { ParameterName: 'query-ttl-millis', ParameterValue: '60000', IsModifiable: 'TRUE' },
+          { ParameterName: 'record-ttl-millis', ParameterValue: '30000', IsModifiable: 'TRUE' },
+          // system-fixed parameter — must be skipped
+          { ParameterName: 'cluster-role', ParameterValue: 'replica', IsModifiable: 'FALSE' },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DAX::ParameterGroup'](ctx({}, 'my-pg'));
+      expect(out).toEqual({
+        ParameterGroupName: 'my-pg',
+        Description: 'tuned',
+        ParameterNameValues: {
+          'query-ttl-millis': '60000',
+          'record-ttl-millis': '30000',
+        },
+      });
+      const call = dax.commandCalls(DescribeDaxParametersCommand)[0]!;
+      expect(call.args[0].input).toEqual({ ParameterGroupName: 'my-pg' });
+    });
+
+    it('the parameter group is absent -> ResourceGoneError (deleted out of band)', async () => {
+      dax.on(DescribeParameterGroupsCommand).resolves({ ParameterGroups: [] } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::DAX::ParameterGroup'](ctx({}, 'my-pg'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('no physical id -> undefined (skipped)', async () => {
+      expect(await SDK_OVERRIDES['AWS::DAX::ParameterGroup'](ctx({}, ''))).toBeUndefined();
+    });
+  });
+
+  describe('SubnetGroup', () => {
+    it('projects name/description + flattens Subnets to a SubnetIds list', async () => {
+      dax.on(DescribeSubnetGroupsCommand).resolves({
+        SubnetGroups: [
+          {
+            SubnetGroupName: 'my-subnet-grp',
+            Description: 'dax subnets',
+            VpcId: 'vpc-123',
+            Subnets: [
+              { SubnetIdentifier: 'subnet-aaa', SubnetAvailabilityZone: 'us-east-1a' },
+              { SubnetIdentifier: 'subnet-bbb', SubnetAvailabilityZone: 'us-east-1b' },
+            ],
+          },
+        ],
+      } as never);
+      const out = await SDK_OVERRIDES['AWS::DAX::SubnetGroup'](ctx({}, 'my-subnet-grp'));
+      expect(out).toEqual({
+        SubnetGroupName: 'my-subnet-grp',
+        Description: 'dax subnets',
+        SubnetIds: ['subnet-aaa', 'subnet-bbb'],
+      });
+      const call = dax.commandCalls(DescribeSubnetGroupsCommand)[0]!;
+      expect(call.args[0].input).toEqual({ SubnetGroupNames: ['my-subnet-grp'] });
+    });
+
+    it('the subnet group is absent -> ResourceGoneError (deleted out of band)', async () => {
+      dax.on(DescribeSubnetGroupsCommand).resolves({ SubnetGroups: [] } as never);
+      await expect(
+        SDK_OVERRIDES['AWS::DAX::SubnetGroup'](ctx({}, 'my-subnet-grp'))
+      ).rejects.toBeInstanceOf(ResourceGoneError);
+    });
+
+    it('no physical id -> undefined (skipped)', async () => {
+      expect(await SDK_OVERRIDES['AWS::DAX::SubnetGroup'](ctx({}, ''))).toBeUndefined();
+    });
   });
 });

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -2446,7 +2446,7 @@ describe('SES inbound receipt-rule family (Cloud Control read-gap: no handlers)'
 
 describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
   describe('ClientVpnEndpoint', () => {
-    it('projects the CFn-declarable props + derives SelfServicePortal from the URL', async () => {
+    it('projects the CFn-declarable props (SelfServicePortal is NOT read — see below)', async () => {
       ec2.on(DescribeClientVpnEndpointsCommand).resolves({
         ClientVpnEndpoints: [
           {
@@ -2506,7 +2506,6 @@ describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
         VpcId: 'vpc-123',
         SessionTimeoutHours: 12,
         DisconnectOnSessionTimeout: false,
-        SelfServicePortal: 'enabled',
         ConnectionLogOptions: {
           Enabled: true,
           CloudwatchLogGroup: '/aws/vpn',
@@ -2534,12 +2533,20 @@ describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
       expect(call.args[0].input).toEqual({ ClientVpnEndpointIds: ['cvpn-endpoint-abc'] });
     });
 
-    it('SelfServicePortal is disabled when no SelfServicePortalUrl is returned', async () => {
+    it('SelfServicePortal is NOT projected even when a URL is returned (live: URL present when disabled too)', async () => {
       ec2.on(DescribeClientVpnEndpointsCommand).resolves({
-        ClientVpnEndpoints: [{ ClientVpnEndpointId: 'cvpn-endpoint-abc', Description: 'x' }],
+        ClientVpnEndpoints: [
+          {
+            ClientVpnEndpointId: 'cvpn-endpoint-abc',
+            Description: 'x',
+            // AWS returns a portal URL for EVERY endpoint, enabled or not — so it is unusable.
+            SelfServicePortalUrl: 'https://self-service.clientvpn.amazonaws.com/endpoints/cvpn',
+          },
+        ],
       } as never);
       const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnEndpoint'](ctx({}, 'cvpn-endpoint-abc'));
-      expect(out).toEqual({ Description: 'x', SelfServicePortal: 'disabled' });
+      expect(out).toEqual({ Description: 'x' });
+      expect(out).not.toHaveProperty('SelfServicePortal');
     });
 
     it('the endpoint is absent -> ResourceGoneError (deleted out of band)', async () => {
@@ -2575,6 +2582,7 @@ describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
         })
       );
       expect(out).toEqual({
+        ClientVpnEndpointId: 'cvpn-endpoint-abc',
         TargetNetworkCidr: '192.168.0.0/16',
         AccessGroupId: 'grp-1',
         Description: 'admins',
@@ -2591,7 +2599,11 @@ describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
       const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnAuthorizationRule'](
         ctx({ ClientVpnEndpointId: 'cvpn-endpoint-abc', TargetNetworkCidr: '0.0.0.0/0' })
       );
-      expect(out).toEqual({ TargetNetworkCidr: '0.0.0.0/0', AuthorizeAllGroups: true });
+      expect(out).toEqual({
+        ClientVpnEndpointId: 'cvpn-endpoint-abc',
+        TargetNetworkCidr: '0.0.0.0/0',
+        AuthorizeAllGroups: true,
+      });
     });
 
     it('no matching rule -> ResourceGoneError (deleted out of band)', async () => {


### PR DESCRIPTION
Closes #534.

The EC2 ClientVPN family (`ClientVpnEndpoint`, `ClientVpnAuthorizationRule`, `ClientVpnTargetNetworkAssociation`) and the DAX family (`Cluster`, `ParameterGroup`, `SubnetGroup`) are all NON_PROVISIONABLE (no Cloud Control read handler) → silently skipped on every check. Adds `SDK_OVERRIDES` readers for all six (ec2 `DescribeClientVpn*` / dax `Describe*`), projecting the CFn-declarable surface, FP-safe (project only what AWS returns), read-only. Child readers resolve the parent id from the declared Ref; the rule reader matches by `TargetNetworkCidr` + `AccessGroupId`; DAX ParameterGroup projects only `IsModifiable!='FALSE'` params (not the ~30 system defaults).

**Live-verified** (us-east-1, real ClientVPN endpoint + DAX cluster): all six types READ (no skips), no declared-drift FPs, an out-of-band `ClientVpnEndpoint.Description` change is DETECTED. Live verification also caught+fixed two FPs (2nd commit): AWS returns a `SelfServicePortalUrl` for EVERY endpoint (even when disabled), so the `URL→enabled` derivation was dropped (it would false-drift a declared `disabled`); and the AuthorizationRule reader now echoes the known parent `ClientVpnEndpointId` (was a readGap). Mock unit tests added.
