### PR TITLE
fix(diff): align unordered-object-array by identity + remap nested-sorted types to the template index

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -84,6 +84,7 @@ import {
   stripAwsTagsDeep,
   UNORDERED_ARRAY_PROPS,
   UNORDERED_NESTED_OBJECT_ARRAY_PATHS,
+  UNORDERED_OBJECT_ARRAY_IDENTITY,
   UNORDERED_OBJECT_ARRAY_PROPS,
   VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
   VERSION_PREFIX_PATHS,
@@ -1432,6 +1433,11 @@ export function classifyResource(
     ];
     let declaredVal: unknown = v;
     let liveVal: unknown = live[k];
+    // For an UNORDERED_OBJECT_ARRAY, the source whose TOP-LEVEL order still matches the
+    // raw template (so a sorted-index finding can be re-mapped back to the template index)
+    // — nested sub-arrays already sorted (so its elements deep-equal the sorted declaredVal's)
+    // but the element ORDER not yet sorted. Set only in the unorderedObjArray branch below.
+    let declaredRemapSource: unknown[] | undefined;
     if (subsetSpec && Array.isArray(v) && Array.isArray(live[k])) {
       const { idField, normalizeId } = subsetSpec;
       const idOf = (e: unknown): string | undefined => {
@@ -1492,12 +1498,21 @@ export function classifyResource(
       // array itself. Without the inner sort, the outer canonical-JSON sort sees a
       // reordered-but-equal nested set as a different element and the positional diff
       // still false-flags it.
-      declaredVal = sortUnorderedObjectArray(
-        nestedSubPaths.length > 0 ? sortNestedObjectArrays(v, nestedSubPaths) : v
-      );
+      // The nested-sorted (but NOT yet top-level-sorted) declared source keeps the raw
+      // template order, so its elements deep-equal the sorted declaredVal's elements AND
+      // its index is the template index — exactly what remapSortedIndexToDeclared needs.
+      const declaredNestedSorted =
+        nestedSubPaths.length > 0 ? sortNestedObjectArrays(v, nestedSubPaths) : v;
+      // Key the sort on the element's IDENTITY field (when the type has one) so a change to a
+      // NON-identity sibling keeps the element aligned on both sides (else a mutable field that
+      // sorts before the identity — Cognito ScopeDescription, Secret KmsKeyId — misaligns).
+      const idField = UNORDERED_OBJECT_ARRAY_IDENTITY[resourceType]?.[k];
+      declaredVal = sortUnorderedObjectArray(declaredNestedSorted, idField);
       liveVal = sortUnorderedObjectArray(
-        nestedSubPaths.length > 0 ? sortNestedObjectArrays(live[k], nestedSubPaths) : live[k]
+        nestedSubPaths.length > 0 ? sortNestedObjectArrays(live[k], nestedSubPaths) : live[k],
+        idField
       );
+      if (Array.isArray(declaredNestedSorted)) declaredRemapSource = declaredNestedSorted;
     } else if (nestedSubPaths.length > 0) {
       declaredVal = sortNestedObjectArrays(v, nestedSubPaths);
       liveVal = sortNestedObjectArrays(live[k], nestedSubPaths);
@@ -1777,9 +1792,13 @@ export function classifyResource(
       // template-order) declared array so the revert plan collapses these into one whole-array
       // replacement (revert reads wholeArrayRevert, never the index).
       const unorderedExtra =
-        unorderedObjArray && Array.isArray(declaredVal) && Array.isArray(v)
+        unorderedObjArray && Array.isArray(declaredVal) && declaredRemapSource
           ? {
-              path: remapSortedIndexToDeclared(d.path, k, declaredVal, v),
+              // Re-map against the nested-sorted-but-raw-top-order source so a type whose
+              // ELEMENTS carry their OWN unordered sub-arrays (ELBv2 ListenerRule Conditions)
+              // still locates the element — a plain-`v` deep-equal would miss it because the
+              // sorted declaredVal element's nested set no longer matches the raw element's.
+              path: remapSortedIndexToDeclared(d.path, k, declaredVal, declaredRemapSource),
               wholeArrayRevert: { path: k, value: v },
             }
           : {};

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3694,6 +3694,32 @@ export const UNORDERED_OBJECT_ARRAY_PROPS: Record<string, ReadonlySet<string>> =
   'AWS::EC2::PrefixList': new Set(['Entries']),
 };
 
+// The IDENTITY field of an UNORDERED_OBJECT_ARRAY_PROPS element, when it HAS one (the
+// discriminated-union sets — WAFv2 RedactedFields, ApplicationSignals BurnRateConfigurations
+// — do NOT, so they are absent). sortUnorderedObjectArray keys on this field FIRST, so a
+// change to a NON-identity sibling field keeps the element in the SAME aligned slot on both
+// sides. WITHOUT it, a plain canonical-JSON sort misaligns whenever the changed field sorts
+// alphabetically BEFORE the identity in the element's keys — Cognito Scope `ScopeDescription`
+// < `ScopeName`, Secret replica `KmsKeyId` < `Region`, ElastiCache `LogFormat`/`LogType`, ASG
+// hook `DefaultResult` < `LifecycleHookName` — so editing that field false-flags the UNCHANGED
+// identity as drift too (a positional-diff FP, live-observed reverting a Cognito Scope's
+// description). Types whose identity ALREADY sorts first (PrefixList `Cidr`, Redshift
+// `ParameterName`, ELBv2 ListenerRule `Field`, IAM `PolicyName`) are listed too for robustness
+// — keying on the identity is correct regardless of alphabetical luck.
+export const UNORDERED_OBJECT_ARRAY_IDENTITY: Record<string, Record<string, string>> = {
+  'AWS::Cognito::UserPoolResourceServer': { Scopes: 'ScopeName' },
+  'AWS::SecretsManager::Secret': { ReplicaRegions: 'Region' },
+  'AWS::ElastiCache::CacheCluster': { LogDeliveryConfigurations: 'LogType' },
+  'AWS::ElastiCache::ReplicationGroup': { LogDeliveryConfigurations: 'LogType' },
+  'AWS::AutoScaling::AutoScalingGroup': { LifecycleHookSpecificationList: 'LifecycleHookName' },
+  'AWS::Redshift::ClusterParameterGroup': { Parameters: 'ParameterName' },
+  'AWS::ElasticLoadBalancingV2::ListenerRule': { Conditions: 'Field' },
+  'AWS::EC2::PrefixList': { Entries: 'Cidr' },
+  'AWS::IAM::Role': { Policies: 'PolicyName' },
+  'AWS::IAM::User': { Policies: 'PolicyName' },
+  'AWS::IAM::Group': { Policies: 'PolicyName' },
+};
+
 // Per-type NESTED array paths AWS returns reordered (dotted from the resource
 // root, e.g. `ContentPolicyConfig.FiltersConfig`). This is the nested twin of
 // UNORDERED_OBJECT_ARRAY_PROPS, which only reaches TOP-LEVEL array keys. Mostly
@@ -3916,11 +3942,28 @@ function canonicalJson(v: unknown): string {
 // reordered-but-equal rule set aligns positionally; equal elements (modulo key order)
 // land in the same slot, so the subsequent element-wise diff sees no drift, while a
 // genuinely changed rule still differs.
-export function sortUnorderedObjectArray(v: unknown): unknown {
+export function sortUnorderedObjectArray(v: unknown, identityField?: string): unknown {
   if (!Array.isArray(v)) return v;
+  // Sort key = the element's IDENTITY field (when the type declares one via
+  // UNORDERED_OBJECT_ARRAY_IDENTITY) FOLLOWED BY the full canonical JSON. Keying on the
+  // identity FIRST keeps an element in the SAME aligned slot on both sides when only a
+  // NON-identity field changes — otherwise, if that mutable field sorts alphabetically
+  // BEFORE the identity in the element's keys (Cognito Scope `ScopeDescription` < `ScopeName`,
+  // Secret replica `KmsKeyId` < `Region`, ElastiCache `LogFormat` < `LogType`, ASG hook
+  // `DefaultResult` < `LifecycleHookName`), a plain canonical-JSON sort moves the changed
+  // element to a different position and the positional diff MISALIGNS, false-flagging the
+  // unchanged identity as drift too. The canonical JSON stays as the tiebreaker so equal
+  // identities (and identity-less elements) keep the previous deterministic order.
+  const keyOf = (e: unknown): string => {
+    const id =
+      identityField && e !== null && typeof e === 'object' && !Array.isArray(e)
+        ? (e as Record<string, unknown>)[identityField]
+        : undefined;
+    return `${id === undefined ? '' : `${String(id)} `}${canonicalJson(e)}`;
+  };
   return [...v].sort((a, b) => {
-    const ka = canonicalJson(a);
-    const kb = canonicalJson(b);
+    const ka = keyOf(a);
+    const kb = keyOf(b);
     return ka < kb ? -1 : ka > kb ? 1 : 0;
   });
 }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3526,6 +3526,23 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
       };
       expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
     });
+
+    it('editing a scope DESCRIPTION reports exactly ONE aligned drift, not a misaligned smear (identity-first sort)', () => {
+      // ScopeDescription sorts BEFORE ScopeName in canonical JSON (D < N), so a plain
+      // canonical-JSON sort would move the edited element and MISALIGN the positional diff —
+      // false-flagging the UNCHANGED ScopeNames of other scopes too. Keying the sort on the
+      // ScopeName identity keeps every element aligned; only zeta.write's description differs.
+      const live = {
+        Scopes: [
+          { ScopeName: 'alpha.read', ScopeDescription: 'alpha scope' },
+          { ScopeName: 'mike.admin', ScopeDescription: 'mike scope' },
+          { ScopeName: 'zeta.write', ScopeDescription: 'HACKED zeta' }, // description only
+        ],
+      };
+      // exactly one drift, on the TEMPLATE index 0 (zeta.write is declared first), the
+      // description — the ScopeName is NOT falsely reported.
+      expect(declaredTiers(T, declared, live)).toEqual(['Scopes.0.ScopeDescription']);
+    });
   });
 
   // An Access Analyzer's `ArchiveRules` is a SET of {RuleName, Filter} AWS echoes
@@ -3725,6 +3742,32 @@ describe('unordered-array declared false positives (R88, found by the wave-2 int
         ],
       };
       expect(declaredTiers(T, declared, live).length).toBeGreaterThan(0);
+    });
+
+    it('reports the drift at the TEMPLATE index even when the drifted element has its OWN reordered nested set (remap via nested-sorted source)', () => {
+      // path-pattern is declared FIRST (template index 0) with its Values in NON-sorted
+      // order, but sorts AFTER host-header (canonical "host-header" < "path-pattern") to
+      // sorted index 1 — AND its Values sub-set is itself re-sorted. A plain deep-equal vs
+      // the raw declared array would then fail to locate the element (the sorted element's
+      // Values no longer match the raw element's order) and fall back to the sorted index.
+      // remapSortedIndexToDeclared must match against the nested-sorted-but-raw-top-order
+      // source and report `Conditions.0.…` (the user's template position).
+      const declaredUnsorted = {
+        Conditions: [
+          { Field: 'path-pattern', PathPatternConfig: { Values: ['/v2/*', '/api/*'] } },
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+        ],
+      };
+      const live = {
+        Conditions: [
+          { Field: 'host-header', HostHeaderConfig: { Values: ['example.com'] } },
+          { Field: 'path-pattern', PathPatternConfig: { Values: ['/CHANGED/*', '/api/*'] } },
+        ],
+      };
+      const paths = declaredTiers(T, declaredUnsorted, live);
+      expect(paths.length).toBeGreaterThan(0);
+      // every reported path uses the TEMPLATE index (0 = path-pattern), not the sorted index (1)
+      expect(paths.every((p) => p.startsWith('Conditions.0.'))).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Correct unordered-object-array alignment + template-index display

Follow-up to #605/#608, found while live-verifying the whole-array-revert generalization on
more CC-reverted unordered types (ELBv2 ListenerRule `Conditions`, Cognito
`UserPoolResourceServer` `Scopes`).

### 1. Identity-first sort — FP fix
These sets are sorted by canonical JSON on both sides before the positional diff. When a
**non-identity** field is edited **and** it sorts alphabetically **before** the identity in
the element's keys, the edited element moves to a different slot and the diff **misaligns**,
false-flagging the *unchanged* identity of other elements as drift.

Affected: Cognito Scope `ScopeDescription` < `ScopeName`, Secret replica `KmsKeyId` < `Region`,
ElastiCache `LogFormat` < `LogType`, ASG hook `DefaultResult` < `LifecycleHookName`.

**Live-observed:** editing one Cognito Scope's description reported **6** declared drifts
(including spurious `ScopeName` changes). Fix: `sortUnorderedObjectArray` keys on the element's
identity field first (new `UNORDERED_OBJECT_ARRAY_IDENTITY`), then canonical JSON — so a
non-identity edit keeps every element aligned. **Live-verified:** the same edit now reports
**one** aligned drift (`Scopes.0.ScopeDescription`).

### 2. Nested-sorted remap — display fix (completes #608)
`remapSortedIndexToDeclared` located the drifted element by deep-equality to re-map the reported
index to the **template** position. For a type whose elements carry their **own** unordered
sub-arrays (ELBv2 `Conditions.*.PathPatternConfig.Values`), the sorted declared element's nested
set no longer deep-equals the raw element's, so the match failed and it fell back to the sorted
index. Match against the nested-sorted-but-raw-top-order source instead. **Live-verified:** an
ELBv2 path-pattern edit reports `Conditions.0.…` (template index), not the sorted index.

### Notes
- Both are display/alignment fixes; **revert is unaffected** (reads `Finding.wholeArrayRevert`, a
  whole-array replace).
- **Live-verified** detect → revert → CLEAN on real ELBv2 ListenerRule + Cognito ResourceServer —
  the #605 whole-array-revert generalization now confirmed on a **3rd and 4th** CC-reverted
  unordered type (after PrefixList #605 and Redshift #608).
- Tests in `classify.test.ts`; all 2899 unit tests pass; typecheck / lint+format / build green.
