### PR TITLE
docs: codify the clean-deploy → zero-potential-drift invariant as a rule

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -37,7 +37,21 @@ non-negotiable", which is enforced by a gate, not by trust.
      means cdkrd's declared template value normalizes differently from the live
      value (a normalization / default-folding bug). `record` snapshots only the
      UNDECLARED dimension, so a surviving post-record drift is necessarily a
-     declared-dimension FP — exactly the class worth catching.
+     declared-dimension FP — exactly the class worth catching. **The invariant
+     (see CLAUDE.md / DESIGN.md): a clean, un-mutated deploy must show ZERO
+     `[Potential Drift]` on a `check` BEFORE `record`, too.** Every value AWS
+     assigns at creation that the template never declared is an initial/default,
+     not a divergence — so it MUST fold to `atDefault`. `[Potential Drift]` is only
+     ever a REAL divergence (a user change, or an AWS out-of-band change AFTER
+     creation like Application Signals adding IAM perms). So `check`-before-`record`
+     on a fresh fixture and read the `[Potential Drift]` list: **every entry there
+     is a fold gap = a bug** (the FP the check-output note + issue link ask users to
+     report). When a candidate default's status is uncertain, **RESOLVE it by
+     verifying** what AWS assigns to a fresh minimal config — never leave it
+     surfaced as "conservative", that just ships the bug. Fold via equality-gated
+     `KNOWN_DEFAULTS` (folds the default, surfaces a change away — detection kept)
+     for mutable meaningful props; value-independent only for create-only /
+     AWS-assigned identifiers / cosmetic values.
    - **False negative (FN) / missed detection** — `record`→`check`→CLEAN does NOT
      exercise detection. So ALSO mutate a **declared, MUTABLE** property out of band
      (the "someone changed it in the console" scenario — Lambda `MemorySize`/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,25 @@ reimplement `cdk diff`. The full design, rationale, and pipeline are in
 terse companion and [docs/redesign-notes.md](docs/redesign-notes.md) for
 pre-publication decisions).
 
+### Core invariant: a clean deploy has ZERO potential drift
+
+A freshly deployed, **un-mutated** stack must produce **zero** `[Potential Drift]`
+on a first `check` (before `record`). Every value AWS assigns at creation — an
+initial/default it materialized that the template never declared — is NOT a
+divergence, so it must fold to `atDefault`, never surface. `[Potential Drift]`
+is reserved for a **real divergence**: a value the USER changed, or one AWS
+changed OUT OF BAND _after_ creation (e.g. enabling Application Signals adding IAM
+permissions later). Anything else appearing there is a **fold gap (a bug)** — this
+is exactly the false positive the `check`-output note + issue link (#581) ask users
+to report. When a candidate default's status is uncertain, **RESOLVE the
+uncertainty by investigation / live verification** (deploy a fresh minimal config,
+observe what AWS assigns undeclared) — never leave a value surfaced as
+"conservative"; that just ships the bug. The fold must PRESERVE out-of-band
+detection: prefer equality-gated `KNOWN_DEFAULTS` (folds the default value,
+surfaces a change away from it) for mutable meaningful props; use
+`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (folds any value) only for create-only /
+AWS-assigned identifiers / cosmetic values where change-detection is not meaningful.
+
 ## The 4-Verb Model
 
 ```bash

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,6 +74,23 @@ PoC-confirmed (CDKToolkit S3 + IAM, us-east-1): biggest noise (readOnly/writeOnl
 attrs) is auto-strippable from the resource schema; residual undeclared signal was
 tiny + meaningful (S3 `AbacStatus`, `OwnershipControls`).
 
+### Invariant: a clean deploy → zero potential drift
+
+A freshly deployed, un-mutated stack must show **zero** `[Potential Drift]` on a
+first `check` (before `record`). Every value AWS materialized at creation — an
+initial/default the template never declared — is not a divergence and must fold to
+`atDefault`. `[Potential Drift]` is only ever a **real** divergence: a value the
+user changed, or one AWS changed out of band _after_ creation (e.g. enabling
+Application Signals adding IAM permissions later). Anything else surfacing there is
+a fold gap = a bug (the false positive the check-output note + issue link ask users
+to report). An uncertain default is resolved by **verifying** what AWS assigns to a
+fresh minimal config — never left surfaced as "conservative". Fold via equality-
+gated `KNOWN_DEFAULTS` (folds the default, surfaces a change away — detection kept)
+for mutable meaningful props; value-independent only for create-only / AWS-assigned
+identifiers / cosmetic values. This is why every `*-rich` fixture doubles as an FP
+oracle: a `record`→`check` CLEAN proves the DECLARED dimension, and a
+`check`-before-`record` with zero potential drift proves the UNDECLARED one.
+
 ## Reuse from cdkd
 
 COPY (low coupling, verified):


### PR DESCRIPTION
Persist the core noise/fold philosophy as a **rule** (CLAUDE.md + DESIGN.md + hunt-bugs skill), so it survives across sessions/terminals rather than living only in memory.

**The invariant**: a freshly deployed, un-mutated stack must show **zero** `[Potential Drift]` on a `check` *before* `record`. Every value AWS materialized at creation (an initial/default the template never declared) is not a divergence and must fold to `atDefault`. `[Potential Drift]` is only ever a **real** divergence — a value the user changed, or one AWS changed **out of band after creation** (e.g. enabling Application Signals adding IAM permissions later). Anything else surfacing there is a **fold gap = a bug** (the false positive the check-output note + issue link from #581 ask users to report).

**Corollary for fold work**: an uncertain default is resolved by **verifying** what AWS assigns to a fresh minimal config — never left surfaced as "conservative" (that just ships the bug). Fold preserving detection: equality-gated `KNOWN_DEFAULTS` (folds the default, surfaces a change away) for mutable meaningful props; value-independent only for create-only / AWS-assigned identifiers / cosmetic values.

Docs-only (no `src/**`) → verify-pr-gate exempt; `vp run check` / typecheck / `vp run test` (2808) pass.