### PR TITLE
feat(noise): fold every AWS-initial value on a fresh Redshift/OpenSearch deploy (zero potential drift)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1014,7 +1014,21 @@ export function classifyResource(
   // NOTE: no `schema.writeOnly.has(k)` guard here — a top-level write-only key was
   // already emitted as a readGap above AND stripped from `declared` by writeOnlyPaths,
   // so it cannot reach this loop (the old guard was dead code for top-level keys).
-  const knownDef = KNOWN_DEFAULTS[resourceType] ?? {};
+  let knownDef = KNOWN_DEFAULTS[resourceType] ?? {};
+  // A Redshift RA3 cluster is ALWAYS encrypted (RA3 mandates encryption — it can never be false)
+  // and AWS enables AvailabilityZoneRelocation for it by default, so an RA3 cluster that declares
+  // neither reads back Encrypted=true / AvailabilityZoneRelocationStatus="enabled" — AWS-forced
+  // initial values, not user intent. Fold them via a NodeType conditional (the reliable in-
+  // template discriminator; a DC2 cluster keeps the false/absent default and is unaffected).
+  // Equality-gated + live-verified on a fresh RA3 single-node deploy. A cluster that declares
+  // either value explicitly is compared in the declared loop, never reaching here.
+  if (
+    resourceType === 'AWS::Redshift::Cluster' &&
+    typeof declaredIn?.['NodeType'] === 'string' &&
+    (declaredIn['NodeType'] as string).startsWith('ra3')
+  ) {
+    knownDef = { ...knownDef, Encrypted: true, AvailabilityZoneRelocationStatus: 'enabled' };
+  }
   // AWS/CDK-generated values for THIS resource (its minted name, a default log group
   // derived from the physical id), with the live physical id substituted in — keyed
   // by property, consulted by the undeclared loop below. Empty when the type has no

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -665,15 +665,20 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       override_main_response_version: 'false',
       'rest.action.multi.allow_explicit_index': 'true',
     },
+    // A domain that declares no deployment strategy reads back the AWS default
+    // "CapacityOptimized" (live-verified on a fresh opensearch-rich deploy, undeclared).
+    // Equality-gated: a different strategy surfaces. (EncryptionAtRestOptions.KmsKeyId — the
+    // AWS-assigned encryption key — folds value-independent via GENERATED_NESTED_PATHS below.)
+    DeploymentStrategyOptions: { DeploymentStrategy: 'CapacityOptimized' },
   },
   // A Redshift cluster reads back a raft of AWS-assigned constant defaults the template never
-  // declares (found by the offline noise sweep). Only the CLEARLY-documented constants are folded
-  // — the AWS-owned-key placeholder, the default ports/retention/track, and the auto/version-
-  // upgrade toggles. Deliberately NOT folded (genuine per-resource state a user should see):
-  // `Encrypted` (security-relevant), `NumberOfNodes` (cluster topology), `AvailabilityZone`
-  // (folded value-independent below like RDS), `AvailabilityZoneRelocationStatus` (default
-  // uncertain), `ClusterParameterGroupName` (DEFAULT_MANAGED_NAME_PATHS). Equality-gated: any
-  // value moved off the default surfaces.
+  // declares (found by the offline noise sweep, live-verified on a fresh redshift-rich RA3
+  // single-node deploy — the clean-deploy=zero-potential-drift invariant). Equality-gated: any
+  // value moved off the default surfaces. `NumberOfNodes` folds at 1 (the single-node default; a
+  // resize to a multi-node cluster surfaces). `Encrypted` and `AvailabilityZoneRelocationStatus`
+  // are NodeType-DERIVED (RA3 is always encrypted + AWS enables AZ relocation) so they fold via a
+  // classify conditional keyed on the declared NodeType, not here. `ClusterVersion` is the AWS-
+  // assigned engine version → value-independent below; `AvailabilityZone` likewise.
   'AWS::Redshift::Cluster': {
     Port: 5439,
     AutomatedSnapshotRetentionPeriod: 1,
@@ -682,6 +687,7 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     AquaConfigurationStatus: 'auto',
     MaintenanceTrackName: 'current',
     KmsKeyId: 'AWS_OWNED_KMS_KEY',
+    NumberOfNodes: 1,
   },
   'AWS::EC2::VPCEndpoint': {
     IpAddressType: 'ipv4',
@@ -1745,6 +1751,10 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   // fold the LogGroup path itself, value-independently — a CUSTOM log group is DECLARED and
   // compared in the declared loop, never reaching here.
   'AWS::Lambda::Function': new Set(['LoggingConfig.LogGroup']),
+  // An OpenSearch domain that declares no explicit KMS key reads back the AWS-assigned key id
+  // (a GUID) inside EncryptionAtRestOptions — never a constant, never user intent when undeclared
+  // (like RDS KmsKeyId). Live-verified undeclared on a fresh opensearch-rich deploy.
+  'AWS::OpenSearchService::Domain': new Set(['EncryptionAtRestOptions.KmsKeyId']),
 };
 
 // Undeclared TOP-LEVEL keys whose AWS-chosen default is NON-DETERMINISTIC — the value
@@ -1868,7 +1878,15 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   (an object {OffPeakWindow:{WindowStartTime:{Hours,Minutes}},Enabled}); AWS enables it and
   //   assigns the start time per domain, so fold the whole property value-independent (a domain
   //   that DECLARES an off-peak window is compared in the declared loop).
-  'AWS::Redshift::Cluster': new Set(['PreferredMaintenanceWindow', 'AvailabilityZone']),
+  //   AWS::Redshift::Cluster.ClusterVersion — a cluster that pins no explicit version reads back
+  //   the concrete engine version AWS provisioned ("1.0" today). "use the current default" is
+  //   satisfied by whatever version is current, so it is not user intent when undeclared (a user
+  //   who cares DECLARES ClusterVersion → compared). Live-verified undeclared on a fresh deploy.
+  'AWS::Redshift::Cluster': new Set([
+    'PreferredMaintenanceWindow',
+    'AvailabilityZone',
+    'ClusterVersion',
+  ]),
   'AWS::OpenSearchService::Domain': new Set(['OffPeakWindowOptions']),
   //   AWS::AmazonMQ::Broker.MaintenanceWindowStartTime — a broker that declares no window reads
   //   back an AWS-assigned one as an OBJECT ({DayOfWeek, TimeOfDay, TimeZone}); value-independent

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5305,10 +5305,13 @@ describe('managed param-group names + Redshift/OpenSearch defaults fold', () => 
         'MaintenanceTrackName',
         'KmsKeyId',
         'AvailabilityZone',
+        'NumberOfNodes', // single-node default, KNOWN_DEFAULTS 1
       ])
     );
-    // deliberately NOT folded — a user should see these
-    expect(r.undeclared).toEqual(expect.arrayContaining(['Encrypted', 'NumberOfNodes']));
+    // Encrypted stays undeclared WITHOUT a declared NodeType: the RA3 always-encrypted conditional
+    // needs the NodeType discriminator, so absent it a true is treated as a real (DC2-style) enable
+    // and surfaces. (A declared RA3 NodeType folds it — see the clean-deploy invariant describe.)
+    expect(r.undeclared).toContain('Encrypted');
     // a non-default port surfaces (equality-gated)
     expect(t('AWS::Redshift::Cluster', {}, { Port: 5555 }).undeclared).toContain('Port');
   });
@@ -5354,6 +5357,89 @@ describe('managed param-group names + Redshift/OpenSearch defaults fold', () => 
     );
     expect(declared.declared.some((p) => p.startsWith('OffPeakWindowOptions'))).toBe(true);
     expect(declared.atDefault).not.toContain('OffPeakWindowOptions');
+  });
+});
+
+// The clean-deploy -> zero-potential-drift invariant, live-verified on a fresh redshift-rich
+// (RA3 single-node) + opensearch-rich deploy: EVERY undeclared value AWS returned must fold.
+describe('Redshift/OpenSearch clean-deploy invariant (all AWS-initial values fold)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const t = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    tiers(
+      classifyResource({ logicalId: 'R', resourceType, physicalId: 'p', declared }, live, bare)
+    );
+
+  it('a fresh RA3 single-node Redshift cluster has ZERO undeclared (every AWS-initial value folds)', () => {
+    // exactly what a fresh redshift-rich deploy returns undeclared (live-verified)
+    const r = t(
+      'AWS::Redshift::Cluster',
+      { NodeType: 'ra3.large', ClusterType: 'single-node' },
+      {
+        AvailabilityZoneRelocationStatus: 'enabled', // RA3 conditional
+        Encrypted: true, // RA3 always encrypted (conditional)
+        NumberOfNodes: 1, // single-node KNOWN_DEFAULT
+        ClusterVersion: '1.0', // AWS-assigned version, value-independent
+      }
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toEqual(
+      expect.arrayContaining([
+        'AvailabilityZoneRelocationStatus',
+        'Encrypted',
+        'NumberOfNodes',
+        'ClusterVersion',
+      ])
+    );
+  });
+
+  it('the RA3 conditional is NodeType-gated — a DC2 cluster does NOT fold Encrypted=true, and a resize surfaces', () => {
+    // DC2 (not always-encrypted): an undeclared Encrypted=true is a REAL enable → must surface
+    const dc2 = t('AWS::Redshift::Cluster', { NodeType: 'dc2.large' }, { Encrypted: true });
+    expect(dc2.undeclared).toContain('Encrypted');
+    // detection preserved on RA3 too: NumberOfNodes off the single-node default surfaces
+    const resized = t('AWS::Redshift::Cluster', { NodeType: 'ra3.large' }, { NumberOfNodes: 4 });
+    expect(resized.undeclared).toContain('NumberOfNodes');
+  });
+
+  it('a fresh OpenSearch domain folds the AWS-assigned deployment strategy + encryption key', () => {
+    // mirrors the real live shape: EncryptionAtRestOptions is partially declared ({Enabled:true}),
+    // so classify descends and the AWS-added KmsKeyId sub-key folds value-independent (nested).
+    const r = t(
+      'AWS::OpenSearchService::Domain',
+      { EncryptionAtRestOptions: { Enabled: true } },
+      {
+        DeploymentStrategyOptions: { DeploymentStrategy: 'CapacityOptimized' },
+        EncryptionAtRestOptions: {
+          KmsKeyId: 'db99576a-7bcf-4386-a93e-0334efbed006',
+          Enabled: true,
+        },
+      }
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toContain('DeploymentStrategyOptions');
+    // the nested AWS-assigned key folds value-independent (generated tier), whatever its GUID
+    expect(r.generated).toContain('EncryptionAtRestOptions.KmsKeyId');
+    // a non-default deployment strategy surfaces (equality-gated)
+    expect(
+      t(
+        'AWS::OpenSearchService::Domain',
+        {},
+        { DeploymentStrategyOptions: { DeploymentStrategy: 'Custom' } }
+      ).undeclared
+    ).toContain('DeploymentStrategyOptions');
   });
 });
 

--- a/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.Domain66AC69E0.json
@@ -202,7 +202,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "DeploymentStrategyOptions",
@@ -250,7 +250,7 @@
       "constructPath": "CdkRealDriftIntegOpensearchRich/Domain"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Domain66AC69E0",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "EncryptionAtRestOptions.KmsKeyId",

--- a/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
@@ -205,7 +205,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "DeploymentStrategyOptions",
@@ -253,7 +253,7 @@
       "constructPath": "CdkdriftIntegHarvest13/OpenSearch"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "OpenSearch587998CD",
       "resourceType": "AWS::OpenSearchService::Domain",
       "path": "EncryptionAtRestOptions.KmsKeyId",

--- a/tests/corpus/AWS__Redshift__Cluster.Cluster.json
+++ b/tests/corpus/AWS__Redshift__Cluster.Cluster.json
@@ -3,18 +3,17 @@
   "resource": {
     "logicalId": "Cluster",
     "resourceType": "AWS::Redshift::Cluster",
-    "physicalId": "cluster-htpccw5gbpx7",
-    "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster",
+    "physicalId": "cluster-v8dz6fiuvmd4",
+    "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster",
     "declared": {
-      "ClusterSubnetGroupName": "subnetgroup-zmqkahqqya4b",
+      "ClusterSubnetGroupName": "subnetgroup-qzf7qdhzf8wr",
       "ClusterType": "single-node",
-      "ClusterVersion": "1.0",
       "DBName": "probe",
       "MasterUserPassword": "Cdkrd-Probe-123",
       "MasterUsername": "admin",
       "NodeType": "ra3.large",
       "PubliclyAccessible": false,
-      "VpcSecurityGroupIds": ["sg-0cc77d6b500db3d5a", "sg-067f8171539f6773b"]
+      "VpcSecurityGroupIds": ["sg-0f37569c9ef5a1288"]
     }
   },
   "liveRaw": {
@@ -28,23 +27,23 @@
     "ClusterParameterGroupName": "default.redshift-2.0",
     "AllowVersionUpgrade": true,
     "Endpoint": {
-      "Address": "cluster-htpccw5gbpx7.c5qzh3zoxdm2.us-east-1.redshift.amazonaws.com",
+      "Address": "cluster-v8dz6fiuvmd4.c5qzh3zoxdm2.us-east-1.redshift.amazonaws.com",
       "Port": "5439"
     },
-    "VpcSecurityGroupIds": ["sg-067f8171539f6773b", "sg-0cc77d6b500db3d5a"],
+    "VpcSecurityGroupIds": ["sg-0f37569c9ef5a1288"],
     "MaintenanceTrackName": "current",
-    "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:111111111111:namespace:5cf1a143-b7b1-4b0f-a225-6291197b377b",
+    "ClusterNamespaceArn": "arn:aws:redshift:us-east-1:111111111111:namespace:078d9e64-8c3e-46f0-b46c-391f609729f4",
     "MultiAZ": false,
     "Tags": [],
     "IamRoles": [],
     "ClusterVersion": "1.0",
     "KmsKeyId": "AWS_OWNED_KMS_KEY",
     "AvailabilityZone": "us-east-1a",
-    "PreferredMaintenanceWindow": "sat:04:30-sat:05:00",
+    "PreferredMaintenanceWindow": "wed:10:00-wed:10:30",
     "ClusterType": "single-node",
     "ClusterSecurityGroups": [],
-    "ClusterIdentifier": "cluster-htpccw5gbpx7",
-    "ClusterSubnetGroupName": "subnetgroup-zmqkahqqya4b",
+    "ClusterIdentifier": "cluster-v8dz6fiuvmd4",
+    "ClusterSubnetGroupName": "subnetgroup-qzf7qdhzf8wr",
     "LoggingProperties": {
       "LogExports": []
     },
@@ -121,8 +120,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "MasterUserPassword",
       "note": "write-only — cannot be read back",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -130,8 +129,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AutomatedSnapshotRetentionPeriod",
       "actual": 1,
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -139,8 +138,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AvailabilityZoneRelocationStatus",
       "actual": "enabled",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -148,8 +147,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AquaConfigurationStatus",
       "actual": "auto",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -157,8 +156,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "Encrypted",
       "actual": true,
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -166,8 +165,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "Port",
       "actual": 5439,
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -175,8 +174,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "NumberOfNodes",
       "actual": 1,
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -184,8 +183,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "ClusterParameterGroupName",
       "actual": "default.redshift-2.0",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -193,8 +192,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AllowVersionUpgrade",
       "actual": true,
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -202,8 +201,17 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "MaintenanceTrackName",
       "actual": "current",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Cluster",
+      "resourceType": "AWS::Redshift::Cluster",
+      "path": "ClusterVersion",
+      "actual": "1.0",
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -211,8 +219,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "KmsKeyId",
       "actual": "AWS_OWNED_KMS_KEY",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -220,17 +228,17 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "AvailabilityZone",
       "actual": "us-east-1a",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::Redshift::Cluster",
       "path": "PreferredMaintenanceWindow",
-      "actual": "sat:04:30-sat:05:00",
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "actual": "wed:10:00-wed:10:30",
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     },
     {
       "tier": "atDefault",
@@ -238,8 +246,8 @@
       "resourceType": "AWS::Redshift::Cluster",
       "path": "ManualSnapshotRetentionPeriod",
       "actual": -1,
-      "physicalId": "cluster-htpccw5gbpx7",
-      "constructPath": "CdkRealDriftIntegRedshiftProbe/Cluster"
+      "physicalId": "cluster-v8dz6fiuvmd4",
+      "constructPath": "CdkRealDriftIntegRedshiftRich/Cluster"
     }
   ]
 }

--- a/tests/integration/redshift-rich/app.ts
+++ b/tests/integration/redshift-rich/app.ts
@@ -1,0 +1,45 @@
+// CDK app for the cdk-real-drift redshift-rich integration test.
+// AWS::Redshift::Cluster is a common data-warehouse primitive. This fixture is the
+// FP oracle for the "clean deploy -> zero potential drift" invariant (CLAUDE.md /
+// DESIGN.md): a minimal RA3 single-node cluster declares only identity/sizing, so
+// every OTHER value AWS returns is an initial/default it materialized. On a first
+// `check` BEFORE `record`, NONE of them may surface as [Potential Drift] — they must
+// all fold to atDefault. The RA3 node type is deliberate: RA3 clusters are ALWAYS
+// encrypted, so `Encrypted=true` is an AWS-forced initial value (not user intent);
+// `NumberOfNodes` is derived from `ClusterType=single-node`; `AvailabilityZone` /
+// param-group name / snapshot windows / port are AWS-assigned. Mirrors the shape of
+// the previously-orphaned Cluster corpus case (ra3.large, single-node).
+// A single-node ra3.large on an isolated VPC is the cheapest provisionable RA3.
+import { App, Stack } from "aws-cdk-lib";
+import { SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { CfnCluster, CfnClusterSubnetGroup } from "aws-cdk-lib/aws-redshift";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegRedshiftRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  natGateways: 0,
+  maxAzs: 2,
+  subnetConfiguration: [{ name: "priv", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+const sg = new SecurityGroup(stack, "Sg", { vpc });
+
+const subnetGroup = new CfnClusterSubnetGroup(stack, "SubnetGroup", {
+  description: "cdkrd integ redshift subnet group",
+  subnetIds: vpc.isolatedSubnets.map((s) => s.subnetId),
+});
+
+const cluster = new CfnCluster(stack, "Cluster", {
+  clusterType: "single-node",
+  nodeType: "ra3.large",
+  dbName: "probe",
+  masterUsername: "admin",
+  masterUserPassword: "Cdkrd-Probe-123",
+  clusterSubnetGroupName: subnetGroup.ref,
+  vpcSecurityGroupIds: [sg.securityGroupId],
+  publiclyAccessible: false,
+});
+cluster.addDependency(subnetGroup);
+
+app.synth();

--- a/tests/integration/redshift-rich/cdk.json
+++ b/tests/integration/redshift-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/redshift-rich/package.json
+++ b/tests/integration/redshift-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-redshift-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture: Redshift RA3 single-node cluster — undeclared AWS-initial defaults FP oracle (clean deploy = zero potential drift). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/redshift-rich/verify.sh
+++ b/tests/integration/redshift-rich/verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# cdk-real-drift redshift-rich integration test (real AWS).
+# The "clean deploy -> ZERO potential drift" invariant oracle (CLAUDE.md / DESIGN.md):
+# deploy -> check BEFORE record MUST show no [Potential Drift] (every undeclared value
+# is an AWS-assigned initial/default and must fold to atDefault) -> record -> check
+# stays CLEAN. A missing fold regresses the invariant and fails here. A cleanup trap
+# destroys even on failure, so a failed run leaves no orphans.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegRedshiftRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check BEFORE record: ZERO potential drift + no declared FP ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-redshift-rich-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "false declared drift (exit $rc)"
+grep -q "CFn-Declared Drift" /tmp/cdkrd-redshift-rich-pre.out && fail "a declared property was wrongly reported as drift"
+grep -q "Potential Drift" /tmp/cdkrd-redshift-rich-pre.out \
+  && fail "clean deploy has [Potential Drift] — an AWS-assigned initial value is not folded (invariant regressed)"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

Enforces the **clean-deploy → zero potential drift** invariant (codified in #586) for Redshift + OpenSearch. This directly resolves the *"uncertain → conservative skip"* gap left in #585: the uncertainty was **resolved by live verification** (deploy a fresh minimal config, observe exactly what AWS assigns undeclared) — per the invariant, never leaving an AWS-initial value surfaced as potential drift.

Live-verified on fresh `redshift-rich` (RA3 single-node) + `opensearch-rich` deploys, the remaining undeclared AWS-initial values now all fold:

**Redshift::Cluster**
| value | mechanism |
|-------|-----------|
| `NumberOfNodes` 1 | KNOWN_DEFAULTS (single-node default; a resize surfaces) |
| `ClusterVersion` | VALUE_INDEPENDENT (AWS-assigned engine version) |
| `Encrypted` / `AvailabilityZoneRelocationStatus` | **NodeType-gated conditional**: an RA3 cluster is ALWAYS encrypted and AWS enables AZ relocation, so these fold ONLY when the declared `NodeType` is `ra3.*`. A DC2 cluster keeps the false/absent default and a real enable still surfaces — **detection preserved** |

**OpenSearch::Domain**
| value | mechanism |
|-------|-----------|
| `DeploymentStrategyOptions` "CapacityOptimized" | KNOWN_DEFAULTS |
| `EncryptionAtRestOptions.KmsKeyId` | GENERATED_NESTED_PATHS (AWS-assigned key GUID, value-independent, like RDS KmsKeyId) |

## Fixture

Recreates the previously-**orphaned** Redshift Cluster corpus as a live `redshift-rich` fixture (RA3 single-node — the cheapest provisionable RA3). Its `verify.sh` asserts the invariant directly: `check` **before** `record` must show **no** `[Potential Drift]`.

## Test

- Regenerates 4 affected golden-corpus cases (now **ZERO undeclared**) + adds a fresh `redshift-rich` Cluster case + classify unit tests (RA3 conditional is NodeType-gated; a resize / non-default value / DC2 encrypted still surfaces).
- `vp run typecheck` / `vp run check` (0 errors) / `vp pack` / `vp test run` (**2813 tests**) pass.
- **Live-verified**: `redshift-rich` INTEG PASS — `check` before `record` shows zero potential drift; `record` reports "no undeclared values to record"; `record`→`check` CLEAN. Both stacks torn down, **SWEEP CLEAN**.
- All 7 core integration fixtures **INTEG PASS**.
