### PR TITLE
fix(diff): fold a nested declared empty value vs absent/empty live (Scheduler SqsParameters)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1434,6 +1434,16 @@ export function classifyResource(
       // so the unresolvable leaf never becomes a false `declared` drift vs the symbol,
       // while its RESOLVED siblings still compare normally (the WAVE20-F1 fix).
       if (d.stateValue === UNRESOLVED || hasUnresolved(d.stateValue)) continue;
+      // A NESTED declared trivially-EMPTY value (an empty sub-config `{}`, `[]`, or a
+      // `false`/`""` leaf) whose live counterpart is ABSENT or equally empty is not drift:
+      // many services simply OMIT an empty optional sub-object on read (Scheduler
+      // `Target.SqsParameters: {}` reads back undefined). This mirrors the top-level
+      // `!(k in live)` branch's rule that a declared EMPTY collection vs absent is not drift,
+      // applied to a sub-path the top-level branch can't reach (the parent IS present). Gated
+      // on the DECLARED side being empty, so a declared empty value against a POPULATED live
+      // value still differs and surfaces as real drift.
+      if (isTrivialEmpty(d.stateValue) && (d.awsValue === undefined || isTrivialEmpty(d.awsValue)))
+        continue;
       // A `[{<name>,<value>}]` pair set the service reorders + default-fills (Firehose
       // processor `Parameters`, RDS OptionGroup `OptionSettings`): when every declared
       // entry is present in live with an equal value (declared subset of live), the

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -155,6 +155,66 @@ describe('classifyResource (the heart)', () => {
     expect(drifted.declared).toEqual(['Value']);
   });
 
+  // Reported bug: EventBridge Scheduler declares `Target.SqsParameters: {}` (an empty
+  // optional sub-config), but the live read OMITS the key entirely — the drift-calculator
+  // emits a per-leaf record `Target.SqsParameters` with desired `{}` / actual undefined,
+  // false-flagging every clean deploy as declared drift. A NESTED declared trivially-empty
+  // value whose live counterpart is absent (or equally empty) is not drift.
+  it('nested declared empty sub-object vs absent live is not drift (Scheduler SqsParameters)', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const res: DesiredResource = {
+      logicalId: 'Scheduler',
+      resourceType: 'AWS::Scheduler::Schedule',
+      physicalId: 'sched-phys',
+      declared: {
+        Target: { Arn: 'arn:aws:lambda:...', RoleArn: 'arn:aws:iam:...', SqsParameters: {} },
+      },
+    };
+    // Live omits the empty SqsParameters entirely — no declared drift.
+    const clean = tiers(
+      classifyResource(
+        res,
+        { Target: { Arn: 'arn:aws:lambda:...', RoleArn: 'arn:aws:iam:...' } },
+        emptySchema
+      )
+    );
+    expect(clean.declared).toEqual([]);
+  });
+
+  // The empty-vs-absent fold is gated on the DECLARED side being trivially empty: a
+  // declared EMPTY collection the live read POPULATED out of band is still real drift.
+  it('nested declared empty collection vs a populated live value still surfaces as drift', () => {
+    const emptySchema: SchemaInfo = {
+      readOnly: new Set(),
+      writeOnly: new Set(),
+      createOnly: new Set(),
+      readOnlyPaths: [],
+      writeOnlyPaths: [],
+      createOnlyPaths: [],
+      defaults: {},
+      defaultPaths: {},
+    };
+    const res: DesiredResource = {
+      logicalId: 'Widget',
+      resourceType: 'AWS::Example::Widget',
+      physicalId: 'w-phys',
+      declared: { Config: { Name: 'w', Items: [] } }, // declared empty list
+    };
+    const drifted = tiers(
+      classifyResource(res, { Config: { Name: 'w', Items: ['x', 'y'] } }, emptySchema)
+    );
+    expect(drifted.declared).toEqual(['Config.Items']);
+  });
+
   // A CloudFormation JSON-STRING property (AWS::Config::ConfigRule InputParameters):
   // CDK declares it as an object, Cloud Control returns it parsed. It must be compared
   // and reported as a WHOLE UNIT at the top-level path — never descended — so the revert


### PR DESCRIPTION
## Problem

A real stack (`<metrics-etl-dev-stack>`, EventBridge Scheduler) reported 3 false-positive **CFn-Declared** drifts:

```
<metrics-etl-dev-stack>/EtlProcessor/Scheduler.Target.SqsParameters (AWS::Scheduler::Schedule)
    desired={}
    actual =undefined
```

The CDK template declares `Target.SqsParameters: {}` (an empty optional sub-config). The live read simply OMITS the key — many services drop an empty optional sub-object on read. The nested drift-calculator emits a per-leaf record `{path: 'Target.SqsParameters', stateValue: {}, awsValue: undefined}`, which the classify loop reported as declared drift on every clean deploy.

## Root cause

The top-level `!(k in live)` branch already folds this ("a declared EMPTY collection `{}`/`[]` vs absent is not drift"), but that branch only fires when the top-level *property* is absent. Here the parent (`Target`) IS present in live, so the empty sub-value reaches the nested `calculateResourceDrift` loop, which had no equivalent guard.

## Fix

In the nested drift loop in `classify.ts`, skip a leaf whose **declared** side is trivially empty (`{}`/`[]`/`false`/`""`) and whose live counterpart is absent or equally empty. Gated on the declared side being empty, so a declared empty collection the live read POPULATED out of band is still real drift.

## Verification

- New unit tests: nested declared `{}` vs absent live -> CLEAN; declared empty list vs populated live -> still drift.
- Full suite: 2759 passed.
- Live re-run against the real stack (`--profile <dev-profile>`, read-only): the 3 drifts are gone, result is **CLEAN**, and the other tiers (atDefault=113, generated=13, readGap=2) are unchanged.
