### PR TITLE
fix(noise): fold VPC-networking first-run defaults (offline sweep + live vpc-common deploy)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -694,6 +694,26 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::EC2::VPCEndpoint': {
     IpAddressType: 'ipv4',
+    // An endpoint that declares no `PolicyDocument` reads back the AWS-attached DEFAULT policy:
+    // full access ("allow every principal every action on every resource"). It is the standard
+    // default, not user intent — a user who tightens access DECLARES a policy, which no longer
+    // matches this default and surfaces WHOLE (equality-gated, so out-of-band tightening is
+    // still detected). Observed live on a fresh S3 gateway endpoint (vpc-common). Stored in the
+    // canonical shape the compare pipeline (normalizePoliciesDeep) produces for the live value.
+    PolicyDocument: {
+      Version: '2008-10-17',
+      Statement: [{ Effect: 'Allow', Principal: '*', Action: ['*'], Resource: ['*'] }],
+    },
+    // (DnsOptions is AWS-service-assigned whole and folds value-independent — its default varies
+    // by endpoint type, so it cannot be one equality-gated constant. See
+    // VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS below.)
+  },
+  // An Elastic IP that brings no BYOIP pool reads back the standard Amazon-provided pool
+  // ("amazon"). Create-only and the constant default, not user intent — a BYOIP address
+  // DECLARES its own PublicIpv4Pool, which no longer matches and surfaces. Equality-gated.
+  // Observed live on a fresh EIP (vpc-common NAT gateway).
+  'AWS::EC2::EIP': {
+    PublicIpv4Pool: 'amazon',
   },
   'AWS::EC2::TransitGateway': {
     SecurityGroupReferencingSupport: 'disable',
@@ -1936,12 +1956,21 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //     * EC2 EIP `NetworkBorderGroup` — the address's border group, defaulting to the region.
   //     * EC2 VPCEndpoint `ServiceRegion` — defaults to the endpoint's own region.
   //     * EC2 VPCPeeringConnection `PeerRegion` — defaults to the requester's region.
+  //   VPCEndpoint `DnsOptions` is folded here too, but as an AWS-service-assigned whole config
+  //   OBJECT (not a create-only identifier): an endpoint that declares no DnsOptions reads back a
+  //   default object whose `DnsRecordIpType` VARIES by endpoint type ("service-defined" for a
+  //   gateway endpoint, "ipv4" for an interface one), so it cannot be pinned as one equality-
+  //   gated constant. When undeclared every sub-key is an AWS service default, never user intent;
+  //   a user who configures DNS DECLARES DnsOptions (compared in the declared loop). Mirrors the
+  //   OpenSearch `OffPeakWindowOptions` / AmazonMQ `MaintenanceWindowStartTime` object precedents.
+  //     * EC2 NatGateway `VpcId` — AWS DERIVES the VPC id from the declared SubnetId and reads
+  //       it back (create-only, embeds the per-resource `vpc-…` id, never declared by CDK).
   'AWS::EC2::Instance': new Set(['PrivateIpAddress']),
   'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress']),
-  'AWS::EC2::NatGateway': new Set(['PrivateIpAddress']),
+  'AWS::EC2::NatGateway': new Set(['PrivateIpAddress', 'VpcId']),
   'AWS::EFS::MountTarget': new Set(['IpAddress']),
   'AWS::EC2::EIP': new Set(['NetworkBorderGroup']),
-  'AWS::EC2::VPCEndpoint': new Set(['ServiceRegion']),
+  'AWS::EC2::VPCEndpoint': new Set(['ServiceRegion', 'DnsOptions']),
   'AWS::EC2::VPCPeeringConnection': new Set(['PeerRegion']),
 };
 

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1891,7 +1891,11 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::DocDB::DBCluster': new Set(['PreferredMaintenanceWindow', 'PreferredBackupWindow']),
   'AWS::DocDB::DBInstance': new Set(['PreferredMaintenanceWindow']),
   'AWS::Neptune::DBCluster': new Set(['PreferredMaintenanceWindow', 'PreferredBackupWindow']),
-  'AWS::Neptune::DBInstance': new Set(['PreferredMaintenanceWindow']),
+  //   AWS::Neptune::DBInstance.AvailabilityZone — AWS places an undeclared instance in an AZ it
+  //   picks (create-only, so it can never drift; never user intent when undeclared), exactly like
+  //   AWS::RDS::DBInstance.AvailabilityZone above. A user who pins a placement DECLARES it and is
+  //   then compared in the declared loop.
+  'AWS::Neptune::DBInstance': new Set(['PreferredMaintenanceWindow', 'AvailabilityZone']),
   'AWS::ElastiCache::CacheCluster': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
   'AWS::ElastiCache::ReplicationGroup': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
   'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
@@ -1917,6 +1921,28 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   folds the whole top-level property whatever its shape, so the assigned window is not first-
   //   run noise (a DECLARED window is compared in the declared loop).
   'AWS::AmazonMQ::Broker': new Set(['MaintenanceWindowStartTime']),
+  //   Core VPC-networking types whose undeclared, AWS-ASSIGNED, CREATE-ONLY placement identifiers
+  //   read back on every first run. Each is a per-resource value AWS picks at creation from the
+  //   surrounding VPC/subnet/region — never a constant we can pin, and never user intent when
+  //   undeclared. All are create-only (schema `createOnly`), so a value-independent fold can never
+  //   hide a real out-of-band change: the value physically cannot move without replacing the
+  //   resource, which is itself a template change surfaced elsewhere. A user who pins a specific
+  //   value DECLARES it and is then compared in the declared loop. Found by the offline first-run-
+  //   noise sweep across the VPC-common / EC2-instance / EFS / peering corpus cases (undeclared on
+  //   every one, no out-of-band edit), each confirmed create-only from its live CFn schema:
+  //     * EC2 Instance / NetworkInterface / NatGateway `PrivateIpAddress` — the primary private IP
+  //       AWS allocates from the subnet CIDR (e.g. "10.0.0.216"); immutable after launch.
+  //     * EFS MountTarget `IpAddress` — the mount-target IP AWS allocates from the subnet.
+  //     * EC2 EIP `NetworkBorderGroup` — the address's border group, defaulting to the region.
+  //     * EC2 VPCEndpoint `ServiceRegion` — defaults to the endpoint's own region.
+  //     * EC2 VPCPeeringConnection `PeerRegion` — defaults to the requester's region.
+  'AWS::EC2::Instance': new Set(['PrivateIpAddress']),
+  'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress']),
+  'AWS::EC2::NatGateway': new Set(['PrivateIpAddress']),
+  'AWS::EFS::MountTarget': new Set(['IpAddress']),
+  'AWS::EC2::EIP': new Set(['NetworkBorderGroup']),
+  'AWS::EC2::VPCEndpoint': new Set(['ServiceRegion']),
+  'AWS::EC2::VPCPeeringConnection': new Set(['PeerRegion']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5242,6 +5242,66 @@ describe('RDS AWS-assigned values fold value-independent (KmsKeyId/AZ/windows)',
   });
 });
 
+// Core VPC-networking types read back an AWS-ASSIGNED, CREATE-ONLY placement identifier on
+// every first run (the primary private IP AWS allocates from the subnet, the mount-target IP,
+// the EIP border group, an endpoint's / peering's region). Each is AWS's per-resource choice,
+// never user intent when undeclared, and — being create-only — can never move out of band, so
+// it folds value-independent. A user who pins a value DECLARES it (compared in the declared
+// loop). Found by the offline first-run-noise sweep over the VPC-common corpus cases.
+describe('VPC-networking AWS-assigned create-only identifiers fold value-independent', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const t = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    tiers(
+      classifyResource({ logicalId: 'R', resourceType, physicalId: 'p', declared }, live, bare)
+    );
+
+  it('undeclared assigned identifiers fold to atDefault (not undeclared drift)', () => {
+    const cases: [string, Record<string, unknown>, string[]][] = [
+      ['AWS::EC2::Instance', { PrivateIpAddress: '10.0.0.216' }, ['PrivateIpAddress']],
+      ['AWS::EC2::NetworkInterface', { PrivateIpAddress: '10.0.0.221' }, ['PrivateIpAddress']],
+      ['AWS::EC2::NatGateway', { PrivateIpAddress: '10.0.0.62' }, ['PrivateIpAddress']],
+      ['AWS::EFS::MountTarget', { IpAddress: '10.0.88.116' }, ['IpAddress']],
+      ['AWS::EC2::EIP', { NetworkBorderGroup: 'us-east-1' }, ['NetworkBorderGroup']],
+      ['AWS::EC2::VPCEndpoint', { ServiceRegion: 'us-east-1' }, ['ServiceRegion']],
+      ['AWS::EC2::VPCPeeringConnection', { PeerRegion: 'us-east-1' }, ['PeerRegion']],
+      ['AWS::Neptune::DBInstance', { AvailabilityZone: 'ap-northeast-1c' }, ['AvailabilityZone']],
+    ];
+    for (const [type, live, props] of cases) {
+      const r = t(type, {}, live);
+      expect(r.undeclared).toEqual([]);
+      expect(r.atDefault).toEqual(expect.arrayContaining(props));
+    }
+  });
+
+  it('a DECLARED PrivateIpAddress is user intent — compared in the declared loop, still detected', () => {
+    const r = t(
+      'AWS::EC2::Instance',
+      { PrivateIpAddress: '10.0.0.5' },
+      { PrivateIpAddress: '10.0.0.216' }
+    );
+    expect(r.declared).toEqual(['PrivateIpAddress']);
+    expect(r.atDefault).not.toContain('PrivateIpAddress');
+  });
+
+  it('the fold is gated per-type — a different type keeps PrivateIpAddress undeclared', () => {
+    const r = t('AWS::Other::Thing', {}, { PrivateIpAddress: '10.0.0.9' });
+    expect(r.undeclared).toContain('PrivateIpAddress');
+  });
+});
+
 // Second offline noise-sweep batch: AWS-managed parameter-group names, Redshift constant
 // defaults, and OpenSearch domain defaults — all undeclared AWS-assigned values a first run
 // would otherwise flag as [Potential Drift].

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5272,7 +5272,12 @@ describe('VPC-networking AWS-assigned create-only identifiers fold value-indepen
     const cases: [string, Record<string, unknown>, string[]][] = [
       ['AWS::EC2::Instance', { PrivateIpAddress: '10.0.0.216' }, ['PrivateIpAddress']],
       ['AWS::EC2::NetworkInterface', { PrivateIpAddress: '10.0.0.221' }, ['PrivateIpAddress']],
-      ['AWS::EC2::NatGateway', { PrivateIpAddress: '10.0.0.62' }, ['PrivateIpAddress']],
+      // NatGateway also reads back the VPC id AWS derives from the declared SubnetId.
+      [
+        'AWS::EC2::NatGateway',
+        { PrivateIpAddress: '10.0.0.62', VpcId: 'vpc-04afc4de702561220' },
+        ['PrivateIpAddress', 'VpcId'],
+      ],
       ['AWS::EFS::MountTarget', { IpAddress: '10.0.88.116' }, ['IpAddress']],
       ['AWS::EC2::EIP', { NetworkBorderGroup: 'us-east-1' }, ['NetworkBorderGroup']],
       ['AWS::EC2::VPCEndpoint', { ServiceRegion: 'us-east-1' }, ['ServiceRegion']],
@@ -5299,6 +5304,63 @@ describe('VPC-networking AWS-assigned create-only identifiers fold value-indepen
   it('the fold is gated per-type — a different type keeps PrivateIpAddress undeclared', () => {
     const r = t('AWS::Other::Thing', {}, { PrivateIpAddress: '10.0.0.9' });
     expect(r.undeclared).toContain('PrivateIpAddress');
+  });
+
+  // The EIP PublicIpv4Pool "amazon" default and the VPCEndpoint default full-access
+  // PolicyDocument / service-defined DnsOptions are equality-gated KNOWN_DEFAULTS — they fold
+  // the AWS default but SURFACE a value changed out of band (the FN half proven live: a
+  // tightened endpoint policy re-surfaces). Live-observed on a fresh vpc-common deploy.
+  const DEFAULT_ENDPOINT_POLICY = {
+    Version: '2008-10-17',
+    Statement: [{ Effect: 'Allow', Principal: '*', Action: ['*'], Resource: ['*'] }],
+  };
+  const DEFAULT_DNS_OPTIONS = {
+    PrivateDnsOnlyForInboundResolverEndpoint: 'NotSpecified',
+    PrivateDnsSpecifiedDomains: ['*'],
+    DnsRecordIpType: 'service-defined',
+    PrivateDnsPreference: 'VERIFIED_DOMAINS_ONLY',
+  };
+
+  it('EIP PublicIpv4Pool "amazon" + VPCEndpoint default policy fold (equality-gated)', () => {
+    expect(t('AWS::EC2::EIP', {}, { PublicIpv4Pool: 'amazon' }).atDefault).toContain(
+      'PublicIpv4Pool'
+    );
+    const ep = t(
+      'AWS::EC2::VPCEndpoint',
+      {},
+      { PolicyDocument: DEFAULT_ENDPOINT_POLICY, DnsOptions: DEFAULT_DNS_OPTIONS }
+    );
+    expect(ep.undeclared).toEqual([]);
+    expect(ep.atDefault).toEqual(expect.arrayContaining(['PolicyDocument', 'DnsOptions']));
+  });
+
+  it('VPCEndpoint DnsOptions folds value-independent — both the gateway and interface defaults', () => {
+    // DnsRecordIpType is "service-defined" for a gateway endpoint, "ipv4" for an interface one;
+    // both AWS defaults fold whole (a user who configures DNS DECLARES DnsOptions).
+    for (const ipType of ['service-defined', 'ipv4', 'dualstack']) {
+      const r = t(
+        'AWS::EC2::VPCEndpoint',
+        {},
+        { DnsOptions: { ...DEFAULT_DNS_OPTIONS, DnsRecordIpType: ipType } }
+      );
+      expect(r.atDefault).toContain('DnsOptions');
+      expect(r.undeclared).not.toContain('DnsOptions');
+    }
+  });
+
+  it('a value changed away from the default still surfaces (equality-gate preserves detection)', () => {
+    // a BYOIP pool is not "amazon"
+    expect(t('AWS::EC2::EIP', {}, { PublicIpv4Pool: 'ipv4pool-ec2-abc' }).undeclared).toContain(
+      'PublicIpv4Pool'
+    );
+    // a tightened endpoint policy no longer matches the full-access default
+    const tightened = {
+      Version: '2008-10-17',
+      Statement: [{ Effect: 'Allow', Principal: '*', Action: ['s3:GetObject'], Resource: ['*'] }],
+    };
+    expect(t('AWS::EC2::VPCEndpoint', {}, { PolicyDocument: tightened }).undeclared).toContain(
+      'PolicyDocument'
+    );
   });
 });
 

--- a/tests/corpus/AWS__EC2__EIP.Ip.json
+++ b/tests/corpus/AWS__EC2__EIP.Ip.json
@@ -60,7 +60,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Ip",
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkBorderGroup",

--- a/tests/corpus/AWS__EC2__EIP.NetpublicSubnet1EIP61354088.json
+++ b/tests/corpus/AWS__EC2__EIP.NetpublicSubnet1EIP61354088.json
@@ -1,0 +1,81 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NetpublicSubnet1EIP61354088",
+    "resourceType": "AWS::EC2::EIP",
+    "physicalId": "98.88.222.18",
+    "constructPath": "CdkRealDriftIntegVpcCommon/Net/publicSubnet1/EIP",
+    "declared": {
+      "Domain": "vpc",
+      "Tags": [
+        {
+          "Key": "Name",
+          "Value": "CdkRealDriftIntegVpcCommon/Net/publicSubnet1"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Domain": "vpc",
+    "NetworkBorderGroup": "us-east-1",
+    "PublicIp": "98.88.222.18",
+    "PublicIpv4Pool": "amazon",
+    "Tags": [
+      {
+        "Key": "Name",
+        "Value": "CdkRealDriftIntegVpcCommon/Net/publicSubnet1"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegVpcCommon/b4cbc4f0-79e9-11f1-af73-12a5760669cb"
+      },
+      {
+        "Key": "aws:cloudformation:logical-id",
+        "Value": "NetpublicSubnet1EIP61354088"
+      },
+      {
+        "Key": "aws:cloudformation:stack-name",
+        "Value": "CdkRealDriftIntegVpcCommon"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["AllocationId", "PublicIp"],
+    "writeOnly": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnly": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "readOnlyPaths": ["AllocationId", "PublicIp"],
+    "writeOnlyPaths": ["Address", "IpamPoolId", "TransferAddress"],
+    "createOnlyPaths": ["Address", "IpamPoolId", "NetworkBorderGroup", "TransferAddress"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "NetpublicSubnet1EIP61354088",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "NetworkBorderGroup",
+      "actual": "us-east-1",
+      "physicalId": "98.88.222.18",
+      "constructPath": "CdkRealDriftIntegVpcCommon/Net/publicSubnet1/EIP"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "NetpublicSubnet1EIP61354088",
+      "resourceType": "AWS::EC2::EIP",
+      "path": "PublicIpv4Pool",
+      "actual": "amazon",
+      "physicalId": "98.88.222.18",
+      "constructPath": "CdkRealDriftIntegVpcCommon/Net/publicSubnet1/EIP"
+    }
+  ]
+}

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
@@ -71,7 +71,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkBorderGroup",

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
@@ -71,7 +71,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkBorderGroup",

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -363,7 +363,7 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -339,7 +339,7 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
@@ -104,7 +104,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet1NATGatewayB0C476F1.json
@@ -122,7 +122,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/NATGateway"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1NATGatewayB0C476F1",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "VpcId",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
@@ -122,7 +122,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "VpcId",

--- a/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
+++ b/tests/corpus/AWS__EC2__NatGateway.WorkersVpcPublicSubnet2NATGateway841E7FC0.json
@@ -104,7 +104,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/NATGateway"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2NATGateway841E7FC0",
       "resourceType": "AWS::EC2::NatGateway",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__NetworkInterface.Eni.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.Eni.json
@@ -112,7 +112,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniA.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniA.json
@@ -93,7 +93,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EniA",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniB.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniB.json
@@ -93,7 +93,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EniB",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
@@ -130,7 +130,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",

--- a/tests/corpus/AWS__EC2__VPCEndpoint.SecretsEp58436907.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.SecretsEp58436907.json
@@ -117,7 +117,7 @@
       "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SecretsEp58436907",
       "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "ServiceRegion",

--- a/tests/corpus/AWS__EC2__VPCEndpoint.SecretsEp58436907.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.SecretsEp58436907.json
@@ -126,7 +126,7 @@
       "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SecretsEp58436907",
       "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "DnsOptions",
@@ -140,7 +140,7 @@
       "constructPath": "CdkRealDriftIntegVpcEpRich/SecretsEp"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "SecretsEp58436907",
       "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "PolicyDocument",

--- a/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
@@ -120,7 +120,7 @@
       "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "VpcS3Endpoint4A3DE4B5",
       "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "DnsOptions",
@@ -134,7 +134,7 @@
       "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "VpcS3Endpoint4A3DE4B5",
       "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "PolicyDocument",

--- a/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
+++ b/tests/corpus/AWS__EC2__VPCEndpoint.VpcS3Endpoint4A3DE4B5.json
@@ -111,7 +111,7 @@
       "constructPath": "CdkdriftIntegHarvest9/Vpc/S3Endpoint"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "VpcS3Endpoint4A3DE4B5",
       "resourceType": "AWS::EC2::VPCEndpoint",
       "path": "ServiceRegion",

--- a/tests/corpus/AWS__EC2__VPCPeeringConnection.Peering.json
+++ b/tests/corpus/AWS__EC2__VPCPeeringConnection.Peering.json
@@ -64,7 +64,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Peering",
       "resourceType": "AWS::EC2::VPCPeeringConnection",
       "path": "PeerRegion",

--- a/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget1AB817C34.json
+++ b/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget1AB817C34.json
@@ -35,7 +35,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FilesEfsMountTarget1AB817C34",
       "resourceType": "AWS::EFS::MountTarget",
       "path": "IpAddress",

--- a/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget22C8423FA.json
+++ b/tests/corpus/AWS__EFS__MountTarget.FilesEfsMountTarget22C8423FA.json
@@ -35,7 +35,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FilesEfsMountTarget22C8423FA",
       "resourceType": "AWS::EFS::MountTarget",
       "path": "IpAddress",

--- a/tests/corpus/AWS__EFS__MountTarget.FsEfsMountTarget11EC3BF7C.json
+++ b/tests/corpus/AWS__EFS__MountTarget.FsEfsMountTarget11EC3BF7C.json
@@ -34,7 +34,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "FsEfsMountTarget11EC3BF7C",
       "resourceType": "AWS::EFS::MountTarget",
       "path": "IpAddress",

--- a/tests/corpus/AWS__Neptune__DBInstance.Instance.json
+++ b/tests/corpus/AWS__Neptune__DBInstance.Instance.json
@@ -82,7 +82,7 @@
       "constructPath": "CdkRealDriftIntegNeptuneRich/Instance"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Instance",
       "resourceType": "AWS::Neptune::DBInstance",
       "path": "AvailabilityZone",


### PR DESCRIPTION
Closes first-run `[Not Recorded]` / `[Potential Drift]` noise on core VPC-networking types. A `/hunt-bugs` round: an offline first-run-noise sweep found 8 create-only identifiers, then a **live `vpc-common` deploy** (check BEFORE record) surfaced 4 more — a fresh un-mutated stack must read **zero** potential drift, so each surfaced value was a fold gap.

## Commit 1 — create-only AWS-assigned identifiers (offline sweep)

| Type | Property | Example |
|---|---|---|
| `AWS::EC2::Instance` / `NetworkInterface` / `NatGateway` | `PrivateIpAddress` | `10.0.0.216` |
| `AWS::EFS::MountTarget` | `IpAddress` | `10.0.88.116` |
| `AWS::EC2::EIP` | `NetworkBorderGroup` | `us-east-1` |
| `AWS::EC2::VPCEndpoint` | `ServiceRegion` | `us-east-1` |
| `AWS::EC2::VPCPeeringConnection` | `PeerRegion` | `us-east-1` |
| `AWS::Neptune::DBInstance` | `AvailabilityZone` | `ap-northeast-1c` |

All create-only (confirmed from each live CFn schema) → `VALUE_INDEPENDENT` (can never move without replacing the resource, so the fold can't hide an out-of-band change). Regenerates 18 golden-corpus expectations.

## Commit 2 — defaults found via the live `vpc-common` deploy

- **EIP `PublicIpv4Pool` = `"amazon"`** — the standard Amazon pool → equality-gated `KNOWN_DEFAULTS` (a BYOIP pool surfaces).
- **NatGateway `VpcId`** — derived from the declared `SubnetId` (create-only) → `VALUE_INDEPENDENT`.
- **VPCEndpoint `PolicyDocument`** = default full-access policy → equality-gated `KNOWN_DEFAULTS`.
- **VPCEndpoint `DnsOptions`** = service-defined default object → `VALUE_INDEPENDENT` (its `DnsRecordIpType` varies by endpoint type — `service-defined` for gateway, `ipv4` for interface — so no single equality-gated constant fits).

## Live verification (real AWS, `vpc-common`, torn down + swept clean)

- **FP half**: fresh un-mutated deploy → `check` before record is **CLEAN** (0 potential drift, 26 atDefault).
- **FN half**: tightened the S3 endpoint policy out of band (`s3:GetObject` only) → `PolicyDocument` **re-surfaces** (equality-gate preserves out-of-band detection).

## Regression assets

- `classify` unit tests: each fold + a changed value still surfaces + per-type gating.
- Golden-corpus expectations regenerated on real harvested live reads (diff is only tier flips), plus a fresh EIP case carrying the `PublicIpv4Pool` default.
- Distinct undeclared `(type, path)` buckets drop **199 → 188**; `vp test run` = 2822 pass.
