### PR TITLE
feat(read): read EB Environment OptionSettings + fold multi-platform + null/empty option defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,11 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   (supplement an `AWS::MSK::Configuration` with its writeOnly `ServerProperties`
   Kafka blob — an out-of-band `update-configuration` revision is otherwise
   invisible),
+  `elasticbeanstalk:DescribeConfigurationSettings` (supplements an
+  `AWS::ElasticBeanstalk::Environment` with its writeOnly `OptionSettings` — the
+  full resolved option set; an out-of-band console edit to any environment option
+  is otherwise invisible, and the service-filled default options fold to
+  `atDefault`),
   `servicediscovery:GetNamespace` (reads a Cloud Map
   `HttpNamespace` / `PrivateDnsNamespace` / `PublicDnsNamespace` — incl. the Arn an
   ECS Service Connect namespace `Fn::GetAtt` resolves against)

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -408,21 +408,29 @@ interface CompositeSubsetSpec {
   // every live-only entry is 'undeclared' (recorded inventory; a later change still surfaces).
   entryTier?: (entry: Record<string, unknown>, liveArray: unknown) => 'atDefault' | 'undeclared';
 }
+// AWS (both an EB ConfigurationTemplate and an Environment) materializes the FULL option set
+// from the declared subset; fold each service-filled extra to its first-run default (equality-
+// gate / derive-from-EnvironmentType / value-independent — see ebOptionSettingTier), so a clean
+// template / environment shows zero potential drift. The Environment reads its OptionSettings
+// back via the SDK_SUPPLEMENTS DescribeConfigurationSettings reader (writeOnly-but-readable).
+const ebOptionSettingsEntryTier: NonNullable<CompositeSubsetSpec['entryTier']> = (
+  entry,
+  liveArray
+) => {
+  const arr = Array.isArray(liveArray) ? (liveArray as Record<string, unknown>[]) : [];
+  const envEntry = arr.find((e) => e && e.OptionName === 'EnvironmentType');
+  const envType = typeof envEntry?.Value === 'string' ? envEntry.Value : 'LoadBalanced';
+  return ebOptionSettingTier(entry.Namespace, entry.OptionName, entry.Value, envType);
+};
+const ebOptionSettingsSubsetSpec: CompositeSubsetSpec = {
+  re: /(^|\.)OptionSettings$/,
+  keyFields: ['Namespace', 'OptionName'],
+  ignoreFields: new Set(['ResourceName']),
+  entryTier: ebOptionSettingsEntryTier,
+};
 const COMPOSITE_KEY_SUBSET_PATHS: Record<string, CompositeSubsetSpec> = {
-  'AWS::ElasticBeanstalk::ConfigurationTemplate': {
-    re: /(^|\.)OptionSettings$/,
-    keyFields: ['Namespace', 'OptionName'],
-    ignoreFields: new Set(['ResourceName']),
-    // AWS materializes the FULL option set from the declared subset; fold each service-filled
-    // extra to its first-run default (equality-gate / derive-from-EnvironmentType / value-
-    // independent — see ebOptionSettingTier), so a clean template shows zero potential drift.
-    entryTier: (entry, liveArray) => {
-      const arr = Array.isArray(liveArray) ? (liveArray as Record<string, unknown>[]) : [];
-      const envEntry = arr.find((e) => e && e.OptionName === 'EnvironmentType');
-      const envType = typeof envEntry?.Value === 'string' ? envEntry.Value : 'LoadBalanced';
-      return ebOptionSettingTier(entry.Namespace, entry.OptionName, entry.Value, envType);
-    },
-  },
+  'AWS::ElasticBeanstalk::ConfigurationTemplate': ebOptionSettingsSubsetSpec,
+  'AWS::ElasticBeanstalk::Environment': ebOptionSettingsSubsetSpec,
 };
 
 // Align a declared object array to a live one BY a composite identity key, ignoring the

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1928,7 +1928,7 @@ export const EB_OPTION_DEFAULTS: Record<string, string> = {
   'aws:elasticbeanstalk:control|RollbackLaunchOnFailure': 'false',
   'aws:elasticbeanstalk:environment:proxy|ProxyServer': 'nginx',
   'aws:elasticbeanstalk:environment|LoadBalancerType': 'classic',
-  'aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled': 'false',
+  'aws:elasticbeanstalk:environment|ServiceRole': 'AWSServiceRoleForElasticBeanstalk',
   'aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold': 'Ok',
   'aws:elasticbeanstalk:healthreporting:system|SystemType': 'enhanced',
   'aws:elasticbeanstalk:hostmanager|LogPublicationControl': 'false',
@@ -1955,6 +1955,20 @@ export const EB_OPTION_DEFAULTS: Record<string, string> = {
   'aws:elb:policies|ConnectionDrainingTimeout': '20',
   'aws:elb:policies|ConnectionSettingIdleTimeout': '60',
   'aws:rds:dbinstance|HasCoupledDatabase': 'false',
+  // Platform-specific option defaults (observed on non-Docker ConfigurationTemplates). The
+  // per-language container namespaces + the Corretto build-tool env vars are stable platform
+  // defaults; a change away still surfaces.
+  'aws:elasticbeanstalk:container:python|NumProcesses': '1',
+  'aws:elasticbeanstalk:container:python|NumThreads': '15',
+  'aws:elasticbeanstalk:container:python|WSGIPath': 'application',
+  'aws:elasticbeanstalk:application:environment|GRADLE_HOME': '/usr/local/gradle',
+  'aws:elasticbeanstalk:application:environment|M2': '/usr/local/apache-maven/bin',
+  'aws:elasticbeanstalk:application:environment|M2_HOME': '/usr/local/apache-maven',
+  'aws:elasticbeanstalk:container:php:phpini|allow_url_fopen': 'On',
+  'aws:elasticbeanstalk:container:php:phpini|display_errors': 'Off',
+  'aws:elasticbeanstalk:container:php:phpini|max_execution_time': '60',
+  'aws:elasticbeanstalk:container:php:phpini|memory_limit': '256M',
+  'aws:elasticbeanstalk:container:php:phpini|zlib.output_compression': 'Off',
 };
 export const EB_OPTION_DERIVED: Record<string, Record<string, string>> = {
   'aws:autoscaling:asg|MaxSize': { SingleInstance: '1', LoadBalanced: '4' },
@@ -1966,13 +1980,23 @@ export const EB_OPTION_DERIVED: Record<string, Record<string, string>> = {
 export const EB_OPTION_VALUE_INDEPENDENT: ReadonlySet<string> = new Set([
   'aws:autoscaling:launchconfiguration|ImageId',
   'aws:autoscaling:launchconfiguration|InstanceType',
+  // the environment's own EC2 security group (an awseb-e-… generated name) + the ELB's
+  'aws:autoscaling:launchconfiguration|SecurityGroups',
+  'aws:elb:loadbalancer|SecurityGroups',
   'aws:cloudformation:template:parameter|AppSource',
   'aws:cloudformation:template:parameter|HooksPkgUrl',
   'aws:cloudformation:template:parameter|InstanceTypeFamily',
+  // an aggregate echo of the app EnvironmentVariables (includes per-deploy paths like the
+  // Python venv staging dir), so any value is a reflection of the declared env vars, not intent
+  'aws:cloudformation:template:parameter|EnvironmentVariables',
   'aws:ec2:instances|InstanceTypes',
   'aws:ec2:instances|SupportedArchitectures',
+  // the platform-injected Python venv path carries a random per-deploy staging id
+  'aws:elasticbeanstalk:application:environment|PYTHONPATH',
   'aws:elasticbeanstalk:healthreporting:system|ConfigDocument',
-  'aws:elb:loadbalancer|SecurityGroups',
+  // AWS materializes EnhancedHealthAuthEnabled false on a bare template but true on a live
+  // environment — differs by resource kind, so fold value-independent rather than FP one side
+  'aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled',
 ]);
 // Classify one live-only EB OptionSettings entry: 'atDefault' when it is at its AWS first-run
 // default (value-independent, derived-from-EnvironmentType, or equality-gated constant), else
@@ -1984,6 +2008,10 @@ export function ebOptionSettingTier(
   value: unknown,
   envType: string
 ): 'atDefault' | 'undeclared' {
+  // An unset option: DescribeConfigurationSettings returns many option keys with a null or
+  // empty Value (BlockDeviceMappings, VPCId, Notification*, RootVolume*, …). Unset is not
+  // drift → fold. A change TO a non-empty value is not '' so it still runs the tables below.
+  if (value == null || value === '') return 'atDefault';
   const key = `${String(namespace)}|${String(optionName)}`;
   if (EB_OPTION_VALUE_INDEPENDENT.has(key)) return 'atDefault';
   const derived = EB_OPTION_DERIVED[key];

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -9,6 +9,10 @@
 import { AppSyncClient, ListApiKeysCommand } from '@aws-sdk/client-appsync';
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
+import {
+  DescribeConfigurationSettingsCommand,
+  ElasticBeanstalkClient,
+} from '@aws-sdk/client-elastic-beanstalk';
 import { CognitoSyncClient, GetCognitoEventsCommand } from '@aws-sdk/client-cognito-sync';
 import {
   BatchGetProjectsCommand,
@@ -2503,7 +2507,35 @@ const supplementLexBot: SupplementReader = async ({ physicalId, region }) => {
   }
 };
 
+// AWS::ElasticBeanstalk::Environment — OptionSettings is writeOnly in the registry schema, so
+// Cloud Control never echoes the environment's configuration and a console edit to any option
+// (RetentionInDays, an app EnvironmentVariable, health config, ...) was invisible. The full
+// resolved option set IS readable via elasticbeanstalk:DescribeConfigurationSettings. Project
+// it as OptionSettings (exempted from the writeOnly strip via OVERRIDE_READABLE_WRITEONLY) so
+// the composite-key subset compares the declared options and folds the service-filled extras
+// (ebOptionSettingTier). ApplicationName comes from the declared model; EnvironmentName is the
+// physical id. FP-safe: any failure or empty read skips the field (keep the CC model).
+const supplementElasticBeanstalkEnvironment: SupplementReader = async ({
+  physicalId,
+  declared,
+  region,
+}) => {
+  const envName = str(physicalId);
+  const appName = str(declared.ApplicationName);
+  if (!envName || !appName) return undefined;
+  const c = new ElasticBeanstalkClient({ region, ...READ_RETRY });
+  const r = await c.send(
+    new DescribeConfigurationSettingsCommand({
+      ApplicationName: appName,
+      EnvironmentName: envName,
+    })
+  );
+  const opts = r.ConfigurationSettings?.[0]?.OptionSettings;
+  return Array.isArray(opts) && opts.length > 0 ? { OptionSettings: opts } : undefined;
+};
+
 export const SDK_SUPPLEMENTS: Record<string, SupplementReader> = {
+  'AWS::ElasticBeanstalk::Environment': supplementElasticBeanstalkEnvironment,
   'AWS::Lex::Bot': supplementLexBot,
   'AWS::MSK::Configuration': supplementMskConfiguration,
   'AWS::ElasticLoadBalancingV2::TrustStore': supplementTrustStore,

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -39,6 +39,11 @@ export async function getSchemaInfo(
 // and the top-level TagSpecifications stay writeOnly — the override does not project them.)
 export const OVERRIDE_READABLE_WRITEONLY: Record<string, readonly string[]> = {
   'AWS::EC2::LaunchTemplate': ['LaunchTemplateData'],
+  // AWS::ElasticBeanstalk::Environment `OptionSettings` is writeOnly (CC never echoes the
+  // environment configuration), but the SDK_SUPPLEMENTS reader fetches the full resolved set
+  // via elasticbeanstalk:DescribeConfigurationSettings — so compare it (the composite-key
+  // subset folds the service-filled extras), not readGap.
+  'AWS::ElasticBeanstalk::Environment': ['OptionSettings'],
   // AWS::MSK::Configuration `ServerProperties` is writeOnly (CC never echoes the
   // server.properties blob); the SDK_SUPPLEMENTS reader fetches the latest revision's
   // decoded properties via kafka:DescribeConfigurationRevision, so compare it (through

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2537,6 +2537,51 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     it('an unknown option is undeclared (surfaces)', () => {
       expect(ebOptionSettingTier('aws:x', 'Novel', 'v', 'LoadBalanced')).toBe('undeclared');
     });
+
+    it('an unset option (null or empty Value) folds — DescribeConfigurationSettings returns many', () => {
+      expect(ebOptionSettingTier('aws:ec2:vpc', 'VPCId', null, 'LoadBalanced')).toBe('atDefault');
+      expect(
+        ebOptionSettingTier('aws:autoscaling:asg', 'Custom Availability Zones', '', 'LoadBalanced')
+      ).toBe('atDefault');
+      // a novel option that is SET (non-empty) still surfaces
+      expect(ebOptionSettingTier('aws:x', 'Novel', 'set', 'LoadBalanced')).toBe('undeclared');
+    });
+
+    it('EnhancedHealthAuthEnabled folds value-independent (template reads false, environment true)', () => {
+      const k = [
+        'aws:elasticbeanstalk:healthreporting:system',
+        'EnhancedHealthAuthEnabled',
+      ] as const;
+      expect(ebOptionSettingTier(k[0], k[1], 'false', 'LoadBalanced')).toBe('atDefault');
+      expect(ebOptionSettingTier(k[0], k[1], 'true', 'SingleInstance')).toBe('atDefault');
+    });
+
+    it('platform-specific constants fold (PHP memory_limit, Python WSGIPath) and surface when changed', () => {
+      expect(
+        ebOptionSettingTier(
+          'aws:elasticbeanstalk:container:php:phpini',
+          'memory_limit',
+          '256M',
+          'LoadBalanced'
+        )
+      ).toBe('atDefault');
+      expect(
+        ebOptionSettingTier(
+          'aws:elasticbeanstalk:container:php:phpini',
+          'memory_limit',
+          '512M',
+          'LoadBalanced'
+        )
+      ).toBe('undeclared');
+      expect(
+        ebOptionSettingTier(
+          'aws:elasticbeanstalk:container:python',
+          'WSGIPath',
+          'application',
+          'LoadBalanced'
+        )
+      ).toBe('atDefault');
+    });
   });
 
   describe('ElasticBeanstalk Application/Environment top-level first-run defaults (2026-07-07)', () => {

--- a/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplateCorretto.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplateCorretto.json
@@ -1,0 +1,1751 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbTemplateCorretto",
+    "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+    "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+    "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-ebpf-app",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "LoadBalanced"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.12.3 running Corretto 21"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Corretto 21 running on 64bit Amazon Linux 2023/4.12.3",
+    "ApplicationName": "cdkrd-hunt-ebpf-app",
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-0fc4e3ac933697c31",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_corretto21_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Corretto.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      {
+        "Value": "M2=/usr/local/apache-maven/bin,M2_HOME=/usr/local/apache-maven,GRADLE_HOME=/usr/local/gradle",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_corretto21_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      {
+        "Value": "/usr/local/gradle",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "GRADLE_HOME"
+      },
+      {
+        "Value": "/usr/local/apache-maven/bin",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "M2"
+      },
+      {
+        "Value": "/usr/local/apache-maven",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "M2_HOME"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      {
+        "Value": "LoadBalanced",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType"
+      },
+      {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      {
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      }
+    ],
+    "TemplateName": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.12.3 running Corretto 21"
+  },
+  "schema": {
+    "readOnly": ["TemplateName"],
+    "writeOnly": ["EnvironmentId"],
+    "createOnly": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "readOnlyPaths": ["TemplateName"],
+    "writeOnlyPaths": [
+      "EnvironmentId",
+      "SourceConfiguration.ApplicationName",
+      "SourceConfiguration.TemplateName"
+    ],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-0fc4e3ac933697c31",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|BreachDuration]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|EvaluationPeriods]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|MeasureName]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Period]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Statistic]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Unit]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_corretto21_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Corretto.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|EnvironmentVariables]",
+      "actual": {
+        "Value": "M2=/usr/local/apache-maven/bin,M2_HOME=/usr/local/apache-maven,GRADLE_HOME=/usr/local/gradle",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_corretto21_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:application:environment|GRADLE_HOME]",
+      "actual": {
+        "Value": "/usr/local/gradle",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "GRADLE_HOME"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:application:environment|M2]",
+      "actual": {
+        "Value": "/usr/local/apache-maven/bin",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "M2"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:application:environment|M2_HOME]",
+      "actual": {
+        "Value": "/usr/local/apache-maven",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "M2_HOME"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|LoadBalancerType]",
+      "actual": {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|HealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Interval]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Target]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|UnhealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstancePort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstanceProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|CrossZone]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPSPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerSSLPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionSettingIdleTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplateCorretto",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Corretto 21 running on 64bit Amazon Linux 2023/4.12.3",
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplateCorretto-RHjPUIU67PuO",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplateCorretto"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplatePhp.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplatePhp.json
@@ -1,0 +1,1789 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbTemplatePhp",
+    "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+    "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+    "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-ebpf-app",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "LoadBalanced"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running PHP 8.3"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/PHP 8.3 running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-hunt-ebpf-app",
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-031ae9d63a2e599f9",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_php83_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-PHP.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_php83_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "On",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "allow_url_fopen"
+      },
+      {
+        "Value": "Off",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "display_errors"
+      },
+      {
+        "Value": "60",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "max_execution_time"
+      },
+      {
+        "Value": "256M",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "memory_limit"
+      },
+      {
+        "Value": "Off",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "zlib.output_compression"
+      },
+      {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      {
+        "Value": "LoadBalanced",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType"
+      },
+      {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      {
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      }
+    ],
+    "TemplateName": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running PHP 8.3"
+  },
+  "schema": {
+    "readOnly": ["TemplateName"],
+    "writeOnly": ["EnvironmentId"],
+    "createOnly": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "readOnlyPaths": ["TemplateName"],
+    "writeOnlyPaths": [
+      "EnvironmentId",
+      "SourceConfiguration.ApplicationName",
+      "SourceConfiguration.TemplateName"
+    ],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-031ae9d63a2e599f9",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|BreachDuration]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|EvaluationPeriods]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|MeasureName]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Period]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Statistic]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Unit]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_php83_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-PHP.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_php83_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:php:phpini|allow_url_fopen]",
+      "actual": {
+        "Value": "On",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "allow_url_fopen"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:php:phpini|display_errors]",
+      "actual": {
+        "Value": "Off",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "display_errors"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:php:phpini|max_execution_time]",
+      "actual": {
+        "Value": "60",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "max_execution_time"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:php:phpini|memory_limit]",
+      "actual": {
+        "Value": "256M",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "memory_limit"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:php:phpini|zlib.output_compression]",
+      "actual": {
+        "Value": "Off",
+        "Namespace": "aws:elasticbeanstalk:container:php:phpini",
+        "OptionName": "zlib.output_compression"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|LoadBalancerType]",
+      "actual": {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|HealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Interval]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Target]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|UnhealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstancePort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstanceProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|CrossZone]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPSPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerSSLPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionSettingIdleTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePhp",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/PHP 8.3 running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePhp-yi28P4tKKFqn",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePhp"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplatePython.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__ConfigurationTemplate.EbTemplatePython.json
@@ -1,0 +1,1789 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbTemplatePython",
+    "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+    "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+    "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-ebpf-app",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "LoadBalanced"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Python 3.13"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Python 3.13 running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-hunt-ebpf-app",
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-029dd4cce862b33fe",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_python313_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Python.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      {
+        "Value": "PYTHONPATH=/var/app/venv/staging-LQM1lest/bin",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_python313_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      {
+        "Value": "/var/app/venv/staging-LQM1lest/bin",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "PYTHONPATH"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      {
+        "Value": "1",
+        "Namespace": "aws:elasticbeanstalk:container:python",
+        "OptionName": "NumProcesses"
+      },
+      {
+        "Value": "15",
+        "Namespace": "aws:elasticbeanstalk:container:python",
+        "OptionName": "NumThreads"
+      },
+      {
+        "Value": "application",
+        "Namespace": "aws:elasticbeanstalk:container:python",
+        "OptionName": "WSGIPath"
+      },
+      {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      {
+        "Value": "LoadBalanced",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType"
+      },
+      {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      {
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      }
+    ],
+    "TemplateName": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Python 3.13"
+  },
+  "schema": {
+    "readOnly": ["TemplateName"],
+    "writeOnly": ["EnvironmentId"],
+    "createOnly": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "readOnlyPaths": ["TemplateName"],
+    "writeOnlyPaths": [
+      "EnvironmentId",
+      "SourceConfiguration.ApplicationName",
+      "SourceConfiguration.TemplateName"
+    ],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "EnvironmentId",
+      "PlatformArn",
+      "SolutionStackName",
+      "SourceConfiguration"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Any",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "360",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "4",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "ami-029dd4cce862b33fe",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Value": "t3.micro",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingLaunchConfiguration",
+        "Value": "5 minute",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Value": "tcp,22,22,0.0.0.0/0",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|BreachDuration]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "BreachDuration"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|EvaluationPeriods]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "EvaluationPeriods"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleDownPolicy",
+        "Value": "-1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|LowerThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "2000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "LowerThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|MeasureName]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "NetworkOut",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "MeasureName"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Period]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "5",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Period"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Statistic]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Average",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Statistic"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|Unit]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmLow",
+        "Value": "Bytes",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "Unit"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperBreachScaleIncrement]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingScaleUpPolicy",
+        "Value": "1",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperBreachScaleIncrement"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:trigger|UpperThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBCloudwatchAlarmHigh",
+        "Value": "6000000",
+        "Namespace": "aws:autoscaling:trigger",
+        "OptionName": "UpperThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "false",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "Time",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Value": "PT30M",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_python313_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Python.zip",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|EnvironmentVariables]",
+      "actual": {
+        "Value": "PYTHONPATH=/var/app/venv/staging-LQM1lest/bin",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_python313_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Value": "80",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Value": "t3",
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Value": "t3.micro, t3.small",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Value": "capacity-optimized",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Value": "70",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Value": "x86_64",
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Value": "public",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:application:environment|PYTHONPATH]",
+      "actual": {
+        "Value": "/var/app/venv/staging-LQM1lest/bin",
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "PYTHONPATH"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|StreamLogs]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Value": "7",
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Value": "100",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Value": "Percentage",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Value": "AllAtOnce",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Value": "600",
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:python|NumProcesses]",
+      "actual": {
+        "Value": "1",
+        "Namespace": "aws:elasticbeanstalk:container:python",
+        "OptionName": "NumProcesses"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:python|NumThreads]",
+      "actual": {
+        "Value": "15",
+        "Namespace": "aws:elasticbeanstalk:container:python",
+        "OptionName": "NumThreads"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:container:python|WSGIPath]",
+      "actual": {
+        "Value": "application",
+        "Namespace": "aws:elasticbeanstalk:container:python",
+        "OptionName": "WSGIPath"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Value": "22",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Value": "0",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Value": "Migration",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|LoadBalancerType]",
+      "actual": {
+        "Value": "classic",
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "LoadBalancerType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Value": "nginx",
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Value": "Ok",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Value": "enhanced",
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Value": "true",
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Value": "email",
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|HealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "3",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "HealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Interval]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "10",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Interval"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Target]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "TCP:80",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Target"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "Timeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:healthcheck|UnhealthyThreshold]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "5",
+        "Namespace": "aws:elb:healthcheck",
+        "OptionName": "UnhealthyThreshold"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstancePort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstancePort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|InstanceProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "InstanceProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "true",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:listener:80|ListenerProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:listener:80",
+        "OptionName": "ListenerProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|CrossZone]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "CrossZone"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "80",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerHTTPSPort]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "OFF",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerHTTPSPort"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTP",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|LoadBalancerSSLPortProtocol]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "HTTPS",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "LoadBalancerSSLPortProtocol"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:loadbalancer|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "{\"Ref\":\"AWSEBLoadBalancerSecurityGroup\"}",
+        "Namespace": "aws:elb:loadbalancer",
+        "OptionName": "SecurityGroups"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "false",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingEnabled"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionDrainingTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "20",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionDrainingTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:elb:policies|ConnectionSettingIdleTimeout]",
+      "actual": {
+        "ResourceName": "AWSEBLoadBalancer",
+        "Value": "60",
+        "Namespace": "aws:elb:policies",
+        "OptionName": "ConnectionSettingIdleTimeout"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Value": "false",
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase"
+      },
+      "nested": true,
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbTemplatePython",
+      "resourceType": "AWS::ElasticBeanstalk::ConfigurationTemplate",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Python 3.13 running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "CdkRealDriftIntegEbPlatforms-EbTemplatePython-z3sXWz5KEavX",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbTemplatePython"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnvRead.json
+++ b/tests/corpus/AWS__ElasticBeanstalk__Environment.EbEnvRead.json
@@ -1,0 +1,1628 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EbEnv",
+    "resourceType": "AWS::ElasticBeanstalk::Environment",
+    "physicalId": "cdkrd-hunt-ebpf-env",
+    "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv",
+    "declared": {
+      "ApplicationName": "cdkrd-hunt-ebpf-app",
+      "EnvironmentName": "cdkrd-hunt-ebpf-env",
+      "OptionSettings": [
+        {
+          "Namespace": "aws:elasticbeanstalk:environment",
+          "OptionName": "EnvironmentType",
+          "Value": "SingleInstance"
+        },
+        {
+          "Namespace": "aws:autoscaling:launchconfiguration",
+          "OptionName": "IamInstanceProfile",
+          "Value": "CdkRealDriftIntegEbPlatforms-EbInstanceProfile-QkbPGF6v1xPM"
+        },
+        {
+          "Namespace": "aws:elasticbeanstalk:application:environment",
+          "OptionName": "GREETING",
+          "Value": "hello-from-cdkrd"
+        },
+        {
+          "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+          "OptionName": "StreamLogs",
+          "Value": "true"
+        }
+      ],
+      "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker"
+    }
+  },
+  "liveRaw": {
+    "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+    "ApplicationName": "cdkrd-hunt-ebpf-app",
+    "EnvironmentName": "cdkrd-hunt-ebpf-env",
+    "Tier": {
+      "Type": "Standard",
+      "Version": "1.0",
+      "Name": "WebServer"
+    },
+    "SolutionStackName": "64bit Amazon Linux 2023 v4.13.3 running Docker",
+    "EndpointURL": "3.226.15.20",
+    "CNAMEPrefix": "cdkrd-hunt-ebpf-env",
+    "Tags": [],
+    "OptionSettings": [
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones",
+        "Value": "Any"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown",
+        "Value": "360"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Custom Availability Zones",
+        "Value": ""
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize",
+        "Value": "1"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "BlockDeviceMappings"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1",
+        "Value": "true"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "EC2KeyName"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "IamInstanceProfile",
+        "Value": "CdkRealDriftIntegEbPlatforms-EbInstanceProfile-QkbPGF6v1xPM"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId",
+        "Value": "ami-0787263f73f2dcb8b"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType",
+        "Value": "t3.micro"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "LaunchTemplateTagPropagationEnabled"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval",
+        "Value": "5 minute"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeIOPS"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeSize"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeThroughput"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeType"
+      },
+      {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction",
+        "Value": "tcp,22,22,0.0.0.0/0"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SecurityGroups",
+        "Value": "awseb-e-7k58e7ph74-stack-AWSEBSecurityGroup-uvld49GMKk65"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MaxBatchSize"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MinInstancesInService"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "PauseTime"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled",
+        "Value": "false"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType",
+        "Value": "Time"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout",
+        "Value": "PT30M"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables",
+        "Value": "GREETING=hello-from-cdkrd"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily",
+        "Value": "t3"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes",
+        "Value": "t3.micro, t3.small"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy",
+        "Value": "capacity-optimized"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotMaxPrice"
+      },
+      {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures",
+        "Value": "x86_64"
+      },
+      {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "AssociatePublicIpAddress"
+      },
+      {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme",
+        "Value": "public"
+      },
+      {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBSubnets"
+      },
+      {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "Subnets"
+      },
+      {
+        "ResourceName": "AWSEBSecurityGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "VPCId"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:application",
+        "OptionName": "Application Healthcheck URL",
+        "Value": ""
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:application:environment",
+        "OptionName": "GREETING",
+        "Value": "hello-from-cdkrd"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "StreamLogs",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize",
+        "Value": "100"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType",
+        "Value": "Percentage"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy",
+        "Value": "AllAtOnce"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout",
+        "Value": "600"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort",
+        "Value": "22"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout",
+        "Value": "0"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType",
+        "Value": "Migration"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "EnvironmentType",
+        "Value": "SingleInstance"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Bucket"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Key"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ServiceRole",
+        "Value": "AWSServiceRoleForElasticBeanstalk"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer",
+        "Value": "nginx"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument",
+        "Value": "{\"Version\":1,\"CloudWatchMetrics\":{\"Instance\":{\"CPUIrq\":null,\"LoadAverage5min\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"CPUUser\":null,\"LoadAverage1min\":null,\"ApplicationLatencyP50\":null,\"CPUIdle\":null,\"InstanceHealth\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"RootFilesystemUtil\":null,\"ApplicationLatencyP90\":null,\"CPUSystem\":null,\"ApplicationLatencyP75\":null,\"CPUSoftirq\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"CPUIowait\":null,\"CPUNice\":null},\"Environment\":{\"InstancesSevere\":null,\"InstancesDegraded\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP85\":null,\"InstancesUnknown\":null,\"ApplicationLatencyP90\":null,\"InstancesInfo\":null,\"InstancesPending\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP10\":null,\"ApplicationLatencyP99\":null,\"ApplicationRequestsTotal\":null,\"InstancesNoData\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests2xx\":null,\"InstancesOk\":null,\"InstancesWarning\":null}}}"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold",
+        "Value": "Ok"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType",
+        "Value": "enhanced"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "PreferredStartTime"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ServiceRoleForManagedUpdates",
+        "Value": ""
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "UpdateLevel"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances",
+        "Value": "true"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Endpoint"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol",
+        "Value": "email"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic ARN"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic Name"
+      },
+      {
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled",
+        "Value": "false"
+      },
+      {
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase",
+        "Value": "false"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["EndpointURL"],
+    "writeOnly": ["TemplateName"],
+    "createOnly": ["ApplicationName", "CNAMEPrefix", "EnvironmentName", "SolutionStackName"],
+    "readOnlyPaths": ["EndpointURL"],
+    "writeOnlyPaths": ["TemplateName"],
+    "createOnlyPaths": [
+      "ApplicationName",
+      "CNAMEPrefix",
+      "EnvironmentName",
+      "SolutionStackName",
+      "Tier.Name",
+      "Tier.Type"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["OptionSettings"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Availability Zones",
+        "Value": "Any"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Cooldown]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Cooldown",
+        "Value": "360"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|Custom Availability Zones]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "Custom Availability Zones",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|EnableCapacityRebalancing]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "EnableCapacityRebalancing",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|MaxSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MaxSize",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:asg|MinSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:asg",
+        "OptionName": "MinSize",
+        "Value": "1"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|BlockDeviceMappings]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "BlockDeviceMappings"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableDefaultEC2SecurityGroup]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableDefaultEC2SecurityGroup",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|DisableIMDSv1]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "DisableIMDSv1",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|EC2KeyName]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "EC2KeyName"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|ImageId]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "ImageId",
+        "Value": "ami-0787263f73f2dcb8b"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|InstanceType]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "InstanceType",
+        "Value": "t3.micro"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|LaunchTemplateTagPropagationEnabled]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "LaunchTemplateTagPropagationEnabled"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|MonitoringInterval]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "MonitoringInterval",
+        "Value": "5 minute"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeIOPS]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeIOPS"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeSize]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeSize"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeThroughput]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeThroughput"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|RootVolumeType]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "RootVolumeType"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SSHSourceRestriction]",
+      "actual": {
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SSHSourceRestriction",
+        "Value": "tcp,22,22,0.0.0.0/0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:launchconfiguration|SecurityGroups]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:autoscaling:launchconfiguration",
+        "OptionName": "SecurityGroups",
+        "Value": "awseb-e-7k58e7ph74-stack-AWSEBSecurityGroup-uvld49GMKk65"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|MaxBatchSize]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MaxBatchSize"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|MinInstancesInService]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "MinInstancesInService"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|PauseTime]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "PauseTime"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateEnabled]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|RollingUpdateType]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "RollingUpdateType",
+        "Value": "Time"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:autoscaling:updatepolicy:rollingupdate|Timeout]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:autoscaling:updatepolicy:rollingupdate",
+        "OptionName": "Timeout",
+        "Value": "PT30M"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|AppSource]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "AppSource",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/sampleapp/EBSampleApp-Docker.zip"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|EnvironmentVariables]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "EnvironmentVariables",
+        "Value": "GREETING=hello-from-cdkrd"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|HooksPkgUrl]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "HooksPkgUrl",
+        "Value": "https://elasticbeanstalk-platform-assets-us-east-1.s3.amazonaws.com/stalks/eb_docker_amazon_linux_2023_1.0.2939.0_20260625064821/lib/hooks.tar.gz"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstancePort]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstancePort",
+        "Value": "80"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:cloudformation:template:parameter|InstanceTypeFamily]",
+      "actual": {
+        "Namespace": "aws:cloudformation:template:parameter",
+        "OptionName": "InstanceTypeFamily",
+        "Value": "t3"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|EnableSpot]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "EnableSpot",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|InstanceTypes]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "InstanceTypes",
+        "Value": "t3.micro, t3.small"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotAllocationStrategy]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotAllocationStrategy",
+        "Value": "capacity-optimized"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandAboveBasePercentage]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandAboveBasePercentage",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotFleetOnDemandBase]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotFleetOnDemandBase",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SpotMaxPrice]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SpotMaxPrice"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:instances|SupportedArchitectures]",
+      "actual": {
+        "Namespace": "aws:ec2:instances",
+        "OptionName": "SupportedArchitectures",
+        "Value": "x86_64"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|AssociatePublicIpAddress]",
+      "actual": {
+        "ResourceName": "AWSEBEC2LaunchTemplate",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "AssociatePublicIpAddress"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|ELBScheme]",
+      "actual": {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBScheme",
+        "Value": "public"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|ELBSubnets]",
+      "actual": {
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "ELBSubnets"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|Subnets]",
+      "actual": {
+        "ResourceName": "AWSEBAutoScalingGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "Subnets"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:ec2:vpc|VPCId]",
+      "actual": {
+        "ResourceName": "AWSEBSecurityGroup",
+        "Namespace": "aws:ec2:vpc",
+        "OptionName": "VPCId"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:application|Application Healthcheck URL]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:application",
+        "OptionName": "Application Healthcheck URL",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|DeleteOnTerminate]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs|RetentionInDays]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|DeleteOnTerminate]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "DeleteOnTerminate",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|HealthStreamingEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "HealthStreamingEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:cloudwatch:logs:health|RetentionInDays]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:cloudwatch:logs:health",
+        "OptionName": "RetentionInDays",
+        "Value": "7"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSize]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSize",
+        "Value": "100"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|BatchSizeType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "BatchSizeType",
+        "Value": "Percentage"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|DeploymentPolicy]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "DeploymentPolicy",
+        "Value": "AllAtOnce"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|IgnoreHealthCheck]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "IgnoreHealthCheck",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:command|Timeout]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:command",
+        "OptionName": "Timeout",
+        "Value": "600"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|DefaultSSHPort]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "DefaultSSHPort",
+        "Value": "22"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchTimeout]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchTimeout",
+        "Value": "0"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|LaunchType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "LaunchType",
+        "Value": "Migration"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:control|RollbackLaunchOnFailure]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:control",
+        "OptionName": "RollbackLaunchOnFailure",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ExternalExtensionsS3Bucket]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Bucket"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ExternalExtensionsS3Key]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ExternalExtensionsS3Key"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment|ServiceRole]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment",
+        "OptionName": "ServiceRole",
+        "Value": "AWSServiceRoleForElasticBeanstalk"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:environment:proxy|ProxyServer]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:environment:proxy",
+        "OptionName": "ProxyServer",
+        "Value": "nginx"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|ConfigDocument]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "ConfigDocument",
+        "Value": "{\"CloudWatchMetrics\":{\"Environment\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"InstancesDegraded\":null,\"InstancesInfo\":null,\"InstancesNoData\":null,\"InstancesOk\":null,\"InstancesPending\":null,\"InstancesSevere\":null,\"InstancesUnknown\":null,\"InstancesWarning\":null},\"Instance\":{\"ApplicationLatencyP10\":null,\"ApplicationLatencyP50\":null,\"ApplicationLatencyP75\":null,\"ApplicationLatencyP85\":null,\"ApplicationLatencyP90\":null,\"ApplicationLatencyP95\":null,\"ApplicationLatencyP99\":null,\"ApplicationLatencyP99.9\":null,\"ApplicationRequests2xx\":null,\"ApplicationRequests3xx\":null,\"ApplicationRequests4xx\":null,\"ApplicationRequests5xx\":null,\"ApplicationRequestsTotal\":null,\"CPUIdle\":null,\"CPUIowait\":null,\"CPUIrq\":null,\"CPUNice\":null,\"CPUSoftirq\":null,\"CPUSystem\":null,\"CPUUser\":null,\"InstanceHealth\":null,\"LoadAverage1min\":null,\"LoadAverage5min\":null,\"RootFilesystemUtil\":null}},\"Version\":1}"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|EnhancedHealthAuthEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "EnhancedHealthAuthEnabled",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|HealthCheckSuccessThreshold]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "HealthCheckSuccessThreshold",
+        "Value": "Ok"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:healthreporting:system|SystemType]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:healthreporting:system",
+        "OptionName": "SystemType",
+        "Value": "enhanced"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:hostmanager|LogPublicationControl]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:hostmanager",
+        "OptionName": "LogPublicationControl",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ManagedActionsEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ManagedActionsEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|PreferredStartTime]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "PreferredStartTime"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions|ServiceRoleForManagedUpdates]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions",
+        "OptionName": "ServiceRoleForManagedUpdates",
+        "Value": ""
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|InstanceRefreshEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "InstanceRefreshEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:managedactions:platformupdate|UpdateLevel]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+        "OptionName": "UpdateLevel"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:monitoring|Automatically Terminate Unhealthy Instances]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:monitoring",
+        "OptionName": "Automatically Terminate Unhealthy Instances",
+        "Value": "true"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Endpoint]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Endpoint"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Protocol]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Protocol",
+        "Value": "email"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Topic ARN]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic ARN"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:sns:topics|Notification Topic Name]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:sns:topics",
+        "OptionName": "Notification Topic Name"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:elasticbeanstalk:xray|XRayEnabled]",
+      "actual": {
+        "Namespace": "aws:elasticbeanstalk:xray",
+        "OptionName": "XRayEnabled",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "OptionSettings[aws:rds:dbinstance|HasCoupledDatabase]",
+      "actual": {
+        "Namespace": "aws:rds:dbinstance",
+        "OptionName": "HasCoupledDatabase",
+        "Value": "false"
+      },
+      "nested": true,
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "PlatformArn",
+      "actual": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux 2023/4.13.3",
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EbEnv",
+      "resourceType": "AWS::ElasticBeanstalk::Environment",
+      "path": "Tier",
+      "actual": {
+        "Type": "Standard",
+        "Version": "1.0",
+        "Name": "WebServer"
+      },
+      "physicalId": "cdkrd-hunt-ebpf-env",
+      "constructPath": "CdkRealDriftIntegEbPlatforms/EbEnv"
+    }
+  ]
+}

--- a/tests/integration/eb-platforms-rich/app.ts
+++ b/tests/integration/eb-platforms-rich/app.ts
@@ -1,0 +1,93 @@
+// CDK app for the cdk-real-drift Elastic Beanstalk multi-platform + Environment-read test.
+// Two dimensions the earlier EB rounds (#598/#600/#603) did not cover:
+//   1. ConfigurationTemplates on NON-Docker platforms (Python / Node.js / Corretto / PHP) —
+//      the OptionSettings default tables were pinned only from the Docker platform, so a
+//      different platform may materialize options the tables miss (they must still fold to
+//      atDefault: zero potential drift). ConfigurationTemplates provision NOTHING → cheap.
+//   2. An Environment whose OptionSettings is now read back via the DescribeConfigurationSettings
+//      SDK supplement (was a writeOnly readGap) — a declared option must be VERIFIED and the
+//      service-filled extras must fold.
+import { App, CfnOutput, Stack } from "aws-cdk-lib";
+import {
+  CfnApplication,
+  CfnConfigurationTemplate,
+  CfnEnvironment,
+} from "aws-cdk-lib/aws-elasticbeanstalk";
+import { CfnInstanceProfile, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+
+const DOCKER = "64bit Amazon Linux 2023 v4.13.3 running Docker";
+const PLATFORMS: Record<string, string> = {
+  Python: "64bit Amazon Linux 2023 v4.13.3 running Python 3.13",
+  Node: "64bit Amazon Linux 2023 v6.11.3 running Node.js 22",
+  Corretto: "64bit Amazon Linux 2023 v4.12.3 running Corretto 21",
+  Php: "64bit Amazon Linux 2023 v4.13.3 running PHP 8.3",
+};
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEbPlatforms");
+
+const application = new CfnApplication(stack, "EbApp", {
+  applicationName: "cdkrd-hunt-ebpf-app",
+});
+
+// One ConfigurationTemplate per non-Docker platform (LoadBalanced, to exercise the richest
+// option surface). Cheap: a template launches nothing.
+for (const [name, solutionStackName] of Object.entries(PLATFORMS)) {
+  const t = new CfnConfigurationTemplate(stack, `EbTemplate${name}`, {
+    applicationName: application.applicationName!,
+    solutionStackName,
+    optionSettings: [
+      {
+        namespace: "aws:elasticbeanstalk:environment",
+        optionName: "EnvironmentType",
+        value: "LoadBalanced",
+      },
+    ],
+  });
+  t.addDependency(application);
+}
+
+// A Docker SingleInstance Environment whose OptionSettings is read back via the supplement.
+const instanceRole = new Role(stack, "EbInstanceRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  managedPolicies: [
+    { managedPolicyArn: "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier" },
+  ],
+});
+const instanceProfile = new CfnInstanceProfile(stack, "EbInstanceProfile", {
+  roles: [instanceRole.roleName],
+});
+const environment = new CfnEnvironment(stack, "EbEnv", {
+  applicationName: application.applicationName!,
+  environmentName: "cdkrd-hunt-ebpf-env",
+  solutionStackName: DOCKER,
+  optionSettings: [
+    {
+      namespace: "aws:elasticbeanstalk:environment",
+      optionName: "EnvironmentType",
+      value: "SingleInstance",
+    },
+    {
+      namespace: "aws:autoscaling:launchconfiguration",
+      optionName: "IamInstanceProfile",
+      value: instanceProfile.ref,
+    },
+    {
+      namespace: "aws:elasticbeanstalk:application:environment",
+      optionName: "GREETING",
+      value: "hello-from-cdkrd",
+    },
+    {
+      // a declared, readable, mutable option — the FN target for the supplement read
+      namespace: "aws:elasticbeanstalk:cloudwatch:logs",
+      optionName: "StreamLogs",
+      value: "true",
+    },
+  ],
+});
+environment.addDependency(application);
+
+new CfnOutput(stack, "ApplicationName", { value: application.applicationName! });
+new CfnOutput(stack, "EnvironmentName", { value: environment.environmentName! });
+
+app.synth();

--- a/tests/integration/eb-platforms-rich/cdk.json
+++ b/tests/integration/eb-platforms-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/eb-platforms-rich/package.json
+++ b/tests/integration/eb-platforms-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-eb-platforms-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift eb-platforms-rich multi-platform + Environment-read integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/eb-platforms-rich/verify.sh
+++ b/tests/integration/eb-platforms-rich/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Zero-potential-drift invariant test (real AWS) across EB platforms + an Environment read:
+#   - ConfigurationTemplates on Python / Node.js / Corretto / PHP (platform-specific option
+#     defaults must fold — the tables were originally pinned only from Docker).
+#   - A Docker SingleInstance Environment whose OptionSettings is read back via the
+#     DescribeConfigurationSettings SDK supplement (was a writeOnly readGap); its declared
+#     options are verified and the service-filled extras fold.
+# A `check` BEFORE record MUST be CLEAN — any [Potential Drift] is a fold gap. NOTE: this
+# fixture deploys a real Environment (one t3.micro, ~5 min), so it is not cheap.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEbPlatforms
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+if [ -n "${CDKRD_CORPUS_DIR:-}" ]; then
+  echo "=== [$STACK] harvest corpus (pre-record) ==="
+  $CLI check "$STACK" --region "$REGION" || true
+fi
+
+echo "=== [$STACK] check BEFORE record MUST be CLEAN (every platform + env option folds) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK-pre.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK potential drift on fresh templates/env ---"; fail "expected CLEAN before record (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -52,6 +52,10 @@ import {
   DescribeMetricFiltersCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import {
+  DescribeConfigurationSettingsCommand,
+  ElasticBeanstalkClient,
+} from '@aws-sdk/client-elastic-beanstalk';
+import {
   GetClassifierCommand,
   GetConnectionCommand,
   GetTableCommand,
@@ -109,6 +113,7 @@ const dlm = mockClient(DLMClient);
 const dms = mockClient(DatabaseMigrationServiceClient);
 const mediaconvert = mockClient(MediaConvertClient);
 const dax = mockClient(DAXClient);
+const eb = mockClient(ElasticBeanstalkClient);
 const lex = mockClient(LexModelsV2Client);
 
 const ctx = (declared: Record<string, unknown>, physicalId = '', accountId = '123456789012') => ({
@@ -144,6 +149,7 @@ beforeEach(() => {
     mediaconvert,
     dax,
     lex,
+    eb,
   ])
     m.reset();
 });
@@ -2832,6 +2838,52 @@ describe('DAX family (NON_PROVISIONABLE, issue #534)', () => {
   });
 });
 describe('SDK supplements', () => {
+  it('ElasticBeanstalk::Environment: projects OptionSettings from DescribeConfigurationSettings', async () => {
+    eb.on(DescribeConfigurationSettingsCommand).resolves({
+      ConfigurationSettings: [
+        {
+          OptionSettings: [
+            {
+              Namespace: 'aws:elasticbeanstalk:cloudwatch:logs',
+              OptionName: 'StreamLogs',
+              Value: 'true',
+            },
+            { Namespace: 'aws:ec2:vpc', OptionName: 'VPCId', Value: null as unknown as string },
+          ],
+        },
+      ],
+    });
+    const out = await SDK_SUPPLEMENTS['AWS::ElasticBeanstalk::Environment'](
+      ctx({ ApplicationName: 'my-app' }, 'my-env')
+    );
+    expect(out).toEqual({
+      OptionSettings: [
+        {
+          Namespace: 'aws:elasticbeanstalk:cloudwatch:logs',
+          OptionName: 'StreamLogs',
+          Value: 'true',
+        },
+        { Namespace: 'aws:ec2:vpc', OptionName: 'VPCId', Value: null },
+      ],
+    });
+    const call = eb.commandCalls(DescribeConfigurationSettingsCommand)[0]!.args[0].input;
+    expect(call).toEqual({ ApplicationName: 'my-app', EnvironmentName: 'my-env' });
+  });
+
+  it('ElasticBeanstalk::Environment: no ApplicationName or empty read → undefined (keep CC model)', async () => {
+    expect(
+      await SDK_SUPPLEMENTS['AWS::ElasticBeanstalk::Environment'](ctx({}, 'my-env'))
+    ).toBeUndefined();
+    eb.on(DescribeConfigurationSettingsCommand).resolves({
+      ConfigurationSettings: [{ OptionSettings: [] }],
+    });
+    expect(
+      await SDK_SUPPLEMENTS['AWS::ElasticBeanstalk::Environment'](
+        ctx({ ApplicationName: 'a' }, 'e')
+      )
+    ).toBeUndefined();
+  });
+
   it('Lex::Bot: reconstructs BotLocales (locale + custom slot type + intent + slot) from the lexv2-models tree walk', async () => {
     lex.on(ListBotLocalesCommand).resolves({ botLocaleSummaries: [{ localeId: 'en_US' }] });
     lex.on(DescribeBotLocaleCommand).resolves({


### PR DESCRIPTION
## EB OptionSettings completeness: read the Environment + multi-platform + null/empty defaults

The two follow-ups flagged after #603 (which pinned the fold only from the **Docker** platform's `ConfigurationTemplate`).

### 1. Read the Environment's OptionSettings (was a writeOnly readGap)

An EB `Environment`'s `OptionSettings` is `writeOnly` in the registry schema, so Cloud Control never echoes it — an out-of-band console edit to any environment option (log retention, an app env var, health config, …) was **invisible** (FN). Add:
- a `SDK_SUPPLEMENTS` reader (`elasticbeanstalk:DescribeConfigurationSettings`) projecting the full resolved option set,
- the `OVERRIDE_READABLE_WRITEONLY` exemption so it's compared,
- the `ebOptionSettingTier` fold applied to the Environment too (shared composite-subset spec).

A declared environment option is now **verified**; the service-filled extras fold. Live-proven: an out-of-band `StreamLogs` `true`→`false` on a declared option is detected.

### 2. Multi-platform + null/empty option defaults

The tables were pinned only from Docker. Add:
- **Platform-specific constants** (equality-gate) observed on Python / Corretto / PHP templates: `container:python` `NumProcesses`/`NumThreads`/`WSGIPath`, Corretto build-tool env vars (`M2`/`M2_HOME`/`GRADLE_HOME`), `container:php:phpini` (`memory_limit`, `max_execution_time`, …).
- **Value-independent** the moving/derived ones: the app `EnvironmentVariables` aggregate echo, the Python venv `PYTHONPATH` (random per-deploy staging path), the generated EC2 `SecurityGroups`, and `EnhancedHealthAuthEnabled` (reads `false` on a bare template but `true` on a live environment — differs by resource kind).
- **A universal null/empty-`Value` fold**: `DescribeConfigurationSettings` returns many *unset* option keys (`VPCId`, `RootVolume*`, `Notification*`, …) with a `null`/`""` Value. Unset is not drift; a change to a non-empty value still runs the tables (detection kept).

### Live verification (probe: 4 non-Docker templates + a Docker SingleInstance Environment)

- Fresh `check`-before-record is **CLEAN** across all (0 potential drift; 427 atDefault).
- A declared environment option change (`StreamLogs`, read via the supplement) is **detected**.

### Assets

- `eb-platforms-rich` fixture (+ `verify.sh`), 4 golden-corpus cases (Environment read + Python/PHP/Corretto templates), unit tests (supplement mock + null/empty/platform/value-independent fold tiers), and the README supplement-list entry.
- No new dependency (`@aws-sdk/client-elastic-beanstalk` already added in #600). `vp` typecheck / lint / pack / **2885 tests** pass.
