### PR TITLE
feat(diff): descend undeclared Athena WorkGroupConfiguration leaf-by-leaf (#565)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1237,9 +1237,13 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   },
   'AWS::Athena::WorkGroup': {
     // A workgroup that declares no configuration reads back AWS's defaults: the config is
-    // enforced on member queries, and the engine version auto-selects. Observed live.
+    // enforced on member queries, the engine version auto-selects, and CloudWatch query
+    // metrics are published. Observed live. These fold when WorkGroupConfiguration is DESCENDED
+    // (DESCEND_UNDECLARED_OBJECT_PATHS, #565) because a non-default sibling made the whole
+    // object miss the whole-object fold; RequesterPaysEnabled:false folds as trivially-empty.
     'WorkGroupConfiguration.EnforceWorkGroupConfiguration': true,
     'WorkGroupConfiguration.EngineVersion': { SelectedEngineVersion: 'AUTO' },
+    'WorkGroupConfiguration.PublishCloudWatchMetricsEnabled': true,
   },
   'AWS::EKS::Cluster': {
     // A cluster that declares SubnetIds (partially declaring ResourcesVpcConfig, so it is
@@ -1626,6 +1630,16 @@ export const GENERATED_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
 // the single value worth recording.
 export const DESCEND_UNDECLARED_OBJECT_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::EKS::Cluster': new Set(['KubernetesNetworkConfig']),
+  // A workgroup that declares no WorkGroupConfiguration reads back AWS's whole default config;
+  // when it matches the default exactly the whole-object KNOWN_DEFAULTS fold (above) folds it
+  // atDefault. But once ONE sub-key is set out of band (a ResultConfiguration output location, a
+  // BytesScannedCutoffPerQuery cap) the whole object no longer matches and surfaces WHOLE,
+  // obscuring which sub-key changed. Descend so the four constant defaults fold
+  // (EnforceWorkGroupConfiguration / EngineVersion / PublishCloudWatchMetricsEnabled via
+  // KNOWN_DEFAULT_PATHS, RequesterPaysEnabled:false as trivially-empty) and only the record-
+  // worthy residue surfaces. Every other sub-key is a meaningful config value (not noise), so
+  // fragmenting is the desired behavior here. Follow-up to #555 (#565).
+  'AWS::Athena::WorkGroup': new Set(['WorkGroupConfiguration']),
 };
 
 // Value-DEPENDENT generated-name fold, scoped by type + top-level path. Folds a live value

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -8535,6 +8535,43 @@ describe('#531 EKS + Athena first-run default folds', () => {
     expect(t.atDefault).toEqual(['State', 'WorkGroupConfiguration']);
     expect(t.undeclared).toEqual([]);
   });
+
+  it('Athena WorkGroup: a non-default sub-key surfaces alone; the constant defaults still fold (#565)', () => {
+    const res: DesiredResource = {
+      logicalId: 'Wg',
+      resourceType: 'AWS::Athena::WorkGroup',
+      physicalId: 'cdkrd-wg',
+      declared: { Name: 'cdkrd-wg' },
+    };
+    const t = tiers(
+      classifyResource(
+        res,
+        {
+          Name: 'cdkrd-wg',
+          State: 'ENABLED',
+          // WorkGroupConfiguration is fully undeclared, but one sub-key (an out-of-band scan cap)
+          // is non-default, so the whole-object KNOWN_DEFAULTS fold misses and it is DESCENDED
+          // (#565): the constants fold and only BytesScannedCutoffPerQuery surfaces.
+          WorkGroupConfiguration: {
+            EnforceWorkGroupConfiguration: true,
+            EngineVersion: { SelectedEngineVersion: 'AUTO' },
+            PublishCloudWatchMetricsEnabled: true,
+            RequesterPaysEnabled: false,
+            BytesScannedCutoffPerQuery: 10_000_000,
+          },
+        },
+        emptySchema
+      )
+    );
+    expect(t.atDefault).toEqual([
+      'State',
+      'WorkGroupConfiguration.EnforceWorkGroupConfiguration',
+      'WorkGroupConfiguration.EngineVersion',
+      'WorkGroupConfiguration.PublishCloudWatchMetricsEnabled',
+    ]);
+    // RequesterPaysEnabled:false drops as trivially-empty; only the residue surfaces.
+    expect(t.undeclared).toEqual(['WorkGroupConfiguration.BytesScannedCutoffPerQuery']);
+  });
 });
 
 describe('#535 AOSS / SAMLProvider / ENI first-run default folds', () => {


### PR DESCRIPTION
Follow-up to #555 / PR #560 (closes #565).

## What

Extend `DESCEND_UNDECLARED_OBJECT_PATHS` — the curated per-`(type, path)` allowlist that descends a FULLY-undeclared top-level object leaf-by-leaf so `KNOWN_DEFAULT_PATHS` folds its constant sub-keys — from its EKS-only seed to **Athena `WorkGroup.WorkGroupConfiguration`**.

## Why

A workgroup that declares no `WorkGroupConfiguration` reads back AWS's whole default config. When it matches the default **exactly**, the whole-object `KNOWN_DEFAULTS` fold already folds it `atDefault` (unchanged — covered by the existing corpus cases). But once **one** sub-key is set out of band (a `ResultConfiguration` output location, a `BytesScannedCutoffPerQuery` cap), the whole object no longer matches and surfaces **whole**, obscuring which sub-key actually changed.

Descending fixes that: the four constant defaults fold
- `EnforceWorkGroupConfiguration: true`, `EngineVersion: {SelectedEngineVersion: 'AUTO'}`, `PublishCloudWatchMetricsEnabled: true` via `KNOWN_DEFAULT_PATHS`
- `RequesterPaysEnabled: false` as trivially-empty

…and only the record-worthy residue surfaces (`WorkGroupConfiguration.BytesScannedCutoffPerQuery`, etc.). Every other `WorkGroupConfiguration` sub-key is a meaningful config value (not noise), so fragmenting is the desired behavior here — this is the strict improvement the opt-in gate is for.

## Other candidates examined & deferred

- **EC2 `Instance` `MetadataOptions` / `CpuOptions`** (present as whole-undeclared objects in the corpus) — deferred: `CpuOptions` (`CoreCount`/`ThreadsPerCore`) is **instance-type-derived**, not a constant default, and `MetadataOptions` carries the security-relevant `HttpTokens`. Neither splits cleanly into "constants + small residue", so descending them would fragment into noise / hide a derived value.
- OpenSearch `SnapshotOptions`/`OffPeakWindowOptions`, SES `ReputationOptions` — need a fresh-deploy confirmation of their exact default sub-keys before adding; left for a later follow-up.

## Verification

- New unit test: a WorkGroup with a non-default `BytesScannedCutoffPerQuery` → constants fold `atDefault`, only the residue surfaces `undeclared`.
- Existing "whole default folds whole" test + both Athena corpus cases unchanged (they match the whole default exactly, so the whole-object fold still wins before the descend).
- Full suite: 2758 passing. typecheck / lint+format / build green.
