### PR TITLE
fix(report): put undeclared/potential value on its own actual= line

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ explainable, so the same change shows up:
 $ npx cdkrd check
 === cdkrd check: ApiStack (us-east-1) ===
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
-  ApiStack/ApiRole.Policies (AWS::IAM::Role) — appeared since record = [{"PolicyName":"manual-debug-access", ...}]
+  ApiStack/ApiRole.Policies (AWS::IAM::Role) — appeared since record
+      actual =[{"PolicyName":"manual-debug-access", ...}]
 
 ─────────────────────────────────
 result: 1 drift(s) (undeclared=1)
@@ -70,8 +71,10 @@ No baseline yet — live-only values can't be confirmed as drift, but declared d
       actual ="test"
 
 [Potential Drift: 2] (live-only and not yet in your .cdkrd baseline, so cdkrd can't tell whether it's intended or an out-of-band change — Record to accept it, or Revert to remove it)
-  ApiStack/Queue.RedrivePolicy (AWS::SQS::Queue) = {"maxReceiveCount":5}
-  ApiStack/Role.Policies (AWS::IAM::Role) = [{"PolicyName":"adhoc", ...}]
+  ApiStack/Queue.RedrivePolicy (AWS::SQS::Queue)
+      actual ={"maxReceiveCount":5}
+  ApiStack/Role.Policies (AWS::IAM::Role)
+      actual =[{"PolicyName":"adhoc", ...}]
 
 ─────────────────────────────────────────────────────────────
 result: 3 findings — 1 drift (declared=1) + 2 potential drift
@@ -112,7 +115,8 @@ your CloudFormation template, the kind `cdk drift` can't see:
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
-  ApiStack/Role.Policies (AWS::IAM::Role) — changed since record = [{"PolicyName":"adhoc", ...}, {"PolicyName":"manual-debug-access", ...}]
+  ApiStack/Role.Policies (AWS::IAM::Role) — changed since record
+      actual =[{"PolicyName":"adhoc", ...}, {"PolicyName":"manual-debug-access", ...}]
 
 ─────────────────────────────────
 result: 1 drift(s) (undeclared=1)

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -137,7 +137,11 @@ export function formatFinding(f: Finding): string {
     // whole array dump (the property stays recorded; this is the WHICH-element view).
     s += formatArrayDelta(f.arrayDelta);
   else if (f.tier === 'undeclared' || f.tier === 'atDefault' || f.tier === 'generated')
-    s += ` = ${style.actual(j(f.actual))}`;
+    // Put the live value on its OWN indented line, aligned with declared's `actual =`
+    // column — a long ARN/JSON list crammed inline after the id was unreadable, and it read
+    // inconsistently next to a declared drift's stacked desired/actual. An undeclared value
+    // has only the live side, so it's a single `actual =` line (no desired to contrast).
+    s += `\n      actual =${style.actual(j(f.actual))}`;
   // A non-classifying origin hint (diff/hints.ts) — the finding is still real drift; this
   // just names where the live value likely came from. Readable (style.note) trailing line
   // below the values — it is meant to be read, so NOT dim.

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -119,6 +119,24 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     expect(code).toBe(1);
     expect(text).toContain('[CFn-Undeclared Drift: 1]');
   });
+
+  it('an undeclared value renders on its OWN indented line (actual =), not inline after the id', () => {
+    // A long ARN/JSON list crammed inline after the id was unreadable and read inconsistently
+    // next to a declared drift's stacked desired/actual. The live value now sits on its own
+    // `actual =` line, aligned with declared's actual column.
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      resourceType: 'AWS::Lambda::Function',
+      path: 'Layers',
+      actual: ['arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:80'],
+    };
+    const out = formatFinding(f);
+    expect(out).toBe(
+      'Fn.Layers (AWS::Lambda::Function)\n      actual =["arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:80"]'
+    );
+    expect(out).not.toContain(') = ['); // never crammed inline after the (type)
+  });
 });
 
 describe('report', () => {
@@ -463,7 +481,9 @@ describe('report', () => {
     it('--verbose expands atDefault to a full section with each value shown', () => {
       const { text } = run([AD('TracingConfig')], { verbose: true });
       expect(text).toContain('[At AWS Default: 1]');
-      expect(text).toContain('L.TracingConfig (AWS::Lambda::Function) = {"Mode":"PassThrough"}');
+      expect(text).toContain(
+        'L.TracingConfig (AWS::Lambda::Function)\n      actual ={"Mode":"PassThrough"}'
+      );
       expect(text).not.toContain('info:');
     });
 
@@ -503,7 +523,9 @@ describe('report', () => {
     it('--verbose expands generated to a full section showing each value', () => {
       const { text } = run([G('TopicName')], { verbose: true });
       expect(text).toContain('[AWS Generated: 1]');
-      expect(text).toContain('L.TopicName (AWS::SNS::Topic) = "Stack-TopicABC123-9F16VRgpExOs"');
+      expect(text).toContain(
+        'L.TopicName (AWS::SNS::Topic)\n      actual ="Stack-TopicABC123-9F16VRgpExOs"'
+      );
       expect(text).not.toContain('info:');
     });
   });


### PR DESCRIPTION
## Problem

An undeclared finding — **Potential Drift**, or a real undeclared drift — rendered its live value **inline** after the id:

```
  ApiStack/.../GetStudents.Layers (AWS::Lambda::Function) = ["arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:80"]
```

With a long ARN / JSON list that line was hard to read, and it read **inconsistently** right next to a declared drift, whose `desired` / `actual` sit on their own stacked indented lines.

## Fix

Render the live value on its **own indented line**, aligned with declared's `actual =` column. An undeclared value has only the live side, so it's a single `actual =` line (no desired to contrast).

```
[CFn-Declared Drift: 1] (...)
  .../ServiceRole.ManagedPolicyArns (AWS::IAM::Role)
      desired=[...]
      actual =[...]

[Potential Drift: 1] (...)
  .../GetStudents.Layers (AWS::Lambda::Function)
      actual =["arn:aws:lambda:ap-northeast-1:580247275435:layer:LambdaInsightsExtension:80"]
```

Applies to the `undeclared` / `atDefault` / `generated` tiers (the `arrayDelta` branch already stacked its output).

## Tests

- New: `formatFinding` stacks the value on an `actual =` line and never crams it inline after `(type)`.
- Updated the `atDefault` / `generated` `--verbose` expansion assertions to the stacked form.
- Full suite: 2732 passing.

## Docs

README output samples updated to the stacked form.
