### PR TITLE
docs(readme): add an 'In a nutshell' intent equation up top

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,27 @@
 Drift detection for AWS CDK that sees what your template can't, including the
 **properties you never declared**. Detect it, record it, or revert it.
 
+**In a nutshell:**
+
+```text
+live AWS state  vs  ( CFn template + AWS defaults + .cdkrd baseline )
+```
+
+`cdkrd` compares your real deployed resources against your intent, which is three
+things combined:
+
+- **CFn template** — the properties you **declared**.
+- **AWS defaults** — undeclared properties still sitting at their AWS default,
+  subtracted automatically (you maintain nothing here).
+- **.cdkrd baseline** — a small committed file recording the **undeclared** values
+  that actually differ from the default and you've accepted.
+
+The baseline is **optional**: with just the first two, `cdkrd` already catches
+drift on your declared properties and undeclared properties that drift away from
+their AWS default (plus out-of-band deletes) — no setup required. The baseline
+only adds one more thing: confirming drift on undeclared values that were
+non-default from the start, which your template never mentions.
+
 ## Why
 
 Someone tweaks one of your resources from the console: an extra inline policy on a


### PR DESCRIPTION
## What

Adds an **"In a nutshell"** block at the very top of the README (right after the
lead, before `## Why`) that captures cdkrd's concept as a single intent equation:

```text
live AWS state  vs  ( CFn template + AWS defaults + .cdkrd baseline )
```

Followed by a three-bullet breakdown and an explicit note that the baseline is
**optional** — cdkrd already catches declared drift, undeclared-away-from-default
drift, and out-of-band deletes with no setup. This foreshadows the existing
"Your first run needs no baseline" section.

## Why

New readers had no one-liner mental model up front. The equation makes the
reality-vs-intent framing land immediately, and including `AWS defaults` as a
term prevents the misread that a baseline is required to detect anything.

## Scope

Docs-only (README.md). No src/tests touched.
