### PR TITLE
fix(noise): fold Amazon Location first-run defaults (all 5 types) + converge Tracker PositionFiltering revert

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -998,12 +998,30 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     ],
   },
   // Amazon Location deprecated `PricingPlan` parameter — the service echoes the constant
-  // "RequestBasedUsage" on every tracker / geofence collection even though the parameter
-  // is deprecated and un-settable (observed live on hunt 2026-07-03, #492). Equality-gated.
+  // "RequestBasedUsage" on EVERY Location resource (tracker / geofence collection / place
+  // index / map / route calculator) even though the parameter is deprecated and
+  // un-settable (observed live on hunt 2026-07-03 #492, then on all five types
+  // location-rich 2026-07-07). Equality-gated. Also folds each type's other constant
+  // first-run defaults the template never declares: a Tracker with no PositionFiltering
+  // reads back "TimeBased" (the service default; AccuracyBased/DistanceBased are the other
+  // settable values, so a change re-surfaces), and a PlaceIndex with no
+  // DataSourceConfiguration reads back {IntendedUse:"SingleUse"} (the default; "Storage"
+  // is the other value). Both observed live on a fresh location-rich stack (2026-07-07).
   'AWS::Location::Tracker': {
     PricingPlan: 'RequestBasedUsage',
+    PositionFiltering: 'TimeBased',
   },
   'AWS::Location::GeofenceCollection': {
+    PricingPlan: 'RequestBasedUsage',
+  },
+  'AWS::Location::PlaceIndex': {
+    PricingPlan: 'RequestBasedUsage',
+    DataSourceConfiguration: { IntendedUse: 'SingleUse' },
+  },
+  'AWS::Location::Map': {
+    PricingPlan: 'RequestBasedUsage',
+  },
+  'AWS::Location::RouteCalculator': {
     PricingPlan: 'RequestBasedUsage',
   },
   // hunt 2026-07-03 round B (#496): constant service defaults on zero-coverage type

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -103,6 +103,11 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // idempotent whether or not the omit no-ops.
   'AWS::AppRunner::Service\0HealthCheckConfiguration',
   'AWS::AppRunner::Service\0NetworkConfiguration',
+  // Amazon Location UpdateTracker IGNORES an omitted PositionFiltering (live-observed on
+  // location-rich 2026-07-07: a `remove` revert of an out-of-band AccuracyBased reported
+  // SUCCESS yet the live value stayed AccuracyBased — "1 drift remain"). Write the
+  // "TimeBased" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
+  'AWS::Location::Tracker\0PositionFiltering',
 ]);
 
 /**

--- a/tests/corpus/AWS__Location__GeofenceCollection.GeofenceCollection.json
+++ b/tests/corpus/AWS__Location__GeofenceCollection.GeofenceCollection.json
@@ -1,0 +1,53 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GeofenceCollection",
+    "resourceType": "AWS::Location::GeofenceCollection",
+    "physicalId": "cdkrd-geofence-rich",
+    "constructPath": "CdkRealDriftIntegLocationRich/GeofenceCollection",
+    "declared": {
+      "CollectionName": "cdkrd-geofence-rich",
+      "Description": "cdkrd location geofence collection rich"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd location geofence collection rich",
+    "CollectionArn": "arn:aws:geo:us-east-1:111111111111:geofence-collection/cdkrd-geofence-rich",
+    "CollectionName": "cdkrd-geofence-rich",
+    "CreateTime": "2026-07-07T14:46:07.390Z",
+    "UpdateTime": "2026-07-07T14:46:07.390Z",
+    "PricingPlan": "RequestBasedUsage",
+    "Arn": "arn:aws:geo:us-east-1:111111111111:geofence-collection/cdkrd-geofence-rich",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "CollectionArn", "CreateTime", "UpdateTime"],
+    "writeOnly": [],
+    "createOnly": ["CollectionName", "KmsKeyId"],
+    "readOnlyPaths": ["Arn", "CollectionArn", "CreateTime", "UpdateTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["CollectionName", "KmsKeyId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "GeofenceCollection",
+      "resourceType": "AWS::Location::GeofenceCollection",
+      "path": "PricingPlan",
+      "actual": "RequestBasedUsage",
+      "physicalId": "cdkrd-geofence-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/GeofenceCollection"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Location__Map.Map.json
+++ b/tests/corpus/AWS__Location__Map.Map.json
@@ -1,0 +1,60 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Map",
+    "resourceType": "AWS::Location::Map",
+    "physicalId": "cdkrd-map-rich",
+    "constructPath": "CdkRealDriftIntegLocationRich/Map",
+    "declared": {
+      "Configuration": {
+        "Style": "VectorEsriNavigation"
+      },
+      "Description": "cdkrd location map rich",
+      "MapName": "cdkrd-map-rich"
+    }
+  },
+  "liveRaw": {
+    "MapName": "cdkrd-map-rich",
+    "Description": "cdkrd location map rich",
+    "Configuration": {
+      "Style": "VectorEsriNavigation",
+      "CustomLayers": []
+    },
+    "CreateTime": "2026-07-07T14:46:07.502Z",
+    "UpdateTime": "2026-07-07T14:46:07.502Z",
+    "PricingPlan": "RequestBasedUsage",
+    "Arn": "arn:aws:geo:us-east-1:111111111111:map/cdkrd-map-rich",
+    "MapArn": "arn:aws:geo:us-east-1:111111111111:map/cdkrd-map-rich",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreateTime", "MapArn", "UpdateTime"],
+    "writeOnly": [],
+    "createOnly": ["Configuration", "MapName"],
+    "readOnlyPaths": ["Arn", "CreateTime", "MapArn", "UpdateTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Configuration", "MapName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Map",
+      "resourceType": "AWS::Location::Map",
+      "path": "PricingPlan",
+      "actual": "RequestBasedUsage",
+      "physicalId": "cdkrd-map-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/Map"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Location__PlaceIndex.PlaceIndex.json
+++ b/tests/corpus/AWS__Location__PlaceIndex.PlaceIndex.json
@@ -1,0 +1,69 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "PlaceIndex",
+    "resourceType": "AWS::Location::PlaceIndex",
+    "physicalId": "cdkrd-place-index-rich",
+    "constructPath": "CdkRealDriftIntegLocationRich/PlaceIndex",
+    "declared": {
+      "DataSource": "Esri",
+      "Description": "cdkrd location place index rich",
+      "IndexName": "cdkrd-place-index-rich"
+    }
+  },
+  "liveRaw": {
+    "IndexName": "cdkrd-place-index-rich",
+    "Description": "cdkrd location place index rich",
+    "IndexArn": "arn:aws:geo:us-east-1:111111111111:place-index/cdkrd-place-index-rich",
+    "CreateTime": "2026-07-07T14:46:07.517Z",
+    "UpdateTime": "2026-07-07T14:46:07.517Z",
+    "PricingPlan": "RequestBasedUsage",
+    "DataSourceConfiguration": {
+      "IntendedUse": "SingleUse"
+    },
+    "Arn": "arn:aws:geo:us-east-1:111111111111:place-index/cdkrd-place-index-rich",
+    "Tags": [],
+    "DataSource": "Esri"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreateTime", "IndexArn", "UpdateTime"],
+    "writeOnly": [],
+    "createOnly": ["DataSource", "IndexName"],
+    "readOnlyPaths": ["Arn", "CreateTime", "IndexArn", "UpdateTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["DataSource", "IndexName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "PlaceIndex",
+      "resourceType": "AWS::Location::PlaceIndex",
+      "path": "PricingPlan",
+      "actual": "RequestBasedUsage",
+      "physicalId": "cdkrd-place-index-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/PlaceIndex"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "PlaceIndex",
+      "resourceType": "AWS::Location::PlaceIndex",
+      "path": "DataSourceConfiguration",
+      "actual": {
+        "IntendedUse": "SingleUse"
+      },
+      "physicalId": "cdkrd-place-index-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/PlaceIndex"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Location__RouteCalculator.RouteCalculator.json
+++ b/tests/corpus/AWS__Location__RouteCalculator.RouteCalculator.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RouteCalculator",
+    "resourceType": "AWS::Location::RouteCalculator",
+    "physicalId": "cdkrd-route-calculator-rich",
+    "constructPath": "CdkRealDriftIntegLocationRich/RouteCalculator",
+    "declared": {
+      "CalculatorName": "cdkrd-route-calculator-rich",
+      "DataSource": "Esri",
+      "Description": "cdkrd location route calculator rich"
+    }
+  },
+  "liveRaw": {
+    "CalculatorName": "cdkrd-route-calculator-rich",
+    "Description": "cdkrd location route calculator rich",
+    "CreateTime": "2026-07-07T14:46:07.469Z",
+    "UpdateTime": "2026-07-07T14:46:07.469Z",
+    "PricingPlan": "RequestBasedUsage",
+    "CalculatorArn": "arn:aws:geo:us-east-1:111111111111:route-calculator/cdkrd-route-calculator-rich",
+    "Arn": "arn:aws:geo:us-east-1:111111111111:route-calculator/cdkrd-route-calculator-rich",
+    "Tags": [],
+    "DataSource": "Esri"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CalculatorArn", "CreateTime", "UpdateTime"],
+    "writeOnly": [],
+    "createOnly": ["CalculatorName", "DataSource"],
+    "readOnlyPaths": ["Arn", "CalculatorArn", "CreateTime", "UpdateTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["CalculatorName", "DataSource"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RouteCalculator",
+      "resourceType": "AWS::Location::RouteCalculator",
+      "path": "PricingPlan",
+      "actual": "RequestBasedUsage",
+      "physicalId": "cdkrd-route-calculator-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/RouteCalculator"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Location__Tracker.Tracker.json
+++ b/tests/corpus/AWS__Location__Tracker.Tracker.json
@@ -1,0 +1,64 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Tracker",
+    "resourceType": "AWS::Location::Tracker",
+    "physicalId": "cdkrd-tracker-rich",
+    "constructPath": "CdkRealDriftIntegLocationRich/Tracker",
+    "declared": {
+      "Description": "cdkrd location tracker rich",
+      "TrackerName": "cdkrd-tracker-rich"
+    }
+  },
+  "liveRaw": {
+    "TrackerName": "cdkrd-tracker-rich",
+    "Description": "cdkrd location tracker rich",
+    "EventBridgeEnabled": false,
+    "CreateTime": "2026-07-07T14:46:07.493Z",
+    "UpdateTime": "2026-07-07T14:46:07.493Z",
+    "PricingPlan": "RequestBasedUsage",
+    "PositionFiltering": "TimeBased",
+    "Arn": "arn:aws:geo:us-east-1:111111111111:tracker/cdkrd-tracker-rich",
+    "TrackerArn": "arn:aws:geo:us-east-1:111111111111:tracker/cdkrd-tracker-rich",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreateTime", "TrackerArn", "UpdateTime"],
+    "writeOnly": [],
+    "createOnly": ["KmsKeyId", "TrackerName"],
+    "readOnlyPaths": ["Arn", "CreateTime", "TrackerArn", "UpdateTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["KmsKeyId", "TrackerName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Tracker",
+      "resourceType": "AWS::Location::Tracker",
+      "path": "PricingPlan",
+      "actual": "RequestBasedUsage",
+      "physicalId": "cdkrd-tracker-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/Tracker"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Tracker",
+      "resourceType": "AWS::Location::Tracker",
+      "path": "PositionFiltering",
+      "actual": "TimeBased",
+      "physicalId": "cdkrd-tracker-rich",
+      "constructPath": "CdkRealDriftIntegLocationRich/Tracker"
+    }
+  ]
+}

--- a/tests/integration/location-rich/app.ts
+++ b/tests/integration/location-rich/app.ts
@@ -1,0 +1,57 @@
+// CDK app for the cdk-real-drift location-rich false-positive integration test.
+// Amazon Location Service (AWS::Location::*) is an entirely uncovered service in the
+// corpus. Its resources fold AWS-assigned first-run values the template never
+// declares — ARNs, CreateTime/UpdateTime, and echoed service defaults such as a
+// Tracker's PositionFiltering (TimeBased) or a PlaceIndex's
+// DataSourceConfiguration.IntendedUse (SingleUse). Several default-prone props are
+// deliberately left UNDECLARED here so a `check` BEFORE record is a clean
+// false-positive oracle for those undeclared first-run defaults.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnGeofenceCollection,
+  CfnMap,
+  CfnPlaceIndex,
+  CfnRouteCalculator,
+  CfnTracker,
+} from "aws-cdk-lib/aws-location";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLocationRich");
+
+// PlaceIndex: declare DataSource + name + description; leave DataSourceConfiguration
+// (AWS fills IntendedUse=SingleUse) and PricingPlan UNDECLARED.
+new CfnPlaceIndex(stack, "PlaceIndex", {
+  dataSource: "Esri",
+  indexName: "cdkrd-place-index-rich",
+  description: "cdkrd location place index rich",
+});
+
+// Map: Configuration.Style is required; leave nothing else declared.
+new CfnMap(stack, "Map", {
+  configuration: { style: "VectorEsriNavigation" },
+  mapName: "cdkrd-map-rich",
+  description: "cdkrd location map rich",
+});
+
+// GeofenceCollection: minimal; PricingPlan/PricingPlanDataSource are deprecated and
+// left undeclared.
+new CfnGeofenceCollection(stack, "GeofenceCollection", {
+  collectionName: "cdkrd-geofence-rich",
+  description: "cdkrd location geofence collection rich",
+});
+
+// Tracker: leave PositionFiltering (AWS fills TimeBased), EventBridgeEnabled and
+// KmsKeyEnableGeospatialQueries UNDECLARED to surface default-fill.
+new CfnTracker(stack, "Tracker", {
+  trackerName: "cdkrd-tracker-rich",
+  description: "cdkrd location tracker rich",
+});
+
+// RouteCalculator: declare DataSource + name + description.
+new CfnRouteCalculator(stack, "RouteCalculator", {
+  dataSource: "Esri",
+  calculatorName: "cdkrd-route-calculator-rich",
+  description: "cdkrd location route calculator rich",
+});
+
+app.synth();

--- a/tests/integration/location-rich/cdk.json
+++ b/tests/integration/location-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/location-rich/package.json
+++ b/tests/integration/location-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-location-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift location-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/location-rich/verify.sh
+++ b/tests/integration/location-rich/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> check BEFORE record (fresh
+# potential-drift oracle) -> record baseline -> check MUST be CLEAN.
+# Amazon Location Service resources fold AWS-assigned first-run values (ARNs,
+# CreateTime/UpdateTime, and echoed service defaults like Tracker PositionFiltering).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLocationRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (fresh-deploy potential-drift oracle) ==="
+$CLI check "$STACK" --region "$REGION" --verbose | tee "/tmp/cdkrd-$STACK-fresh.out"
+
+echo "=== [$STACK] harvest corpus (fresh, pre-record) ==="
+CDKRD_CORPUS_DIR="/tmp/corpus-location-rich" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -683,6 +683,28 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('Amazon Location first-run defaults fold on ALL five resource types', () => {
+    // The deprecated `PricingPlan` parameter is echoed as the constant
+    // "RequestBasedUsage" on EVERY Location resource, not just Tracker/GeofenceCollection
+    // (the original #492 entries) — PlaceIndex/Map/RouteCalculator were an unguarded
+    // allowlist gap surfaced live on location-rich (2026-07-07). A Tracker with no
+    // PositionFiltering reads back "TimeBased", and a PlaceIndex with no
+    // DataSourceConfiguration reads back {IntendedUse:"SingleUse"}. All equality-gated.
+    for (const t of [
+      'AWS::Location::Tracker',
+      'AWS::Location::GeofenceCollection',
+      'AWS::Location::PlaceIndex',
+      'AWS::Location::Map',
+      'AWS::Location::RouteCalculator',
+    ]) {
+      expect(KNOWN_DEFAULTS[t].PricingPlan).toBe('RequestBasedUsage');
+    }
+    expect(KNOWN_DEFAULTS['AWS::Location::Tracker'].PositionFiltering).toBe('TimeBased');
+    expect(KNOWN_DEFAULTS['AWS::Location::PlaceIndex'].DataSourceConfiguration).toEqual({
+      IntendedUse: 'SingleUse',
+    });
+  });
+
   it('common stateful/streaming-type constant defaults from the offline corpus sweep', () => {
     // Constant, documented service defaults common stateful/streaming types report as
     // first-run undeclared noise. Verified against the golden corpus (RDS DBInstance

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -415,6 +415,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Location Tracker PositionFiltering (SET-DEFAULT) -> add op writing TimeBased, not a no-op remove', () => {
+    // AWS::Location::Tracker PositionFiltering is in REVERT_SET_DEFAULT_PATHS: UpdateTracker
+    // leaves the value UNCHANGED when it is OMITTED, so a bare `remove` of an out-of-band
+    // AccuracyBased is a silent no-op (Cloud Control reports SUCCESS yet the live
+    // AccuracyBased persists — "1 drift remain"; proven live on location-rich 2026-07-07).
+    // Revert must write the "TimeBased" default (from KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Location::Tracker',
+      path: 'PositionFiltering',
+      actual: 'AccuracyBased',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/PositionFiltering',
+      value: 'TimeBased',
+      prior: 'AccuracyBased',
+    });
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.


### PR DESCRIPTION
## What

Bug hunt on **Amazon Location Service** (`AWS::Location::*`) — an entirely
uncovered service. A fresh `location-rich` deploy surfaced two live bugs.

### FP — first-run fold gap (5 potential-drift on a clean deploy → 0)
- The deprecated `PricingPlan` echo (`"RequestBasedUsage"`) was folded only on
  `Tracker`/`GeofenceCollection` (#492) — an unguarded allowlist gap. `PlaceIndex`,
  `Map`, `RouteCalculator` surfaced it as `[Potential Drift]`.
- Two never-folded constant defaults: `Tracker.PositionFiltering` → `"TimeBased"`,
  `PlaceIndex.DataSourceConfiguration` → `{IntendedUse:"SingleUse"}`.
- All registered as **equality-gated** `KNOWN_DEFAULTS` (a change away still
  surfaces). Fresh `check` before `record` now shows **0 potential drift**
  (7 `atDefault`), live-verified.

### Revert no-op — `REVERT_SET_DEFAULT_PATHS`
Amazon Location `UpdateTracker` **ignores an omitted `PositionFiltering`**, so a
`remove` revert of an out-of-band `AccuracyBased` reported SUCCESS yet the live
value persisted (`"1 drift remain"`, proven live). Added
`AWS::Location::Tracker\0PositionFiltering` so revert writes `"TimeBased"`
explicitly → live-verified convergence.

## Live verification (real AWS, torn down clean)
- Fresh deploy → `check` before record = **0 potential drift** (7 atDefault).
- FN (declared): mutate `Tracker.Description` → detected → revert → CLEAN.
- Equality-gate: mutate `PositionFiltering`→`AccuracyBased` → **surfaced** →
  revert → live back to `TimeBased` + CLEAN.
- Stack deleted, `sweep-orphans.sh` SWEEP CLEAN.

## Tests
- `location-rich` integ fixture + **5 golden-corpus cases** (all fold `atDefault`).
- Unit tests for the fold (all 5 types) and the set-default revert.
- `vp run typecheck` / `vp check` / `vp pack` / `vp test run` (2901) all green.
