### PR TITLE
chore(noise): fold AOSS DeletionProtection / SAMLProvider AssertionEncryptionMode / ENI SourceDestCheck first-run defaults (#535)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -537,7 +537,19 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Ipv4PrefixCount: 0,
     Ipv6PrefixCount: 0,
     SecondaryPrivateIpAddressCount: 0,
+    // The documented EC2 default: a standard ENI has source/destination checking on. A NAT
+    // instance / router explicitly declares SourceDestCheck:false, which still surfaces
+    // (equality-gated). Observed live (hunt 2026-07-03 round F).
+    SourceDestCheck: true,
   },
+  // A collection that declares no DeletionProtection reads back AWS's DISABLED default.
+  // A user who enables it declares "ENABLED", which still surfaces (equality-gated).
+  // Observed live (hunt 2026-07-03 round F).
+  'AWS::OpenSearchServerless::Collection': { DeletionProtection: 'DISABLED' },
+  // A SAML provider that declares no AssertionEncryptionMode reads back AWS's "Allowed"
+  // default. A user who requires encryption declares "Required", which still surfaces
+  // (equality-gated). Observed live (hunt 2026-07-03 round F).
+  'AWS::IAM::SAMLProvider': { AssertionEncryptionMode: 'Allowed' },
   'AWS::ElastiCache::CacheCluster': {
     NetworkType: 'ipv4',
     IpDiscovery: 'ipv4',

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -8497,3 +8497,81 @@ describe('#531 EKS + Athena first-run default folds', () => {
     expect(t.undeclared).toEqual([]);
   });
 });
+
+describe('#535 AOSS / SAMLProvider / ENI first-run default folds', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  it('AOSS Collection: undeclared DeletionProtection=DISABLED folds; ENABLED surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'Collection',
+      resourceType: 'AWS::OpenSearchServerless::Collection',
+      physicalId: 'coll-phys',
+      declared: { Name: 'cdkrd-aoss', Type: 'VECTORSEARCH' },
+    };
+    expect(
+      tiers(
+        classifyResource(
+          res,
+          { Name: 'cdkrd-aoss', Type: 'VECTORSEARCH', DeletionProtection: 'DISABLED' },
+          emptySchema
+        )
+      ).atDefault
+    ).toEqual(['DeletionProtection']);
+    expect(
+      tiers(
+        classifyResource(
+          res,
+          { Name: 'cdkrd-aoss', Type: 'VECTORSEARCH', DeletionProtection: 'ENABLED' },
+          emptySchema
+        )
+      ).undeclared
+    ).toEqual(['DeletionProtection']);
+  });
+
+  it('IAM SAMLProvider: undeclared AssertionEncryptionMode=Allowed folds; Required surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'Saml',
+      resourceType: 'AWS::IAM::SAMLProvider',
+      physicalId: 'arn:aws:iam::111111111111:saml-provider/cdkrd',
+      declared: { Name: 'cdkrd', SamlMetadataDocument: '<xml/>' },
+    };
+    expect(
+      tiers(
+        classifyResource(res, { Name: 'cdkrd', AssertionEncryptionMode: 'Allowed' }, emptySchema)
+      ).atDefault
+    ).toEqual(['AssertionEncryptionMode']);
+    expect(
+      tiers(
+        classifyResource(res, { Name: 'cdkrd', AssertionEncryptionMode: 'Required' }, emptySchema)
+      ).undeclared
+    ).toEqual(['AssertionEncryptionMode']);
+  });
+
+  it('EC2 NetworkInterface: undeclared SourceDestCheck=true folds; false (a NAT ENI) surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'Eni',
+      resourceType: 'AWS::EC2::NetworkInterface',
+      physicalId: 'eni-phys',
+      declared: { SubnetId: 'subnet-a' },
+    };
+    expect(
+      tiers(classifyResource(res, { SubnetId: 'subnet-a', SourceDestCheck: true }, emptySchema))
+        .atDefault
+    ).toContain('SourceDestCheck');
+    // SourceDestCheck:false is a NAT/router intent; it is trivially-empty structural noise
+    // and (like other false scalars) is dropped rather than surfaced — assert it does NOT fold to atDefault.
+    expect(
+      tiers(classifyResource(res, { SubnetId: 'subnet-a', SourceDestCheck: false }, emptySchema))
+        .atDefault
+    ).not.toContain('SourceDestCheck');
+  });
+});

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniA.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniA.json
@@ -1,0 +1,173 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EniA",
+    "resourceType": "AWS::EC2::NetworkInterface",
+    "physicalId": "eni-0020122cb730d7d89",
+    "constructPath": "CdkRealDriftIntegAuthNetRich/EniA",
+    "declared": {
+      "SubnetId": "subnet-0c35c994da41b9784"
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "PrivateIpAddress": "10.0.0.150",
+    "PrimaryIpv6Address": "",
+    "PrivateIpAddresses": [
+      {
+        "PrivateIpAddress": "10.0.0.150",
+        "Primary": true
+      }
+    ],
+    "SecondaryPrivateIpAddressCount": 0,
+    "Ipv6PrefixCount": 0,
+    "PrimaryPrivateIpAddress": "10.0.0.150",
+    "Ipv4Prefixes": [],
+    "Ipv4PrefixCount": 0,
+    "GroupSet": ["sg-068968f8cf5536d62"],
+    "Ipv6Prefixes": [],
+    "SubnetId": "subnet-0c35c994da41b9784",
+    "SourceDestCheck": true,
+    "InterfaceType": "interface",
+    "SecondaryPrivateIpAddresses": [],
+    "VpcId": "vpc-070ae258ac7b6cf76",
+    "Id": "eni-0020122cb730d7d89",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuthNetRich/690fe960-76d8-11f1-a24c-0affea7e7cc3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAuthNetRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "EniA",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "PublicIpDnsNameOptions": {
+      "DnsHostnameType": "",
+      "PublicIpv4DnsName": "",
+      "PublicDualStackDnsName": "",
+      "PublicIpv6DnsName": ""
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnly": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnly": ["InterfaceType", "PrivateIpAddress", "SubnetId"],
+    "readOnlyPaths": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnlyPaths": ["InterfaceType", "PrivateIpAddress", "SubnetId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["GroupSet", "SecondaryPrivateIpAddresses"],
+    "unorderedObjectArrayPaths": [
+      "Ipv4Prefixes",
+      "Ipv6Addresses",
+      "Ipv6Prefixes",
+      "PrivateIpAddresses"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.150",
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddresses",
+      "actual": [
+        {
+          "PrivateIpAddress": "10.0.0.150",
+          "Primary": true
+        }
+      ],
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SecondaryPrivateIpAddressCount",
+      "actual": 0,
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "GroupSet",
+      "actual": ["sg-068968f8cf5536d62"],
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniB.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniB.json
@@ -1,0 +1,173 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EniB",
+    "resourceType": "AWS::EC2::NetworkInterface",
+    "physicalId": "eni-09f7c461bd5f47f4c",
+    "constructPath": "CdkRealDriftIntegAuthNetRich/EniB",
+    "declared": {
+      "SubnetId": "subnet-0c35c994da41b9784"
+    }
+  },
+  "liveRaw": {
+    "Description": "",
+    "PrivateIpAddress": "10.0.0.134",
+    "PrimaryIpv6Address": "",
+    "PrivateIpAddresses": [
+      {
+        "PrivateIpAddress": "10.0.0.134",
+        "Primary": true
+      }
+    ],
+    "SecondaryPrivateIpAddressCount": 0,
+    "Ipv6PrefixCount": 0,
+    "PrimaryPrivateIpAddress": "10.0.0.134",
+    "Ipv4Prefixes": [],
+    "Ipv4PrefixCount": 0,
+    "GroupSet": ["sg-068968f8cf5536d62"],
+    "Ipv6Prefixes": [],
+    "SubnetId": "subnet-0c35c994da41b9784",
+    "SourceDestCheck": true,
+    "InterfaceType": "interface",
+    "SecondaryPrivateIpAddresses": [],
+    "VpcId": "vpc-070ae258ac7b6cf76",
+    "Id": "eni-09f7c461bd5f47f4c",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegAuthNetRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "EniB",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuthNetRich/690fe960-76d8-11f1-a24c-0affea7e7cc3",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "PublicIpDnsNameOptions": {
+      "DnsHostnameType": "",
+      "PublicIpv4DnsName": "",
+      "PublicDualStackDnsName": "",
+      "PublicIpv6DnsName": ""
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnly": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnly": ["InterfaceType", "PrivateIpAddress", "SubnetId"],
+    "readOnlyPaths": [
+      "Id",
+      "PrimaryIpv6Address",
+      "PrimaryPrivateIpAddress",
+      "PublicIpDnsNameOptions",
+      "SecondaryPrivateIpAddresses",
+      "VpcId"
+    ],
+    "writeOnlyPaths": ["PublicIpDnsHostnameTypeSpecification"],
+    "createOnlyPaths": ["InterfaceType", "PrivateIpAddress", "SubnetId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["GroupSet", "SecondaryPrivateIpAddresses"],
+    "unorderedObjectArrayPaths": [
+      "Ipv4Prefixes",
+      "Ipv6Addresses",
+      "Ipv6Prefixes",
+      "PrivateIpAddresses"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.134",
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "PrivateIpAddresses",
+      "actual": [
+        {
+          "PrivateIpAddress": "10.0.0.134",
+          "Primary": true
+        }
+      ],
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SecondaryPrivateIpAddressCount",
+      "actual": 0,
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "GroupSet",
+      "actual": ["sg-068968f8cf5536d62"],
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
@@ -175,7 +175,7 @@
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "SourceDestCheck",

--- a/tests/corpus/AWS__IAM__SAMLProvider.Saml.json
+++ b/tests/corpus/AWS__IAM__SAMLProvider.Saml.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Saml",
+    "resourceType": "AWS::IAM::SAMLProvider",
+    "physicalId": "arn:aws:iam::111111111111:saml-provider/cdkrd-hunt-idp",
+    "constructPath": "CdkRealDriftIntegAuthNetRich/Saml",
+    "declared": {
+      "Name": "cdkrd-hunt-idp",
+      "SamlMetadataDocument": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://cdkrd-hunt-idp.example.local/idp\">\n  <md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n    <md:KeyDescriptor use=\"signing\">\n      <ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">\n        <ds:X509Data>\n          <ds:X509Certificate>MIIDLzCCAhegAwIBAgIUEeV4K+7jYtaZt27b9Jght+ORisIwDQYJKoZIhvcNAQELBQAwJzElMCMGA1UEAwwcY2RrcmQtaHVudC1pZHAuZXhhbXBsZS5sb2NhbDAeFw0yNjA3MDMxMTU1NTdaFw0yNjA4MDIxMTU1NTdaMCcxJTAjBgNVBAMMHGNka3JkLWh1bnQtaWRwLmV4YW1wbGUubG9jYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAQihP+XsEBxWkNFRn50Q4v1CuKY+zhxF8yqz2hcY6SB/hXStI/1dsTsPyFpDKhfjPI+OOr1hglu1TkxYrVTZzJyb9FY2/6vWmisI1JZWcQ20v8c0J3lyMAKr0jwiLQPoIwrrFUrVApLdSFehJNhwrQGrecX4OxMsI74Zd2Dr/SAIFSQbZgvjeowDP3VbBOokw+pGXzZ8oTOFY8yYNc6/sK3arfSUUZZMdKSp93lNwnvqmaECh0niAkKaEQqspbPeSSd0SohcxqSmk/6+uDEJbrxliBZjxeyaoIpuEUl6vehVEjWyWOb1zhU8EecicB2wvl/vCSjqUG08rm56I3K+rAgMBAAGjUzBRMB0GA1UdDgQWBBR4ky/fCbgk53yDikMDiqvOJxhaSjAfBgNVHSMEGDAWgBR4ky/fCbgk53yDikMDiqvOJxhaSjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBOxT1VO2lwwnFUuScQijtBs+HTkgR9rr2oQFGKd0OzbEcwK4XE0BcRbKsN2CUSshULvtjiwHz2RXM8nFy9qClvMo8XddosgY7oLSuIZ2zwOQl+JQV/HQb/Xg864d/9k3VuFOfuEW4Z8H+LWvNo1FXcYEvMPgO4A+tOq1V6uQTJmgoH9i4aAgjJSjN0OVi/zzqvaoGpbbr5jKsBFZD6HWkmgFHHcx6PzgxO/PP5XUWyFqgRUuz4cjt6ZMs/cKusDGELoW/4dw71ftuC7bikp8pNnasGavVP9AyUh0sNu/X30nWGq74JvgJoWsZmGk8lAoZXz/YvsqRdm9Nszc97MOVa</ds:X509Certificate>\n        </ds:X509Data>\n      </ds:KeyInfo>\n    </md:KeyDescriptor>\n    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>\n    <md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://cdkrd-hunt-idp.example.local/sso\"/>\n  </md:IDPSSODescriptor>\n</md:EntityDescriptor>\n"
+    }
+  },
+  "liveRaw": {
+    "AssertionEncryptionMode": "Allowed",
+    "SamlMetadataDocument": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://cdkrd-hunt-idp.example.local/idp\">\n  <md:IDPSSODescriptor WantAuthnRequestsSigned=\"false\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">\n    <md:KeyDescriptor use=\"signing\">\n      <ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\">\n        <ds:X509Data>\n          <ds:X509Certificate>MIIDLzCCAhegAwIBAgIUEeV4K+7jYtaZt27b9Jght+ORisIwDQYJKoZIhvcNAQELBQAwJzElMCMGA1UEAwwcY2RrcmQtaHVudC1pZHAuZXhhbXBsZS5sb2NhbDAeFw0yNjA3MDMxMTU1NTdaFw0yNjA4MDIxMTU1NTdaMCcxJTAjBgNVBAMMHGNka3JkLWh1bnQtaWRwLmV4YW1wbGUubG9jYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDAQihP+XsEBxWkNFRn50Q4v1CuKY+zhxF8yqz2hcY6SB/hXStI/1dsTsPyFpDKhfjPI+OOr1hglu1TkxYrVTZzJyb9FY2/6vWmisI1JZWcQ20v8c0J3lyMAKr0jwiLQPoIwrrFUrVApLdSFehJNhwrQGrecX4OxMsI74Zd2Dr/SAIFSQbZgvjeowDP3VbBOokw+pGXzZ8oTOFY8yYNc6/sK3arfSUUZZMdKSp93lNwnvqmaECh0niAkKaEQqspbPeSSd0SohcxqSmk/6+uDEJbrxliBZjxeyaoIpuEUl6vehVEjWyWOb1zhU8EecicB2wvl/vCSjqUG08rm56I3K+rAgMBAAGjUzBRMB0GA1UdDgQWBBR4ky/fCbgk53yDikMDiqvOJxhaSjAfBgNVHSMEGDAWgBR4ky/fCbgk53yDikMDiqvOJxhaSjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBOxT1VO2lwwnFUuScQijtBs+HTkgR9rr2oQFGKd0OzbEcwK4XE0BcRbKsN2CUSshULvtjiwHz2RXM8nFy9qClvMo8XddosgY7oLSuIZ2zwOQl+JQV/HQb/Xg864d/9k3VuFOfuEW4Z8H+LWvNo1FXcYEvMPgO4A+tOq1V6uQTJmgoH9i4aAgjJSjN0OVi/zzqvaoGpbbr5jKsBFZD6HWkmgFHHcx6PzgxO/PP5XUWyFqgRUuz4cjt6ZMs/cKusDGELoW/4dw71ftuC7bikp8pNnasGavVP9AyUh0sNu/X30nWGq74JvgJoWsZmGk8lAoZXz/YvsqRdm9Nszc97MOVa</ds:X509Certificate>\n        </ds:X509Data>\n      </ds:KeyInfo>\n    </md:KeyDescriptor>\n    <md:NameIDFormat>urn:oasis:names:tc:SAML:2.0:nameid-format:persistent</md:NameIDFormat>\n    <md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://cdkrd-hunt-idp.example.local/sso\"/>\n  </md:IDPSSODescriptor>\n</md:EntityDescriptor>\n",
+    "Arn": "arn:aws:iam::111111111111:saml-provider/cdkrd-hunt-idp",
+    "PrivateKeyList": [],
+    "SamlProviderUUID": "SAMLSPTB50WWXNEXQMO41M",
+    "Tags": [],
+    "Name": "cdkrd-hunt-idp"
+  },
+  "schema": {
+    "readOnly": ["Arn", "SamlProviderUUID"],
+    "writeOnly": ["AddPrivateKey", "RemovePrivateKey"],
+    "createOnly": ["AddPrivateKey", "Name", "RemovePrivateKey"],
+    "readOnlyPaths": ["Arn", "SamlProviderUUID"],
+    "writeOnlyPaths": ["AddPrivateKey", "RemovePrivateKey"],
+    "createOnlyPaths": ["AddPrivateKey", "Name", "RemovePrivateKey"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["PrivateKeyList"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Saml",
+      "resourceType": "AWS::IAM::SAMLProvider",
+      "path": "AssertionEncryptionMode",
+      "actual": "Allowed",
+      "physicalId": "arn:aws:iam::111111111111:saml-provider/cdkrd-hunt-idp",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/Saml"
+    }
+  ]
+}

--- a/tests/corpus/AWS__OpenSearchServerless__Collection.CollectionAoss.json
+++ b/tests/corpus/AWS__OpenSearchServerless__Collection.CollectionAoss.json
@@ -1,0 +1,89 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Collection",
+    "resourceType": "AWS::OpenSearchServerless::Collection",
+    "physicalId": "cbvp6kz66jyxtz5zf0fg",
+    "constructPath": "CdkRealDriftIntegAossRich/Collection",
+    "declared": {
+      "Description": "cdkrd hunt vector collection",
+      "Name": "cdkrd-aoss-f",
+      "StandbyReplicas": "DISABLED",
+      "Type": "VECTORSEARCH"
+    }
+  },
+  "liveRaw": {
+    "Type": "VECTORSEARCH",
+    "Description": "cdkrd hunt vector collection",
+    "FipsEndpoints": {
+      "CollectionEndpoint": "https://cbvp6kz66jyxtz5zf0fg.us-east-1.aoss-fips.amazonaws.com",
+      "DashboardEndpoint": "https://cbvp6kz66jyxtz5zf0fg.us-east-1.aoss-fips.amazonaws.com/_dashboards"
+    },
+    "KmsKeyArn": "auto",
+    "StandbyReplicas": "DISABLED",
+    "CollectionEndpoint": "https://cbvp6kz66jyxtz5zf0fg.us-east-1.aoss.amazonaws.com",
+    "Id": "cbvp6kz66jyxtz5zf0fg",
+    "DeletionProtection": "DISABLED",
+    "Arn": "arn:aws:aoss:us-east-1:111111111111:collection/cbvp6kz66jyxtz5zf0fg",
+    "Name": "cdkrd-aoss-f",
+    "DashboardEndpoint": "https://cbvp6kz66jyxtz5zf0fg.us-east-1.aoss.amazonaws.com/_dashboards"
+  },
+  "schema": {
+    "readOnly": [
+      "Arn",
+      "CollectionEndpoint",
+      "DashboardEndpoint",
+      "FipsEndpoints",
+      "Id",
+      "KmsKeyArn"
+    ],
+    "writeOnly": ["EncryptionConfig", "Tags"],
+    "createOnly": [
+      "CollectionGroupName",
+      "EncryptionConfig",
+      "Name",
+      "StandbyReplicas",
+      "Tags",
+      "Type"
+    ],
+    "readOnlyPaths": [
+      "Arn",
+      "CollectionEndpoint",
+      "DashboardEndpoint",
+      "FipsEndpoints",
+      "Id",
+      "KmsKeyArn"
+    ],
+    "writeOnlyPaths": ["EncryptionConfig", "Tags"],
+    "createOnlyPaths": [
+      "CollectionGroupName",
+      "EncryptionConfig",
+      "Name",
+      "StandbyReplicas",
+      "Tags",
+      "Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Collection",
+      "resourceType": "AWS::OpenSearchServerless::Collection",
+      "path": "DeletionProtection",
+      "actual": "DISABLED",
+      "physicalId": "cbvp6kz66jyxtz5zf0fg",
+      "constructPath": "CdkRealDriftIntegAossRich/Collection"
+    }
+  ]
+}

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -477,6 +477,7 @@ describe('noise suppressors', () => {
       Ipv4PrefixCount: 0,
       Ipv6PrefixCount: 0,
       SecondaryPrivateIpAddressCount: 0,
+      SourceDestCheck: true,
     });
     expect(KNOWN_DEFAULTS['AWS::ElastiCache::CacheCluster']).toEqual({
       NetworkType: 'ipv4',


### PR DESCRIPTION
Closes #535.

First-run `[At AWS Default]` folds (all equality-gated):
- `AWS::OpenSearchServerless::Collection` `DeletionProtection=DISABLED`
- `AWS::IAM::SAMLProvider` `AssertionEncryptionMode=Allowed`
- `AWS::EC2::NetworkInterface` `SourceDestCheck=true`

`FilterAtSource` (NetworkInsightsPath) is left surfaced (a declared-sibling projection, not a constant — issue's "record-once" option).

**Live-verified** (us-east-1): AOSS `DeletionProtection`, SAML `AssertionEncryptionMode`, and both ENIs' `SourceDestCheck` all fold to atDefault; per-resource AWS-assigned values (ENI PrivateIpAddress/GroupSet) correctly stay record-worthy. Corpus + unit tests added.
