### PR TITLE
fix(noise): fold Elastic Beanstalk first-run defaults (Application/Template/Environment)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -37,6 +37,27 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // config; ApplicationMode is createOnly so it cannot drift). Equality-gated. Observed
   // live on a fresh READY Flink app (streaming-rich fixture, 2026-07-03; #509).
   'AWS::KinesisAnalyticsV2::Application': { ApplicationMode: 'STREAMING' },
+  // An Elastic Beanstalk Application that declares no ResourceLifecycleConfig reads back
+  // the constant service default: a version-lifecycle policy carrying both rules present
+  // but DISABLED (Enabled:false, MaxCount 200 / MaxAgeInDays 180, DeleteSourceFromS3:false).
+  // Equality-gated: enable a lifecycle rule out of band and the object no longer matches,
+  // so it re-surfaces as real undeclared drift. Observed live on a fresh elasticbeanstalk-
+  // rich Application (2026-07-07).
+  'AWS::ElasticBeanstalk::Application': {
+    ResourceLifecycleConfig: {
+      VersionLifecycleConfig: {
+        MaxCountRule: { DeleteSourceFromS3: false, Enabled: false, MaxCount: 200 },
+        MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+      },
+    },
+  },
+  // An Elastic Beanstalk Environment that declares no Tier reads back the constant default
+  // WebServer/Standard/1.0 tier. Equality-gated: a Worker-tier environment
+  // ({Name:"Worker",Type:"SQS/HTTP"}) no longer matches, so it surfaces. Observed live on
+  // a fresh elasticbeanstalk-rich Environment (2026-07-07).
+  'AWS::ElasticBeanstalk::Environment': {
+    Tier: { Type: 'Standard', Version: '1.0', Name: 'WebServer' },
+  },
   // S3 versioning can never return to the never-enabled state — a revert "remove"
   // lands on Suspended, which IS the off state. Without this entry an undeclared
   // {Status:"Suspended"} re-reports forever and revert can never converge (R46).
@@ -1856,6 +1877,17 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   value-independent: undeclared, so whatever window AWS chose is its default, not user
   //   intent. A DECLARED window goes through the declared loop (compared), unaffected.
   'AWS::KinesisAnalyticsV2::Application': new Set(['ApplicationMaintenanceConfiguration']),
+  //   AWS::ElasticBeanstalk::ConfigurationTemplate / ::Environment.PlatformArn — a template
+  //   or environment that declares a SolutionStackName (not a PlatformArn) reads back the
+  //   platform ARN AWS DERIVED from it ("arn:aws:elasticbeanstalk:<region>::platform/<name>/
+  //   <version>"). The two are alternative ways to name the same platform, so the derived
+  //   ARN is a pure reflection of the declared SolutionStackName — its value carries the
+  //   region and a platform VERSION that moves as AWS republishes, so it is not a constant we
+  //   can pin. Fold value-independent: undeclared, so whatever ARN AWS returns is not user
+  //   intent (a DECLARED PlatformArn goes through the declared loop, compared). Observed live
+  //   on a fresh elasticbeanstalk-rich template + environment (2026-07-07).
+  'AWS::ElasticBeanstalk::ConfigurationTemplate': new Set(['PlatformArn']),
+  'AWS::ElasticBeanstalk::Environment': new Set(['PlatformArn']),
   //   AWS::ApiGateway::Authorizer.AuthType — a REST-API authorizer's schema carries NO
   //   `AuthType` property (the template declares `Type`: TOKEN / REQUEST /
   //   COGNITO_USER_POOLS); AWS DERIVES and reads back AuthType from it ("custom" for

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2428,13 +2428,11 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       );
       expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
       const undeclared = findings.filter((f) => f.tier === 'undeclared');
-      // the three service-filled extras surface (composite-key path), plus the top-level
-      // PlatformArn echo (undeclared inventory, recordable — NOT a declared drift).
+      // the three service-filled extras surface (composite-key path). NOT a declared drift.
       expect(undeclared.map((f) => f.path).sort()).toEqual([
         'OptionSettings[aws:autoscaling:asg|Availability Zones]',
         'OptionSettings[aws:autoscaling:asg|Cooldown]',
         'OptionSettings[aws:elb:healthcheck|HealthyThreshold]',
-        'PlatformArn',
       ]);
       // the OptionSettings extras are nested inventory
       expect(
@@ -2442,6 +2440,11 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
           .filter((f) => f.path.startsWith('OptionSettings'))
           .every((f) => f.nested === true)
       ).toBe(true);
+      // the top-level PlatformArn echo (AWS-derived from the declared SolutionStackName)
+      // folds value-independent to atDefault, not surfaced as first-run drift (2026-07-07).
+      expect(findings.filter((f) => f.tier === 'atDefault').map((f) => f.path)).toEqual([
+        'PlatformArn',
+      ]);
     });
 
     it('a genuine change to a DECLARED setting value still surfaces as declared drift (fail-closed)', () => {
@@ -2467,6 +2470,87 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
         emptySchema
       ).filter((f) => f.tier === 'declared');
       expect(declaredF).toHaveLength(1);
+    });
+  });
+
+  describe('ElasticBeanstalk Application/Environment top-level first-run defaults (2026-07-07)', () => {
+    it('an Application that declares no ResourceLifecycleConfig folds the disabled default to atDefault', () => {
+      const T = 'AWS::ElasticBeanstalk::Application';
+      const dflt = {
+        VersionLifecycleConfig: {
+          MaxCountRule: { DeleteSourceFromS3: false, Enabled: false, MaxCount: 200 },
+          MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+        },
+      };
+      const t = tiers(
+        classifyResource(
+          res(T, { ApplicationName: 'app', Description: 'x' }),
+          { ApplicationName: 'app', Description: 'x', ResourceLifecycleConfig: dflt },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual(['ResourceLifecycleConfig']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('fail-closed: an ENABLED version-lifecycle rule out of band never folds to atDefault', () => {
+      const T = 'AWS::ElasticBeanstalk::Application';
+      const enabled = {
+        VersionLifecycleConfig: {
+          MaxCountRule: { DeleteSourceFromS3: true, Enabled: true, MaxCount: 200 },
+          MaxAgeRule: { DeleteSourceFromS3: false, MaxAgeInDays: 180, Enabled: false },
+        },
+      };
+      const t = tiers(
+        classifyResource(
+          res(T, { ApplicationName: 'app' }),
+          { ApplicationName: 'app', ResourceLifecycleConfig: enabled },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual([]);
+      expect(t.undeclared).toEqual(['ResourceLifecycleConfig']);
+    });
+
+    it('an Environment folds the default WebServer/Standard/1.0 Tier and the derived PlatformArn', () => {
+      const T = 'AWS::ElasticBeanstalk::Environment';
+      const t = tiers(
+        classifyResource(
+          res(T, {
+            ApplicationName: 'app',
+            EnvironmentName: 'env',
+            SolutionStackName: '64bit Amazon Linux 2023 v4.13.3 running Docker',
+          }),
+          {
+            ApplicationName: 'app',
+            EnvironmentName: 'env',
+            SolutionStackName: '64bit Amazon Linux 2023 v4.13.3 running Docker',
+            Tier: { Type: 'Standard', Version: '1.0', Name: 'WebServer' },
+            PlatformArn:
+              'arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3',
+          },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual(['PlatformArn', 'Tier']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('fail-closed: a Worker-tier Environment out of band never folds to atDefault', () => {
+      const T = 'AWS::ElasticBeanstalk::Environment';
+      const t = tiers(
+        classifyResource(
+          res(T, { ApplicationName: 'app', EnvironmentName: 'env' }),
+          {
+            ApplicationName: 'app',
+            EnvironmentName: 'env',
+            Tier: { Type: 'SQS/HTTP', Version: '1.0', Name: 'Worker' },
+          },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual([]);
+      expect(t.undeclared).toEqual(['Tier']);
     });
   });
 

--- a/tests/corpus/AWS__ElasticBeanstalk__Application.EbApp.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__Application.EbApp.json
@@ -1,0 +1,74 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbApp",
+    "resourceType": "AWS::ElasticBeanstalk::Application",
+    "physicalId": "cdkrd-hunt-eb-app",
+    "constructPath": "CdkRealDriftIntegEbRich/EbApp",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-eb-app",
+      "Description": "cdkrd bug-hunt Elastic Beanstalk application"
+    }
+  },
+  "liveRaw": {
+    "ApplicationName": "cdkrd-hunt-eb-app",
+    "Description": "cdkrd bug-hunt Elastic Beanstalk application",
+    "ResourceLifecycleConfig": {
+      "VersionLifecycleConfig": {
+        "MaxCountRule": {
+          "DeleteSourceFromS3": false,
+          "Enabled": false,
+          "MaxCount": 200
+        },
+        "MaxAgeRule": {
+          "DeleteSourceFromS3": false,
+          "MaxAgeInDays": 180,
+          "Enabled": false
+        }
+      }
+    }
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["ApplicationName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApplicationName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbApp",
+      "resourceType": "AWS::ElasticBeanstalk::Application",
+      "path": "ResourceLifecycleConfig",
+      "actual": {
+        "VersionLifecycleConfig": {
+          "MaxCountRule": {
+            "DeleteSourceFromS3": false,
+            "Enabled": false,
+            "MaxCount": 200
+          },
+          "MaxAgeRule": {
+            "DeleteSourceFromS3": false,
+            "MaxAgeInDays": 180,
+            "Enabled": false
+          }
+        }
+      },
+      "physicalId": "cdkrd-hunt-eb-app",
+      "constructPath": "CdkRealDriftIntegEbRich/EbApp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplate.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplate.json
@@ -1,0 +1,1080 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbTemplate",
+    "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+    "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+    "constructPath": "CdkRealDriftIntegEbRich/EbTemplate",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-eb-app",
+      "Description": "cdkrd bug-hunt configuration template",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "SingleInstance"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "InstanceType",
+          "Value": "t3.micro"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-hunt-eb-app",
+    "Description": "cdkrd bug-hunt configuration template",
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-0787263f73f2dcb8b",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      {
+        "Value": "t3.micro",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      {
+        "Value": "SingleInstance",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType"
+      },
+      {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      {
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      }
+    ],
+    "TemplateName": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
+  },
+  "schema": {
+    "readOnly": ["TemplateName"],
+    "writeOnly": ["EnvironmentId"],
+    "createOnly": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "readOnlyPaths": ["TemplateName"],
+    "writeOnlyPaths": [
+      "EnvironmentId",
+      "SourceConfiguration.ApplicationName",
+      "SourceConfiguration.TemplateName"
+    ],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-0787263f73f2dcb8b",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Value": "t3.micro",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplate",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnv.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnv.json
@@ -1,0 +1,118 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbEnv",
+    "resourceType": "AWS::ElasticBeanstalk::Environment",
+    "physicalId": "cdkrd-hunt-eb-env",
+    "constructPath": "CdkRealDriftIntegEbRich/EbEnv",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-eb-app",
+      "Description": "cdkrd bug-hunt environment",
+      "EnvironmentName": "cdkrd-hunt-eb-env",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "SingleInstance"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "IamInstanceProfile",
+          "Value": "CdkRealDriftIntegEbRich-EbInstanceProfile-Z84zCb1AVfNF"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "InstanceType",
+          "Value": "t3.micro"
+        },
+        {
+          "Namespace": "aws:elasticbeanstalk:application:environment",
+          "OptionName": "GREETING",
+          "Value": "hello-from-cdkrd"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-hunt-eb-app",
+    "Description": "cdkrd bug-hunt environment",
+    "EnvironmentName": "cdkrd-hunt-eb-env",
+    "Tier": {
+      "Type": "Standard",
+      "Version": "1.0",
+      "Name": "WebServer"
+    },
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker",
+    "EndpointURL": "100.56.81.152",
+    "CNAMEPrefix": "cdkrd-hunt-eb-env",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["EndpointURL"],
+    "writeOnly": ["OptionSettings", "TemplateName"],
+    "createOnly": ["ApplicationName", "CNAMEPrefix", "EnvironmentName", "SolutionStackName"],
+    "readOnlyPaths": ["EndpointURL"],
+    "writeOnlyPaths": [
+      "OptionSettings",
+      "OptionSettings.*.Namespace",
+      "OptionSettings.*.OptionName",
+      "OptionSettings.*.ResourceName",
+      "OptionSettings.*.Value",
+      "TemplateName"
+    ],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "CNAMEPrefix",
+      "EnvironmentName",
+      "SolutionStackName",
+      "Tier.Name",
+      "Tier.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings",
+      "note": "write-only — cannot be read back",
+      "physicalId": "cdkrd-hunt-eb-env",
+      "constructPath": "CdkRealDriftIntegEbRich/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "cdkrd-hunt-eb-env",
+      "constructPath": "CdkRealDriftIntegEbRich/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "Tier",
+      "actual": {
+        "Type": "Standard",
+        "Version": "1.0",
+        "Name": "WebServer"
+      },
+      "physicalId": "cdkrd-hunt-eb-env",
+      "constructPath": "CdkRealDriftIntegEbRich/EbEnv"
+    }
+  ]
+}

--- a/tests/integration/elasticbeanstalk-rich/app.ts
+++ b/tests/integration/elasticbeanstalk-rich/app.ts
@@ -1,0 +1,92 @@
+// CDK app for the cdk-real-drift Elastic Beanstalk false-positive test. Elastic
+// Beanstalk is a classic managed-PaaS choice, and the `aws-elasticbeanstalk` L1
+// module emits three resource types cdkrd has never exercised as live reads:
+// Application, ConfigurationTemplate, and Environment. All three carry AWS-filled
+// option-setting surface (the ConfigurationTemplate/Environment OptionSettings AWS
+// materializes at create — see #493), plus create-only identifiers. A freshly
+// deployed + recorded stack with NO out-of-band change MUST report CLEAN, and a
+// check BEFORE record must fold every AWS-assigned default to atDefault (zero
+// [Potential Drift]).
+import { App, CfnOutput, Stack } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnConfigurationTemplate,
+  CfnEnvironment,
+} from "aws-cdk-lib/aws-elasticbeanstalk";
+import { CfnInstanceProfile, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+// Pinned solution stack (Docker on AL2023) — a SingleInstance env keeps the deploy
+// to one t3.micro with no load balancer, so it is cheap and quick to tear down.
+const SOLUTION_STACK = "64bit Amazon Linux 2023 v4.13.3 running Docker";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEbRich");
+
+const instanceRole = new Role(stack, "EbInstanceRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  managedPolicies: [
+    { managedPolicyArn: "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier" },
+  ],
+});
+const instanceProfile = new CfnInstanceProfile(stack, "EbInstanceProfile", {
+  roles: [instanceRole.roleName],
+});
+
+const application = new CfnApplication(stack, "EbApp", {
+  applicationName: "cdkrd-hunt-eb-app",
+  description: "cdkrd bug-hunt Elastic Beanstalk application",
+});
+
+const template = new CfnConfigurationTemplate(stack, "EbTemplate", {
+  applicationName: application.applicationName!,
+  solutionStackName: SOLUTION_STACK,
+  description: "cdkrd bug-hunt configuration template",
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "SingleInstance",
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "InstanceType",
+      value: "t3.micro",
+    },
+  ],
+});
+template.addDependency(application);
+
+const environment = new CfnEnvironment(stack, "EbEnv", {
+  applicationName: application.applicationName!,
+  environmentName: "cdkrd-hunt-eb-env",
+  solutionStackName: SOLUTION_STACK,
+  description: "cdkrd bug-hunt environment",
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "SingleInstance",
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "IamInstanceProfile",
+      value: instanceProfile.ref,
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "InstanceType",
+      value: "t3.micro",
+    },
+    {
+      namespace: "aws:elasticbeanstalk:application:environment",
+      optionName: "GREETING",
+      value: "hello-from-cdkrd",
+    },
+  ],
+});
+environment.addDependency(application);
+
+new CfnOutput(stack, "EnvironmentName", { value: environment.environmentName! });
+new CfnOutput(stack, "ApplicationName", { value: application.applicationName! });
+
+app.synth();

--- a/tests/integration/elasticbeanstalk-rich/cdk.json
+++ b/tests/integration/elasticbeanstalk-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elasticbeanstalk-rich/package.json
+++ b/tests/integration/elasticbeanstalk-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-elasticbeanstalk-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift elasticbeanstalk-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/elasticbeanstalk-rich/verify-detect.sh
+++ b/tests/integration/elasticbeanstalk-rich/verify-detect.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Missed-detection (FN) integration test (real AWS): with the elasticbeanstalk-rich
+# stack DEPLOYED and RECORDED (run by verify.sh first, or standalone), mutate the
+# declared mutable Application Description out of band -> `check --fail` MUST detect
+# (exit 1) -> `revert --yes` MUST restore the declared Description -> `check --fail`
+# MUST be CLEAN again. Run while the stack is still up; does NOT deploy or clean up.
+#
+# Note: Cloud Control's UpdateResource on an EB Application echoes a spurious
+# "Parameter ServiceRole is invalid" error even though the Description patch applies,
+# so the revert prints a FAILED line but converges (the post-revert re-read confirms
+# CLEAN). The assertion below is on the converged live value, not the revert message.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEbRich
+REGION="${AWS_REGION:-us-east-1}"
+APP=cdkrd-hunt-eb-app
+DECLARED_DESC="cdkrd bug-hunt Elastic Beanstalk application"
+CLI="node $ROOT/dist/cli.js"
+fail() { echo "INTEG FAIL ($STACK detect): $*"; exit 1; }
+
+echo "=== [$STACK] mutate Application Description out of band ==="
+aws elasticbeanstalk update-application --application-name "$APP" \
+  --description "DRIFTED-out-of-band" --region "$REGION" >/dev/null || fail "mutate description"
+
+echo "=== [$STACK] check MUST detect the declared Description drift (exit 1) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-detect.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift detection (exit 1), got $rc"
+grep -q "Description" "/tmp/cdkrd-$STACK-detect.out" || fail "drift output does not mention Description"
+
+echo "=== [$STACK] revert (converges despite the CC ServiceRole message) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || true
+
+echo "=== [$STACK] check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"
+
+LIVE_DESC=$(aws elasticbeanstalk describe-applications --application-names "$APP" \
+  --region "$REGION" --query 'Applications[0].Description' --output text)
+[ "$LIVE_DESC" = "$DECLARED_DESC" ] || fail "live description not restored (got $LIVE_DESC)"
+
+echo "INTEG PASS ($STACK detect)"

--- a/tests/integration/elasticbeanstalk-rich/verify.sh
+++ b/tests/integration/elasticbeanstalk-rich/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. Elastic Beanstalk: Application, ConfigurationTemplate (OptionSettings
+# AWS fills at create — #493), and a SingleInstance Environment. Any drift on a clean
+# recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEbRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] check BEFORE record (potential-drift must be empty) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-pre.out"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## Bug-hunt round: Elastic Beanstalk

Deployed a fresh `elasticbeanstalk-rich` fixture (Application + ConfigurationTemplate + a SingleInstance Environment) — a common, previously-uncovered managed-PaaS surface. A `check` **before** `record` on the clean deploy surfaced **55 potential drift**, of which **4** are unambiguous AWS-assigned first-run defaults the template never declares → they must fold to `atDefault` (core zero-potential-drift invariant).

### Fold gaps fixed

| Type | Path | Fold | Rationale |
| --- | --- | --- | --- |
| `AWS::ElasticBeanstalk::Application` | `ResourceLifecycleConfig` | `KNOWN_DEFAULTS` | The disabled default version-lifecycle policy. Equality-gated — enabling a rule out of band still surfaces. |
| `AWS::ElasticBeanstalk::Environment` | `Tier` | `KNOWN_DEFAULTS` | Default `WebServer/Standard/1.0`. A Worker tier still surfaces. |
| `AWS::ElasticBeanstalk::ConfigurationTemplate` | `PlatformArn` | `VALUE_INDEPENDENT` | AWS derives it from the declared `SolutionStackName`; region + moving platform version make it non-constant. |
| `AWS::ElasticBeanstalk::Environment` | `PlatformArn` | `VALUE_INDEPENDENT` | Same derivation. |

### Kept as-is (accepted precedent)

The remaining **51** are `ConfigurationTemplate` `OptionSettings` service-fill — AWS materializes the full resolved option set (~51 entries) from a 2-entry declared subset. These stay as **undeclared inventory** (recorded; a later change surfaces), consistent with the existing `RDS::OptionGroup` / `Firehose` `NAME_VALUE_SUBSET` and the `#493` `COMPOSITE_KEY_SUBSET` precedent. Equality-gating ~51 context-dependent options (env-type / platform-version / instance-derived: `ImageId`, `AppSource`, `InstanceTypes`, …) is infeasible and FP-prone, so folding them value-independent would lose meaningful detection. Flagged here for the maintainer as a possible future "fold subset-fill to atDefault class-wide" direction.

### Detection (FN half) — verified live

An out-of-band `update-application --description` change is **detected** (declared drift, exit 1), and `revert` restores it to CLEAN. Note: Cloud Control `UpdateResource` on an EB Application echoes a spurious `Parameter ServiceRole is invalid` line but the Description patch **does** apply — the post-revert re-read confirms CLEAN (a minor cosmetic revert-message quirk, not an FP/FN; noted for a future look).

### Assets left behind

- `tests/integration/elasticbeanstalk-rich/` fixture + `verify.sh` (clean-FP) + `verify-detect.sh` (FN cycle).
- 3 harvested golden-corpus cases (`corpus-replay` regression, offline).
- Unit tests for all 4 folds incl. fail-closed guards (enabled lifecycle rule / Worker tier never fold).

### Cleanup

Stack deleted via `delstack`; `bughunt-track.sh verify` → GONE + SWEEP CLEAN; gate cleared.

### Test plan

- [x] `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (48 files, 2842 tests) all pass.
- [x] Live: deploy → check-before-record (4 folds → atDefault) → record → check CLEAN → detect → revert → CLEAN.
