### PR TITLE
fix(synth): stop red-wrapping the construct-annotation validation report

### DIFF
--- a/src/synth/io-host.ts
+++ b/src/synth/io-host.ts
@@ -12,6 +12,19 @@
 // cdk-local. A genuine synth failure still surfaces: the subprocess exits non-zero,
 // toolkit-lib throws, and cdkrd's own error handling reports it (a different path
 // from these per-line E1002 passthrough messages).
+//
+// A third code needs the same INFO re-tag: `CDK_TOOLKIT_E9600`, the construct-
+// annotation validation report (the `aws:cdk:warning|error` a synth emits, e.g.
+// noSubnetRouteTableId). toolkit-lib registers this ONE code at ERROR level even for
+// a report whose only contents are WARNINGS, yet its formatter
+// (validate-formatting.ts) already colors each line per severity (yellow WARNING,
+// orange ERROR, grey rule hint) and DOCUMENTS that it must be emitted at a neutral
+// level so the IoHost does not wrap the whole block in a single color. Left at ERROR,
+// NonInteractiveIoHost paints the entire block red (chalk.red) — bleeding red over
+// the otherwise-default description + construct path, while only the pre-baked yellow
+// "WARNING" label survives (via chalk's nested-reset restoration). Re-tagging to INFO
+// (chalk.reset = no wrap) restores the intended per-severity coloring; a genuine
+// policy FAILURE still shows its own orange/red ERROR label from the formatter.
 import { NonInteractiveIoHost } from '@aws-cdk/toolkit-lib';
 import type { IoMessage } from '@aws-cdk/toolkit-lib';
 
@@ -20,6 +33,9 @@ type Level = IoMessage<unknown>['level'];
 // CDK app subprocess passthrough message codes (toolkit-lib source-builder.ts).
 const APP_STDOUT = 'CDK_ASSEMBLY_I1001';
 const APP_STDERR = 'CDK_ASSEMBLY_E1002';
+// Construct-annotation validation report (toolkit-lib validate-formatting.ts) —
+// ERROR-level but self-colored, so it must NOT be re-wrapped in a single color.
+const VALIDATION_REPORT = 'CDK_TOOLKIT_E9600';
 
 export type IoPlan = { action: 'drop' } | { action: 'emit'; level: Level };
 
@@ -27,11 +43,14 @@ export type IoPlan = { action: 'drop' } | { action: 'emit'; level: Level };
  * Decide what QuietIoHost does with a message (pure, so it is unit-testable):
  *  - the CDK app's own stdout/stderr passthrough -> emit at INFO (default color, like
  *    cdk-local; never the alarming red the E1002/error tag would otherwise produce);
+ *  - the construct-annotation validation report -> emit at INFO so its own per-severity
+ *    coloring shows through instead of the ERROR-level red wrap (see file header);
  *  - a real toolkit warning / error -> emit unchanged (still yellow / red);
  *  - everything else (toolkit info/debug/trace chatter) -> drop.
  */
 export function planIoMessage(msg: Pick<IoMessage<unknown>, 'code' | 'level'>): IoPlan {
   if (msg.code === APP_STDOUT || msg.code === APP_STDERR) return { action: 'emit', level: 'info' };
+  if (msg.code === VALIDATION_REPORT) return { action: 'emit', level: 'info' };
   if (msg.level === 'warn' || msg.level === 'error') return { action: 'emit', level: msg.level };
   return { action: 'drop' };
 }

--- a/tests/io-host.test.ts
+++ b/tests/io-host.test.ts
@@ -18,6 +18,17 @@ describe('planIoMessage (QuietIoHost routing)', () => {
     });
   });
 
+  it('re-tags the construct-annotation validation report (E9600, error) to info so it is not red', () => {
+    // toolkit-lib registers the Construct Annotations validation report at ERROR level
+    // even when it only carries WARNINGS; its formatter already colors each line per
+    // severity, so we downgrade to info to avoid the whole block being wrapped in red
+    // (which would bleed red over the description + construct path).
+    expect(planIoMessage({ code: 'CDK_TOOLKIT_E9600', level: 'error' })).toEqual({
+      action: 'emit',
+      level: 'info',
+    });
+  });
+
   it('still surfaces a REAL toolkit error unchanged (stays red)', () => {
     // a genuine synth failure (not the app-stderr passthrough) keeps its error level
     expect(planIoMessage({ code: 'CDK_ASSEMBLY_E1111', level: 'error' })).toEqual({


### PR DESCRIPTION
## Problem

On a `cdkrd check`, CDK **construct-annotation warnings** surfaced during synth
(e.g. `noSubnetRouteTableId`) render with the wrong colors: the `WARNING` label
is yellow (correct), but the **description text and the construct path are red**,
making a mere warning look like an error.

```
WARNING No routeTableId was provided ... (More info: ...) (Construct Annotations)
   <aurora-cluster-dev-stack>/Database/Subnet1
   Acknowledge with 'Construct-Annotations::@aws-cdk/aws-ec2:noSubnetRouteTableId'
```
(description + path shown red)

## Root cause

toolkit-lib (>=1.32.0, which `^1.28.0` floats up to on fresh installs) surfaces
the construct-annotation validation report under a single message code
`CDK_TOOLKIT_E9600`, registered at **ERROR** level — even for a report whose only
contents are WARNINGS.

Its own formatter (`validate-formatting.ts`) already colors each line per
severity (yellow `WARNING`, orange `ERROR`, grey rule hint) and **documents** that
the message must be emitted at a neutral level so the IoHost does not wrap the
whole block in a single color. But because the code is registered ERROR-level,
`NonInteractiveIoHost` wraps the entire block in `chalk.red`. Only the pre-baked
yellow `WARNING` survives — via chalk's nested-reset restoration (`\x1b[39m` ->
`\x1b[31m`) — while every otherwise-default span (description, construct path)
bleeds red.

## Fix

Re-tag `CDK_TOOLKIT_E9600` to **INFO** in `planIoMessage` (`chalk.reset` = no
outer wrap) — the same treatment already applied to the `CDK_ASSEMBLY_E1002`
app-stderr passthrough. The formatter's intended per-severity coloring then shows
through. A genuine policy failure still shows its own orange/red `ERROR` label
from the formatter.

The fix keys on the message **code**, so it is version-safe: inert on 1.28.0
(which surfaces annotations via a different `[warn at ...]` path) and correct on
>=1.32.0.

## Verification

Raw-ANSI capture against toolkit-lib 1.32.0 (a real `noSubnetRouteTableId` synth
warning), in a pty with color forced:

- **Before:** `\x1b[31m` wraps the block -> description + construct path render red.
- **After:** no `\x1b[31m` anywhere -> `WARNING` bold-yellow, description + path
  default color, plugin name + `Acknowledge` grey.

- `vp run typecheck` — pass
- `vp check --fix` — pass
- `vp pack` — pass
- `vp test run` — 48 files, 2814 tests pass (incl. new `planIoMessage` E9600 case)
