### PR TITLE
fix(revert): set-default AppRunner HealthCheck/Network on revert (avoid silent no-op)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -94,6 +94,15 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // value persists), so write the default policy (TransferSecurityPolicy-2018-11) back
   // explicitly. The value comes from KNOWN_DEFAULTS.
   'AWS::Transfer::Server\0SecurityPolicyName',
+  // App Runner UpdateService IGNORES an omitted top-level config object (live-observed:
+  // a `remove` revert of an out-of-band HealthCheckConfiguration reports SUCCESS yet the
+  // live value persists — mutated Interval 5->10 survived the revert). Write the whole
+  // KNOWN_DEFAULTS default object back explicitly so revert converges. NetworkConfiguration
+  // is the same provider behavior (top-level object AWS materializes; UpdateService keeps
+  // the existing value on omit) and writing its default public-IPV4 config back is safe /
+  // idempotent whether or not the omit no-ops.
+  'AWS::AppRunner::Service\0HealthCheckConfiguration',
+  'AWS::AppRunner::Service\0NetworkConfiguration',
 ]);
 
 /**

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -326,6 +326,40 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('App Runner HealthCheckConfiguration (SET-DEFAULT) -> add op writing the whole default object, not a no-op remove', () => {
+    // AWS::AppRunner::Service HealthCheckConfiguration is in REVERT_SET_DEFAULT_PATHS:
+    // UpdateService leaves the config UNCHANGED when it is OMITTED, so a bare `remove` of an
+    // out-of-band health check is a silent no-op (Cloud Control reports SUCCESS yet the live
+    // Interval:10 persists; proven live). Revert must write the whole default object back —
+    // the first OBJECT-valued SET-DEFAULT entry.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::AppRunner::Service',
+      path: 'HealthCheckConfiguration',
+      actual: {
+        Protocol: 'TCP',
+        Path: '/',
+        Interval: 10,
+        Timeout: 2,
+        HealthyThreshold: 1,
+        UnhealthyThreshold: 5,
+      },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/HealthCheckConfiguration',
+      value: {
+        Protocol: 'TCP',
+        Path: '/',
+        Interval: 5,
+        Timeout: 2,
+        HealthyThreshold: 1,
+        UnhealthyThreshold: 5,
+      },
+    });
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.


### PR DESCRIPTION
Follow-up to #597 (the `/hunt-bugs` revert-live-test lesson from #599 applied to App Runner).

**Bug (live-proven):** App Runner `UpdateService` ignores an omitted top-level config object, so a `remove` revert of an out-of-band `HealthCheckConfiguration` (or `NetworkConfiguration`) is a **silent no-op** — Cloud Control reports SUCCESS yet the live value persists. Reproduced live: mutated `HealthCheckConfiguration.Interval` 5→10 out of band → `check` detected it → `revert` reported "CLEAN after revert" but the live Interval **stayed 10**.

**Fix:** add both to `REVERT_SET_DEFAULT_PATHS` so revert writes the whole `KNOWN_DEFAULTS` default object back explicitly. **Live-verified:** after the fix the revert plan says "→ AWS default" and the live Interval returns to **5**. First object-valued SET-DEFAULT entry (the plan.ts write path already handles object values).

Unit test added; all 2857 unit tests pass. AppRunner stack deployed + torn down, orphans swept SWEEP CLEAN.
