### PR TITLE
feat(noise): fold managed param-group names + Redshift/OpenSearch AWS-assigned defaults

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -654,6 +654,34 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::OpenSearchService::Domain': {
     IPAddressType: 'ipv4',
+    // AWS-materialized defaults a domain reads back on every first run (found by the offline
+    // noise sweep, unanimous across the corpus domains): the automated-snapshot hour AWS assigns
+    // (0 = midnight UTC) and the two default AdvancedOptions the service always returns. Equality-
+    // gated: a domain that sets a non-default snapshot hour / advanced option no longer matches
+    // and surfaces. (OffPeakWindowOptions — an AWS-ASSIGNED window object — folds value-
+    // independent below, not here, since its start time is AWS's per-domain choice, not a constant.)
+    SnapshotOptions: { AutomatedSnapshotStartHour: 0 },
+    AdvancedOptions: {
+      override_main_response_version: 'false',
+      'rest.action.multi.allow_explicit_index': 'true',
+    },
+  },
+  // A Redshift cluster reads back a raft of AWS-assigned constant defaults the template never
+  // declares (found by the offline noise sweep). Only the CLEARLY-documented constants are folded
+  // — the AWS-owned-key placeholder, the default ports/retention/track, and the auto/version-
+  // upgrade toggles. Deliberately NOT folded (genuine per-resource state a user should see):
+  // `Encrypted` (security-relevant), `NumberOfNodes` (cluster topology), `AvailabilityZone`
+  // (folded value-independent below like RDS), `AvailabilityZoneRelocationStatus` (default
+  // uncertain), `ClusterParameterGroupName` (DEFAULT_MANAGED_NAME_PATHS). Equality-gated: any
+  // value moved off the default surfaces.
+  'AWS::Redshift::Cluster': {
+    Port: 5439,
+    AutomatedSnapshotRetentionPeriod: 1,
+    ManualSnapshotRetentionPeriod: -1,
+    AllowVersionUpgrade: true,
+    AquaConfigurationStatus: 'auto',
+    MaintenanceTrackName: 'current',
+    KmsKeyId: 'AWS_OWNED_KMS_KEY',
   },
   'AWS::EC2::VPCEndpoint': {
     IpAddressType: 'ipv4',
@@ -1537,6 +1565,19 @@ export const DEFAULT_MANAGED_NAME_PATHS: Record<string, Record<string, RegExp>> 
     DBParameterGroupName: /^default\./,
     OptionGroupName: /^default:/,
   },
+  // The RDS-family + cache engines mirror the RDS `default.<engine><version>` precedent: a
+  // cluster/instance/cache that declares no explicit parameter group reads back the AWS-managed
+  // default group name (`default.redis7`, `default.docdb5.0`, `default.neptune1.3`,
+  // `default.redshift-2.0`, `default.memorydb-redis7`). The name is version-derived (not a
+  // pinnable constant), so it is regex-matched — a CUSTOM group name a user attached does not
+  // start with `default.` and still surfaces. Undeclared-only, like the RDS precedent. Found by
+  // the offline first-run-noise sweep across the corpus.
+  'AWS::ElastiCache::CacheCluster': { CacheParameterGroupName: /^default\./ },
+  'AWS::DocDB::DBCluster': { DBClusterParameterGroupName: /^default\./ },
+  'AWS::Neptune::DBCluster': { DBClusterParameterGroupName: /^default\./ },
+  'AWS::Neptune::DBInstance': { DBParameterGroupName: /^default\./ },
+  'AWS::Redshift::Cluster': { ClusterParameterGroupName: /^default\./ },
+  'AWS::MemoryDB::Cluster': { ParameterGroupName: /^default\./ },
 };
 
 // Top-level UNDECLARED keys that are ALWAYS a service-minted, AWS-managed generated
@@ -1821,7 +1862,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::ElastiCache::ReplicationGroup': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
   'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
   'AWS::MemoryDB::Cluster': new Set(['MaintenanceWindow', 'SnapshotWindow']),
-  'AWS::Redshift::Cluster': new Set(['PreferredMaintenanceWindow']),
+  //   AWS::Redshift::Cluster.AvailabilityZone — AWS places an undeclared cluster in an AZ it picks
+  //   (create-only, never user intent when undeclared), exactly like RDS AvailabilityZone above.
+  //   OffPeakWindowOptions on an OpenSearch domain is the AWS-ASSIGNED off-peak maintenance window
+  //   (an object {OffPeakWindow:{WindowStartTime:{Hours,Minutes}},Enabled}); AWS enables it and
+  //   assigns the start time per domain, so fold the whole property value-independent (a domain
+  //   that DECLARES an off-peak window is compared in the declared loop).
+  'AWS::Redshift::Cluster': new Set(['PreferredMaintenanceWindow', 'AvailabilityZone']),
+  'AWS::OpenSearchService::Domain': new Set(['OffPeakWindowOptions']),
   //   AWS::AmazonMQ::Broker.MaintenanceWindowStartTime — a broker that declares no window reads
   //   back an AWS-assigned one as an OBJECT ({DayOfWeek, TimeOfDay, TimeZone}); value-independent
   //   folds the whole top-level property whatever its shape, so the assigned window is not first-

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5239,6 +5239,124 @@ describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)',
   });
 });
 
+// Second offline noise-sweep batch: AWS-managed parameter-group names, Redshift constant
+// defaults, and OpenSearch domain defaults — all undeclared AWS-assigned values a first run
+// would otherwise flag as [Potential Drift].
+describe('managed param-group names + Redshift/OpenSearch defaults fold', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const t = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    tiers(
+      classifyResource({ logicalId: 'R', resourceType, physicalId: 'p', declared }, live, bare)
+    );
+
+  it('the AWS-managed default.* parameter-group name folds (regex), a custom one still surfaces', () => {
+    const cases: [string, string, string][] = [
+      ['AWS::ElastiCache::CacheCluster', 'CacheParameterGroupName', 'default.redis7'],
+      ['AWS::DocDB::DBCluster', 'DBClusterParameterGroupName', 'default.docdb5.0'],
+      ['AWS::Neptune::DBCluster', 'DBClusterParameterGroupName', 'default.neptune1.3'],
+      ['AWS::Neptune::DBInstance', 'DBParameterGroupName', 'default.neptune1.3'],
+      ['AWS::Redshift::Cluster', 'ClusterParameterGroupName', 'default.redshift-2.0'],
+      ['AWS::MemoryDB::Cluster', 'ParameterGroupName', 'default.memorydb-redis7'],
+    ];
+    for (const [type, prop, val] of cases) {
+      expect(t(type, {}, { [prop]: val }).atDefault).toContain(prop);
+      // a custom (non-default.*) group name is real undeclared inventory
+      expect(t(type, {}, { [prop]: 'my-custom-group' }).undeclared).toContain(prop);
+    }
+  });
+
+  it('Redshift constant defaults fold; security/topology values stay undeclared', () => {
+    const r = t(
+      'AWS::Redshift::Cluster',
+      {},
+      {
+        Port: 5439,
+        AutomatedSnapshotRetentionPeriod: 1,
+        ManualSnapshotRetentionPeriod: -1,
+        AllowVersionUpgrade: true,
+        AquaConfigurationStatus: 'auto',
+        MaintenanceTrackName: 'current',
+        KmsKeyId: 'AWS_OWNED_KMS_KEY',
+        AvailabilityZone: 'us-east-1a',
+        Encrypted: true,
+        NumberOfNodes: 1,
+      }
+    );
+    expect(r.atDefault).toEqual(
+      expect.arrayContaining([
+        'Port',
+        'AutomatedSnapshotRetentionPeriod',
+        'ManualSnapshotRetentionPeriod',
+        'AllowVersionUpgrade',
+        'AquaConfigurationStatus',
+        'MaintenanceTrackName',
+        'KmsKeyId',
+        'AvailabilityZone',
+      ])
+    );
+    // deliberately NOT folded — a user should see these
+    expect(r.undeclared).toEqual(expect.arrayContaining(['Encrypted', 'NumberOfNodes']));
+    // a non-default port surfaces (equality-gated)
+    expect(t('AWS::Redshift::Cluster', {}, { Port: 5555 }).undeclared).toContain('Port');
+  });
+
+  it('OpenSearch domain defaults fold; the AWS-assigned off-peak window folds value-independent', () => {
+    const r = t(
+      'AWS::OpenSearchService::Domain',
+      {},
+      {
+        SnapshotOptions: { AutomatedSnapshotStartHour: 0 },
+        AdvancedOptions: {
+          override_main_response_version: 'false',
+          'rest.action.multi.allow_explicit_index': 'true',
+        },
+        OffPeakWindowOptions: {
+          OffPeakWindow: { WindowStartTime: { Hours: 2, Minutes: 0 } },
+          Enabled: true,
+        },
+      }
+    );
+    expect(r.atDefault).toEqual(
+      expect.arrayContaining(['SnapshotOptions', 'AdvancedOptions', 'OffPeakWindowOptions'])
+    );
+    // a non-default snapshot hour surfaces (equality-gated)
+    expect(
+      t(
+        'AWS::OpenSearchService::Domain',
+        {},
+        { SnapshotOptions: { AutomatedSnapshotStartHour: 3 } }
+      ).undeclared
+    ).toContain('SnapshotOptions');
+    // a DECLARED off-peak window is user intent — compared (descended), NOT value-independent
+    // folded; a divergent start hour surfaces as declared drift on the nested path.
+    const declared = t(
+      'AWS::OpenSearchService::Domain',
+      { OffPeakWindowOptions: { OffPeakWindow: { WindowStartTime: { Hours: 5, Minutes: 0 } } } },
+      {
+        OffPeakWindowOptions: {
+          OffPeakWindow: { WindowStartTime: { Hours: 2, Minutes: 0 } },
+          Enabled: true,
+        },
+      }
+    );
+    expect(declared.declared.some((p) => p.startsWith('OffPeakWindowOptions'))).toBe(true);
+    expect(declared.atDefault).not.toContain('OffPeakWindowOptions');
+  });
+});
+
 describe('RDS engine-derived defaults fold to atDefault', () => {
   const bare: SchemaInfo = {
     readOnly: new Set(),

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterEB0386A7.json
@@ -134,7 +134,7 @@
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterEB0386A7",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "DBClusterParameterGroupName",

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
@@ -115,7 +115,7 @@
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "DBClusterParameterGroupName",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
@@ -100,7 +100,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "CacheParameterGroupName",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
@@ -157,7 +157,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "CacheParameterGroupName",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.memcached.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.memcached.json
@@ -102,7 +102,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "CacheParameterGroupName",

--- a/tests/corpus/AWS__MemoryDB__Cluster.Cluster.json
+++ b/tests/corpus/AWS__MemoryDB__Cluster.Cluster.json
@@ -99,7 +99,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::MemoryDB::Cluster",
       "path": "ParameterGroupName",

--- a/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
+++ b/tests/corpus/AWS__Neptune__DBCluster.Cluster.json
@@ -164,7 +164,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Neptune::DBCluster",
       "path": "DBClusterParameterGroupName",

--- a/tests/corpus/AWS__Neptune__DBInstance.Instance.json
+++ b/tests/corpus/AWS__Neptune__DBInstance.Instance.json
@@ -73,7 +73,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Instance",
       "resourceType": "AWS::Neptune::DBInstance",
       "path": "DBParameterGroupName",

--- a/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
@@ -170,7 +170,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "SnapshotOptions",
@@ -181,7 +181,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "AdvancedOptions",
@@ -213,7 +213,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "OffPeakWindowOptions",

--- a/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
@@ -173,7 +173,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "SnapshotOptions",
@@ -184,7 +184,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "AdvancedOptions",
@@ -216,7 +216,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "OffPeakWindowOptions",

--- a/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Cluster.sgreorder.json
@@ -125,7 +125,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AutomatedSnapshotRetentionPeriod",
@@ -143,7 +143,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AquaConfigurationStatus",
@@ -161,7 +161,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "Port",
@@ -179,7 +179,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "ClusterParameterGroupName",
@@ -188,7 +188,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AllowVersionUpgrade",
@@ -197,7 +197,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "MaintenanceTrackName",
@@ -206,7 +206,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "KmsKeyId",
@@ -215,7 +215,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AvailabilityZone",
@@ -233,7 +233,7 @@
       "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "ManualSnapshotRetentionPeriod",


### PR DESCRIPTION
## What

The second offline first-run-noise sweep batch (`scripts/measure-noise.sh` over the golden corpus) — the follow-up explicitly deferred in #584. All are undeclared **AWS-assigned** values a first run would otherwise show as `[Potential Drift]`.

**DEFAULT_MANAGED_NAME_PATHS** (regex `default.*`, a custom name still surfaces) — mirrors the RDS `DBParameterGroupName` precedent:
- ElastiCache CacheCluster, DocDB DBCluster, Neptune DBCluster/DBInstance, Redshift Cluster, MemoryDB Cluster

**KNOWN_DEFAULTS** (equality-gated — any value off the default surfaces):
- Redshift Cluster: Port 5439, AutomatedSnapshotRetentionPeriod 1, ManualSnapshotRetentionPeriod -1, AllowVersionUpgrade true, AquaConfigurationStatus auto, MaintenanceTrackName current, KmsKeyId AWS_OWNED_KMS_KEY
- OpenSearch Domain: SnapshotOptions {AutomatedSnapshotStartHour 0}, the two default AdvancedOptions

**VALUE_INDEPENDENT**:
- Redshift Cluster AvailabilityZone (AWS-placed, like RDS)
- OpenSearch Domain OffPeakWindowOptions (AWS-assigned window object — folded whole)

## Deliberately NOT folded

Genuine state a user should see (still CANDIDATE in `measure-noise` for a later pass): Redshift `Encrypted` (security), `NumberOfNodes` (topology), `AvailabilityZoneRelocationStatus` (default uncertain); OpenSearch `DeploymentStrategyOptions` (uncertain) + nested `EncryptionAtRestOptions.KmsKeyId`.

## Test

- Regenerates the **11 affected golden-corpus cases** (undeclared → atDefault) + 3 classify unit tests (each folds; a custom name / non-default value / declared window still surfaces).
- `vp run typecheck` / `vp run check` (0 errors) / `vp pack` / `vp test run` (**2808 tests**) pass.
- **Live-verified** on a fresh `elasticache-cachecluster-rich` deploy: the managed `default.redis7` param-group name folds to `atDefault` (not potential drift). Stack torn down, **SWEEP CLEAN**.
- All 7 core integration fixtures **INTEG PASS**, orphans swept clean.
