### PR TITLE
feat(report): show construct path within the stack + keep ignore rules consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ explainable, so the same change shows up:
 $ npx cdkrd check
 === cdkrd check: ApiStack (us-east-1) ===
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
-  ApiStack/ApiRole.Policies (AWS::IAM::Role) — appeared since record
+  ApiRole.Policies (AWS::IAM::Role) — appeared since record
       actual =[{"PolicyName":"manual-debug-access", ...}]
 
 ─────────────────────────────────
@@ -66,14 +66,14 @@ The first time you run `check` on a stack, before recording anything:
 No baseline yet — live-only values can't be confirmed as drift, but declared drift and out-of-band deletes always can.
 
 [CFn-Declared Drift: 1] (declared in your CloudFormation template — the live value differs)
-  ApiStack/Topic.DisplayName (AWS::SNS::Topic)
+  Topic.DisplayName (AWS::SNS::Topic)
       desired="prod-alerts"
       actual ="test"
 
 [Potential Drift: 2] (live-only and not yet in your .cdkrd baseline, so cdkrd can't tell whether it's intended or an out-of-band change — Record to accept it, or Revert to remove it)
-  ApiStack/Queue.RedrivePolicy (AWS::SQS::Queue)
+  Queue.RedrivePolicy (AWS::SQS::Queue)
       actual ={"maxReceiveCount":5}
-  ApiStack/Role.Policies (AWS::IAM::Role)
+  Role.Policies (AWS::IAM::Role)
       actual =[{"PolicyName":"adhoc", ...}]
 
 ─────────────────────────────────────────────────────────────
@@ -115,7 +115,7 @@ your CloudFormation template, the kind `cdk drift` can't see:
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
-  ApiStack/Role.Policies (AWS::IAM::Role) — changed since record
+  Role.Policies (AWS::IAM::Role) — changed since record
       actual =[{"PolicyName":"adhoc", ...}, {"PolicyName":"manual-debug-access", ...}]
 
 ─────────────────────────────────
@@ -372,7 +372,7 @@ $ npx cdkrd check --pre-deploy
 (--pre-deploy) comparing live state against the LOCAL synth template
 === cdkrd check: ApiStack (us-east-1) ===
 [CFn-Declared Drift: 1]
-  ApiStack/Api/Handler.MemorySize (AWS::Lambda::Function)
+  Api/Handler.MemorySize (AWS::Lambda::Function)
       desired=1024
       actual =2048
 
@@ -424,8 +424,11 @@ ignore:
 - Every rule is a mapping `{ path, stack?, account?, region? }`. `cdkrd ignore`
   writes the unscoped form (and is **comment-preserving and append-only**: it keeps
   your existing comments and layout, and appends new rules at the end — you own the
-  order). `path` is an exact `<constructPath>.<path>` (or `<logicalId>.<path>` on a
-  non-CDK stack); the optional `stack` / `account` / `region` scopes are a hand-edit.
+  order). `path` is an exact `<constructPath>.<path>` — the construct path WITHIN the
+  stack (the stack/Stage prefix stripped), byte-identical to what `cdkrd check` prints, so
+  you can copy what you see (or `<logicalId>.<path>` on a non-CDK stack). Rules written with
+  the older full `<stack>/<constructPath>.<path>` form still match. The optional `stack` /
+  `account` / `region` scopes are a hand-edit.
 - All four fields accept the same `*` / `?` glob, and a parent `path` covers child
   paths. The three scope axes — **stack, account, region** — are exactly the
   baseline file's identity axes. **Account** keeps a `stack: "Prod*"` rule from
@@ -444,7 +447,7 @@ that folds everything informational.
 ```console
 === cdkrd check: ApiStack (us-east-1) ===
 [CFn-Declared Drift: 1]
-  ApiStack/UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
+  UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"
       actual ="Suspended"
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -978,13 +978,16 @@ applied right after `applyBaseline` everywhere (check / revert / record / the
 interactive flow), so the tier is uniform across commands. It re-tags
 matching `declared` / `undeclared` findings to `ignored` (never `deleted` — a path
 rule must not silence a resource deletion; the already-informational tiers are left
-alone). The `path` pattern globs (`*` / `?`) against EITHER `<logicalId>.<path>` OR
-(when present) `<constructPath>.<path>`, so both styles work: the logicalId
-(`ApiRole1234ABCD.Policies`) is the CloudFormation template's resource key — always
+alone). The `path` pattern globs (`*` / `?`) against THREE targets, so every style
+works: `<logicalId>.<path>` — the CloudFormation template's resource key, always
 present, so rules work on ANY stack, **CDK or not** (raw CloudFormation / SAM); the
-constructPath (`MyStack/ApiRole.Policies`) is the human-friendly id `cdk-local` also
-targets by, offered as an additional match target (it comes from optional
-`aws:cdk:path` Metadata, so it can't be the only key). A parent-segment rule
+WITHIN-stack `<constructPath>.<path>` (the stack/Stage prefix stripped via
+`withinStackPath`, e.g. `ApiRole.Policies`) — byte-identical to what the report prints
+and what `ignoreRuleFor` now writes, so a rule is "copy what you see"; and the FULL
+`<stack>/<constructPath>.<path>` (`MyStack/ApiRole.Policies`, or a Stage's
+`dev-main/AuroraDB/...`) — kept so rules authored before the strip still match. The
+constructPath forms come from optional `aws:cdk:path` Metadata (absent on non-CDK
+stacks), so logicalId is the always-present fallback. A parent-segment rule
 (`X.Policies`) covers child paths (`X.Policies.0.PolicyName`).
 Ignored findings drop out of the revert plan and the record-set automatically
 (neither acts on the `ignored` tier). A malformed `ignore.yaml` — invalid YAML,

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -492,7 +492,9 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
       return { wrote: false, refused: false, added: 0 };
     }
   }
-  const { path, added, alreadyPresent } = await addIgnoreRules(chosen.map(ignoreRuleFor));
+  const { path, added, alreadyPresent } = await addIgnoreRules(
+    chosen.map((f) => ignoreRuleFor(f, stackName))
+  );
   if (added.length > 0) {
     const dup = alreadyPresent.length > 0 ? `, ${alreadyPresent.length} already present` : '';
     console.log(style.ok(`ignore rule(s) added: ${path} (${added.length} new${dup})`));

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -49,6 +49,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { type Document, isSeq, parseDocument, YAMLSeq } from 'yaml';
 import { matchesGlob, matchesPathGlob } from '../commands/glob-match.js';
+import { withinStackPath } from '../construct-path.js';
 import type { Finding } from '../types.js';
 
 // An ignore rule. `path` is the glob against "<logicalId>.<path>" /
@@ -154,13 +155,18 @@ function validateIgnoreEntry(entry: unknown, index: number): void {
  * rule (just `path`); the optional `stack` / `region` scopes stay hand-authored (the
  * verb writes the simplest rule; narrowing is a manual edit). Prefer the human-friendly
  * `<constructPath>.<path>` when present (CDK stacks): it is what `cdk-local` targets on
- * and it embeds the stack name, so it is naturally stack-scoped and readable in the
- * git-committed config diff. Falls back to `<logicalId>.<path>`, which is ALWAYS present
- * (the CloudFormation key) so a rule is always writable even on a non-CDK / metadata-
- * stripped stack. Pure + exported; `applyIgnores` matches on EITHER target, so both work.
+ * and readable in the git-committed config diff. The construct path is written WITHIN the
+ * stack (the stack/Stage prefix stripped, given `stackName`) so it is byte-identical to
+ * what the report prints for the finding — copy what you see. Naturally stack-scoped even
+ * without the prefix (a `stack:` scope narrows further). Falls back to `<logicalId>.<path>`,
+ * ALWAYS present (the CloudFormation key) so a rule is writable even on a non-CDK /
+ * metadata-stripped stack. Pure + exported; `applyIgnores` matches the within-stack path,
+ * the full construct path (older rules), AND the logicalId, so every form works.
  */
-export function ignoreRuleFor(finding: Finding): IgnoreRuleObject {
-  const id = finding.constructPath ?? finding.logicalId;
+export function ignoreRuleFor(finding: Finding, stackName = ''): IgnoreRuleObject {
+  const id = finding.constructPath
+    ? withinStackPath(finding.constructPath, stackName)
+    : finding.logicalId;
   return { path: finding.path ? `${id}.${finding.path}` : id };
 }
 
@@ -363,7 +369,14 @@ export function applyIgnores(
     // (a trailing dot would only match via the parent-segment fallback — fragile).
     const suffix = f.path ? `.${f.path}` : '';
     const targets = [`${f.logicalId}${suffix}`];
-    if (f.constructPath) targets.push(`${f.constructPath}${suffix}`);
+    if (f.constructPath) {
+      // The within-stack path is what the report shows and what `ignoreRuleFor` now writes;
+      // the FULL construct path is kept too so rules authored before the strip (or a
+      // Stage's full `dev-main/AuroraDB/...` form) still match. When there is no stack
+      // prefix to strip, both are identical — a harmless duplicate (`some` short-circuits).
+      targets.push(`${withinStackPath(f.constructPath, stackName)}${suffix}`);
+      targets.push(`${f.constructPath}${suffix}`);
+    }
     const hit = rules.find(
       (r) =>
         (r.stackGlob === undefined || matchesGlob(r.stackGlob, stackName)) &&

--- a/src/construct-path.ts
+++ b/src/construct-path.ts
@@ -1,0 +1,28 @@
+// The construct path WITHIN its stack — the stack (and any enclosing CDK Stage) prefix
+// removed. CDK forms the CloudFormation stack name by `-`-joining the leading construct-
+// path segments (the enclosing Stage ids + the Stack construct id), while the construct
+// path (`aws:cdk:path`) `/`-joins the same segments:
+//
+//   plain stack   MyStack/Api/Handler       stackName = MyStack      -> Api/Handler
+//   CDK Stage     dev-main/AuroraDB/Db/PG    stackName = dev-main-AuroraDB -> Db/PG
+//
+// So strip the leading run of `/`-segments whose `-`-join equals the stack name. The
+// report header already states the stack name, so repeating it on every finding line is
+// noise — and dropping it makes the Stage form (a `/`-separated path beside a `-`-joined
+// name) read consistently instead of looking like two different stack identifiers.
+//
+// Robust to the naming variants: a hyphen INSIDE a stack/stage id is fine (the whole
+// segments are joined and compared to the actual stackName, never split); a stack whose id
+// already bakes in the stage (`dev-main-AuroraDB/...`) strips as one segment; a nested
+// Stage (`a/b/Stack/...` -> `a-b-Stack`) strips all of them. When nothing matches — e.g. an
+// explicitly overridden `stackName` that no longer mirrors the construct ids — the path is
+// returned UNCHANGED (a safe, self-contained fallback, never a wrong strip).
+export function withinStackPath(constructPath: string, stackName: string): string {
+  const segs = constructPath.split('/');
+  // Largest k first so the most specific (full stage+stack) prefix wins; only one k can
+  // match anyway, since stackName is exactly the `-`-join of those leading segments.
+  for (let k = segs.length - 1; k >= 1; k--) {
+    if (segs.slice(0, k).join('-') === stackName) return segs.slice(k).join('/');
+  }
+  return constructPath;
+}

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -19,10 +19,18 @@
 // one-line-per-tier bullet list when 2+ (R37); `--verbose` expands them to full
 // sections (below result, as a footer). 0-count tiers are never printed. The
 // "surfaced, never silently dropped" invariant is preserved by the counts.
+import { withinStackPath } from '../construct-path.js';
 import { deepEqual } from '../diff/drift-calculator.js';
 import { annotateHints } from '../diff/hints.js';
 import type { ArrayDelta, Finding, Tier } from '../types.js';
 import { style } from './style.js';
+
+// The report header is `<stackName> (<region>)`; recover the bare stack name (used to
+// strip the stack/Stage prefix off each finding's construct path). Only a TRAILING
+// ` (...)` is removed, so a stack name that itself contains parens survives.
+function stackNameFromHeader(header: string): string {
+  return header.replace(/\s*\([^)]*\)\s*$/, '');
+}
 
 // Strip SGR color codes to measure a line's VISIBLE width (for the result-line rule).
 // Built from the ESC char via fromCharCode so no control byte sits in a regex literal.
@@ -101,12 +109,18 @@ export interface ReportOptions {
 // section, are excluded from the drift verdict/exit, and the result line points
 // at `cdkrd record`.
 
-export function formatFinding(f: Finding): string {
+export function formatFinding(f: Finding, stackName = ''): string {
   // prefer the CDK construct path for the human-facing id; fall back to logical id
   // (the id stays uncolored — it gets copy-pasted; only the values are styled,
   // and style.* is the identity when stdout is not a TTY, so piped output and
-  // unit-test assertions see plain text)
-  const id = f.constructPath ?? f.logicalId;
+  // unit-test assertions see plain text). The construct path is shown WITHIN its stack
+  // (the stack/Stage prefix stripped — the header already names the stack), so a Stage's
+  // `dev-main/AuroraDB/...` no longer sits beside the `dev-main-AuroraDB` header looking
+  // like a different id. `stackName` defaults to '' (no strip) for direct unit calls; the
+  // report passes the real name. The displayed id stays byte-identical to the ignore-rule
+  // path token (both are `withinStackPath(...).<path>`), so what you see IS what an
+  // ignore.yaml rule uses.
+  const id = f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId;
   // R78: an ELB attribute-bag drift names the changed attribute by Key
   // (LoadBalancerAttributes[idle_timeout.timeout_seconds]) rather than a bare
   // array index, so the report points at the exact setting.
@@ -258,6 +272,7 @@ function groupReasons(items: Finding[]): string {
 
 export function report(rawFindings: Finding[], header: string, opts: ReportOptions = {}): number {
   const log = opts.log ?? console.log;
+  const stackName = stackNameFromHeader(header);
   // Annotate origin hints (diff/hints.ts) here, at the single render chokepoint, so the
   // text report, the --json payload, and the --pre-deploy report all carry them. A hint is
   // display-only — it never changes a tier — so the `drifted` verdict below is unaffected.
@@ -305,7 +320,7 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
         color(`[${name}: ${items.length}]`) +
         (note ? ' ' + style.note(`(${note})`) : '')
     );
-    for (const f of items) log('  ' + formatFinding(f));
+    for (const f of items) log('  ' + formatFinding(f, stackName));
     return true;
   };
   const tierSection = (tier: Tier, leadingBlank: boolean): boolean =>

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -499,6 +499,30 @@ describe('ignoreRuleFor', () => {
     expect(ignoreRuleFor(f)).toEqual({ path: 'MyStack/ApiRole.Policies' });
   });
 
+  it('writes the WITHIN-stack path when given the stack name (matches what the report shows)', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'ApiRole1234ABCD',
+      constructPath: 'MyStack/ApiRole',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      actual: [{}],
+    };
+    // plain stack + a CDK Stage both collapse to the same within-stack rule
+    expect(ignoreRuleFor(f, 'MyStack')).toEqual({ path: 'ApiRole.Policies' });
+    expect(
+      ignoreRuleFor({ ...f, constructPath: 'dev-main/AuroraDB/ApiRole' }, 'dev-main-AuroraDB')
+    ).toEqual({ path: 'ApiRole.Policies' });
+    // round-trip: the within-stack rule the verb now writes matches the finding it came from
+    expect(ign([f], 'MyStack', cfg([ignoreRuleFor(f, 'MyStack')]))[0]?.tier).toBe('ignored');
+    const staged: Finding = { ...f, constructPath: 'dev-main/AuroraDB/ApiRole' };
+    expect(
+      ign([staged], 'dev-main-AuroraDB', cfg([ignoreRuleFor(staged, 'dev-main-AuroraDB')]))[0]?.tier
+    ).toBe('ignored');
+    // and an OLDER full-path rule (pre-strip) still matches (back-compat)
+    expect(ign([f], 'MyStack', cfg([p('MyStack/ApiRole.Policies')]))[0]?.tier).toBe('ignored');
+  });
+
   it('falls back to logicalId when constructPath is absent (non-CDK stack)', () => {
     expect(ignoreRuleFor(declared('ApiRole', 'Policies'))).toEqual({ path: 'ApiRole.Policies' });
   });

--- a/tests/construct-path.test.ts
+++ b/tests/construct-path.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { withinStackPath } from '../src/construct-path.js';
+
+describe('withinStackPath (strip the stack/Stage prefix off a construct path)', () => {
+  it('plain stack: strips the single leading stack-id segment', () => {
+    expect(withinStackPath('MyStack/Api/Handler', 'MyStack')).toBe('Api/Handler');
+  });
+
+  it('a stack id composed with the stage (e.g. `${stage}-Name`) strips as ONE segment', () => {
+    // the common manual pattern: `new Stack(app, `${stage}-AuroraDB`)` — the whole first
+    // segment IS the stack name, so it strips even though it contains a hyphen.
+    expect(withinStackPath('dev-main-AuroraDB/Database/ParameterGroup', 'dev-main-AuroraDB')).toBe(
+      'Database/ParameterGroup'
+    );
+  });
+
+  it('CDK Stage: strips BOTH the stage and stack segments (path is /-joined, name is -joined)', () => {
+    // aws:cdk:path = `dev-main/AuroraDB/Database/ParameterGroup`, CFn stackName =
+    // `dev-main-AuroraDB` — the two leading segments `-`-join to the stack name.
+    expect(withinStackPath('dev-main/AuroraDB/Database/ParameterGroup', 'dev-main-AuroraDB')).toBe(
+      'Database/ParameterGroup'
+    );
+  });
+
+  it('nested Stages strip every enclosing segment', () => {
+    expect(withinStackPath('a/b/Stack/Res/Sub', 'a-b-Stack')).toBe('Res/Sub');
+  });
+
+  it('a stage/stack id that itself contains a hyphen still matches (whole segments joined)', () => {
+    expect(withinStackPath('dev-main/aurora-db/Res', 'dev-main-aurora-db')).toBe('Res');
+  });
+
+  it('overridden stackName that no longer mirrors the construct ids: returns UNCHANGED (safe)', () => {
+    // `new Stack(app, 'AuroraDB', { stackName: 'prod-db' })` — construct path leads with the
+    // construct id `AuroraDB`, not `prod-db`, so nothing strips rather than stripping wrongly.
+    expect(withinStackPath('AuroraDB/Database/PG', 'prod-db')).toBe('AuroraDB/Database/PG');
+  });
+
+  it('empty stackName (direct/unit call): returns UNCHANGED (no strip)', () => {
+    expect(withinStackPath('MyStack/Api', '')).toBe('MyStack/Api');
+  });
+
+  it('a resource directly under the stack (single trailing segment) still strips the stack', () => {
+    expect(withinStackPath('MyStack/Api', 'MyStack')).toBe('Api');
+  });
+});

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -137,6 +137,51 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     );
     expect(out).not.toContain(') = ['); // never crammed inline after the (type)
   });
+
+  it('shows the construct path WITHIN the stack (stack/Stage prefix stripped, header names the stack)', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'ParameterGroup9AB',
+      constructPath: 'dev-main-AuroraDB/Database/ParameterGroup',
+      resourceType: 'AWS::RDS::DBClusterParameterGroup',
+      path: 'Parameters.autocommit',
+      desired: '0',
+      actual: '1',
+    };
+    // plain / stage-composed stack id: the leading stack segment is dropped
+    expect(formatFinding(f, 'dev-main-AuroraDB')).toContain(
+      'Database/ParameterGroup.Parameters.autocommit (AWS::RDS::DBClusterParameterGroup)'
+    );
+    // a CDK Stage: aws:cdk:path is `dev-main/AuroraDB/...` while the name is `dev-main-AuroraDB`
+    expect(
+      formatFinding(
+        { ...f, constructPath: 'dev-main/AuroraDB/Database/ParameterGroup' },
+        'dev-main-AuroraDB'
+      )
+    ).toContain('Database/ParameterGroup.Parameters.autocommit (');
+    // no stackName (direct call) or a non-matching (overridden) name: path stays full
+    expect(formatFinding(f)).toContain('dev-main-AuroraDB/Database/ParameterGroup.Parameters');
+    expect(formatFinding(f, 'prod-db')).toContain(
+      'dev-main-AuroraDB/Database/ParameterGroup.Parameters'
+    );
+  });
+
+  it('report() strips the stack prefix using the stack name parsed from the header', () => {
+    const f: Finding = {
+      tier: 'declared',
+      logicalId: 'Role1234',
+      constructPath: 'ApiStack/ApiRole',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Description',
+      desired: 'a',
+      actual: 'b',
+    };
+    const lines: string[] = [];
+    report([f], 'ApiStack (us-east-1)', { log: (s) => lines.push(s) });
+    const text = lines.join('\n');
+    expect(text).toContain('ApiRole.Description (AWS::IAM::Role)');
+    expect(text).not.toContain('ApiStack/ApiRole'); // the redundant stack prefix is gone
+  });
 });
 
 describe('report', () => {


### PR DESCRIPTION
## What

A finding's construct path repeated the stack name on every line — redundant with the `=== cdkrd check: <stack> ===` header — and in a **CDK Stage** it read especially oddly: the path is `dev-main/AuroraDB/...` (slash-joined) while the header stack name is `<aurora-cluster-dev-stack>` (hyphen-joined), so the same stack looked like two different ids.

Now the report shows the construct path **within the stack**:

```
# before
  <aurora-cluster-dev-stack>/Database/ParameterGroup.Parameters.autocommit (AWS::RDS::DBClusterParameterGroup)
      actual ="1"
# after
  Database/ParameterGroup.Parameters.autocommit (AWS::RDS::DBClusterParameterGroup)
      actual ="1"
```

## How

New `withinStackPath(constructPath, stackName)`: CDK forms the CFn stack name by `-`-joining the leading construct-path segments (Stage ids + Stack id) while the path `/`-joins them, so strip the longest leading run whose `-`-join equals the stack name. Handles:

| case | constructPath | stackName | shown |
|---|---|---|---|
| plain | `MyStack/Api/Handler` | `MyStack` | `Api/Handler` |
| stage-composed id | `<aurora-cluster-dev-stack>/Db/PG` | `<aurora-cluster-dev-stack>` | `Db/PG` |
| CDK Stage | `dev-main/AuroraDB/Db/PG` | `<aurora-cluster-dev-stack>` | `Db/PG` |
| nested Stage | `a/b/Stack/Res` | `a-b-Stack` | `Res` |
| overridden `stackName` | `AuroraDB/Db/PG` | `prod-db` | `AuroraDB/Db/PG` (unchanged — safe) |

## Consistency with ignore.yaml (you flagged this)

Kept the `.` join (**not** a new `›` separator) so the displayed finding id is **byte-identical to the ignore-rule path token** — what you see is what an `ignore.yaml` rule uses. To hold that:

- `ignoreRuleFor` now writes the **within-stack** path (given the stack name).
- `applyIgnores` matches the within-stack path, the **full** construct path (older rules / a Stage's slash form), **and** the logicalId — so every form works and **existing ignore.yaml files keep matching**.

`--json` is unchanged: `findings[].constructPath` stays the full path (the machine contract).

## Tests

- `withinStackPath` unit matrix (plain / stage-composed / Stage / nested / hyphens-in-ids / override / empty).
- report strips via the header-parsed stack name.
- `ignoreRuleFor` writes + `applyIgnores` matches the stripped form round-trip, with full-path back-compat.
- Full suite: 2771 passing.

## Follow-up (separate PR)

Apply the same within-stack strip to the **revert-plan display**, the **surviving-drift list**, and the **ignore-picker labels** for full cross-command consistency. This PR deliberately scopes to the `check` report + ignore matching (what we discussed); the revert samples in the README are intentionally left with the full path to match the current code.
