### PR TITLE
fix(revert): converge Location PlaceIndex DataSourceConfiguration revert (avoid silent no-op)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -108,6 +108,12 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // SUCCESS yet the live value stayed AccuracyBased — "1 drift remain"). Write the
   // "TimeBased" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
   'AWS::Location::Tracker\0PositionFiltering',
+  // Amazon Location UpdatePlaceIndex likewise IGNORES an omitted DataSourceConfiguration
+  // (live-observed 2026-07-07: a `remove` revert of an out-of-band IntendedUse=Storage
+  // reported SUCCESS yet the live value stayed Storage — "1 drift remain"). Write the whole
+  // {IntendedUse:"SingleUse"} default object back explicitly (2nd object-valued entry after
+  // AppRunner) so revert converges.
+  'AWS::Location::PlaceIndex\0DataSourceConfiguration',
 ]);
 
 /**

--- a/tests/integration/location-placeindex-revert/app.ts
+++ b/tests/integration/location-placeindex-revert/app.ts
@@ -1,0 +1,19 @@
+// CDK app for the cdk-real-drift location-placeindex-revert integration test.
+// A PlaceIndex with no DataSourceConfiguration reads back {IntendedUse:"SingleUse"},
+// folded to atDefault by #609. DataSourceConfiguration is a MUTABLE property
+// (createOnly is only DataSource/IndexName), so this fixture live-tests the REVERT of
+// an out-of-band IntendedUse change back to the default — verifying the fold's
+// equality-gate detection AND that revert actually converges (not a silent no-op).
+import { App, Stack } from "aws-cdk-lib";
+import { CfnPlaceIndex } from "aws-cdk-lib/aws-location";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegLocationPlaceIndexRevert");
+
+new CfnPlaceIndex(stack, "PlaceIndex", {
+  dataSource: "Esri",
+  indexName: "cdkrd-placeindex-revert",
+  description: "cdkrd location place index revert test",
+});
+
+app.synth();

--- a/tests/integration/location-placeindex-revert/cdk.json
+++ b/tests/integration/location-placeindex-revert/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/location-placeindex-revert/package.json
+++ b/tests/integration/location-placeindex-revert/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-location-placeindex-revert",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift location-placeindex-revert integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/location-placeindex-revert/verify.sh
+++ b/tests/integration/location-placeindex-revert/verify.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Live-test the REVERT of a folded MUTABLE Location default (PlaceIndex
+# DataSourceConfiguration.IntendedUse, folded to {IntendedUse:"SingleUse"} by #609):
+#   1. deploy -> check BEFORE record MUST be ZERO potential drift (fold works)
+#   2. record baseline
+#   3. mutate IntendedUse -> Storage out of band -> check MUST surface it
+#      (equality-gate detection preserved)
+#   4. revert -> live IntendedUse MUST return to SingleUse + check CLEAN
+#      (if UpdatePlaceIndex ignores an omitted DataSourceConfiguration, the `remove`
+#       revert is a silent no-op and this fails -> REVERT_SET_DEFAULT_PATHS needed)
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegLocationPlaceIndexRevert
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+IDX=cdkrd-placeindex-revert
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy ==="
+npx cdk deploy -f "$STACK" --require-approval never >/tmp/pir-deploy.log 2>&1 || { tail -30 /tmp/pir-deploy.log; fail "deploy"; }
+
+echo "=== [1] check BEFORE record — MUST be ZERO potential drift ==="
+$CLI check "$STACK" --region "$REGION" --fail --verbose | tee /tmp/pir-fresh.out
+[ "${PIPESTATUS[0]}" -eq 0 ] || fail "expected ZERO potential drift on fresh deploy"
+
+echo "=== [2] harvest corpus (fixed binary) ==="
+rm -rf /tmp/corpus-pir
+CDKRD_CORPUS_DIR=/tmp/corpus-pir $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [3] mutate IntendedUse -> Storage out of band ==="
+aws location update-place-index --index-name "$IDX" --data-source-configuration IntendedUse=Storage --region "$REGION" >/dev/null || fail "update-place-index"
+$CLI check "$STACK" --region "$REGION" --fail >/tmp/pir-detect.out 2>&1
+rc=$?
+[ "$rc" -ne 0 ] || { cat /tmp/pir-detect.out; fail "equality-gate FAILED to surface IntendedUse change"; }
+grep -qi "DataSourceConfiguration\|IntendedUse" /tmp/pir-detect.out || { cat /tmp/pir-detect.out; fail "detect output missing DataSourceConfiguration"; }
+echo "  surfaced IntendedUse=Storage (exit $rc) OK"
+
+echo "=== [4] revert -> live IntendedUse MUST return to SingleUse ==="
+$CLI revert "$STACK" --region "$REGION" --yes >/tmp/pir-revert.out 2>&1 || { cat /tmp/pir-revert.out; fail "revert"; }
+LIVE_IU=$(aws location describe-place-index --index-name "$IDX" --region "$REGION" --query 'DataSourceConfiguration.IntendedUse' --output text)
+echo "  live IntendedUse after revert: $LIVE_IU"
+[ "$LIVE_IU" = "SingleUse" ] || fail "revert did NOT converge IntendedUse to SingleUse (got $LIVE_IU) -> REVERT_SET_DEFAULT_PATHS needed"
+$CLI check "$STACK" --region "$REGION" --fail >/tmp/pir-postrevert.out 2>&1 || { cat /tmp/pir-postrevert.out; fail "expected CLEAN after revert"; }
+echo "  revert -> live SingleUse + CLEAN OK"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -415,6 +415,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Location PlaceIndex DataSourceConfiguration (SET-DEFAULT) -> add op writing the default object, not a no-op remove', () => {
+    // AWS::Location::PlaceIndex DataSourceConfiguration is in REVERT_SET_DEFAULT_PATHS:
+    // UpdatePlaceIndex leaves the config UNCHANGED when it is OMITTED, so a bare `remove` of
+    // an out-of-band IntendedUse=Storage is a silent no-op (Cloud Control reports SUCCESS yet
+    // the live Storage persists — "1 drift remain"; proven live 2026-07-07). Revert must write
+    // the whole {IntendedUse:"SingleUse"} default object back (2nd object-valued entry).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Location::PlaceIndex',
+      path: 'DataSourceConfiguration',
+      actual: { IntendedUse: 'Storage' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DataSourceConfiguration',
+      value: { IntendedUse: 'SingleUse' },
+      prior: { IntendedUse: 'Storage' },
+    });
+  });
+
   it('Location Tracker PositionFiltering (SET-DEFAULT) -> add op writing TimeBased, not a no-op remove', () => {
     // AWS::Location::Tracker PositionFiltering is in REVERT_SET_DEFAULT_PATHS: UpdateTracker
     // leaves the value UNCHANGED when it is OMITTED, so a bare `remove` of an out-of-band


### PR DESCRIPTION
## What
Follow-up to #609. A `PlaceIndex`'s `DataSourceConfiguration` folds to
`{IntendedUse:"SingleUse"}` (atDefault), but it is a **mutable** property and
reverting an out-of-band `IntendedUse=Storage` was a **silent no-op**: Amazon Location
`UpdatePlaceIndex` IGNORES an omitted `DataSourceConfiguration`, so the `remove` revert
reported SUCCESS yet the live value stayed `Storage` (`"1 drift remain"`, proven live).

## Fix
Add `AWS::Location::PlaceIndex\0DataSourceConfiguration` to `REVERT_SET_DEFAULT_PATHS`
(the 2nd object-valued entry after AppRunner) so revert writes the whole
`{IntendedUse:"SingleUse"}` default back explicitly and converges.

## Live verification (real AWS, torn down clean)
- Fresh deploy → `check` before record = **0 potential drift** (fold intact).
- Mutate `IntendedUse`→`Storage` → **surfaced** (equality-gate detection preserved).
- `revert` → live `IntendedUse` **back to `SingleUse`** + CLEAN.
- Stack deleted, SWEEP CLEAN.

## Tests
- `location-placeindex-revert` integ fixture + revert-plan unit test.
- `typecheck` / `lint` / `pack` / `test` (2907) all green.
