### PR TITLE
test(corpus): add RDS + Redshift reordered-SG golden cases (pin isIdLike id-set fold)

### DIFF
--- a/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.sgreorder.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Db5D02A0A9.sgreorder.json
@@ -1,0 +1,440 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Db5D02A0A9",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+    "constructPath": "CdkRealDriftIntegRdsSgSet/Db",
+    "declared": {
+      "AllocatedStorage": "20",
+      "BackupRetentionPeriod": 0,
+      "CopyTagsToSnapshot": true,
+      "DBInstanceClass": "db.t3.micro",
+      "DBSubnetGroupName": "cdkrealdriftintegrdssgset-dbsubnetgroup6f6c177a-xunenso8j5uk",
+      "DeleteAutomatedBackups": true,
+      "Engine": "mysql",
+      "EngineVersion": "8.0",
+      "MasterUserPassword": "__cdkrd_corpus_unresolved__",
+      "MasterUsername": "__cdkrd_corpus_unresolved__",
+      "PubliclyAccessible": false,
+      "StorageType": "gp2",
+      "VPCSecurityGroups": ["sg-0ffb59706a86e4368", "sg-0fc374f7174e89e17", "sg-02a70a5865b6b0826"]
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-07-03T14:35:37Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "3306",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-TW3QSGXWLYQNWS5UXUOWDLK23M",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.mysql8.0",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "3306",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "MultiAZ": false,
+    "Engine": "mysql",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegRdsSgSet/0e4aab50-76ec-11f1-897d-0ea7eed92097",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegRdsSgSet",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Db5D02A0A9",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "IsStorageConfigUpgradeAvailable": false,
+    "EngineVersion": "8.0.45",
+    "StorageType": "gp2",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.t3.micro",
+    "AvailabilityZone": "us-east-1a",
+    "OptionGroupName": "default:mysql-8-0",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrealdriftintegrdssgset-dbsubnetgroup6f6c177a-xunenso8j5uk",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+    "AllocatedStorage": "20",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "admin",
+    "PubliclyAccessible": false,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-03T14:37:06.111Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "07:56-08:26",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": true,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "general-public-license",
+    "PreferredMaintenanceWindow": "fri:06:54-fri:07:24",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-02a70a5865b6b0826", "sg-0ffb59706a86e4368", "sg-0fc374f7174e89e17"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 0,
+    "EnableCloudwatchLogsExports": []
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DeleteAutomatedBackups",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MasterUsername",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DatabaseInsightsMode",
+      "actual": "standard",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageEncrypted",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "Port",
+      "actual": "3306",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.mysql8.0",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:mysql-8-0",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AutoMinorVersionUpgrade",
+      "actual": true,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredBackupWindow",
+      "actual": "07:56-08:26",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "NetworkType",
+      "actual": "IPV4",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EngineLifecycleSupport",
+      "actual": "open-source-rds-extended-support",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "general-public-license",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "fri:06:54-fri:07:24",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "ManageMasterUserPassword",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Db5D02A0A9",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnableIAMDatabaseAuthentication",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegrdssgset-db5d02a0a9-chowsuaceqaa",
+      "constructPath": "CdkRealDriftIntegRdsSgSet/Db"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
@@ -1,0 +1,245 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Cluster",
+    "resourceType": "AWS::Redshift::Cluster",
+    "physicalId": "cluster-htpccw5gbpx7",
+    "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster",
+    "declared": {
+      "ClusterSubnetGroupName": "subnetgroup-zmqkahqqya4b",
+      "ClusterType": "single-node",
+      "ClusterVersion": "1.0",
+      "DBName": "probe",
+      "MasterUserPassword": "Cdkrd-Probe-123",
+      "MasterUsername": "admin",
+      "NodeType": "ra3.large",
+      "PubliclyAccessible": false,
+      "VpcSecurityGroupIds": ["sg-0cc77d6b500db3d5a", "sg-067f8171539f6773b"]
+    }
+  },
+  "liveRaw": {
+    "AutomatedSnapshotRetentionPeriod": 1,
+    "AvailabilityZoneRelocationStatus": "enabled",
+    "AquaConfigurationStatus": "auto",
+    "Encrypted": true,
+    "Port": 5439,
+    "NumberOfNodes": 1,
+    "EnhancedVpcRouting": false,
+    "ClusterParameterGroupName": "default.redshift-2.0",
+    "AllowVersionUpgrade": true,
+    "Endpoint": {
+      "Address": "cluster-htpccw5gbpx7.c5qzh3zoxdm2.us-east-1.redshift.amazonaws.com",
+      "Port": "5439"
+    },
+    "VpcSecurityGroupIds": ["sg-067f8171539f6773b", "sg-0cc77d6b500db3d5a"],
+    "MaintenanceTrackName": "current",
+    "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:111111111111:namespace:5cf1a143-b7b1-4b0f-a225-6291197b377b",
+    "MultiAZ": false,
+    "Tags": [],
+    "IamRoles": [],
+    "ClusterVersion": "1.0",
+    "KmsKeyId": "AWS_OWNED_KMS_KEY",
+    "AvailabilityZone": "us-east-1a",
+    "PreferredMaintenanceWindow": "sat:04:30-sat:05:00",
+    "ClusterType": "single-node",
+    "ClusterSecurityGroups": [],
+    "ClusterIdentifier": "cluster-htpccw5gbpx7",
+    "ClusterSubnetGroupName": "subnetgroup-zmqkahqqya4b",
+    "LoggingProperties": {
+      "LogExports": []
+    },
+    "NodeType": "ra3.large",
+    "MasterUsername": "admin",
+    "DBName": "probe",
+    "PubliclyAccessible": false,
+    "ManualSnapshotRetentionPeriod": -1
+  },
+  "schema": {
+    "readOnly": ["ClusterNamespaceArn", "DeferMaintenanceIdentifier", "MasterPasswordSecretArn"],
+    "writeOnly": [
+      "Classic",
+      "DeferMaintenance",
+      "DeferMaintenanceDuration",
+      "ManageMasterPassword",
+      "MasterUserPassword",
+      "SnapshotIdentifier"
+    ],
+    "createOnly": [
+      "ClusterIdentifier",
+      "ClusterSubnetGroupName",
+      "DBName",
+      "MasterUsername",
+      "OwnerAccount",
+      "SnapshotClusterIdentifier",
+      "SnapshotIdentifier"
+    ],
+    "readOnlyPaths": [
+      "ClusterNamespaceArn",
+      "DeferMaintenanceIdentifier",
+      "Endpoint.Address",
+      "Endpoint.Port",
+      "MasterPasswordSecretArn"
+    ],
+    "writeOnlyPaths": [
+      "Classic",
+      "DeferMaintenance",
+      "DeferMaintenanceDuration",
+      "ManageMasterPassword",
+      "MasterUserPassword",
+      "SnapshotIdentifier"
+    ],
+    "createOnlyPaths": [
+      "ClusterIdentifier",
+      "ClusterSubnetGroupName",
+      "DBName",
+      "MasterUsername",
+      "OwnerAccount",
+      "SnapshotClusterIdentifier",
+      "SnapshotIdentifier"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "ClusterSecurityGroups",
+      "IamRoles",
+      "LoggingProperties.LogExports",
+      "VpcSecurityGroupIds"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "MasterUserPassword",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AutomatedSnapshotRetentionPeriod",
+      "actual": 1,
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AvailabilityZoneRelocationStatus",
+      "actual": "enabled",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AquaConfigurationStatus",
+      "actual": "auto",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "Encrypted",
+      "actual": true,
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "Port",
+      "actual": 5439,
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "NumberOfNodes",
+      "actual": 1,
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ClusterParameterGroupName",
+      "actual": "default.redshift-2.0",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AllowVersionUpgrade",
+      "actual": true,
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "MaintenanceTrackName",
+      "actual": "current",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "KmsKeyId",
+      "actual": "AWS_OWNED_KMS_KEY",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1a",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "sat:04:30-sat:05:00",
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ManualSnapshotRetentionPeriod",
+      "actual": -1,
+      "physicalId": "cluster-htpccw5gbpx7",
+      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+    }
+  ]
+}


### PR DESCRIPTION
Promotes the live reads from the #549 SG-set hunt as golden corpus. On a fresh deploy AWS returned a declared VPC-security-group set in a **different order** than the template — RDS DBInstance and Redshift Cluster both — and cdkrd stayed CLEAN via the generic `isIdLike` canonicalizer. #549 added the classify unit test; this makes `corpus-replay` exercise the id-set fold end-to-end on the **real reordered data** (expected CLEAN, so a future break of `isIdLike` fails a unit test).

Only the two reordered-SG cases are promoted; the fixtures' VPC/subnet/route-table/EFS/ELB boilerplate is already well-represented and intentionally not re-added.

Test-only (corpus JSON); no `src/**` change. 🤖 /hunt-bugs follow-up.