### PR TITLE
feat(report): drop the redundant cdkrd from the section banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ explainable, so the same change shows up:
 
 ```console
 $ npx cdkrd check
-=== cdkrd check: ApiStack (us-east-1) ===
+=== check: ApiStack (us-east-1) ===
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
   ApiRole.Policies (AWS::IAM::Role) — appeared since record
       actual =[{"PolicyName":"manual-debug-access", ...}]
@@ -62,7 +62,7 @@ turns up.
 The first time you run `check` on a stack, before recording anything:
 
 ```console
-=== cdkrd check: ApiStack (us-east-1) ===
+=== check: ApiStack (us-east-1) ===
 No baseline yet — live-only values can't be confirmed as drift, but declared drift and out-of-band deletes always can.
 
 [CFn-Declared Drift: 1] (declared in your CloudFormation template — the live value differs)
@@ -113,7 +113,7 @@ surfaces as **`[CFn-Undeclared Drift]`**: confirmed drift on a value that isn't 
 your CloudFormation template, the kind `cdk drift` can't see:
 
 ```console
-=== cdkrd check: ApiStack (us-east-1) ===
+=== check: ApiStack (us-east-1) ===
 [CFn-Undeclared Drift: 1] (live-only (not in your CloudFormation template), changed from your .cdkrd baseline — the differentiator)
   Role.Policies (AWS::IAM::Role) — changed since record
       actual =[{"PolicyName":"adhoc", ...}, {"PolicyName":"manual-debug-access", ...}]
@@ -156,7 +156,7 @@ prompt). Baselines stay a reviewed, git-committed artifact either way; CI never
 writes one. It re-reads each touched resource afterward to verify it converged:
 
 ```console
-=== cdkrd revert: ApiStack (us-east-1) ===
+=== revert: ApiStack (us-east-1) ===
 
   ApiRole (AWS::IAM::Role)
     - Policies -> remove (undeclared, not in baseline)
@@ -370,7 +370,7 @@ reverts it:
 ```console
 $ npx cdkrd check --pre-deploy
 (--pre-deploy) comparing live state against the LOCAL synth template
-=== cdkrd check: ApiStack (us-east-1) ===
+=== check: ApiStack (us-east-1) ===
 [CFn-Declared Drift: 1]
   Api/Handler.MemorySize (AWS::Lambda::Function)
       desired=1024
@@ -445,7 +445,7 @@ Two parts: the **drift sections** in full detail, then a one-line `info:` footer
 that folds everything informational.
 
 ```console
-=== cdkrd check: ApiStack (us-east-1) ===
+=== check: ApiStack (us-east-1) ===
 [CFn-Declared Drift: 1]
   UploadBucket.VersioningConfiguration.Status (AWS::S3::Bucket)
       desired="Enabled"

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -535,7 +535,7 @@ export function formatPlan(
   plan: RevertPlan,
   opts: PlanDisplayOptions = {}
 ): string[] {
-  const lines: string[] = [`\n=== cdkrd revert: ${stackName} (${region}) ===`];
+  const lines: string[] = [`\n=== revert: ${stackName} (${region}) ===`];
   if (opts.unrecordedGuidance) {
     // A fork, not a sequence (R55): recording these values endorses them (they
     // leave the report) — it is NOT a step toward reverting them.

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -326,7 +326,7 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
   const tierSection = (tier: Tier, leadingBlank: boolean): boolean =>
     section(byTier(tier), TIER_NAMES[tier], TIER_NOTES[tier], tierStyle(tier), leadingBlank);
 
-  log(style.header(`=== cdkrd check: ${header} ===`));
+  log(style.header(`=== check: ${header} ===`));
   // When STANDOUT live-only values have no baseline yet, say so up front: with nothing
   // to compare against, cdkrd genuinely CANNOT tell whether they are intentional or an
   // out-of-band change — that ambiguity (not "all clear") is why they are POTENTIAL

--- a/src/report/style.ts
+++ b/src/report/style.ts
@@ -10,7 +10,7 @@
 import pc from 'picocolors';
 
 export interface Style {
-  header: (s: string) => string; // === cdkrd check/revert: ... === banners
+  header: (s: string) => string; // === check/revert: ... === banners
   resultLabel: (s: string) => string; // the `result:` prefix — the conclusion anchor
   driftTier: (s: string) => string; // deleted / declared section titles
   undeclaredTier: (s: string) => string; // the differentiator tier title

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -622,7 +622,7 @@ describe('report', () => {
     it('CLEAN with one informational tier is exactly 3 lines: header/result/info, no blanks', () => {
       const { text } = run([skipped]);
       expect(text.split('\n')).toEqual([
-        '=== cdkrd check: stack (us-east-1) ===',
+        '=== check: stack (us-east-1) ===',
         'result: CLEAN',
         'info: skipped=1 — NOT checked (coverage incomplete: custom resource 1) — run with --verbose for the list',
       ]);
@@ -630,7 +630,7 @@ describe('report', () => {
 
     it('drift: first section under the header; verdict FRAMED by a rule, blank before the frame (R48)', () => {
       const lines = run([F('declared')]).text.split('\n');
-      expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
+      expect(lines[0]).toBe('=== check: stack (us-east-1) ===');
       expect(lines[1]).toMatch(/^\[CFn-Declared Drift: 1\]/); // no stray blank after the header
       const resultIdx = lines.findIndex((l) => l.startsWith('result:'));
       expect(lines[resultIdx - 1]).toMatch(/^─+$/); // top rule directly above the verdict
@@ -642,12 +642,12 @@ describe('report', () => {
 
     it('CLEAN stack is NOT framed by rules — nothing above the verdict to get lost under', () => {
       const lines = run([]).text.split('\n');
-      expect(lines).toEqual(['=== cdkrd check: stack (us-east-1) ===', 'result: CLEAN']);
+      expect(lines).toEqual(['=== check: stack (us-east-1) ===', 'result: CLEAN']);
     });
 
     it('two drift sections: blank BETWEEN them, none after the header (R48)', () => {
       const lines = run([F('declared'), F('undeclared', 'Q')]).text.split('\n');
-      expect(lines[0]).toBe('=== cdkrd check: stack (us-east-1) ===');
+      expect(lines[0]).toBe('=== check: stack (us-east-1) ===');
       expect(lines[1]).toMatch(/^\[CFn-Declared Drift: 1\]/);
       const undeclaredIdx = lines.findIndex((l) => l.startsWith('[CFn-Undeclared'));
       expect(lines[undeclaredIdx - 1]).toBe(''); // grouping blank between sections
@@ -662,10 +662,10 @@ describe('report', () => {
       separate();
       report([], 'StackB (us-east-1)', { log });
       expect(out.join('\n').split('\n')).toEqual([
-        '=== cdkrd check: StackA (ap-northeast-1) ===',
+        '=== check: StackA (ap-northeast-1) ===',
         'result: CLEAN',
         '',
-        '=== cdkrd check: StackB (us-east-1) ===',
+        '=== check: StackB (us-east-1) ===',
         'result: CLEAN',
       ]);
     });


### PR DESCRIPTION
## What

The per-stack banner was `=== cdkrd check: <stack> (<region>) ===` (and `=== cdkrd revert: ... ===`). The `cdkrd` binary name is self-evident from the invocation — noise repeated on every stack section. Drop it:

```
# before
=== cdkrd check: <etl-app-dev-stack> (ap-northeast-1) ===
# after
=== check: <etl-app-dev-stack> (ap-northeast-1) ===
```

## Why keep the verb (`check` / `revert`)?

Because a single `cdkrd check` run can emit **both** banners: `check`'s interactive prompt offers Revert/Record/Ignore inline (the primary UX), so picking Revert runs it in the same command and prints a `=== revert: <stack> ===` action right below the `=== check: <stack> ===` report. The verb is what distinguishes them (and pairs check with revert across commands). Dropping the verb too (`=== <stack> ===`) would make the check report and the revert action look identical.

## Scope

Only `check` and `revert` have `===` banners (record/ignore print status lines). No integ script greps the banner (verified). Updated the `report.test.ts` assertions, README samples, and the `style.ts` comment. Full suite: 2790 passing.
