### PR TITLE
fix(report): readable default-fg for explanatory prose + rule-framed result:

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,7 +103,7 @@ NEW (cdkd does NOT have these):
   CloudWatch Application Signals / Lambda Insights auto-instrumentation footprint
   (an added Insights layer + tracer execution policy). A hint NEVER folds or
   re-tiers the finding (an unexpected account-wide enablement stays visible as
-  real drift); it only names the likely source in a dim trailing line.
+  real drift); it only names the likely source in a readable trailing line.
 - **golden corpus** — recorded real pipeline inputs+findings, replayed offline in CI (R63)
 
 ## Roadmap (private until Phase 4)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ $ npx cdkrd check
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
   ApiStack/ApiRole.Policies (AWS::IAM::Role) — appeared since record = [{"PolicyName":"manual-debug-access", ...}]
 
+─────────────────────────────────
 result: 1 drift(s) (undeclared=1)
+─────────────────────────────────
 ```
 
 ![cdkrd finds an out-of-band inline policy that `cdk drift` reports as zero](demo/demo.gif)
@@ -71,7 +73,9 @@ No baseline yet — live-only values can't be confirmed as drift, but declared d
   ApiStack/Queue.RedrivePolicy (AWS::SQS::Queue) = {"maxReceiveCount":5}
   ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
 
+─────────────────────────────────────────────────────────────
 result: 3 findings — 1 drift (declared=1) + 2 potential drift
+─────────────────────────────────────────────────────────────
 
 ApiStack: drift found — what do you want to do?
   ❯ Nothing (decide later)
@@ -110,7 +114,9 @@ your CloudFormation template, the kind `cdk drift` can't see:
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
   ApiStack/Role.Policies (AWS::IAM::Role) — changed since record = [{"PolicyName":"adhoc", ...}, {"PolicyName":"manual-debug-access", ...}]
 
+─────────────────────────────────
 result: 1 drift(s) (undeclared=1)
+─────────────────────────────────
 ```
 
 `record` covers live-only state only, not a `[CFn-Declared Drift]`; the other
@@ -366,7 +372,9 @@ $ npx cdkrd check --pre-deploy
       desired=1024
       actual =2048
 
+───────────────────────────────
 result: 1 drift(s) (declared=1)
+───────────────────────────────
 ```
 
 `desired` is what your local code is about to set; `actual` is live now: someone
@@ -436,7 +444,9 @@ that folds everything informational.
       desired="Enabled"
       actual ="Suspended"
 
+───────────────────────────────
 result: 1 drift(s) (declared=1)
+───────────────────────────────
 info:
   - readGap=1 (declared but unverifiable — AWS doesn't return them on read, not drift: 1 write-only)
   - skipped=2 (custom resource 2)
@@ -454,7 +464,7 @@ info:
 - **`↳` origin hint**: when a finding's live value has a recognizable external
   source — e.g. the CloudWatch Application Signals / Lambda Insights
   auto-instrumentation footprint (an added Insights layer + tracer execution
-  policy, typically enabled account-wide, not per-resource) — a dim `↳` line names
+  policy, typically enabled account-wide, not per-resource) — a `↳` line names
   the likely source. It's an explanation only: the finding is still real drift and
   still drives the exit, so an unexpected account-wide enablement is never hidden.
 - **`info:` footer** folds the informational tiers to per-reason counts
@@ -467,8 +477,12 @@ info:
 | `nested`                                         | an undeclared sub-key inside a property you _did_ declare (e.g. a CloudFront origin gaining `ConnectionTimeout`, or an API Gateway method's `Integration.PassthroughBehavior`). Surfaced in full like a top-level undeclared value — a non-default nested value is a real out-of-band setting — and recordable. (Catalogued AWS defaults are folded upstream as `atDefault`/`generated`, so only genuine settings remain.) |
 | `readGap` / `unresolved` / `skipped` / `ignored` | values cdkrd can't confidently compare, reported honestly rather than guessed (never false drift).                                                                                                                                                                                                                                                                                                                         |
 
-`^result:` is the greppable verdict. Colorized on a TTY (`NO_COLOR` respected);
-piped / CI / `--json` output is plain text.
+`^result:` is the greppable verdict, framed by a horizontal rule when there is
+drift so it stands out from the findings above (a CLEAN stack stays compact).
+Colorized on a TTY (`NO_COLOR` respected): red/yellow/green for the verdicts and
+tiers, while explanatory prose (tier notes, the `↳` hint, the `info:` footer) uses
+your terminal's default foreground so it stays legible on any theme — dim/gray is
+reserved for picker rows you aren't on. Piped / CI / `--json` output is plain text.
 
 ### JSON output contract
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -624,7 +624,7 @@ eventual consistency (the slow full re-gather used to grant that propagation
 time by accident). When drift survives, each surviving finding is listed
 (id.path + tier) under the `N drift(s) remain.` line so the user doesn't have
 to re-run `check` to learn what failed to converge (R46); if unrecorded values
-remain after a clean revert, one dim pointer line names the count (they are not
+remain after a clean revert, one pointer line names the count (they are not
 drift, but silence would read as "all decided" — R62). Exit semantics: no
 drift at all → `no drift to revert.` + exit 0; findings exist but **nothing
 is revertable** →
@@ -995,9 +995,12 @@ tiers are never printed. Section headers carry the count INSIDE the brackets
 (`[CFn-Declared Drift: 3]`, the explanatory note outside) — a bare digit right of
 `]` read as noise (R48). No blank line precedes the header; the FIRST drift
 section follows the header directly, later sections get a grouping blank, and
-`result:` gets a blank line before it ONLY when a drift section was printed —
-the verdict must not read as a member of the section above it, while a CLEAN
-stack with one informational tier stays exactly 3 lines (R48 revising R37).
+when a drift section was printed `result:` is FRAMED by a horizontal rule above
+and below (preceded by a blank line) so the verdict stands out from the wall of
+findings — bold alone got lost. `result:` keeps column 0 (the `^result:` grep
+contract; the rules are their own lines) and the rule width tracks the verdict
+line. A CLEAN stack (no sections) skips the frame and stays exactly 3 lines
+(R48 revising R37).
 The check loop puts one blank line between consecutive stack reports in a
 multi-stack run. The `result:` line carries the
 verdict + non-zero drift counts only (the informational breakdown lives on `info:`,
@@ -1058,10 +1061,16 @@ values are tagged `unrecorded`(Potential Drift), not mislabeled confirmed drift:
 out first, so its removal pass would misread every recorded entry).
 **Color (R43):** output is colorized via semantic helpers
 ([style.ts](../src/report/style.ts), picocolors) — green/red bold verdicts,
-yellow undeclared tier, dim informational footers — ONLY when stdout is a real
-TTY and`NO_COLOR`is unset. Piped / CI /`--json`output is byte-identical
-plain text (the helpers are the identity), so the greppable invariant holds;`FORCE_COLOR` is deliberately ignored. The pure formatters (`formatFinding`'s
-ids, `formatPlan`) stay plain; styling happens at the printing edge.
+yellow undeclared tier, a bold `result:` label framed by a horizontal rule —
+ONLY when stdout is a real TTY and`NO_COLOR`is unset. Explanatory prose that is
+MEANT TO BE READ (tier notes, the `↳`origin hint, the`info:`footer) uses the`note`helper = the terminal DEFAULT foreground, so it stays legible on any theme;`dim`(SGR 2) was removed there because on dark terminals it rendered unreadable
+and wore the same "don't read me" style as the picker chrome.`dim` (`infoTier`)
+is now reserved for genuinely secondary UI you are NOT meant to read closely — the
+non-focused / skip picker rows. Piped / CI /`--json`output is byte-identical plain
+text (the helpers are the identity — the rule lines print in both, only color
+differs), so the greppable invariant holds;`FORCE_COLOR` is deliberately ignored.
+The pure formatters (`formatFinding`'s ids, `formatPlan`) stay plain; styling
+happens at the printing edge.
 
 A declared **top-level write-only** property (e.g. an IAM Role's
 `AssumeRolePolicyDocument`) is surfaced as a `readGap` (note: `write-only — cannot

--- a/src/commands/action-picker.ts
+++ b/src/commands/action-picker.ts
@@ -113,9 +113,9 @@ export function actionChip(action: FindingAction): string {
   return `[ ${center(action, CHIP_WIDTH)} ]`;
 }
 
-/** The dim key-hint line shown under the message. Pure + exported for unit tests.
- *  The action picker only runs inside check's interactive flow, where Esc returns to
- *  the action menu — so `esc = back` (R130). */
+/** The key-hint line shown under the message (readable — it is meant to be read, so
+ *  style.note not dim). Pure + exported for unit tests. The action picker only runs inside
+ *  check's interactive flow, where Esc returns to the action menu — so `esc = back` (R130). */
 export function actionPickerHint(): string {
   return 'type = filter · ↑↓ = move · space = cycle · → = all (filtered) · ⌫ = clear · enter = apply · esc = back';
 }
@@ -182,17 +182,17 @@ export function renderPickerFrame(
 ): string {
   if (done) return `${S_BAR_START}  ${message}\n${S_BAR}  ${summarizeChoices(actions)}`;
   const vis = visible ?? rows.map((_, i) => i);
-  const header = `${S_BAR_START}  ${message}\n${S_BAR}  ${style.infoTier(actionPickerHint())}`;
+  const header = `${S_BAR_START}  ${message}\n${S_BAR}  ${style.note(actionPickerHint())}`;
   // Show the active filter (and a match count) so the narrowing is visible; the row body is
   // the visible subset, with the cursor an index INTO that subset (vi), pointing at the
   // original row visible[vi].
   const filterLine =
     filter.trim().length > 0
-      ? `${S_BAR}  ${style.cursor(`filter: ${filter}`)}${style.infoTier(` (${vis.length} match${vis.length === 1 ? '' : 'es'})`)}`
+      ? `${S_BAR}  ${style.cursor(`filter: ${filter}`)}${style.note(` (${vis.length} match${vis.length === 1 ? '' : 'es'})`)}`
       : undefined;
   const body =
     vis.length === 0
-      ? `${S_BAR}  ${style.infoTier(`(no rows match "${filter.trim()}" — ⌫ to clear)`)}`
+      ? `${S_BAR}  ${style.note(`(no rows match "${filter.trim()}" — ⌫ to clear)`)}`
       : vis
           .map(
             (origIdx, vi) =>

--- a/src/commands/bulk-multiselect.ts
+++ b/src/commands/bulk-multiselect.ts
@@ -32,7 +32,8 @@ export function bulkSelectValues(options: { value: string }[], action: 'all' | '
   return action === 'all' ? options.map((o) => o.value) : [];
 }
 
-/** The dim key-hint line shown under the message. Pure + exported for unit tests.
+/** The key-hint line shown under the message (readable — style.note, not dim: it is
+ *  meant to be read). Pure + exported for unit tests.
  *  `esc = cancel` is listed last (R130): Esc aborts the prompt — in check's interactive
  *  flow that returns to the action menu, in a standalone `record`/`ignore` it cancels
  *  the command; either way the selection is discarded, so `cancel` is accurate in both. */
@@ -74,7 +75,7 @@ export async function bulkMultiselect(
       if (this.state === 'submit' || this.state === 'cancel') {
         return `${S_BAR_START}  ${message}\n${S_BAR}  ${(this.value ?? []).length} selected`;
       }
-      const header = `${S_BAR_START}  ${message}\n${S_BAR}  ${style.infoTier(bulkSelectHint())}`;
+      const header = `${S_BAR_START}  ${message}\n${S_BAR}  ${style.note(bulkSelectHint())}`;
       const selected = new Set(this.value ?? []);
       const rows = this.options.map(
         (opt, i) =>

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -498,7 +498,7 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
     console.log(style.ok(`ignore rule(s) added: ${path} (${added.length} new${dup})`));
   } else {
     console.log(
-      style.infoTier(
+      style.note(
         `${stackName}: all ${alreadyPresent.length} selected rule(s) already present — config unchanged`
       )
     );
@@ -806,12 +806,12 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
         revertSelectOptions(plan)
       );
       if (picked === undefined) {
-        console.log(style.infoTier('aborted.'));
+        console.log(style.note('aborted.'));
         return { exit: 0, aborted: true };
       }
       plan = filterRevertPlan(plan, new Set(picked));
       if (plan.items.length === 0) {
-        console.log(style.infoTier('nothing selected — aborted.'));
+        console.log(style.note('nothing selected — aborted.'));
         return { exit: 0, aborted: true };
       }
     }
@@ -820,7 +820,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       message: revertConfirmMessage(stackName, opCount, plan.notRevertable.length),
     });
     if (isCancel(ok) || !ok) {
-      console.log(style.infoTier('aborted.'));
+      console.log(style.note('aborted.'));
       return { exit: 0, aborted: true };
     }
   }
@@ -852,7 +852,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       const reason = (hint ?? 'transient error').split(' — ')[0];
       const secs = Math.max(1, Math.round(delayMs / 1000));
       console.log(
-        style.infoTier(`    ↻ ${displayId}: ${reason} — retry ${attempt} (next in ${secs}s)…`)
+        style.note(`    ↻ ${displayId}: ${reason} — retry ${attempt} (next in ${secs}s)…`)
       );
     },
   });
@@ -944,7 +944,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       if (s.hint) {
         const suffix =
           waitMs === undefined ? ' (or re-run with --wait to block until it settles)' : '';
-        console.log(style.infoTier(`    ↳ ${s.hint}${suffix}`));
+        console.log(style.note(`    ↳ ${s.hint}${suffix}`));
       }
     }
   }
@@ -955,7 +955,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // plan.items and carries every other finding forward from the original gather.
   const touched = new Set(plan.items.map((i) => i.logicalId));
   console.log(
-    '\n' + style.infoTier(`verifying convergence (re-reading ${touched.size} resource(s))...`)
+    '\n' + style.note(`verifying convergence (re-reading ${touched.size} resource(s))...`)
   );
   const reconcile = (findings: Finding[]): Finding[] =>
     applyIgnores(
@@ -1005,7 +1005,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   const unrecordedLeft = unrecordedCount(post);
   if (unrecordedLeft > 0)
     console.log(
-      style.infoTier(
+      style.note(
         `  (${unrecordedLeft} unrecorded value(s) still await a baseline — run cdkrd record)`
       )
     );
@@ -1014,7 +1014,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // own `FAILED:` line above and bumped the exit to 2 in the apply loop.)
   if (unverified > 0)
     console.log(
-      style.infoTier(
+      style.note(
         `  (${unverified} resource(s) could not be re-read to verify — re-run cdkrd check to confirm)`
       )
     );

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -5,10 +5,12 @@
 //   header -> DRIFT tier sections (full detail) -> result: -> info: footer
 // Spacing (R37, revised by R48): no blank line before the header; the FIRST drift
 // section follows the header directly (no stray blank); subsequent sections get a
-// blank line between them (grouping); `result:` gets a blank line before it ONLY
-// when at least one drift section was printed — so the verdict never reads as a
-// member of the section above it, while a CLEAN stack with one informational tier
-// stays exactly 3 lines. Section headers carry the count INSIDE the brackets
+// blank line between them (grouping); when at least one drift section was printed
+// `result:` is FRAMED by a horizontal rule above and below (with a blank line before
+// the frame) so the verdict stands out from the wall of findings — bold alone got lost;
+// a CLEAN stack (no sections) skips the frame and stays exactly 3 lines. `result:` keeps
+// column 0 for the `^result:` grep contract (the rules are their own lines). Section
+// headers carry the count INSIDE the brackets
 // (`[CFn-Declared Drift: 3]`) — a bare digit to the right of `]` read as noise (R48);
 // the explanatory note follows outside the brackets. DRIFT tiers
 // (deleted/declared/undeclared) are ALWAYS shown in full — they are the point.
@@ -21,6 +23,10 @@ import { deepEqual } from '../diff/drift-calculator.js';
 import { annotateHints } from '../diff/hints.js';
 import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
+
+// Strip SGR color codes to measure a line's VISIBLE width (for the result-line rule).
+// Built from the ESC char via fromCharCode so no control byte sits in a regex literal.
+const ANSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
 
 // Section headers are Title Case (not all-caps) — uniform and readable, and crucially
 // so `CFn-Declared Drift` vs `CFn-Undeclared Drift`, which share the `CFn-` prefix, the
@@ -133,8 +139,9 @@ export function formatFinding(f: Finding): string {
   else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
     s += ` = ${style.actual(j(f.actual))}`;
   // A non-classifying origin hint (diff/hints.ts) — the finding is still real drift; this
-  // just names where the live value likely came from. Dim trailing line, below the values.
-  if (f.hint) s += `\n      ${style.infoTier(`↳ ${f.hint}`)}`;
+  // just names where the live value likely came from. Readable (style.note) trailing line
+  // below the values — it is meant to be read, so NOT dim.
+  if (f.hint) s += `\n      ${style.note(`↳ ${f.hint}`)}`;
   return s;
 }
 
@@ -206,7 +213,8 @@ function formatArrayDelta(d: ArrayDelta): string {
 }
 
 // section-title color by tier: deleted/declared = red (drift), undeclared =
-// yellow (the differentiator), informational tiers = dim.
+// yellow (the differentiator), informational tiers = readable default (style.note,
+// not dim — a --verbose info section is content to read).
 function tierStyle(t: Tier): (s: string) => string {
   // All three DRIFT tiers are RED — they are drift (exit-affecting). undeclared was
   // previously yellow (undeclaredTier), which collided with the [Potential Drift] section
@@ -215,7 +223,7 @@ function tierStyle(t: Tier): (s: string) => string {
   // review" — so colour alone separates drift (red) from to-review (yellow). R125.
   if (t === 'deleted' || t === 'added' || t === 'declared' || t === 'undeclared')
     return style.driftTier;
-  return style.infoTier;
+  return style.note;
 }
 
 // A short, human label for WHY an informational finding is not actionable drift, so
@@ -276,7 +284,8 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
   // folded-count machinery below is a no-op rather than a special case.
   const unrecordedShown = unrecordedItems;
   const nestedFolded: Finding[] = [];
-  // Count inside the brackets (`[NAME: N]`), explanation outside (dim) — see the
+  // Count inside the brackets (`[NAME: N]`), explanation outside (readable — style.note,
+  // not dim: it is meant to be read) — see the
   // layout comment at the top (R48). `leadingBlank` separates a section from
   // whatever precedes it; the FIRST drift section sits directly under the header.
   const section = (
@@ -290,7 +299,7 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
     log(
       (leadingBlank ? '\n' : '') +
         color(`[${name}: ${items.length}]`) +
-        (note ? ' ' + style.infoTier(`(${note})`) : '')
+        (note ? ' ' + style.note(`(${note})`) : '')
     );
     for (const f of items) log('  ' + formatFinding(f));
     return true;
@@ -361,7 +370,7 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
     resultBody =
       `${drifted + shown} findings — ${style.drift(`${drifted} drift`)} (${driftCounts})` +
       ` + ${style.undeclaredTier(`${shown} potential drift`)}` +
-      style.infoTier(nestedTail);
+      style.note(nestedTail);
   } else {
     // the verdict is the one line that must stand out: green CLEAN / red drift count.
     // "CLEAN" is reserved for a truly clean stack (nothing unrecorded). With only FOLDED
@@ -376,17 +385,29 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
           : style.clean('CLEAN');
     const unrecordedNote =
       shown > 0
-        ? style.undeclaredTier(` · ${shown} potential drift`) + style.infoTier(nestedTail)
+        ? style.undeclaredTier(` · ${shown} potential drift`) + style.note(nestedTail)
         : folded > 0
-          ? style.infoTier(
-              ` · ${folded} live-only value(s) to record as baseline (run cdkrd record)`
-            )
+          ? style.note(` · ${folded} live-only value(s) to record as baseline (run cdkrd record)`)
           : '';
     resultBody = `${verdict}${unrecordedNote}`;
   }
-  // A blank line before the verdict ONLY when drift sections were printed — it must
-  // not read as a member of the last section (R48); a CLEAN stack stays 3 lines.
-  log((driftSections > 0 ? '\n' : '') + `result: ${resultBody}`);
+  // The verdict is the one line that must stand out. Bold alone got lost under a wall of
+  // findings, so when drift sections were printed the verdict is FRAMED with a horizontal
+  // rule above and below (and a blank line separating it from the section above — R48). A
+  // leading glyph was rejected: `result:` must stay at column 0 for the `^result:` CI/integ
+  // grep contract, and the rules are their own lines so grep is untouched. The rule width
+  // tracks the (uncolored) verdict length so it reads intentional. A CLEAN stack (no
+  // sections) keeps its compact 3-line form — nothing above it to get lost under.
+  const resultLine = `${style.resultLabel('result:')} ${resultBody}`;
+  if (driftSections > 0) {
+    const width = resultLine.replace(ANSI_RE, '').length;
+    const rule = style.note('─'.repeat(width));
+    log('\n' + rule);
+    log(resultLine);
+    log(rule);
+  } else {
+    log(resultLine);
+  }
   // INFORMATIONAL tiers: footer below result. Each tier is either EXPANDED to a full
   // section or FOLDED into the `info:` summary. --verbose expands all of them;
   // --show-all expands ONLY atDefault (inventory mode lists every undeclared value but
@@ -444,11 +465,11 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
       `undeclared-subkey=${nestedFolded.length} (undeclared live-only values inside a declared object — record to record; --show-all to list)`
     );
   if (summaries.length === 1) {
-    log(style.infoTier(`info: ${summaries[0]} — run with --verbose for the list`));
+    log(style.note(`info: ${summaries[0]} — run with --verbose for the list`));
   } else if (summaries.length > 1) {
-    log(style.infoTier('info:'));
-    for (const s of summaries) log(style.infoTier(`  - ${s}`));
-    log(style.infoTier('  run with --verbose for the list'));
+    log(style.note('info:'));
+    for (const s of summaries) log(style.note(`  - ${s}`));
+    log(style.note('  run with --verbose for the list'));
   }
   return drifted === 0 ? 0 : 1;
 }

--- a/src/report/style.ts
+++ b/src/report/style.ts
@@ -11,9 +11,16 @@ import pc from 'picocolors';
 
 export interface Style {
   header: (s: string) => string; // === cdkrd check/revert: ... === banners
+  resultLabel: (s: string) => string; // the `result:` prefix — the conclusion anchor
   driftTier: (s: string) => string; // deleted / declared section titles
   undeclaredTier: (s: string) => string; // the differentiator tier title
-  infoTier: (s: string) => string; // informational tier titles + info:/note footers
+  // Secondary UI chrome you're NOT meant to read closely: picker key-hints, the skip
+  // chip, aborted/retry status lines. Dim (SGR 2) is correct HERE — it recedes.
+  infoTier: (s: string) => string;
+  // Explanatory prose you ARE meant to read: tier notes, origin hints (↳), the info:
+  // footer. Terminal DEFAULT foreground — legible on any theme (dim was unreadable on
+  // dark terminals and wrongly wore the "don't read me" style of the picker chrome).
+  note: (s: string) => string;
   clean: (s: string) => string; // result: CLEAN / CLEAN after revert. / no drift
   drift: (s: string) => string; // result: N drift(s) / N drift(s) remain.
   desired: (s: string) => string; // desired= value (what it should be)
@@ -27,9 +34,14 @@ export interface Style {
 export function makeStyle(c: ReturnType<typeof pc.createColors>): Style {
   return {
     header: c.bold,
+    resultLabel: c.bold,
     driftTier: (s) => c.bold(c.red(s)),
     undeclaredTier: (s) => c.bold(c.yellow(s)),
     infoTier: c.dim,
+    // Terminal default foreground (identity) — no dim, no fixed color, so it stays
+    // legible whatever the terminal theme. Structure (parentheses, `↳`, the `info:`
+    // prefix, indentation) carries the "this is secondary" cue instead of color.
+    note: (s) => s,
     clean: (s) => c.bold(c.green(s)),
     drift: (s) => c.bold(c.red(s)),
     desired: c.green,

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -557,12 +557,21 @@ describe('report', () => {
       ]);
     });
 
-    it('drift: first section directly under the header; blank line BEFORE result: (R48)', () => {
+    it('drift: first section under the header; verdict FRAMED by a rule, blank before the frame (R48)', () => {
       const lines = run([F('declared')]).text.split('\n');
       expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
       expect(lines[1]).toMatch(/^\[CFn-Declared Drift: 1\]/); // no stray blank after the header
       const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
-      expect(lines[resultIdx - 1]).toBe(''); // the verdict is separated from the section above
+      expect(lines[resultIdx - 1]).toMatch(/^─+$/); // top rule directly above the verdict
+      expect(lines[resultIdx - 2]).toBe(''); // blank separates the framed verdict from the section above
+      expect(lines[resultIdx + 1]).toMatch(/^─+$/); // bottom rule
+      // rule width tracks the verdict line so the frame reads intentional
+      expect(lines[resultIdx - 1]?.length).toBe(lines[resultIdx]?.length);
+    });
+
+    it('CLEAN stack is NOT framed by rules — nothing above the verdict to get lost under', () => {
+      const lines = run([]).text.split('\n');
+      expect(lines).toEqual(['=== cdkrd check: stack (us-east-1) ===', 'result: CLEAN']);
     });
 
     it('two drift sections: blank BETWEEN them, none after the header (R48)', () => {

--- a/tests/style.test.ts
+++ b/tests/style.test.ts
@@ -21,6 +21,22 @@ describe('style (R43 — colors only on a TTY)', () => {
     expect(s.driftTier('x')).toContain(`${ESC}[31m`); // red
   });
 
+  it('note is the terminal DEFAULT foreground even with colors on — never dim, never a fixed color', () => {
+    // Explanatory prose (tier notes, ↳ origin hints, the info: footer) is meant to be
+    // READ. Dim (SGR 2) rendered it low-contrast / unreadable on dark terminals and wore
+    // the same "don't read me" style as the picker chrome. note() must add NO SGR at all
+    // so it inherits whatever the terminal theme uses for normal text.
+    const s = makeStyle(pc.createColors(true));
+    expect(s.note(SAMPLE)).toBe(SAMPLE); // identity — no ESC, no dim, no color
+    expect(s.infoTier(SAMPLE)).toContain(`${ESC}[2m`); // UI chrome stays dim (deliberate)
+  });
+
+  it('result: is bolded so the conclusion still anchors the eye once info is no longer dim', () => {
+    const s = makeStyle(pc.createColors(true));
+    expect(s.resultLabel('result:')).toContain(`${ESC}[1m`); // bold
+    expect(s.resultLabel('result:')).toContain('result:');
+  });
+
   it('the module-level style is the identity in a non-TTY environment (this test run)', () => {
     // vitest workers run with piped stdio, so this asserts the real default path
     expect(style.drift(SAMPLE)).toBe(SAMPLE);


### PR DESCRIPTION
## Problem

The report's explanatory prose — tier notes `(declared in your CloudFormation template …)`, `↳` origin hints, and the `info:` footer — rendered in `dim` (SGR 2, gray). Two issues:

1. **Unreadable on dark terminals.** `dim` is low-contrast and theme-dependent; it effectively assumes a light background.
2. **Wrong signal.** It wore the *same* "don't read me" style as the non-focused picker rows — but this text is meant to be **read**.

## Fix

Split the semantic palette in `style.ts`:

- **`note`** = terminal **DEFAULT foreground** (identity — no dim, no fixed color) → legible on any theme. Used for prose meant to be read: tier notes, `↳` hints, the `info:` footer, and the read-me UI chrome (picker key-hints, no-match / match-count lines, `aborted.` / retry / verifying / convergence status, post-action pointers).
- **`infoTier`** (dim) is now **reserved** for genuinely secondary UI you are NOT meant to read closely — the non-focused / skip picker rows.

Because the footer is no longer dimmed, the verdict had to stand out on its own:

- **`result:` is bold**, and when a drift section was printed it is **framed by a horizontal rule** above and below (blank line before the frame). Bold alone got lost under a wall of findings.
- A leading glyph (`▶`) was **rejected**: `result:` must stay at column 0 for the `^result:` CI/integ grep contract. The rules are their own lines, so grep is untouched. Rule width tracks the verdict line.
- A **CLEAN** stack (no sections) skips the frame and keeps its compact 3-line form.

## Before / after

```
# before (dim gray, hard to read; result blends into the footer)
[CFn-Declared Drift: 1] (declared in your CloudFormation template — the live value differs)   ← dim
result: 2 findings — 1 drift (declared=1) + 1 potential drift
info: …                                                                                        ← dim

# after (default fg = readable; result framed)
[CFn-Declared Drift: 1] (declared in your CloudFormation template — the live value differs)   ← default fg

─────────────────────────────────────────────────────────────
result: 2 findings — 1 drift (declared=1) + 1 potential drift    ← bold label, framed
─────────────────────────────────────────────────────────────
info: …                                                                                        ← default fg
```

## Tests

- `style.test.ts`: `note` stays identity even with colors ON (never dim, never a fixed color); `resultLabel` emits bold.
- `report.test.ts`: verdict is rule-framed with a blank line before the frame and width == verdict length; CLEAN stays unframed (compact).
- Full suite: 2731 passing. `^result:` grep contract preserved.

## Docs

README output samples show the rule; the `↳` "dim" wording is corrected; README / DESIGN / ARCHITECTURE color-scheme notes updated to describe `note` vs the reserved `dim`.

## Note on scope

`result:` framing is TTY-independent structure (rule lines print in piped output too, only color differs) — consistent with the report's existing "only color differs by TTY" principle. This is a cosmetic/legibility change; no detection behavior, flags, or revert paths changed.
