### PR TITLE
fix(revert): add Elastic Beanstalk SDK writers (avoid spurious CC ServiceRole error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@aws-sdk/client-ec2": "^3.1066.0",
     "@aws-sdk/client-ecs": "^3.1066.0",
     "@aws-sdk/client-efs": "^3.1070.0",
+    "@aws-sdk/client-elastic-beanstalk": "^3.1080.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.1068.0",
     "@aws-sdk/client-elasticache": "^3.1075.0",
     "@aws-sdk/client-eventbridge": "^3.1069.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       '@aws-sdk/client-efs':
         specifier: ^3.1070.0
         version: 3.1070.0
+      '@aws-sdk/client-elastic-beanstalk':
+        specifier: ^3.1080.0
+        version: 3.1080.0
       '@aws-sdk/client-elastic-load-balancing-v2':
         specifier: ^3.1068.0
         version: 3.1068.0
@@ -399,6 +402,10 @@ packages:
     resolution: {integrity: sha512-A/yKmE4v/JIAB2mTcJ0vLgA88NAAUg3/0zWP2HpOJ2b9GRjzpU1Sw0WOnfF14x9SYKlpIMMsaAyrJ1a6Rl6VBw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-elastic-beanstalk@3.1080.0':
+    resolution: {integrity: sha512-5KLoXppxJHmp9ap2IKGF6Ii10cI11AbM95H3sr9ndeT7tsH5sdFQSVtV2ukfsgrgWreUxoLhBrD/sEqyh4cMyw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-elastic-load-balancing-v2@3.1068.0':
     resolution: {integrity: sha512-itFsCad2P278FiIQDeIcGz8g7CITQUHjOwCtla/vW4/DLtDggg2noy/tzIffOspEgkKvA0Dh9Q9czij1v1fvtQ==}
     engines: {node: '>=20.0.0'}
@@ -531,6 +538,10 @@ packages:
     resolution: {integrity: sha512-WRWEgIq6vx+NU6ot3VrRu4Jovj9MIObitSi6of/GV5THDDPccBhivCRNkWJutMM+m3GvdeI3l/UbGNcoOobxOA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.28':
+    resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     resolution: {integrity: sha512-4L/REssieLON1hVsTzZucP1p2u5jmPNejyh/9BCGZXr93IalBbhRPCrtKIKwMTu9yRGr/bcKzhrQocByKLSzLQ==}
     engines: {node: '>=20.0.0'}
@@ -543,12 +554,20 @@ packages:
     resolution: {integrity: sha512-+KDA3uc/HZ1vIneGu5QMQb0gAXDYrm2vOE60+BJ7lS0YinMQ5i2oV4PR1A16XkF6K1IbSwjEHd1hQIIgMsK48w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.54':
+    resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.48':
     resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.55':
     resolution: {integrity: sha512-1gBfkWY3RWeBlCoB9lIJjXMx45/54wxcgfzv6BY9otTmMrZPcNPi1v+MwZxxaCUg441NV3jsr1efnFNCXiW70g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.56':
+    resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.53':
@@ -559,12 +578,20 @@ packages:
     resolution: {integrity: sha512-CV2md+PXvABwRjApWGhQ0wACy9WSFIhnUGrovLcjnjBCd/46TbuivLADtkF8IWNjtCQmQ+2IagSaxqBYqXBNAQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.61':
+    resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.52':
     resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.59':
     resolution: {integrity: sha512-JG4S9yyA1GFzJdJXqLKrUzZbyK+VDp2QIsJD7YOicJHAhqymfHpDJIok2dLnhOdVB0I37RjdC53uOwCMVS00gw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.60':
+    resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.55':
@@ -595,12 +622,20 @@ packages:
     resolution: {integrity: sha512-S6Slq3Tx7bvFk5yc34XNADyZYTX2HUXvaFAnowGRQnhjBO8J/mP62Fn7lxvJwjaDyYm/7gh9h6HEHaltRyMFXw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.63':
+    resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.46':
     resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.53':
     resolution: {integrity: sha512-EhfH+MQlqOMCkXIVa8MMObPzAQqwTTtxA7KhEJiyPeuNVA8PLOOUpgK7nBrgaDaGiIDLN/9LpGdaHuDjomeRTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.54':
+    resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.52':
@@ -611,12 +646,20 @@ packages:
     resolution: {integrity: sha512-h8793pOjcImx0SB+VcLONcaQQ57VAvKVuqyewQMRKqqH+CSXsG2dwOeLMUJPMxLdNvL7dXOM0ueTukyNUnu5mA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.60':
+    resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.59':
     resolution: {integrity: sha512-VoyO9+vl3XVmpZwn4obskrWIkrA/Jf3lSe1E3ZERlaN9u0D4YZ6+HywC3+L98QOXqZesEfedk67gRER8tK8+8w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.60':
+    resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.1066.0':
@@ -673,6 +716,10 @@ packages:
     resolution: {integrity: sha512-A8PIePF9NIIOJ/4Lg1rl9xm/+QaKkHGetq+Z9wb5B+3Da31YYXRo8n7IDMh5C+HQI5eyEmjrwkGWVdYtnLtbXQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.28':
+    resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
@@ -691,6 +738,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1079.0':
     resolution: {integrity: sha512-cbietrLlHPhhmbnMPTuDS4Zj/KNGhY+3vVhn6dwjO6Dqzrwothzg2srtcY34T9mlICsTXn34avDoWLHSntP54A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1080.0':
+    resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.12':
@@ -4071,6 +4122,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-elastic-beanstalk@3.1080.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/credential-provider-node': 3.972.63
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-elastic-load-balancing-v2@3.1068.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4485,6 +4547,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     dependencies:
       '@aws-sdk/nested-clients': 3.997.20
@@ -4509,6 +4582,14 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.48':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4522,6 +4603,16 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.55':
     dependencies:
       '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/fetch-http-handler': 5.6.2
@@ -4561,6 +4652,22 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/credential-provider-env': 3.972.54
+      '@aws-sdk/credential-provider-http': 3.972.56
+      '@aws-sdk/credential-provider-login': 3.972.60
+      '@aws-sdk/credential-provider-process': 3.972.54
+      '@aws-sdk/credential-provider-sso': 3.972.60
+      '@aws-sdk/credential-provider-web-identity': 3.972.60
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.52':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4574,6 +4681,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.27
       '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
@@ -4677,6 +4793,20 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.63':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.54
+      '@aws-sdk/credential-provider-http': 3.972.56
+      '@aws-sdk/credential-provider-ini': 3.972.61
+      '@aws-sdk/credential-provider-process': 3.972.54
+      '@aws-sdk/credential-provider-sso': 3.972.60
+      '@aws-sdk/credential-provider-web-identity': 3.972.60
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.46':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4688,6 +4818,14 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.53':
     dependencies:
       '@aws-sdk/core': 3.974.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
@@ -4713,6 +4851,16 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/token-providers': 3.1080.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4726,6 +4874,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.27
       '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
@@ -4854,6 +5011,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.28':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -4888,6 +5056,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.27
       '@aws-sdk/nested-clients': 3.997.27
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1080.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -51,6 +51,11 @@ import {
   PutMetricFilterCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import {
+  ElasticBeanstalkClient,
+  UpdateApplicationCommand,
+  UpdateEnvironmentCommand,
+} from '@aws-sdk/client-elastic-beanstalk';
+import {
   DocDBClient,
   ModifyDBClusterCommand,
   ModifyDBInstanceCommand,
@@ -1954,7 +1959,63 @@ const writeLexBotLocales: SdkWriter = async (ctx, ops) => {
   }
 };
 
+// AWS::ElasticBeanstalk::Application / ::Environment — Cloud Control CAN read these, but
+// its UpdateResource echoes a spurious "Parameter ServiceRole is invalid. Must be a valid
+// IAM Role ARN" GeneralServiceException (the CC handler injects a ServiceRole it cannot
+// resolve) even though the patch itself is applicable — the revert prints a FAILED line
+// but happens to converge. Route revert through EB's own UpdateApplication /
+// UpdateEnvironment (PARTIAL updates) so ONLY the drifted, mutable top-level props are sent
+// and no spurious ServiceRole validation is triggered. The declared model IS the revert
+// target; an op that REMOVES a prop clears it (EB treats an empty Description as cleared).
+//
+// The revertable declared surface is thin: ApplicationName / EnvironmentName are create-only
+// identities, the Environment's Tier is create-only, and its OptionSettings is write-only
+// (read gap) — so a DECLARED drift only ever lands on Description. ResourceLifecycleConfig
+// (Application) needs a separate UpdateApplicationResourceLifecycle call and is left to CC
+// (it folds atDefault when undeclared, so a declared drift on it is rare); a future writer
+// can extend the allowlist.
+const EB_APPLICATION_MODIFY_PARAMS = new Set(['Description']);
+const writeElasticBeanstalkApplication: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['ApplicationName']);
+  if (!name) throw new Error('cannot resolve Elastic Beanstalk ApplicationName for revert');
+  const input: { ApplicationName: string; Description?: string } = { ApplicationName: name };
+  let any = false;
+  for (const op of ops) {
+    const top = op.path.replace(/^\//, '').split('/')[0];
+    if (top && EB_APPLICATION_MODIFY_PARAMS.has(top)) {
+      // add -> declared value; remove -> clear (empty string, which EB reads as unset)
+      input[top as 'Description'] = op.op === 'remove' ? '' : (str(ctx.declared[top]) ?? '');
+      any = true;
+    }
+  }
+  if (!any) return;
+  await new ElasticBeanstalkClient({ region: ctx.region }).send(
+    new UpdateApplicationCommand(input)
+  );
+};
+
+const EB_ENVIRONMENT_MODIFY_PARAMS = new Set(['Description']);
+const writeElasticBeanstalkEnvironment: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['EnvironmentName']);
+  if (!name) throw new Error('cannot resolve Elastic Beanstalk EnvironmentName for revert');
+  const input: { EnvironmentName: string; Description?: string } = { EnvironmentName: name };
+  let any = false;
+  for (const op of ops) {
+    const top = op.path.replace(/^\//, '').split('/')[0];
+    if (top && EB_ENVIRONMENT_MODIFY_PARAMS.has(top)) {
+      input[top as 'Description'] = op.op === 'remove' ? '' : (str(ctx.declared[top]) ?? '');
+      any = true;
+    }
+  }
+  if (!any) return;
+  await new ElasticBeanstalkClient({ region: ctx.region }).send(
+    new UpdateEnvironmentCommand(input)
+  );
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
+  'AWS::ElasticBeanstalk::Application': writeElasticBeanstalkApplication,
+  'AWS::ElasticBeanstalk::Environment': writeElasticBeanstalkEnvironment,
   'AWS::CodeBuild::ReportGroup': writeCodeBuildReportGroup,
   'AWS::DAX::Cluster': writeDaxCluster,
   'AWS::DAX::ParameterGroup': writeDaxParameterGroup,

--- a/tests/integration/elasticbeanstalk-rich/verify-detect.sh
+++ b/tests/integration/elasticbeanstalk-rich/verify-detect.sh
@@ -5,10 +5,9 @@
 # (exit 1) -> `revert --yes` MUST restore the declared Description -> `check --fail`
 # MUST be CLEAN again. Run while the stack is still up; does NOT deploy or clean up.
 #
-# Note: Cloud Control's UpdateResource on an EB Application echoes a spurious
-# "Parameter ServiceRole is invalid" error even though the Description patch applies,
-# so the revert prints a FAILED line but converges (the post-revert re-read confirms
-# CLEAN). The assertion below is on the converged live value, not the revert message.
+# Revert goes through the EB SDK writer (UpdateApplication), NOT Cloud Control — CC's
+# UpdateResource echoes a spurious "Parameter ServiceRole is invalid" error, so the
+# writer avoids it and the revert reports a clean "reverted" (no FAILED line).
 set -uo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/../../.." && pwd)"
@@ -30,8 +29,8 @@ rc=${PIPESTATUS[0]}
 [ "$rc" -eq 1 ] || fail "expected drift detection (exit 1), got $rc"
 grep -q "Description" "/tmp/cdkrd-$STACK-detect.out" || fail "drift output does not mention Description"
 
-echo "=== [$STACK] revert (converges despite the CC ServiceRole message) ==="
-$CLI revert "$STACK" --region "$REGION" --yes || true
+echo "=== [$STACK] revert MUST restore the declared Description (EB SDK writer) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
 
 echo "=== [$STACK] check MUST be CLEAN after revert ==="
 $CLI check "$STACK" --region "$REGION" --fail || fail "expected CLEAN after revert"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -527,6 +527,20 @@ describe('buildRevertPlan', () => {
     }
   });
 
+  it('ElasticBeanstalk Application/Environment Description -> sdk item (CC UpdateResource FPs on ServiceRole)', () => {
+    // EB is CC-READABLE, but its CC UpdateResource echoes a spurious "ServiceRole is invalid"
+    // GeneralServiceException, so a declared Description drift must route to the EB SDK writer
+    // (UpdateApplication / UpdateEnvironment), not a Cloud Control patch.
+    for (const rt of ['AWS::ElasticBeanstalk::Application', 'AWS::ElasticBeanstalk::Environment']) {
+      const plan = buildRevertPlan(
+        [F({ tier: 'declared', resourceType: rt, path: 'Description', desired: 'a', actual: 'b' })],
+        undefined
+      );
+      expect(plan.notRevertable, rt).toHaveLength(0);
+      expect(plan.items[0], rt).toMatchObject({ kind: 'sdk', resourceType: rt });
+    }
+  });
+
   it('Cognito IdentityPool: CognitoEvents -> prop-scoped sdk item, a base prop -> cc item', () => {
     // The IdentityPool SDK override only ENRICHES the CC read with the writeOnly
     // CognitoEvents, so it is CC_REVERTABLE_DESPITE_READ_OVERRIDE: base-property reverts

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -63,6 +63,11 @@ import {
   ModifyDBInstanceCommand,
 } from '@aws-sdk/client-docdb';
 import {
+  ElasticBeanstalkClient,
+  UpdateApplicationCommand,
+  UpdateEnvironmentCommand,
+} from '@aws-sdk/client-elastic-beanstalk';
+import {
   GetClassifierCommand,
   GetConnectionCommand,
   GetJobCommand,
@@ -168,6 +173,7 @@ const sns = mockClient(SNSClient);
 const sqs = mockClient(SQSClient);
 const serviceDiscovery = mockClient(ServiceDiscoveryClient);
 const docdb = mockClient(DocDBClient);
+const eb = mockClient(ElasticBeanstalkClient);
 const cloudfront = mockClient(CloudFrontClient);
 const wafv2 = mockClient(WAFV2Client);
 const opensearch = mockClient(OpenSearchClient);
@@ -222,6 +228,7 @@ beforeEach(() => {
   sqs.reset();
   serviceDiscovery.reset();
   docdb.reset();
+  eb.reset();
   cloudfront.reset();
   wafv2.reset();
   opensearch.reset();
@@ -1463,6 +1470,72 @@ describe('DocDB DBInstance writer (CC read+write gap; mirror of the cluster writ
         windowOp('sun:05:00-sun:06:00'),
       ])
     ).rejects.toThrow(/instance identifier/);
+  });
+});
+
+describe('ElasticBeanstalk Application/Environment writers (CC UpdateResource ServiceRole FP)', () => {
+  const descOp = (value: unknown): PatchOp => ({
+    op: 'add',
+    path: '/Description',
+    value,
+    human: 'Description -> deployed-template value',
+  });
+
+  it('reverts an Application Description via UpdateApplication (declared value, only the drifted prop)', async () => {
+    eb.on(UpdateApplicationCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({
+        physicalId: 'my-app',
+        declared: { ApplicationName: 'my-app', Description: 'declared' },
+      }),
+      [descOp('declared')]
+    );
+    const calls = eb.commandCalls(UpdateApplicationCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({ ApplicationName: 'my-app', Description: 'declared' });
+  });
+
+  it('a remove op clears the Application Description (empty string)', async () => {
+    eb.on(UpdateApplicationCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Application'](
+      ctx({ physicalId: 'my-app', declared: { ApplicationName: 'my-app' } }),
+      [{ op: 'remove', path: '/Description', human: 'clear Description' }]
+    );
+    expect(eb.commandCalls(UpdateApplicationCommand)[0]!.args[0].input).toEqual({
+      ApplicationName: 'my-app',
+      Description: '',
+    });
+  });
+
+  it('reverts an Environment Description via UpdateEnvironment', async () => {
+    eb.on(UpdateEnvironmentCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Environment'](
+      ctx({
+        physicalId: 'my-env',
+        declared: { EnvironmentName: 'my-env', Description: 'declared' },
+      }),
+      [descOp('declared')]
+    );
+    const calls = eb.commandCalls(UpdateEnvironmentCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({ EnvironmentName: 'my-env', Description: 'declared' });
+  });
+
+  it('an off-allowlist prop (create-only Tier) sends NO update — never accidentally mutated', async () => {
+    eb.on(UpdateEnvironmentCommand).resolves({});
+    await SDK_WRITERS['AWS::ElasticBeanstalk::Environment'](
+      ctx({ physicalId: 'my-env', declared: { EnvironmentName: 'my-env' } }),
+      [{ op: 'add', path: '/Tier', value: { Name: 'Worker' }, human: 'x' }]
+    );
+    expect(eb.commandCalls(UpdateEnvironmentCommand)).toHaveLength(0);
+  });
+
+  it('throws when the Application name is unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::ElasticBeanstalk::Application'](ctx({ physicalId: '', declared: {} }), [
+        descOp('x'),
+      ])
+    ).rejects.toThrow(/ApplicationName/);
   });
 });
 


### PR DESCRIPTION
## EB revert: avoid the spurious Cloud Control ServiceRole error

Follow-up to #598. When reverting a declared drift on `AWS::ElasticBeanstalk::Application` / `::Environment`, Cloud Control `UpdateResource` echoes a spurious `Parameter ServiceRole is invalid. Must be a valid IAM Role ARN` `GeneralServiceException` — the CC handler injects a `ServiceRole` it can't resolve. The patch happens to converge, but `revert` prints a **FAILED** line, which reads as "revert didn't work" even though it did.

### Fix

Route EB revert through the service's own `UpdateApplication` / `UpdateEnvironment` (PARTIAL updates) via `SDK_WRITERS`, so only the drifted mutable prop is sent and no spurious ServiceRole validation fires. EB is CC-**readable** but CC-**unwritable** here — same shape as CloudFront's writer.

The revertable declared surface is thin: `ApplicationName`/`EnvironmentName` are create-only identities, the Environment's `Tier` is create-only, and its `OptionSettings` is write-only — so it reduces to `Description` today (a `remove` op clears it). The allowlist is easy to extend later.

### Verification

- Unit: EB writer tests (declared value / remove-clears / off-allowlist no-op / unresolvable-id throw) + revert-plan routing test (EB Description → `kind='sdk'`). `vp` typecheck / lint / pack / **2856 tests** pass.
- **Live** (real AWS): deploy → record → mutate `Description` out of band → `check` detects (exit 1) → `revert` prints a clean `reverted: EbApp` (no FAILED line) → `check` CLEAN, live description restored. Stack torn down via `delstack`; sweep clean.

### Notes

- Adds `@aws-sdk/client-elastic-beanstalk` (the `@smithy/types` 4.15.0 override holds).
- Updates `elasticbeanstalk-rich/verify-detect.sh` to assert a clean revert (drops the old `|| true` / ServiceRole-quirk note).
