### PR TITLE
fix(synth): color the construct-annotation report yellow, not red

### DIFF
--- a/src/synth/io-host.ts
+++ b/src/synth/io-host.ts
@@ -13,18 +13,24 @@
 // toolkit-lib throws, and cdkrd's own error handling reports it (a different path
 // from these per-line E1002 passthrough messages).
 //
-// A third code needs the same INFO re-tag: `CDK_TOOLKIT_E9600`, the construct-
-// annotation validation report (the `aws:cdk:warning|error` a synth emits, e.g.
+// A third code needs re-tagging: `CDK_TOOLKIT_E9600`, the construct-annotation
+// validation report (the `aws:cdk:warning|error` a synth emits, e.g.
 // noSubnetRouteTableId). toolkit-lib registers this ONE code at ERROR level even for
-// a report whose only contents are WARNINGS, yet its formatter
-// (validate-formatting.ts) already colors each line per severity (yellow WARNING,
-// orange ERROR, grey rule hint) and DOCUMENTS that it must be emitted at a neutral
-// level so the IoHost does not wrap the whole block in a single color. Left at ERROR,
-// NonInteractiveIoHost paints the entire block red (chalk.red) — bleeding red over
-// the otherwise-default description + construct path, while only the pre-baked yellow
-// "WARNING" label survives (via chalk's nested-reset restoration). Re-tagging to INFO
-// (chalk.reset = no wrap) restores the intended per-severity coloring; a genuine
-// policy FAILURE still shows its own orange/red ERROR label from the formatter.
+// a report whose only contents are WARNINGS, so NonInteractiveIoHost paints the
+// entire block RED (chalk.red) — bleeding red over the description + construct path,
+// while only the pre-baked yellow "WARNING" label survives (via chalk's nested-reset
+// restoration). Red for a mere warning is misleading.
+//
+// We re-tag it to WARN (not INFO): every line of this report is headed by the
+// formatter's own severity label — a yellow `WARNING` for the ubiquitous
+// aws:cdk:warning annotations cdkrd sees — so a WARN wrap (chalk.yellow) paints the
+// WHOLE block yellow to MATCH that label, exactly like every other cdkrd synth
+// warning (which is already emitted at WARN = yellow). The formatter's explicit
+// per-severity label colors still survive the outer yellow: an ERROR-severity line
+// keeps its orange `ERROR` label (its own ansi256 code wins over the wrap), and the
+// grey rule hints stay grey — only the otherwise-default body inherits the yellow.
+// So a warnings-only report reads as one consistent yellow warning, and a mixed
+// report still shows each line's severity via its label.
 import { NonInteractiveIoHost } from '@aws-cdk/toolkit-lib';
 import type { IoMessage } from '@aws-cdk/toolkit-lib';
 
@@ -34,7 +40,8 @@ type Level = IoMessage<unknown>['level'];
 const APP_STDOUT = 'CDK_ASSEMBLY_I1001';
 const APP_STDERR = 'CDK_ASSEMBLY_E1002';
 // Construct-annotation validation report (toolkit-lib validate-formatting.ts) —
-// ERROR-level but self-colored, so it must NOT be re-wrapped in a single color.
+// ERROR-level (misleading red) but every line is severity-labelled, so we re-tag to
+// WARN: a yellow wrap matches the yellow WARNING label, like every other cdkrd warning.
 const VALIDATION_REPORT = 'CDK_TOOLKIT_E9600';
 
 export type IoPlan = { action: 'drop' } | { action: 'emit'; level: Level };
@@ -43,14 +50,15 @@ export type IoPlan = { action: 'drop' } | { action: 'emit'; level: Level };
  * Decide what QuietIoHost does with a message (pure, so it is unit-testable):
  *  - the CDK app's own stdout/stderr passthrough -> emit at INFO (default color, like
  *    cdk-local; never the alarming red the E1002/error tag would otherwise produce);
- *  - the construct-annotation validation report -> emit at INFO so its own per-severity
- *    coloring shows through instead of the ERROR-level red wrap (see file header);
+ *  - the construct-annotation validation report -> emit at WARN so the whole block is
+ *    yellow (matching its WARNING label) instead of the misleading ERROR-level red
+ *    wrap; per-severity labels still survive (see file header);
  *  - a real toolkit warning / error -> emit unchanged (still yellow / red);
  *  - everything else (toolkit info/debug/trace chatter) -> drop.
  */
 export function planIoMessage(msg: Pick<IoMessage<unknown>, 'code' | 'level'>): IoPlan {
   if (msg.code === APP_STDOUT || msg.code === APP_STDERR) return { action: 'emit', level: 'info' };
-  if (msg.code === VALIDATION_REPORT) return { action: 'emit', level: 'info' };
+  if (msg.code === VALIDATION_REPORT) return { action: 'emit', level: 'warn' };
   if (msg.level === 'warn' || msg.level === 'error') return { action: 'emit', level: msg.level };
   return { action: 'drop' };
 }

--- a/tests/io-host.test.ts
+++ b/tests/io-host.test.ts
@@ -18,14 +18,14 @@ describe('planIoMessage (QuietIoHost routing)', () => {
     });
   });
 
-  it('re-tags the construct-annotation validation report (E9600, error) to info so it is not red', () => {
+  it('re-tags the construct-annotation validation report (E9600, error) to warn so the whole block is yellow, not red', () => {
     // toolkit-lib registers the Construct Annotations validation report at ERROR level
-    // even when it only carries WARNINGS; its formatter already colors each line per
-    // severity, so we downgrade to info to avoid the whole block being wrapped in red
-    // (which would bleed red over the description + construct path).
+    // even when it only carries WARNINGS; the default IoHost would then wrap it in red.
+    // We re-tag to warn so the block is yellow to match its own WARNING label (and like
+    // every other cdkrd synth warning), rather than the misleading error red.
     expect(planIoMessage({ code: 'CDK_TOOLKIT_E9600', level: 'error' })).toEqual({
       action: 'emit',
-      level: 'info',
+      level: 'warn',
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #590. Make the CDK construct-annotation warning render as a
**consistently yellow** warning instead of "yellow label + default-color body".

#590 re-tagged the construct-annotation validation report (`CDK_TOOLKIT_E9600`,
which toolkit-lib registers at **ERROR** level even for warnings-only reports)
from ERROR to **INFO**. That stopped the misleading red wrap, but left the
description + construct path in the terminal default color while only the
`WARNING` label stayed yellow.

## Change

Re-tag `E9600` to **WARN** (not INFO). Every line of this report is headed by the
formatter's own severity label — a yellow `WARNING` for the ubiquitous
`aws:cdk:warning` annotations cdkrd surfaces — so a WARN wrap (`chalk.yellow`)
paints the whole block yellow to **match that label**, exactly like every other
cdkrd synth warning (already emitted at WARN = yellow).

| | WARNING label | description | construct path | `(Construct Annotations)` / `Acknowledge` |
|---|---|---|---|---|
| before #590 | yellow | **red** | **red** | grey |
| after #590 (`info`) | yellow | default color | default color | grey |
| this PR (`warn`) | yellow | **yellow** | **yellow** | grey |

The formatter's explicit per-severity label colors still survive the outer
yellow: an `ERROR`-severity line keeps its orange `ERROR` label (its own ansi256
code wins over the wrap), and grey rule hints stay grey — only the
otherwise-default body inherits the yellow. So a warnings-only report reads as one
consistent yellow warning, and a mixed report still shows each line's severity via
its label.

## Verification

Raw-ANSI capture against toolkit-lib 1.32.0 (a real `noSubnetRouteTableId` synth
warning), in a pty with color forced:

- Whole block wrapped `\x1b[33m` (yellow); WARNING + description + construct path
  all render yellow; grey accents preserved; **no `\x1b[31m` red anywhere**.

- `vp run typecheck` / `vp check --fix` / `vp pack` — pass
- `vp test run` — 48 files, 2814 tests pass (E9600 routing test updated to `warn`)
