### PR TITLE
fix(noise): fold Grafana + DataSync first-run default noise

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1381,11 +1381,14 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'ContainerProperties.FargatePlatformConfiguration.PlatformVersion': 'LATEST',
   },
   // DataSync task nested service defaults (observed live on hunt 2026-07-03 round B,
-  // #496): a task whose declared `Options` block leaves these unset reads them back at
-  // the documented transfer defaults, and a declared `Schedule` reads back Status ENABLED
-  // (the schedule is active on create). Equality-gated per path — a task that pins any
-  // Option / disables its schedule out of band no longer matches and surfaces. Per-input
-  // BytesPerSecond -1 is the documented "unlimited" sentinel.
+  // #496; TaskQueueing + PreserveDeletedFiles added on hunt 2026-07-07): a task whose
+  // declared `Options` block leaves these unset reads them back at the documented
+  // transfer defaults, and a declared `Schedule` reads back Status ENABLED (the schedule
+  // is active on create). Equality-gated per path — a task that pins any Option / disables
+  // its schedule out of band no longer matches and surfaces. Per-input BytesPerSecond -1
+  // is the documented "unlimited" sentinel. TaskQueueing defaults ENABLED and
+  // PreserveDeletedFiles defaults PRESERVE (both live-verified undeclared on the
+  // datasync-rich fixture — the two the round-B entry missed).
   'AWS::DataSync::Task': {
     'Options.Atime': 'BEST_EFFORT',
     'Options.Mtime': 'PRESERVE',
@@ -1396,6 +1399,8 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     'Options.ObjectTags': 'PRESERVE',
     'Options.BytesPerSecond': -1,
     'Options.SecurityDescriptorCopyFlags': 'NONE',
+    'Options.TaskQueueing': 'ENABLED',
+    'Options.PreserveDeletedFiles': 'PRESERVE',
     'Schedule.Status': 'ENABLED',
   },
 };
@@ -1972,6 +1977,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::EC2::EIP': new Set(['NetworkBorderGroup']),
   'AWS::EC2::VPCEndpoint': new Set(['ServiceRegion', 'DnsOptions']),
   'AWS::EC2::VPCPeeringConnection': new Set(['PeerRegion']),
+  //   AWS::Grafana::Workspace.GrafanaVersion — a workspace that pins no explicit version reads
+  //   back the concrete Grafana version AWS provisioned ("10.4" today). AWS assigns the current
+  //   GA default at creation, and that default moves over time (a fresh deploy next year reads a
+  //   newer version), so it is not a constant we can pin and is never user intent when undeclared
+  //   — a user who cares about the version DECLARES GrafanaVersion → compared in the declared loop.
+  //   Same shape as AWS::Redshift::Cluster.ClusterVersion / AWS::ECS::Service.PlatformVersion
+  //   above. Live-verified undeclared on a fresh grafana-rich deploy ("10.4"), no out-of-band edit.
+  'AWS::Grafana::Workspace': new Set(['GrafanaVersion']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -5485,6 +5485,155 @@ describe('managed param-group names + Redshift/OpenSearch defaults fold', () => 
   });
 });
 
+// AWS DataSync Task: a task whose declared Options block leaves the transfer knobs unset reads
+// them all back at the documented service defaults. The round-B entry (#496) covered most but
+// missed Options.TaskQueueing (ENABLED) + Options.PreserveDeletedFiles (PRESERVE); both surfaced
+// as potential drift on a fresh datasync-rich deploy (hunt 2026-07-07). Equality-gated, so a
+// changed value still surfaces.
+describe('DataSync Task Options first-run defaults fold', () => {
+  const bareD: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const liveOptions = {
+    Atime: 'BEST_EFFORT',
+    Mtime: 'PRESERVE',
+    Uid: 'NONE',
+    Gid: 'NONE',
+    PreserveDevices: 'NONE',
+    PosixPermissions: 'NONE',
+    ObjectTags: 'PRESERVE',
+    BytesPerSecond: -1,
+    SecurityDescriptorCopyFlags: 'NONE',
+    TaskQueueing: 'ENABLED',
+    PreserveDeletedFiles: 'PRESERVE',
+  };
+
+  it('a task with a partial declared Options block folds every AWS-default sub-key (incl. TaskQueueing + PreserveDeletedFiles)', () => {
+    const r = tiers(
+      classifyResource(
+        {
+          logicalId: 'Task',
+          resourceType: 'AWS::DataSync::Task',
+          physicalId: 'arn:aws:datasync:us-east-1:1:task/task-0',
+          // a real task declares a couple of Options and leaves the rest to AWS
+          declared: { Options: { VerifyMode: 'ONLY_FILES_TRANSFERRED', LogLevel: 'OFF' } },
+        },
+        { Options: { VerifyMode: 'ONLY_FILES_TRANSFERRED', LogLevel: 'OFF', ...liveOptions } },
+        bareD
+      )
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toEqual(
+      expect.arrayContaining(['Options.TaskQueueing', 'Options.PreserveDeletedFiles'])
+    );
+  });
+
+  it('equality-gated: a task that disables queueing / removes deleted files surfaces (detection preserved)', () => {
+    const r = tiers(
+      classifyResource(
+        {
+          logicalId: 'Task',
+          resourceType: 'AWS::DataSync::Task',
+          physicalId: 'arn:aws:datasync:us-east-1:1:task/task-0',
+          declared: { Options: { VerifyMode: 'ONLY_FILES_TRANSFERRED' } },
+        },
+        {
+          Options: {
+            VerifyMode: 'ONLY_FILES_TRANSFERRED',
+            TaskQueueing: 'DISABLED',
+            PreserveDeletedFiles: 'REMOVE',
+          },
+        },
+        bareD
+      )
+    );
+    expect(r.undeclared).toEqual(
+      expect.arrayContaining(['Options.TaskQueueing', 'Options.PreserveDeletedFiles'])
+    );
+  });
+});
+
+// Amazon Managed Grafana: a workspace that declares no GrafanaVersion reads back the concrete
+// GA version AWS provisioned at creation ("10.4" today) — an AWS-assigned value that moves over
+// time, so it folds value-independent (undeclared only). Live-verified on a fresh grafana-rich
+// deploy (hunt 2026-07-07).
+describe('Grafana Workspace GrafanaVersion fold (AWS-assigned version)', () => {
+  const bareG: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const decl = {
+    Name: 'cdkrd-grafana-rich',
+    AccountAccessType: 'CURRENT_ACCOUNT',
+    AuthenticationProviders: ['SAML'],
+    PermissionType: 'SERVICE_MANAGED',
+  };
+
+  it('an undeclared AWS-assigned GrafanaVersion folds to atDefault (zero potential drift)', () => {
+    const r = tiers(
+      classifyResource(
+        {
+          logicalId: 'Workspace',
+          resourceType: 'AWS::Grafana::Workspace',
+          physicalId: 'g-f76beca787',
+          declared: decl,
+        },
+        { ...decl, GrafanaVersion: '10.4' },
+        bareG
+      )
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toContain('GrafanaVersion');
+  });
+
+  it('value-independent: a future default version also folds when undeclared', () => {
+    const r = tiers(
+      classifyResource(
+        {
+          logicalId: 'Workspace',
+          resourceType: 'AWS::Grafana::Workspace',
+          physicalId: 'g-abc',
+          declared: decl,
+        },
+        { ...decl, GrafanaVersion: '11.2' },
+        bareG
+      )
+    );
+    expect(r.atDefault).toContain('GrafanaVersion');
+  });
+
+  it('a DECLARED GrafanaVersion is still compared (out-of-band upgrade surfaces as declared drift)', () => {
+    const declared = { ...decl, GrafanaVersion: '9.4' };
+    const r = tiers(
+      classifyResource(
+        {
+          logicalId: 'Workspace',
+          resourceType: 'AWS::Grafana::Workspace',
+          physicalId: 'g-abc',
+          declared,
+        },
+        { ...declared, GrafanaVersion: '10.4' },
+        bareG
+      )
+    );
+    expect(r.declared).toContain('GrafanaVersion');
+    expect(r.atDefault).not.toContain('GrafanaVersion');
+  });
+});
+
 // The clean-deploy -> zero-potential-drift invariant, live-verified on a fresh redshift-rich
 // (RA3 single-node) + opensearch-rich deploy: EVERY undeclared value AWS returned must fold.
 describe('Redshift/OpenSearch clean-deploy invariant (all AWS-initial values fold)', () => {

--- a/tests/corpus/AWS__DataSync__LocationS3.SrcLoc.json
+++ b/tests/corpus/AWS__DataSync__LocationS3.SrcLoc.json
@@ -1,0 +1,90 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SrcLoc",
+    "resourceType": "AWS::DataSync::LocationS3",
+    "physicalId": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
+    "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc",
+    "declared": {
+      "S3BucketArn": "arn:aws:s3:::cdkrd-ds-src-111111111111",
+      "S3Config": {
+        "BucketAccessRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegDataSyncRich-DsRole9B0CCAF1-cVz0MmYK0xqy"
+      },
+      "Subdirectory": "/in"
+    }
+  },
+  "liveRaw": {
+    "S3StorageClass": "STANDARD",
+    "S3Config": {
+      "BucketAccessRoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegDataSyncRich-DsRole9B0CCAF1-cVz0MmYK0xqy"
+    },
+    "LocationUri": "s3://cdkrd-ds-src-111111111111/in/",
+    "LocationArn": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftIntegDataSyncRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SrcLoc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegDataSyncRich/0169a6e0-79ec-11f1-a04f-0e62a9b969df",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LocationArn", "LocationUri"],
+    "writeOnly": ["S3BucketArn", "Subdirectory"],
+    "createOnly": ["S3BucketArn"],
+    "readOnlyPaths": ["LocationArn", "LocationUri"],
+    "writeOnlyPaths": ["S3BucketArn", "Subdirectory"],
+    "createOnlyPaths": ["S3BucketArn"],
+    "defaults": {
+      "S3StorageClass": "STANDARD"
+    },
+    "defaultPaths": {
+      "S3StorageClass": "STANDARD"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "SrcLoc",
+      "resourceType": "AWS::DataSync::LocationS3",
+      "path": "S3BucketArn",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "SrcLoc",
+      "resourceType": "AWS::DataSync::LocationS3",
+      "path": "Subdirectory",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SrcLoc",
+      "resourceType": "AWS::DataSync::LocationS3",
+      "path": "S3StorageClass",
+      "actual": "STANDARD",
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/SrcLoc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__DataSync__Task.Task.json
+++ b/tests/corpus/AWS__DataSync__Task.Task.json
@@ -1,0 +1,214 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Task",
+    "resourceType": "AWS::DataSync::Task",
+    "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+    "constructPath": "CdkRealDriftIntegDataSyncRich/Task",
+    "declared": {
+      "DestinationLocationArn": "arn:aws:datasync:us-east-1:111111111111:location/loc-04cf76201d4fbe02b",
+      "Name": "cdkrd-ds-task",
+      "Options": {
+        "LogLevel": "OFF",
+        "OverwriteMode": "ALWAYS",
+        "TransferMode": "CHANGED",
+        "VerifyMode": "ONLY_FILES_TRANSFERRED"
+      },
+      "SourceLocationArn": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded"
+    }
+  },
+  "liveRaw": {
+    "Status": "AVAILABLE",
+    "SourceNetworkInterfaceArns": [],
+    "DestinationLocationArn": "arn:aws:datasync:us-east-1:111111111111:location/loc-04cf76201d4fbe02b",
+    "Options": {
+      "VerifyMode": "ONLY_FILES_TRANSFERRED",
+      "Gid": "NONE",
+      "Atime": "BEST_EFFORT",
+      "OverwriteMode": "ALWAYS",
+      "PreserveDevices": "NONE",
+      "Mtime": "PRESERVE",
+      "TaskQueueing": "ENABLED",
+      "TransferMode": "CHANGED",
+      "LogLevel": "OFF",
+      "ObjectTags": "PRESERVE",
+      "Uid": "NONE",
+      "BytesPerSecond": -1,
+      "PosixPermissions": "NONE",
+      "PreserveDeletedFiles": "PRESERVE",
+      "SecurityDescriptorCopyFlags": "NONE"
+    },
+    "Excludes": [],
+    "TaskMode": "BASIC",
+    "Name": "cdkrd-ds-task",
+    "TaskArn": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+    "Includes": [],
+    "DestinationNetworkInterfaceArns": [],
+    "Schedule": {},
+    "SourceLocationArn": "arn:aws:datasync:us-east-1:111111111111:location/loc-0f0c8cdfe1bd8cded",
+    "Tags": [
+      {
+        "Value": "Task",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegDataSyncRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegDataSyncRich/0169a6e0-79ec-11f1-a04f-0e62a9b969df",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "DestinationNetworkInterfaceArns",
+      "SourceNetworkInterfaceArns",
+      "Status",
+      "TaskArn"
+    ],
+    "writeOnly": [],
+    "createOnly": ["DestinationLocationArn", "SourceLocationArn", "TaskMode"],
+    "readOnlyPaths": [
+      "DestinationNetworkInterfaceArns",
+      "SourceNetworkInterfaceArns",
+      "Status",
+      "TaskArn"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DestinationLocationArn", "SourceLocationArn", "TaskMode"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["DestinationNetworkInterfaceArns", "SourceNetworkInterfaceArns"],
+    "unorderedObjectArrayPaths": ["Excludes", "Includes"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "TaskMode",
+      "actual": "BASIC",
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.Gid",
+      "actual": "NONE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.Atime",
+      "actual": "BEST_EFFORT",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.PreserveDevices",
+      "actual": "NONE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.Mtime",
+      "actual": "PRESERVE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.TaskQueueing",
+      "actual": "ENABLED",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.ObjectTags",
+      "actual": "PRESERVE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.Uid",
+      "actual": "NONE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.BytesPerSecond",
+      "actual": -1,
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.PosixPermissions",
+      "actual": "NONE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.PreserveDeletedFiles",
+      "actual": "PRESERVE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Task",
+      "resourceType": "AWS::DataSync::Task",
+      "path": "Options.SecurityDescriptorCopyFlags",
+      "actual": "NONE",
+      "nested": true,
+      "physicalId": "arn:aws:datasync:us-east-1:111111111111:task/task-01953111e9a9cd335",
+      "constructPath": "CdkRealDriftIntegDataSyncRich/Task"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Grafana__Workspace.Workspace.json
+++ b/tests/corpus/AWS__Grafana__Workspace.Workspace.json
@@ -1,0 +1,95 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Workspace",
+    "resourceType": "AWS::Grafana::Workspace",
+    "physicalId": "g-f76beca787",
+    "constructPath": "CdkRealDriftIntegGrafanaRich/Workspace",
+    "declared": {
+      "AccountAccessType": "CURRENT_ACCOUNT",
+      "AuthenticationProviders": ["SAML"],
+      "DataSources": ["CLOUDWATCH", "PROMETHEUS"],
+      "Description": "cdkrd grafana rich",
+      "Name": "cdkrd-grafana-rich",
+      "NotificationDestinations": ["SNS"],
+      "PermissionType": "SERVICE_MANAGED",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegGrafanaRich-GrafanaRole3A2DB257-NppwcJCDUEsq"
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "NotificationDestinations": ["SNS"],
+    "Description": "cdkrd grafana rich",
+    "CreationTimestamp": "2026-07-07T10:03:22.593Z",
+    "PermissionType": "SERVICE_MANAGED",
+    "SamlConfigurationStatus": "NOT_CONFIGURED",
+    "AccountAccessType": "CURRENT_ACCOUNT",
+    "OrganizationalUnits": [],
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftIntegGrafanaRich-GrafanaRole3A2DB257-NppwcJCDUEsq",
+    "Name": "cdkrd-grafana-rich",
+    "GrafanaVersion": "10.4",
+    "DataSources": ["CLOUDWATCH", "PROMETHEUS"],
+    "Endpoint": "g-f76beca787.grafana-workspace.us-east-1.amazonaws.com",
+    "AuthenticationProviders": ["SAML"],
+    "Id": "g-f76beca787",
+    "ModificationTimestamp": "2026-07-07T10:03:22.593Z"
+  },
+  "schema": {
+    "readOnly": [
+      "CreationTimestamp",
+      "Endpoint",
+      "Id",
+      "ModificationTimestamp",
+      "SamlConfigurationStatus",
+      "SsoClientId",
+      "Status"
+    ],
+    "writeOnly": ["ClientToken"],
+    "createOnly": ["ClientToken"],
+    "readOnlyPaths": [
+      "CreationTimestamp",
+      "Endpoint",
+      "Id",
+      "ModificationTimestamp",
+      "SamlConfigurationStatus",
+      "SsoClientId",
+      "Status"
+    ],
+    "writeOnlyPaths": ["ClientToken"],
+    "createOnlyPaths": ["ClientToken"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "AuthenticationProviders",
+      "DataSources",
+      "NetworkAccessControl.PrefixListIds",
+      "NetworkAccessControl.VpceIds",
+      "NotificationDestinations",
+      "OrganizationalUnits",
+      "SamlConfiguration.AllowedOrganizations",
+      "SamlConfiguration.RoleValues.Admin",
+      "SamlConfiguration.RoleValues.Editor",
+      "VpcConfiguration.SecurityGroupIds",
+      "VpcConfiguration.SubnetIds"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Workspace",
+      "resourceType": "AWS::Grafana::Workspace",
+      "path": "GrafanaVersion",
+      "actual": "10.4",
+      "physicalId": "g-f76beca787",
+      "constructPath": "CdkRealDriftIntegGrafanaRich/Workspace"
+    }
+  ]
+}

--- a/tests/integration/datasync-rich/app.ts
+++ b/tests/integration/datasync-rich/app.ts
@@ -1,0 +1,76 @@
+// CDK app for the cdk-real-drift datasync-rich false-positive integration test.
+// AWS DataSync (AWS::DataSync::LocationS3 + ::Task) is a common data-migration
+// service. A Task folds a large Options block of AWS-assigned defaults — VerifyMode,
+// OverwriteMode, Atime, Mtime, Uid, Gid, PreserveDeletedFiles, PosixPermissions,
+// TaskQueueing, LogLevel, TransferMode, ObjectTags, etc. — none of which the user
+// declares. A LocationS3 folds S3StorageClass + a normalized Subdirectory. A clean
+// `record`->`check` is a strong false-positive oracle for those undeclared defaults.
+import { App, Stack } from "aws-cdk-lib";
+import { RemovalPolicy } from "aws-cdk-lib";
+import { CfnLocationS3, CfnTask } from "aws-cdk-lib/aws-datasync";
+import { Role, ServicePrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegDataSyncRich");
+
+const src = new Bucket(stack, "Src", {
+  bucketName: `cdkrd-ds-src-${stack.account}`,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+const dst = new Bucket(stack, "Dst", {
+  bucketName: `cdkrd-ds-dst-${stack.account}`,
+  removalPolicy: RemovalPolicy.DESTROY,
+});
+
+const role = new Role(stack, "DsRole", {
+  assumedBy: new ServicePrincipal("datasync.amazonaws.com"),
+});
+role.addToPolicy(
+  new PolicyStatement({
+    actions: [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+      "s3:ListMultipartUploadParts",
+      "s3:AbortMultipartUpload",
+    ],
+    resources: [src.bucketArn, `${src.bucketArn}/*`, dst.bucketArn, `${dst.bucketArn}/*`],
+  })
+);
+
+const srcLoc = new CfnLocationS3(stack, "SrcLoc", {
+  s3BucketArn: src.bucketArn,
+  s3Config: { bucketAccessRoleArn: role.roleArn },
+  subdirectory: "/in",
+});
+// Depend on the whole Role construct (incl. its DefaultPolicy), not just the Role
+// resource — DataSync runs an s3:ListObjectsV2 access test at location-create time,
+// so the inline policy must exist first or the create fails "Access denied".
+srcLoc.node.addDependency(role);
+
+const dstLoc = new CfnLocationS3(stack, "DstLoc", {
+  s3BucketArn: dst.bucketArn,
+  s3Config: { bucketAccessRoleArn: role.roleArn },
+  subdirectory: "/out",
+});
+dstLoc.node.addDependency(role);
+
+new CfnTask(stack, "Task", {
+  name: "cdkrd-ds-task",
+  sourceLocationArn: srcLoc.ref,
+  destinationLocationArn: dstLoc.ref,
+  options: {
+    verifyMode: "ONLY_FILES_TRANSFERRED",
+    overwriteMode: "ALWAYS",
+    transferMode: "CHANGED",
+    logLevel: "OFF",
+  },
+});
+
+app.synth();

--- a/tests/integration/datasync-rich/cdk.json
+++ b/tests/integration/datasync-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/datasync-rich/package.json
+++ b/tests/integration/datasync-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-datasync-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift datasync-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/datasync-rich/verify.sh
+++ b/tests/integration/datasync-rich/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. A DataSync Task folds a large Options block of AWS-assigned defaults
+# (VerifyMode, Atime, Mtime, Uid, Gid, PreserveDeletedFiles, TaskQueueing, LogLevel,
+# TransferMode, ObjectTags, ...) and a LocationS3 folds S3StorageClass + a normalized
+# Subdirectory; any drift on a clean recorded stack is a default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegDataSyncRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (fresh-deploy potential-drift oracle) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK-fresh.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/grafana-rich/app.ts
+++ b/tests/integration/grafana-rich/app.ts
@@ -1,0 +1,30 @@
+// CDK app for the cdk-real-drift grafana-rich false-positive integration test.
+// Amazon Managed Grafana (AWS::Grafana::Workspace) is a common managed-observability
+// dashboard service. A workspace folds a large set of AWS-assigned defaults —
+// GrafanaVersion (AWS expands to a concrete patch), Status, Endpoint, Creation
+// timestamp, DataSources, NotificationDestinations, and the SERVICE_MANAGED
+// permission model — none declared. A clean `record`->`check` is a strong
+// false-positive oracle for those undeclared first-run defaults.
+import { App, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { CfnWorkspace } from "aws-cdk-lib/aws-grafana";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegGrafanaRich");
+
+const role = new Role(stack, "GrafanaRole", {
+  assumedBy: new ServicePrincipal("grafana.amazonaws.com"),
+});
+
+new CfnWorkspace(stack, "Workspace", {
+  name: "cdkrd-grafana-rich",
+  description: "cdkrd grafana rich",
+  accountAccessType: "CURRENT_ACCOUNT",
+  authenticationProviders: ["SAML"],
+  permissionType: "SERVICE_MANAGED",
+  roleArn: role.roleArn,
+  dataSources: ["CLOUDWATCH", "PROMETHEUS"],
+  notificationDestinations: ["SNS"],
+});
+
+app.synth();

--- a/tests/integration/grafana-rich/cdk.json
+++ b/tests/integration/grafana-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/grafana-rich/package.json
+++ b/tests/integration/grafana-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-grafana-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift grafana-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/grafana-rich/verify-detect.sh
+++ b/tests/integration/grafana-rich/verify-detect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Grafana Workspace detect + revert integration test (real AWS): the "someone edited
+# the workspace in the console" scenario. Deploy -> record -> change the DECLARED
+# MUTABLE Description out of band -> check MUST DETECT (exit 1) -> revert -> check MUST
+# be CLEAN and Description restored. Verified live on hunt 2026-07-07 (revert via
+# Cloud Control UpdateResource; the workspace is FULLY_MUTABLE).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGrafanaRich
+NAME=cdkrd-grafana-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+WSID="$(aws grafana list-workspaces --region "$REGION" --query "workspaces[?name=='$NAME'].id" --output text)"
+[ -n "$WSID" ] && [ "$WSID" != "None" ] || fail "could not resolve workspace id"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: change Description (console-edit) ==="
+aws grafana update-workspace --workspace-id "$WSID" --region "$REGION" \
+  --workspace-description "MUTATED-OOB" >/dev/null || fail "inject drift"
+# wait for the workspace to settle back to ACTIVE
+until [ "$(aws grafana describe-workspace --workspace-id "$WSID" --region "$REGION" --query 'workspace.status' --output text)" = "ACTIVE" ]; do sleep 5; done
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-grafana-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "Description" /tmp/cdkrd-grafana-detect.out || fail "Description not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+until [ "$(aws grafana describe-workspace --workspace-id "$WSID" --region "$REGION" --query 'workspace.status' --output text)" = "ACTIVE" ]; do sleep 5; done
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live Description MUST be restored ==="
+GOT="$(aws grafana describe-workspace --workspace-id "$WSID" --region "$REGION" --query 'workspace.description' --output text)"
+[ "$GOT" = "cdkrd grafana rich" ] || fail "live Description not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/grafana-rich/verify.sh
+++ b/tests/integration/grafana-rich/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. An Amazon Managed Grafana workspace folds many AWS-assigned
+# first-run defaults (GrafanaVersion patch expansion, Status, Endpoint, Creation
+# timestamp, SERVICE_MANAGED permission model); any drift on a clean recorded stack
+# is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegGrafanaRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (fresh-deploy potential-drift oracle) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK-fresh.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

Bug-hunt round (2026-07-07): a fresh, un-mutated deploy of two previously-uncovered
common types surfaced **three** undeclared AWS-assigned values as `[Potential Drift]`
— fold gaps that violate the clean-deploy zero-potential-drift invariant.

| Type | Path | Fix |
| --- | --- | --- |
| `AWS::Grafana::Workspace` | `GrafanaVersion` (`"10.4"`) | value-independent fold (undeclared) |
| `AWS::DataSync::Task` | `Options.TaskQueueing` (`ENABLED`) | equality-gated `KNOWN_DEFAULT_PATHS` |
| `AWS::DataSync::Task` | `Options.PreserveDeletedFiles` (`PRESERVE`) | equality-gated `KNOWN_DEFAULT_PATHS` |

- **GrafanaVersion**: AWS assigns the current GA version when the workspace declares
  none, and that default moves over time — not a constant we can pin, never user
  intent when undeclared. Folded value-independent, mirroring
  `AWS::Redshift::Cluster.ClusterVersion` / `AWS::ECS::Service.PlatformVersion`. A
  **declared** `GrafanaVersion` is still compared (out-of-band upgrade surfaces).
- **DataSync TaskQueueing / PreserveDeletedFiles**: the two documented Option
  defaults the round-B entry (#496) missed. Equality-gated, so a task that pins
  `DISABLED` / `REMOVE` out of band still surfaces.

## Verification (real AWS, us-east-1)

- **FP**: both stacks read `CLEAN` (0 potential drift) after the fix; every
  undeclared value folds to `atDefault`.
- **FN**: mutated the declared, mutable `Workspace.Description` out of band → `check`
  detected declared drift (exit 1) → `revert` (Cloud Control `UpdateResource`) →
  `check` CLEAN → live value restored.
- All tracked stacks deleted via `delstack`, `sweep-orphans.sh` reports SWEEP CLEAN.

## Left behind (regression assets)

- classify unit tests (Grafana version fold + value-independence + declared-still-detected;
  DataSync Options fold + equality-gate).
- Three golden-corpus cases (`AWS__Grafana__Workspace`, `AWS__DataSync__Task`,
  `AWS__DataSync__LocationS3`) — replayed offline by `corpus-replay`.
- `grafana-rich` (+ `verify-detect.sh`) and `datasync-rich` regression fixtures.

## Note

Timestream (`AWS::Timestream::Database`) was also scoped but is **closed to new
customers** on this account (`AccessDeniedException: "Only existing Timestream for
LiveAnalytics customers can access the service"`), so no fixture ships for it.
