### PR TITLE
fix(report): show unordered-object-array drift at the TEMPLATE index, not the sorted index

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -863,6 +863,32 @@ export function normalizeLiveModel(
   return live;
 }
 
+// A per-element drift inside an UNORDERED_OBJECT_ARRAY is computed on arrays SORTED by
+// canonical JSON on both sides, so the drift path's leading array index is the SORTED
+// position — which need not match the user's TEMPLATE order (declared [require_ssl,
+// enable_user_activity_logging, …] sorts to [enable_user_activity_logging, …], so a
+// change to the 2nd declared entry reports as index 0). Re-map that index back to the
+// element's position in the raw (template-order) declared array so the reported path
+// matches what the user actually wrote. Display-only: revert reads Finding.wholeArrayRevert
+// (a whole-array replace), never this index. Falls back to the sorted path if the element
+// can't be located (e.g. a type whose nested sub-arrays were also re-sorted, so the sorted
+// element no longer deep-equals its raw form).
+function remapSortedIndexToDeclared(
+  path: string,
+  arrayKey: string,
+  sortedDeclared: unknown[],
+  rawDeclared: unknown[]
+): string {
+  const prefix = `${arrayKey}.`;
+  if (!path.startsWith(prefix)) return path;
+  const m = /^(\d+)(\..*|)$/.exec(path.slice(prefix.length));
+  if (!m) return path;
+  const el = sortedDeclared[Number(m[1])];
+  if (el === undefined) return path;
+  const rawIdx = rawDeclared.findIndex((e) => deepEqual(e, el));
+  return rawIdx < 0 ? path : `${arrayKey}.${rawIdx}${m[2]}`;
+}
+
 export function classifyResource(
   resource: DesiredResource,
   liveRaw: Record<string, unknown>,
@@ -1743,6 +1769,20 @@ export function classifyResource(
         deepEqual(d.awsValue, knownDef[d.path])
       )
         continue;
+      // An UNORDERED_OBJECT_ARRAY element drift: the array was sorted on BOTH sides before
+      // this per-element diff, so `d.path`'s index is the SORTED position — which does not
+      // map to the live array's raw index (a Cloud Control sub-path patch would hit the wrong
+      // live element) NOR to the user's template order. Re-map the reported index to the raw
+      // TEMPLATE position so the path matches what the user wrote, and carry the WHOLE (raw,
+      // template-order) declared array so the revert plan collapses these into one whole-array
+      // replacement (revert reads wholeArrayRevert, never the index).
+      const unorderedExtra =
+        unorderedObjArray && Array.isArray(declaredVal) && Array.isArray(v)
+          ? {
+              path: remapSortedIndexToDeclared(d.path, k, declaredVal, v),
+              wholeArrayRevert: { path: k, value: v },
+            }
+          : {};
       findings.push({
         tier: 'declared',
         logicalId,
@@ -1750,13 +1790,7 @@ export function classifyResource(
         path: d.path,
         desired: d.stateValue,
         actual: d.awsValue,
-        // An UNORDERED_OBJECT_ARRAY element drift: the array was sorted on BOTH sides
-        // before this per-element diff, so `d.path`'s index is the SORTED position, which
-        // does NOT map to the live array's raw index — a Cloud Control sub-path patch would
-        // hit the wrong live element. Carry the WHOLE (raw, template-order) declared array so
-        // the revert plan collapses these into one whole-array replacement. The REPORT still
-        // shows this precise per-element line; only revert reads `wholeArrayRevert`.
-        ...(unorderedObjArray ? { wholeArrayRevert: { path: k, value: v } } : {}),
+        ...unorderedExtra,
       });
     }
   }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -4023,6 +4023,28 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
       };
       expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
     });
+
+    it('reports the drift at the TEMPLATE index, not the sorted index (remapSortedIndexToDeclared)', () => {
+      // Template order is deliberately NON-sorted: 192.168.0.0/24 is declared FIRST
+      // (index 0) but sorts LAST (canonical JSON "10.0…" < "10.1…" < "192…"). Editing
+      // its Description must report `Entries.0.…` (the user's template position), not the
+      // sorted `Entries.2.…` — otherwise the index points at a different declared entry.
+      const declaredUnsorted = {
+        Entries: [
+          { Cidr: '192.168.0.0/24', Description: 'branch' },
+          { Cidr: '10.0.0.0/16', Description: 'corp-a' },
+          { Cidr: '10.1.0.0/16', Description: 'corp-b' },
+        ],
+      };
+      const live = {
+        Entries: [
+          { Cidr: '10.0.0.0/16', Description: 'corp-a' },
+          { Cidr: '10.1.0.0/16', Description: 'corp-b' },
+          { Cidr: '192.168.0.0/24', Description: 'CHANGED' },
+        ],
+      };
+      expect(declaredTiers(T, declaredUnsorted, live)).toEqual(['Entries.0.Description']);
+    });
   });
 
   describe('AutoScaling group MetricsCollection.Metrics / NotificationConfigurations.NotificationTypes reordered (nested scalar sets, found by asg-notification-metrics)', () => {


### PR DESCRIPTION
## Report the TEMPLATE index for unordered-object-array drift

Follow-up to #605. An `UNORDERED_OBJECT_ARRAY` (SecurityGroup rules, PrefixList
`Entries`, Redshift `ClusterParameterGroup` `Parameters`, IAM inline `Policies`, …) is
compared with **both** sides sorted by canonical JSON, so a per-element declared-drift
finding's leading array index was the **sorted** position — which need not match the
user's **template** order.

Example: a param group declaring
`[require_ssl, enable_user_activity_logging, max_concurrency_scaling_clusters]` sorts to
`[enable_user_activity_logging, …]`, so an out-of-band edit to the **2nd** declared
parameter reported as `Parameters.0.ParameterValue` — an index pointing at a *different*
declared entry than the one that changed.

### Fix
`remapSortedIndexToDeclared` re-maps the reported index back to the element's position in
the raw (template-order) declared array, so the path matches what the user wrote
(`Parameters.1.…`). **Display-only** — revert reads `Finding.wholeArrayRevert` (a
whole-array replace), never this index, so convergence is unaffected. Falls back to the
sorted path when the element can't be located (a type whose nested sub-arrays were also
re-sorted no longer deep-equals its raw form).

### Verification
- **Live** on a real Redshift `ClusterParameterGroup`: an out-of-band
  `enable_user_activity_logging` edit now reports `Parameters.1.ParameterValue`
  (template index) instead of `.0` (sorted); `revert` still converges CLEAN. This
  **also** confirms #605's whole-array-revert generalization holds live on a *second*
  CC-reverted unordered-object-array type (not just PrefixList).
- Unit test in `classify.test.ts` (template order deliberately non-sorted); all unit
  tests pass; typecheck / lint+format / build green.
