### PR TITLE
feat(report): note potential-drift false positives + link the issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,12 @@ Each block above is one kind of finding, and neither needed a baseline:
 - **`[Potential Drift]`**: settings that live only on the real resource, not in
   your template. cdkrd detects these too: it strips the obvious noise (AWS
   defaults, auto-generated names) so what's left is the values most likely to be
-  real drift. They're only _potential_ because there's no baseline yet.
+  real drift. They're only _potential_ because there's no baseline yet — and,
+  being an unconfirmed best-effort guess, this is the one tier that **can include
+  false positives** (an AWS-managed default or noise the fold tables didn't yet
+  strip). Confirmed `[CFn-Declared Drift]` never guesses. If a potential-drift
+  value is really noise, [please report it](https://github.com/go-to-k/cdk-real-drift/issues)
+  so it becomes a fold-table fix.
 
 At the prompt you act on each finding: **record** it (accept and watch),
 **revert** it (undo the change), or **ignore** it (stop reporting).
@@ -630,6 +635,18 @@ Control cannot sub-path patch it).
 informational, never guessed (zero false drift). For the full list of what it does
 not do (revert's boundaries, nested stacks, per-type read gaps, stack-state
 handling), see [docs/limitations.md](docs/limitations.md).
+
+The exception to zero-false-drift is the **`[Potential Drift]`** tier: with no
+baseline yet, cdkrd can't confirm those live-only values, so it strips the noise
+it recognizes and shows the rest as a best-effort guess — which can occasionally
+surface an AWS-managed default or noise it hasn't catalogued (a false positive).
+
+## Reporting issues
+
+Found a false positive in `[Potential Drift]` (an AWS-managed default or noise
+that should have been folded), a missed detection, or any other bug? Please
+[open an issue](https://github.com/go-to-k/cdk-real-drift/issues) — noise reports
+turn directly into fold-table fixes and make the next run quieter for everyone.
 
 ## FAQ
 

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -355,8 +355,19 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
       style.undeclaredTier,
       driftSections > 0
     )
-  )
+  ) {
     driftSections++;
+    // Potential drift is UNCONFIRMED by definition (no baseline), so it is the one tier
+    // where a value can be a false positive — an AWS-managed default or noise that slipped
+    // the fold tables. Point the user at the issue tracker so those become fold-table fixes.
+    // Scoped to THIS tier only (a `↳` note like the origin hint): declared / deleted drift
+    // is confirmed against the template, never guessed, so it carries no such caveat.
+    log(
+      style.note(
+        '  ↳ this tier is a best-effort guess and can include false positives — if a value here is really an AWS-managed default or noise, please report it: https://github.com/go-to-k/cdk-real-drift/issues'
+      )
+    );
+  }
   // result: line — the conclusion. Lists ONLY the non-zero DRIFT tier counts (the
   // informational breakdown lives on the `info:` line, so the two never duplicate);
   // CLEAN prints just `CLEAN`. `^result:` stays greppable for the verdict; the formal

--- a/tests/report.test.ts
+++ b/tests/report.test.ts
@@ -34,6 +34,22 @@ describe('report unrecorded findings (R60/R62 — per finding: never decided is 
     );
   });
 
+  it('the Potential Drift section carries a false-positive caveat + issue-tracker link', () => {
+    const { text } = run([U(), U('Q')]);
+    // Potential drift is the one unconfirmed tier, so it points the user at the tracker
+    // (noise reports become fold-table fixes). Scoped as a `↳` note like the origin hint.
+    expect(text).toContain('can include false positives');
+    expect(text).toContain('https://github.com/go-to-k/cdk-real-drift/issues');
+  });
+
+  it('the false-positive caveat is scoped to Potential Drift — confirmed drift never carries it', () => {
+    // A declared drift with NO potential-drift values: the guess/false-positive note must
+    // not appear (declared drift is confirmed against the template, never guessed).
+    const { text } = run([F('declared')]);
+    expect(text).not.toContain('can include false positives');
+    expect(text).not.toContain('/issues');
+  });
+
   it('nested undeclared values are SURFACED in [Potential Drift], like top-level ones', () => {
     // 2 top-level + 3 nested = 5 shown potential drift. The R96 fold is gone: a nested
     // undeclared value that survived the upstream atDefault/generated/KNOWN_DEFAULT_PATHS


### PR DESCRIPTION
## What

The `[Potential Drift]` tier is unconfirmed by definition — with no baseline yet,
cdkrd cannot tell an intentional live-only setting from an out-of-band change, so
it strips the noise it recognizes and shows the rest as a best-effort guess. That
makes it the one tier that can surface a **false positive** (an AWS-managed default
or noise the fold tables have not yet catalogued).

This PR makes that honest to the user and turns FP reports into fixes:

- **check output**: a scoped `↳` note under the `[Potential Drift]` section (same
  convention as the origin hint) saying the tier is a best-effort guess that can
  include false positives, with the issue-tracker link. Shown **only** when the
  section prints — confirmed `[CFn-Declared Drift]` / `[Deleted]` are compared
  against the template and carry no such caveat.
- **README**: the caveat on the `[Potential Drift]` explanation + a new
  **Reporting issues** section, so noise reports become fold-table fixes.

## Why

Noise that slips the fold tables shows up here as a visible, denylist-able false
positive (never a silent false negative). Telling the user that — and where to
report it — closes the loop: each report becomes a `KNOWN_DEFAULTS` / fold-table
fix that makes the next run quieter.

## Test

- New unit tests in `tests/report.test.ts`: the caveat + issue link appear when
  Potential Drift is shown, and are absent when only confirmed drift is present.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (2800 tests) all pass.
