### PR TITLE
fix(diff): fold Glue::Job derived capacity + SG rule peer-name echo

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1756,6 +1756,29 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   when undeclared — a user who sets a custom Username declares it (compared in the declared
   //   loop). Fold value-independent. Observed live first-run (hunt 2026-07-03 round E).
   'AWS::EKS::AccessEntry': new Set(['Username']),
+  //   AWS::Glue::Job.MaxCapacity / .AllocatedCapacity — a job that sizes itself with the modern
+  //   `WorkerType` + `NumberOfWorkers` pair (a glueetl / gluestreaming job on Glue 2.0+) declares
+  //   NEITHER capacity field; AWS DERIVES both from the worker sizing and reads them back
+  //   (G.1X × 10 workers → MaxCapacity 10 / AllocatedCapacity 10; G.025X × 2 → MaxCapacity 0.5 /
+  //   AllocatedCapacity 0). The two are mutually exclusive with WorkerType/NumberOfWorkers, so
+  //   when undeclared they can only be an AWS reflection of the declared sizing, never user intent
+  //   — and a real change to the sizing surfaces on `WorkerType` / `NumberOfWorkers` in the
+  //   declared loop. `AllocatedCapacity` is additionally a legacy field AWS always echoes. Fold
+  //   value-independent so every DPU value folds without a table (a job that instead DECLARES
+  //   MaxCapacity — a Python-shell job — goes through the declared loop, compared). Observed live
+  //   first-run on dev-main-Db2Csv (five G.1X ETL jobs + one G.025X streaming job), no edit.
+  'AWS::Glue::Job': new Set(['MaxCapacity', 'AllocatedCapacity']),
+  //   AWS::EC2::SecurityGroupIngress / ::SecurityGroupEgress.SourceSecurityGroupName — a rule that
+  //   references its peer group by id (`SourceSecurityGroupId`, the CDK default) declares no
+  //   `SourceSecurityGroupName`; AWS DERIVES and reads back the referenced group's NAME
+  //   ("dev-main-Db2Csv-Glue-sg") from that id. It can never be a constant we pin (it embeds the
+  //   per-group name), and when undeclared it is a pure reflection of the declared
+  //   SourceSecurityGroupId, not user intent — a real change to the peer surfaces on
+  //   `SourceSecurityGroupId` in the declared loop. Fold value-independent. (A user who references
+  //   a peer by name — EC2-Classic style — DECLARES SourceSecurityGroupName, compared.) Observed
+  //   live first-run on dev-main-Db2Csv's self-referencing Glue SG ingress, no edit.
+  'AWS::EC2::SecurityGroupIngress': new Set(['SourceSecurityGroupName']),
+  'AWS::EC2::SecurityGroupEgress': new Set(['SourceSecurityGroupName']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -964,6 +964,38 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t('AWS::ApiGateway::Authorizer', { AuthType: 'custom' }).undeclared).toEqual([]);
   });
 
+  it('dev-main-Db2Csv first-run folds: Glue::Job derived capacity / SG rule peer-name echo', () => {
+    // Undeclared values a fresh dev-main-Db2Csv stack reported with NO out-of-band edit.
+    const t = (rt: string, live: Record<string, unknown>) =>
+      tiers(classifyResource(bare(rt), live, emptySchema));
+
+    // A glueetl job sized with WorkerType/NumberOfWorkers declares neither capacity field;
+    // AWS derives both and reads them back (G.1X × 10 → 10, G.025X × 2 → 0.5). Value-
+    // independent, so every DPU value folds; a job that DECLARES MaxCapacity still surfaces.
+    expect(t('AWS::Glue::Job', { MaxCapacity: 10, AllocatedCapacity: 10 }).atDefault).toEqual([
+      'AllocatedCapacity',
+      'MaxCapacity',
+    ]);
+    expect(t('AWS::Glue::Job', { MaxCapacity: 0.5, AllocatedCapacity: 0 }).atDefault).toEqual([
+      'AllocatedCapacity',
+      'MaxCapacity',
+    ]);
+    expect(t('AWS::Glue::Job', { MaxCapacity: 10 }).undeclared).toEqual([]);
+
+    // A rule referencing its peer by id (SourceSecurityGroupId) reads back the peer group's
+    // NAME — an AWS reflection of the declared id, never user intent when undeclared.
+    expect(
+      t('AWS::EC2::SecurityGroupIngress', { SourceSecurityGroupName: 'dev-main-Db2Csv-Glue-sg' })
+        .atDefault
+    ).toEqual(['SourceSecurityGroupName']);
+    expect(
+      t('AWS::EC2::SecurityGroupEgress', { SourceSecurityGroupName: 'some-other-sg' }).atDefault
+    ).toEqual(['SourceSecurityGroupName']);
+    expect(
+      t('AWS::EC2::SecurityGroupIngress', { SourceSecurityGroupName: 'x' }).undeclared
+    ).toEqual([]);
+  });
+
   it('hunt-lowcov first-run folds: S3Express DirectoryBucket / S3Tables TableBucket / Logs Delivery family', () => {
     // Constant service defaults observed live on fresh s3express-s3tables-rich and
     // cloudfront-kvs-logs-delivery deploys with NO out-of-band edit — first-run noise

--- a/tests/corpus/AWS__EC2__SecurityGroupIngress.SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupIngress.SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB.json
@@ -79,7 +79,7 @@
       "constructPath": "CdkRealDriftIntegSgProto/Sg/from CdkRealDriftIntegSgProtoSg90F3118B:9000"
     },
     {
-      "tier": "generated",
+      "tier": "atDefault",
       "logicalId": "SgfromCdkRealDriftIntegSgProtoSg90F3118B9000D4C163DB",
       "resourceType": "AWS::EC2::SecurityGroupIngress",
       "path": "SourceSecurityGroupName",

--- a/tests/corpus/AWS__EC2__SecurityGroupIngress.WebSgIngress.json
+++ b/tests/corpus/AWS__EC2__SecurityGroupIngress.WebSgIngress.json
@@ -78,7 +78,7 @@
       "constructPath": "CdkRealDriftIntegDogfoodWebapp/Web/Service/SecurityGroup/from CdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F40:80"
     },
     {
-      "tier": "generated",
+      "tier": "atDefault",
       "logicalId": "WebServiceSecurityGroupfromCdkRealDriftIntegDogfoodWebappWebLBSecurityGroup85857F408013CF9C8D",
       "resourceType": "AWS::EC2::SecurityGroupIngress",
       "path": "SourceSecurityGroupName",

--- a/tests/corpus/AWS__Glue__Job.GlueJob.json
+++ b/tests/corpus/AWS__Glue__Job.GlueJob.json
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
       "path": "AllocatedCapacity",


### PR DESCRIPTION
## What

Fold two more first-run false positives observed on the real `<etl-app-2-dev-stack>`
stack (<dev-profile>, acct <account-id>), reported via `cdkrd check`.

### 1. `AWS::Glue::Job` — `MaxCapacity` / `AllocatedCapacity`

A job sized with the modern `WorkerType` + `NumberOfWorkers` pair (a
`glueetl` / `gluestreaming` job on Glue 2.0+) declares NEITHER capacity field;
AWS DERIVES both from the worker sizing and reads them back:

- `G.1X` × 10 workers → `MaxCapacity` 10 / `AllocatedCapacity` 10
- `G.025X` × 2 workers → `MaxCapacity` 0.5 / `AllocatedCapacity` 0

The two are mutually exclusive with `WorkerType`/`NumberOfWorkers`, so when
undeclared they can only be an AWS reflection of the declared sizing, never user
intent — a real sizing change surfaces on `WorkerType` / `NumberOfWorkers` in the
declared loop. `AllocatedCapacity` is additionally a legacy field AWS always
echoes. Folded value-independent (a Python-shell job that instead DECLARES
`MaxCapacity` still goes through the declared loop, compared).

### 2. `AWS::EC2::SecurityGroupIngress` / `::SecurityGroupEgress` — `SourceSecurityGroupName`

A rule referencing its peer group by id (`SourceSecurityGroupId`, the CDK
default) declares no `SourceSecurityGroupName`; AWS derives and reads back the
peer group's NAME from that id. When the peer name is CDK-generated it was
already folded (`generated` tier); but a CUSTOM name (`<etl-app-2-dev-stack>-Glue-sg`)
slipped through as `undeclared`. Folded value-independent so it folds regardless
of the name (a user referencing a peer BY name — EC2-Classic style — declares
`SourceSecurityGroupName`, compared).

Both via `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (undeclared-only → `atDefault`;
a declared value is always compared, so no false negative).

## Test

- New `classify.test.ts` case covering both DPU forms + both SG rule types.
- Two SG corpus cases move `SourceSecurityGroupName` `generated` → `atDefault`
  (still folded); the Glue corpus case moves `AllocatedCapacity`
  `undeclared` → `atDefault`.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (2761) all green.

Live re-verify against the source stack was blocked by an expired <dev-profile> token;
the classification change is fully reproduced by the unit + corpus-replay tests.
