### PR TITLE
chore(noise): fold ClientVPN + DAX first-run defaults (#554)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -661,6 +661,23 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::EC2::IPAM': {
     MeteredAccount: 'ipam-owner',
   },
+  // A Client VPN endpoint that declares neither VpnPort nor DisconnectOnSessionTimeout
+  // reads back the constant service defaults (port 443, disconnect-on-timeout on).
+  // Observed live on a fresh ClientVPN deploy (us-east-1, 2026-07-03; #554 from #534's
+  // live verify). Equality-gated: flip either out of band (e.g. VpnPort=1194) and the
+  // value no longer matches, so it re-surfaces as real undeclared drift.
+  'AWS::EC2::ClientVpnEndpoint': {
+    VpnPort: 443,
+    DisconnectOnSessionTimeout: true,
+  },
+  // A DAX cluster that declares no ClusterEndpointEncryptionType reads back "NONE" (the
+  // constant service default; the only other value, "TLS", is an explicit opt-in).
+  // Observed live on a fresh DAX deploy (us-east-1, 2026-07-03; #554). Equality-gated.
+  // (PreferredMaintenanceWindow / SecurityGroupIds and the ParameterGroup's parameter
+  // values are per-resource/AWS-assigned, so they are deliberately NOT folded here.)
+  'AWS::DAX::Cluster': {
+    ClusterEndpointEncryptionType: 'NONE',
+  },
   // Managed Prometheus materializes a WorkspaceConfiguration of service defaults
   // (150-day retention, 60s rule-query offset / out-of-order window) on every
   // workspace that never declared one.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -831,6 +831,27 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ]);
   });
 
+  it('#554: ClientVPN + DAX first-run defaults fold; an out-of-band change surfaces', () => {
+    const t = (rt: string, live: Record<string, unknown>) =>
+      tiers(classifyResource(bare(rt), live, emptySchema));
+    // ClientVpnEndpoint VpnPort 443 / DisconnectOnSessionTimeout true → fold; a flipped
+    // port (1194) or disabled disconnect surfaces as real undeclared drift.
+    expect(
+      t('AWS::EC2::ClientVpnEndpoint', {
+        VpnPort: 443,
+        DisconnectOnSessionTimeout: true,
+      }).atDefault.sort()
+    ).toEqual(['DisconnectOnSessionTimeout', 'VpnPort']);
+    expect(t('AWS::EC2::ClientVpnEndpoint', { VpnPort: 1194 }).undeclared).toEqual(['VpnPort']);
+    // DAX ClusterEndpointEncryptionType NONE → fold; TLS (an explicit opt-in) surfaces.
+    expect(t('AWS::DAX::Cluster', { ClusterEndpointEncryptionType: 'NONE' }).atDefault).toEqual([
+      'ClusterEndpointEncryptionType',
+    ]);
+    expect(t('AWS::DAX::Cluster', { ClusterEndpointEncryptionType: 'TLS' }).undeclared).toEqual([
+      'ClusterEndpointEncryptionType',
+    ]);
+  });
+
   it('LineLink first-run folds: GlobalTable WarmThroughput / ESM Enabled / Authorizer AuthType', () => {
     // Three undeclared values a fresh dev LineLink stack reported with NO out-of-band
     // edit — first-run noise that must fold to atDefault, while a meaningful change to


### PR DESCRIPTION
Closes #554.

First-run `[Not Recorded]` noise on a fresh ClientVPN + DAX deploy (values observed live during #534's verification, real AWS us-east-1). Equality-gated `KNOWN_DEFAULTS` folds so a genuine out-of-band change still surfaces.

| Type | Path | Fresh-deploy value |
|---|---|---|
| `AWS::EC2::ClientVpnEndpoint` | `VpnPort` | `443` |
| `AWS::EC2::ClientVpnEndpoint` | `DisconnectOnSessionTimeout` | `true` |
| `AWS::DAX::Cluster` | `ClusterEndpointEncryptionType` | `"NONE"` |

DAX `PreferredMaintenanceWindow` / `SecurityGroupIds` and the ParameterGroup parameter values are per-resource/AWS-assigned → deliberately NOT folded.

## Tests
- New `classify.test.ts` case (#554): each default folds to `atDefault`; a flipped value (`VpnPort:1194`, `ClusterEndpointEncryptionType:'TLS'`) still surfaces as `undeclared`.
- Covered by the generic "EVERY KNOWN_DEFAULTS entry folds to atDefault" test.
- Full suite: 2729 passed.

The readers (#546) are already live-verified; these are pure equality-gated folds of the exact fresh-deploy values.
