### PR TITLE
test(corpus): re-harvest cluster-child Aurora cases with clusterEcho folding

### DIFF
--- a/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterreader2204550C.json
@@ -3,12 +3,12 @@
   "resource": {
     "logicalId": "Clusterreader2204550C",
     "resourceType": "AWS::RDS::DBInstance",
-    "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+    "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
     "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader",
     "declared": {
-      "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-o3epflljsjiq",
+      "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
       "DBInstanceClass": "db.t3.medium",
-      "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-oqmfjbomker7",
+      "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-qcotzkg46m1p",
       "Engine": "aurora-mysql",
       "PromotionTier": 2,
       "PubliclyAccessible": false
@@ -19,20 +19,20 @@
     "StorageEncrypted": false,
     "StatusInfos": [],
     "CertificateDetails": {
-      "ValidTill": "2027-06-21T07:32:44Z",
+      "ValidTill": "2027-07-04T09:01:02Z",
       "CAIdentifier": "rds-ca-rsa2048-g1"
     },
     "Port": "3306",
-    "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-o3epflljsjiq",
+    "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
     "AdditionalStorageVolumes": [],
     "StorageThroughput": 0,
-    "DbiResourceId": "db-GZPIQNF6L26HAPR22QZNWTLAJM",
+    "DbiResourceId": "db-U7IYYQDMAC2JK7XVQYFSNFDCOI",
     "ReadReplicaDBClusterIdentifiers": [],
     "MonitoringInterval": 0,
-    "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-oqmfjbomker7",
-    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+    "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-qcotzkg46m1p",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
     "Endpoint": {
-      "Address": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Address": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq.caxxotukouxo.us-east-1.rds.amazonaws.com",
       "Port": "3306",
       "HostedZoneId": "Z2R2ITUGPM61AM"
     },
@@ -40,7 +40,7 @@
     "Engine": "aurora-mysql",
     "Tags": [
       {
-        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraRich/0ded9860-6d42-11f1-9a70-0afffc629ddf",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraRich/8c5b5eb0-7785-11f1-a76d-0e05c02647c9",
         "Key": "aws:cloudformation:stack-id"
       },
       {
@@ -61,9 +61,9 @@
     "EnablePerformanceInsights": false,
     "ReadReplicaDBInstanceIdentifiers": [],
     "AutoMinorVersionUpgrade": true,
-    "DBSubnetGroupName": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-ydu1wwuhbiwr",
+    "DBSubnetGroupName": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-psr4wrwiotnh",
     "DeletionProtection": false,
-    "DBInstanceIdentifier": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+    "DBInstanceIdentifier": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
     "AllocatedStorage": "1",
     "MasterUserSecret": {},
     "DBSecurityGroups": [],
@@ -71,19 +71,19 @@
     "PromotionTier": 2,
     "PubliclyAccessible": false,
     "AssociatedRoles": [],
-    "InstanceCreateTime": "2026-06-21T07:34:35.127Z",
+    "InstanceCreateTime": "2026-07-04T09:02:49.032Z",
     "ProcessorFeatures": [],
-    "PreferredBackupWindow": "09:36-10:06",
+    "PreferredBackupWindow": "04:52-05:22",
     "NetworkType": "IPV4",
     "DedicatedLogVolume": false,
     "CopyTagsToSnapshot": false,
     "EngineLifecycleSupport": "open-source-rds-extended-support",
     "LicenseModel": "general-public-license",
-    "PreferredMaintenanceWindow": "mon:05:31-mon:06:01",
+    "PreferredMaintenanceWindow": "sun:09:06-sun:09:36",
     "BackupTarget": "region",
     "CACertificateIdentifier": "rds-ca-rsa2048-g1",
     "ManageMasterUserPassword": false,
-    "VPCSecurityGroups": ["sg-026f2d5597a41d0de"],
+    "VPCSecurityGroups": ["sg-000f500770b637b04"],
     "EnableIAMDatabaseAuthentication": false,
     "BackupRetentionPeriod": 3,
     "EnableCloudwatchLogsExports": []
@@ -126,37 +126,20 @@
       "UseLatestRestorableTime"
     ],
     "createOnly": [
-      "AutoMinorVersionUpgrade",
-      "AvailabilityZone",
-      "BackupRetentionPeriod",
       "BackupTarget",
       "CharacterSetName",
       "CustomIAMInstanceProfile",
       "DBClusterIdentifier",
-      "DBClusterSnapshotIdentifier",
       "DBInstanceIdentifier",
       "DBName",
-      "DBParameterGroupName",
-      "DBSnapshotIdentifier",
       "DBSubnetGroupName",
       "DBSystemId",
-      "Engine",
       "KmsKeyId",
       "MasterUsername",
-      "MultiAZ",
       "NcharCharacterSetName",
-      "PerformanceInsightsKMSKeyId",
-      "PreferredMaintenanceWindow",
-      "RestoreTime",
-      "SourceDBClusterIdentifier",
-      "SourceDBInstanceAutomatedBackupsArn",
-      "SourceDBInstanceIdentifier",
-      "SourceDbiResourceId",
       "SourceRegion",
       "StorageEncrypted",
-      "StorageType",
-      "Timezone",
-      "UseLatestRestorableTime"
+      "Timezone"
     ],
     "readOnlyPaths": [
       "AutomaticRestartTime",
@@ -204,82 +187,98 @@
       "UseLatestRestorableTime"
     ],
     "createOnlyPaths": [
-      "AutoMinorVersionUpgrade",
-      "AvailabilityZone",
-      "BackupRetentionPeriod",
       "BackupTarget",
       "CharacterSetName",
       "CustomIAMInstanceProfile",
       "DBClusterIdentifier",
-      "DBClusterSnapshotIdentifier",
       "DBInstanceIdentifier",
       "DBName",
-      "DBParameterGroupName",
-      "DBSnapshotIdentifier",
       "DBSubnetGroupName",
       "DBSystemId",
-      "Engine",
       "KmsKeyId",
       "MasterUsername",
-      "MultiAZ",
       "NcharCharacterSetName",
-      "PerformanceInsightsKMSKeyId",
-      "PreferredMaintenanceWindow",
-      "RestoreTime",
-      "SourceDBClusterIdentifier",
-      "SourceDBInstanceAutomatedBackupsArn",
-      "SourceDBInstanceIdentifier",
-      "SourceDbiResourceId",
       "SourceRegion",
       "StorageEncrypted",
-      "StorageType",
-      "Timezone",
-      "UseLatestRestorableTime"
+      "Timezone"
     ],
     "defaults": {},
-    "defaultPaths": {}
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
   },
   "opts": {
     "accountId": "111111111111",
     "region": "us-east-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "clusterEchoModel": {
+      "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq": {
+        "DatabaseInsightsMode": "standard",
+        "StorageEncrypted": false,
+        "AssociatedRoles": [],
+        "EnableHttpEndpoint": false,
+        "EngineMode": "provisioned",
+        "Port": 3306,
+        "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
+        "PreferredBackupWindow": "04:52-05:22",
+        "Endpoint": {
+          "Address": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+          "Port": "3306"
+        },
+        "NetworkType": "IPV4",
+        "VpcSecurityGroupIds": ["sg-000f500770b637b04"],
+        "CopyTagsToSnapshot": true,
+        "Engine": "aurora-mysql",
+        "Tags": [
+          {
+            "Value": "ClusterEB0386A7",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraRich/8c5b5eb0-7785-11f1-a76d-0e05c02647c9",
+            "Key": "aws:cloudformation:stack-id"
+          },
+          {
+            "Value": "CdkRealDriftIntegAuroraRich",
+            "Key": "aws:cloudformation:stack-name"
+          }
+        ],
+        "EngineLifecycleSupport": "open-source-rds-extended-support",
+        "EngineVersion": "8.0.mysql_aurora.3.10.4",
+        "StorageType": "aurora",
+        "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1b"],
+        "StorageEncryptionType": "sse-rds",
+        "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
+        "EnableLocalWriteForwarding": false,
+        "PreferredMaintenanceWindow": "sat:03:13-sat:03:43",
+        "DBClusterResourceId": "cluster-5R45T5IRGIZCL7UDM6G3BZCMNY",
+        "AutoMinorVersionUpgrade": true,
+        "DBSubnetGroupName": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-psr4wrwiotnh",
+        "DeletionProtection": false,
+        "AllocatedStorage": 1,
+        "ManageMasterUserPassword": false,
+        "MasterUserSecret": {},
+        "MasterUsername": "admin",
+        "ReadEndpoint": {
+          "Address": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+        },
+        "EnableIAMDatabaseAuthentication": false,
+        "DBClusterParameterGroupName": "cdkrealdriftintegaurorarich-clusterpg55741fc3-cguestkurlpg",
+        "BackupRetentionPeriod": 3,
+        "EnableCloudwatchLogsExports": []
+      }
+    }
   },
   "expected": [
     {
       "tier": "atDefault",
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
-      "path": "DatabaseInsightsMode",
-      "actual": "standard",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "StorageEncrypted",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "Port",
-      "actual": "3306",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageThroughput",
       "actual": 0,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -288,7 +287,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
       "actual": 0,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -297,25 +296,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MultiAZ",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EngineVersion",
-      "actual": "8.0.mysql_aurora.3.10.4",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "StorageType",
-      "actual": "aurora",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -324,7 +305,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
       "actual": "us-east-1b",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -333,7 +314,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
       "actual": "default:aurora-mysql-8-0",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -342,61 +323,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "EnablePerformanceInsights",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "AutoMinorVersionUpgrade",
-      "actual": true,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "DBSubnetGroupName",
-      "actual": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-ydu1wwuhbiwr",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "AllocatedStorage",
-      "actual": "1",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "MasterUsername",
-      "actual": "admin",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "PreferredBackupWindow",
-      "actual": "09:36-10:06",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "NetworkType",
-      "actual": "IPV4",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -405,7 +332,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DedicatedLogVolume",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -414,16 +341,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CopyTagsToSnapshot",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EngineLifecycleSupport",
-      "actual": "open-source-rds-extended-support",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -432,7 +350,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
       "actual": "general-public-license",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -440,8 +358,8 @@
       "logicalId": "Clusterreader2204550C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",
-      "actual": "mon:05:31-mon:06:01",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "actual": "sun:09:06-sun:09:36",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -450,7 +368,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "BackupTarget",
       "actual": "region",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     },
     {
@@ -459,43 +377,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",
       "actual": "rds-ca-rsa2048-g1",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "ManageMasterUserPassword",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "VPCSecurityGroups",
-      "actual": ["sg-026f2d5597a41d0de"],
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EnableIAMDatabaseAuthentication",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterreader2204550C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "BackupRetentionPeriod",
-      "actual": 3,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-9tqhhigyq20l",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterreader2204550c-ic4wvgtr3jpq",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/reader"
     }
   ]

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.json
@@ -3,12 +3,12 @@
   "resource": {
     "logicalId": "Clusterwriter2D9E9F4C",
     "resourceType": "AWS::RDS::DBInstance",
-    "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+    "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
     "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer",
     "declared": {
-      "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-o3epflljsjiq",
+      "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
       "DBInstanceClass": "db.t3.medium",
-      "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-oqmfjbomker7",
+      "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-qcotzkg46m1p",
       "Engine": "aurora-mysql",
       "PromotionTier": 0,
       "PubliclyAccessible": false
@@ -19,20 +19,20 @@
     "StorageEncrypted": false,
     "StatusInfos": [],
     "CertificateDetails": {
-      "ValidTill": "2027-06-21T07:26:35Z",
+      "ValidTill": "2027-07-04T08:54:49Z",
       "CAIdentifier": "rds-ca-rsa2048-g1"
     },
     "Port": "3306",
-    "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-o3epflljsjiq",
+    "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
     "AdditionalStorageVolumes": [],
     "StorageThroughput": 0,
-    "DbiResourceId": "db-CFQWGWZF5HDC37FPV5GXED2XQU",
+    "DbiResourceId": "db-YF2VELNZZSLU54LBVUI6NXQIP4",
     "ReadReplicaDBClusterIdentifiers": [],
     "MonitoringInterval": 0,
-    "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-oqmfjbomker7",
-    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+    "DBParameterGroupName": "cdkrealdriftintegaurorarich-instancepgc266ef90-qcotzkg46m1p",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
     "Endpoint": {
-      "Address": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Address": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld.caxxotukouxo.us-east-1.rds.amazonaws.com",
       "Port": "3306",
       "HostedZoneId": "Z2R2ITUGPM61AM"
     },
@@ -40,7 +40,7 @@
     "Engine": "aurora-mysql",
     "Tags": [
       {
-        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraRich/0ded9860-6d42-11f1-9a70-0afffc629ddf",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraRich/8c5b5eb0-7785-11f1-a76d-0e05c02647c9",
         "Key": "aws:cloudformation:stack-id"
       },
       {
@@ -61,9 +61,9 @@
     "EnablePerformanceInsights": false,
     "ReadReplicaDBInstanceIdentifiers": [],
     "AutoMinorVersionUpgrade": true,
-    "DBSubnetGroupName": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-ydu1wwuhbiwr",
+    "DBSubnetGroupName": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-psr4wrwiotnh",
     "DeletionProtection": false,
-    "DBInstanceIdentifier": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+    "DBInstanceIdentifier": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
     "AllocatedStorage": "1",
     "MasterUserSecret": {},
     "DBSecurityGroups": [],
@@ -71,19 +71,19 @@
     "PromotionTier": 0,
     "PubliclyAccessible": false,
     "AssociatedRoles": [],
-    "InstanceCreateTime": "2026-06-21T07:29:03.713Z",
+    "InstanceCreateTime": "2026-07-04T08:57:13.843Z",
     "ProcessorFeatures": [],
-    "PreferredBackupWindow": "09:36-10:06",
+    "PreferredBackupWindow": "04:52-05:22",
     "NetworkType": "IPV4",
     "DedicatedLogVolume": false,
     "CopyTagsToSnapshot": false,
     "EngineLifecycleSupport": "open-source-rds-extended-support",
     "LicenseModel": "general-public-license",
-    "PreferredMaintenanceWindow": "sun:03:40-sun:04:10",
+    "PreferredMaintenanceWindow": "sat:03:14-sat:03:44",
     "BackupTarget": "region",
     "CACertificateIdentifier": "rds-ca-rsa2048-g1",
     "ManageMasterUserPassword": false,
-    "VPCSecurityGroups": ["sg-026f2d5597a41d0de"],
+    "VPCSecurityGroups": ["sg-000f500770b637b04"],
     "EnableIAMDatabaseAuthentication": false,
     "BackupRetentionPeriod": 3,
     "EnableCloudwatchLogsExports": []
@@ -126,37 +126,20 @@
       "UseLatestRestorableTime"
     ],
     "createOnly": [
-      "AutoMinorVersionUpgrade",
-      "AvailabilityZone",
-      "BackupRetentionPeriod",
       "BackupTarget",
       "CharacterSetName",
       "CustomIAMInstanceProfile",
       "DBClusterIdentifier",
-      "DBClusterSnapshotIdentifier",
       "DBInstanceIdentifier",
       "DBName",
-      "DBParameterGroupName",
-      "DBSnapshotIdentifier",
       "DBSubnetGroupName",
       "DBSystemId",
-      "Engine",
       "KmsKeyId",
       "MasterUsername",
-      "MultiAZ",
       "NcharCharacterSetName",
-      "PerformanceInsightsKMSKeyId",
-      "PreferredMaintenanceWindow",
-      "RestoreTime",
-      "SourceDBClusterIdentifier",
-      "SourceDBInstanceAutomatedBackupsArn",
-      "SourceDBInstanceIdentifier",
-      "SourceDbiResourceId",
       "SourceRegion",
       "StorageEncrypted",
-      "StorageType",
-      "Timezone",
-      "UseLatestRestorableTime"
+      "Timezone"
     ],
     "readOnlyPaths": [
       "AutomaticRestartTime",
@@ -204,82 +187,98 @@
       "UseLatestRestorableTime"
     ],
     "createOnlyPaths": [
-      "AutoMinorVersionUpgrade",
-      "AvailabilityZone",
-      "BackupRetentionPeriod",
       "BackupTarget",
       "CharacterSetName",
       "CustomIAMInstanceProfile",
       "DBClusterIdentifier",
-      "DBClusterSnapshotIdentifier",
       "DBInstanceIdentifier",
       "DBName",
-      "DBParameterGroupName",
-      "DBSnapshotIdentifier",
       "DBSubnetGroupName",
       "DBSystemId",
-      "Engine",
       "KmsKeyId",
       "MasterUsername",
-      "MultiAZ",
       "NcharCharacterSetName",
-      "PerformanceInsightsKMSKeyId",
-      "PreferredMaintenanceWindow",
-      "RestoreTime",
-      "SourceDBClusterIdentifier",
-      "SourceDBInstanceAutomatedBackupsArn",
-      "SourceDBInstanceIdentifier",
-      "SourceDbiResourceId",
       "SourceRegion",
       "StorageEncrypted",
-      "StorageType",
-      "Timezone",
-      "UseLatestRestorableTime"
+      "Timezone"
     ],
     "defaults": {},
-    "defaultPaths": {}
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
   },
   "opts": {
     "accountId": "111111111111",
     "region": "us-east-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "clusterEchoModel": {
+      "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld": {
+        "DatabaseInsightsMode": "standard",
+        "StorageEncrypted": false,
+        "AssociatedRoles": [],
+        "EnableHttpEndpoint": false,
+        "EngineMode": "provisioned",
+        "Port": 3306,
+        "DBClusterIdentifier": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
+        "PreferredBackupWindow": "04:52-05:22",
+        "Endpoint": {
+          "Address": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+          "Port": "3306"
+        },
+        "NetworkType": "IPV4",
+        "VpcSecurityGroupIds": ["sg-000f500770b637b04"],
+        "CopyTagsToSnapshot": true,
+        "Engine": "aurora-mysql",
+        "Tags": [
+          {
+            "Value": "ClusterEB0386A7",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraRich/8c5b5eb0-7785-11f1-a76d-0e05c02647c9",
+            "Key": "aws:cloudformation:stack-id"
+          },
+          {
+            "Value": "CdkRealDriftIntegAuroraRich",
+            "Key": "aws:cloudformation:stack-name"
+          }
+        ],
+        "EngineLifecycleSupport": "open-source-rds-extended-support",
+        "EngineVersion": "8.0.mysql_aurora.3.10.4",
+        "StorageType": "aurora",
+        "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1b"],
+        "StorageEncryptionType": "sse-rds",
+        "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah",
+        "EnableLocalWriteForwarding": false,
+        "PreferredMaintenanceWindow": "sat:03:13-sat:03:43",
+        "DBClusterResourceId": "cluster-5R45T5IRGIZCL7UDM6G3BZCMNY",
+        "AutoMinorVersionUpgrade": true,
+        "DBSubnetGroupName": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-psr4wrwiotnh",
+        "DeletionProtection": false,
+        "AllocatedStorage": 1,
+        "ManageMasterUserPassword": false,
+        "MasterUserSecret": {},
+        "MasterUsername": "admin",
+        "ReadEndpoint": {
+          "Address": "cdkrealdriftintegaurorarich-clustereb0386a7-yshqucbvgtah.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+        },
+        "EnableIAMDatabaseAuthentication": false,
+        "DBClusterParameterGroupName": "cdkrealdriftintegaurorarich-clusterpg55741fc3-cguestkurlpg",
+        "BackupRetentionPeriod": 3,
+        "EnableCloudwatchLogsExports": []
+      }
+    }
   },
   "expected": [
     {
       "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
-      "path": "DatabaseInsightsMode",
-      "actual": "standard",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "StorageEncrypted",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "Port",
-      "actual": "3306",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageThroughput",
       "actual": 0,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -288,7 +287,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
       "actual": 0,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -297,25 +296,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MultiAZ",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EngineVersion",
-      "actual": "8.0.mysql_aurora.3.10.4",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "StorageType",
-      "actual": "aurora",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -324,7 +305,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
       "actual": "us-east-1a",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -333,7 +314,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
       "actual": "default:aurora-mysql-8-0",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -342,61 +323,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "EnablePerformanceInsights",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "AutoMinorVersionUpgrade",
-      "actual": true,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "DBSubnetGroupName",
-      "actual": "cdkrealdriftintegaurorarich-clustersubnetsdcfa5cb7-ydu1wwuhbiwr",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "AllocatedStorage",
-      "actual": "1",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "MasterUsername",
-      "actual": "admin",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "PreferredBackupWindow",
-      "actual": "09:36-10:06",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "NetworkType",
-      "actual": "IPV4",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -405,7 +332,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DedicatedLogVolume",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -414,16 +341,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CopyTagsToSnapshot",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EngineLifecycleSupport",
-      "actual": "open-source-rds-extended-support",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -432,7 +350,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
       "actual": "general-public-license",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -440,8 +358,8 @@
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",
-      "actual": "sun:03:40-sun:04:10",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "actual": "sat:03:14-sat:03:44",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -450,7 +368,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "BackupTarget",
       "actual": "region",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     },
     {
@@ -459,43 +377,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",
       "actual": "rds-ca-rsa2048-g1",
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "ManageMasterUserPassword",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "VPCSecurityGroups",
-      "actual": ["sg-026f2d5597a41d0de"],
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EnableIAMDatabaseAuthentication",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
-      "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "BackupRetentionPeriod",
-      "actual": 3,
-      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-nwixs263nwg3",
+      "physicalId": "cdkrealdriftintegaurorarich-clusterwriter2d9e9f4c-cslal4eai7ld",
       "constructPath": "CdkRealDriftIntegAuroraRich/Cluster/writer"
     }
   ]

--- a/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
+++ b/tests/corpus/AWS__RDS__DBInstance.Clusterwriter2D9E9F4C.sv2.json
@@ -3,10 +3,10 @@
   "resource": {
     "logicalId": "Clusterwriter2D9E9F4C",
     "resourceType": "AWS::RDS::DBInstance",
-    "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+    "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
     "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer",
     "declared": {
-      "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+      "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-58dwonk4fbbt",
       "DBInstanceClass": "db.serverless",
       "Engine": "aurora-mysql",
       "PromotionTier": 0,
@@ -18,20 +18,20 @@
     "StorageEncrypted": false,
     "StatusInfos": [],
     "CertificateDetails": {
-      "ValidTill": "2027-06-29T11:31:49Z",
+      "ValidTill": "2027-07-04T08:55:51Z",
       "CAIdentifier": "rds-ca-rsa2048-g1"
     },
     "Port": "3306",
-    "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-bkvmo1skckhw",
+    "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-58dwonk4fbbt",
     "AdditionalStorageVolumes": [],
     "StorageThroughput": 0,
-    "DbiResourceId": "db-F637HVJJ2LL6FWZA4FTG7RIFYY",
+    "DbiResourceId": "db-ICWW25QYJSMHAQFDC5YUOHRTQM",
     "ReadReplicaDBClusterIdentifiers": [],
     "MonitoringInterval": 0,
     "DBParameterGroupName": "default.aurora-mysql8.0",
-    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+    "DBInstanceArn": "arn:aws:rds:us-east-1:111111111111:db:cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
     "Endpoint": {
-      "Address": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg.caxxotukouxo.us-east-1.rds.amazonaws.com",
+      "Address": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn.caxxotukouxo.us-east-1.rds.amazonaws.com",
       "Port": "3306",
       "HostedZoneId": "Z2R2ITUGPM61AM"
     },
@@ -39,7 +39,7 @@
     "Engine": "aurora-mysql",
     "Tags": [
       {
-        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/7a227110-73ad-11f1-b4dd-0ebd39200b5f",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/8c5459d0-7785-11f1-b2c7-0eb34d492f0f",
         "Key": "aws:cloudformation:stack-id"
       },
       {
@@ -60,9 +60,9 @@
     "EnablePerformanceInsights": false,
     "ReadReplicaDBInstanceIdentifiers": [],
     "AutoMinorVersionUpgrade": true,
-    "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-zupsaropnp1d",
+    "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-bcuddbksav3j",
     "DeletionProtection": false,
-    "DBInstanceIdentifier": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+    "DBInstanceIdentifier": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
     "AllocatedStorage": "1",
     "MasterUserSecret": {},
     "DBSecurityGroups": [],
@@ -70,19 +70,19 @@
     "PromotionTier": 0,
     "PubliclyAccessible": false,
     "AssociatedRoles": [],
-    "InstanceCreateTime": "2026-06-29T11:34:05.883Z",
+    "InstanceCreateTime": "2026-07-04T08:58:10.212Z",
     "ProcessorFeatures": [],
-    "PreferredBackupWindow": "03:33-04:03",
+    "PreferredBackupWindow": "04:56-05:26",
     "NetworkType": "IPV4",
     "DedicatedLogVolume": false,
     "CopyTagsToSnapshot": false,
     "EngineLifecycleSupport": "open-source-rds-extended-support",
     "LicenseModel": "general-public-license",
-    "PreferredMaintenanceWindow": "mon:03:18-mon:03:48",
+    "PreferredMaintenanceWindow": "fri:07:05-fri:07:35",
     "BackupTarget": "region",
     "CACertificateIdentifier": "rds-ca-rsa2048-g1",
     "ManageMasterUserPassword": false,
-    "VPCSecurityGroups": ["sg-000cdddd33579002e"],
+    "VPCSecurityGroups": ["sg-0a05b84be2169d0d2"],
     "EnableIAMDatabaseAuthentication": false,
     "BackupRetentionPeriod": 7,
     "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"]
@@ -204,49 +204,84 @@
     "defaults": {},
     "defaultPaths": {},
     "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
     "freeFormMapPaths": []
   },
   "opts": {
     "accountId": "111111111111",
     "region": "us-east-1",
     "kmsAliasTargets": {},
-    "oaiCanonicalIds": {}
+    "oaiCanonicalIds": {},
+    "clusterEchoModel": {
+      "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn": {
+        "DatabaseInsightsMode": "standard",
+        "StorageEncrypted": false,
+        "AssociatedRoles": [],
+        "EnableHttpEndpoint": true,
+        "EngineMode": "provisioned",
+        "Port": 3306,
+        "DBClusterIdentifier": "cdkrealdriftintegaurorasv2-clustereb0386a7-58dwonk4fbbt",
+        "PreferredBackupWindow": "04:56-05:26",
+        "Endpoint": {
+          "Address": "cdkrealdriftintegaurorasv2-clustereb0386a7-58dwonk4fbbt.cluster-caxxotukouxo.us-east-1.rds.amazonaws.com",
+          "Port": "3306"
+        },
+        "NetworkType": "IPV4",
+        "VpcSecurityGroupIds": ["sg-0a05b84be2169d0d2"],
+        "CopyTagsToSnapshot": true,
+        "Engine": "aurora-mysql",
+        "Tags": [
+          {
+            "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegAuroraSv2/8c5459d0-7785-11f1-b2c7-0eb34d492f0f",
+            "Key": "aws:cloudformation:stack-id"
+          },
+          {
+            "Value": "ClusterEB0386A7",
+            "Key": "aws:cloudformation:logical-id"
+          },
+          {
+            "Value": "CdkRealDriftIntegAuroraSv2",
+            "Key": "aws:cloudformation:stack-name"
+          }
+        ],
+        "EngineLifecycleSupport": "open-source-rds-extended-support",
+        "EngineVersion": "8.0.mysql_aurora.3.08.0",
+        "StorageType": "aurora",
+        "AvailabilityZones": ["us-east-1c", "us-east-1a", "us-east-1b"],
+        "ServerlessV2ScalingConfiguration": {
+          "MinCapacity": 0.5,
+          "MaxCapacity": 2
+        },
+        "StorageEncryptionType": "sse-rds",
+        "DBClusterArn": "arn:aws:rds:us-east-1:111111111111:cluster:cdkrealdriftintegaurorasv2-clustereb0386a7-58dwonk4fbbt",
+        "EnableLocalWriteForwarding": false,
+        "PreferredMaintenanceWindow": "thu:08:09-thu:08:39",
+        "DBClusterResourceId": "cluster-BQH64FEBTSXBHY2CCDKKOX67AU",
+        "AutoMinorVersionUpgrade": true,
+        "DBSubnetGroupName": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-bcuddbksav3j",
+        "DeletionProtection": false,
+        "AllocatedStorage": 1,
+        "ManageMasterUserPassword": false,
+        "MasterUserSecret": {},
+        "MasterUsername": "admin",
+        "ReadEndpoint": {
+          "Address": "cdkrealdriftintegaurorasv2-clustereb0386a7-58dwonk4fbbt.cluster-ro-caxxotukouxo.us-east-1.rds.amazonaws.com"
+        },
+        "EnableIAMDatabaseAuthentication": false,
+        "DBClusterParameterGroupName": "default.aurora-mysql8.0",
+        "BackupRetentionPeriod": 7,
+        "EnableCloudwatchLogsExports": ["audit", "error", "general", "slowquery"]
+      }
+    }
   },
   "expected": [
     {
       "tier": "atDefault",
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
-      "path": "DatabaseInsightsMode",
-      "actual": "standard",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "StorageEncrypted",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "Port",
-      "actual": "3306",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
       "path": "StorageThroughput",
       "actual": 0,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -255,7 +290,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MonitoringInterval",
       "actual": 0,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -264,7 +299,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DBParameterGroupName",
       "actual": "default.aurora-mysql8.0",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -273,25 +308,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "MultiAZ",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EngineVersion",
-      "actual": "8.0.mysql_aurora.3.08.0",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "StorageType",
-      "actual": "aurora",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -300,7 +317,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "AvailabilityZone",
       "actual": "us-east-1a",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -309,7 +326,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "OptionGroupName",
       "actual": "default:aurora-mysql-8-0",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -318,61 +335,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "EnablePerformanceInsights",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "AutoMinorVersionUpgrade",
-      "actual": true,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "DBSubnetGroupName",
-      "actual": "cdkrealdriftintegaurorasv2-clustersubnetsdcfa5cb7-zupsaropnp1d",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "AllocatedStorage",
-      "actual": "1",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "MasterUsername",
-      "actual": "admin",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "PreferredBackupWindow",
-      "actual": "03:33-04:03",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "NetworkType",
-      "actual": "IPV4",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -381,7 +344,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "DedicatedLogVolume",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -390,16 +353,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CopyTagsToSnapshot",
       "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EngineLifecycleSupport",
-      "actual": "open-source-rds-extended-support",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -408,7 +362,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "LicenseModel",
       "actual": "general-public-license",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -416,8 +370,8 @@
       "logicalId": "Clusterwriter2D9E9F4C",
       "resourceType": "AWS::RDS::DBInstance",
       "path": "PreferredMaintenanceWindow",
-      "actual": "mon:03:18-mon:03:48",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "actual": "fri:07:05-fri:07:35",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -426,7 +380,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "BackupTarget",
       "actual": "region",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     },
     {
@@ -435,52 +389,7 @@
       "resourceType": "AWS::RDS::DBInstance",
       "path": "CACertificateIdentifier",
       "actual": "rds-ca-rsa2048-g1",
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "ManageMasterUserPassword",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "VPCSecurityGroups",
-      "actual": ["sg-000cdddd33579002e"],
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EnableIAMDatabaseAuthentication",
-      "actual": false,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "BackupRetentionPeriod",
-      "actual": 7,
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
-      "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Clusterwriter2D9E9F4C",
-      "resourceType": "AWS::RDS::DBInstance",
-      "path": "EnableCloudwatchLogsExports",
-      "actual": ["audit", "error", "general", "slowquery"],
-      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-471dbmab57sg",
+      "physicalId": "cdkrealdriftintegaurorasv2-clusterwriter2d9e9f4c-tn04y33u97fn",
       "constructPath": "CdkRealDriftIntegAuroraSv2/Cluster/writer"
     }
   ]


### PR DESCRIPTION
## What

Follow-up to #582. The classic Aurora reader/writer and sv2 writer golden cases were recorded **before** `clusterEchoModel` (#521) existed, so their `opts` lacked it and their `expected` findings carried the ~16 cluster-echo props **un-folded** — a stale picture of what a live `check` actually produces. #582 made the corpus format persist `clusterEchoModel`; this re-harvests the three from a fresh real deploy so they carry it and fold correctly:

| case | before | after | class |
|------|--------|-------|-------|
| classic reader | 28 | **12** | db.t3.medium |
| classic writer | 28 | **12** | db.t3.medium |
| sv2 writer | 30 | **13** | db.serverless |

All three are now all-`atDefault` — a clean FP oracle (the instance echoes its cluster with zero false drift), consistent with the sv2 reader case added in #582.

## Test

- Live-harvested from real `aurora-rich` + `aurora-serverless-v2-rich` deploys; both `check --fail` (no baseline) CLEAN, no declared drift. Stacks torn down, **SWEEP CLEAN**.
- `vp run typecheck` / `vp run check` (0 errors) / `vp pack` / `vp test run` (**2803 tests**, corpus-replay reproduces the new expected exactly) all pass.
- Data-only change (`tests/corpus/**`); no `src/**` touched.
