### PR TITLE
test(integ): live fixtures + golden corpus for Lex structural revert (#564) and Athena descend (#565)

### DIFF
--- a/tests/corpus/AWS__Athena__WorkGroup.WgDescend.json
+++ b/tests/corpus/AWS__Athena__WorkGroup.WgDescend.json
@@ -1,0 +1,127 @@
+{
+  "corpusVersion": 1,
+  "description": "#565: a workgroup declaring NO WorkGroupConfiguration with ONE non-default sub-key set out of band (BytesScannedCutoffPerQuery) DESCENDS leaf-by-leaf — only that sub-key surfaces undeclared while the constant defaults fold atDefault (DESCEND_UNDECLARED_OBJECT_PATHS), instead of the whole object surfacing.",
+  "resource": {
+    "logicalId": "WgDescend",
+    "resourceType": "AWS::Athena::WorkGroup",
+    "physicalId": "cdkrd-integ-athena-descend",
+    "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend",
+    "declared": {
+      "Description": "cdkrd athena-descend fixture",
+      "Name": "cdkrd-integ-athena-descend",
+      "RecursiveDeleteOption": true,
+      "State": "ENABLED"
+    }
+  },
+  "liveRaw": {
+    "WorkGroupConfiguration": {
+      "EnforceWorkGroupConfiguration": true,
+      "EngineVersion": {
+        "SelectedEngineVersion": "AUTO",
+        "EffectiveEngineVersion": "Athena engine version 3"
+      },
+      "PublishCloudWatchMetricsEnabled": true,
+      "BytesScannedCutoffPerQuery": 10000000,
+      "RequesterPaysEnabled": false
+    },
+    "Description": "cdkrd athena-descend fixture",
+    "State": "ENABLED",
+    "CreationTime": "1783103433",
+    "Tags": [],
+    "Name": "cdkrd-integ-athena-descend"
+  },
+  "schema": {
+    "readOnly": ["CreationTime"],
+    "writeOnly": ["RecursiveDeleteOption", "WorkGroupConfigurationUpdates"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": [
+      "CreationTime",
+      "WorkGroupConfiguration.EngineVersion.EffectiveEngineVersion",
+      "WorkGroupConfigurationUpdates.EngineVersion.EffectiveEngineVersion"
+    ],
+    "writeOnlyPaths": [
+      "RecursiveDeleteOption",
+      "WorkGroupConfiguration.AdditionalConfiguration",
+      "WorkGroupConfiguration.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfiguration.EngineConfiguration.CoordinatorDpuSize",
+      "WorkGroupConfiguration.EngineConfiguration.DefaultExecutorDpuSize",
+      "WorkGroupConfiguration.EngineConfiguration.MaxConcurrentDpus",
+      "WorkGroupConfiguration.EngineConfiguration.SparkProperties",
+      "WorkGroupConfigurationUpdates"
+    ],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": [
+      "WorkGroupConfiguration.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfiguration.EngineConfiguration.Classifications.*.Properties",
+      "WorkGroupConfiguration.EngineConfiguration.SparkProperties",
+      "WorkGroupConfiguration.MonitoringConfiguration.CloudWatchLoggingConfiguration.LogTypes",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.AdditionalConfigs",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.Classifications.*.Properties",
+      "WorkGroupConfigurationUpdates.EngineConfiguration.SparkProperties",
+      "WorkGroupConfigurationUpdates.MonitoringConfiguration.CloudWatchLoggingConfiguration.LogTypes"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "WgDescend",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "RecursiveDeleteOption",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-integ-athena-descend",
+      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WgDescend",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration.EnforceWorkGroupConfiguration",
+      "actual": true,
+      "nested": true,
+      "physicalId": "cdkrd-integ-athena-descend",
+      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WgDescend",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration.EngineVersion",
+      "actual": {
+        "SelectedEngineVersion": "AUTO"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-integ-athena-descend",
+      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "WgDescend",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration.PublishCloudWatchMetricsEnabled",
+      "actual": true,
+      "nested": true,
+      "physicalId": "cdkrd-integ-athena-descend",
+      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "WgDescend",
+      "resourceType": "AWS::Athena::WorkGroup",
+      "path": "WorkGroupConfiguration.BytesScannedCutoffPerQuery",
+      "actual": 10000000,
+      "nested": true,
+      "physicalId": "cdkrd-integ-athena-descend",
+      "constructPath": "CdkRealDriftIntegAthenaDescend/WgDescend"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Lex__Bot.Bot.json
+++ b/tests/corpus/AWS__Lex__Bot.Bot.json
@@ -1,0 +1,205 @@
+{
+  "corpusVersion": 1,
+  "description": "#527/#564: a Lex V2 bot whose writeOnly BotLocales (two user intents + a custom slot type + the built-in FallbackIntent) is fully reconstructed by the lexv2-models tree walk must classify CLEAN against the declared template — a reader regression guard (id->name resolution, resolutionStrategy enum translation, FallbackIntent).",
+  "resource": {
+    "logicalId": "Bot",
+    "resourceType": "AWS::Lex::Bot",
+    "physicalId": "YVVVR3Y3FN",
+    "constructPath": "CdkRealDriftIntegLexStructural/Bot",
+    "declared": {
+      "AutoBuildBotLocales": true,
+      "BotLocales": [
+        {
+          "Intents": [
+            {
+              "Name": "OrderFlowers",
+              "SampleUtterances": [
+                {
+                  "Utterance": "I want to order flowers"
+                },
+                {
+                  "Utterance": "Order some flowers"
+                }
+              ]
+            },
+            {
+              "Name": "Greeting",
+              "SampleUtterances": [
+                {
+                  "Utterance": "hello"
+                },
+                {
+                  "Utterance": "hi there"
+                }
+              ]
+            },
+            {
+              "Name": "FallbackIntent",
+              "ParentIntentSignature": "AMAZON.FallbackIntent"
+            }
+          ],
+          "LocaleId": "en_US",
+          "NluConfidenceThreshold": 0.4,
+          "SlotTypes": [
+            {
+              "Name": "FlowerType",
+              "SlotTypeValues": [
+                {
+                  "SampleValue": {
+                    "Value": "roses"
+                  }
+                },
+                {
+                  "SampleValue": {
+                    "Value": "lilies"
+                  }
+                }
+              ],
+              "ValueSelectionSetting": {
+                "ResolutionStrategy": "ORIGINAL_VALUE"
+              }
+            }
+          ]
+        }
+      ],
+      "DataPrivacy": {
+        "ChildDirected": false
+      },
+      "IdleSessionTTLInSeconds": 300,
+      "Name": "cdkrd-integ-lex-structural",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLexStructural-BotRoleC29E333A-B9ebChScC5me"
+    }
+  },
+  "liveRaw": {
+    "ErrorLogSettings": {
+      "Enabled": false
+    },
+    "IdleSessionTTLInSeconds": 300,
+    "Id": "YVVVR3Y3FN",
+    "Arn": "arn:aws:lex:us-east-1:111111111111:bot/YVVVR3Y3FN",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegLexStructural-BotRoleC29E333A-B9ebChScC5me",
+    "Name": "cdkrd-integ-lex-structural",
+    "DataPrivacy": {
+      "ChildDirected": false
+    },
+    "BotTags": [
+      {
+        "Value": "Bot",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegLexStructural/473baf10-770d-11f1-8c6b-0e32f81bf1ef",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegLexStructural",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "BotLocales": [
+      {
+        "LocaleId": "en_US",
+        "NluConfidenceThreshold": 0.4,
+        "SlotTypes": [
+          {
+            "Name": "FlowerType",
+            "SlotTypeValues": [
+              {
+                "SampleValue": {
+                  "Value": "roses"
+                }
+              },
+              {
+                "SampleValue": {
+                  "Value": "lilies"
+                }
+              }
+            ],
+            "ValueSelectionSetting": {
+              "ResolutionStrategy": "ORIGINAL_VALUE"
+            }
+          }
+        ],
+        "Intents": [
+          {
+            "Name": "Greeting",
+            "SampleUtterances": [
+              {
+                "Utterance": "hello"
+              },
+              {
+                "Utterance": "hi there"
+              }
+            ]
+          },
+          {
+            "Name": "OrderFlowers",
+            "SampleUtterances": [
+              {
+                "Utterance": "I want to order flowers"
+              },
+              {
+                "Utterance": "Order some flowers"
+              }
+            ]
+          },
+          {
+            "Name": "FallbackIntent",
+            "ParentIntentSignature": "AMAZON.FallbackIntent"
+          }
+        ]
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [
+      "AutoBuildBotLocales",
+      "BotFileS3Location",
+      "Replication",
+      "TestBotAliasSettings",
+      "TestBotAliasTags"
+    ],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [
+      "AutoBuildBotLocales",
+      "BotFileS3Location",
+      "Replication",
+      "TestBotAliasSettings",
+      "TestBotAliasTags"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["Replication.ReplicaRegions"],
+    "unorderedObjectArrayPaths": [
+      "BotLocales",
+      "TestBotAliasSettings.BotAliasLocaleSettings",
+      "TestBotAliasSettings.ConversationLogSettings.AudioLogSettings",
+      "TestBotAliasSettings.ConversationLogSettings.TextLogSettings"
+    ],
+    "freeFormMapPaths": [
+      "BotLocales.*.Intents.*.IntentConfirmationSetting.PromptSpecification.PromptAttemptsSpecification",
+      "BotLocales.*.Intents.*.Slots.*.SubSlotSetting.SlotSpecifications",
+      "BotLocales.*.Intents.*.Slots.*.ValueElicitationSetting.PromptSpecification.PromptAttemptsSpecification"
+    ]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Bot",
+      "resourceType": "AWS::Lex::Bot",
+      "path": "AutoBuildBotLocales",
+      "note": "write-only — cannot be read back",
+      "physicalId": "YVVVR3Y3FN",
+      "constructPath": "CdkRealDriftIntegLexStructural/Bot"
+    }
+  ]
+}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -86,6 +86,19 @@ These do NOT run in CI (they need credentials and mutate a real account):
   Distribution and asserts its schema-annotated nested defaults
   (`CustomOriginConfig.HTTPSPort`/`OriginReadTimeout`, `PriceClass`, …) fold as
   `atDefault` rather than `undeclared` (R103). CloudFront deploy/destroy are slow.
+- **After changing** the fully-undeclared-object descend
+  (`DESCEND_UNDECLARED_OBJECT_PATHS` in `src/normalize/noise.ts`, the descend branch
+  in `src/diff/classify.ts`): run `athena-descend` — it deploys a workgroup declaring
+  NO `WorkGroupConfiguration` (whole default folds `atDefault`), then sets ONE
+  non-default sub-key out of band and asserts cdkrd surfaces ONLY the descended
+  `WorkGroupConfiguration.BytesScannedCutoffPerQuery` (not the whole object), the
+  constants still folding (#565).
+- **After changing** the Lex BotLocales writer (`writeLexBotLocales` in
+  `src/revert/writers.ts`): run `lex-structural` — it deploys a Lex V2 bot (two user
+  intents + a custom slot type + the built-in FallbackIntent), then DELETES a whole
+  intent out of band and asserts `revert` RECREATES it (`CreateIntent`), and ADDS a
+  whole intent out of band and asserts `revert` DELETES it (`DeleteIntent`), never
+  touching the auto-managed FallbackIntent (#553 update + #564 structural).
 - Scripts that share a fixture/stack (`basic`'s four) must run sequentially,
   never concurrently.
 - **After changing exit-code or baseline semantics** (report-only/--fail, the

--- a/tests/integration/athena-descend/app.ts
+++ b/tests/integration/athena-descend/app.ts
@@ -1,0 +1,22 @@
+// Integration fixture for #565: descend a FULLY-undeclared Athena WorkGroupConfiguration
+// leaf-by-leaf. The workgroup declares NO WorkGroupConfiguration, so a clean deploy reads back
+// AWS's whole default config and folds it WHOLE (atDefault). The verify script then sets ONE
+// non-default sub-key out of band; the whole-object fold now misses, and cdkrd DESCENDS so only
+// that sub-key surfaces (WorkGroupConfiguration.BytesScannedCutoffPerQuery) while the constant
+// defaults still fold — instead of surfacing the whole object. Also the corpus-harvest source
+// for the descend case (AWS__Athena__WorkGroup.WgDescend.json).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnWorkGroup } from "aws-cdk-lib/aws-athena";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAthenaDescend");
+
+new CfnWorkGroup(stack, "WgDescend", {
+  name: "cdkrd-integ-athena-descend",
+  description: "cdkrd athena-descend fixture",
+  recursiveDeleteOption: true,
+  state: "ENABLED",
+  // deliberately NO workGroupConfiguration — it reads back AWS's whole default.
+});
+
+app.synth();

--- a/tests/integration/athena-descend/cdk.json
+++ b/tests/integration/athena-descend/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/athena-descend/verify.sh
+++ b/tests/integration/athena-descend/verify.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Integration test #565 (real AWS): an out-of-band non-default sub-key on an undeclared
+# WorkGroupConfiguration DESCENDS to a single nested finding instead of surfacing the whole
+# object; the constant defaults still fold.
+#   deploy -> record baseline -> check CLEAN (whole default folds atDefault)
+#   -> inject one non-default sub-key -> check DETECTS only the descended sub-key -> destroy.
+# Run with CDKRD_CORPUS_DIR=<dir> to record the golden-corpus case for the descend.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkRealDriftIntegAthenaDescend
+WG=cdkrd-integ-athena-descend
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+# Harvest only at the descend point (not on the clean check); unset so the CLEAN check doesn't record.
+CORPUS_DIR="${CDKRD_CORPUS_DIR:-}"; unset CDKRD_CORPUS_DIR
+
+cleanup() {
+  echo "--- cleanup ---"
+  aws athena delete-work-group --work-group "$WG" --recursive-delete-option --region "$REGION" >/dev/null 2>&1 || true
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+echo "=== record baseline ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check CLEAN (whole default WorkGroupConfiguration folds atDefault) ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after record"
+
+echo "=== inject ONE non-default sub-key out of band (BytesScannedCutoffPerQuery) ==="
+aws athena update-work-group --work-group "$WG" --region "$REGION" \
+  --configuration-updates 'BytesScannedCutoffPerQuery=10000000' || fail "update-work-group"
+sleep 5
+
+echo "=== check DETECTS the descended sub-key ONLY ==="
+$CLI check "$STACK" --region "$REGION" --json > /tmp/cdkrd-athena-descend.json || true
+$CLI check "$STACK" --region "$REGION" --show-all || true
+
+if [ -n "$CORPUS_DIR" ]; then
+  echo "=== harvest corpus (descended WorkGroupConfiguration) ==="
+  CDKRD_CORPUS_DIR="$CORPUS_DIR" $CLI check "$STACK" --region "$REGION" >/dev/null || true
+fi
+
+node -e '
+const j=require("/tmp/cdkrd-athena-descend.json");
+const wg=(j.findings||[]).filter(f=>f.resourceType==="AWS::Athena::WorkGroup");
+const drift=wg.filter(f=>f.tier==="undeclared"||f.tier==="declared").map(f=>f.path);
+console.error("WorkGroup findings:",JSON.stringify(wg.map(f=>({tier:f.tier,path:f.path}))));
+if(!wg.some(f=>f.path==="WorkGroupConfiguration.BytesScannedCutoffPerQuery"&&(f.tier==="undeclared"||f.tier==="declared")))
+  { console.error("FAIL: descended sub-key not found as drift"); process.exit(1); }
+if(drift.includes("WorkGroupConfiguration"))
+  { console.error("FAIL: whole WorkGroupConfiguration surfaced (not descended)"); process.exit(1); }
+console.error("OK: only the descended BytesScannedCutoffPerQuery sub-key surfaced as drift");
+' || fail "descend assertion (see /tmp/cdkrd-athena-descend.json)"
+
+echo "INTEG PASS: athena-descend (#565)"

--- a/tests/integration/lex-structural/app.ts
+++ b/tests/integration/lex-structural/app.ts
@@ -1,0 +1,69 @@
+// Integration fixture for #564: Lex Bot BotLocales STRUCTURAL revert (create/delete whole
+// intents). A bot with two user intents (OrderFlowers, Greeting) + a custom slot type + the
+// built-in FallbackIntent. The verify script deletes a whole intent out of band (revert must
+// RECREATE it) and adds a whole intent out of band (revert must DELETE it), never touching
+// FallbackIntent. Also the corpus-harvest source for a fully-reconstructed BotLocales
+// (AWS__Lex__Bot.Bot.json) — a clean-deploy #527 reader regression guard.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnBot } from "aws-cdk-lib/aws-lex";
+import { Role, ServicePrincipal, PolicyStatement, Effect } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLexStructural");
+
+const role = new Role(stack, "BotRole", {
+  assumedBy: new ServicePrincipal("lexv2.amazonaws.com"),
+});
+role.addToPolicy(
+  new PolicyStatement({
+    effect: Effect.ALLOW,
+    actions: ["polly:SynthesizeSpeech", "comprehend:DetectSentiment"],
+    resources: ["*"],
+  }),
+);
+
+new CfnBot(stack, "Bot", {
+  name: "cdkrd-integ-lex-structural",
+  roleArn: role.roleArn,
+  // NOTE: CDK L1 does NOT PascalCase this nested prop; CloudFormation requires the raw
+  // `ChildDirected` key (`childDirected` fails early validation). strip-types drops the type
+  // annotation at runtime, so the raw-cased object passes through to the template.
+  dataPrivacy: { ChildDirected: false } as unknown as CfnBot.DataPrivacyProperty,
+  idleSessionTtlInSeconds: 300,
+  autoBuildBotLocales: true,
+  botLocales: [
+    {
+      localeId: "en_US",
+      nluConfidenceThreshold: 0.4,
+      slotTypes: [
+        {
+          name: "FlowerType",
+          valueSelectionSetting: { resolutionStrategy: "ORIGINAL_VALUE" },
+          slotTypeValues: [
+            { sampleValue: { value: "roses" } },
+            { sampleValue: { value: "lilies" } },
+          ],
+        },
+      ],
+      intents: [
+        {
+          name: "OrderFlowers",
+          sampleUtterances: [
+            { utterance: "I want to order flowers" },
+            { utterance: "Order some flowers" },
+          ],
+        },
+        {
+          name: "Greeting",
+          sampleUtterances: [{ utterance: "hello" }, { utterance: "hi there" }],
+        },
+        {
+          name: "FallbackIntent",
+          parentIntentSignature: "AMAZON.FallbackIntent",
+        },
+      ],
+    },
+  ],
+});
+
+app.synth();

--- a/tests/integration/lex-structural/cdk.json
+++ b/tests/integration/lex-structural/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/lex-structural/verify.sh
+++ b/tests/integration/lex-structural/verify.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Integration test #564 (real AWS, AWS-mutating): Lex Bot BotLocales STRUCTURAL revert.
+#   deploy -> record baseline -> check CLEAN (harvest corpus here)
+#   TEST A: delete a whole intent (Greeting) out of band -> check DETECTS -> revert RECREATES it
+#   TEST B: add a whole intent (Rogue) out of band     -> check DETECTS -> revert DELETES it
+#   throughout, the built-in FallbackIntent is never created or deleted. -> destroy.
+# Run with CDKRD_CORPUS_DIR=<dir> to record the golden-corpus case for the CLEAN reconstructed
+# BotLocales (AWS__Lex__Bot.Bot.json — a #527 reader regression guard).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE" || exit 1
+STACK=CdkRealDriftIntegLexStructural
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+LOC=en_US
+# Harvest only at the clean point (not on every check); unset so drift checks don't record.
+CORPUS_DIR="${CDKRD_CORPUS_DIR:-}"; unset CDKRD_CORPUS_DIR
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+lex() { aws lexv2-models "$@" --region "$REGION"; }
+intent_id() { lex list-intents --bot-id "$BOT" --bot-version DRAFT --locale-id "$LOC" \
+  --query "intentSummaries[?intentName=='$1'].intentId | [0]" --output text; }
+wait_built() {
+  for _ in $(seq 1 90); do
+    S=$(lex describe-bot-locale --bot-id "$BOT" --bot-version DRAFT --locale-id "$LOC" \
+      --query botLocaleStatus --output text 2>/dev/null || echo "?")
+    case "$S" in
+      Built|NotBuilt) return 0 ;;
+      Failed) echo "locale build FAILED"; return 1 ;;
+    esac
+    sleep 5
+  done
+  echo "timed out waiting for locale build"; return 1
+}
+build_locale() { lex build-bot-locale --bot-id "$BOT" --bot-version DRAFT --locale-id "$LOC" >/dev/null || return 1; sleep 3; wait_built; }
+
+echo "=== build ==="; (cd "$ROOT" && vp run build) || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+
+BOT="$(aws cloudformation describe-stack-resources --stack-name "$STACK" --region "$REGION" \
+  --query "StackResources[?ResourceType=='AWS::Lex::Bot'].PhysicalResourceId" --output text)"
+[ -n "$BOT" ] || fail "no bot id"
+echo "bot id = $BOT"
+wait_built || fail "initial locale not built"
+
+echo "=== record baseline ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check CLEAN (fresh deploy) ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || { $CLI check "$STACK" --region "$REGION" --show-all; fail "expected CLEAN after record"; }
+
+if [ -n "$CORPUS_DIR" ]; then
+  echo "=== harvest corpus (clean reconstructed BotLocales) ==="
+  CDKRD_CORPUS_DIR="$CORPUS_DIR" $CLI check "$STACK" --region "$REGION" >/dev/null || true
+fi
+
+# ---------------- TEST A: out-of-band DELETE of a whole intent -> revert RECREATES ----------------
+echo "=== TEST A: delete Greeting intent out of band ==="
+GID="$(intent_id Greeting)"; [ -n "$GID" ] && [ "$GID" != "None" ] || fail "Greeting intent id not found"
+lex delete-intent --bot-id "$BOT" --bot-version DRAFT --locale-id "$LOC" --intent-id "$GID" >/dev/null || fail "delete-intent"
+build_locale || fail "build after delete"
+
+echo "=== check DETECTS the missing intent ==="
+$CLI check "$STACK" --region "$REGION" --show-all | tee /tmp/cdkrd-lex-A-pre.txt
+grep -qi "Greeting\|BotLocales" /tmp/cdkrd-lex-A-pre.txt || fail "missing-intent drift not reported"
+
+echo "=== revert --yes (must CreateIntent Greeting) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert A returned non-zero"
+wait_built || fail "locale not built after revert A"
+RGID="$(intent_id Greeting)"; [ -n "$RGID" ] && [ "$RGID" != "None" ] || fail "Greeting NOT recreated by revert"
+echo "Greeting recreated with id $RGID"
+
+echo "=== check CLEAN after revert A ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || { $CLI check "$STACK" --region "$REGION" --show-all; fail "drift remains after revert A"; }
+
+# ---------------- TEST B: out-of-band ADD of a whole intent -> revert DELETES ----------------
+echo "=== TEST B: add Rogue intent out of band ==="
+lex create-intent --bot-id "$BOT" --bot-version DRAFT --locale-id "$LOC" \
+  --intent-name Rogue --sample-utterances '[{"utterance":"rogue one"},{"utterance":"rogue two"}]' >/dev/null || fail "create-intent Rogue"
+build_locale || fail "build after add"
+
+echo "=== check DETECTS the extra intent ==="
+$CLI check "$STACK" --region "$REGION" --show-all | tee /tmp/cdkrd-lex-B-pre.txt
+grep -qi "Rogue\|BotLocales" /tmp/cdkrd-lex-B-pre.txt || fail "extra-intent drift not reported"
+
+echo "=== revert --yes (must DeleteIntent Rogue) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert B returned non-zero"
+wait_built || fail "locale not built after revert B"
+BGID="$(intent_id Rogue)"
+[ -z "$BGID" ] || [ "$BGID" = "None" ] || fail "Rogue NOT deleted by revert (id=$BGID)"
+echo "Rogue deleted"
+
+echo "=== FallbackIntent survived both reverts ==="
+FID="$(intent_id FallbackIntent)"; [ -n "$FID" ] && [ "$FID" != "None" ] || fail "FallbackIntent was destroyed"
+echo "FallbackIntent intact (id $FID)"
+
+echo "=== check CLEAN after revert B ==="
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || { $CLI check "$STACK" --region "$REGION" --show-all; fail "drift remains after revert B"; }
+
+echo "INTEG PASS: lex-structural (#564)"


### PR DESCRIPTION
Follow-up to #570 (#564) / #567 (#565): promote the two real-AWS live-tests used to verify those PRs into **permanent integration fixtures**, and harvest their **golden-corpus** cases.

## Fixtures (real AWS, self-cleaning)

- **`tests/integration/lex-structural/`** (#564) — deploys a Lex V2 bot (two user intents `OrderFlowers`/`Greeting` + a custom slot type + the built-in `FallbackIntent`). Deletes a whole intent out of band → asserts `revert` **recreates** it (`CreateIntent`); adds a whole intent out of band → asserts `revert` **deletes** it (`DeleteIntent`); `FallbackIntent` is never created or deleted. Each step ends CLEAN.
- **`tests/integration/athena-descend/`** (#565) — deploys a workgroup declaring **no** `WorkGroupConfiguration` (whole default folds `atDefault`), sets one non-default sub-key out of band, and asserts cdkrd surfaces **only** the descended `WorkGroupConfiguration.BytesScannedCutoffPerQuery` (not the whole object), the constants still folding.

## Golden corpus (offline replay guards)

- **`AWS__Lex__Bot.Bot.json`** — a fully reconstructed `BotLocales` (id→name resolution, `resolutionStrategy` enum translation, `FallbackIntent`) classifies CLEAN against the declared template. A #527 reader regression guard.
- **`AWS__Athena__WorkGroup.WgDescend.json`** — locks in the #565 descend (constants `atDefault` + only `BytesScannedCutoffPerQuery` `undeclared`).

Both fixtures run with `CDKRD_CORPUS_DIR=<dir>` to record the corpus (per README "Recording golden-corpus cases"); account ids auto-sanitized.

## Verification

Both fixtures were run against real AWS this session — **INTEG PASS**, torn down clean, `sweep-orphans.sh` reports SWEEP CLEAN. Both corpus cases replay green in `corpus-replay.test.ts`. Full unit suite 2790 passing; typecheck / lint+format / build green.

README "When to run" entries added for both. **Tests-only change** (no `src/**`).
