### PR TITLE
fix(noise): fold Elastic Beanstalk ConfigurationTemplate OptionSettings to atDefault (zero first-run drift)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -57,6 +57,7 @@ import {
   CONTEXT_DEFAULTS,
   DEFAULT_MANAGED_NAME_PATHS,
   DESCEND_UNDECLARED_OBJECT_PATHS,
+  ebOptionSettingTier,
   ENGINE_DEFAULTS,
   GENERATED_LOGICALID_PREFIX_PATHS,
   GENERATED_NESTED_PATHS,
@@ -401,12 +402,26 @@ interface CompositeSubsetSpec {
   re: RegExp;
   keyFields: string[];
   ignoreFields: ReadonlySet<string>;
+  // Optional per-entry tier for the live-only (service-filled) extras. Given the entry and the
+  // full live array, return 'atDefault' when the entry is at its AWS first-run default (folds,
+  // invariant) or 'undeclared' otherwise (surfaces — a change away from the default). Absent →
+  // every live-only entry is 'undeclared' (recorded inventory; a later change still surfaces).
+  entryTier?: (entry: Record<string, unknown>, liveArray: unknown) => 'atDefault' | 'undeclared';
 }
 const COMPOSITE_KEY_SUBSET_PATHS: Record<string, CompositeSubsetSpec> = {
   'AWS::ElasticBeanstalk::ConfigurationTemplate': {
     re: /(^|\.)OptionSettings$/,
     keyFields: ['Namespace', 'OptionName'],
     ignoreFields: new Set(['ResourceName']),
+    // AWS materializes the FULL option set from the declared subset; fold each service-filled
+    // extra to its first-run default (equality-gate / derive-from-EnvironmentType / value-
+    // independent — see ebOptionSettingTier), so a clean template shows zero potential drift.
+    entryTier: (entry, liveArray) => {
+      const arr = Array.isArray(liveArray) ? (liveArray as Record<string, unknown>[]) : [];
+      const envEntry = arr.find((e) => e && e.OptionName === 'EnvironmentType');
+      const envType = typeof envEntry?.Value === 'string' ? envEntry.Value : 'LoadBalanced';
+      return ebOptionSettingTier(entry.Namespace, entry.OptionName, entry.Value, envType);
+    },
   },
 };
 
@@ -1516,7 +1531,7 @@ export function classifyResource(
             const r = lo as Record<string, unknown>;
             const key = ckSubsetSpec.keyFields.map((f) => String(r[f])).join('|');
             findings.push({
-              tier: 'undeclared',
+              tier: ckSubsetSpec.entryTier?.(r, d.awsValue) ?? 'undeclared',
               logicalId,
               resourceType,
               path: `${d.path}[${key}]`,

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1855,6 +1855,132 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::OpenSearchService::Domain': new Set(['EncryptionAtRestOptions.KmsKeyId']),
 };
 
+// Elastic Beanstalk ConfigurationTemplate `OptionSettings` first-run default fold. A template
+// declares a handful of option settings; AWS materializes the FULL resolved set (~50 for a
+// SingleInstance env, ~80 for LoadBalanced) keyed by `Namespace|OptionName`. Every extra the
+// template never declared is an AWS default and must fold to atDefault (the zero-potential-
+// drift invariant), while a change AWAY from the default must still surface. The composite-key
+// subset surfacing (classify.ts) consults `ebOptionSettingTier` per live-only entry.
+//
+// Three tiers per the CLAUDE.md fold-strategy order:
+//  - EB_OPTION_DEFAULTS — equality-gated constants: fold when the live value equals the pinned
+//    default; a change away surfaces (detection kept). The default choice.
+//  - EB_OPTION_DERIVED — the default is a deterministic function of the sibling `EnvironmentType`
+//    option (SingleInstance vs LoadBalanced), so compute it and equality-gate the computed value
+//    (detection kept). MaxSize (1 vs 4) and the spot on-demand-above-base % (0 vs 70) observed live.
+//  - EB_OPTION_VALUE_INDEPENDENT — last resort: AWS-assigned values that MOVE (the platform AMI id,
+//    the versioned sample-app / hooks S3 URLs, the health ConfigDocument blob, the derived instance
+//    type family) or a per-resource `{Ref}` (the ELB security group). Folds any value → loses
+//    change-detection; acceptable only because it is undeclared (declare the option to detect it).
+// Values pinned from a live SingleInstance + LoadBalanced ConfigurationTemplate pair (2026-07-07).
+export const EB_OPTION_DEFAULTS: Record<string, string> = {
+  'aws:autoscaling:asg|Availability Zones': 'Any',
+  'aws:autoscaling:asg|Cooldown': '360',
+  'aws:autoscaling:asg|EnableCapacityRebalancing': 'false',
+  'aws:autoscaling:asg|MinSize': '1',
+  'aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup': 'false',
+  'aws:autoscaling:launchconfiguration|DisableIMDSv1': 'true',
+  'aws:autoscaling:launchconfiguration|MonitoringInterval': '5 minute',
+  'aws:autoscaling:launchconfiguration|SSHSourceRestriction': 'tcp,22,22,0.0.0.0/0',
+  'aws:autoscaling:trigger|BreachDuration': '5',
+  'aws:autoscaling:trigger|EvaluationPeriods': '1',
+  'aws:autoscaling:trigger|LowerBreachScaleIncrement': '-1',
+  'aws:autoscaling:trigger|LowerThreshold': '2000000',
+  'aws:autoscaling:trigger|MeasureName': 'NetworkOut',
+  'aws:autoscaling:trigger|Period': '5',
+  'aws:autoscaling:trigger|Statistic': 'Average',
+  'aws:autoscaling:trigger|Unit': 'Bytes',
+  'aws:autoscaling:trigger|UpperBreachScaleIncrement': '1',
+  'aws:autoscaling:trigger|UpperThreshold': '6000000',
+  'aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled': 'false',
+  'aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType': 'Time',
+  'aws:autoscaling:updatepolicy:rollingupdate|Timeout': 'PT30M',
+  'aws:cloudformation:template:parameter|InstancePort': '80',
+  'aws:ec2:instances|EnableSpot': 'false',
+  'aws:ec2:instances|SpotAllocationStrategy': 'capacity-optimized',
+  'aws:ec2:instances|SpotFleetOnDemandBase': '0',
+  'aws:ec2:vpc|ELBScheme': 'public',
+  'aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate': 'false',
+  'aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled': 'false',
+  'aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays': '7',
+  'aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate': 'false',
+  'aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays': '7',
+  'aws:elasticbeanstalk:cloudwatch:logs|StreamLogs': 'false',
+  'aws:elasticbeanstalk:command|BatchSize': '100',
+  'aws:elasticbeanstalk:command|BatchSizeType': 'Percentage',
+  'aws:elasticbeanstalk:command|DeploymentPolicy': 'AllAtOnce',
+  'aws:elasticbeanstalk:command|IgnoreHealthCheck': 'false',
+  'aws:elasticbeanstalk:command|Timeout': '600',
+  'aws:elasticbeanstalk:control|DefaultSSHPort': '22',
+  'aws:elasticbeanstalk:control|LaunchTimeout': '0',
+  'aws:elasticbeanstalk:control|LaunchType': 'Migration',
+  'aws:elasticbeanstalk:control|RollbackLaunchOnFailure': 'false',
+  'aws:elasticbeanstalk:environment:proxy|ProxyServer': 'nginx',
+  'aws:elasticbeanstalk:environment|LoadBalancerType': 'classic',
+  'aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled': 'false',
+  'aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold': 'Ok',
+  'aws:elasticbeanstalk:healthreporting:system|SystemType': 'enhanced',
+  'aws:elasticbeanstalk:hostmanager|LogPublicationControl': 'false',
+  'aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled': 'false',
+  'aws:elasticbeanstalk:managedactions|ManagedActionsEnabled': 'false',
+  'aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances': 'true',
+  'aws:elasticbeanstalk:sns:topics|Notification Protocol': 'email',
+  'aws:elasticbeanstalk:xray|XRayEnabled': 'false',
+  'aws:elb:healthcheck|HealthyThreshold': '3',
+  'aws:elb:healthcheck|Interval': '10',
+  'aws:elb:healthcheck|Target': 'TCP:80',
+  'aws:elb:healthcheck|Timeout': '5',
+  'aws:elb:healthcheck|UnhealthyThreshold': '5',
+  'aws:elb:listener:80|InstancePort': '80',
+  'aws:elb:listener:80|InstanceProtocol': 'HTTP',
+  'aws:elb:listener:80|ListenerEnabled': 'true',
+  'aws:elb:listener:80|ListenerProtocol': 'HTTP',
+  'aws:elb:loadbalancer|CrossZone': 'false',
+  'aws:elb:loadbalancer|LoadBalancerHTTPPort': '80',
+  'aws:elb:loadbalancer|LoadBalancerHTTPSPort': 'OFF',
+  'aws:elb:loadbalancer|LoadBalancerPortProtocol': 'HTTP',
+  'aws:elb:loadbalancer|LoadBalancerSSLPortProtocol': 'HTTPS',
+  'aws:elb:policies|ConnectionDrainingEnabled': 'false',
+  'aws:elb:policies|ConnectionDrainingTimeout': '20',
+  'aws:elb:policies|ConnectionSettingIdleTimeout': '60',
+  'aws:rds:dbinstance|HasCoupledDatabase': 'false',
+};
+export const EB_OPTION_DERIVED: Record<string, Record<string, string>> = {
+  'aws:autoscaling:asg|MaxSize': { SingleInstance: '1', LoadBalanced: '4' },
+  'aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage': {
+    SingleInstance: '0',
+    LoadBalanced: '70',
+  },
+};
+export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
+  'aws:autoscaling:launchconfiguration|ImageId',
+  'aws:autoscaling:launchconfiguration|InstanceType',
+  'aws:cloudformation:template:parameter|AppSource',
+  'aws:cloudformation:template:parameter|HooksPkgUrl',
+  'aws:cloudformation:template:parameter|InstanceTypeFamily',
+  'aws:ec2:instances|InstanceTypes',
+  'aws:ec2:instances|SupportedArchitectures',
+  'aws:elasticbeanstalk:healthreporting:system|ConfigDocument',
+  'aws:elb:loadbalancer|SecurityGroups',
+]);
+// Classify one live-only EB OptionSettings entry: 'atDefault' when it is at its AWS first-run
+// default (value-independent, derived-from-EnvironmentType, or equality-gated constant), else
+// 'undeclared' so a change away from the default still surfaces. `envType` is the sibling
+// `EnvironmentType` option's value (defaults to LoadBalanced, AWS's default when unset).
+export function ebOptionSettingTier(
+  namespace: unknown,
+  optionName: unknown,
+  value: unknown,
+  envType: string
+): 'atDefault' | 'undeclared' {
+  const key = `${String(namespace)}|${String(optionName)}`;
+  if (EB_OPTION_VALUE_INDEPENDENT.has(key)) return 'atDefault';
+  const derived = EB_OPTION_DERIVED[key];
+  if (derived) return derived[envType] === value ? 'atDefault' : 'undeclared';
+  if (key in EB_OPTION_DEFAULTS && EB_OPTION_DEFAULTS[key] === value) return 'atDefault';
+  return 'undeclared';
+}
+
 // Undeclared TOP-LEVEL keys whose AWS-chosen default is NON-DETERMINISTIC — the value
 // varies by account / CDK feature-flag / creation date, so a single KNOWN_DEFAULTS value
 // cannot fold every valid form (folding one leaves the other as false undeclared drift).

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vite-plus/test';
 import { classifyResource, matchesKnownDefault, normalizeLiveModel } from '../src/diff/classify.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
-import { KNOWN_DEFAULT_PATHS, KNOWN_DEFAULTS } from '../src/normalize/noise.js';
+import {
+  ebOptionSettingTier,
+  KNOWN_DEFAULT_PATHS,
+  KNOWN_DEFAULTS,
+} from '../src/normalize/noise.js';
 import { buildRevertPlan } from '../src/revert/plan.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
 
@@ -2420,31 +2424,32 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       },
     ];
 
-    it('a reordered + default-filled OptionSettings (with live-only ResourceName) is NOT declared drift; live-only settings surface as undeclared', () => {
+    it('a reordered + default-filled OptionSettings is NOT declared drift; each service-filled extra folds to its first-run default (atDefault) or surfaces if off-default', () => {
       const findings = classifyResource(
         res(T, declared),
         liveModel(liveDefaultFilled),
         emptySchema
       );
       expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
+      // `Availability Zones` = "Any" is at its AWS default → folds to atDefault (invariant),
+      // as does the top-level PlatformArn echo. `Cooldown` = "30" (default 360) and
+      // `HealthyThreshold` = "tcp" (default 3) are OFF their defaults → still surface as
+      // undeclared, so an out-of-band change to a service-filled option is not hidden.
+      expect(
+        findings
+          .filter((f) => f.tier === 'atDefault')
+          .map((f) => f.path)
+          .sort()
+      ).toEqual(['OptionSettings[aws:autoscaling:asg|Availability Zones]', 'PlatformArn']);
       const undeclared = findings.filter((f) => f.tier === 'undeclared');
-      // the three service-filled extras surface (composite-key path). NOT a declared drift.
       expect(undeclared.map((f) => f.path).sort()).toEqual([
-        'OptionSettings[aws:autoscaling:asg|Availability Zones]',
         'OptionSettings[aws:autoscaling:asg|Cooldown]',
         'OptionSettings[aws:elb:healthcheck|HealthyThreshold]',
       ]);
-      // the OptionSettings extras are nested inventory
+      // the OptionSettings extras (folded or surfaced) are nested inventory
       expect(
-        undeclared
-          .filter((f) => f.path.startsWith('OptionSettings'))
-          .every((f) => f.nested === true)
+        findings.filter((f) => f.path.startsWith('OptionSettings')).every((f) => f.nested === true)
       ).toBe(true);
-      // the top-level PlatformArn echo (AWS-derived from the declared SolutionStackName)
-      // folds value-independent to atDefault, not surfaced as first-run drift (2026-07-07).
-      expect(findings.filter((f) => f.tier === 'atDefault').map((f) => f.path)).toEqual([
-        'PlatformArn',
-      ]);
     });
 
     it('a genuine change to a DECLARED setting value still surfaces as declared drift (fail-closed)', () => {
@@ -2470,6 +2475,67 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
         emptySchema
       ).filter((f) => f.tier === 'declared');
       expect(declaredF).toHaveLength(1);
+    });
+
+    // OptionSettings fold tiers surfaced through classify (equality-gate + value-independent +
+    // unknown). envType comes from the sibling EnvironmentType option (declared LoadBalanced).
+    const opt = (namespace: string, optionName: string, value: string) => ({
+      Namespace: namespace,
+      OptionName: optionName,
+      Value: value,
+    });
+    const tiersOf = (extra: object) =>
+      tiers(
+        classifyResource(res(T, declared), liveModel([...liveDefaultFilled, extra]), emptySchema)
+      );
+
+    it('an equality-gated constant folds at its default and surfaces when changed away', () => {
+      const at = tiersOf(opt('aws:elasticbeanstalk:cloudwatch:logs', 'RetentionInDays', '7'));
+      expect(at.atDefault).toContain(
+        'OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]'
+      );
+      const off = tiersOf(opt('aws:elasticbeanstalk:cloudwatch:logs', 'RetentionInDays', '30'));
+      expect(off.undeclared).toContain(
+        'OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]'
+      );
+    });
+
+    it('a value-independent option (the platform ImageId AMI) folds regardless of value', () => {
+      const at = tiersOf(opt('aws:autoscaling:launchconfiguration', 'ImageId', 'ami-0deadbeef'));
+      expect(at.atDefault).toContain('OptionSettings[aws:autoscaling:launchconfiguration|ImageId]');
+    });
+
+    it('an UNKNOWN option (not in any table) still surfaces as undeclared (fail-open to visibility)', () => {
+      const t = tiersOf(opt('aws:elasticbeanstalk:customns', 'SomeNovelOption', 'x'));
+      expect(t.undeclared).toContain(
+        'OptionSettings[aws:elasticbeanstalk:customns|SomeNovelOption]'
+      );
+    });
+  });
+
+  describe('ebOptionSettingTier (EB OptionSettings first-run default classifier)', () => {
+    it('equality-gated constant: at default → atDefault, changed away → undeclared', () => {
+      const k = ['aws:elasticbeanstalk:cloudwatch:logs', 'RetentionInDays'] as const;
+      expect(ebOptionSettingTier(k[0], k[1], '7', 'LoadBalanced')).toBe('atDefault');
+      expect(ebOptionSettingTier(k[0], k[1], '30', 'LoadBalanced')).toBe('undeclared');
+    });
+
+    it('derived-from-EnvironmentType: MaxSize default is 1 (SingleInstance) / 4 (LoadBalanced)', () => {
+      const k = ['aws:autoscaling:asg', 'MaxSize'] as const;
+      expect(ebOptionSettingTier(k[0], k[1], '1', 'SingleInstance')).toBe('atDefault');
+      expect(ebOptionSettingTier(k[0], k[1], '4', 'SingleInstance')).toBe('undeclared'); // 4 is the LB default, not SingleInstance's
+      expect(ebOptionSettingTier(k[0], k[1], '4', 'LoadBalanced')).toBe('atDefault');
+      expect(ebOptionSettingTier(k[0], k[1], '8', 'LoadBalanced')).toBe('undeclared');
+    });
+
+    it('value-independent: the platform AMI id folds at any value', () => {
+      const k = ['aws:autoscaling:launchconfiguration', 'ImageId'] as const;
+      expect(ebOptionSettingTier(k[0], k[1], 'ami-000', 'LoadBalanced')).toBe('atDefault');
+      expect(ebOptionSettingTier(k[0], k[1], 'ami-fff', 'LoadBalanced')).toBe('atDefault');
+    });
+
+    it('an unknown option is undeclared (surfaces)', () => {
+      expect(ebOptionSettingTier('aws:x', 'Novel', 'v', 'LoadBalanced')).toBe('undeclared');
     });
   });
 

--- a/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplateBalanced.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplateBalanced.json
@@ -1,0 +1,1694 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbTemplateBalanced",
+    "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+    "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+    "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-ebct-app",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "LoadBalanced"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-hunt-ebct-app",
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-0787263f73f2dcb8b",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      {
+        "Value": "LoadBalanced",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType"
+      },
+      {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      {
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      }
+    ],
+    "TemplateName": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
+  },
+  "schema": {
+    "readOnly": ["TemplateName"],
+    "writeOnly": ["EnvironmentId"],
+    "createOnly": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "readOnlyPaths": ["TemplateName"],
+    "writeOnlyPaths": [
+      "EnvironmentId",
+      "SourceConfiguration.ApplicationName",
+      "SourceConfiguration.TemplateName"
+    ],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-0787263f73f2dcb8b",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|BreachDuration]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|EvaluationPeriods]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|MeasureName]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Period]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Statistic]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Unit]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|LoadBalancerType]",
+      "actual": {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|HealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Interval]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Target]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|UnhealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstancePort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstanceProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|CrossZone]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPSPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerSSLPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionSettingIdleTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateBalanced",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateBalanced-ZmAduHCUdAAd",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateBalanced"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplateSingle.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplateSingle.json
@@ -1,23 +1,17 @@
 {
   "corpusVersion": 1,
   "resource": {
-    "logicalId": "EbTemplate",
+    "logicalId": "EbTemplateSingle",
     "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
-    "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-    "constructPath": "CdkRealDriftIntegEbRich/EbTemplate",
+    "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+    "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle",
     "declared": {
-      "ApplicationName": "cdkrd-hunt-eb-app",
-      "Description": "cdkrd bug-hunt configuration template",
+      "ApplicationName": "cdkrd-hunt-ebct-app",
       "OptionSettings": [
         {
           "Namespace": "aws:elasticbeanstalk:environment",
           "OptionName": "EnvironmentType",
           "Value": "SingleInstance"
-        },
-        {
-          "Namespace": "aws:autoscaling:launchconfiguration",
-          "OptionName": "InstanceType",
-          "Value": "t3.micro"
         }
       ],
       "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
@@ -25,8 +19,7 @@
   },
   "liveRaw": {
     "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
-    "ApplicationName": "cdkrd-hunt-eb-app",
-    "Description": "cdkrd bug-hunt configuration template",
+    "ApplicationName": "cdkrd-hunt-ebct-app",
     "OptionSettings": [
       {
         "ResourceName": "AWSEBAutoScalingGroup",
@@ -134,7 +127,7 @@
         "OptionName": "EnableSpot"
       },
       {
-        "Value": "t3.micro",
+        "Value": "t3.micro, t3.small",
         "Namespace": "aws:ec2:instances",
         "OptionName": "InstanceTypes"
       },
@@ -304,7 +297,7 @@
         "OptionName": "HasCoupledDatabase"
       }
     ],
-    "TemplateName": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
+    "TemplateName": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
     "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
   },
   "schema": {
@@ -345,7 +338,7 @@
   "expected": [
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
       "actual": {
@@ -355,12 +348,12 @@
         "OptionName": "Availability Zones"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
       "actual": {
@@ -370,12 +363,12 @@
         "OptionName": "Cooldown"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
       "actual": {
@@ -385,12 +378,12 @@
         "OptionName": "EnableCapacityRebalancing"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
       "actual": {
@@ -400,12 +393,12 @@
         "OptionName": "MaxSize"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
       "actual": {
@@ -415,12 +408,12 @@
         "OptionName": "MinSize"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
       "actual": {
@@ -429,12 +422,12 @@
         "OptionName": "DisableDefaultEC2SecurityGroup"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
       "actual": {
@@ -443,12 +436,12 @@
         "OptionName": "DisableIMDSv1"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
       "actual": {
@@ -458,12 +451,26 @@
         "OptionName": "ImageId"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
       "actual": {
@@ -473,12 +480,12 @@
         "OptionName": "MonitoringInterval"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
       "actual": {
@@ -487,12 +494,12 @@
         "OptionName": "SSHSourceRestriction"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
       "actual": {
@@ -502,12 +509,12 @@
         "OptionName": "RollingUpdateEnabled"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
       "actual": {
@@ -517,12 +524,12 @@
         "OptionName": "RollingUpdateType"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
       "actual": {
@@ -532,12 +539,12 @@
         "OptionName": "Timeout"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
       "actual": {
@@ -546,12 +553,12 @@
         "OptionName": "AppSource"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
       "actual": {
@@ -560,12 +567,12 @@
         "OptionName": "HooksPkgUrl"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
       "actual": {
@@ -574,12 +581,12 @@
         "OptionName": "InstancePort"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
       "actual": {
@@ -588,12 +595,12 @@
         "OptionName": "InstanceTypeFamily"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
       "actual": {
@@ -602,26 +609,26 @@
         "OptionName": "EnableSpot"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
       "actual": {
-        "Value": "t3.micro",
+        "Value": "t3.micro, t3.small",
         "Namespace": "aws:ec2:instances",
         "OptionName": "InstanceTypes"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
       "actual": {
@@ -630,12 +637,12 @@
         "OptionName": "SpotAllocationStrategy"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
       "actual": {
@@ -644,12 +651,12 @@
         "OptionName": "SpotFleetOnDemandAboveBasePercentage"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
       "actual": {
@@ -658,12 +665,12 @@
         "OptionName": "SpotFleetOnDemandBase"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
       "actual": {
@@ -672,12 +679,12 @@
         "OptionName": "SupportedArchitectures"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
       "actual": {
@@ -686,12 +693,12 @@
         "OptionName": "ELBScheme"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
       "actual": {
@@ -700,12 +707,12 @@
         "OptionName": "DeleteOnTerminate"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
       "actual": {
@@ -714,12 +721,12 @@
         "OptionName": "RetentionInDays"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
       "actual": {
@@ -728,12 +735,12 @@
         "OptionName": "StreamLogs"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
       "actual": {
@@ -742,12 +749,12 @@
         "OptionName": "DeleteOnTerminate"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
       "actual": {
@@ -756,12 +763,12 @@
         "OptionName": "HealthStreamingEnabled"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
       "actual": {
@@ -770,12 +777,12 @@
         "OptionName": "RetentionInDays"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
       "actual": {
@@ -784,12 +791,12 @@
         "OptionName": "BatchSize"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
       "actual": {
@@ -798,12 +805,12 @@
         "OptionName": "BatchSizeType"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
       "actual": {
@@ -812,12 +819,12 @@
         "OptionName": "DeploymentPolicy"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
       "actual": {
@@ -826,12 +833,12 @@
         "OptionName": "IgnoreHealthCheck"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
       "actual": {
@@ -840,12 +847,12 @@
         "OptionName": "Timeout"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
       "actual": {
@@ -854,12 +861,12 @@
         "OptionName": "DefaultSSHPort"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
       "actual": {
@@ -868,12 +875,12 @@
         "OptionName": "LaunchTimeout"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
       "actual": {
@@ -882,12 +889,12 @@
         "OptionName": "LaunchType"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
       "actual": {
@@ -896,12 +903,12 @@
         "OptionName": "RollbackLaunchOnFailure"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
       "actual": {
@@ -910,12 +917,12 @@
         "OptionName": "ProxyServer"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
       "actual": {
@@ -924,12 +931,12 @@
         "OptionName": "ConfigDocument"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
       "actual": {
@@ -938,12 +945,12 @@
         "OptionName": "EnhancedHealthAuthEnabled"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
       "actual": {
@@ -952,12 +959,12 @@
         "OptionName": "HealthCheckSuccessThreshold"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
       "actual": {
@@ -966,12 +973,12 @@
         "OptionName": "SystemType"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
       "actual": {
@@ -980,12 +987,12 @@
         "OptionName": "LogPublicationControl"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
       "actual": {
@@ -994,12 +1001,12 @@
         "OptionName": "ManagedActionsEnabled"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
       "actual": {
@@ -1008,12 +1015,12 @@
         "OptionName": "InstanceRefreshEnabled"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
       "actual": {
@@ -1022,12 +1029,12 @@
         "OptionName": "Automatically Terminate Unhealthy Instances"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
       "actual": {
@@ -1036,12 +1043,12 @@
         "OptionName": "Notification Protocol"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
       "actual": {
@@ -1050,12 +1057,12 @@
         "OptionName": "XRayEnabled"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
       "actual": {
@@ -1064,17 +1071,17 @@
         "OptionName": "HasCoupledDatabase"
       },
       "nested": true,
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     },
     {
       "tier": "atDefault",
-      "logicalId": "EbTemplate",
+      "logicalId": "EbTemplateSingle",
       "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
       "path": "PlatformArn",
       "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
-      "physicalId": "CdkRealDriftIntegEbRich-EbTemplate-wwcSqIxxE8f2",
-      "constructPath": "CdkRealDriftIntegEbRich/EbTemplate"
+      "physicalId": "CdkRealDriftIntegEbConfigTemplate-EbTemplateSingle-mlOVtc6QJDoe",
+      "constructPath": "CdkRealDriftIntegEbConfigTemplate/EbTemplateSingle"
     }
   ]
 }

--- a/tests/integration/eb-configtemplate-rich/app.ts
+++ b/tests/integration/eb-configtemplate-rich/app.ts
@@ -1,0 +1,51 @@
+// CDK app for the cdk-real-drift Elastic Beanstalk ConfigurationTemplate OptionSettings
+// fold test. A ConfigurationTemplate provisions NOTHING (no EC2/ELB — it is just a saved
+// config), so this stack is cheap and fast. AWS materializes the FULL resolved option set
+// (~51 entries) from the handful the template declares; every undeclared extra must fold to
+// atDefault (zero [Potential Drift] on a first check). Two templates — SingleInstance and
+// LoadBalanced — pin which option defaults are env-type CONTEXT-DEPENDENT (e.g. MaxSize:
+// SingleInstance=1 vs LoadBalanced=4) so the fold can DERIVE those from EnvironmentType.
+import { App, CfnOutput, Stack } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnConfigurationTemplate,
+} from "aws-cdk-lib/aws-elasticbeanstalk";
+
+const SOLUTION_STACK = "64bit Amazon Linux 2023 v4.13.3 running Docker";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEbConfigTemplate");
+
+const application = new CfnApplication(stack, "EbApp", {
+  applicationName: "cdkrd-hunt-ebct-app",
+});
+
+const single = new CfnConfigurationTemplate(stack, "EbTemplateSingle", {
+  applicationName: application.applicationName!,
+  solutionStackName: SOLUTION_STACK,
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "SingleInstance",
+    },
+  ],
+});
+single.addDependency(application);
+
+const balanced = new CfnConfigurationTemplate(stack, "EbTemplateBalanced", {
+  applicationName: application.applicationName!,
+  solutionStackName: SOLUTION_STACK,
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "LoadBalanced",
+    },
+  ],
+});
+balanced.addDependency(application);
+
+new CfnOutput(stack, "ApplicationName", { value: application.applicationName! });
+
+app.synth();

--- a/tests/integration/eb-configtemplate-rich/cdk.json
+++ b/tests/integration/eb-configtemplate-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eb-configtemplate-rich/package.json
+++ b/tests/integration/eb-configtemplate-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eb-configtemplate-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eb-configtemplate-rich OptionSettings-fold integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eb-configtemplate-rich/verify.sh
+++ b/tests/integration/eb-configtemplate-rich/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Zero-potential-drift invariant test (real AWS): deploy two EB ConfigurationTemplates
+# (SingleInstance + LoadBalanced) and assert a `check` BEFORE record is already CLEAN —
+# AWS materializes the full ~50-80 option set from the 1 declared option, and every
+# service-filled extra MUST fold to atDefault (equality-gate / derive-from-EnvironmentType /
+# value-independent). A ConfigurationTemplate provisions NOTHING, so this is cheap + fast.
+# Any [Potential Drift] on the fresh templates is a fold gap (a bug).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEbConfigTemplate
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] check BEFORE record MUST be CLEAN (every filled option folds to atDefault) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-pre.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK potential drift on fresh templates ---"; fail "expected CLEAN before record (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## EB ConfigurationTemplate OptionSettings → atDefault (zero first-run drift)

Follow-up to #598/#600. A fresh EB `ConfigurationTemplate` surfaced **~51** (SingleInstance) / **~81** (LoadBalanced) `[Potential Drift]` entries on a `check`-before-record: AWS materializes the FULL resolved option set from the handful the template declares, and every service-filled extra was classified `undeclared`. Per the zero-potential-drift invariant that is a fold gap — **a value the user never changed must not surface**.

### Fix — the CLAUDE.md fold-strategy order applied per option

New `ebOptionSettingTier` + tables in `noise.ts`, wired through a new optional `entryTier` on the composite-key subset spec in `classify.ts` (changes the pushed tier `undeclared`→`atDefault` per entry):

1. **Equality-gate constants** (`EB_OPTION_DEFAULTS`, ~70 pinned) — fold at the default, surface a change away (**detection kept**).
2. **Derive from the sibling `EnvironmentType`** (`EB_OPTION_DERIVED`) — `MaxSize` is `1` (SingleInstance) vs `4` (LoadBalanced); spot on-demand-above-base % is `0` vs `70`. Compute + equality-gate the derived value (**detection kept**). *This is the tier the #598 notes said was "infeasible" — it is derivable.*
3. **Value-independent** only for values AWS moves / per-resource ids (`EB_OPTION_VALUE_INDEPENDENT`): the platform AMI id, the versioned sample-app / hooks S3 URLs, the health `ConfigDocument`, the derived instance-type family, the ELB security-group `{Ref}`. An **unknown** option still surfaces (fail-open to visibility).

### Live verification (cheap two-ConfigurationTemplate probe — no instances)

- Fresh `check`-before-record on **both** env types is **CLEAN** (0 potential drift; 135 atDefault across the two templates).
- Detection preserved: an out-of-band change to an **equality-gated** option (`RetentionInDays` 7→30) **and** a **derived** one (LoadBalanced `MaxSize` 4→8) both still surface as `undeclared`.

### Assets

- `eb-configtemplate-rich` fixture + `verify.sh` (asserts the zero-drift invariant).
- 2 new golden-corpus cases (SingleInstance + LoadBalanced), and the existing `EbTemplate` case's `expected` regenerated (fold applied — the reviewable behavior change).
- Unit tests for all three tiers (fold-at-default, surface-when-changed, derive-by-EnvironmentType, value-independent, unknown-surfaces).
- `vp` typecheck / lint / pack / **2866 tests** pass.
