### PR TITLE
docs(invariant): make the fold-strategy decision order explicit (equality-gate → derive → value-independent)

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -48,10 +48,22 @@ non-negotiable", which is enforced by a gate, not by trust.
      is a fold gap = a bug** (the FP the check-output note + issue link ask users to
      report). When a candidate default's status is uncertain, **RESOLVE it by
      verifying** what AWS assigns to a fresh minimal config — never leave it
-     surfaced as "conservative", that just ships the bug. Fold via equality-gated
-     `KNOWN_DEFAULTS` (folds the default, surfaces a change away — detection kept)
-     for mutable meaningful props; value-independent only for create-only /
-     AWS-assigned identifiers / cosmetic values.
+     surfaced as "conservative", that just ships the bug. A value the user never
+     changed showing on a first `check` is the bug, not an acceptable state:
+     **do NOT rationalize leaving it `undeclared` as "honest", and shrinking the
+     count from N to "a few" is not a fix — the target is zero.** Fold by escalating
+     through the CLAUDE.md **fold-strategy decision order**, stopping at the first
+     that applies: (1) equality-gated constant (`KNOWN_DEFAULTS` /
+     `KNOWN_DEFAULT_PATHS`) — folds the default, surfaces a change away (detection
+     kept); (2) **derived** default (`CONTEXT_DEFAULTS` = f(region), `ENGINE_DEFAULTS`
+     = f(engine), or a value computed from a sibling / declared prop — e.g. an EB
+     `MaxSize` default derivable from its `EnvironmentType`) when the default is a
+     deterministic function of the declared inputs rather than a constant (detection
+     still kept) — **before calling a default "context-dependent, can't fold", ask
+     "can I DERIVE it?"**; (3) value-independent ONLY as a last resort, for a default
+     AWS moves (platform AMI, versioned URL, GA version) or a per-resource
+     identifier / cosmetic value that cannot be pinned or derived (loses detection —
+     acceptable only because it is undeclared, so a user who cares declares it).
    - **False negative (FN) / missed detection** — `record`→`check`→CLEAN does NOT
      exercise detection. So ALSO mutate a **declared, MUTABLE** property out of band
      (the "someone changed it in the console" scenario — Lambda `MemorySize`/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,36 @@ is exactly the false positive the `check`-output note + issue link (#581) ask us
 to report. When a candidate default's status is uncertain, **RESOLVE the
 uncertainty by investigation / live verification** (deploy a fresh minimal config,
 observe what AWS assigns undeclared) — never leave a value surfaced as
-"conservative"; that just ships the bug. The fold must PRESERVE out-of-band
-detection: prefer equality-gated `KNOWN_DEFAULTS` (folds the default value,
-surfaces a change away from it) for mutable meaningful props; use
-`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (folds any value) only for create-only /
-AWS-assigned identifiers / cosmetic values where change-detection is not meaningful.
+"conservative"; that just ships the bug. A value the user never changed appearing on
+a first `check` IS the bug, not an acceptable state — **do NOT rationalize leaving it
+`undeclared` as "honest".** Shrinking a fixture's first-`check` noise from 51 lines to
+"a few" is not a fix; **the target is zero.**
+
+**Fold-strategy decision order** — the fold must PRESERVE out-of-band detection where
+the value is meaningful, so escalate through these in order and stop at the first that
+applies; reach for the next tier only because the prior one genuinely cannot express
+the default:
+
+1. **Equality-gated constant** (`KNOWN_DEFAULTS` top-level / `KNOWN_DEFAULT_PATHS`
+   nested) — folds the exact default value and still surfaces any change away from it.
+   The DEFAULT choice for any default that is a stable constant.
+2. **Derived default** (`CONTEXT_DEFAULTS` = f(region), `ENGINE_DEFAULTS` = f(engine),
+   or a value computed from a sibling / declared property — e.g. an EB Environment's
+   `MaxSize` default is derivable from its `EnvironmentType` option: SingleInstance→1,
+   LoadBalanced→4). When the default is not a single constant but a DETERMINISTIC
+   FUNCTION of the declared inputs, COMPUTE it and equality-gate against the computed
+   value — detection is still preserved. **Before labelling a default
+   "context-dependent, can't fold", ask "can I DERIVE it from the declared inputs?" —
+   usually you can.** Do not skip to tier 3 just because a constant does not fit.
+3. **Value-independent** (`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` & nested kin) —
+   LAST resort, and it LOSES change-detection (folds any value). Use ONLY when the
+   default genuinely cannot be pinned OR derived: AWS moves it over time (a platform
+   AMI id, a versioned asset URL, a GA engine version), or it is a per-resource
+   AWS-assigned identifier / cosmetic value. Acceptable only because the value is
+   UNDECLARED — the user delegated it to AWS, so whatever AWS assigns is not user
+   intent; a user who cares about it DECLARES it, which is then detected in the
+   declared dimension. Never value-independent a value the user can meaningfully set
+   and would want to catch drifting when a constant or a derivation could fold it.
 
 ## The 4-Verb Model
 


### PR DESCRIPTION
Lands the conceptual guidance sharpened during the EB bug-hunt (#598/#600) into the committed rules, so future fold/feature work follows it by default.

## What changed

**CLAUDE.md — Core invariant** and **hunt-bugs skill — FP guidance**:

- Makes explicit that a value the user never changed appearing on a first `check` **is the bug**, not an acceptable state — do NOT rationalize leaving it `undeclared` as "honest", and shrinking first-check noise from N lines to "a few" is **not a fix; the target is zero**.
- Adds the **fold-strategy decision order** (stop at the first tier that applies):
  1. **Equality-gated constant** (`KNOWN_DEFAULTS` / `KNOWN_DEFAULT_PATHS`) — folds the default, still surfaces a change away (detection kept).
  2. **Derived default** (`CONTEXT_DEFAULTS` = f(region), `ENGINE_DEFAULTS` = f(engine), or a value computed from a sibling/declared prop — e.g. an EB `MaxSize` default derivable from its `EnvironmentType`: SingleInstance→1, LoadBalanced→4). When the default is a deterministic function of the declared inputs rather than a constant, compute + equality-gate it (detection kept). **Before calling a default "context-dependent, can't fold", ask "can I DERIVE it?"** — the tier that was missing before.
  3. **Value-independent** — last resort only, for a default AWS moves (platform AMI, versioned URL, GA version) or a per-resource identifier/cosmetic that cannot be pinned or derived. Loses change-detection; acceptable only because the value is undeclared (a user who cares declares it → detected in the declared dimension).

Docs/tooling-only (no `src/**`) → `check` + `docs` cover it; verify-pr-gate exempt.