### PR TITLE
docs(readme): bold the three verbs in the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
 Drift detection for AWS CDK that sees what your template can't, including the
-**properties you never declared**. Detect it, record it, or revert it.
+**properties you never declared**. **Detect** it, **record** it, or **revert** it.
 
 **In a nutshell:**
 


### PR DESCRIPTION
Bold the three action verbs (**Detect** / **record** / **revert**) in the top-of-README tagline so the eye lands on the core actions. Docs-only, no wording change.