### PR TITLE
fix(noise): fold classic ELB first-run defaults + case-insensitive listener protocol (zero first-run drift)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -58,6 +58,17 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ElasticBeanstalk::Environment': {
     Tier: { Type: 'Standard', Version: '1.0', Name: 'WebServer' },
   },
+  // A classic ElasticLoadBalancing::LoadBalancer (CLB) that declares neither
+  // ConnectionSettings nor ConnectionDrainingPolicy reads both back fully materialized
+  // with AWS's constant first-run defaults: a 60-second idle timeout, and connection
+  // draining DISABLED with a 300-second timeout. Neither is user intent — the template
+  // never declared them. Equality-gated: raise the idle timeout out of band, or enable
+  // draining, and the object no longer matches so it re-surfaces as real undeclared drift.
+  // Observed live on a fresh internal CLB (elb-classic-rich, 2026-07-07).
+  'AWS::ElasticLoadBalancing::LoadBalancer': {
+    ConnectionSettings: { IdleTimeout: 60 },
+    ConnectionDrainingPolicy: { Enabled: false, Timeout: 300 },
+  },
   // S3 versioning can never return to the never-enabled state — a revert "remove"
   // lands on Suspended, which IS the off state. Without this entry an undeclared
   // {Status:"Suspended"} re-reports forever and revert can never converge (R46).
@@ -2014,6 +2025,16 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   on a fresh elasticbeanstalk-rich template + environment (2026-07-07).
   'AWS::ElasticBeanstalk::ConfigurationTemplate': new Set(['PlatformArn']),
   'AWS::ElasticBeanstalk::Environment': new Set(['PlatformArn']),
+  //   AWS::ElasticLoadBalancing::LoadBalancer.AvailabilityZones — a VPC classic ELB
+  //   declares `Subnets` (AvailabilityZones and Subnets are mutually exclusive), and AWS
+  //   reads back the AvailabilityZones it PLACED the ELB in — the AZs of those subnets
+  //   (["us-east-1a","us-east-1b"]). The value is a pure reflection of where the declared
+  //   subnets live, which is itself an unresolved Fn::Select(Fn::GetAZs), so it cannot be
+  //   pinned to a constant nor derived offline. Undeclared → whatever AZs AWS chose are not
+  //   user intent; a user who wants specific AZs declares AvailabilityZones instead of
+  //   Subnets, which is then compared in the declared loop. Observed live on a fresh
+  //   internal CLB (elb-classic-rich, 2026-07-07).
+  'AWS::ElasticLoadBalancing::LoadBalancer': new Set(['AvailabilityZones']),
   //   AWS::ApiGateway::Authorizer.AuthType — a REST-API authorizer's schema carries NO
   //   `AuthType` property (the template declares `Type`: TOKEN / REQUEST /
   //   COGNITO_USER_POOLS); AWS DERIVES and reads back AuthType from it ("custom" for
@@ -2649,6 +2670,17 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
   // indices to `*`. Two header names that differ beyond case are a genuine change and
   // still surface. Observed live on a fresh WAF logging deploy.
   'AWS::WAFv2::LoggingConfiguration': new Set(['RedactedFields.*.SingleHeader.Name']),
+  // A classic ELB listener's Protocol / InstanceProtocol — CDK emits the value LOWERCASE
+  // (`http` / `tcp`) in the template, but the ElasticLoadBalancing API canonicalizes it
+  // UPPERCASE (`HTTP` / `TCP`) on the live read, so a case-sensitive compare false-flags
+  // DECLARED drift on the whole declared Listeners array of every fresh CLB. The `*`
+  // matches the array index (the path arrives as `Listeners.0.Protocol`). The valid
+  // protocols differ beyond case (HTTP/HTTPS/TCP/SSL), so case-insensitive equality hides
+  // no real change. Observed live on a fresh internal CLB (elb-classic-rich, 2026-07-07).
+  'AWS::ElasticLoadBalancing::LoadBalancer': new Set([
+    'Listeners.*.Protocol',
+    'Listeners.*.InstanceProtocol',
+  ]),
 };
 export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2620,6 +2620,106 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  describe('classic ELB (ElasticLoadBalancing::LoadBalancer) first-run defaults (2026-07-07)', () => {
+    const T = 'AWS::ElasticLoadBalancing::LoadBalancer';
+
+    it('undeclared ConnectionSettings/ConnectionDrainingPolicy/AvailabilityZones fold to atDefault', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { Scheme: 'internal', CrossZone: true }),
+          {
+            Scheme: 'internal',
+            CrossZone: true,
+            ConnectionSettings: { IdleTimeout: 60 },
+            ConnectionDrainingPolicy: { Enabled: false, Timeout: 300 },
+            AvailabilityZones: ['us-east-1a', 'us-east-1b'],
+          },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual([
+        'AvailabilityZones',
+        'ConnectionDrainingPolicy',
+        'ConnectionSettings',
+      ]);
+      expect(t.undeclared).toEqual([]);
+      expect(t.declared).toEqual([]);
+    });
+
+    it('fail-closed: a raised idle timeout / enabled draining out of band never folds', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { Scheme: 'internal' }),
+          {
+            Scheme: 'internal',
+            ConnectionSettings: { IdleTimeout: 120 },
+            ConnectionDrainingPolicy: { Enabled: true, Timeout: 300 },
+          },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual([]);
+      expect(t.undeclared).toEqual(['ConnectionDrainingPolicy', 'ConnectionSettings']);
+    });
+
+    it('value-independent: AvailabilityZones folds at any AZ placement (subnet-derived echo)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { Scheme: 'internal' }),
+          { Scheme: 'internal', AvailabilityZones: ['eu-west-1b', 'eu-west-1c'] },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual(['AvailabilityZones']);
+      expect(t.undeclared).toEqual([]);
+    });
+
+    it('declared listener Protocol/InstanceProtocol are compared case-insensitively (no FP)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, {
+            Listeners: [
+              {
+                LoadBalancerPort: '80',
+                InstancePort: '80',
+                Protocol: 'http',
+                InstanceProtocol: 'http',
+              },
+            ],
+          }),
+          {
+            Listeners: [
+              {
+                LoadBalancerPort: '80',
+                InstancePort: '80',
+                Protocol: 'HTTP',
+                InstanceProtocol: 'HTTP',
+                PolicyNames: [],
+              },
+            ],
+          },
+          emptySchema
+        )
+      );
+      expect(t.declared).toEqual([]);
+    });
+
+    it('fail-closed: a genuinely changed listener protocol (HTTP->TCP) still surfaces as declared drift', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, {
+            Listeners: [{ LoadBalancerPort: '80', InstancePort: '80', Protocol: 'http' }],
+          }),
+          {
+            Listeners: [{ LoadBalancerPort: '80', InstancePort: '80', Protocol: 'TCP' }],
+          },
+          emptySchema
+        )
+      );
+      expect(t.declared).toEqual(['Listeners.0.Protocol']);
+    });
+  });
+
   describe('VpcLattice ServiceNetwork SharingConfig service default (#483)', () => {
     const T = 'AWS::VpcLattice::ServiceNetwork';
 

--- a/tests/corpus/AWS__ElasticLoadBalancing__LoadBalancer.Clb487D7D46.json
+++ b/tests/corpus/AWS__ElasticLoadBalancing__LoadBalancer.Clb487D7D46.json
@@ -1,0 +1,149 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Clb487D7D46",
+    "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+    "physicalId": "CdkRealDr-Clb487D7-1SB68UAD4G0DU",
+    "constructPath": "CdkRealDriftIntegElbClassicRich/Clb",
+    "declared": {
+      "CrossZone": true,
+      "HealthCheck": {
+        "HealthyThreshold": "2",
+        "Interval": "30",
+        "Target": "HTTP:80/",
+        "Timeout": "5",
+        "UnhealthyThreshold": "5"
+      },
+      "Listeners": [
+        {
+          "InstancePort": "80",
+          "InstanceProtocol": "http",
+          "LoadBalancerPort": "80",
+          "Protocol": "http"
+        }
+      ],
+      "Scheme": "internal",
+      "SecurityGroups": ["sg-0cb73956afc8276be"],
+      "Subnets": ["subnet-0450ec64327b46376", "subnet-0da3a00a8c0763133"]
+    }
+  },
+  "liveRaw": {
+    "SecurityGroups": ["sg-0cb73956afc8276be"],
+    "ConnectionDrainingPolicy": {
+      "Timeout": 300,
+      "Enabled": false
+    },
+    "Scheme": "internal",
+    "AvailabilityZones": ["us-east-1a", "us-east-1b"],
+    "SourceSecurityGroup": {
+      "GroupName": "CdkRealDriftIntegElbClassicRich-ClbSecurityGroup02737D77-fNfqqUjX1tMc",
+      "OwnerAlias": "111111111111"
+    },
+    "HealthCheck": {
+      "Target": "HTTP:80/",
+      "UnhealthyThreshold": "5",
+      "Timeout": "5",
+      "HealthyThreshold": "2",
+      "Interval": "30"
+    },
+    "CanonicalHostedZoneNameID": "Z35SXDOTRQ7X7K",
+    "CanonicalHostedZoneName": "",
+    "DNSName": "internal-CdkRealDr-Clb487D7-1SB68UAD4G0DU-912641998.us-east-1.elb.amazonaws.com",
+    "LoadBalancerName": "CdkRealDr-Clb487D7-1SB68UAD4G0DU",
+    "Listeners": [
+      {
+        "PolicyNames": [],
+        "InstancePort": "80",
+        "LoadBalancerPort": "80",
+        "Protocol": "HTTP",
+        "InstanceProtocol": "HTTP"
+      }
+    ],
+    "Subnets": ["subnet-0450ec64327b46376", "subnet-0da3a00a8c0763133"],
+    "CrossZone": true,
+    "AppCookieStickinessPolicy": [],
+    "LBCookieStickinessPolicy": [],
+    "ConnectionSettings": {
+      "IdleTimeout": 60
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegElbClassicRich/fe131820-7a07-11f1-bc4c-0affd6b97895",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegElbClassicRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Clb487D7D46",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneName",
+      "CanonicalHostedZoneNameID",
+      "DNSName",
+      "SourceSecurityGroup"
+    ],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerName", "Scheme"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneName",
+      "CanonicalHostedZoneNameID",
+      "DNSName",
+      "SourceSecurityGroup",
+      "SourceSecurityGroup.GroupName",
+      "SourceSecurityGroup.OwnerAlias"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LoadBalancerName", "Scheme"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "ConnectionDrainingPolicy",
+      "actual": {
+        "Timeout": 300,
+        "Enabled": false
+      },
+      "physicalId": "CdkRealDr-Clb487D7-1SB68UAD4G0DU",
+      "constructPath": "CdkRealDriftIntegElbClassicRich/Clb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b"],
+      "physicalId": "CdkRealDr-Clb487D7-1SB68UAD4G0DU",
+      "constructPath": "CdkRealDriftIntegElbClassicRich/Clb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "ConnectionSettings",
+      "actual": {
+        "IdleTimeout": 60
+      },
+      "physicalId": "CdkRealDr-Clb487D7-1SB68UAD4G0DU",
+      "constructPath": "CdkRealDriftIntegElbClassicRich/Clb"
+    }
+  ]
+}

--- a/tests/integration/elb-classic-rich/app.ts
+++ b/tests/integration/elb-classic-rich/app.ts
@@ -1,0 +1,53 @@
+// CDK app for the cdk-real-drift elb-classic-rich integration test. Classic
+// ElasticLoadBalancing::LoadBalancer (CLB) is read NATIVELY via Cloud Control
+// (full CRUD handlers, single-segment primaryIdentifier LoadBalancerName). Classic
+// ELB is a heavy default-filler: on create AWS materializes ConnectionSettings
+// (IdleTimeout 60), ConnectionDrainingPolicy (disabled), a HealthCheck bag,
+// Policies, CrossZone, Scheme, and an auto SecurityGroup — none of which the
+// template declares. Per the core invariant a clean deploy of this stack must
+// produce ZERO [Potential Drift] on a first `check` before `record`: every
+// AWS-assigned initial must fold to atDefault. This fixture is the FP oracle for
+// that. Internal (internetFacing:false) CLB in isolated subnets keeps it
+// self-contained and cheap (no NAT, no data path).
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  LoadBalancer,
+  LoadBalancingProtocol,
+} from "aws-cdk-lib/aws-elasticloadbalancing";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElbClassicRich");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "iso", subnetType: SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }],
+});
+
+// Declare only a health check + one listener. Everything else (ConnectionSettings,
+// ConnectionDrainingPolicy, CrossZone, Policies, Scheme, SecurityGroups) is left to
+// AWS so the first `check` surfaces its undeclared fills — the FP hunting ground.
+const lb = new LoadBalancer(stack, "Clb", {
+  vpc,
+  internetFacing: false,
+  subnetSelection: { subnetType: SubnetType.PRIVATE_ISOLATED },
+  healthCheck: {
+    port: 80,
+    path: "/",
+    protocol: LoadBalancingProtocol.HTTP,
+    interval: undefined,
+    timeout: undefined,
+    healthyThreshold: undefined,
+    unhealthyThreshold: undefined,
+  },
+});
+
+lb.addListener({
+  externalPort: 80,
+  externalProtocol: LoadBalancingProtocol.HTTP,
+  internalPort: 80,
+  internalProtocol: LoadBalancingProtocol.HTTP,
+});
+
+app.synth();

--- a/tests/integration/elb-classic-rich/cdk.json
+++ b/tests/integration/elb-classic-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elb-classic-rich/package.json
+++ b/tests/integration/elb-classic-rich/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-elb-classic-rich",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/elb-classic-rich/verify-detect.sh
+++ b/tests/integration/elb-classic-rich/verify-detect.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# FN half (real AWS): mutate a DECLARED mutable property out of band (classic ELB
+# HealthCheck.Interval 30->15) and assert `check` DETECTS it, `revert` restores it,
+# and a re-check is CLEAN. Then repeat for an UNDECLARED folded default
+# (ConnectionSettings.IdleTimeout 60->120) to prove the equality-gate re-surfaces an
+# out-of-band change and revert converges it back to the default.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegElbClassicRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+LB="$(cat /tmp/elb-lbname.txt)"; fail(){ echo "DETECT FAIL: $*"; exit 1; }
+
+echo "=== record baseline (clean) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail record
+
+echo "=== A: mutate DECLARED HealthCheck.Interval 30->15 out of band ==="
+aws elb configure-health-check --load-balancer-name "$LB" --region "$REGION" \
+  --health-check Target=HTTP:80/,Interval=15,Timeout=5,UnhealthyThreshold=5,HealthyThreshold=2 >/dev/null || fail mutate-hc
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 1 ] || fail "expected DETECT (exit 1) got $rc for HealthCheck mutation"
+echo "  -> detected. revert:"
+$CLI revert "$STACK" --region "$REGION" --yes || fail revert-hc
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after HealthCheck revert got $rc"
+echo "  -> HealthCheck revert CLEAN"
+
+echo "=== B: mutate UNDECLARED folded ConnectionSettings.IdleTimeout 60->120 ==="
+aws elb modify-load-balancer-attributes --load-balancer-name "$LB" --region "$REGION" \
+  --load-balancer-attributes "ConnectionSettings={IdleTimeout=120}" >/dev/null || fail mutate-idle
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 1 ] || fail "expected DETECT (exit 1) got $rc for IdleTimeout mutation (equality-gate)"
+echo "  -> detected. revert:"
+$CLI revert "$STACK" --region "$REGION" --yes || fail revert-idle
+$CLI check "$STACK" --region "$REGION" --fail; rc=$?
+[ "$rc" -eq 0 ] || fail "expected CLEAN after IdleTimeout revert got $rc"
+IDLE=$(aws elb describe-load-balancer-attributes --load-balancer-name "$LB" --region "$REGION" \
+  --query 'LoadBalancerAttributes.ConnectionSettings.IdleTimeout' --output text)
+[ "$IDLE" = "60" ] || fail "IdleTimeout not restored to 60 (live=$IDLE) — revert was a silent no-op"
+echo "  -> IdleTimeout restored to 60 live"
+echo "DETECT+REVERT PASS ($STACK)"

--- a/tests/integration/elb-classic-rich/verify.sh
+++ b/tests/integration/elb-classic-rich/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy a classic ELB, then a FIRST
+# `check` BEFORE `record` MUST be CLEAN (core invariant: zero [Potential Drift] on a
+# clean, un-mutated deploy). Then record -> check MUST also be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegElbClassicRich; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected first-check CLEAN got $rc"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected CLEAN got $rc"
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

A bug-hunt on the classic `AWS::ElasticLoadBalancing::LoadBalancer` (CLB) — a
common, still-widely-used, CC-readable type with **zero** prior coverage. A fresh
internal CLB produced **5 false positives** on a first `check` before `record`,
violating the core invariant (a clean deploy must show zero `[Potential Drift]`).

### Fixes (`src/normalize/noise.ts`)

- **Declared FP (2):** a listener's `Protocol` / `InstanceProtocol` — CDK emits
  the value lowercase (`http`) but the ELB API canonicalizes it uppercase (`HTTP`)
  on read, false-flagging declared drift on the whole `Listeners` array. Folded via
  `CASE_INSENSITIVE_PATHS` (`Listeners.*.Protocol` / `.InstanceProtocol`). A real
  protocol change (HTTP→TCP) still surfaces.
- **Undeclared FP (3):** AWS materializes `ConnectionSettings` (IdleTimeout 60) and
  `ConnectionDrainingPolicy` (Enabled:false, Timeout:300) as constant first-run
  defaults → `KNOWN_DEFAULTS` (equality-gated: a raised idle timeout / enabled
  draining re-surfaces). `AvailabilityZones` is a subnet-derived echo that can't be
  pinned or derived offline → `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (undeclared,
  so not user intent; a user who wants specific AZs declares `AvailabilityZones`
  instead of `Subnets`, which is then compared in the declared loop).

## Live-verified (real AWS, us-east-1)

- First `check` (no baseline) → **CLEAN** (atDefault=11, potential drift = 0).
- **Detection:** out-of-band `HealthCheck.Interval` 30→15 → detected → `revert` → CLEAN.
- **Folded-mutable revert:** out-of-band `ConnectionSettings.IdleTimeout` 60→120
  re-surfaces (equality-gate holds) → `revert` restores it to 60 **live** (CC `remove`
  converges — no silent no-op, so no `REVERT_SET_DEFAULT_PATHS` needed).

## Tests

- New golden-corpus case `AWS__ElasticLoadBalancing__LoadBalancer` (replayed offline
  by `corpus-replay`).
- 5 `classify` unit tests (folds + fail-closed + case-insensitive + genuine change).
- Regression fixture `tests/integration/elb-classic-rich/` (`verify.sh` +
  `verify-detect.sh`).

Core integration fixtures (basic/lambda/iam/revert/policies) all `INTEG PASS`;
orphan sweep CLEAN.
