### PR TITLE
fix(noise): fold classic ELB HTTPS listener's AWS-assigned SSL negotiation Policies (zero first-run drift)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2062,7 +2062,17 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   user intent; a user who wants specific AZs declares AvailabilityZones instead of
   //   Subnets, which is then compared in the declared loop. Observed live on a fresh
   //   internal CLB (elb-classic-rich, 2026-07-07).
-  'AWS::ElasticLoadBalancing::LoadBalancer': new Set(['AvailabilityZones']),
+  //   AWS::ElasticLoadBalancing::LoadBalancer.Policies — a CLB with an HTTPS/SSL listener
+  //   that declares only a SSLCertificateId (no explicit SSL policy) reads back an
+  //   AWS-assigned SSL negotiation policy: `[{PolicyType:"SSLNegotiationPolicyType",
+  //   PolicyName:"ELBSecurityPolicy-2016-08", Attributes:[~100 cipher on/off flags]}]`. The
+  //   default predefined policy NAME AWS assigns moves over time as AWS publishes newer
+  //   security policies, and the huge cipher `Attributes` list is a derived function of the
+  //   name that cannot be practically pinned. Undeclared → whatever policy AWS assigned is
+  //   its default, not user intent; a user who wants a specific SSL policy declares
+  //   `Policies`, which is then compared in the declared loop. Observed live on a fresh
+  //   internet-facing CLB with an HTTPS listener (elb-classic-https, 2026-07-07).
+  'AWS::ElasticLoadBalancing::LoadBalancer': new Set(['AvailabilityZones', 'Policies']),
   //   AWS::ApiGateway::Authorizer.AuthType — a REST-API authorizer's schema carries NO
   //   `AuthType` property (the template declares `Type`: TOKEN / REQUEST /
   //   COGNITO_USER_POOLS); AWS DERIVES and reads back AuthType from it ("custom" for

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2719,6 +2719,27 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       expect(t.undeclared).toEqual([]);
     });
 
+    it('value-independent: an AWS-assigned SSL negotiation Policies bag folds (HTTPS listener)', () => {
+      const t = tiers(
+        classifyResource(
+          res(T, { Scheme: 'internet-facing' }),
+          {
+            Scheme: 'internet-facing',
+            Policies: [
+              {
+                PolicyType: 'SSLNegotiationPolicyType',
+                PolicyName: 'ELBSecurityPolicy-2016-08',
+                Attributes: [{ Name: 'Protocol-TLSv1.2', Value: 'true' }],
+              },
+            ],
+          },
+          emptySchema
+        )
+      );
+      expect(t.atDefault).toEqual(['Policies']);
+      expect(t.undeclared).toEqual([]);
+    });
+
     it('declared listener Protocol/InstanceProtocol are compared case-insensitively (no FP)', () => {
       const t = tiers(
         classifyResource(

--- a/tests/corpus/AWS__ElasticLoadBalancing__LoadBalancer.ClbHttps.json
+++ b/tests/corpus/AWS__ElasticLoadBalancing__LoadBalancer.ClbHttps.json
@@ -1,0 +1,931 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Clb487D7D46",
+    "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+    "physicalId": "CdkRealDr-Clb487D7-10MLS26VMORO9",
+    "constructPath": "CdkRealDriftIntegElbClassicHttps/Clb",
+    "declared": {
+      "CrossZone": true,
+      "HealthCheck": {
+        "HealthyThreshold": "2",
+        "Interval": "30",
+        "Target": "HTTP:80/",
+        "Timeout": "5",
+        "UnhealthyThreshold": "5"
+      },
+      "Listeners": [
+        {
+          "InstancePort": "80",
+          "InstanceProtocol": "http",
+          "LoadBalancerPort": "443",
+          "Protocol": "https",
+          "SSLCertificateId": "arn:aws:iam::111111111111:server-certificate/cdkrd-elb-https-hunt"
+        }
+      ],
+      "Scheme": "internet-facing",
+      "SecurityGroups": ["sg-0e2c1b4f8c663c6da"],
+      "Subnets": ["subnet-001501329c9f7420f", "subnet-033abed149c5f143b"]
+    }
+  },
+  "liveRaw": {
+    "SecurityGroups": ["sg-0e2c1b4f8c663c6da"],
+    "ConnectionDrainingPolicy": {
+      "Timeout": 300,
+      "Enabled": false
+    },
+    "Policies": [
+      {
+        "PolicyType": "SSLNegotiationPolicyType",
+        "PolicyName": "ELBSecurityPolicy-2016-08",
+        "Attributes": [
+          {
+            "Value": "ELBSecurityPolicy-2016-08",
+            "Name": "Reference-Security-Policy"
+          },
+          {
+            "Value": "true",
+            "Name": "Protocol-TLSv1"
+          },
+          {
+            "Value": "false",
+            "Name": "Protocol-SSLv3"
+          },
+          {
+            "Value": "true",
+            "Name": "Protocol-TLSv1.1"
+          },
+          {
+            "Value": "true",
+            "Name": "Protocol-TLSv1.2"
+          },
+          {
+            "Value": "true",
+            "Name": "Server-Defined-Cipher-Order"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-ECDSA-AES128-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-RSA-AES128-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-ECDSA-AES128-SHA"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-RSA-AES128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-AES128-SHA"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-RSA-AES256-GCM-SHA384"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-ECDSA-AES256-SHA384"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-RSA-AES256-SHA384"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-RSA-AES256-SHA"
+          },
+          {
+            "Value": "true",
+            "Name": "ECDHE-ECDSA-AES256-SHA"
+          },
+          {
+            "Value": "true",
+            "Name": "AES128-GCM-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "AES128-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "AES128-SHA"
+          },
+          {
+            "Value": "true",
+            "Name": "AES256-GCM-SHA384"
+          },
+          {
+            "Value": "true",
+            "Name": "AES256-SHA256"
+          },
+          {
+            "Value": "true",
+            "Name": "AES256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-AES128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "CAMELLIA128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EDH-RSA-DES-CBC3-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DES-CBC3-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ECDHE-RSA-RC4-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "RC4-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ECDHE-ECDSA-RC4-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-AES256-GCM-SHA384"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-AES256-GCM-SHA384"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-AES256-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-AES256-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-AES256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-AES256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-CAMELLIA256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-CAMELLIA256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "CAMELLIA256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EDH-DSS-DES-CBC3-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-AES128-GCM-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-AES128-GCM-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-AES128-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-AES128-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-CAMELLIA128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-CAMELLIA128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-AES128-GCM-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-AES128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-AES128-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-AES256-GCM-SHA384"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-AES256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-AES256-SHA256"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-CAMELLIA128-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-CAMELLIA256-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-DES-CBC3-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-RC4-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "ADH-SEED-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-DSS-SEED-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DHE-RSA-SEED-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EDH-DSS-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EDH-RSA-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "IDEA-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "RC4-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "SEED-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "DES-CBC3-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "DES-CBC-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "RC2-CBC-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "PSK-AES256-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "PSK-3DES-EDE-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "KRB5-DES-CBC3-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "KRB5-DES-CBC3-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "PSK-AES128-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "PSK-RC4-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "KRB5-RC4-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "KRB5-RC4-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "KRB5-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "KRB5-DES-CBC-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-EDH-RSA-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-EDH-DSS-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-ADH-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-RC2-CBC-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-KRB5-RC2-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-KRB5-DES-CBC-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-KRB5-RC2-CBC-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-KRB5-DES-CBC-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-ADH-RC4-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-RC4-MD5"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-KRB5-RC4-SHA"
+          },
+          {
+            "Value": "false",
+            "Name": "EXP-KRB5-RC4-MD5"
+          }
+        ],
+        "LoadBalancerPorts": [],
+        "InstancePorts": []
+      }
+    ],
+    "Scheme": "internet-facing",
+    "AvailabilityZones": ["us-east-1a", "us-east-1b"],
+    "SourceSecurityGroup": {
+      "GroupName": "CdkRealDriftIntegElbClassicHttps-ClbSecurityGroup02737D77-7LYGxXrVB1JJ",
+      "OwnerAlias": "111111111111"
+    },
+    "HealthCheck": {
+      "Target": "HTTP:80/",
+      "UnhealthyThreshold": "5",
+      "Timeout": "5",
+      "HealthyThreshold": "2",
+      "Interval": "30"
+    },
+    "CanonicalHostedZoneNameID": "Z35SXDOTRQ7X7K",
+    "CanonicalHostedZoneName": "CdkRealDr-Clb487D7-10MLS26VMORO9-330809204.us-east-1.elb.amazonaws.com",
+    "DNSName": "CdkRealDr-Clb487D7-10MLS26VMORO9-330809204.us-east-1.elb.amazonaws.com",
+    "LoadBalancerName": "CdkRealDr-Clb487D7-10MLS26VMORO9",
+    "Listeners": [
+      {
+        "PolicyNames": ["ELBSecurityPolicy-2016-08"],
+        "InstancePort": "80",
+        "LoadBalancerPort": "443",
+        "Protocol": "HTTPS",
+        "SSLCertificateId": "arn:aws:iam::111111111111:server-certificate/cdkrd-elb-https-hunt",
+        "InstanceProtocol": "HTTP"
+      }
+    ],
+    "Subnets": ["subnet-001501329c9f7420f", "subnet-033abed149c5f143b"],
+    "CrossZone": true,
+    "AppCookieStickinessPolicy": [],
+    "LBCookieStickinessPolicy": [],
+    "ConnectionSettings": {
+      "IdleTimeout": 60
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegElbClassicHttps/17540110-7a11-11f1-9919-0affdae009b1",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegElbClassicHttps",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Clb487D7D46",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CanonicalHostedZoneName",
+      "CanonicalHostedZoneNameID",
+      "DNSName",
+      "SourceSecurityGroup"
+    ],
+    "writeOnly": [],
+    "createOnly": ["LoadBalancerName", "Scheme"],
+    "readOnlyPaths": [
+      "CanonicalHostedZoneName",
+      "CanonicalHostedZoneNameID",
+      "DNSName",
+      "SourceSecurityGroup",
+      "SourceSecurityGroup.GroupName",
+      "SourceSecurityGroup.OwnerAlias"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["LoadBalancerName", "Scheme"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "ConnectionDrainingPolicy",
+      "actual": {
+        "Timeout": 300,
+        "Enabled": false
+      },
+      "physicalId": "CdkRealDr-Clb487D7-10MLS26VMORO9",
+      "constructPath": "CdkRealDriftIntegElbClassicHttps/Clb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "Policies",
+      "actual": [
+        {
+          "PolicyType": "SSLNegotiationPolicyType",
+          "PolicyName": "ELBSecurityPolicy-2016-08",
+          "Attributes": [
+            {
+              "Value": "false",
+              "Name": "ADH-AES128-GCM-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-AES128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-AES128-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-AES256-GCM-SHA384"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-AES256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-AES256-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-CAMELLIA128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-CAMELLIA256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-DES-CBC3-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-RC4-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "ADH-SEED-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "AES128-GCM-SHA256"
+            },
+            {
+              "Value": "true",
+              "Name": "AES128-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "AES128-SHA256"
+            },
+            {
+              "Value": "true",
+              "Name": "AES256-GCM-SHA384"
+            },
+            {
+              "Value": "true",
+              "Name": "AES256-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "AES256-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "CAMELLIA128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "CAMELLIA256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DES-CBC-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DES-CBC3-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "DES-CBC3-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-AES128-GCM-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-AES128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-AES128-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-AES256-GCM-SHA384"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-AES256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-AES256-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-CAMELLIA128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-CAMELLIA256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-DSS-SEED-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-AES128-GCM-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-AES128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-AES128-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-AES256-GCM-SHA384"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-AES256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-AES256-SHA256"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-CAMELLIA128-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-CAMELLIA256-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "DHE-RSA-SEED-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-ECDSA-AES128-GCM-SHA256"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-ECDSA-AES128-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-ECDSA-AES128-SHA256"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-ECDSA-AES256-GCM-SHA384"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-ECDSA-AES256-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-ECDSA-AES256-SHA384"
+            },
+            {
+              "Value": "false",
+              "Name": "ECDHE-ECDSA-RC4-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-RSA-AES128-GCM-SHA256"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-RSA-AES128-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-RSA-AES128-SHA256"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-RSA-AES256-GCM-SHA384"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-RSA-AES256-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "ECDHE-RSA-AES256-SHA384"
+            },
+            {
+              "Value": "false",
+              "Name": "ECDHE-RSA-RC4-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EDH-DSS-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EDH-DSS-DES-CBC3-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EDH-RSA-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EDH-RSA-DES-CBC3-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-ADH-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-ADH-RC4-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-EDH-DSS-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-EDH-RSA-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-KRB5-DES-CBC-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-KRB5-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-KRB5-RC2-CBC-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-KRB5-RC2-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-KRB5-RC4-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-KRB5-RC4-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-RC2-CBC-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "EXP-RC4-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "IDEA-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "KRB5-DES-CBC-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "KRB5-DES-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "KRB5-DES-CBC3-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "KRB5-DES-CBC3-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "KRB5-RC4-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "KRB5-RC4-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "PSK-3DES-EDE-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "PSK-AES128-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "PSK-AES256-CBC-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "PSK-RC4-SHA"
+            },
+            {
+              "Value": "false",
+              "Name": "Protocol-SSLv3"
+            },
+            {
+              "Value": "true",
+              "Name": "Protocol-TLSv1"
+            },
+            {
+              "Value": "true",
+              "Name": "Protocol-TLSv1.1"
+            },
+            {
+              "Value": "true",
+              "Name": "Protocol-TLSv1.2"
+            },
+            {
+              "Value": "false",
+              "Name": "RC2-CBC-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "RC4-MD5"
+            },
+            {
+              "Value": "false",
+              "Name": "RC4-SHA"
+            },
+            {
+              "Value": "ELBSecurityPolicy-2016-08",
+              "Name": "Reference-Security-Policy"
+            },
+            {
+              "Value": "false",
+              "Name": "SEED-SHA"
+            },
+            {
+              "Value": "true",
+              "Name": "Server-Defined-Cipher-Order"
+            }
+          ],
+          "LoadBalancerPorts": [],
+          "InstancePorts": []
+        }
+      ],
+      "physicalId": "CdkRealDr-Clb487D7-10MLS26VMORO9",
+      "constructPath": "CdkRealDriftIntegElbClassicHttps/Clb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "AvailabilityZones",
+      "actual": ["us-east-1a", "us-east-1b"],
+      "physicalId": "CdkRealDr-Clb487D7-10MLS26VMORO9",
+      "constructPath": "CdkRealDriftIntegElbClassicHttps/Clb"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Clb487D7D46",
+      "resourceType": "AWS::ElasticLoadBalancing::LoadBalancer",
+      "path": "ConnectionSettings",
+      "actual": {
+        "IdleTimeout": 60
+      },
+      "physicalId": "CdkRealDr-Clb487D7-10MLS26VMORO9",
+      "constructPath": "CdkRealDriftIntegElbClassicHttps/Clb"
+    }
+  ]
+}

--- a/tests/integration/elb-classic-https/app.ts
+++ b/tests/integration/elb-classic-https/app.ts
@@ -1,0 +1,46 @@
+// CDK app for the cdk-real-drift elb-classic-https integration test. A follow-up to
+// elb-classic-rich (#604) covering the UNEXERCISED classic-ELB angle: an
+// INTERNET-FACING LoadBalancer with an HTTPS listener. An HTTPS/SSL listener makes
+// AWS auto-assign a default SSL negotiation `Policies` entry (an
+// `ELBSecurityPolicy-*` reference security policy) that the template never declares —
+// a fresh undeclared-fill class the internal HTTP-only #604 fixture could not surface.
+// Per the core invariant a clean deploy must produce ZERO [Potential Drift] on a first
+// `check`. The HTTPS listener needs a server certificate; the verify script uploads a
+// self-signed IAM server certificate and passes its ARN via `-c certArn=...`.
+import { App, Stack } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import {
+  LoadBalancer,
+  LoadBalancingProtocol,
+} from "aws-cdk-lib/aws-elasticloadbalancing";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegElbClassicHttps");
+
+const certArn = stack.node.tryGetContext("certArn");
+if (!certArn) throw new Error("pass -c certArn=<iam-server-cert-arn>");
+
+const vpc = new Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [{ name: "pub", subnetType: SubnetType.PUBLIC, cidrMask: 24 }],
+});
+
+// Internet-facing CLB with an HTTPS listener. Only the listener + cert are declared;
+// AWS's auto-assigned SSL negotiation Policies, ConnectionSettings, and
+// ConnectionDrainingPolicy are left undeclared so a first `check` surfaces any fill.
+const lb = new LoadBalancer(stack, "Clb", {
+  vpc,
+  internetFacing: true,
+  healthCheck: { port: 80 },
+});
+
+lb.addListener({
+  externalPort: 443,
+  externalProtocol: LoadBalancingProtocol.HTTPS,
+  internalPort: 80,
+  internalProtocol: LoadBalancingProtocol.HTTP,
+  sslCertificateArn: certArn,
+});
+
+app.synth();

--- a/tests/integration/elb-classic-https/cdk.json
+++ b/tests/integration/elb-classic-https/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/elb-classic-https/package.json
+++ b/tests/integration/elb-classic-https/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-elb-classic-https",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/elb-classic-https/verify.sh
+++ b/tests/integration/elb-classic-https/verify.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): an internet-facing classic ELB with an
+# HTTPS listener. Uploads a self-signed IAM server certificate (deleted on cleanup),
+# then a FIRST `check` BEFORE `record` MUST be CLEAN (core invariant), and record ->
+# check MUST also be CLEAN. Exercises AWS's auto-assigned SSL negotiation Policies.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegElbClassicHttps; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+CERTNAME=cdkrd-elb-https-hunt
+cleanup(){
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -c certArn="$CERTARN" -f -y >/dev/null 2>&1 || true
+  aws iam delete-server-certificate --server-certificate-name "$CERTNAME" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== upload self-signed IAM server certificate ==="
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/elbhttps.key -out /tmp/elbhttps.crt \
+  -subj "/CN=cdkrd-elb-https-test.example.com" 2>/dev/null || fail gen-cert
+CERTARN=$(aws iam upload-server-certificate --server-certificate-name "$CERTNAME" \
+  --certificate-body file:///tmp/elbhttps.crt --private-key file:///tmp/elbhttps.key \
+  --query 'ServerCertificateMetadata.Arn' --output text 2>/dev/null) \
+  || CERTARN=$(aws iam get-server-certificate --server-certificate-name "$CERTNAME" \
+       --query 'ServerCertificate.ServerCertificateMetadata.Arn' --output text)
+[ -n "$CERTARN" ] || fail cert-arn
+sleep 8 # let IAM propagate the cert before ELB references it
+
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" -c certArn="$CERTARN" --require-approval never || fail deploy
+echo "=== first check (no baseline) MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" -c certArn="$CERTARN" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected first-check CLEAN got $rc"
+echo "=== record ==="; $CLI record "$STACK" --region "$REGION" -c certArn="$CERTARN" --yes || fail record
+echo "=== check MUST be CLEAN ==="; $CLI check "$STACK" --region "$REGION" -c certArn="$CERTARN" --fail
+rc=$?; [ "$rc" -eq 0 ] || fail "expected CLEAN got $rc"
+echo "INTEG PASS ($STACK)"


### PR DESCRIPTION
## What

Follow-up to #604 covering the **unexercised** classic-ELB angle: an
**internet-facing** `AWS::ElasticLoadBalancing::LoadBalancer` with an **HTTPS
listener**. #604's fixture was internal + HTTP-only, so it could not surface the
one undeclared fill an HTTPS listener triggers.

A fresh internet-facing CLB with an HTTPS listener produced **1 false positive** on
a first `check` before `record` (violating the core invariant):

```
Policies=[{PolicyType:"SSLNegotiationPolicyType",
           PolicyName:"ELBSecurityPolicy-2016-08",
           Attributes:[~100 cipher on/off flags]}]
```

AWS auto-assigns a default SSL negotiation policy the template never declared (it
declared only `SSLCertificateId`).

### Fix (`src/normalize/noise.ts`)

`Policies` → `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`: the default predefined
policy **name** AWS assigns moves over time as AWS publishes newer security policies,
and the derived cipher `Attributes` list can't be practically pinned. Undeclared →
not user intent; a user who wants a specific SSL policy declares `Policies`, which is
then compared in the declared loop.

## Live-verified (real AWS, us-east-1)

- Internet-facing CLB + HTTPS listener (self-signed IAM server certificate).
- First `check` (no baseline) → **CLEAN** (atDefault=12).
- The #604 folds (`ConnectionSettings` / `ConnectionDrainingPolicy` /
  `AvailabilityZones`) and the case-insensitive listener protocol (`https`→`HTTPS`)
  all hold on this internet-facing config too.

## Tests

- New golden-corpus case `AWS__ElasticLoadBalancing__LoadBalancer.ClbHttps` (distinct
  from #604's internal-HTTP case; replayed offline by `corpus-replay`).
- 1 `classify` unit test (SSL negotiation `Policies` folds value-independent).
- Regression fixture `tests/integration/elb-classic-https/` (self-signed IAM cert +
  cleanup).

Core integration fixtures (basic/lambda/iam/revert/policies) all `INTEG PASS`; orphan
sweep CLEAN.
