### PR TITLE
fix(noise): fold Events ApiDestination InvocationRateLimitPerSecond default (bug hunt: events-apidest-rich)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -37,6 +37,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // config; ApplicationMode is createOnly so it cannot drift). Equality-gated. Observed
   // live on a fresh READY Flink app (streaming-rich fixture, 2026-07-03; #509).
   'AWS::KinesisAnalyticsV2::Application': { ApplicationMode: 'STREAMING' },
+  // An EventBridge API destination that declares no InvocationRateLimitPerSecond reads
+  // back AWS's constant default of 300 requests/second (the documented default + maximum
+  // when the property is omitted). Equality-gated: a user who sets a throttle (e.g. 10)
+  // or an out-of-band console change no longer matches 300 and re-surfaces as real
+  // undeclared drift. Observed live on a fresh events-apidest-rich ApiDestination
+  // (2026-07-08).
+  'AWS::Events::ApiDestination': { InvocationRateLimitPerSecond: 300 },
   // An Elastic Beanstalk Application that declares no ResourceLifecycleConfig reads back
   // the constant service default: a version-lifecycle policy carrying both rules present
   // but DISABLED (Enabled:false, MaxCount 200 / MaxAgeInDays 180, DeleteSourceFromS3:false).

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -114,6 +114,11 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // {IntendedUse:"SingleUse"} default object back explicitly (2nd object-valued entry after
   // AppRunner) so revert converges.
   'AWS::Location::PlaceIndex\0DataSourceConfiguration',
+  // EventBridge UpdateApiDestination IGNORES an omitted InvocationRateLimitPerSecond
+  // (live-observed on events-apidest-rich 2026-07-08: a `remove` revert of an out-of-band
+  // 50 reported SUCCESS yet the live value stayed 50 — "1 drift remain"). Write the 300
+  // default (from KNOWN_DEFAULTS) back explicitly so revert converges.
+  'AWS::Events::ApiDestination\0InvocationRateLimitPerSecond',
 ]);
 
 /**

--- a/tests/corpus/AWS__Events__ApiDestination.ApiDestination.json
+++ b/tests/corpus/AWS__Events__ApiDestination.ApiDestination.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiDestination",
+    "resourceType": "AWS::Events::ApiDestination",
+    "physicalId": "cdkrd-apidest-rich",
+    "constructPath": "CdkRealDriftIntegEventsApiDestRich/ApiDestination",
+    "declared": {
+      "ConnectionArn": "arn:aws:events:us-east-1:111111111111:connection/cdkrd-apidest-connection/e3a665cf-85d3-4365-bf01-f5a0dd2ffc1f",
+      "Description": "cdkrd api destination",
+      "HttpMethod": "POST",
+      "InvocationEndpoint": "https://example.com/webhook",
+      "Name": "cdkrd-apidest-rich"
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd api destination",
+    "ConnectionArn": "arn:aws:events:us-east-1:111111111111:connection/cdkrd-apidest-connection/e3a665cf-85d3-4365-bf01-f5a0dd2ffc1f",
+    "InvocationEndpoint": "https://example.com/webhook",
+    "Arn": "arn:aws:events:us-east-1:111111111111:api-destination/cdkrd-apidest-rich/b13b4ef9-ab7a-4217-8710-8d9e7a0384a4",
+    "ArnForPolicy": "arn:aws:events:us-east-1:111111111111:api-destination/cdkrd-apidest-rich",
+    "HttpMethod": "POST",
+    "Name": "cdkrd-apidest-rich",
+    "InvocationRateLimitPerSecond": 300
+  },
+  "schema": {
+    "readOnly": ["Arn", "ArnForPolicy"],
+    "writeOnly": [],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "ArnForPolicy"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "ApiDestination",
+      "resourceType": "AWS::Events::ApiDestination",
+      "path": "InvocationRateLimitPerSecond",
+      "actual": 300,
+      "physicalId": "cdkrd-apidest-rich",
+      "constructPath": "CdkRealDriftIntegEventsApiDestRich/ApiDestination"
+    }
+  ]
+}

--- a/tests/integration/events-apidest-rich/app.ts
+++ b/tests/integration/events-apidest-rich/app.ts
@@ -1,0 +1,40 @@
+// CDK app for the cdk-real-drift events-apidest-rich false-positive integration test.
+// EventBridge API Destinations (AWS::Events::Connection + AWS::Events::ApiDestination)
+// are a common outbound-webhook integration. A Connection folds an AuthorizationType,
+// nested AuthParameters (API-key), and an AWS-created SecretArn / State into AWS's
+// model; an ApiDestination folds an InvocationRateLimitPerSecond default (300) that
+// the template never declares. A clean `record`->`check` is a strong false-positive
+// oracle for those undeclared, AWS-assigned values.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnApiDestination, CfnConnection } from "aws-cdk-lib/aws-events";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegEventsApiDestRich");
+
+const connection = new CfnConnection(stack, "Connection", {
+  name: "cdkrd-apidest-connection",
+  description: "cdkrd api destination connection",
+  authorizationType: "API_KEY",
+  authParameters: {
+    apiKeyAuthParameters: {
+      apiKeyName: "x-api-key",
+      apiKeyValue: "cdkrd-placeholder-key",
+    },
+    invocationHttpParameters: {
+      headerParameters: [
+        { key: "x-custom-header", value: "cdkrd", isValueSecret: false },
+      ],
+    },
+  },
+});
+
+new CfnApiDestination(stack, "ApiDestination", {
+  name: "cdkrd-apidest-rich",
+  description: "cdkrd api destination",
+  connectionArn: connection.attrArn,
+  invocationEndpoint: "https://example.com/webhook",
+  httpMethod: "POST",
+  // InvocationRateLimitPerSecond deliberately NOT declared -> AWS defaults it to 300.
+});
+
+app.synth();

--- a/tests/integration/events-apidest-rich/cdk.json
+++ b/tests/integration/events-apidest-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/events-apidest-rich/package.json
+++ b/tests/integration/events-apidest-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-events-apidest-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift events-apidest-rich false-positive integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/events-apidest-rich/verify-detect.sh
+++ b/tests/integration/events-apidest-rich/verify-detect.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# EventBridge ApiDestination detect + revert integration test (real AWS): the
+# "someone changed the HTTP method in the console" scenario. Deploy -> record ->
+# flip the DECLARED MUTABLE HttpMethod POST->PUT out of band -> check MUST DETECT
+# (exit 1) -> revert -> check MUST be CLEAN and HttpMethod restored to POST.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEventsApiDestRich
+NAME=cdkrd-apidest-rich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== record baseline ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== out-of-band: HttpMethod POST->PUT (console-edit) ==="
+aws events update-api-destination --name "$NAME" --region "$REGION" \
+  --http-method PUT >/dev/null || fail "inject drift"
+
+echo "=== check MUST DETECT declared drift ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-apidest-detect.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 1 ] || fail "expected drift exit 1, got $rc"
+grep -qi "HttpMethod" /tmp/cdkrd-apidest-detect.out || fail "HttpMethod not reported"
+
+echo "=== revert (write declared value back) ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail "revert"
+
+echo "=== check MUST be CLEAN after revert ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) after revert"
+
+echo "=== live HttpMethod MUST be restored to POST ==="
+GOT="$(aws events describe-api-destination --name "$NAME" --region "$REGION" --query "HttpMethod" --output text)"
+[ "$GOT" = "POST" ] || fail "live HttpMethod not restored (got: $GOT)"
+
+echo "INTEG PASS ($STACK detect+revert)"

--- a/tests/integration/events-apidest-rich/verify.sh
+++ b/tests/integration/events-apidest-rich/verify.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# False-positive integration test (real AWS): deploy -> record baseline -> check
+# MUST be CLEAN. An EventBridge Connection folds AuthorizationType + nested
+# AuthParameters + an AWS-created SecretArn/State; an ApiDestination folds an
+# undeclared InvocationRateLimitPerSecond default (300). Any drift on a clean
+# recorded stack is a normalization / default-folding FP.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegEventsApiDestRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check BEFORE record (first-run noise oracle) ==="
+$CLI check "$STACK" --region "$REGION" | tee "/tmp/cdkrd-$STACK-firstrun.out" || true
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check MUST be CLEAN ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee "/tmp/cdkrd-$STACK.out"
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || { echo "--- FALSE POSITIVE: $STACK reported drift on a clean recorded stack ---"; fail "expected CLEAN (exit 0), got $rc"; }
+
+echo "INTEG PASS ($STACK)"

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -706,6 +706,18 @@ describe('noise suppressors', () => {
     });
   });
 
+  it('EventBridge ApiDestination undeclared InvocationRateLimitPerSecond folds to the 300 default (bug-hunt: events-apidest-rich)', () => {
+    // An ApiDestination that declares no InvocationRateLimitPerSecond reads back AWS's
+    // constant default of 300 req/s (the documented default + maximum when omitted). It
+    // surfaced as a first-run [Potential Drift] FP on a clean deploy until folded. Equality-
+    // gated, so a user-set throttle or out-of-band change no longer matches 300 and re-
+    // surfaces (proven live 2026-07-08; exercised end-to-end by the AWS__Events__
+    // ApiDestination.ApiDestination corpus-replay case).
+    expect(KNOWN_DEFAULTS['AWS::Events::ApiDestination']).toEqual({
+      InvocationRateLimitPerSecond: 300,
+    });
+  });
+
   it('common stateful/streaming-type constant defaults from the offline corpus sweep', () => {
     // Constant, documented service defaults common stateful/streaming types report as
     // first-run undeclared noise. Verified against the golden corpus (RDS DBInstance

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -457,6 +457,27 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Events ApiDestination InvocationRateLimitPerSecond (SET-DEFAULT) -> add op writing 300, not a no-op remove', () => {
+    // AWS::Events::ApiDestination InvocationRateLimitPerSecond is in REVERT_SET_DEFAULT_PATHS:
+    // UpdateApiDestination leaves the value UNCHANGED when it is OMITTED, so a bare `remove` of
+    // an out-of-band 50 is a silent no-op (Cloud Control reports SUCCESS yet the live 50
+    // persists — "1 drift remain"; proven live on events-apidest-rich 2026-07-08). Revert must
+    // write the 300 default (from KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Events::ApiDestination',
+      path: 'InvocationRateLimitPerSecond',
+      actual: 50,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/InvocationRateLimitPerSecond',
+      value: 300,
+      prior: 50,
+    });
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.


### PR DESCRIPTION
## What

Bug-hunt round on **EventBridge API destinations** (`AWS::Events::Connection` +
`AWS::Events::ApiDestination`), a common outbound-webhook integration.

### FP fixed
An ApiDestination that declares no `InvocationRateLimitPerSecond` reads back AWS's
constant default of **300** req/s (the documented default + maximum when omitted).
It surfaced as a first-run `[Potential Drift]` **false positive** on a clean,
un-mutated deploy. Folded to `atDefault` via an equality-gated `KNOWN_DEFAULTS`
entry — a user-set throttle or an out-of-band change no longer matches 300 and still
re-surfaces (detection preserved, proven live: 300→50 re-surfaced).

### Revert convergence (silent no-op) fixed
Revert of that out-of-band change was a **silent no-op**: `UpdateApiDestination`
ignores an omitted `InvocationRateLimitPerSecond`, so a bare `remove` reported
SUCCESS yet left the live value at 50 (Transfer #597 class). Added the type to
`REVERT_SET_DEFAULT_PATHS` so revert writes the 300 default explicitly and
converges (proven live: 50→300, then `check` CLEAN).

## Live-proven (real AWS, us-east-1, torn down + swept clean)
- clean deploy → first `check` CLEAN (rate limit folds to `atDefault`) ✅
- declared `HttpMethod` POST→PUT → `check` DETECTS → `revert` → CLEAN, restored ✅
- undeclared rate-limit 300→50 → `check` DETECTS → `revert` → 300, CLEAN ✅

## Tests
- `noise-and-strip`: KNOWN_DEFAULTS fold assertion
- `revert-plan`: SET-DEFAULT add-op (writes 300, not a no-op remove)
- `AWS__Events__ApiDestination.ApiDestination` corpus-replay regression guard
- `events-apidest-rich` integration fixture + `verify.sh` / `verify-detect.sh`

SSM::Document was also deployed + hunted this round → **CLEAN** on first check
(Content shape folds, `UpdateMethod` transparent readGap); already covered by the
`ssm` fixture + corpus, so no fixture added.
