### PR TITLE
fix(revert): whole-array replace for unordered-object-array drift + fold PrefixList Entries reorder

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1742,6 +1742,13 @@ export function classifyResource(
         path: d.path,
         desired: d.stateValue,
         actual: d.awsValue,
+        // An UNORDERED_OBJECT_ARRAY element drift: the array was sorted on BOTH sides
+        // before this per-element diff, so `d.path`'s index is the SORTED position, which
+        // does NOT map to the live array's raw index — a Cloud Control sub-path patch would
+        // hit the wrong live element. Carry the WHOLE (raw, template-order) declared array so
+        // the revert plan collapses these into one whole-array replacement. The REPORT still
+        // shows this precise per-element line; only revert reads `wholeArrayRevert`.
+        ...(unorderedObjArray ? { wholeArrayRevert: { path: k, value: v } } : {}),
       });
     }
   }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3607,6 +3607,21 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
   // set was tested in the SAME deploy with two conditions and WAF PRESERVED their order,
   // so it is NOT folded — observed-only.)
   'AWS::WAFv2::LoggingConfiguration': new Set(['RedactedFields']),
+  // An EC2 managed prefix list's `Entries` is a SET of {Cidr, Description} route
+  // entries. AWS stores them as a set, not an ordered list: after any out-of-band
+  // `ModifyManagedPrefixList` (the console/API "someone edited it" path this tool
+  // exists to catch) the live entries come back REORDERED relative to the template
+  // (declared [10.0.0.0/16, 10.1.0.0/16, 192.168.0.0/24] read back
+  // [192.168.0.0/24, 10.1.0.0/16, 10.0.0.0/16]), so a positional compare
+  // false-flags every shifted entry's Cidr AND Description as declared drift and
+  // MISATTRIBUTES a single real change (one entry's Description edited) as several
+  // positional diffs. The element key `Cidr` is NOT one of canonicalizeTagListsDeep's
+  // IDENTITY_FIELDS (Key/Id/AttributeName/IndexName/Name), so that keyed canonicalizer
+  // can't align it — hence the per-type opt-in. Sorting both sides by canonical JSON
+  // aligns equal entries by Cidr (the first sorted key); a genuine entry
+  // add/remove/description-change still differs. Observed live on a fresh
+  // ec2-prefixlist-rich deploy whose entries were reordered by an out-of-band modify.
+  'AWS::EC2::PrefixList': new Set(['Entries']),
 };
 
 // Per-type NESTED array paths AWS returns reordered (dotted from the resource

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -291,13 +291,30 @@ export function buildRevertPlan(
   const itemsByLogical = new Map<string, RevertItem>();
   const notRevertable: NotRevertable[] = [];
   const recorded = baseline?.recorded ?? [];
+  // Collapse the per-element findings of an UNORDERED_OBJECT_ARRAY into ONE whole-array
+  // replacement (see Finding.wholeArrayRevert): classify sorted both sides before the diff,
+  // so each finding's array index is a SORTED position that does NOT map to the live raw
+  // index — a Cloud Control sub-path patch would corrupt the wrong live element. Reverting
+  // the WHOLE declared array converges deterministically regardless of live order. Track the
+  // (logicalId, arrayPath) pairs already emitted so N element findings yield ONE op.
+  const wholeArrayEmitted = new Set<string>();
 
-  for (const f of findings) {
+  for (let f of findings) {
     // Show the construct path WITHIN the stack (stack/Stage prefix stripped), the same as the
     // check report — the revert banner already names the stack. Full path when unstripped.
     const displayId = f.constructPath
       ? withinStackPath(f.constructPath, opts.stackName ?? '')
       : f.logicalId;
+    // Rewrite a per-element unordered-object-array finding to its whole-array path+value, and
+    // drop the duplicates (one op per array). A finding whose path is ALREADY the whole array
+    // (a length-mismatch drift, e.g. an SG whose live rules reflect sibling resources) is left
+    // untouched — its revert is already a whole-array replace.
+    if (f.tier === 'declared' && f.wholeArrayRevert && f.path !== f.wholeArrayRevert.path) {
+      const waKey = `${f.logicalId}\0${f.wholeArrayRevert.path}`;
+      if (wholeArrayEmitted.has(waKey)) continue;
+      wholeArrayEmitted.add(waKey);
+      f = { ...f, path: f.wholeArrayRevert.path, desired: f.wholeArrayRevert.value };
+    }
     if (f.tier === 'deleted') {
       // a resource deleted out of band cannot be patched back — it must be
       // recreated by re-deploying the stack.

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,17 @@ export interface Finding {
   // policy (real IAM grants). Mirrors DesiredResource.siblingPolicyNames; only the
   // 'unresolved' sentinel is propagated (the resolved case is already filtered out).
   siblingPolicyNames?: 'unresolved' | undefined;
+  // declared tier only: this per-element finding lives inside an UNORDERED_OBJECT_ARRAY
+  // (a SET the service returns REORDERED — SecurityGroup rules, PrefixList Entries, …).
+  // classify sorts BOTH sides by canonical JSON before the positional subset diff, so the
+  // finding's array-index segment is the SORTED position, which does NOT map to the live
+  // array's raw index. A Cloud Control index patch (`add /Entries/2/Description`) would then
+  // hit the WRONG live element and corrupt it (proven live on a reordered PrefixList). So
+  // revert must NOT sub-path patch such a finding: it carries the WHOLE declared array here
+  // and the revert plan collapses every per-element finding of the same array into ONE
+  // whole-array `add /<path>` replacement (converges deterministically regardless of live
+  // order). The per-element REPORT is unaffected — this is revert-only metadata.
+  wholeArrayRevert?: { path: string; value: unknown } | undefined;
 }
 
 // Element-level delta of a recorded-but-changed undeclared identity-keyed object

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3844,6 +3844,42 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
     });
   });
 
+  describe('EC2 PrefixList Entries reordered (object set keyed by Cidr ∉ IDENTITY_FIELDS, found by ec2-prefixlist-rich)', () => {
+    const T = 'AWS::EC2::PrefixList';
+    const declared = {
+      Entries: [
+        { Cidr: '10.0.0.0/16', Description: 'corp-a' },
+        { Cidr: '10.1.0.0/16', Description: 'corp-b' },
+        { Cidr: '192.168.0.0/24', Description: 'branch' },
+      ],
+    };
+
+    it('AWS returning Entries reordered by an out-of-band modify is NOT drift', () => {
+      // A ModifyManagedPrefixList reorders the set; the same entries in a different
+      // order must not false-flag every shifted entry's Cidr/Description.
+      const live = {
+        Entries: [
+          { Cidr: '192.168.0.0/24', Description: 'branch' },
+          { Cidr: '10.1.0.0/16', Description: 'corp-b' },
+          { Cidr: '10.0.0.0/16', Description: 'corp-a' },
+        ],
+      };
+      expect(declaredTiers(T, declared, live)).toEqual([]);
+    });
+
+    it('a genuine entry description change still surfaces (no over-fold), even when reordered', () => {
+      // 10.1.0.0/16 description edited AND the set reordered — exactly one real drift.
+      const live = {
+        Entries: [
+          { Cidr: '192.168.0.0/24', Description: 'branch' },
+          { Cidr: '10.1.0.0/16', Description: 'HACKED' },
+          { Cidr: '10.0.0.0/16', Description: 'corp-a' },
+        ],
+      };
+      expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('AutoScaling group MetricsCollection.Metrics / NotificationConfigurations.NotificationTypes reordered (nested scalar sets, found by asg-notification-metrics)', () => {
     const T = 'AWS::AutoScaling::AutoScalingGroup';
 

--- a/tests/corpus/AWS__EC2__PrefixList.PLD5425AEA.json
+++ b/tests/corpus/AWS__EC2__PrefixList.PLD5425AEA.json
@@ -1,0 +1,85 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PLD5425AEA",
+    "resourceType": "AWS::EC2::PrefixList",
+    "physicalId": "pl-008cfc131622cb678",
+    "constructPath": "CdkRealDriftIntegEc2PrefixListRich/PL",
+    "declared": {
+      "AddressFamily": "IPv4",
+      "Entries": [
+        {
+          "Cidr": "10.0.0.0/16",
+          "Description": "corp-a"
+        },
+        {
+          "Cidr": "10.1.0.0/16",
+          "Description": "corp-b"
+        },
+        {
+          "Cidr": "192.168.0.0/24",
+          "Description": "branch"
+        }
+      ],
+      "MaxEntries": 10,
+      "PrefixListName": "cdkrd-prefixlist-rich"
+    }
+  },
+  "liveRaw": {
+    "MaxEntries": 10,
+    "OwnerId": "111111111111",
+    "PrefixListId": "pl-008cfc131622cb678",
+    "Version": 6,
+    "PrefixListName": "cdkrd-prefixlist-rich",
+    "Entries": [
+      {
+        "Description": "branch",
+        "Cidr": "192.168.0.0/24"
+      },
+      {
+        "Description": "corp-b",
+        "Cidr": "10.1.0.0/16"
+      },
+      {
+        "Description": "corp-a",
+        "Cidr": "10.0.0.0/16"
+      }
+    ],
+    "AddressFamily": "IPv4",
+    "Arn": "arn:aws:ec2:us-east-1:111111111111:prefix-list/pl-008cfc131622cb678",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegEc2PrefixListRich/0f398c00-7a09-11f1-a445-0ef7e0e36b7f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegEc2PrefixListRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "PLD5425AEA",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "OwnerId", "PrefixListId", "Version"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["Arn", "OwnerId", "PrefixListId", "Version"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__S3__StorageLens.Lens.json
+++ b/tests/corpus/AWS__S3__StorageLens.Lens.json
@@ -1,0 +1,70 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Lens",
+    "resourceType": "AWS::S3::StorageLens",
+    "physicalId": "cdkrd-storagelens-rich",
+    "constructPath": "CdkRealDriftIntegS3StorageLensRich/Lens",
+    "declared": {
+      "StorageLensConfiguration": {
+        "AccountLevel": {
+          "ActivityMetrics": {
+            "IsEnabled": true
+          },
+          "BucketLevel": {
+            "ActivityMetrics": {
+              "IsEnabled": true
+            }
+          }
+        },
+        "Id": "cdkrd-storagelens-rich",
+        "IsEnabled": true
+      }
+    }
+  },
+  "liveRaw": {
+    "StorageLensConfiguration": {
+      "AccountLevel": {
+        "ActivityMetrics": {
+          "IsEnabled": true
+        },
+        "BucketLevel": {
+          "ActivityMetrics": {
+            "IsEnabled": true
+          }
+        }
+      },
+      "IsEnabled": true,
+      "Id": "cdkrd-storagelens-rich",
+      "StorageLensArn": "arn:aws:s3:us-east-1:111111111111:storage-lens/cdkrd-storagelens-rich"
+    },
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["StorageLensConfiguration.StorageLensArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["StorageLensConfiguration.Id"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "StorageLensConfiguration.AccountLevel.StorageLensGroupLevel.StorageLensGroupSelectionCriteria.Exclude",
+      "StorageLensConfiguration.AccountLevel.StorageLensGroupLevel.StorageLensGroupSelectionCriteria.Include",
+      "StorageLensConfiguration.Exclude.Buckets",
+      "StorageLensConfiguration.Exclude.Regions",
+      "StorageLensConfiguration.Include.Buckets",
+      "StorageLensConfiguration.Include.Regions"
+    ],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/ec2-prefixlist-rich/app.ts
+++ b/tests/integration/ec2-prefixlist-rich/app.ts
@@ -1,0 +1,22 @@
+// EC2 managed prefix list (AWS::EC2::PrefixList) — a common, FREE VPC/SG building block
+// no fixture exercises yet. Its `Entries` is an object array ({Cidr, Description}), the
+// classic set-like-reorder FP axis, and MaxEntries/AddressFamily/Tags are mutable props
+// good for the FN (detect->revert) half. Clean record->check is the FP oracle;
+// PrefixList is CC-readable and FULLY_MUTABLE.
+import { App, Stack } from "aws-cdk-lib";
+import { PrefixList } from "aws-cdk-lib/aws-ec2";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEc2PrefixListRich");
+
+new PrefixList(stack, "PL", {
+  prefixListName: "cdkrd-prefixlist-rich",
+  maxEntries: 10,
+  entries: [
+    { cidr: "10.0.0.0/16", description: "corp-a" },
+    { cidr: "10.1.0.0/16", description: "corp-b" },
+    { cidr: "192.168.0.0/24", description: "branch" },
+  ],
+});
+
+app.synth();

--- a/tests/integration/ec2-prefixlist-rich/cdk.json
+++ b/tests/integration/ec2-prefixlist-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/ec2-prefixlist-rich/package.json
+++ b/tests/integration/ec2-prefixlist-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-ec2-prefixlist-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift ec2-prefixlist-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/ec2-prefixlist-rich/verify.sh
+++ b/tests/integration/ec2-prefixlist-rich/verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEc2PrefixListRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] check BEFORE record (first-run noise oracle) ==="; $CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK.firstrun"
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/integration/s3-storagelens-rich/app.ts
+++ b/tests/integration/s3-storagelens-rich/app.ts
@@ -1,0 +1,26 @@
+// S3 Storage Lens configuration (AWS::S3::StorageLens) — a common, FREE (default
+// metrics) org/account-level analytics config that no fixture exercises yet. It has a
+// deep nested StorageLensConfiguration object with many boolean metric toggles AWS
+// materializes at creation (ActivityMetrics/DetailedStatusCodesMetrics/... IsEnabled),
+// exactly the first-run undeclared-default noise this hunt targets. Clean record->check
+// is the FP oracle; StorageLens is CC-readable and FULLY_MUTABLE.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnStorageLens } from "aws-cdk-lib/aws-s3";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegS3StorageLensRich");
+
+new CfnStorageLens(stack, "Lens", {
+  storageLensConfiguration: {
+    id: "cdkrd-storagelens-rich",
+    isEnabled: true,
+    accountLevel: {
+      bucketLevel: {
+        activityMetrics: { isEnabled: true },
+      },
+      activityMetrics: { isEnabled: true },
+    },
+  },
+});
+
+app.synth();

--- a/tests/integration/s3-storagelens-rich/cdk.json
+++ b/tests/integration/s3-storagelens-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/s3-storagelens-rich/package.json
+++ b/tests/integration/s3-storagelens-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-s3-storagelens-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift s3-storagelens-rich integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/s3-storagelens-rich/verify.sh
+++ b/tests/integration/s3-storagelens-rich/verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record -> check MUST be CLEAN.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegS3StorageLensRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+cleanup() { echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== [$STACK] deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== [$STACK] check BEFORE record (first-run noise oracle) ==="; $CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK.firstrun"
+echo "=== [$STACK] record ==="; $CLI record "$STACK" --region "$REGION" --yes || fail record
+echo "=== [$STACK] check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}; [ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE ---"; fail "expected CLEAN got $rc"; }
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -149,6 +149,61 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('unordered-object-array: per-element findings collapse to ONE whole-array replace (Finding.wholeArrayRevert)', () => {
+    // classify sorts an UNORDERED_OBJECT_ARRAY (EC2 PrefixList Entries) on BOTH sides
+    // before the per-element diff, so a finding's index is a SORTED position that does
+    // NOT map to the live array's raw index — a Cloud Control sub-path patch
+    // (`add /Entries/2/Description`) would corrupt the wrong live element (proven live).
+    // The whole (raw, template-order) declared array on wholeArrayRevert must collapse
+    // every element finding of the same array into ONE whole-array `add /Entries`.
+    const wholeEntries = [
+      { Cidr: '10.0.0.0/16', Description: 'corp-a' },
+      { Cidr: '10.1.0.0/16', Description: 'corp-b' },
+      { Cidr: '192.168.0.0/24', Description: 'branch' },
+    ];
+    // two per-element findings for the same array (e.g. two shifted entries)
+    const f1 = F({
+      resourceType: 'AWS::EC2::PrefixList',
+      path: 'Entries.1.Description',
+      desired: 'corp-b',
+      actual: 'HACKED',
+      wholeArrayRevert: { path: 'Entries', value: wholeEntries },
+    });
+    const f2 = F({
+      resourceType: 'AWS::EC2::PrefixList',
+      path: 'Entries.2.Cidr',
+      desired: '192.168.0.0/24',
+      actual: '10.0.0.0/16',
+      wholeArrayRevert: { path: 'Entries', value: wholeEntries },
+    });
+    const plan = buildRevertPlan([f1, f2], undefined);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('cc');
+    expect(plan.items[0]!.ops).toHaveLength(1);
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Entries',
+      value: wholeEntries,
+    });
+  });
+
+  it('unordered-object-array already at whole-array path (length-mismatch drift) is NOT rewritten', () => {
+    // A finding whose path is ALREADY the whole array — e.g. an SG whose live rules
+    // reflect sibling resources so the array LENGTHS differ — keeps its own path/value;
+    // the collapse only fires for per-element (sub-path) findings.
+    const declaredRules = [{ CidrIp: '10.0.0.0/8', IpProtocol: 'tcp', FromPort: 443, ToPort: 443 }];
+    const f = F({
+      resourceType: 'AWS::EC2::SecurityGroup',
+      path: 'SecurityGroupIngress',
+      desired: declaredRules,
+      actual: [...declaredRules, { CidrIp: '0.0.0.0/0', IpProtocol: '-1' }],
+      wholeArrayRevert: { path: 'SecurityGroupIngress', value: declaredRules },
+    });
+    const plan = buildRevertPlan([f], undefined);
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.ops[0]).toMatchObject({ op: 'add', path: '/SecurityGroupIngress' });
+  });
+
   it('ManagedPolicy attachment detach -> SDK item, op carries the member on attributeKey', () => {
     // a declared-but-detached Role finding (path Roles, attributeKey = role name) must
     // route to the SDK writer (ManagedPolicy is a whole-type writer) and carry the


### PR DESCRIPTION
## Bug hunt: EC2 PrefixList + S3 Storage Lens

Two new common, CC-readable, `FULLY_MUTABLE`, free types (`ec2-prefixlist-rich`,
`s3-storagelens-rich`), both first-run **CLEAN** (zero FP). The PrefixList hunt
surfaced a false positive **and** a serious revert-corruption bug.

### 1. FP — PrefixList `Entries` reorder
An EC2 managed prefix list's `Entries` is a **set** of `{Cidr, Description}`. After
any out-of-band `ModifyManagedPrefixList` (the console/API path this tool exists to
catch) AWS returns the entries **reordered**, so a positional compare false-flagged
every shifted entry's `Cidr`/`Description` and misattributed a single real change to
several positional diffs. Fold: add `Entries` to `UNORDERED_OBJECT_ARRAY_PROPS`
(`Cidr` ∉ `IDENTITY_FIELDS` → per-type opt-in). Live-verified: a reordered but
content-equal read is CLEAN; a real description edit still detects.

### 2. Revert corruption of unordered-object-arrays (the serious one)
`classify` sorts an `UNORDERED_OBJECT_ARRAY` on **both** sides before the per-element
diff, so a finding's array index is the **sorted** position, which does **not** map to
the live array's raw index. The Cloud Control sub-path patch (`add /Entries/2/Description`)
then hit the **wrong** live element and **corrupted** it — live-proven: reverting one
entry's description overwrote a *different* entry and left the real drift unfixed
(2 drifts remained).

Fix: `Finding.wholeArrayRevert` carries the whole (raw, template-order) declared array;
`buildRevertPlan` collapses every per-element finding of the same array into **one**
whole-array `add /<path>` replacement, which converges deterministically regardless of
live order. This **generalizes** to every CC-reverted unordered-object-array type
(Redshift `Parameters`, ELBv2 `ListenerRule` `Conditions`, Secret `ReplicaRegions`, …).
A finding already at the whole-array path (an SG length-mismatch drift, sibling
reflection) is left untouched; IAM inline `Policies` (SDK writer) route to their
prop-writer as before. Live-verified: revert now converges CLEAN with no collateral
corruption.

### Tests
- `classify.test.ts`: PrefixList reorder-fold + genuine-change detection.
- `revert-plan.test.ts`: whole-array collapse + dedup + already-whole-array-untouched.
- 2 golden-corpus cases (the PrefixList case has a **reordered** `liveRaw` so
  `corpus-replay` exercises the fold offline).
- All 2875 unit tests pass; typecheck / lint+format / build green.

### Live verification
Deployed both stacks to real AWS (us-east-1), confirmed first-run CLEAN, drove the full
detect → revert → CLEAN cycle on a reordered prefix list, and tore both down (`delstack`,
sweep clean). No `record` was needed for the FP oracle — both were CLEAN before `record`.
