### PR TITLE
feat(revert): show construct path within the stack in revert/surviving/picker displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,11 @@ writes one. It re-reads each touched resource afterward to verify it converged:
 ```console
 === cdkrd revert: ApiStack (us-east-1) ===
 
-  ApiStack/ApiRole (AWS::IAM::Role)
+  ApiRole (AWS::IAM::Role)
     - Policies -> remove (undeclared, not in baseline)
 
 Apply 1 revert op(s) to ApiStack? This WRITES to AWS. · yes
-  reverted: ApiStack/ApiRole
+  reverted: ApiRole
 
 verifying convergence (re-reading 1 resource(s))...
 ApiStack: CLEAN after revert.

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -24,6 +24,7 @@ import {
   type CdkrdConfig,
   ignoreRuleFor,
 } from '../config/config-file.js';
+import { withinStackPath } from '../construct-path.js';
 import { style } from '../report/style.js';
 import { bulkMultiselect } from './bulk-multiselect.js';
 import { CC_IDENTIFIER_ADAPTERS } from '../read/router.js';
@@ -81,10 +82,12 @@ export function revertConfirmMessage(
  * "survives" — re-listing 100+ lines the user just saw in the report is noise.
  * Show up to `cap` entries, then a one-line fold. Pure + exported for tests.
  */
-export function formatSurvivingDrift(remaining: Finding[], cap = 10): string[] {
+export function formatSurvivingDrift(remaining: Finding[], stackName = '', cap = 10): string[] {
+  const idOf = (f: Finding): string =>
+    f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId;
   const lines = remaining
     .slice(0, cap)
-    .map((f) => `  - ${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''} (${f.tier})`);
+    .map((f) => `  - ${idOf(f)}${f.path ? `.${f.path}` : ''} (${f.tier})`);
   if (remaining.length > cap)
     lines.push(`  ... and ${remaining.length - cap} more — run \`cdkrd check\` for the full list`);
   return lines;
@@ -438,13 +441,17 @@ const ignoreFindingKey = (f: Finding): string => `${f.logicalId}::${f.path}`;
  * exported so the "starts unselected" invariant is unit-tested without a TTY.
  */
 export function ignoreSelectOptions(
-  ignorable: Finding[]
+  ignorable: Finding[],
+  stackName = ''
 ): { value: string; label: string; selected: boolean }[] {
-  return ignorable.map((f) => ({
-    value: ignoreFindingKey(f),
-    label: `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''} (${f.tier})`,
-    selected: false,
-  }));
+  return ignorable.map((f) => {
+    const id = f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId;
+    return {
+      value: ignoreFindingKey(f),
+      label: `${id}${f.path ? `.${f.path}` : ''} (${f.tier})`,
+      selected: false,
+    };
+  });
 }
 
 /**
@@ -479,7 +486,7 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
     }
     const picked = await bulkMultiselect(
       ignoreSelectMessage(stackName),
-      ignoreSelectOptions(ignorable)
+      ignoreSelectOptions(ignorable, stackName)
     );
     if (picked === undefined) {
       console.error(`note: ${stackName}: ignore cancelled — config unchanged`);
@@ -755,6 +762,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     removeUnrecorded: includeRemovals,
     schemas: gathered.schemas,
     siblingSgRules: buildSiblingSgRules(gathered.desired),
+    stackName,
   });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {
@@ -1023,7 +1031,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // Say WHICH drift survived — without this the user must re-run `check` just to
   // learn what didn't converge (R46). A terse id-per-line pointer, not a report;
   // capped so a no-baseline partial revert doesn't re-list 100+ lines (R52).
-  for (const line of formatSurvivingDrift(remainingDrift)) console.log(line);
+  for (const line of formatSurvivingDrift(remainingDrift, stackName)) console.log(line);
   // remaining drift OR an unverifiable re-read both mean "not confirmed clean" → exit 1
   // (a failed delete already set 2). Never return 0 ("converged") when we could not check.
   if (remaining > 0 || unverified > 0) worst = Math.max(worst, 1);

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -10,6 +10,7 @@
 // Not revertable: readGap / unresolved / skipped, and (v1) the SDK-override
 // CC-gap types (revert for those is a follow-up).
 import type { BaselineFile } from '../baseline/baseline-file.js';
+import { withinStackPath } from '../construct-path.js';
 import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import {
   awsManagedTags,
@@ -212,6 +213,10 @@ export interface RevertOptions {
   // resourceType -> schema, so create-only property drift is reported as
   // notRevertable up front (an in-place patch would fail at apply time).
   schemas?: Map<string, SchemaInfo>;
+  // The stack name — used to strip the stack/Stage prefix off each finding's construct path
+  // for display (`withinStackPath`), matching what `cdkrd check` shows. Absent (unit calls) =
+  // no strip, the full construct path.
+  stackName?: string;
   // Rules declared by sibling standalone SecurityGroupIngress/Egress resources, keyed by the
   // SG's physical id. Reverting an AWS::EC2::SecurityGroup's SecurityGroupIngress/Egress is a
   // whole-array Cloud Control replacement; the live SG REFLECTS these sibling-declared rules,
@@ -274,7 +279,11 @@ export function buildRevertPlan(
   const recorded = baseline?.recorded ?? [];
 
   for (const f of findings) {
-    const displayId = f.constructPath ?? f.logicalId;
+    // Show the construct path WITHIN the stack (stack/Stage prefix stripped), the same as the
+    // check report — the revert banner already names the stack. Full path when unstripped.
+    const displayId = f.constructPath
+      ? withinStackPath(f.constructPath, opts.stackName ?? '')
+      : f.logicalId;
     if (f.tier === 'deleted') {
       // a resource deleted out of band cannot be patched back — it must be
       // recreated by re-deploying the stack.

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -64,6 +64,26 @@ const baseline = (recorded: BaselineFile['recorded']): BaselineFile => ({
 });
 
 describe('buildRevertPlan', () => {
+  it('displayId shows the construct path WITHIN the stack when opts.stackName is given', () => {
+    const f = F({
+      tier: 'declared',
+      logicalId: 'PG9AB',
+      constructPath: 'dev-main/AuroraDB/Database/ParameterGroup',
+      resourceType: 'AWS::RDS::DBClusterParameterGroup',
+      path: 'Parameters.autocommit',
+      desired: '0',
+      actual: '1',
+    });
+    // a CDK Stage: aws:cdk:path is `dev-main/AuroraDB/...`, the CFn name is `dev-main-AuroraDB`
+    expect(
+      buildRevertPlan([f], undefined, { stackName: 'dev-main-AuroraDB' }).items[0]!.displayId
+    ).toBe('Database/ParameterGroup');
+    // no stackName (unit default): the full construct path is kept
+    expect(buildRevertPlan([f], undefined).items[0]!.displayId).toBe(
+      'dev-main/AuroraDB/Database/ParameterGroup'
+    );
+  });
+
   it('declared drift -> add op with the deployed-template (desired) value', () => {
     const plan = buildRevertPlan(
       [F({ tier: 'declared', desired: 'Enabled', actual: 'Suspended' })],

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -26,6 +26,7 @@ import {
   filterRevertPlan,
   formatPlan,
   formatSurvivingDrift,
+  ignoreSelectOptions,
   includeUnrecordedRemovals,
   resolveInteractiveRevertExit,
   revertConfirmMessage,
@@ -1036,6 +1037,53 @@ describe('formatSurvivingDrift (R52 — cap the post-revert survivor list)', () 
       },
     ]);
     expect(lines[0]).toBe('  - Stack/Bucket (deleted)');
+  });
+
+  it('strips the stack/Stage prefix off the construct path when given the stack name', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'PG',
+      constructPath: 'dev-main/AuroraDB/Database/ParameterGroup',
+      resourceType: 'AWS::RDS::DBClusterParameterGroup',
+      path: 'Parameters.autocommit',
+    };
+    expect(formatSurvivingDrift([f], 'dev-main-AuroraDB')[0]).toBe(
+      '  - Database/ParameterGroup.Parameters.autocommit (undeclared)'
+    );
+    // no stackName -> full path (unchanged)
+    expect(formatSurvivingDrift([f])[0]).toBe(
+      '  - dev-main/AuroraDB/Database/ParameterGroup.Parameters.autocommit (undeclared)'
+    );
+  });
+});
+
+describe('ignoreSelectOptions', () => {
+  const uf = (over: Partial<Finding>): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'R',
+    resourceType: 'AWS::X::Y',
+    path: 'P',
+    ...over,
+  });
+
+  it('starts every row UNSELECTED (a required decision, R137)', () => {
+    expect(ignoreSelectOptions([uf({}), uf({ logicalId: 'S' })]).every((o) => !o.selected)).toBe(
+      true
+    );
+  });
+
+  it('labels with the construct path WITHIN the stack when given the stack name', () => {
+    const f = uf({
+      constructPath: 'dev-main/AuroraDB/Database/ParameterGroup',
+      path: 'Parameters.autocommit',
+    });
+    expect(ignoreSelectOptions([f], 'dev-main-AuroraDB')[0]!.label).toBe(
+      'Database/ParameterGroup.Parameters.autocommit (undeclared)'
+    );
+    // no stackName -> full construct path
+    expect(ignoreSelectOptions([f])[0]!.label).toBe(
+      'dev-main/AuroraDB/Database/ParameterGroup.Parameters.autocommit (undeclared)'
+    );
   });
 });
 


### PR DESCRIPTION
## What

Follow-up to #573. That PR stripped the stack/Stage prefix off the construct path in the **`cdkrd check`** report. This applies the same strip to **every remaining surface** that prints a finding's construct path, so `cdkrd revert` and the interactive picker match what `check` shows:

```
# revert, before
  ApiStack/ApiRole (AWS::IAM::Role)
    - Policies -> remove (undeclared, not in baseline)
  reverted: ApiStack/ApiRole
# after
  ApiRole (AWS::IAM::Role)
    - Policies -> remove (undeclared, not in baseline)
  reverted: ApiRole
```

## How

- `buildRevertPlan` takes `opts.stackName` and strips each item's `displayId` via `withinStackPath`. **Everything downstream reads `item.displayId`** — `formatPlan`, `revertSelectOptions`, the retry lines, the `reverted:` / `FAILED:` lines — so they all strip automatically (one change covers the whole revert output).
- `formatSurvivingDrift` and `ignoreSelectOptions` take the stack name and strip the raw findings they format directly.
- The `.`/`/` grammar is unchanged — `/` for the construct path, `.` for the property path, no new separator (consistent with #573 and the `ignore.yaml` token).

Absent `stackName` (all direct unit calls) keeps the full construct path, so existing tests are untouched.

## Tests

- `buildRevertPlan` displayId strip (CDK Stage + no-strip cases).
- `formatSurvivingDrift` strip.
- `ignoreSelectOptions` strip **+ the starts-unselected invariant** (this function had no tests at all before).
- Full suite: 2786 passing.

README revert sample updated. With this, `check` and `revert` show finding ids identically — the last piece before re-recording the demo GIF once.
