### PR TITLE
feat(corpus): persist clusterEchoModel + bucketNotificationManaged so cluster-child cases replay

### DIFF
--- a/src/corpus/record.ts
+++ b/src/corpus/record.ts
@@ -77,6 +77,15 @@ export interface CorpusCase {
     // the SG's physical id. Only present (and only its own entry) on an AWS::EC2::SecurityGroup
     // case, so replay reproduces the sibling-rule subtraction; optional for back-compat.
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+    // This bucket's own physical id, present only when its S3 notifications are managed by a
+    // Custom::S3BucketNotifications CR, so replay reproduces the NotificationConfiguration drop.
+    // Stored as an array (JSON has no Set); replay revives it to a Set. Optional for back-compat.
+    bucketNotificationManaged?: string[];
+    // The parent DBCluster's live model keyed by THIS instance's physical id — present only on a
+    // CLUSTER_ECHO_CHILD case (an Aurora DBInstance echoing its cluster), so replay reproduces the
+    // cluster-echo strip. Without it a fresh-harvested reader/writer replays the un-folded echo
+    // props as false undeclared drift. Optional for back-compat (pre-clusterEcho cases lack it).
+    clusterEchoModel?: Record<string, Record<string, unknown>>;
   };
   expected: Finding[]; // what classifyResource produced at record time (reviewed at commit)
 }
@@ -108,6 +117,8 @@ export function buildCorpusCase(
     kmsAliasTargets: Record<string, string>;
     oaiCanonicalIds: Record<string, string>;
     siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+    bucketNotificationManaged?: Set<string>;
+    clusterEchoModel?: Record<string, Record<string, unknown>>;
   },
   findings: Finding[]
 ): CorpusCase {
@@ -116,6 +127,16 @@ export function buildCorpusCase(
   const sgSibling =
     resource.resourceType === 'AWS::EC2::SecurityGroup' && resource.physicalId
       ? opts.siblingSgRules?.[resource.physicalId]
+      : undefined;
+  // Same shape as sgSibling: carry ONLY this resource's own entry from the stack-wide maps, so a
+  // cluster-echo / bucket-notification case replays its strip without bloating every case.
+  const bucketNotif =
+    resource.physicalId && opts.bucketNotificationManaged?.has(resource.physicalId)
+      ? [resource.physicalId]
+      : undefined;
+  const echoModel =
+    resource.physicalId && opts.clusterEchoModel?.[resource.physicalId]
+      ? opts.clusterEchoModel[resource.physicalId]
       : undefined;
   const c: CorpusCase = {
     corpusVersion: 1,
@@ -151,6 +172,10 @@ export function buildCorpusCase(
       ...(sgSibling && resource.physicalId
         ? { siblingSgRules: { [resource.physicalId]: sgSibling } }
         : {}),
+      ...(bucketNotif ? { bucketNotificationManaged: bucketNotif } : {}),
+      ...(echoModel && resource.physicalId
+        ? { clusterEchoModel: { [resource.physicalId]: echoModel } }
+        : {}),
     },
     expected: findings,
   };
@@ -171,6 +196,25 @@ export function reviveSchema(s: CorpusCase['schema']): SchemaInfo {
     unorderedScalarPaths: s.unorderedScalarPaths ?? [],
     unorderedObjectArrayPaths: s.unorderedObjectArrayPaths ?? [],
     freeFormMapPaths: s.freeFormMapPaths ?? [],
+  };
+}
+
+/** Revive a case's stored opts into the shape classifyResource expects: the JSON case
+ *  stores `bucketNotificationManaged` as an array (JSON has no Set) but classify wants a
+ *  Set, so convert it; every other opts field passes through unchanged. Both replay call
+ *  sites (corpus-replay + measure-noise) go through here so they stay in lockstep. */
+export function reviveOpts(o: CorpusCase['opts']): Omit<
+  CorpusCase['opts'],
+  'bucketNotificationManaged'
+> & {
+  bucketNotificationManaged?: Set<string>;
+} {
+  const { bucketNotificationManaged, ...rest } = o;
+  return {
+    ...rest,
+    ...(bucketNotificationManaged
+      ? { bucketNotificationManaged: new Set(bucketNotificationManaged) }
+      : {}),
   };
 }
 

--- a/tests/corpus-record.test.ts
+++ b/tests/corpus-record.test.ts
@@ -91,4 +91,106 @@ describe('corpus recording (R63)', () => {
     // JSON-safe end to end
     expect(() => JSON.stringify(c)).not.toThrow();
   });
+
+  const baseSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  it('buildCorpusCase persists ONLY this instance clusterEchoModel entry, sanitized', () => {
+    // The key is the instance physical id, which for RDS never embeds the account id (same
+    // assumption siblingSgRules relies on — sanitizeAccountId walks values, not keys); the echo
+    // model VALUES can carry account-scoped ARNs and must sanitize consistently with liveRaw.
+    const resource: DesiredResource = {
+      logicalId: 'Reader',
+      resourceType: 'AWS::RDS::DBInstance',
+      physicalId: 'db-reader-abc',
+      declared: {},
+    };
+    const c = buildCorpusCase(
+      resource,
+      { Engine: 'aurora-mysql' },
+      baseSchema,
+      {
+        accountId: '123456789012',
+        region: 'us-east-1',
+        kmsAliasTargets: {},
+        oaiCanonicalIds: {},
+        // stack-wide map with TWO instances — only this one's entry must be carried
+        clusterEchoModel: {
+          'db-reader-abc': {
+            MasterUsername: 'admin',
+            KmsKeyId: 'arn:aws:kms:us-east-1:123456789012:key/k',
+          },
+          'db-other-xyz': { MasterUsername: 'other' },
+        },
+      },
+      []
+    );
+    expect(Object.keys(c.opts.clusterEchoModel ?? {})).toEqual(['db-reader-abc']);
+    // account id sanitized inside the carried echo model, consistently with liveRaw
+    expect(c.opts.clusterEchoModel?.['db-reader-abc']).toEqual({
+      MasterUsername: 'admin',
+      KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/k',
+    });
+    // a resource with no echo entry gets no clusterEchoModel key
+    const noEcho = buildCorpusCase(
+      { ...resource, physicalId: 'db-x' },
+      {},
+      baseSchema,
+      {
+        accountId: '',
+        region: 'us-east-1',
+        kmsAliasTargets: {},
+        oaiCanonicalIds: {},
+        clusterEchoModel: { 'db-reader-abc': {} },
+      },
+      []
+    );
+    expect(noEcho.opts.clusterEchoModel).toBeUndefined();
+  });
+
+  it('buildCorpusCase persists bucketNotificationManaged as this bucket own id (array)', () => {
+    const bucket: DesiredResource = {
+      logicalId: 'B',
+      resourceType: 'AWS::S3::Bucket',
+      physicalId: 'my-bucket',
+      declared: {},
+    };
+    const managed = buildCorpusCase(
+      bucket,
+      {},
+      baseSchema,
+      {
+        accountId: '',
+        region: 'us-east-1',
+        kmsAliasTargets: {},
+        oaiCanonicalIds: {},
+        bucketNotificationManaged: new Set(['my-bucket', 'other-bucket']),
+      },
+      []
+    );
+    expect(managed.opts.bucketNotificationManaged).toEqual(['my-bucket']);
+    // a bucket NOT in the managed set gets no key
+    const plain = buildCorpusCase(
+      bucket,
+      {},
+      baseSchema,
+      {
+        accountId: '',
+        region: 'us-east-1',
+        kmsAliasTargets: {},
+        oaiCanonicalIds: {},
+        bucketNotificationManaged: new Set(['other-bucket']),
+      },
+      []
+    );
+    expect(plain.opts.bucketNotificationManaged).toBeUndefined();
+  });
 });

--- a/tests/corpus-replay.test.ts
+++ b/tests/corpus-replay.test.ts
@@ -9,7 +9,12 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vite-plus/test';
-import { type CorpusCase, decodeUnresolved, reviveSchema } from '../src/corpus/record.js';
+import {
+  type CorpusCase,
+  decodeUnresolved,
+  reviveOpts,
+  reviveSchema,
+} from '../src/corpus/record.js';
 import { classifyResource } from '../src/diff/classify.js';
 import type { DesiredResource, Finding } from '../src/types.js';
 
@@ -37,13 +42,14 @@ describe('golden corpus replay (R63)', () => {
         ...c.resource,
         declared: decodeUnresolved(c.resource.declared),
       } as DesiredResource;
-      // classify strips/mutates its inputs' copies — pass fresh clones so a
-      // case file is never the thing being mutated.
+      // classify strips/mutates its inputs' copies — pass fresh clones so a case file is
+      // never the thing being mutated. reviveOpts turns the stored bucketNotificationManaged
+      // array back into the Set classify expects (clusterEchoModel passes through as-is).
       const got = classifyResource(
         resource,
         structuredClone(c.liveRaw),
         reviveSchema(c.schema),
-        c.opts
+        reviveOpts(c.opts)
       );
       expect([...got].sort(byTierPath)).toEqual([...c.expected].sort(byTierPath));
     });

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.sv2.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.sv2.json
@@ -1,0 +1,396 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Clusterreader2204550C",
+    "resourceType": "AWS::RDS::DBInstance",
+    "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+    "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader",
+    "declared": {
+      "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-glae5frftx8u",
+      "DBInstanceClass": "db.serverless",
+      "Engine": "aurora-mysql",
+      "PromotionTier": 1,
+      "PubliclyAccessible": false
+    }
+  },
+  "liveRaw": {
+    "DatabaseInsightsMode": "standard",
+    "StorageEncrypted": false,
+    "StatusInfos": [],
+    "CertificateDetails": {
+      "ValidTill": "2027-07-04T06:01:37Z",
+      "CAIdentifier": "rds-ca-rsa2048-g1"
+    },
+    "Port": "3306",
+    "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-glae5frftx8u",
+    "AdditionalStorageVolumes": [],
+    "StorageThroughput": 0,
+    "DbiResourceId": "db-XOTTI2AOJVNMUPDCC3N7OO5XUU",
+    "ReadReplicaDBClusterIdentifiers": [],
+    "MonitoringInterval": 0,
+    "DBParameterGroupName": "default.aurora-mysql8.0",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+    "Endpoint": {
+      "Address": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Port": "3306",
+      "HostedZoneId": "Z2R2ITUGPM61AM"
+    },
+    "MultiAZ": false,
+    "Engine": "aurora-mysql",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/40c26110-776c-11f1-aec1-121a4259779f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegAuroraSv2",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Clusterreader2204550C",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "EngineVersion": "8.0.mysql_aurora.3.08.0",
+    "StorageType": "aurora",
+    "DBInstanceStatus": "available",
+    "DBInstanceClass": "db.serverless",
+    "AvailabilityZone": "us-east-1b",
+    "OptionGroupName": "default:aurora-mysql-8-0",
+    "EnablePerformanceInsights": false,
+    "ReadReplicaDBInstanceIdentifiers": [],
+    "AutoMinorVersionUpgrade": true,
+    "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-iai7apoevto2",
+    "DeletionProtection": false,
+    "DBInstanceIdentifier": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+    "AllocatedStorage": "1",
+    "MasterUserSecret": {},
+    "DBSecurityGroups": [],
+    "MasterUsername": "admin",
+    "PromotionTier": 1,
+    "PubliclyAccessible": false,
+    "AssociatedRoles": [],
+    "InstanceCreateTime": "2026-07-04T06:03:02.856Z",
+    "ProcessorFeatures": [],
+    "PreferredBackupWindow": "05:27-05:57",
+    "NetworkType": "IPV4",
+    "DedicatedLogVolume": false,
+    "CopyTagsToSnapshot": false,
+    "EngineLifecycleSupport": "open-source-rds-extended-support",
+    "LicenseModel": "general-public-license",
+    "PreferredMaintenanceWindow": "tue:04:20-tue:04:50",
+    "BackupTarget": "region",
+    "CACertificateIdentifier": "rds-ca-rsa2048-g1",
+    "ManageMasterUserPassword": false,
+    "VPCSecurityGroups": ["sg-0ecd8ce87c76822b1"],
+    "EnableIAMDatabaseAuthentication": false,
+    "BackupRetentionPeriod": 7,
+    "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"]
+  },
+  "schema": {
+    "readOnly": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnly": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnly": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "readOnlyPaths": [
+      "AutomaticRestartTime",
+      "CertificateDetails",
+      "CertificateDetails.CAIdentifier",
+      "CertificateDetails.ValidTill",
+      "DBInstanceArn",
+      "DBInstanceStatus",
+      "DbiResourceId",
+      "Endpoint",
+      "Endpoint.Address",
+      "Endpoint.HostedZoneId",
+      "Endpoint.Port",
+      "InstanceCreateTime",
+      "IsStorageConfigUpgradeAvailable",
+      "LatestRestorableTime",
+      "ListenerEndpoint",
+      "ListenerEndpoint.Address",
+      "ListenerEndpoint.HostedZoneId",
+      "ListenerEndpoint.Port",
+      "MasterUserSecret.SecretArn",
+      "PercentProgress",
+      "ReadReplicaDBClusterIdentifiers",
+      "ReadReplicaDBInstanceIdentifiers",
+      "ResumeFullAutomationModeTime",
+      "SecondaryAvailabilityZone",
+      "StatusInfos"
+    ],
+    "writeOnlyPaths": [
+      "AllowMajorVersionUpgrade",
+      "ApplyImmediately",
+      "AutomaticBackupReplicationKmsKeyId",
+      "CertificateRotationRestart",
+      "DBSnapshotIdentifier",
+      "DeleteAutomatedBackups",
+      "MasterUserAuthenticationType",
+      "MasterUserPassword",
+      "RestoreTime",
+      "SourceDBInstanceAutomatedBackupsArn",
+      "SourceDBInstanceIdentifier",
+      "SourceDbiResourceId",
+      "SourceRegion",
+      "TdeCredentialPassword",
+      "UseDefaultProcessorFeatures",
+      "UseLatestRestorableTime"
+    ],
+    "createOnlyPaths": [
+      "BackupTarget",
+      "CharacterSetName",
+      "CustomIAMInstanceProfile",
+      "DBClusterIdentifier",
+      "DBInstanceIdentifier",
+      "DBName",
+      "DBSubnetGroupName",
+      "DBSystemId",
+      "KmsKeyId",
+      "MasterUsername",
+      "NcharCharacterSetName",
+      "SourceRegion",
+      "StorageEncrypted",
+      "Timezone"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {},
+    "clusterEchoModel": {
+      "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph": {
+        "DatabaseInsightsMode": "standard",
+        "StorageEncrypted": false,
+        "AssociatedRoles": [],
+        "EnableHttpEndpoint": true,
+        "EngineMode": "provisioned",
+        "Port": 3306,
+        "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-glae5frftx8u",
+        "PreferredBackupWindow": "05:27-05:57",
+        "Endpoint": {
+          "Address": "cdkrealdriftintegaurorasv2-clustereb0386a7-glae5frftx8u.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+          "Port": "3306"
+        },
+        "NetworkType": "IPV4",
+        "VpcSecurityGroupIds": ["sg-0ecd8ce87c76822b1"],
+        "CopyTagsToSnapshot": true,
+        "Engine": "aurora-mysql",
+        "Tags": [
+          {
+            "Value": "ClusterEB0386A7",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "CdkRealDriftIntegAuroraSv2",
+            "Key": "aws:cloudformation:stack-name"
+          },
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/40c26110-776c-11f1-aec1-121a4259779f",
+            "Key": "aws:cloudformation:stack-id"
+          }
+        ],
+        "EngineLifecycleSupport": "open-source-rds-extended-support",
+        "EngineVersion": "8.0.mysql_aurora.3.08.0",
+        "StorageType": "aurora",
+        "AvailabilityZones": ["us-east-1f", "us-east-1a", "us-east-1b"],
+        "ServerlessV2ScalingConfiguration": {
+          "MinCapacity": 0.5,
+          "MaxCapacity": 2
+        },
+        "StorageEncryptionType": "sse-rds",
+        "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrealdriftintegaurorasv2-clustereb0386a7-glae5frftx8u",
+        "EnableLocalWriteForwarding": false,
+        "PreferredMaintenanceWindow": "sat:04:46-sat:05:16",
+        "DBClusterResourceId": "cluster-VC62GCGB353RTSGIDBBVJ5AJQ4",
+        "AutoMinorVersionUpgrade": true,
+        "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-iai7apoevto2",
+        "DeletionProtection": false,
+        "AllocatedStorage": 1,
+        "ManageMasterUserPassword": false,
+        "MasterUserSecret": {},
+        "MasterUsername": "admin",
+        "ReadEndpoint": {
+          "Address": "cdkrealdriftintegaurorasv2-clustereb0386a7-glae5frftx8u.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+        },
+        "EnableIAMDatabaseAuthentication": false,
+        "DBClusterParameterGroupName": "default.aurora-mysql8.0",
+        "BackupRetentionPeriod": 7,
+        "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"]
+      }
+    }
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "StorageThroughput",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MonitoringInterval",
+      "actual": 0,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DBParameterGroupName",
+      "actual": "default.aurora-mysql8.0",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "MultiAZ",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "AvailabilityZone",
+      "actual": "us-east-1b",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "OptionGroupName",
+      "actual": "default:aurora-mysql-8-0",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "EnablePerformanceInsights",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "DedicatedLogVolume",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CopyTagsToSnapshot",
+      "actual": false,
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "LicenseModel",
+      "actual": "general-public-license",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "PreferredMaintenanceWindow",
+      "actual": "tue:04:20-tue:04:50",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "BackupTarget",
+      "actual": "region",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clusterreader2204550C",
+      "resourceType": "AWS::RDS::DBInstance",
+      "path": "CACertificateIdentifier",
+      "actual": "rds-ca-rsa2048-g1",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterreader2204550c-8wypdjneofph",
+      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/reader"
+    }
+  ]
+}

--- a/tests/measure-noise.test.ts
+++ b/tests/measure-noise.test.ts
@@ -23,7 +23,12 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vite-plus/test';
-import { type CorpusCase, decodeUnresolved, reviveSchema } from '../src/corpus/record.js';
+import {
+  type CorpusCase,
+  decodeUnresolved,
+  reviveOpts,
+  reviveSchema,
+} from '../src/corpus/record.js';
 import { classifyResource } from '../src/diff/classify.js';
 import type { DesiredResource } from '../src/types.js';
 
@@ -73,7 +78,7 @@ function mineUndeclared(): Bucket[] {
         resource,
         structuredClone(c.liveRaw),
         reviveSchema(c.schema),
-        c.opts
+        reviveOpts(c.opts)
       );
     } catch {
       continue; // a malformed case never blocks the sweep


### PR DESCRIPTION
## What

The golden-corpus `opts` persisted only `accountId/region/kmsAliasTargets/oaiCanonicalIds/siblingSgRules`, but `classifyResource` also consumes **`clusterEchoModel`** (CLUSTER_ECHO_CHILD, #521 — an Aurora `DBInstance` echoing its parent `DBCluster`'s cluster-level config) and **`bucketNotificationManaged`**. Because those two were dropped from a recorded case, a freshly harvested cluster-child instance **failed its own replay**: the echo props the live check folded (via `clusterEchoModel`) resurfaced offline as extra findings — 6 of them as `undeclared` **false positives** — so the sv2 Aurora reader could not be committed as a golden case.

## Changes

- **`buildCorpusCase`** persists both, mirroring the `siblingSgRules` pattern: carry ONLY this resource's own entry, keyed by its physical id (RDS/SG physical ids never embed the account id, so key sanitization is a no-op; the echo model *values* sanitize with the rest of the case).
- **`reviveOpts`** (new): `bucketNotificationManaged` is stored as an array (JSON has no `Set`) and revived to a `Set`; every other opts field passes through. Both replay call sites (`corpus-replay` + `measure-noise`) route through it so they never drift apart.
- Adds the **sv2 Aurora reader** golden case (`db.serverless`, 13 findings all `atDefault` — a clean FP oracle: the reader echoes its cluster with zero false drift). Live-harvested from a real deploy and replay-verified.
- Unit tests: per-resource `clusterEchoModel` / `bucketNotificationManaged` persistence + sanitization + the "no entry → no key" case.

## Why it matters

Answers the "does a writer **and reader** Aurora not false-positive?" question with permanent OFFLINE coverage (the reader FP prevention already passed live in `aurora-serverless-v2-rich/verify.sh`; now it's regression-locked without AWS). The format is backward-compatible — existing cases lack the new optional fields and replay unchanged.

## Test

- `vp run typecheck` / `vp run check` (0 errors) / `vp pack` / `vp test run` (**2803 tests**) pass.
- Live: deployed `aurora-serverless-v2-rich` (writer+reader), `check --fail` CLEAN (no declared FP), harvested the reader with the new binary (opts now carries `clusterEchoModel`), corpus-replay **PASS** (13/13 atDefault). Torn down, **SWEEP CLEAN**.
- All 7 core integration fixtures **INTEG PASS**, orphans swept clean.
