### PR TITLE
test(classify): pin SG/id-array set-reorder fold with real observed sg-ids

### DIFF
--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1221,6 +1221,46 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
       ).toEqual(['Triggers.0.GitConfiguration.Push.0.Branches.Includes']);
     });
 
+    // Live-observed (rds-sgset / redshift-probe fixtures): AWS returns a declared
+    // VPC-security-group ID SET in a DIFFERENT order than the template (RDS DBInstance
+    // declared [sg-0ffb…, sg-0fc3…, sg-02a7…] read back [sg-02a7…, sg-0ffb…, sg-0fc3…]).
+    // Unlike the CodePipeline glob sets above, the elements ARE resource ids, so the
+    // GENERIC content-based `isIdLike` canonicalizer folds them with NO per-type table —
+    // this pins that end-to-end for the whole SG/subnet/ARN-id-set class. A genuine SG
+    // add/remove still changes the multiset and reports.
+    it('id-array fold: RDS DBInstance VPCSecurityGroups reorder (real sg-ids) is NOT drift', () => {
+      const db = (sgs: string[]): DesiredResource => ({
+        logicalId: 'Db',
+        resourceType: 'AWS::RDS::DBInstance',
+        physicalId: 'cdkrd-rds-sgset',
+        declared: { VPCSecurityGroups: sgs },
+      });
+      // same SG set, AWS canonical order -> no drift (isIdLike sorts both sides)
+      expect(
+        classifyResource(
+          db(['sg-0ffb59706a86e4368', 'sg-0fc374f7174e89e17', 'sg-02a70a5865b6b0826']),
+          {
+            VPCSecurityGroups: [
+              'sg-02a70a5865b6b0826',
+              'sg-0ffb59706a86e4368',
+              'sg-0fc374f7174e89e17',
+            ],
+          },
+          emptySchema
+        )
+      ).toEqual([]);
+      // a genuine SG removal still changes the multiset -> reports
+      expect(
+        tiers(
+          classifyResource(
+            db(['sg-0ffb59706a86e4368', 'sg-0fc374f7174e89e17', 'sg-02a70a5865b6b0826']),
+            { VPCSecurityGroups: ['sg-02a70a5865b6b0826', 'sg-0ffb59706a86e4368'] },
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['VPCSecurityGroups']);
+    });
+
     // Schema-driven fold (insertionOrder:false): ECS marks RequiresCompatibilities
     // insertionOrder:false, so the launch-type set AWS sorts alphabetically (declared
     // [FARGATE, EC2] read back [EC2, FARGATE]) folds from the schema — no per-type entry.


### PR DESCRIPTION
## What

Follow-up to the CodePipeline trigger-filter FP fix (#541). A hunt of the broader
`uniqueItems` set-reorder class across **GuardDuty, EventBridge, Lambda ESM, and
security-group / AZ id-sets** found **no new bug** — cdkrd is already robust:

- **SG / subnet / ARN id-SETS** are folded order-insensitively by the GENERIC content-based
  `isIdLike` canonicalizer (no per-type table). Live-proven: RDS DBInstance **and** Redshift
  Cluster both returned a declared `VPCSecurityGroups` set in a **different order** than the
  template on a fresh deploy, yet `check` was CLEAN.
- **GuardDuty**: no `uniqueItems` scalar arrays at all (filters are object/JSON) → not an FP source.
- **EventBridge Rule**: only `insertionOrder:true` arrays (path params are genuinely ordered) → not an FP source.
- **Redshift `ClusterVersion` "1.0"** does not expand to a concrete build → no partial→concrete version FP.

Why CodePipeline #541 needed a manual `UNORDERED_ARRAY_PROPS` entry but these do not: its
filter elements are branch globs / file paths (`release/*`, `src/**`) — **not** id-like — so
they escape `isIdLike`; `sg-*` / `subnet-*` / `arn:` elements do not.

## Change

A single classify-level regression test using the **real observed sg-ids** from the live hunt:
a reordered `VPCSecurityGroups` set is not drift, and a genuine SG removal still reports. This
pins the end-to-end id-array fold for the whole SG/subnet/ARN-id-set class (the existing
`noise-and-strip` test covers only the `SubnetIds` canonicalizer in isolation). Test-only; no
`src/**` change.

🤖 Found via `/hunt-bugs` (SG-set / EventBridge / GuardDuty follow-up).
