### PR TITLE
fix(diff): fold IAM User/Group sibling policies + Path and ECS Cluster sibling capacity providers + ClusterSettings default

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -225,10 +225,20 @@ export async function loadDesired(
   }
 
   const resources: DesiredResource[] = [];
-  // Roles whose inline Policies are managed by SIBLING AWS::IAM::Policy resources
-  // (the CDK pattern). classify uses the per-role POLICY NAMES to drop only the
-  // sibling-owned live entries — an out-of-band inline policy still surfaces.
-  const rolesWithSiblingPolicy = collectRolesWithSiblingPolicies(template.Resources ?? {}, ctx);
+  // IAM principals (Role / User / Group) whose inline Policies are managed by SIBLING
+  // AWS::IAM::Policy resources (the CDK pattern). classify uses the per-principal POLICY
+  // NAMES to drop only the sibling-owned live entries — an out-of-band inline policy still
+  // surfaces.
+  const principalsWithSiblingPolicy = collectPrincipalsWithSiblingPolicies(
+    template.Resources ?? {},
+    ctx
+  );
+  // ECS Cluster logicalIds whose CapacityProviders / DefaultCapacityProviderStrategy are
+  // declared by a sibling AWS::ECS::ClusterCapacityProviderAssociations resource (the only
+  // CFn way to set them). classify drops those reflected live props on the flagged cluster.
+  const clustersWithSiblingCapacityProviders = collectClustersWithSiblingCapacityProviders(
+    template.Resources ?? {}
+  );
 
   for (const [logicalId, res] of Object.entries(
     (template.Resources ?? {}) as Record<string, any>
@@ -245,12 +255,25 @@ export async function loadDesired(
       // re-resolves declaredRaw once liveAttrs is populated, reducing UNRESOLVED.
       declared: resolveProperties(declaredRaw, ctx),
       declaredRaw,
-      siblingPolicyNames:
-        res.Type === 'AWS::IAM::Role' ? rolesWithSiblingPolicy.get(logicalId) : undefined,
+      siblingPolicyNames: IAM_PRINCIPAL_TYPES.has(res.Type)
+        ? principalsWithSiblingPolicy.get(logicalId)
+        : undefined,
+      hasSiblingCapacityProviders:
+        res.Type === 'AWS::ECS::Cluster'
+          ? clustersWithSiblingCapacityProviders.has(logicalId)
+          : undefined,
     });
   }
   return { stackName, region, accountId, resources, rawTemplate, ctx, stackStatusWarning };
 }
+
+// The IAM principal types an AWS::IAM::Policy can attach an inline policy to, via its
+// Roles / Users / Groups reference lists (the CDK `<Principal>DefaultPolicy` pattern).
+const IAM_PRINCIPAL_TYPES: ReadonlySet<string> = new Set([
+  'AWS::IAM::Role',
+  'AWS::IAM::User',
+  'AWS::IAM::Group',
+]);
 
 // CDK construct paths end in "/Resource" for the L1 node; drop it for readability
 // (e.g. "MyStack/Bucket/Resource" -> "MyStack/Bucket").
@@ -259,30 +282,56 @@ function prettyConstructPath(p: string): string {
 }
 
 /**
- * Map each role logicalId to the PolicyNames of the sibling AWS::IAM::Policy
- * resources attached to it. A sibling whose PolicyName cannot be resolved to a
- * string (an intrinsic the resolver can't evaluate) marks the role 'unresolved' —
- * classify then falls back to suppressing the whole live Policies property rather
- * than risk a false positive on the unidentifiable sibling entry.
+ * Map each IAM principal logicalId (Role / User / Group) to the PolicyNames of the
+ * sibling AWS::IAM::Policy resources attached to it via its Roles / Users / Groups
+ * reference lists. A sibling whose PolicyName cannot be resolved to a string (an
+ * intrinsic the resolver can't evaluate) marks the principal 'unresolved' — classify
+ * then falls back to suppressing the whole live Policies property rather than risk a
+ * false positive on the unidentifiable sibling entry.
  */
-export function collectRolesWithSiblingPolicies(
+export function collectPrincipalsWithSiblingPolicies(
   resources: Record<string, any>,
   ctx?: ResolverContext
 ): Map<string, string[] | 'unresolved'> {
-  const roles = new Map<string, string[] | 'unresolved'>();
+  const principals = new Map<string, string[] | 'unresolved'>();
   for (const res of Object.values(resources)) {
     if (res?.Type !== 'AWS::IAM::Policy') continue;
     const name = resolvePolicyName(res.Properties?.PolicyName, ctx);
-    for (const r of (res.Properties?.Roles ?? []) as unknown[]) {
+    const refs = [
+      ...((res.Properties?.Roles ?? []) as unknown[]),
+      ...((res.Properties?.Users ?? []) as unknown[]),
+      ...((res.Properties?.Groups ?? []) as unknown[]),
+    ];
+    for (const r of refs) {
       const ref = r && typeof r === 'object' ? (r as Record<string, unknown>).Ref : undefined;
       if (typeof ref !== 'string') continue;
-      const prev = roles.get(ref);
+      const prev = principals.get(ref);
       if (prev === 'unresolved') continue;
-      if (name === undefined) roles.set(ref, 'unresolved');
-      else roles.set(ref, [...(prev ?? []), name]);
+      if (name === undefined) principals.set(ref, 'unresolved');
+      else principals.set(ref, [...(prev ?? []), name]);
     }
   }
-  return roles;
+  return principals;
+}
+
+/**
+ * The set of ECS Cluster logicalIds that a sibling AWS::ECS::ClusterCapacityProviderAssociations
+ * resource references (via its `Cluster: { Ref }`). CapacityProviders and
+ * DefaultCapacityProviderStrategy can only be set through that separate resource — the Cluster's
+ * own schema has no such property — so the association reflects them into the cluster's live model
+ * where they read as false undeclared drift. The association is tracked + compared as its own
+ * resource, so classify drops the reflected props on a flagged cluster.
+ */
+export function collectClustersWithSiblingCapacityProviders(
+  resources: Record<string, any>
+): Set<string> {
+  const clusters = new Set<string>();
+  for (const res of Object.values(resources)) {
+    if (res?.Type !== 'AWS::ECS::ClusterCapacityProviderAssociations') continue;
+    const ref = res.Properties?.Cluster?.Ref;
+    if (typeof ref === 'string') clusters.add(ref);
+  }
+  return clusters;
 }
 
 // CDK emits literal PolicyNames (e.g. "RoleDefaultPolicyABC123"); hand-written

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -268,6 +268,15 @@ const REFLECTED_CHILD_PROPS: Record<string, string> = {
   'AWS::SNS::Topic': 'Subscription',
 };
 
+// IAM principal types whose inline live `Policies` can be sibling-managed by a separate
+// AWS::IAM::Policy resource (the CDK `<Principal>DefaultPolicy` pattern). Used for the
+// revert-hazard guard when the sibling PolicyName was UNRESOLVED (see below).
+const IAM_PRINCIPAL_POLICY_TYPES: ReadonlySet<string> = new Set([
+  'AWS::IAM::Role',
+  'AWS::IAM::User',
+  'AWS::IAM::Group',
+]);
+
 // AWS::EC2::SecurityGroup reflects, in its live SecurityGroupIngress / SecurityGroupEgress
 // arrays, the rules declared by SIBLING standalone AWS::EC2::SecurityGroupIngress /
 // ::SecurityGroupEgress resources that target it. CDK emits such a standalone rule resource
@@ -891,6 +900,17 @@ export function classifyResource(
   // (see REFLECTED_CHILD_PROPS). Fail-open: a declared inline value is still compared.
   const reflected = REFLECTED_CHILD_PROPS[resourceType];
   if (reflected && !(reflected in declared)) delete live[reflected];
+  // An ECS Cluster reflects the CapacityProviders / DefaultCapacityProviderStrategy declared by
+  // its sibling AWS::ECS::ClusterCapacityProviderAssociations resource — the only CFn way to set
+  // them (the Cluster's own schema carries neither). The association is tracked + compared as its
+  // own resource, so leaving them on the cluster's live model reads as false undeclared drift. Drop
+  // them ONLY when a sibling association references this cluster (hasSiblingCapacityProviders); a
+  // cluster with capacity providers set purely out of band (no association resource) keeps them.
+  if (resourceType === 'AWS::ECS::Cluster' && resource.hasSiblingCapacityProviders) {
+    for (const p of ['CapacityProviders', 'DefaultCapacityProviderStrategy']) {
+      if (!(p in declared)) delete live[p];
+    }
+  }
   // Drop declared scalar props AWS re-normalizes on read (SSM Document DocumentFormat:
   // any authored YAML/TEXT is stored + returned as JSON) from BOTH sides so the write-time
   // authoring hint is not a spurious declared drift (see READ_NORMALIZED_DECLARED_PATHS).
@@ -1912,16 +1932,16 @@ export function classifyResource(
   // attach physicalId (for revert) + construct path (display) onto every finding
   const cp = resource.constructPath;
   const pid = resource.physicalId;
-  // R111 fail-open carries a revert hazard: when the role's sibling AWS::IAM::Policy
+  // R111 fail-open carries a revert hazard: when the principal's sibling AWS::IAM::Policy
   // names were UNRESOLVED we did NOT filter the sibling-managed (DefaultPolicy)
   // entries out of the live Policies array (above), so a declared `Policies` diff
   // here lists own + sibling-managed entries together. The per-entry revert writer
-  // (writeIamRoleInlinePolicies) deletes every prior entry the declared set drops —
-  // which would DELETE the sibling-managed inline policy, removing real IAM grants.
-  // We cannot separate them, so mark the Policies finding(s) so the revert plan
-  // refuses to act (a wrong-write to live IAM is worse than an un-reverted FP).
+  // deletes every prior entry the declared set drops — which would DELETE the
+  // sibling-managed inline policy, removing real IAM grants. We cannot separate them,
+  // so mark the Policies finding(s) so the revert plan refuses to act (a wrong-write to
+  // live IAM is worse than an un-reverted FP). Applies to Role / User / Group alike.
   const unresolvedSibling =
-    resourceType === 'AWS::IAM::Role' && resource.siblingPolicyNames === 'unresolved';
+    IAM_PRINCIPAL_POLICY_TYPES.has(resourceType) && resource.siblingPolicyNames === 'unresolved';
   return findings.map((f) => ({
     ...f,
     ...(pid !== undefined && { physicalId: pid }),

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -517,8 +517,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Group': {
     Path: '/',
   },
+  'AWS::IAM::User': {
+    Path: '/',
+  },
   'AWS::IAM::InstanceProfile': {
     Path: '/',
+  },
+  // A fresh ECS Cluster reads back `ClusterSettings: [{Name:'containerInsights',Value:'disabled'}]`
+  // — Container Insights defaults to disabled unless the account-level ECS setting turns it on, and
+  // CDK does not declare it unless `containerInsights` is passed. Equality-gated (an enabled cluster
+  // reports a different Value and re-surfaces). CapacityProviders / DefaultCapacityProviderStrategy
+  // are NOT defaults — they are declared by the sibling ClusterCapacityProviderAssociations resource
+  // and dropped in classify (see hasSiblingCapacityProviders).
+  'AWS::ECS::Cluster': {
+    ClusterSettings: [{ Name: 'containerInsights', Value: 'disabled' }],
   },
   'AWS::Scheduler::Schedule': {
     GroupName: 'default',

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,10 +157,15 @@ export interface DesiredResource {
   constructPath?: string | undefined; // CDK construct path from aws:cdk:path Metadata (display only)
   declared: Record<string, unknown>; // intrinsic-resolved + NoValue-pruned (may carry UNRESOLVED)
   declaredRaw?: Record<string, unknown>; // raw Properties, re-resolved by gather once liveAttrs are read
-  // inline Policies on an IAM Role owned by sibling AWS::IAM::Policy resources (the
-  // CDK pattern). classify drops ONLY the live entries whose PolicyName is listed
-  // here, so an out-of-band inline policy is still reported. 'unresolved' = a
-  // sibling PolicyName is not statically resolvable -> fall back to suppressing the
-  // whole live Policies property (no false positives).
+  // inline Policies on an IAM principal (Role / User / Group) owned by sibling
+  // AWS::IAM::Policy resources (the CDK pattern). classify drops ONLY the live entries
+  // whose PolicyName is listed here, so an out-of-band inline policy is still reported.
+  // 'unresolved' = a sibling PolicyName is not statically resolvable -> fall back to
+  // suppressing the whole live Policies property (no false positives).
   siblingPolicyNames?: string[] | 'unresolved' | undefined;
+  // true when an ECS Cluster's CapacityProviders / DefaultCapacityProviderStrategy are
+  // declared by a sibling AWS::ECS::ClusterCapacityProviderAssociations resource (which
+  // reflects them into the cluster's live model). classify drops the reflected props so
+  // they are not false undeclared drift — the association is tracked as its own resource.
+  hasSiblingCapacityProviders?: boolean | undefined;
 }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -806,6 +806,149 @@ describe('sibling-managed inline Policies (IAM Role)', () => {
   });
 });
 
+// The sibling-managed inline Policies mechanism is NOT Role-only: an AWS::IAM::Policy also
+// attaches to Users and Groups (via its Users / Groups ref lists), the same CDK
+// `<Principal>DefaultPolicy` shape. Observed live on dev-main-db2bq: a data-transfer IAM
+// User read back Path:'/' + an inline Policies entry owned by its sibling DefaultPolicy →
+// two false undeclared drifts. Path is the IAM default (KNOWN_DEFAULTS); the Policies entry
+// is dropped by the sibling filter now that siblingPolicyNames is plumbed for Users/Groups.
+describe('sibling-managed inline Policies (IAM User / Group)', () => {
+  const noSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const DOC = {
+    Version: '2012-10-17',
+    Statement: [
+      { Effect: 'Allow', Action: ['s3:GetBucket*', 's3:GetObject*', 's3:List*'], Resource: '*' },
+    ],
+  };
+  // db2bq's real live shape: PolicyName === the sibling AWS::IAM::Policy's literal name.
+  const sibling = { PolicyName: 'DataTransferIamUserDefaultPolicy758350EB', PolicyDocument: DOC };
+  const rogue = { PolicyName: 'rogue-inline', PolicyDocument: DOC };
+  const principal = (
+    resourceType: string,
+    siblingPolicyNames?: string[] | 'unresolved',
+    declared: Record<string, unknown> = {}
+  ): DesiredResource => ({
+    logicalId: 'P',
+    resourceType,
+    physicalId: 'principal-name',
+    declared,
+    siblingPolicyNames,
+  });
+
+  it('IAM User: Path:/ folds atDefault and the sibling-owned Policies entry is filtered out', () => {
+    const t = tiers(
+      classifyResource(
+        principal('AWS::IAM::User', ['DataTransferIamUserDefaultPolicy758350EB']),
+        { Path: '/', Policies: [sibling] },
+        noSchema
+      )
+    );
+    expect(t.atDefault).toEqual(['Path']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('IAM Group: Path:/ folds atDefault and the sibling-owned Policies entry is filtered out', () => {
+    const t = tiers(
+      classifyResource(
+        principal('AWS::IAM::Group', ['DataTransferIamUserDefaultPolicy758350EB']),
+        { Path: '/', Policies: [sibling] },
+        noSchema
+      )
+    );
+    expect(t.atDefault).toEqual(['Path']);
+    expect(t.undeclared).toEqual([]);
+  });
+
+  it('IAM User: an out-of-band inline policy next to a sibling still surfaces as undeclared', () => {
+    const findings = classifyResource(
+      principal('AWS::IAM::User', ['DataTransferIamUserDefaultPolicy758350EB']),
+      { Policies: [sibling, rogue] },
+      noSchema
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ tier: 'undeclared', path: 'Policies' });
+    const actual = findings[0]!.actual as { PolicyName: string }[];
+    expect(actual.map((p) => p.PolicyName)).toEqual(['rogue-inline']);
+  });
+
+  it('IAM User: an UNRESOLVED sibling stamps the revert-hazard marker on a declared Policies finding', () => {
+    const declared = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }] };
+    const live = { Policies: [{ PolicyName: 'inline-a', PolicyDocument: DOC }, sibling] };
+    const findings = classifyResource(
+      principal('AWS::IAM::User', 'unresolved', declared),
+      live,
+      noSchema
+    );
+    const f = findings.find((x) => x.path === 'Policies');
+    expect(f).toBeDefined();
+    expect(f!.siblingPolicyNames).toBe('unresolved');
+  });
+});
+
+// An ECS Cluster reflects the CapacityProviders / DefaultCapacityProviderStrategy declared by
+// its sibling AWS::ECS::ClusterCapacityProviderAssociations resource (the only CFn way to set
+// them), plus ClusterSettings:[{containerInsights,disabled}] (the AWS default). Observed live on
+// dev-main-db2bq: 3 false undeclared drifts on every Fargate cluster. ClusterSettings folds as a
+// KNOWN_DEFAULT; the two reflected props are dropped when a sibling association is present.
+describe('ECS Cluster sibling capacity providers + ClusterSettings default (dev-main-db2bq)', () => {
+  const noSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const cluster = (hasSiblingCapacityProviders?: boolean): DesiredResource => ({
+    logicalId: 'Cluster',
+    resourceType: 'AWS::ECS::Cluster',
+    physicalId: 'cluster-name',
+    declared: {},
+    hasSiblingCapacityProviders,
+  });
+  // the exact live model db2bq's cluster read back (key order as CC returned it)
+  const live = {
+    ClusterSettings: [{ Value: 'disabled', Name: 'containerInsights' }],
+    CapacityProviders: ['FARGATE', 'FARGATE_SPOT'],
+    DefaultCapacityProviderStrategy: [
+      { CapacityProvider: 'FARGATE', Weight: 0, Base: 0 },
+      { CapacityProvider: 'FARGATE_SPOT', Weight: 1, Base: 0 },
+    ],
+  };
+
+  it('with a sibling association: all three read as clean (ClusterSettings=default, providers dropped)', () => {
+    const t = tiers(classifyResource(cluster(true), structuredClone(live), noSchema));
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toEqual(['ClusterSettings']);
+  });
+
+  it('without a sibling association: the capacity providers DO surface (the guard is load-bearing)', () => {
+    const t = tiers(classifyResource(cluster(false), structuredClone(live), noSchema));
+    expect(t.undeclared).toEqual(['CapacityProviders', 'DefaultCapacityProviderStrategy']);
+    // ClusterSettings still folds as a default regardless of the sibling flag
+    expect(t.atDefault).toEqual(['ClusterSettings']);
+  });
+
+  it('an enabled ClusterSettings is NOT the default and surfaces (equality-gated)', () => {
+    const enabled = {
+      ClusterSettings: [{ Name: 'containerInsights', Value: 'enabled' }],
+    };
+    const t = tiers(classifyResource(cluster(true), enabled, noSchema));
+    expect(t.undeclared).toEqual(['ClusterSettings']);
+  });
+});
+
 describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)', () => {
   const emptySchema: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -9,13 +9,14 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
 import {
   buildResolverContext,
-  collectRolesWithSiblingPolicies,
+  collectClustersWithSiblingCapacityProviders,
+  collectPrincipalsWithSiblingPolicies,
   loadDesired,
   parseTemplateBody,
 } from '../src/desired/template-adapter.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 
-describe('collectRolesWithSiblingPolicies', () => {
+describe('collectPrincipalsWithSiblingPolicies', () => {
   it('maps roles referenced by sibling AWS::IAM::Policy resources to the policy NAMES', () => {
     const resources = {
       MyRole: { Type: 'AWS::IAM::Role' },
@@ -29,7 +30,7 @@ describe('collectRolesWithSiblingPolicies', () => {
       },
       Other: { Type: 'AWS::S3::Bucket' },
     };
-    expect(collectRolesWithSiblingPolicies(resources)).toEqual(
+    expect(collectPrincipalsWithSiblingPolicies(resources)).toEqual(
       new Map([['MyRole', ['MyRoleDefaultPolicyABC', 'extra']]])
     );
   });
@@ -39,7 +40,7 @@ describe('collectRolesWithSiblingPolicies', () => {
       P: { Type: 'AWS::IAM::Policy', Properties: { PolicyName: 'p', Roles: ['literal-name'] } },
       Q: { Type: 'AWS::IAM::ManagedPolicy', Properties: { Roles: [{ Ref: 'R' }] } },
     };
-    expect(collectRolesWithSiblingPolicies(resources).size).toBe(0); // literal not a Ref; ManagedPolicy not Policy
+    expect(collectPrincipalsWithSiblingPolicies(resources).size).toBe(0); // literal not a Ref; ManagedPolicy not Policy
   });
 
   it("marks the role 'unresolved' when a sibling PolicyName cannot be resolved (sticky)", () => {
@@ -58,7 +59,7 @@ describe('collectRolesWithSiblingPolicies', () => {
       },
     };
     // no ctx -> the intrinsic cannot resolve; 'unresolved' wins and stays
-    expect(collectRolesWithSiblingPolicies(resources).get('MyRole')).toBe('unresolved');
+    expect(collectPrincipalsWithSiblingPolicies(resources).get('MyRole')).toBe('unresolved');
   });
 
   it('resolves an intrinsic PolicyName when a resolver ctx is provided', () => {
@@ -72,9 +73,57 @@ describe('collectRolesWithSiblingPolicies', () => {
       },
     };
     const ctx = buildResolverContext({}, {}, {}, 'us-east-1', '111122223333', 's', 'sid');
-    expect(collectRolesWithSiblingPolicies(resources, ctx).get('MyRole')).toEqual([
+    expect(collectPrincipalsWithSiblingPolicies(resources, ctx).get('MyRole')).toEqual([
       'pol-us-east-1',
     ]);
+  });
+
+  it('also maps Users and Groups a sibling policy attaches to (db2bq IAM User pattern)', () => {
+    const resources = {
+      MyUser: { Type: 'AWS::IAM::User' },
+      MyGroup: { Type: 'AWS::IAM::Group' },
+      UserPolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'UserDefaultPolicyA55', Users: [{ Ref: 'MyUser' }] },
+      },
+      GroupPolicy: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'GroupDefaultPolicyB33', Groups: [{ Ref: 'MyGroup' }] },
+      },
+    };
+    const m = collectPrincipalsWithSiblingPolicies(resources);
+    expect(m.get('MyUser')).toEqual(['UserDefaultPolicyA55']);
+    expect(m.get('MyGroup')).toEqual(['GroupDefaultPolicyB33']);
+  });
+});
+
+describe('collectClustersWithSiblingCapacityProviders', () => {
+  it('collects ECS Cluster logicalIds referenced by a ClusterCapacityProviderAssociations sibling', () => {
+    const resources = {
+      MyCluster: { Type: 'AWS::ECS::Cluster' },
+      Assoc: {
+        Type: 'AWS::ECS::ClusterCapacityProviderAssociations',
+        Properties: {
+          Cluster: { Ref: 'MyCluster' },
+          CapacityProviders: ['FARGATE', 'FARGATE_SPOT'],
+          DefaultCapacityProviderStrategy: [{ CapacityProvider: 'FARGATE', Weight: 1 }],
+        },
+      },
+      Other: { Type: 'AWS::ECS::Cluster' }, // no association -> not collected
+    };
+    const s = collectClustersWithSiblingCapacityProviders(resources);
+    expect(s.has('MyCluster')).toBe(true);
+    expect(s.has('Other')).toBe(false);
+  });
+
+  it('ignores a non-Ref Cluster and non-association resources', () => {
+    const resources = {
+      A: {
+        Type: 'AWS::ECS::ClusterCapacityProviderAssociations',
+        Properties: { Cluster: 'literal-cluster-name' },
+      },
+    };
+    expect(collectClustersWithSiblingCapacityProviders(resources).size).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

The real `<etl-app-dev-stack>` stack (<dev-profile>, read-only oracle) surfaced **10 false undeclared drifts** across two false-positive classes. This fixes both. (The 1 declared SQS drift in that same output is **genuine** — see below.)

## False positives fixed

### IAM User / Group
- The sibling-managed inline `Policies` drop was **Role-only**. An `AWS::IAM::Policy` also attaches to **Users** and **Groups** (via its `Users` / `Groups` ref lists) — the same CDK `<Principal>DefaultPolicy` pattern — so the reflected live `Policies` entry read as false undeclared drift. Generalized `collectRolesWithSiblingPolicies` → `collectPrincipalsWithSiblingPolicies` (Roles + Users + Groups); `siblingPolicyNames` is now plumbed for all three, and the `'unresolved'` revert-hazard marker follows.
- `AWS::IAM::User` `Path:'/'` is the AWS default (Role / Group / InstanceProfile already folded it) → added to `KNOWN_DEFAULTS`.

### ECS Cluster
- `CapacityProviders` / `DefaultCapacityProviderStrategy` can only be set via a sibling `AWS::ECS::ClusterCapacityProviderAssociations` resource, which **reflects** them into the cluster's live model. The association is tracked + compared as its own resource, so the reflected props are dropped on the cluster when a sibling references it (`collectClustersWithSiblingCapacityProviders` → `hasSiblingCapacityProviders`). Load-bearing guard: a cluster with providers set purely out of band (no association) still surfaces them.
- `ClusterSettings:[{Name:containerInsights,Value:disabled}]` is the AWS default → added `AWS::ECS::Cluster` to `KNOWN_DEFAULTS` (equality-gated: an `enabled` cluster still surfaces).

## NOT a false positive

The `JobCreator/EventQueue.VisibilityTimeout` finding (`desired=1200`, `actual=0`) is **genuine drift** — confirmed against the deployed CFn template (declares `1200`) and a live `sqs:GetQueueAttributes` (returns `0`). Something set the queue's visibility timeout to 0 out of band; cdkrd is correctly reporting it.

## Tests
- `tests/classify.test.ts`: IAM User/Group sibling-policy filtering + `Path:'/'` fold + unresolved revert-hazard marker; ECS Cluster sibling-provider drop (with/without the sibling guard) + `ClusterSettings` default fold + equality-gated `enabled` still surfacing. Live shapes taken verbatim from the real stack.
- `tests/template-adapter.test.ts`: `collectPrincipalsWithSiblingPolicies` Users/Groups; `collectClustersWithSiblingCapacityProviders`.
- Full suite: 2770 passed.

## Live verification note
Offline verified via unit tests encoding the exact live shapes captured from the real stack (direct AWS reads before the short-lived `<dev-profile>` session expired). A full `cdkrd check` re-run against the live stack requires re-authenticating `<dev-profile>`.
