### PR TITLE
fix(normalize): fold typed<->string leaves inside JSON-string props + proactive AmazonMQ EngineVersion guard

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2036,7 +2036,16 @@ export const ELB_ATTRIBUTE_DEFAULTS_BY_LB_TYPE: Record<string, Record<string, st
 const SENTINEL_UNPARSEABLE = Symbol('unparseable');
 function deepCompareUnordered(a: unknown, b: unknown): boolean {
   if (a === b) return true;
-  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+  const aObj = a !== null && typeof a === 'object';
+  const bObj = b !== null && typeof b === 'object';
+  // Leaf vs leaf: allow the typed<->string collapse. Inside a JSON string AWS serializes
+  // numbers/booleans as quoted strings, so a declared object `{Port: 443, Tls: true}` reads
+  // back as `'{"Port":"443","Tls":"true"}'` — after parse the leaves are `443` vs `"443"`,
+  // which strict `===` would false-drift the whole JSON-string prop. isStringlyEqualScalar
+  // folds only the representation difference; a genuine value change (443 vs 8080) still differs.
+  if (!aObj && !bObj) return isStringlyEqualScalar(a, b);
+  // One side object/array, the other scalar/null: a genuine structural mismatch.
+  if (aObj !== bObj) return false;
   const aArr = Array.isArray(a);
   if (aArr !== Array.isArray(b)) return false;
   if (aArr) {
@@ -2559,6 +2568,14 @@ export const VERSION_PREFIX_PATHS: Record<string, ReadonlySet<string>> = {
   // symmetric isVersionPrefixMatch covers both. A genuine track change (`"1.5"` vs
   // `"1.6.22"`) still differs.
   'AWS::ElastiCache::CacheCluster': new Set(['EngineVersion']),
+  // Amazon MQ resolves a partial EngineVersion the same way (corpus-proven: declared
+  // `"5.18"` provisions the concrete `"5.18.7"`, surfaced in the readOnly
+  // `EngineVersionCurrent`). Today `EngineVersion` itself is writeOnly -> a readGap, so
+  // this entry is a PROACTIVE guard, not an active fold: it fires ONLY if a future
+  // SDK_SUPPLEMENTS reader ever projects the concrete `EngineVersion` back (as was done
+  // for the ElastiCache RG above), at which point a declared `"5.18"` vs live `"5.18.7"`
+  // would otherwise false-drift. Equality-gated + symmetric, so harmless while inert.
+  'AWS::AmazonMQ::Broker': new Set(['EngineVersion']),
 };
 export function isVersionPrefixMatch(declared: unknown, live: unknown): boolean {
   if (typeof declared !== 'string' || typeof live !== 'string') return false;

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4771,6 +4771,20 @@ describe('classifyResource RDS version-track + dynamic-reference (R130)', () => 
     ).toEqual(['EngineVersion']);
   });
 
+  // PROACTIVE guard (corpus-proven latent trap): Amazon MQ resolves a partial EngineVersion
+  // "5.18" to the concrete "5.18.7". Today EngineVersion is writeOnly (a readGap, never in the
+  // live model), so the fold is inert; this pins that IF a future SDK_SUPPLEMENTS reader ever
+  // projects the concrete EngineVersion back, the partial->concrete is folded, not false-drift.
+  it('AmazonMQ Broker EngineVersion "5.18" resolved to live "5.18.7" is NOT declared drift', () => {
+    expect(
+      declaredPaths('AWS::AmazonMQ::Broker', { EngineVersion: '5.18' }, { EngineVersion: '5.18.7' })
+    ).toEqual([]);
+    // a genuine engine-version change still differs
+    expect(
+      declaredPaths('AWS::AmazonMQ::Broker', { EngineVersion: '5.17' }, { EngineVersion: '5.18.7' })
+    ).toEqual(['EngineVersion']);
+  });
+
   it('MasterUsername resolved to UNRESOLVED (dynamic ref) is unresolved, not declared drift', () => {
     // loadDesired resolves the {{resolve:secretsmanager:…}} dynamic reference to
     // UNRESOLVED; classify then emits an `unresolved` finding, never `declared`.

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -332,6 +332,40 @@ describe('noise suppressors', () => {
     expect(isStringlyEqualScalar(true, '1')).toBe(false);
   });
 
+  it('isJsonStringStructEqual: folds typed<->string leaves inside a JSON-string prop', async () => {
+    const { isJsonStringStructEqual } = await import('../src/normalize/noise.js');
+    // A declared structured object whose live counterpart is the same value serialized as
+    // a JSON string, but with the numeric/boolean leaves quoted (AWS stringifies everything
+    // inside a JSON-string prop). Strict `===` at the leaves would false-drift the whole prop.
+    expect(
+      isJsonStringStructEqual(
+        { Port: 443, Tls: true, Name: 'db' },
+        '{"Port":"443","Tls":"true","Name":"db"}'
+      )
+    ).toBe(true);
+    // order-insensitive on the object keys, same as the all-string case
+    expect(
+      isJsonStringStructEqual('{"Tls":"true","Port":"443","Name":"db"}', {
+        Port: 443,
+        Tls: true,
+        Name: 'db',
+      })
+    ).toBe(true);
+    // nested + array leaves fold too
+    expect(
+      isJsonStringStructEqual(
+        { Cfg: { Retries: 3, Ports: [80, 443] } },
+        '{"Cfg":{"Retries":"3","Ports":["80","443"]}}'
+      )
+    ).toBe(true);
+    // a GENUINE value change at a leaf still differs (443 vs 8080)
+    expect(isJsonStringStructEqual({ Port: 443 }, '{"Port":"8080"}')).toBe(false);
+    // a genuine boolean flip still differs
+    expect(isJsonStringStructEqual({ Tls: true }, '{"Tls":"false"}')).toBe(false);
+    // structural mismatch (missing key) still differs
+    expect(isJsonStringStructEqual({ Port: 443, Extra: 1 }, '{"Port":"443"}')).toBe(false);
+  });
+
   it('isStringlyEqualScalarArray: typed<->string element arrays fold, real drift kept (R23)', async () => {
     const { isStringlyEqualScalarArray } = await import('../src/normalize/noise.js');
     // declared typed ports vs AWS stringly form, same order


### PR DESCRIPTION
Two latent-item hardenings surfaced by the CodePipeline / SG-set hunt's offline audit of the FP fold axes.

## 1. `isJsonStringStructEqual` typed↔string leaves (real code gap, defensive)

The object↔JSON-string fold compared leaves with strict `===` (via `deepCompareUnordered`), so a declared object whose live counterpart is the same value serialized with **quoted** leaves — AWS stringifies everything inside a JSON-string prop — would false-drift the whole property:

```
declared {Port: 443, Tls: true}   live '{"Port":"443","Tls":"true"}'
  443 !== "443"  → strict === → whole-prop false drift
```

Leaves now fall through to `isStringlyEqualScalar` (the same typed↔string collapse used elsewhere), folding only the representation difference; a genuine leaf change (`443` vs `8080`, `true` vs `false`) still differs. No live witness yet — defensive — but a confirmed code gap. Blast radius is minimal: `deepCompareUnordered` is only reached via `isJsonStringStructEqual`, used only at `classify.ts:1428`.

## 2. `AmazonMQ::Broker` `EngineVersion` — proactive `VERSION_PREFIX_PATHS` guard

Corpus proves `"5.18"` → `"5.18.7"` expansion, but `EngineVersion` is writeOnly (a readGap) today, so the fold is **inert** — it fires only if a future `SDK_SUPPLEMENTS` reader ever projects the concrete version back (as was done for ElastiCache RG). Equality-gated + symmetric, harmless while inert.

## Non-issue (audited, no change)

Lambda ESM `Topics` / `Queues` reorder: both are `maxItems: 1` single-element arrays → cannot reorder.

## Verification

Unit tests for both changes; full suite (2712) incl `corpus-replay` over ~480 real classify inputs still green (the JSON-string fold path is exercised across the corpus). Item-3 fold live-repro'd against source. All 7 core integration fixtures PASS, SWEEP CLEAN.

🤖 /hunt-bugs follow-up (latent-item hardening).
