### PR TITLE
feat(noise): fold AWS-assigned maintenance/backup/snapshot windows on RDS-family + cache engines

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1805,6 +1805,28 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   live first-run on dev-main-Db2Csv's self-referencing Glue SG ingress, no edit.
   'AWS::EC2::SecurityGroupIngress': new Set(['SourceSecurityGroupName']),
   'AWS::EC2::SecurityGroupEgress': new Set(['SourceSecurityGroupName']),
+  //   The RDS-family + cache engines all mirror the RDS precedent above: a cluster/instance
+  //   that declares no maintenance / backup / snapshot window reads back a window AWS
+  //   RANDOMLY ASSIGNED at creation (e.g. "sat:03:00-sat:04:00", "03:10-03:40"). It is not a
+  //   constant we can pin (AWS picks it per resource/region) and never user intent when
+  //   undeclared — a user who cares DECLARES it and is then compared in the declared loop.
+  //   Fold value-independent, exactly like AWS::RDS::* above. Found by the offline first-run-
+  //   noise sweep across the DocDB / Neptune / ElastiCache / MemoryDB / Redshift corpus cases
+  //   (undeclared on every one, no out-of-band edit). Equality is irrelevant — any window folds.
+  'AWS::DocDB::DBCluster': new Set(['PreferredMaintenanceWindow', 'PreferredBackupWindow']),
+  'AWS::DocDB::DBInstance': new Set(['PreferredMaintenanceWindow']),
+  'AWS::Neptune::DBCluster': new Set(['PreferredMaintenanceWindow', 'PreferredBackupWindow']),
+  'AWS::Neptune::DBInstance': new Set(['PreferredMaintenanceWindow']),
+  'AWS::ElastiCache::CacheCluster': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
+  'AWS::ElastiCache::ReplicationGroup': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
+  'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
+  'AWS::MemoryDB::Cluster': new Set(['MaintenanceWindow', 'SnapshotWindow']),
+  'AWS::Redshift::Cluster': new Set(['PreferredMaintenanceWindow']),
+  //   AWS::AmazonMQ::Broker.MaintenanceWindowStartTime — a broker that declares no window reads
+  //   back an AWS-assigned one as an OBJECT ({DayOfWeek, TimeOfDay, TimeZone}); value-independent
+  //   folds the whole top-level property whatever its shape, so the assigned window is not first-
+  //   run noise (a DECLARED window is compared in the declared loop).
+  'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5164,6 +5164,79 @@ describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)',
     const r = t('AWS::Other::Thing', {}, { KmsKeyId: 'arn:aws:kms:x:1:key/abc' });
     expect(r.undeclared).toContain('KmsKeyId');
   });
+
+  // The RDS-family + cache engines mirror the RDS window precedent: an AWS-assigned
+  // maintenance / backup / snapshot window read back on an undeclared property is AWS's
+  // random choice, not user intent, so it folds value-independent (found by the offline
+  // first-run-noise sweep across the DocDB/Neptune/ElastiCache/MemoryDB/Redshift corpus).
+  it('DocDB / Neptune / ElastiCache / MemoryDB / Redshift AWS-assigned windows fold value-independent', () => {
+    const cases: [string, Record<string, unknown>, string[]][] = [
+      [
+        'AWS::DocDB::DBCluster',
+        { PreferredMaintenanceWindow: 'thu:04:03-thu:04:33', PreferredBackupWindow: '03:10-03:40' },
+        ['PreferredMaintenanceWindow', 'PreferredBackupWindow'],
+      ],
+      [
+        'AWS::DocDB::DBInstance',
+        { PreferredMaintenanceWindow: 'fri:03:49-fri:04:19' },
+        ['PreferredMaintenanceWindow'],
+      ],
+      [
+        'AWS::Neptune::DBCluster',
+        { PreferredMaintenanceWindow: 'sat:14:01-sat:14:31', PreferredBackupWindow: '21:15-21:45' },
+        ['PreferredMaintenanceWindow', 'PreferredBackupWindow'],
+      ],
+      [
+        'AWS::Neptune::DBInstance',
+        { PreferredMaintenanceWindow: 'tue:20:02-tue:20:32' },
+        ['PreferredMaintenanceWindow'],
+      ],
+      [
+        'AWS::ElastiCache::CacheCluster',
+        { PreferredMaintenanceWindow: 'sat:03:00-sat:04:00', SnapshotWindow: '07:30-08:30' },
+        ['PreferredMaintenanceWindow', 'SnapshotWindow'],
+      ],
+      [
+        'AWS::ElastiCache::ReplicationGroup',
+        { PreferredMaintenanceWindow: 'mon:05:00-mon:06:00', SnapshotWindow: '05:00-06:00' },
+        ['PreferredMaintenanceWindow', 'SnapshotWindow'],
+      ],
+      ['AWS::ElastiCache::ServerlessCache', { DailySnapshotTime: '05:30' }, ['DailySnapshotTime']],
+      [
+        'AWS::MemoryDB::Cluster',
+        { MaintenanceWindow: 'fri:07:00-fri:08:00', SnapshotWindow: '09:30-10:30' },
+        ['MaintenanceWindow', 'SnapshotWindow'],
+      ],
+      [
+        'AWS::Redshift::Cluster',
+        { PreferredMaintenanceWindow: 'sat:04:30-sat:05:00' },
+        ['PreferredMaintenanceWindow'],
+      ],
+      // an AWS-assigned window returned as an OBJECT (AmazonMQ) folds whole, value-independent
+      [
+        'AWS::AmazonMQ::Broker',
+        {
+          MaintenanceWindowStartTime: { DayOfWeek: 'FRIDAY', TimeOfDay: '20:00', TimeZone: 'UTC' },
+        },
+        ['MaintenanceWindowStartTime'],
+      ],
+    ];
+    for (const [type, live, props] of cases) {
+      const r = t(type, {}, live);
+      expect(r.undeclared).toEqual([]);
+      expect(r.atDefault).toEqual(expect.arrayContaining(props));
+    }
+  });
+
+  it('a DECLARED cache/DB window is user intent — compared in the declared loop, still detected', () => {
+    const r = t(
+      'AWS::ElastiCache::CacheCluster',
+      { PreferredMaintenanceWindow: 'mon:00:00-mon:01:00' },
+      { PreferredMaintenanceWindow: 'sat:03:00-sat:04:00' }
+    );
+    expect(r.declared).toEqual(['PreferredMaintenanceWindow']);
+    expect(r.atDefault).not.toContain('PreferredMaintenanceWindow');
+  });
 });
 
 describe('RDS engine-derived defaults fold to atDefault', () => {

--- a/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
@@ -152,35 +152,6 @@
   },
   "expected": [
     {
-      "tier": "atDefault",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "AuthenticationStrategy",
-      "actual": "SIMPLE",
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "DataReplicationMode",
-      "actual": "NONE",
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Broker",
-      "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "EncryptionOptions",
-      "actual": {
-        "UseAwsOwnedKey": true
-      },
-      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
-      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
-    },
-    {
       "tier": "readGap",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
@@ -202,12 +173,17 @@
       "tier": "undeclared",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "MaintenanceWindowStartTime",
-      "actual": {
-        "DayOfWeek": "FRIDAY",
-        "TimeOfDay": "20:00",
-        "TimeZone": "UTC"
-      },
+      "path": "SecurityGroups",
+      "actual": ["sg-0a26e23e2310ee0c9"],
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "AuthenticationStrategy",
+      "actual": "SIMPLE",
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
@@ -215,8 +191,19 @@
       "tier": "undeclared",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "SecurityGroups",
-      "actual": ["sg-0a26e23e2310ee0c9"],
+      "path": "SubnetIds",
+      "actual": ["subnet-0ddbb00e7c1d5b679"],
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "EncryptionOptions",
+      "actual": {
+        "UseAwsOwnedKey": true
+      },
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
@@ -230,11 +217,24 @@
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
-      "path": "SubnetIds",
-      "actual": ["subnet-0ddbb00e7c1d5b679"],
+      "path": "MaintenanceWindowStartTime",
+      "actual": {
+        "DayOfWeek": "FRIDAY",
+        "TimeOfDay": "20:00",
+        "TimeZone": "UTC"
+      },
+      "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
+      "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Broker",
+      "resourceType": "AWS::AmazonMQ::Broker",
+      "path": "DataReplicationMode",
+      "actual": "NONE",
       "physicalId": "b-ef12f21b-b6f6-41f8-9282-e98ffc5c0c86",
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     }

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
@@ -107,7 +107,7 @@
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "PreferredBackupWindow",
@@ -116,7 +116,7 @@
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
@@ -97,7 +97,7 @@
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "PreferredBackupWindow",
@@ -106,7 +106,7 @@
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__DocDB__DBInstance.ClusterInstance1448F06E4.json
+++ b/tests/corpus/AWS__DocDB__DBInstance.ClusterInstance1448F06E4.json
@@ -37,7 +37,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterInstance1448F06E4",
       "resourceType": "AWS::DocDB::DBInstance",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
@@ -109,7 +109,7 @@
       "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "PreferredMaintenanceWindow",
@@ -127,7 +127,7 @@
       "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "SnapshotWindow",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
@@ -166,7 +166,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "PreferredMaintenanceWindow",
@@ -184,7 +184,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "SnapshotWindow",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.memcached.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.memcached.json
@@ -111,7 +111,7 @@
       "constructPath": "CdkRealDriftIntegElasticacheMemcached/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
+++ b/tests/corpus/AWS__ElastiCache__ReplicationGroup.ReplicationGroup.json
@@ -226,7 +226,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheRich/ReplicationGroup"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ReplicationGroup",
       "resourceType": "AWS::ElastiCache::ReplicationGroup",
       "path": "SnapshotWindow",

--- a/tests/corpus/AWS__ElastiCache__ServerlessCache.ServerlessCache.json
+++ b/tests/corpus/AWS__ElastiCache__ServerlessCache.ServerlessCache.json
@@ -64,7 +64,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ServerlessCache",
       "resourceType": "AWS::ElastiCache::ServerlessCache",
       "path": "DailySnapshotTime",

--- a/tests/corpus/AWS__MemoryDB__Cluster.Cluster.json
+++ b/tests/corpus/AWS__MemoryDB__Cluster.Cluster.json
@@ -126,7 +126,7 @@
       "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MemoryDB::Cluster",
       "path": "SnapshotWindow",
@@ -162,7 +162,7 @@
       "constructPath": "CdkRealDriftIntegMemoryDb/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MemoryDB::Cluster",
       "path": "MaintenanceWindow",

--- a/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
+++ b/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
@@ -119,7 +119,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Neptune::DBCluster",
       "path": "PreferredMaintenanceWindow",
@@ -128,7 +128,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Neptune::DBCluster",
       "path": "PreferredBackupWindow",

--- a/tests/corpus/AWS__Neptune__DBInstance.Instance.json
+++ b/tests/corpus/AWS__Neptune__DBInstance.Instance.json
@@ -91,7 +91,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Instance"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Instance",
       "resourceType": "AWS::Neptune::DBInstance",
       "path": "PreferredMaintenanceWindow",

--- a/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
@@ -224,7 +224,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "PreferredMaintenanceWindow",


### PR DESCRIPTION
## What

The offline first-run-noise sweep (`scripts/measure-noise.sh`, replaying classify over the 600+ real golden-corpus reads) surfaced **AWS-assigned maintenance / backup / snapshot windows** as `[Potential Drift]` on every DocDB / Neptune / ElastiCache / MemoryDB / Redshift / AmazonMQ first run — the exact class RDS already folds (#533). AWS randomly assigns these windows when the template declares none, so they are AWS's choice, not user intent → fold value-independent (`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`), mirroring `AWS::RDS::*`. A **declared** window is user intent and stays compared in the declared loop (still detected).

| type | props folded |
|------|--------------|
| DocDB DBCluster / DBInstance | PreferredMaintenanceWindow (+ PreferredBackupWindow on cluster) |
| Neptune DBCluster / DBInstance | PreferredMaintenanceWindow (+ PreferredBackupWindow on cluster) |
| ElastiCache CacheCluster / ReplicationGroup | PreferredMaintenanceWindow, SnapshotWindow |
| ElastiCache ServerlessCache | DailySnapshotTime |
| MemoryDB Cluster | MaintenanceWindow, SnapshotWindow |
| Redshift Cluster | PreferredMaintenanceWindow |
| AmazonMQ Broker | MaintenanceWindowStartTime (object — folds whole) |

## Why

These are the highest-precedent, highest-frequency slice of the `measure-noise` CANDIDATE list — all AWS-assigned, all mirroring the RDS window fold. Deliberately **deferred** to a follow-up (still CANDIDATE in the sweep): managed-default param-group names (`default.redisX`…) → `DEFAULT_MANAGED_NAME_PATHS`; Redshift constant defaults (Port 5439, retention periods); OpenSearch window objects.

## Test

- Regenerates the **13 affected golden-corpus cases** (undeclared → atDefault, tier-only diffs) + 2 classify unit tests (each type folds; a declared window still detected).
- `vp run typecheck` / `vp run check` (0 errors) / `vp pack` / `vp test run` (**2805 tests**) pass.
- **Live-verified** on a fresh `elasticache-cachecluster-rich` deploy: the AWS-assigned `PreferredMaintenanceWindow`/`SnapshotWindow` fold to `atDefault` (not potential drift); stack torn down, **SWEEP CLEAN**.
- All 7 core integration fixtures **INTEG PASS**, orphans swept clean.
