### PR TITLE
feat(report): strip the stack prefix in the last 3 construct-path displays

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -21,6 +21,7 @@ import {
 } from '../baseline/baseline-file.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
+import { withinStackPath } from '../construct-path.js';
 import { report, stackSeparator } from '../report/report.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
@@ -111,7 +112,9 @@ export function undeclaredOnlyFindings(findings: Finding[]): Finding[] {
 export function nestedStackWarning(resources: DesiredResource[], stackName: string): string | null {
   const nested = resources.filter((r) => r.resourceType === 'AWS::CloudFormation::Stack');
   if (nested.length === 0) return null;
-  const names = nested.map((r) => r.constructPath ?? r.logicalId).sort();
+  const names = nested
+    .map((r) => (r.constructPath ? withinStackPath(r.constructPath, stackName) : r.logicalId))
+    .sort();
   return `warning: ${stackName} has ${nested.length} nested CloudFormation stack(s) — cdkrd does not recurse into them, so the resources INSIDE them are NOT checked: ${names.join(', ')}`;
 }
 
@@ -126,7 +129,9 @@ export function nestedStackWarning(resources: DesiredResource[], stackName: stri
 export function coverageWarning(findings: Finding[], stackName: string): string | null {
   const skipped = findings.filter((f) => f.tier === 'skipped');
   if (skipped.length === 0) return null;
-  const names = skipped.map((f) => f.constructPath ?? f.logicalId).sort();
+  const names = skipped
+    .map((f) => (f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId))
+    .sort();
   const shown = names.slice(0, 10);
   const more = names.length > shown.length ? `, …(+${names.length - shown.length} more)` : '';
   return `warning: ${stackName}: ${skipped.length} resource(s) were NOT checked (coverage incomplete) — ${shown.join(', ')}${more}; see the skipped breakdown (--verbose)`;

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -22,6 +22,7 @@ import {
   recordedKey,
 } from '../baseline/baseline-file.js';
 import { applyIgnores, type CdkrdConfig, loadConfig } from '../config/config-file.js';
+import { withinStackPath } from '../construct-path.js';
 import type { Desired } from '../desired/template-adapter.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import {
@@ -105,10 +106,12 @@ const tierTag = (f: Finding): string =>
 // so ELB attribute-bag rows are distinguishable in the picker — without it the bag's
 // rows render identically and the user can't tell which attribute they're deciding
 // on (mirrors report.ts's `path[attributeKey]`).
-const pickerLabel = (f: Finding): string =>
-  `${f.constructPath ?? f.logicalId}${f.path ? `.${f.path}` : ''}${
+export const pickerLabel = (f: Finding, stackName = ''): string => {
+  const id = f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId;
+  return `${id}${f.path ? `.${f.path}` : ''}${
     f.attributeKey !== undefined ? `[${f.attributeKey}]` : ''
   }  (${tierTag(f)})`;
+};
 
 // Mirrors report.ts's R96 fold: a NESTED unrecorded undeclared value (a live-only sub-key
 // inside a declared object) collapses out of the report body by default — the live model
@@ -472,7 +475,10 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
   if (scope === null) return null; // scope prompt cancelled → back to the menu
   const scoped =
     scope === 'all' ? decidable : decidable.filter((f) => !isFoldedFinding(f, p.verbose));
-  const rows = scoped.map((f) => ({ label: pickerLabel(f), applicable: applicableActions(f) }));
+  const rows = scoped.map((f) => ({
+    label: pickerLabel(f, p.stackName),
+    applicable: applicableActions(f),
+  }));
   const chosen = await actionPicker(`${p.stackName}: assign an action to each finding`, rows);
   if (chosen === undefined) return null; // picker cancelled (Esc) → back to the menu
   const groups = groupByAction(scoped, chosen);

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -284,6 +284,15 @@ describe('nestedStackWarning (loud coverage gap for nested stacks)', () => {
     );
     expect(w).toContain('NestedXYZ');
   });
+
+  it('strips the stack/Stage prefix off the construct path (matches the report)', () => {
+    const w = nestedStackWarning(
+      [r('AWS::CloudFormation::Stack', { logicalId: 'A', constructPath: 'dev-main/App/Nested' })],
+      'dev-main-App' // a CDK Stage: path is dev-main/App/..., name is dev-main-App
+    );
+    expect(w).toContain('Nested');
+    expect(w).not.toContain('dev-main/App/Nested');
+  });
 });
 
 describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () => {
@@ -322,6 +331,15 @@ describe('coverageWarning / hasCoverageGap (--strict + loud coverage gap)', () =
     const w = coverageWarning(many, 'S')!;
     expect(w).toContain('14 resource(s) were NOT checked');
     expect(w).toContain('…(+4 more)');
+  });
+
+  it('strips the stack/Stage prefix off the construct path (matches the report)', () => {
+    const w = coverageWarning(
+      [skipped('A', { constructPath: 'dev-main/App/Custom' })],
+      'dev-main-App'
+    )!;
+    expect(w).toContain('Custom');
+    expect(w).not.toContain('dev-main/App/Custom');
   });
 
   it('hasCoverageGap is true on a skipped resource', () => {

--- a/tests/interactive-resolve.test.ts
+++ b/tests/interactive-resolve.test.ts
@@ -23,6 +23,7 @@ import { select } from '@clack/prompts';
 import {
   buildScopeOptions,
   isFoldedFinding,
+  pickerLabel,
   resolveInteractively,
 } from '../src/commands/interactive-resolve.js';
 import { ignoreStack, recordStack, revertStack } from '../src/commands/stack-actions.js';
@@ -192,5 +193,35 @@ describe('scope gate narrows the ignore picker to the report-shown findings (def
     expect(vi.mocked(ignoreStack).mock.calls[0]![0].findings).toHaveLength(3);
     // exactly two select calls: top menu + the re-shown menu — no scope prompt in between
     expect(vi.mocked(select)).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('pickerLabel — the per-finding "decide per finding" row (mirrors the report)', () => {
+  const uf = (over: Partial<Finding>): Finding => ({
+    tier: 'undeclared',
+    logicalId: 'R',
+    resourceType: 'AWS::IAM::Role',
+    path: 'Policies',
+    ...over,
+  });
+
+  it('shows the construct path WITHIN the stack when given the stack name', () => {
+    const f = uf({ constructPath: 'dev-main/App/ApiRole' });
+    // a CDK Stage: aws:cdk:path is dev-main/App/..., the CFn name is dev-main-App
+    expect(pickerLabel(f, 'dev-main-App')).toContain('ApiRole.Policies  (');
+    expect(pickerLabel(f, 'dev-main-App')).not.toContain('dev-main/App/ApiRole');
+    // no stackName -> full construct path (unit default)
+    expect(pickerLabel(f)).toContain('dev-main/App/ApiRole.Policies  (');
+  });
+
+  it('keeps the attributeKey suffix after the stripped id', () => {
+    const f = uf({
+      constructPath: 'S/Edge',
+      path: 'LoadBalancerAttributes',
+      attributeKey: 'idle_timeout.timeout_seconds',
+    });
+    expect(pickerLabel(f, 'S')).toContain(
+      'Edge.LoadBalancerAttributes[idle_timeout.timeout_seconds]'
+    );
   });
 });


### PR DESCRIPTION
## What

Completes the within-stack construct-path display (#573 / #574). Three human-facing spots still printed the full `<stack>/<path>` and read inconsistently next to the report:

| site | was | now |
|---|---|---|
| `pickerLabel` — the interactive "decide per finding" row | `Stack/ApiRole.Policies (...)` | `ApiRole.Policies (...)` |
| `nestedStackWarning` — nested-stack coverage warning | `Stack/Nested` | `Nested` |
| `coverageWarning` — skipped-resource coverage warning | `Stack/Custom` | `Custom` |

`pickerLabel`'s own comment says it "mirrors report.ts", yet it showed the full path while the report showed the stripped one — the clearest inconsistency. It now takes the stack name (threaded from the resolve params) and strips via `withinStackPath`; the two warnings already had the stack name in hand.

## Notes

- `pickerLabel` is now exported so it can be unit-tested directly.
- `--json` and the full-path ignore-match target are unchanged.

## Tests

- `pickerLabel` strip (CDK Stage + no-strip + `attributeKey` suffix preserved).
- `nestedStackWarning` / `coverageWarning` strip.
- Full suite: 2798 passing.

With this, **every** human-facing construct-path surface — check report, revert plan/picker/surviving/`reverted:`, the per-finding picker, the coverage warnings, and the ignore-rule write — shows the within-stack path consistently.
