### PR TITLE
fix(report): correct the unresolved explanation — lead with resolution-unable intrinsics

### DIFF
--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -64,7 +64,7 @@ const TIER_NOTES: Partial<Record<Tier, string>> = {
   ignored: 'matched a .cdkrd/ignore.yaml ignore rule — not drift',
   readGap: "declared, but AWS doesn't return it on read so cdkrd can't verify it — not drift",
   unresolved:
-    "declared, but its value references a CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value, so it can't be compared — skipped, not drift",
+    "declared, but its value references a CloudFormation intrinsic cdkrd couldn't resolve to a concrete value — e.g. Fn::GetAZs, a {{resolve:...}} dynamic reference, or an Fn::GetAtt whose target wasn't readable — so it can't be compared, not drift",
   skipped:
     'NOT checked (coverage incomplete) — CC API unsupported / no physical id / custom resource',
 };
@@ -440,11 +440,14 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
       return `readGap=${items.length} (declared but unverifiable — AWS doesn't return them on read, not drift: ${parts.join(', ')})`;
     }
     // unresolved is jargon too: these are declared values whose CloudFormation intrinsic
-    // (Fn::GetAtt, Fn::GetAZs, …) cdkrd could not resolve to a concrete value, so there is
-    // nothing concrete to compare against live — unverifiable, not drift. The generic
-    // groupReasons breakdown would just echo "intrinsic unresolved N", so spell it out.
+    // cdkrd could not resolve to a concrete value, so there is nothing concrete to compare
+    // against live — unverifiable, not drift. The representative examples are ones that are
+    // resolution-unable BY NATURE: Fn::GetAZs and {{resolve:...}} dynamic references (SSM /
+    // Secrets Manager). Fn::GetAtt is NOT listed bare — cdkrd re-resolves it once the target
+    // is read live (gather.ts), so it lands here only when the target itself wasn't readable.
+    // The generic groupReasons breakdown would just echo "intrinsic unresolved N", so spell it out.
     if (t === 'unresolved')
-      return `unresolved=${items.length} (declared values whose CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value — unverifiable, not drift)`;
+      return `unresolved=${items.length} (declared values whose CloudFormation intrinsic cdkrd couldn't resolve to a concrete value — e.g. Fn::GetAZs, a {{resolve:...}} dynamic reference, or an Fn::GetAtt whose target wasn't readable — unverifiable, not drift)`;
     // skipped = resources cdkrd genuinely could NOT read this run (CC-unsupported with
     // no SDK override, read error, missing physical id, custom resource). It is the one
     // info: tier that is a COVERAGE GAP, not a not-drift classification — so it carries

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -545,12 +545,16 @@ describe('report', () => {
       ]);
       expect(code).toBe(0);
       expect(text).toMatch(/^result: CLEAN$/m);
-      // the message must explain WHY (unverifiable intrinsic) and must NOT claim every
-      // unresolved value is a Fn::GetAtt — a Subnet AZ is Fn::Select(Fn::GetAZs).
+      // the message must explain WHY (unverifiable intrinsic) and must lead with the
+      // resolution-unable-by-nature examples (Fn::GetAZs / {{resolve:...}}), NOT imply every
+      // unresolved value is a Fn::GetAtt — cdkrd re-resolves GetAtt once the target reads live
+      // (gather.ts), so it lands here only when the target itself wasn't readable.
       expect(text).toContain(
-        "info: unresolved=2 (declared values whose CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value — unverifiable, not drift)"
+        "info: unresolved=2 (declared values whose CloudFormation intrinsic cdkrd couldn't resolve to a concrete value — e.g. Fn::GetAZs, a {{resolve:...}} dynamic reference, or an Fn::GetAtt whose target wasn't readable — unverifiable, not drift)"
       );
       expect(text).not.toContain('GetAtt unresolved');
+      // Fn::GetAtt must never be the bare leading example (the misleading form we fixed).
+      expect(text).not.toContain('(e.g. Fn::GetAtt');
     });
 
     it('--verbose expands unresolved to a full section listing each declared path', () => {


### PR DESCRIPTION
## Problem

The `unresolved` info-tier explanation led with **`Fn::GetAtt`** as the representative "CloudFormation intrinsic cdkrd couldn't resolve":

```
unresolved=2 (declared values whose CloudFormation intrinsic (e.g. Fn::GetAtt, Fn::GetAZs) cdkrd couldn't resolve to a concrete value — unverifiable, not drift)
```

That's misleading. cdkrd **re-resolves** a `Fn::GetAtt` once the referenced resource is read live (`gather.ts`), so a GetAtt only lands in `unresolved` in the exception where its *target wasn't readable*. The intrinsics that are unresolvable **by nature** are `Fn::GetAZs` and `{{resolve:...}}` dynamic references (SSM / Secrets Manager).

## Fix

Reworded both the summary line (`report.ts:447`) and the tier note (`report.ts:67`) to lead with the resolution-unable-by-nature examples and to qualify `Fn::GetAtt`:

```
unresolved=2 (declared values whose CloudFormation intrinsic cdkrd couldn't resolve to a concrete value — e.g. Fn::GetAZs, a {{resolve:...}} dynamic reference, or an Fn::GetAtt whose target wasn't readable — unverifiable, not drift)
```

## Tests

`report.test.ts` pinned the old string verbatim — updated it, and added a guard that `(e.g. Fn::GetAtt` is never the bare leading example. Full suite: 2757 passing.
