### PR TITLE
fix(noise): fold ApplicationSignals SLO default Goal (bug hunt: slo-notif-rich)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -300,6 +300,21 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       },
     ],
   },
+  // An ApplicationSignals ServiceLevelObjective that omits `Goal` reads it back
+  // fully materialized with AWS's constant default: a rolling 7-day interval,
+  // AttainmentGoal 99, WarningThreshold 50 (the schema documents "a rolling
+  // interval of 7 days" / "99 is used" but does NOT annotate a `default`, so the
+  // schema-driven fold can't reach it). Equality-gated whole-object, so a user who
+  // declares Goal is compared in the declared loop, and any out-of-band change to a
+  // sub-field (a different AttainmentGoal, a calendar interval) no longer matches
+  // and re-surfaces. Observed live on a fresh period-based SLO (slo-notif-rich).
+  'AWS::ApplicationSignals::ServiceLevelObjective': {
+    Goal: {
+      WarningThreshold: 50,
+      AttainmentGoal: 99,
+      Interval: { RollingInterval: { DurationUnit: 'DAY', Duration: 7 } },
+    },
+  },
   // R104 (dogfood noise audit across the harvest fixtures): top-level service
   // defaults AWS materializes that the CFn schema does NOT annotate as `default`
   // (so the schema-driven R103 fold can't reach them). All OBSERVED on real

--- a/tests/corpus/AWS__ApplicationSignals__ServiceLevelObjective.Slo.json
+++ b/tests/corpus/AWS__ApplicationSignals__ServiceLevelObjective.Slo.json
@@ -1,0 +1,177 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Slo",
+    "resourceType": "AWS::ApplicationSignals::ServiceLevelObjective",
+    "physicalId": "arn:aws:application-signals:us-east-1:111111111111:slo/cdkrd-slo-lambda-errors",
+    "constructPath": "CdkRealDriftIntegSloNotif/Slo",
+    "declared": {
+      "Name": "cdkrd-slo-lambda-errors",
+      "Sli": {
+        "ComparisonOperator": "LessThanOrEqualTo",
+        "MetricThreshold": 5,
+        "SliMetric": {
+          "MetricDataQueries": [
+            {
+              "Id": "m1",
+              "MetricStat": {
+                "Metric": {
+                  "Dimensions": [
+                    {
+                      "Name": "FunctionName",
+                      "Value": "cdkrd-slo-fn"
+                    },
+                    {
+                      "Name": "Resource",
+                      "Value": "cdkrd-slo-fn:live"
+                    }
+                  ],
+                  "MetricName": "Errors",
+                  "Namespace": "AWS/Lambda"
+                },
+                "Period": 60,
+                "Stat": "Sum"
+              },
+              "ReturnData": true
+            }
+          ]
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "Sli": {
+      "ComparisonOperator": "LessThanOrEqualTo",
+      "SliMetric": {
+        "MetricDataQueries": [
+          {
+            "ReturnData": true,
+            "MetricStat": {
+              "Stat": "Sum",
+              "Period": 60,
+              "Metric": {
+                "MetricName": "Errors",
+                "Dimensions": [
+                  {
+                    "Value": "cdkrd-slo-fn",
+                    "Name": "FunctionName"
+                  },
+                  {
+                    "Value": "cdkrd-slo-fn:live",
+                    "Name": "Resource"
+                  }
+                ],
+                "Namespace": "AWS/Lambda"
+              }
+            },
+            "Id": "m1"
+          }
+        ]
+      },
+      "MetricThreshold": 5
+    },
+    "Goal": {
+      "WarningThreshold": 50,
+      "AttainmentGoal": 99,
+      "Interval": {
+        "RollingInterval": {
+          "DurationUnit": "DAY",
+          "Duration": 7
+        }
+      }
+    },
+    "Description": "No description",
+    "CreatedTime": 1783440095,
+    "LastUpdatedTime": 1783441161,
+    "EvaluationType": "PeriodBased",
+    "Arn": "arn:aws:application-signals:us-east-1:111111111111:slo/cdkrd-slo-lambda-errors",
+    "Tags": [
+      {
+        "Value": "Slo",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegSloNotif/1a5b0910-7a1d-11f1-9763-0affdc4e9a3f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftIntegSloNotif",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "Name": "cdkrd-slo-lambda-errors"
+  },
+  "schema": {
+    "readOnly": ["Arn", "CreatedTime", "EvaluationType", "LastUpdatedTime"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "CreatedTime", "EvaluationType", "LastUpdatedTime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {
+      "Description": "No description"
+    },
+    "defaultPaths": {
+      "Description": "No description",
+      "ExclusionWindows.*.Reason": "No reason"
+    },
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["BurnRateConfigurations", "ExclusionWindows"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Slo",
+      "resourceType": "AWS::ApplicationSignals::ServiceLevelObjective",
+      "path": "Goal",
+      "actual": {
+        "WarningThreshold": 50,
+        "AttainmentGoal": 99,
+        "Interval": {
+          "RollingInterval": {
+            "DurationUnit": "DAY",
+            "Duration": 7
+          }
+        }
+      },
+      "physicalId": "arn:aws:application-signals:us-east-1:111111111111:slo/cdkrd-slo-lambda-errors",
+      "constructPath": "CdkRealDriftIntegSloNotif/Slo"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Slo",
+      "resourceType": "AWS::ApplicationSignals::ServiceLevelObjective",
+      "path": "Description",
+      "actual": "No description",
+      "physicalId": "arn:aws:application-signals:us-east-1:111111111111:slo/cdkrd-slo-lambda-errors",
+      "constructPath": "CdkRealDriftIntegSloNotif/Slo"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeStarNotifications__NotificationRule.Notif.json
+++ b/tests/corpus/AWS__CodeStarNotifications__NotificationRule.Notif.json
@@ -1,0 +1,101 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Notif",
+    "resourceType": "AWS::CodeStarNotifications::NotificationRule",
+    "physicalId": "arn:aws:codestar-notifications:us-east-1:111111111111:notificationrule/fcc0a5acc48466db7e41e7b7a00f675a6c036e61",
+    "constructPath": "CdkRealDriftIntegSloNotif/Notif",
+    "declared": {
+      "DetailType": "BASIC",
+      "EventTypeIds": [
+        "codebuild-project-build-state-succeeded",
+        "codebuild-project-build-state-failed"
+      ],
+      "Name": "cdkrd-notif-rule",
+      "Resource": "__cdkrd_corpus_unresolved__",
+      "Targets": [
+        {
+          "TargetAddress": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSloNotif-NotifTopic93A3095C-S6ebMlfcexTF",
+          "TargetType": "SNS"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "EventTypeIds": [
+      "codebuild-project-build-state-succeeded",
+      "codebuild-project-build-state-failed"
+    ],
+    "Status": "ENABLED",
+    "CreatedBy": "AROAXXXJN2LNUMUGQSEAZ:AWSCloudFormation",
+    "DetailType": "BASIC",
+    "Resource": "arn:aws:codebuild:us-east-1:111111111111:project/Proj26959B7F-mWzdblEqAYc1",
+    "Targets": [
+      {
+        "TargetType": "SNS",
+        "TargetAddress": "arn:aws:sns:us-east-1:111111111111:CdkRealDriftIntegSloNotif-NotifTopic93A3095C-S6ebMlfcexTF"
+      }
+    ],
+    "Arn": "arn:aws:codestar-notifications:us-east-1:111111111111:notificationrule/fcc0a5acc48466db7e41e7b7a00f675a6c036e61",
+    "Tags": {},
+    "Name": "cdkrd-notif-rule"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["EventTypeId", "TargetAddress"],
+    "createOnly": ["Resource"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["EventTypeId", "TargetAddress"],
+    "createOnlyPaths": ["Resource"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {
+      "alias/aws/acm": "b3729196-d9c5-4e2a-9e8e-d733b92c8317",
+      "alias/aws/appflow": "a2152495-1376-4c30-9183-7ee24ad10386",
+      "alias/aws/backup": "b405e2ab-23b0-48e9-834e-aa3aeeded51d",
+      "alias/aws/cloud9": "c656784b-cd79-45fa-a302-4670428047dc",
+      "alias/aws/codeartifact": "f4915da2-dabd-4aaa-a58b-6cc98c3bcbc6",
+      "alias/aws/codecommit": "f4b560a8-2769-4fdc-95ce-67e234814090",
+      "alias/aws/dms": "8b0bca8d-7f3f-4f19-bebf-bf6c72f3f1e6",
+      "alias/aws/dynamodb": "e6ab85f6-b5b2-4f38-9782-d1d3f0ca9bad",
+      "alias/aws/ebs": "76039e55-2469-4c94-95ab-e12d8615bb98",
+      "alias/aws/elasticfilesystem": "ed4a6b88-bcd1-43fe-beff-35a748bded74",
+      "alias/aws/es": "db99576a-7bcf-4386-a93e-0334efbed006",
+      "alias/aws/kinesis": "51c70be1-ec2a-4e9f-ae04-aa16f1bfdcad",
+      "alias/aws/lambda": "67e127ea-46c8-4b0b-b3de-18a40e8a84a4",
+      "alias/aws/lightsail": "4085ed99-9004-436f-b8c6-e81417e55591",
+      "alias/aws/rds": "9ee8feba-ae18-445a-bcab-306f7748fb6c",
+      "alias/aws/s3": "b471f899-bf30-4944-a7d9-70f37d183eaa",
+      "alias/aws/secretsmanager": "6419a4af-eac7-4cb3-babe-297fdceba8a1",
+      "alias/aws/sns": "aa9c1b5f-821f-418a-a1b1-a60435b7dc1c",
+      "alias/aws/ssm": "4040fe62-b533-4a5d-ab2c-6301fb6bbd2a"
+    },
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "unresolved",
+      "logicalId": "Notif",
+      "resourceType": "AWS::CodeStarNotifications::NotificationRule",
+      "path": "Resource",
+      "physicalId": "arn:aws:codestar-notifications:us-east-1:111111111111:notificationrule/fcc0a5acc48466db7e41e7b7a00f675a6c036e61",
+      "constructPath": "CdkRealDriftIntegSloNotif/Notif"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Notif",
+      "resourceType": "AWS::CodeStarNotifications::NotificationRule",
+      "path": "Status",
+      "actual": "ENABLED",
+      "physicalId": "arn:aws:codestar-notifications:us-east-1:111111111111:notificationrule/fcc0a5acc48466db7e41e7b7a00f675a6c036e61",
+      "constructPath": "CdkRealDriftIntegSloNotif/Notif"
+    }
+  ]
+}

--- a/tests/integration/slo-notif-rich/app.ts
+++ b/tests/integration/slo-notif-rich/app.ts
@@ -1,0 +1,75 @@
+// CDK app for the cdk-real-drift SLO + CodeStar NotificationRule false-positive
+// integration test (bug hunt). Two common, serverless, cheap observability/CI types
+// with NO prior coverage:
+//
+//   AWS::ApplicationSignals::ServiceLevelObjective — a period-based SLO. We DECLARE
+//   only the required Sli (metric + threshold + comparison) and deliberately OMIT
+//   Goal and Description, so AWS fills them at creation: Description -> "No description",
+//   Goal -> a default rolling-7-day interval with AttainmentGoal 99 (and a
+//   WarningThreshold). Every such AWS-assigned undeclared default must fold to
+//   atDefault on a first `check` — anything surfacing is a fold gap. The metric also
+//   carries two Dimensions (an insertionOrder:false array) to probe reorder FPs.
+//
+//   AWS::CodeStarNotifications::NotificationRule — on a CodeBuild project, targeting
+//   an SNS topic. Status defaults to ENABLED and EventTypeIds is an unordered set;
+//   both are FP-prone if AWS echoes them back normalized/reordered.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnServiceLevelObjective } from "aws-cdk-lib/aws-applicationsignals";
+import { CfnNotificationRule } from "aws-cdk-lib/aws-codestarnotifications";
+import { Project, BuildSpec } from "aws-cdk-lib/aws-codebuild";
+import { Topic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegSloNotif");
+
+// Period-based SLO over a plain CloudWatch metric. Goal + Description omitted on
+// purpose so AWS materializes its defaults undeclared.
+new CfnServiceLevelObjective(stack, "Slo", {
+  name: "cdkrd-slo-lambda-errors",
+  sli: {
+    sliMetric: {
+      metricDataQueries: [
+        {
+          id: "m1",
+          returnData: true,
+          metricStat: {
+            metric: {
+              namespace: "AWS/Lambda",
+              metricName: "Errors",
+              dimensions: [
+                { name: "FunctionName", value: "cdkrd-slo-fn" },
+                { name: "Resource", value: "cdkrd-slo-fn:live" },
+              ],
+            },
+            period: 60,
+            stat: "Sum",
+          },
+        },
+      ],
+    },
+    metricThreshold: 5,
+    comparisonOperator: "LessThanOrEqualTo",
+  },
+});
+
+// CodeBuild project + SNS topic to hang a NotificationRule on.
+const project = new Project(stack, "Proj", {
+  buildSpec: BuildSpec.fromObject({
+    version: "0.2",
+    phases: { build: { commands: ["echo hello"] } },
+  }),
+});
+const topic = new Topic(stack, "NotifTopic");
+
+new CfnNotificationRule(stack, "Notif", {
+  name: "cdkrd-notif-rule",
+  detailType: "BASIC",
+  resource: project.projectArn,
+  eventTypeIds: [
+    "codebuild-project-build-state-succeeded",
+    "codebuild-project-build-state-failed",
+  ],
+  targets: [{ targetType: "SNS", targetAddress: topic.topicArn }],
+});
+
+app.synth();

--- a/tests/integration/slo-notif-rich/cdk.json
+++ b/tests/integration/slo-notif-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/slo-notif-rich/package.json
+++ b/tests/integration/slo-notif-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-slo-notif-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift SLO + CodeStar NotificationRule false-positive integration test (bug hunt). Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/slo-notif-rich/verify.sh
+++ b/tests/integration/slo-notif-rich/verify.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# cdk-real-drift SLO + CodeStar NotificationRule false-positive integration test
+# (real AWS, bug hunt). Deploys an ApplicationSignals ServiceLevelObjective (Goal +
+# Description omitted so AWS fills defaults undeclared) and a CodeStarNotifications
+# NotificationRule. Strong assertion: with NO baseline, `check --fail` must exit 0 —
+# every AWS-assigned undeclared default must fold to atDefault, and no declared value
+# may surface as drift. Then record + check stays CLEAN.
+#
+# A cleanup trap destroys even on failure, so a failed run leaves no orphans.
+# Usage:  cd tests/integration/slo-notif-rich && npm install && bash verify.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegSloNotif
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== corpus harvest (fresh, no baseline) ==="
+CDKRD_CORPUS_DIR="${CDKRD_CORPUS_DIR:-/tmp/corpus-slo-notif}" $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+
+echo "=== check --fail (no baseline) must find ZERO potential drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-slo-notif-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "potential drift on a clean fresh deploy (exit $rc) — a fold gap"
+
+echo "=== record then check must stay CLEAN ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after record"
+
+echo "INTEG PASS"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
+import { matchesKnownDefault } from '../src/diff/classify.js';
 import { stripCcApiAwsManagedFields } from '../src/normalize/cc-api-strip.js';
 import {
   awsManagedTags,
@@ -955,6 +956,57 @@ describe('noise suppressors', () => {
       Domain: 'S3',
       S3StorageOptions: { DirectoryListingOptimization: 'DISABLED' },
     });
+  });
+
+  it('ApplicationSignals SLO Goal first-run default (bug-hunt: slo-notif-rich)', () => {
+    // A period-based SLO that omits `Goal` reads it back fully materialized with
+    // AWS's constant default (rolling 7-day interval, AttainmentGoal 99,
+    // WarningThreshold 50) — a whole nested object the CFn schema does NOT annotate
+    // as `default`. Equality-gated whole-object, so an out-of-band change to any
+    // sub-field (a different AttainmentGoal, a calendar interval) no longer matches
+    // and re-surfaces. Exercised live and by the
+    // AWS__ApplicationSignals__ServiceLevelObjective corpus case.
+    expect(KNOWN_DEFAULTS['AWS::ApplicationSignals::ServiceLevelObjective']).toEqual({
+      Goal: {
+        WarningThreshold: 50,
+        AttainmentGoal: 99,
+        Interval: { RollingInterval: { DurationUnit: 'DAY', Duration: 7 } },
+      },
+    });
+    const goalDef = KNOWN_DEFAULTS['AWS::ApplicationSignals::ServiceLevelObjective']!.Goal;
+    // Folds the exact default...
+    expect(
+      matchesKnownDefault(
+        {
+          WarningThreshold: 50,
+          AttainmentGoal: 99,
+          Interval: { RollingInterval: { DurationUnit: 'DAY', Duration: 7 } },
+        },
+        goalDef
+      )
+    ).toBe(true);
+    // ...but an out-of-band change to AttainmentGoal still surfaces (detection kept).
+    expect(
+      matchesKnownDefault(
+        {
+          WarningThreshold: 50,
+          AttainmentGoal: 95,
+          Interval: { RollingInterval: { DurationUnit: 'DAY', Duration: 7 } },
+        },
+        goalDef
+      )
+    ).toBe(false);
+    // ...and a calendar interval (a real, user-meaningful choice) surfaces too.
+    expect(
+      matchesKnownDefault(
+        {
+          WarningThreshold: 50,
+          AttainmentGoal: 99,
+          Interval: { CalendarInterval: { DurationUnit: 'MONTH', Duration: 1 } },
+        },
+        goalDef
+      )
+    ).toBe(false);
   });
 
   it('isCfnTemplateNonAsciiMask: GetTemplate `?`-masked non-ASCII declared value is not drift', () => {


### PR DESCRIPTION
## What

Real-AWS bug hunt on two common, serverless, cheap, previously-uncovered types:
**`AWS::ApplicationSignals::ServiceLevelObjective`** (SLO) and
**`AWS::CodeStarNotifications::NotificationRule`**.

### The bug (FP fold gap)

A period-based SLO that **omits `Goal`** reads it back fully materialized with
AWS's constant default — a rolling 7-day interval, `AttainmentGoal` 99,
`WarningThreshold` 50. The CFn schema documents these in prose but does **not**
annotate a `default`, so the schema-driven fold can't reach it and the whole
`Goal` object surfaced as `[Potential Drift]` on a **clean first `check`** — a
false positive (fold gap).

### The fix

An equality-gated whole-object `KNOWN_DEFAULTS` entry for the SLO `Goal`. It folds
the exact default to `atDefault`, and any out-of-band change to a sub-field still
re-surfaces (detection preserved).

## Live verification (real AWS, us-east-1, torn down + swept clean)

- Fresh deploy, `check` before record: `Slo.Goal` FP → after fix, **`result: CLEAN` (exit 0)**.
- Equality-gate detection: `AttainmentGoal` 99→95 out of band → **re-surfaces** as potential drift (not folded).
- Declared-prop FN: `Sli.MetricThreshold` 5→10 out of band → **detected** (declared drift, exit 1) → `revert` → **live restored to 5**, `check` CLEAN.
- `record` → `check` → CLEAN.
- `NotificationRule`: `Status` default `ENABLED` already folds via schema default — no FP.

## Also

- New golden-corpus cases: `ServiceLevelObjective` + `NotificationRule` (offline
  `corpus-replay` regression, 2 new cases).
- New `slo-notif-rich` integration fixture.
- Unit test asserting the fold + the equality-gate (folds exact default; surfaces
  an off-default `AttainmentGoal` and a calendar interval).

All local gates pass: typecheck / lint+format / build / 2911 unit tests.
