### PR TITLE
feat(revert): SDK writers for CodeBuild ReportGroup / DAX / ClientVPN (#552)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -725,7 +725,15 @@ only when non-zero — unrecorded values are named as such, never folded into
     recurring shape: a CC type is READABLE but its full-model UpdateResource re-validation
     rejects a field AWS itself returns — the per-type SDK writer re-submits via the
     resource's own update API, omitting the offending field. Only a LIVE
-    detect→revert→CLEAN cycle catches these.
+    detect→revert→CLEAN cycle catches these. A SECOND family is the NON_PROVISIONABLE
+    types (no CC read handler at all, read via an `SDK_OVERRIDES` reader): each is
+    revertable only with a matching SDK writer that PARTIAL-modifies the drifted props —
+    `AWS::CodeBuild::ReportGroup` (`UpdateReportGroup`), `AWS::DAX::Cluster`
+    (`UpdateCluster`), `AWS::DAX::ParameterGroup` (`UpdateParameterGroup`), and
+    `AWS::EC2::ClientVpnEndpoint` (`ModifyClientVpnEndpoint`, reshaping the reader's
+    `DnsServers` list into the API's `{CustomDnsServers,Enabled}` and pairing
+    `SecurityGroupIds` with `VpcId`) — all four proven with a live detect→revert→CLEAN
+    cycle (#552).
   - **Property-scoped SDK writers** (`SDK_PROP_WRITERS`): a CC-writable type where
     ONE property must bypass Cloud Control. An IAM Role's top-level `Policies`
     finding reverts per entry (`DeleteRolePolicy` / `PutRolePolicy` by

--- a/src/revert/transient.ts
+++ b/src/revert/transient.ts
@@ -49,20 +49,23 @@ const TRANSIENT_PATTERNS: readonly { pattern: RegExp; hint: string }[] = [
   },
   {
     pattern:
-      /another (operation|update|change|request)[^.]*in progress|operation[^.]*(already )?in progress|update[^.]*in progress|modification[^.]*in progress|currently being (created|updated|modified|deleted|provisioned)|is not in a stable state|resource is in use|please try again|try again (later|in a few)/i,
+      /another (operation|update|change|request)[^.]*in progress|operation[^.]*(already )?in progress|update[^.]*in progress|modification[^.]*in progress|(currently )?being (created|updated|modified|deleted|provisioned)|is not in a stable state|resource is in use|please try again|try again (later|in a few)/i,
     hint: RETRY_HINT,
   },
-  // Stateful resources (RDS / Aurora / DocDB / Neptune / ElastiCache / Redshift) reject
+  // Stateful resources (RDS / Aurora / DocDB / Neptune / ElastiCache / Redshift / DAX) reject
   // a modify while the resource is mid-change with an "invalid state" fault whose message
   // says it is "not in the available state". This is the SAME mid-update-retry-later class
   // as RSLVR-00705 for the DB reverts cdkrd already supports (RDS/DocDB BackupRetention,
   // DBInstanceClass, ElastiCache node type, …): an out-of-band `modify-*` leaves the
   // resource `modifying`/`rebooting` for minutes, so an immediate revert fails and only a
   // later retry succeeds. Matched by the service state-fault codes plus AWS's shared
-  // "not in the available state" / "not in available state" phrasing.
+  // "not in the available state" / "not in available state" phrasing. InvalidClusterStateFault
+  // / InvalidParameterGroupStateFault cover DAX (#552): a fresh dax:update-parameter-group leaves
+  // the group "applying" for a few seconds, so a same-run revert hits "the parameter <x> is being
+  // modified" (live-verified during the #552 detect→revert live-test).
   {
     pattern:
-      /InvalidDBInstanceState|InvalidDBClusterState|InvalidClusterState|InvalidReplicationGroupState|InvalidCacheClusterState|InvalidGlobalClusterState|is not (currently )?in (the |an? )?available state/i,
+      /InvalidDBInstanceState|InvalidDBClusterState|InvalidClusterState|InvalidParameterGroupState|InvalidReplicationGroupState|InvalidCacheClusterState|InvalidGlobalClusterState|is not (currently )?in (the |an? )?available state/i,
     hint: RETRY_HINT,
   },
   // Throttling / rate limiting — retryable, but a distinct hint.

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -104,6 +104,18 @@ import {
 } from '@aws-sdk/client-config-service';
 import { KafkaClient, UpdateConfigurationCommand } from '@aws-sdk/client-kafka';
 import {
+  CodeBuildClient,
+  type ReportExportConfig,
+  type Tag as CodeBuildTag,
+  UpdateReportGroupCommand,
+} from '@aws-sdk/client-codebuild';
+import {
+  DAXClient,
+  UpdateClusterCommand,
+  UpdateParameterGroupCommand as UpdateDaxParameterGroupCommand,
+} from '@aws-sdk/client-dax';
+import { EC2Client, ModifyClientVpnEndpointCommand } from '@aws-sdk/client-ec2';
+import {
   DescribeEventBusCommand,
   EventBridgeClient,
   PutPermissionCommand,
@@ -1380,7 +1392,161 @@ const writeMskConfiguration: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// AWS::CodeBuild::ReportGroup — NON_PROVISIONABLE (read via BatchGetReportGroups; #530).
+// codebuild:UpdateReportGroup re-supplies the two mutable props (exportConfig / tags) WHOLESALE
+// — the reader's projected shape maps back 1:1 (PascalCase CFn → camelCase API). Always send both
+// desired sub-objects so reverting a Tags-only drift never wipes the ExportConfig and vice-versa;
+// they reflect the intended (declared-or-current) full state (desiredModel = live + revert ops).
+// Type is create-only (not modifiable), so it never reaches here. #552.
+const writeCodeBuildReportGroup: SdkWriter = async (ctx, ops) => {
+  const arn = str(ctx.physicalId);
+  if (!arn) throw new Error('cannot resolve CodeBuild ReportGroup ARN for revert');
+  const desired = await desiredModel('AWS::CodeBuild::ReportGroup', ctx, ops);
+  const input: { arn: string; exportConfig?: ReportExportConfig; tags?: CodeBuildTag[] } = { arn };
+  const ec = desired.ExportConfig as Record<string, unknown> | undefined;
+  if (ec) {
+    const s3 = ec.S3Destination as Record<string, unknown> | undefined;
+    input.exportConfig = {
+      exportConfigType: ec.ExportConfigType as ReportExportConfig['exportConfigType'],
+      ...(s3
+        ? {
+            s3Destination: {
+              bucket: str(s3.Bucket),
+              path: str(s3.Path),
+              packaging: str(s3.Packaging) as
+                | NonNullable<ReportExportConfig['s3Destination']>['packaging']
+                | undefined,
+              encryptionKey: str(s3.EncryptionKey),
+              encryptionDisabled:
+                typeof s3.EncryptionDisabled === 'boolean' ? s3.EncryptionDisabled : undefined,
+            },
+          }
+        : {}),
+    };
+  }
+  const tags = desired.Tags as { Key?: unknown; Value?: unknown }[] | undefined;
+  // Always send tags (empty list clears them) so a removed/edited tag reverts; omitting it would
+  // leave AWS's current tags untouched (UpdateReportGroup replaces the tag set wholesale).
+  input.tags = Array.isArray(tags)
+    ? tags.map((t) => ({ key: str(t.Key), value: str(t.Value) }))
+    : [];
+  await new CodeBuildClient({ region: ctx.region }).send(new UpdateReportGroupCommand(input));
+};
+
+// AWS::DAX::Cluster — NON_PROVISIONABLE (read via DescribeClusters; #534). dax:UpdateCluster is a
+// PARTIAL modify (like ModifyDBCluster): send ONLY the drifted top-level props in the mutable
+// allowlist, mapped CFn→API (NotificationTopicARN → NotificationTopicArn). NodeType/ClusterName/
+// SubnetGroupName/IAMRoleARN/ClusterEndpointEncryptionType are create-only → never in the
+// allowlist. #552.
+const DAX_CLUSTER_MODIFY_PARAMS: Record<string, string> = {
+  Description: 'Description',
+  PreferredMaintenanceWindow: 'PreferredMaintenanceWindow',
+  NotificationTopicARN: 'NotificationTopicArn',
+  ParameterGroupName: 'ParameterGroupName',
+  SecurityGroupIds: 'SecurityGroupIds',
+};
+const writeDaxCluster: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['ClusterName']);
+  if (!name) throw new Error('cannot resolve DAX cluster name for revert');
+  const desired = await desiredModel('AWS::DAX::Cluster', ctx, ops);
+  const input: { ClusterName: string; [k: string]: unknown } = { ClusterName: name };
+  let any = false;
+  for (const op of ops) {
+    const top = op.path.replace(/^\//, '').split('/')[0] ?? '';
+    const apiKey = DAX_CLUSTER_MODIFY_PARAMS[top];
+    if (!apiKey) continue;
+    // A revert that CLEARS a value (op removed it, e.g. NotificationTopicARN back to none) sends
+    // the empty string DAX accepts to detach the topic; otherwise send the desired value.
+    const val = desired[top] ?? (apiKey === 'NotificationTopicArn' ? '' : undefined);
+    if (val !== undefined) {
+      input[apiKey] = val;
+      any = true;
+    }
+  }
+  if (!any) return;
+  await new DAXClient({ region: ctx.region }).send(new UpdateClusterCommand(input));
+};
+
+// AWS::DAX::ParameterGroup — NON_PROVISIONABLE (read via DescribeParameters; #534).
+// dax:UpdateParameterGroup updates ONLY the parameters passed (others untouched), so re-assert
+// each DRIFTED parameter to its desired value. The CFn `ParameterNameValues` is a { name → value }
+// map; the API takes a [{ ParameterName, ParameterValue }] list. #552.
+const writeDaxParameterGroup: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['ParameterGroupName']);
+  if (!name) throw new Error('cannot resolve DAX parameter-group name for revert');
+  const desired = await desiredModel('AWS::DAX::ParameterGroup', ctx, ops);
+  const desiredValues = (desired.ParameterNameValues as Record<string, unknown> | undefined) ?? {};
+  // Collect the parameter keys the revert ops touch (path `/ParameterNameValues/<key>`), plus a
+  // whole-map op (`/ParameterNameValues`). Re-send each from the desired map.
+  const keys = new Set<string>();
+  for (const op of ops) {
+    const segs = op.path.replace(/^\//, '').split('/');
+    if (segs[0] !== 'ParameterNameValues') continue;
+    if (segs[1] !== undefined) keys.add(segs[1].replace(/~1/g, '/').replace(/~0/g, '~'));
+    else for (const k of Object.keys(desiredValues)) keys.add(k);
+  }
+  const values = [...keys]
+    .filter((k) => typeof desiredValues[k] === 'string')
+    .map((k) => ({ ParameterName: k, ParameterValue: desiredValues[k] as string }));
+  if (values.length === 0) return;
+  await new DAXClient({ region: ctx.region }).send(
+    new UpdateDaxParameterGroupCommand({ ParameterGroupName: name, ParameterNameValues: values })
+  );
+};
+
+// AWS::EC2::ClientVpnEndpoint — NON_PROVISIONABLE (read via DescribeClientVpnEndpoints; #534).
+// ec2:ModifyClientVpnEndpoint is a PARTIAL modify: send ONLY the drifted top-level props in the
+// mutable allowlist. Two props need reshaping vs the reader's projection: DnsServers (the read is
+// a plain string[]; modify takes a DnsServersOptionsModifyStructure { CustomDnsServers, Enabled }),
+// and SecurityGroupIds (the API requires VpcId alongside it). ServerCertificateArn/ClientCidrBlock/
+// TransportProtocol/VpcId are create-only → not in the allowlist. #552.
+const CLIENT_VPN_SCALAR_PARAMS = new Set([
+  'Description',
+  'SplitTunnel',
+  'VpnPort',
+  'SessionTimeoutHours',
+  'DisconnectOnSessionTimeout',
+]);
+const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
+  const id = str(ctx.physicalId);
+  if (!id) throw new Error('cannot resolve Client VPN endpoint id for revert');
+  const desired = await desiredModel('AWS::EC2::ClientVpnEndpoint', ctx, ops);
+  const input: { ClientVpnEndpointId: string; [k: string]: unknown } = { ClientVpnEndpointId: id };
+  let any = false;
+  const tops = new Set(ops.map((op) => op.path.replace(/^\//, '').split('/')[0] ?? ''));
+  for (const top of tops) {
+    if (CLIENT_VPN_SCALAR_PARAMS.has(top) && desired[top] !== undefined) {
+      input[top] = desired[top];
+      any = true;
+    } else if (top === 'ConnectionLogOptions' && desired.ConnectionLogOptions !== undefined) {
+      input.ConnectionLogOptions = desired.ConnectionLogOptions;
+      any = true;
+    } else if (top === 'DnsServers') {
+      const list = desired.DnsServers as string[] | undefined;
+      input.DnsServers =
+        Array.isArray(list) && list.length > 0
+          ? { CustomDnsServers: list, Enabled: true }
+          : { Enabled: false };
+      any = true;
+    } else if (top === 'SecurityGroupIds') {
+      const list = desired.SecurityGroupIds as string[] | undefined;
+      const vpcId = str(desired.VpcId) ?? str(ctx.declared['VpcId']);
+      if (Array.isArray(list) && list.length > 0 && vpcId) {
+        input.SecurityGroupIds = list;
+        input.VpcId = vpcId;
+        any = true;
+      }
+    }
+  }
+  if (!any) return;
+  await new EC2Client({ region: ctx.region }).send(new ModifyClientVpnEndpointCommand(input));
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
+  'AWS::CodeBuild::ReportGroup': writeCodeBuildReportGroup,
+  'AWS::DAX::Cluster': writeDaxCluster,
+  'AWS::DAX::ParameterGroup': writeDaxParameterGroup,
+  'AWS::EC2::ClientVpnEndpoint': writeEc2ClientVpnEndpoint,
   'AWS::OpenSearchService::Domain': writeOpenSearchDomain,
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,
   'AWS::WAFv2::WebACL': writeWafv2WebAcl,

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -454,6 +454,38 @@ describe('buildRevertPlan', () => {
     expect(plan.items[0]).toMatchObject({ kind: 'cc', resourceType: 'AWS::Scheduler::Schedule' });
   });
 
+  it('#552: NON_PROVISIONABLE types with new SDK writers route to sdk items (not "type not revertable yet")', () => {
+    // CodeBuild ReportGroup / DAX Cluster / DAX ParameterGroup / ClientVpnEndpoint are all
+    // SDK-override READ types (CC has no handler). Once each has an SDK_WRITERS entry, a drift
+    // on it must become a revertable kind='sdk' item, not the "type not revertable yet" refusal.
+    const cases = [
+      { resourceType: 'AWS::CodeBuild::ReportGroup', path: 'ExportConfig.S3Destination.Packaging' },
+      { resourceType: 'AWS::DAX::Cluster', path: 'Description' },
+      { resourceType: 'AWS::DAX::ParameterGroup', path: 'ParameterNameValues.record-ttl-millis' },
+      { resourceType: 'AWS::EC2::ClientVpnEndpoint', path: 'Description' },
+    ];
+    for (const c of cases) {
+      const plan = buildRevertPlan(
+        [
+          F({
+            tier: 'declared',
+            resourceType: c.resourceType,
+            path: c.path,
+            desired: 'x',
+            actual: 'y',
+          }),
+        ],
+        undefined
+      );
+      expect(plan.notRevertable, c.resourceType).toHaveLength(0);
+      expect(plan.items, c.resourceType).toHaveLength(1);
+      expect(plan.items[0], c.resourceType).toMatchObject({
+        kind: 'sdk',
+        resourceType: c.resourceType,
+      });
+    }
+  });
+
   it('Cognito IdentityPool: CognitoEvents -> prop-scoped sdk item, a base prop -> cc item', () => {
     // The IdentityPool SDK override only ENRICHES the CC read with the writeOnly
     // CognitoEvents, so it is CC_REVERTABLE_DESPITE_READ_OVERRIDE: base-property reverts

--- a/tests/transient.test.ts
+++ b/tests/transient.test.ts
@@ -56,6 +56,20 @@ describe('classifyTransient — transient (retry-later) error class', () => {
     }
   });
 
+  it('#552: classifies DAX mid-modify parameter-group / cluster state faults', () => {
+    for (const msg of [
+      // The exact live error from the #552 detect→revert live-test.
+      'InvalidParameterGroupStateFault: The parameter record-ttl-millis is being modified.',
+      'InvalidClusterStateFault: Cluster cdkrd-dax is being modified',
+    ]) {
+      const v = classifyTransient(msg);
+      expect(v.transient).toBe(true);
+      expect(v.hint).toBe(
+        'the resource is still applying a previous update — retry in a few minutes'
+      );
+    }
+  });
+
   it('does NOT misclassify a terminal DB error as the mid-modify state fault', () => {
     for (const msg of [
       'DBInstanceNotFound: DBInstance mydb not found',

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -117,6 +117,24 @@ import {
   UpdateResourceCommand,
 } from '@aws-sdk/client-cloudcontrol';
 import { KafkaClient, UpdateConfigurationCommand } from '@aws-sdk/client-kafka';
+import {
+  BatchGetReportGroupsCommand,
+  CodeBuildClient,
+  UpdateReportGroupCommand,
+} from '@aws-sdk/client-codebuild';
+import {
+  DAXClient,
+  DescribeClustersCommand,
+  DescribeParameterGroupsCommand,
+  DescribeParametersCommand as DescribeDaxParametersCommand,
+  UpdateClusterCommand,
+  UpdateParameterGroupCommand as UpdateDaxParameterGroupCommand,
+} from '@aws-sdk/client-dax';
+import {
+  DescribeClientVpnEndpointsCommand,
+  EC2Client,
+  ModifyClientVpnEndpointCommand,
+} from '@aws-sdk/client-ec2';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import type { OverrideCtx } from '../src/read/overrides.js';
@@ -144,6 +162,9 @@ const cloudwatch = mockClient(CloudWatchClient);
 const dlm = mockClient(DLMClient);
 const cloudcontrol = mockClient(CloudControlClient);
 const kafka = mockClient(KafkaClient);
+const codebuild = mockClient(CodeBuildClient);
+const dax = mockClient(DAXClient);
+const ec2 = mockClient(EC2Client);
 
 const ARN = 'arn:aws:iam::123456789012:policy/p';
 const ctx = (over: Partial<OverrideCtx> = {}): OverrideCtx => ({
@@ -194,6 +215,9 @@ beforeEach(() => {
   cloudwatch.reset();
   dlm.reset();
   cloudcontrol.reset();
+  codebuild.reset();
+  dax.reset();
+  ec2.reset();
 });
 
 describe('CloudWatch AnomalyDetector writer (PutAnomalyDetector upsert, issue #461)', () => {
@@ -1416,6 +1440,253 @@ describe('DocDB DBInstance writer (CC read+write gap; mirror of the cluster writ
         windowOp('sun:05:00-sun:06:00'),
       ])
     ).rejects.toThrow(/instance identifier/);
+  });
+});
+
+describe('CodeBuild ReportGroup writer (NON_PROVISIONABLE; UpdateReportGroup, issue #552)', () => {
+  const RG_ARN = 'arn:aws:codebuild:us-east-1:123456789012:report-group/cdkrd-rg';
+  const packagingOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/ExportConfig/S3Destination/Packaging',
+    value,
+    human: 'ExportConfig.S3Destination.Packaging -> deployed-template value',
+  });
+  // the override reader (BatchGetReportGroups) returns the DRIFTED live model
+  const stubRead = (over: Record<string, unknown> = {}): void => {
+    codebuild.on(BatchGetReportGroupsCommand).resolves({
+      reportGroups: [
+        {
+          name: 'cdkrd-rg',
+          type: 'TEST',
+          exportConfig: {
+            exportConfigType: 'S3',
+            s3Destination: { bucket: 'my-bucket', path: 'reports', packaging: 'ZIP' },
+          },
+          tags: [{ key: 'team', value: 'platform' }],
+          ...over,
+        },
+      ],
+    } as never);
+  };
+
+  it('reverts the ExportConfig packaging + re-sends tags via UpdateReportGroup', async () => {
+    stubRead();
+    codebuild.on(UpdateReportGroupCommand).resolves({});
+    // revert Packaging back to NONE (drifted to ZIP out of band)
+    await SDK_WRITERS['AWS::CodeBuild::ReportGroup'](ctx({ physicalId: RG_ARN }), [
+      packagingOp('NONE'),
+    ]);
+    const calls = codebuild.commandCalls(UpdateReportGroupCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input;
+    expect(input.arn).toBe(RG_ARN);
+    expect(input.exportConfig).toEqual({
+      exportConfigType: 'S3',
+      s3Destination: {
+        bucket: 'my-bucket',
+        path: 'reports',
+        packaging: 'NONE',
+        encryptionKey: undefined,
+        encryptionDisabled: undefined,
+      },
+    });
+    // tags round-trip (camelCase key/value) so a Tags-only edit would not wipe them
+    expect(input.tags).toEqual([{ key: 'team', value: 'platform' }]);
+  });
+
+  it('sends an empty tag list when the group has no tags (clears an out-of-band tag)', async () => {
+    stubRead({ tags: undefined });
+    codebuild.on(UpdateReportGroupCommand).resolves({});
+    await SDK_WRITERS['AWS::CodeBuild::ReportGroup'](ctx({ physicalId: RG_ARN }), [
+      packagingOp('NONE'),
+    ]);
+    expect(codebuild.commandCalls(UpdateReportGroupCommand)[0]!.args[0].input.tags).toEqual([]);
+  });
+
+  it('throws when the report-group ARN is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::CodeBuild::ReportGroup'](ctx({ physicalId: '', declared: {} }), [
+        packagingOp('NONE'),
+      ])
+    ).rejects.toThrow(/ReportGroup ARN/);
+  });
+});
+
+describe('DAX Cluster writer (NON_PROVISIONABLE; UpdateCluster partial modify, issue #552)', () => {
+  const CN = 'cdkrd-dax';
+  const descOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/Description',
+    value,
+    human: 'Description -> deployed-template value',
+  });
+  const stubRead = (over: Record<string, unknown> = {}): void => {
+    dax.on(DescribeClustersCommand).resolves({
+      Clusters: [
+        { ClusterName: CN, Description: 'drifted desc', NodeType: 'dax.r5.large', ...over },
+      ],
+    } as never);
+  };
+
+  it('reverts Description via UpdateCluster, only the drifted prop mapped CFn->API', async () => {
+    stubRead();
+    dax.on(UpdateClusterCommand).resolves({});
+    await SDK_WRITERS['AWS::DAX::Cluster'](ctx({ physicalId: CN }), [descOp('intended desc')]);
+    const calls = dax.commandCalls(UpdateClusterCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({ ClusterName: CN, Description: 'intended desc' });
+  });
+
+  it('maps NotificationTopicARN -> NotificationTopicArn and clears it on a remove', async () => {
+    stubRead({ NotificationConfiguration: { TopicArn: 'arn:aws:sns:us-east-1:123456789012:t' } });
+    dax.on(UpdateClusterCommand).resolves({});
+    // a REMOVE (topic never declared → revert detaches it) sends the empty string DAX accepts
+    await SDK_WRITERS['AWS::DAX::Cluster'](ctx({ physicalId: CN }), [
+      { op: 'remove', path: '/NotificationTopicARN', human: 'NotificationTopicARN -> (none)' },
+    ]);
+    expect(dax.commandCalls(UpdateClusterCommand)[0]!.args[0].input).toEqual({
+      ClusterName: CN,
+      NotificationTopicArn: '',
+    });
+  });
+
+  it('ignores a create-only prop off the modify allowlist (NodeType)', async () => {
+    stubRead();
+    dax.on(UpdateClusterCommand).resolves({});
+    await SDK_WRITERS['AWS::DAX::Cluster'](ctx({ physicalId: CN }), [
+      { op: 'add', path: '/NodeType', value: 'dax.r5.xlarge', human: 'x' },
+    ]);
+    expect(dax.commandCalls(UpdateClusterCommand)).toHaveLength(0);
+  });
+});
+
+describe('DAX ParameterGroup writer (NON_PROVISIONABLE; UpdateParameterGroup, issue #552)', () => {
+  const PGN = 'cdkrd-dax-params';
+  const stubRead = (values: Record<string, string>): void => {
+    dax.on(DescribeParameterGroupsCommand).resolves({
+      ParameterGroups: [{ ParameterGroupName: PGN, Description: 'd' }],
+    } as never);
+    dax.on(DescribeDaxParametersCommand).resolves({
+      Parameters: Object.entries(values).map(([ParameterName, ParameterValue]) => ({
+        ParameterName,
+        ParameterValue,
+        IsModifiable: 'TRUE',
+      })),
+    } as never);
+  };
+
+  it('re-asserts the drifted parameter (map -> [{ParameterName,ParameterValue}] list)', async () => {
+    // desired value (record-ttl-millis) reads back 10000 after applying the revert op
+    stubRead({ 'record-ttl-millis': '10000', 'query-ttl-millis': '5000' });
+    dax.on(UpdateDaxParameterGroupCommand).resolves({});
+    await SDK_WRITERS['AWS::DAX::ParameterGroup'](ctx({ physicalId: PGN }), [
+      {
+        op: 'add',
+        path: '/ParameterNameValues/record-ttl-millis',
+        value: '10000',
+        human: 'ParameterNameValues.record-ttl-millis -> deployed-template value',
+      },
+    ]);
+    const calls = dax.commandCalls(UpdateDaxParameterGroupCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({
+      ParameterGroupName: PGN,
+      // ONLY the drifted key is re-sent (UpdateParameterGroup leaves others untouched)
+      ParameterNameValues: [{ ParameterName: 'record-ttl-millis', ParameterValue: '10000' }],
+    });
+  });
+
+  it('sends nothing when no ParameterNameValues op is present', async () => {
+    stubRead({ 'record-ttl-millis': '10000' });
+    dax.on(UpdateDaxParameterGroupCommand).resolves({});
+    await SDK_WRITERS['AWS::DAX::ParameterGroup'](ctx({ physicalId: PGN }), [
+      { op: 'add', path: '/Description', value: 'x', human: 'x' },
+    ]);
+    expect(dax.commandCalls(UpdateDaxParameterGroupCommand)).toHaveLength(0);
+  });
+});
+
+describe('EC2 ClientVpnEndpoint writer (NON_PROVISIONABLE; ModifyClientVpnEndpoint, issue #552)', () => {
+  const CVID = 'cvpn-endpoint-0123456789abcdef0';
+  const stubRead = (over: Record<string, unknown> = {}): void => {
+    ec2.on(DescribeClientVpnEndpointsCommand).resolves({
+      ClientVpnEndpoints: [
+        {
+          ClientVpnEndpointId: CVID,
+          Description: 'drifted',
+          SplitTunnel: true,
+          VpnPort: 443,
+          TransportProtocol: 'udp',
+          VpcId: 'vpc-abc',
+          ...over,
+        },
+      ],
+    } as never);
+  };
+
+  it('reverts scalar props (Description/SplitTunnel) via ModifyClientVpnEndpoint, drifted only', async () => {
+    stubRead();
+    ec2.on(ModifyClientVpnEndpointCommand).resolves({});
+    await SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+      { op: 'add', path: '/Description', value: 'intended', human: 'Description -> value' },
+    ]);
+    const calls = ec2.commandCalls(ModifyClientVpnEndpointCommand);
+    expect(calls).toHaveLength(1);
+    // the reader read Description as 'drifted', revert op sets it to 'intended'
+    expect(calls[0]!.args[0].input).toEqual({
+      ClientVpnEndpointId: CVID,
+      Description: 'intended',
+    });
+  });
+
+  it('reshapes DnsServers (string[] read -> {CustomDnsServers,Enabled} modify)', async () => {
+    stubRead({ DnsServers: ['10.0.0.2'] });
+    ec2.on(ModifyClientVpnEndpointCommand).resolves({});
+    await SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+      { op: 'add', path: '/DnsServers', value: ['10.0.0.2'], human: 'DnsServers -> value' },
+    ]);
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)[0]!.args[0].input).toEqual({
+      ClientVpnEndpointId: CVID,
+      DnsServers: { CustomDnsServers: ['10.0.0.2'], Enabled: true },
+    });
+  });
+
+  it('clears DnsServers when the revert removes them (Enabled:false)', async () => {
+    stubRead({ DnsServers: undefined });
+    ec2.on(ModifyClientVpnEndpointCommand).resolves({});
+    await SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+      { op: 'remove', path: '/DnsServers', human: 'DnsServers -> (none)' },
+    ]);
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)[0]!.args[0].input).toEqual({
+      ClientVpnEndpointId: CVID,
+      DnsServers: { Enabled: false },
+    });
+  });
+
+  it('sends SecurityGroupIds together with VpcId (API requires the pair)', async () => {
+    stubRead({ SecurityGroupIds: ['sg-111'] });
+    ec2.on(ModifyClientVpnEndpointCommand).resolves({});
+    await SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+      {
+        op: 'add',
+        path: '/SecurityGroupIds',
+        value: ['sg-111'],
+        human: 'SecurityGroupIds -> value',
+      },
+    ]);
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)[0]!.args[0].input).toEqual({
+      ClientVpnEndpointId: CVID,
+      SecurityGroupIds: ['sg-111'],
+      VpcId: 'vpc-abc',
+    });
+  });
+
+  it('throws when the endpoint id is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: '', declared: {} }), [
+        { op: 'add', path: '/Description', value: 'x', human: 'x' },
+      ])
+    ).rejects.toThrow(/endpoint id/);
   });
 });
 


### PR DESCRIPTION
Closes #552. Follow-up from #530 / #534 (detect-only readers): add SDK writers so `revert` can restore an out-of-band change on these NON_PROVISIONABLE types (Cloud Control cannot write them).

## Writers added (`SDK_WRITERS`)
- **CodeBuild ReportGroup** — `codebuild:UpdateReportGroup` (re-supplies `exportConfig` + `tags` wholesale; PascalCase CFn → camelCase API; always sends tags so a Tags-only edit isn't wiped).
- **DAX Cluster** — `dax:UpdateCluster` PARTIAL modify of the mutable allowlist (Description / PreferredMaintenanceWindow / NotificationTopicARN→`NotificationTopicArn` / ParameterGroupName / SecurityGroupIds); create-only props (NodeType, ClusterEndpointEncryptionType, …) are excluded.
- **DAX ParameterGroup** — `dax:UpdateParameterGroup`, re-asserting the drifted params (`{name→value}` map → `[{ParameterName,ParameterValue}]` list; only touched keys re-sent).
- **ClientVpnEndpoint** — `ec2:ModifyClientVpnEndpoint` PARTIAL modify; reshapes the reader's `DnsServers` list into the API's `{CustomDnsServers,Enabled}` and pairs `SecurityGroupIds` with `VpcId`.

Each routes via the existing `SDK_WRITERS` registry → `kind:'sdk'` (added a `revert-plan` test asserting these types are no longer "type not revertable yet").

## Transient classifier (#467 class)
DAX rejects a modify while a prior `update-parameter-group` is still applying with `InvalidParameterGroupStateFault: the parameter <x> is being modified` — added it (+ the `(currently )?being modified` phrasing) to `classifyTransient` so revert auto-retries instead of a bare FAILED. **Caught by the live-test below.**

## Live-test (real AWS, us-east-1) — detect → revert → CLEAN
Deployed a fixture with all four types (default VPC, self-signed ACM server cert for ClientVPN), recorded a clean baseline, then mutated one declared prop on each out of band:
| Type | prop | out-of-band | detected | reverted |
|---|---|---|---|---|
| CodeBuild ReportGroup | ExportConfig.S3Destination.Packaging | NONE→ZIP (+bucket cleared) | ✅ declared | ✅ |
| DAX Cluster | Description | declared-desc→drifted-desc | ✅ declared | ✅ |
| DAX ParameterGroup | ParameterNameValues.record-ttl-millis | 10000→20000 | ✅ declared | ✅ (transient retry) |
| ClientVpnEndpoint | Description | declared-cvpn→drifted-cvpn | ✅ declared | ✅ |

Final `check`: **CLEAN**. Stack torn down via `delstack`, ACM cert + orphan log group swept, `SWEEP CLEAN`.

## Tests
- `writers.test.ts`: 13 new cases (per-writer happy path + reshaping + allowlist gating + unresolvable-id throw).
- `revert-plan.test.ts`: routing to `kind:'sdk'`.
- `transient.test.ts`: DAX state-fault classification (the live-caught error).
- Full suite: 2743 passed.

Not-revertable (unchanged, no modify API): `ClientVpnAuthorizationRule` / `ClientVpnTargetNetworkAssociation`.
