### PR TITLE
fix(noise): fold DocDB + VolumeAttachment first-run default noise

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -773,6 +773,21 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::DocDB::DBCluster': {
     Port: 27017, // DocDB's fixed default port
+    // DocumentDB's documented default backup retention (1 day) — surfaced as undeclared
+    // first-run noise whenever a template omits it. Equality-gated: a longer retention the
+    // user sets (or later changes out of band) is not 1, so it still surfaces.
+    BackupRetentionPeriod: 1,
+  },
+  'AWS::DocDB::DBInstance': {
+    // The current AWS default server certificate authority a DocDB instance reads back on a
+    // fresh deploy — the same constant CA folded for RDS::DBInstance above. Equality-gated:
+    // AWS rotates the default CA over time, so an older/pinned identifier still surfaces.
+    CACertificateIdentifier: 'rds-ca-rsa2048-g1',
+  },
+  'AWS::EC2::VolumeAttachment': {
+    // A standard single-card EBS attachment always reports card index 0; a nonzero index
+    // (a multi-card Nitro instance) is meaningful and still surfaces under the equality gate.
+    EbsCardIndex: 0,
   },
   'AWS::SSM::Association': {
     DocumentVersion: '$DEFAULT', // default when no explicit version is pinned

--- a/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
+++ b/tests/corpus/AWS__DocDB__DBCluster.ClusterVersionFp.json
@@ -79,7 +79,7 @@
       "constructPath": "CdkRealDriftIntegDocdbVersionFp/Cluster"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::DocDB::DBCluster",
       "path": "BackupRetentionPeriod",

--- a/tests/corpus/AWS__DocDB__DBInstance.ClusterInstance1448F06E4.json
+++ b/tests/corpus/AWS__DocDB__DBInstance.ClusterInstance1448F06E4.json
@@ -46,7 +46,7 @@
       "constructPath": "CdkRealDriftIntegDocdbRich/Cluster/Instance1"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ClusterInstance1448F06E4",
       "resourceType": "AWS::DocDB::DBInstance",
       "path": "CACertificateIdentifier",

--- a/tests/corpus/AWS__EC2__VolumeAttachment.DataAttach.json
+++ b/tests/corpus/AWS__EC2__VolumeAttachment.DataAttach.json
@@ -35,7 +35,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "DataAttach",
       "resourceType": "AWS::EC2::VolumeAttachment",
       "path": "EbsCardIndex",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -570,6 +570,23 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('DocDB + VolumeAttachment constant defaults (offline measure-noise sweep)', () => {
+    // Each value was OBSERVED as undeclared first-run noise in the golden corpus and is a
+    // genuine constant service default; equality-gated, so a non-default still surfaces.
+    // DocumentDB's documented 1-day default backup retention (the DBCluster block also
+    // carries the fixed Port 27017 asserted above).
+    expect(KNOWN_DEFAULTS['AWS::DocDB::DBCluster'].BackupRetentionPeriod).toBe(1);
+    // A DocDB instance reads back the same current default server CA as RDS::DBInstance.
+    expect(KNOWN_DEFAULTS['AWS::DocDB::DBInstance']).toEqual({
+      CACertificateIdentifier: 'rds-ca-rsa2048-g1',
+    });
+    expect(KNOWN_DEFAULTS['AWS::RDS::DBInstance'].CACertificateIdentifier).toBe(
+      'rds-ca-rsa2048-g1'
+    );
+    // A standard single-card EBS attachment always reports card index 0.
+    expect(KNOWN_DEFAULTS['AWS::EC2::VolumeAttachment']).toEqual({ EbsCardIndex: 0 });
+  });
+
   it('Lambda EventSourceMapping stream retry/age + Enabled defaults (found by esm-sourceaccess-rich)', () => {
     // -1 is the documented "infinite" default for stream / Kafka event sources (retry
     // forever / no record-age cap); Enabled=true is the first-run default an omitting


### PR DESCRIPTION
## What

Fold three constant AWS-assigned service defaults that surfaced as undeclared
`[Not Recorded]` / best-effort `[Potential Drift]` first-run noise on a fresh
deploy (found via the offline `measure-noise` corpus sweep during a `/hunt-bugs`
round). Each is added to the equality-gated `KNOWN_DEFAULTS` table so the default
value folds to `atDefault` while a non-default the user set (or a later
out-of-band change) still surfaces:

- `AWS::DocDB::DBCluster` `BackupRetentionPeriod` = `1` (DocDB's documented default)
- `AWS::DocDB::DBInstance` `CACertificateIdentifier` = `rds-ca-rsa2048-g1`
  (the same current default server CA already folded for `RDS::DBInstance`)
- `AWS::EC2::VolumeAttachment` `EbsCardIndex` = `0` (standard single-card attachment)

## Why

Pure first-run-noise reduction. The fold is equality-gated, so a promoted default
can never hide a real change — a differing value still classifies as drift.

## Validation

- **Offline FP/FN audit** across all 609 corpus cases (reorder + scalar-normalization
  axes) came back clean — these axes are saturated; the only actionable finding was
  this noise reduction.
- 3 corpus cases reclassified `undeclared` → `atDefault` (real harvested live data,
  replayed offline by `corpus-replay`) + a `noise-and-strip` unit assertion.
- **Live-tested** (real AWS): deployed `docdb-version-fp`, `docdb-rich`,
  `ec2-instance-rich`; the pre-record `check` with this binary places
  `BackupRetentionPeriod=1` in `[At AWS Default]` (folded); all 3 fixtures
  `INTEG PASS`; stacks torn down + orphan sweep CLEAN.
- Full local gate green: typecheck, lint+format, build, 2815 unit tests.
