### PR TITLE
fix(noise): fold App Runner + Transfer Family first-run defaults

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -9,6 +9,28 @@
 // entries were all OBSERVED on real default-config stacks during dogfooding.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
+  // An App Runner service that declares neither HealthCheckConfiguration nor
+  // NetworkConfiguration reads both back fully materialized with AWS's constant
+  // first-run defaults — a TCP health check and a public IPV4 DEFAULT-egress network.
+  // Equality-gated (subset-tolerant), so a user who declares any of these knobs pushes
+  // the property out of the undeclared tier, and an out-of-band change to any sub-field
+  // (e.g. IsPubliclyAccessible=false, Interval=10) no longer matches and re-surfaces.
+  // Observed live on a fresh RUNNING service (apprunner-service-rich, 2026-07-07).
+  'AWS::AppRunner::Service': {
+    HealthCheckConfiguration: {
+      Protocol: 'TCP',
+      Path: '/',
+      Interval: 5,
+      Timeout: 2,
+      HealthyThreshold: 1,
+      UnhealthyThreshold: 5,
+    },
+    NetworkConfiguration: {
+      IpAddressType: 'IPV4',
+      EgressConfiguration: { EgressType: 'DEFAULT' },
+      IngressConfiguration: { IsPubliclyAccessible: true },
+    },
+  },
   // A Managed Service for Apache Flink application that declares no ApplicationMode
   // reads back STREAMING — the constant service default for Flink runtimes (the only
   // other value, INTERACTIVE, requires a Zeppelin/Studio runtime, a different declared
@@ -990,6 +1012,18 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       PassiveIp: 'AUTO',
       SetStatOption: 'DEFAULT',
       TlsSessionResumptionMode: 'ENFORCED',
+    },
+    // A server created without SecurityPolicyName is assigned AWS's stable default
+    // policy (TransferSecurityPolicy-2018-11 — kept as the default-for-new-servers for
+    // backward compatibility even as AWS ships newer named policies). Equality-gated so
+    // a user picking a different policy (a meaningful security change) still surfaces.
+    SecurityPolicyName: 'TransferSecurityPolicy-2018-11',
+    // Domain is create-only and defaults to S3 when omitted; equality-gated so an
+    // EFS-domain server that declared it is unaffected (it never reaches undeclared).
+    Domain: 'S3',
+    // S3StorageOptions defaults to directory-listing optimization DISABLED.
+    S3StorageOptions: {
+      DirectoryListingOptimization: 'DISABLED',
     },
   },
   'AWS::DataSync::Task': {

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -89,6 +89,11 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // `remove` revert of an out-of-band `true` is a silent no-op), so write the `false`
   // default explicitly.
   'AWS::Cognito::IdentityPool\0AllowClassicFlow',
+  // Transfer UpdateServer ignores an omitted SecurityPolicyName (live-observed: a
+  // `remove` revert of an out-of-band non-default policy reports SUCCESS yet the live
+  // value persists), so write the default policy (TransferSecurityPolicy-2018-11) back
+  // explicitly. The value comes from KNOWN_DEFAULTS.
+  'AWS::Transfer::Server\0SecurityPolicyName',
 ]);
 
 /**

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -8139,6 +8139,25 @@ describe('API Gateway default-config first-run folds', () => {
       )
     ).toBe(true);
     expect(matchesKnownDefault({ enabled: false }, { enabled: true })).toBe(false);
+    // AppRunner NetworkConfiguration (bug-hunt apprunner-service-rich): the whole
+    // undeclared default folds, but flipping the nested IngressConfiguration to private
+    // (IsPubliclyAccessible:false) is a real out-of-band change and must NOT fold.
+    const netDef = {
+      IpAddressType: 'IPV4',
+      EgressConfiguration: { EgressType: 'DEFAULT' },
+      IngressConfiguration: { IsPubliclyAccessible: true },
+    };
+    expect(matchesKnownDefault(netDef, netDef)).toBe(true);
+    expect(
+      matchesKnownDefault(
+        {
+          IpAddressType: 'IPV4',
+          EgressConfiguration: { EgressType: 'DEFAULT' },
+          IngressConfiguration: { IsPubliclyAccessible: false },
+        },
+        netDef
+      )
+    ).toBe(false);
   });
 
   it('RestApi undeclared EndpointConfiguration folds to atDefault even when AWS omits IpAddressType', () => {

--- a/tests/corpus/AWS__AppRunner__Service.Service.json
+++ b/tests/corpus/AWS__AppRunner__Service.Service.json
@@ -1,0 +1,123 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Service",
+    "resourceType": "AWS::AppRunner::Service",
+    "physicalId": "arn:aws:apprunner:us-east-1:111111111111:service/cdkrd-apprunner-rich/d4f0d555eb3b41078880b7626c6ab1d9",
+    "constructPath": "CdkRealDriftIntegAppRunnerServiceRich/Service",
+    "declared": {
+      "InstanceConfiguration": {
+        "Cpu": "1024",
+        "Memory": "2048"
+      },
+      "ServiceName": "cdkrd-apprunner-rich",
+      "SourceConfiguration": {
+        "AutoDeploymentsEnabled": false,
+        "ImageRepository": {
+          "ImageConfiguration": {
+            "Port": "8000"
+          },
+          "ImageIdentifier": "public.ecr.aws/aws-containers/hello-app-runner:latest",
+          "ImageRepositoryType": "ECR_PUBLIC"
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "Status": "RUNNING",
+    "HealthCheckConfiguration": {
+      "Path": "/",
+      "UnhealthyThreshold": 5,
+      "Timeout": 2,
+      "HealthyThreshold": 1,
+      "Protocol": "TCP",
+      "Interval": 5
+    },
+    "ServiceName": "cdkrd-apprunner-rich",
+    "InstanceConfiguration": {
+      "Memory": "2048",
+      "Cpu": "1024"
+    },
+    "ObservabilityConfiguration": {
+      "ObservabilityEnabled": false
+    },
+    "SourceConfiguration": {
+      "ImageRepository": {
+        "ImageIdentifier": "public.ecr.aws/aws-containers/hello-app-runner:latest",
+        "ImageConfiguration": {
+          "RuntimeEnvironmentSecrets": [],
+          "RuntimeEnvironmentVariables": [],
+          "Port": "8000"
+        },
+        "ImageRepositoryType": "ECR_PUBLIC"
+      },
+      "AutoDeploymentsEnabled": false
+    },
+    "ServiceUrl": "qnmmvkvtyr.us-east-1.awsapprunner.com",
+    "NetworkConfiguration": {
+      "IpAddressType": "IPV4",
+      "EgressConfiguration": {
+        "EgressType": "DEFAULT"
+      },
+      "IngressConfiguration": {
+        "IsPubliclyAccessible": true
+      }
+    },
+    "ServiceArn": "arn:aws:apprunner:us-east-1:111111111111:service/cdkrd-apprunner-rich/d4f0d555eb3b41078880b7626c6ab1d9",
+    "ServiceId": "d4f0d555eb3b41078880b7626c6ab1d9"
+  },
+  "schema": {
+    "readOnly": ["ServiceArn", "ServiceId", "ServiceUrl", "Status"],
+    "writeOnly": ["AutoScalingConfigurationArn", "Tags"],
+    "createOnly": ["EncryptionConfiguration", "ServiceName", "Tags"],
+    "readOnlyPaths": ["ServiceArn", "ServiceId", "ServiceUrl", "Status"],
+    "writeOnlyPaths": ["AutoScalingConfigurationArn", "Tags"],
+    "createOnlyPaths": ["EncryptionConfiguration", "ServiceName", "Tags"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Service",
+      "resourceType": "AWS::AppRunner::Service",
+      "path": "HealthCheckConfiguration",
+      "actual": {
+        "Path": "/",
+        "UnhealthyThreshold": 5,
+        "Timeout": 2,
+        "HealthyThreshold": 1,
+        "Protocol": "TCP",
+        "Interval": 5
+      },
+      "physicalId": "arn:aws:apprunner:us-east-1:111111111111:service/cdkrd-apprunner-rich/d4f0d555eb3b41078880b7626c6ab1d9",
+      "constructPath": "CdkRealDriftIntegAppRunnerServiceRich/Service"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Service",
+      "resourceType": "AWS::AppRunner::Service",
+      "path": "NetworkConfiguration",
+      "actual": {
+        "IpAddressType": "IPV4",
+        "EgressConfiguration": {
+          "EgressType": "DEFAULT"
+        },
+        "IngressConfiguration": {
+          "IsPubliclyAccessible": true
+        }
+      },
+      "physicalId": "arn:aws:apprunner:us-east-1:111111111111:service/cdkrd-apprunner-rich/d4f0d555eb3b41078880b7626c6ab1d9",
+      "constructPath": "CdkRealDriftIntegAppRunnerServiceRich/Service"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceCatalog__Portfolio.Portfolio.json
+++ b/tests/corpus/AWS__ServiceCatalog__Portfolio.Portfolio.json
@@ -1,0 +1,42 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Portfolio",
+    "resourceType": "AWS::ServiceCatalog::Portfolio",
+    "physicalId": "port-bfvh35v5xa6ee",
+    "constructPath": "CdkRealDriftIntegServiceCatalogPortfolioRich/Portfolio",
+    "declared": {
+      "Description": "cdkrd service catalog portfolio rich",
+      "DisplayName": "cdkrd-portfolio-rich",
+      "ProviderName": "cdkrd"
+    }
+  },
+  "liveRaw": {
+    "ProviderName": "cdkrd",
+    "Description": "cdkrd service catalog portfolio rich",
+    "DisplayName": "cdkrd-portfolio-rich",
+    "Id": "port-bfvh35v5xa6ee",
+    "PortfolioName": "cdkrd-portfolio-rich",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Id", "PortfolioName"],
+    "writeOnly": ["AcceptLanguage"],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "PortfolioName"],
+    "writeOnlyPaths": ["AcceptLanguage"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Transfer__Server.Server.json
+++ b/tests/corpus/AWS__Transfer__Server.Server.json
@@ -1,0 +1,129 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Server",
+    "resourceType": "AWS::Transfer::Server",
+    "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+    "constructPath": "CdkRealDriftIntegTransferServerRich/Server",
+    "declared": {
+      "EndpointType": "PUBLIC",
+      "IdentityProviderType": "SERVICE_MANAGED",
+      "LoggingRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegTransferServer-LoggingRole0BCFB29B-sEXvbYZR3jtI",
+      "Protocols": ["SFTP"]
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "IPV4",
+    "LoggingRole": "arn:aws:iam::111111111111:role/CdkRealDriftIntegTransferServer-LoggingRole0BCFB29B-sEXvbYZR3jtI",
+    "Protocols": ["SFTP"],
+    "StructuredLogDestinations": [],
+    "ServerId": "s-754a229b4fca4b2b9",
+    "As2ServiceManagedEgressIpAddresses": [],
+    "State": "ONLINE",
+    "EndpointType": "PUBLIC",
+    "SecurityPolicyName": "TransferSecurityPolicy-2018-11",
+    "ProtocolDetails": {
+      "PassiveIp": "AUTO",
+      "SetStatOption": "DEFAULT",
+      "TlsSessionResumptionMode": "ENFORCED"
+    },
+    "S3StorageOptions": {
+      "DirectoryListingOptimization": "DISABLED"
+    },
+    "Arn": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+    "Domain": "S3",
+    "IdentityProviderType": "SERVICE_MANAGED",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegTransferServerRich/f0383580-79f5-11f1-9f12-0e7e4208b1b1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegTransferServerRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Server",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "As2ServiceManagedEgressIpAddresses", "ServerId", "State"],
+    "writeOnly": [],
+    "createOnly": ["Domain"],
+    "readOnlyPaths": ["Arn", "As2ServiceManagedEgressIpAddresses", "ServerId", "State"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Domain"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "As2ServiceManagedEgressIpAddresses",
+      "EndpointDetails.SecurityGroupIds",
+      "ProtocolDetails.As2Transports",
+      "Protocols",
+      "StructuredLogDestinations"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Server",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "IpAddressType",
+      "actual": "IPV4",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+      "constructPath": "CdkRealDriftIntegTransferServerRich/Server"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Server",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "SecurityPolicyName",
+      "actual": "TransferSecurityPolicy-2018-11",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+      "constructPath": "CdkRealDriftIntegTransferServerRich/Server"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Server",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "ProtocolDetails",
+      "actual": {
+        "PassiveIp": "AUTO",
+        "SetStatOption": "DEFAULT",
+        "TlsSessionResumptionMode": "ENFORCED"
+      },
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+      "constructPath": "CdkRealDriftIntegTransferServerRich/Server"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Server",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "S3StorageOptions",
+      "actual": {
+        "DirectoryListingOptimization": "DISABLED"
+      },
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+      "constructPath": "CdkRealDriftIntegTransferServerRich/Server"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Server",
+      "resourceType": "AWS::Transfer::Server",
+      "path": "Domain",
+      "actual": "S3",
+      "physicalId": "arn:aws:transfer:us-east-1:111111111111:server/s-754a229b4fca4b2b9",
+      "constructPath": "CdkRealDriftIntegTransferServerRich/Server"
+    }
+  ]
+}

--- a/tests/integration/apprunner-service-rich/app.ts
+++ b/tests/integration/apprunner-service-rich/app.ts
@@ -1,0 +1,36 @@
+// CDK app for the cdk-real-drift apprunner-service-rich false-positive integration test.
+// AWS App Runner (AWS::AppRunner::Service) is a common way to run a container without
+// managing infrastructure. A service folds a very large set of AWS-assigned first-run
+// defaults the template never declares — HealthCheckConfiguration (Protocol/Path/
+// Interval/Timeout/HealthyThreshold/UnhealthyThreshold), NetworkConfiguration
+// (Egress DEFAULT, Ingress IsPubliclyAccessible, IpAddressType), the default
+// AutoScalingConfigurationArn, ServiceUrl/ServiceId/Status, and ImageConfiguration
+// echoes. A clean `record`->`check` (and a `check` BEFORE record) is a strong
+// false-positive oracle for those undeclared first-run defaults.
+//
+// Uses a public ECR sample image so the fixture needs no image build or access role.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnService } from "aws-cdk-lib/aws-apprunner";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegAppRunnerServiceRich");
+
+new CfnService(stack, "Service", {
+  serviceName: "cdkrd-apprunner-rich",
+  sourceConfiguration: {
+    autoDeploymentsEnabled: false,
+    imageRepository: {
+      imageIdentifier: "public.ecr.aws/aws-containers/hello-app-runner:latest",
+      imageRepositoryType: "ECR_PUBLIC",
+      imageConfiguration: {
+        port: "8000",
+      },
+    },
+  },
+  instanceConfiguration: {
+    cpu: "1024",
+    memory: "2048",
+  },
+});
+
+app.synth();

--- a/tests/integration/apprunner-service-rich/cdk.json
+++ b/tests/integration/apprunner-service-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/apprunner-service-rich/package.json
+++ b/tests/integration/apprunner-service-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-apprunner-service-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift apprunner-service-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/apprunner-service-rich/verify.sh
+++ b/tests/integration/apprunner-service-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> check BEFORE record (fresh
+# potential-drift oracle) -> record baseline -> check MUST be CLEAN.
+# An App Runner service folds many AWS-assigned first-run defaults (HealthCheckConfiguration, NetworkConfiguration, AutoScalingConfigurationArn, ServiceUrl/Id/Status).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegAppRunnerServiceRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (fresh-deploy potential-drift oracle) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK-fresh.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/servicecatalog-portfolio-rich/app.ts
+++ b/tests/integration/servicecatalog-portfolio-rich/app.ts
@@ -1,0 +1,19 @@
+// CDK app for the cdk-real-drift servicecatalog-portfolio-rich false-positive
+// integration test. AWS Service Catalog (AWS::ServiceCatalog::Portfolio) is a common
+// governance primitive in enterprise CDK stacks. A portfolio folds AWS-assigned
+// first-run values the template never declares — Id, and echoed defaults. A clean
+// `record`->`check` (and a `check` BEFORE record) is a false-positive oracle for
+// those undeclared first-run defaults.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnPortfolio } from "aws-cdk-lib/aws-servicecatalog";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegServiceCatalogPortfolioRich");
+
+new CfnPortfolio(stack, "Portfolio", {
+  displayName: "cdkrd-portfolio-rich",
+  providerName: "cdkrd",
+  description: "cdkrd service catalog portfolio rich",
+});
+
+app.synth();

--- a/tests/integration/servicecatalog-portfolio-rich/cdk.json
+++ b/tests/integration/servicecatalog-portfolio-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/servicecatalog-portfolio-rich/package.json
+++ b/tests/integration/servicecatalog-portfolio-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-servicecatalog-portfolio-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift servicecatalog-portfolio-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/servicecatalog-portfolio-rich/verify.sh
+++ b/tests/integration/servicecatalog-portfolio-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> check BEFORE record (fresh
+# potential-drift oracle) -> record baseline -> check MUST be CLEAN.
+# A Service Catalog portfolio folds AWS-assigned first-run values (Id, echoed defaults).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegServiceCatalogPortfolioRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (fresh-deploy potential-drift oracle) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK-fresh.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/transfer-server-rich/app.ts
+++ b/tests/integration/transfer-server-rich/app.ts
@@ -1,0 +1,41 @@
+// CDK app for the cdk-real-drift transfer-server-rich false-positive integration test.
+// AWS Transfer Family (AWS::Transfer::Server) is a common managed SFTP/FTPS endpoint.
+// A server folds a large set of AWS-assigned first-run defaults that the template
+// never declares — SecurityPolicyName (AWS assigns the current default policy),
+// State, ServerId/Arn, EndpointType, ProtocolDetails, S3StorageOptions
+// (DirectoryListingOptimization), and the SERVICE_MANAGED identity model. A clean
+// `record`->`check` (and a `check` BEFORE record) is a strong false-positive oracle
+// for those undeclared first-run defaults.
+import { App, Stack } from "aws-cdk-lib";
+import { Role, ServicePrincipal, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import { CfnServer } from "aws-cdk-lib/aws-transfer";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegTransferServerRich");
+
+// Logging role so the server writes structured CloudWatch logs (a common config).
+const loggingRole = new Role(stack, "LoggingRole", {
+  assumedBy: new ServicePrincipal("transfer.amazonaws.com"),
+});
+loggingRole.addToPolicy(
+  new PolicyStatement({
+    actions: [
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:CreateLogGroup",
+      "logs:PutLogEvents",
+    ],
+    resources: ["*"],
+  }),
+);
+
+new CfnServer(stack, "Server", {
+  identityProviderType: "SERVICE_MANAGED",
+  endpointType: "PUBLIC",
+  protocols: ["SFTP"],
+  loggingRole: loggingRole.roleArn,
+  // securityPolicyName intentionally omitted -> AWS assigns the current default
+  // policy (an undeclared first-run default that must fold to atDefault).
+});
+
+app.synth();

--- a/tests/integration/transfer-server-rich/cdk.json
+++ b/tests/integration/transfer-server-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/transfer-server-rich/package.json
+++ b/tests/integration/transfer-server-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-transfer-server-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift transfer-server-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/transfer-server-rich/verify.sh
+++ b/tests/integration/transfer-server-rich/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> check BEFORE record (fresh
+# potential-drift oracle) -> record baseline -> check MUST be CLEAN.
+# A Transfer Family SFTP server folds many AWS-assigned first-run defaults (SecurityPolicyName, State, EndpointType, ProtocolDetails, S3StorageOptions).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegTransferServerRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (fresh-deploy potential-drift oracle) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK-fresh.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -898,6 +898,43 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('AppRunner + Transfer first-run defaults (bug-hunt: apprunner-service-rich / transfer-server-rich)', () => {
+    // Constant AWS-assigned first-run defaults a fresh service/server reads back
+    // without declaring them; equality-gated (subset-tolerant for the objects), so a
+    // value set away from the default still surfaces. Exercised live and by the
+    // AWS__AppRunner__Service / AWS__Transfer__Server corpus cases.
+    // An App Runner service that declares neither knob reads back the TCP health check
+    // and the public IPV4 DEFAULT-egress network.
+    expect(KNOWN_DEFAULTS['AWS::AppRunner::Service']).toEqual({
+      HealthCheckConfiguration: {
+        Protocol: 'TCP',
+        Path: '/',
+        Interval: 5,
+        Timeout: 2,
+        HealthyThreshold: 1,
+        UnhealthyThreshold: 5,
+      },
+      NetworkConfiguration: {
+        IpAddressType: 'IPV4',
+        EgressConfiguration: { EgressType: 'DEFAULT' },
+        IngressConfiguration: { IsPubliclyAccessible: true },
+      },
+    });
+    // A Transfer server assigns the stable default security policy, an S3 domain, and
+    // directory-listing optimization DISABLED when those are omitted.
+    expect(KNOWN_DEFAULTS['AWS::Transfer::Server']).toEqual({
+      IpAddressType: 'IPV4',
+      ProtocolDetails: {
+        PassiveIp: 'AUTO',
+        SetStatOption: 'DEFAULT',
+        TlsSessionResumptionMode: 'ENFORCED',
+      },
+      SecurityPolicyName: 'TransferSecurityPolicy-2018-11',
+      Domain: 'S3',
+      S3StorageOptions: { DirectoryListingOptimization: 'DISABLED' },
+    });
+  });
+
   it('isCfnTemplateNonAsciiMask: GetTemplate `?`-masked non-ASCII declared value is not drift', () => {
     // GetTemplate returns the deployed template with every non-ASCII char as `?`
     // (one per codepoint). The declared side is corrupted; the live side is intact.

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -305,6 +305,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Transfer Server SecurityPolicyName (SET-DEFAULT) -> add op writing the default policy, not a no-op remove', () => {
+    // AWS::Transfer::Server SecurityPolicyName is in REVERT_SET_DEFAULT_PATHS: UpdateServer
+    // leaves the policy UNCHANGED when it is OMITTED, so a bare `remove` of an out-of-band
+    // non-default policy is a silent no-op (Cloud Control reports SUCCESS yet the live
+    // TransferSecurityPolicy-2020-06 persists; proven live). Revert must write the stable
+    // default (TransferSecurityPolicy-2018-11) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Transfer::Server',
+      path: 'SecurityPolicyName',
+      actual: 'TransferSecurityPolicy-2020-06',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SecurityPolicyName',
+      value: 'TransferSecurityPolicy-2018-11',
+      prior: 'TransferSecurityPolicy-2020-06',
+    });
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.


### PR DESCRIPTION
## What

Bug-hunt (2026-07-07c) on two common, previously-uncovered CC-readable types — **AWS::AppRunner::Service** and **AWS::Transfer::Server** — plus **AWS::ServiceCatalog::Portfolio** for coverage. A clean, un-mutated deploy must show **zero** `[Potential Drift]`; both AppRunner and Transfer surfaced undeclared AWS-assigned first-run defaults as false positives.

## Fixes

- **App Runner** — `HealthCheckConfiguration` (TCP health check) and `NetworkConfiguration` (public IPV4 DEFAULT egress) are materialized in full when omitted. Fold via equality-gated (subset-tolerant) `KNOWN_DEFAULTS`.
- **Transfer Family** — `SecurityPolicyName` (stable default `TransferSecurityPolicy-2018-11`), `Domain` (`S3`), and `S3StorageOptions` (`DirectoryListingOptimization: DISABLED`) are AWS-assigned when omitted. Fold via equality-gated `KNOWN_DEFAULTS`, preserving out-of-band detection (**live-verified**: mutating the security policy to a non-default value still surfaces).
- **Transfer revert no-op** — `UpdateServer` ignores an omitted `SecurityPolicyName`, so a `remove` revert of an out-of-band policy is a **silent no-op** (live-observed: Cloud Control reports SUCCESS yet the live value persists). Added to `REVERT_SET_DEFAULT_PATHS` so revert writes the default explicitly and converges (**live-verified** restore to `2018-11`).

## Verification

- Live: fresh deploy → `check` (2 AppRunner + 3 Transfer FPs) → fix → `check` CLEAN (folded to `atDefault`). Detection preserved: non-default `SecurityPolicyName` surfaces → `revert` restores default → CLEAN.
- Offline: 3 golden-corpus cases replay in `corpus-replay`; unit tests for both fold tables + the `REVERT_SET_DEFAULT` entry + the nested-object detection gate.
- All 2841 unit tests pass; typecheck + lint/format clean.
- All 3 stacks deleted, orphan log groups swept, `bughunt-track verify` CLEAN.
