### PR TITLE
fix(noise): fold Cognito IdentityPool/UserPool auto-generated names (bug hunt: identity-obs)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1851,9 +1851,9 @@ export const DESCEND_UNDECLARED_OBJECT_PATHS: Record<string, ReadonlySet<string>
 };
 
 // Value-DEPENDENT generated-name fold, scoped by type + top-level path. Folds a live value
-// to `generated` ONLY when it is the `<logicalId>-<random>` CFn auto-generated form — the
-// resource's logical id, a `-`, then CFn's 12+ char random suffix — for a type whose
-// no-explicit-name physical name takes that shape WITHOUT a `<stack>-` prefix (so the
+// to `generated` ONLY when it is the `<logicalId><sep><random>` CFn auto-generated form — the
+// resource's logical id, a `-` or `_` separator, then CFn's 12+ char random suffix — for a type
+// whose no-explicit-name physical name takes that shape WITHOUT a `<stack>-` prefix (so the
 // isCfnGeneratedName stack-prefix branches miss it). UNLIKE the value-independent
 // GENERATED_TOPLEVEL_PATHS, an undeclared user-SET name (no logical-id prefix) does NOT match
 // and still surfaces as real drift. Deliberately NOT applied generically in
@@ -1862,18 +1862,27 @@ export const DESCEND_UNDECLARED_OBJECT_PATHS: Record<string, ReadonlySet<string>
 // names and over-fold — this table gates it to the specific types/paths observed to need it.
 //   AWS::Cognito::UserPoolClient.ClientName — reads back `<logicalId>-<random>` when the
 //   template declares no ClientName (observed live).
+//   AWS::Cognito::IdentityPool.IdentityPoolName — reads back `<logicalId>_<random>` when the
+//   template declares no IdentityPoolName (observed live: logical id "IdPool" →
+//   "IdPool_r5WzZ9554da2"). The separator is an underscore, not a hyphen — identity-pool
+//   names use a different generated form — so isLogicalIdPrefixedGeneratedName accepts both.
+//   AWS::Cognito::UserPool.UserPoolName — reads back `<logicalId>-<random>` when the template
+//   declares no UserPoolName (observed live across corpus: "Pool88FC4FF9F-jVGU9rNojAd7",
+//   "Users0A0EEA89-RYUoEBfJwQHo"). Same class as the sibling ClientName — audited in.
 export const GENERATED_LOGICALID_PREFIX_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Cognito::UserPoolClient': new Set(['ClientName']),
+  'AWS::Cognito::IdentityPool': new Set(['IdentityPoolName']),
+  'AWS::Cognito::UserPool': new Set(['UserPoolName']),
 };
 
-// True when `value` is the `<logicalId>-<random>` CFn auto-generated-name form: the logical
-// id, a `-`, then CFn's random suffix. Consulted only for GENERATED_LOGICALID_PREFIX_PATHS
-// entries. Pure + exported for unit tests.
-const CFN_LOGICALID_RANDOM = /-[0-9A-Za-z]{12,}$/;
+// True when `value` is the `<logicalId><sep><random>` CFn auto-generated-name form: the logical
+// id, a `-` OR `_` separator, then CFn's random suffix. Consulted only for
+// GENERATED_LOGICALID_PREFIX_PATHS entries. Pure + exported for unit tests.
+const CFN_LOGICALID_RANDOM = /[-_][0-9A-Za-z]{12,}$/;
 export function isLogicalIdPrefixedGeneratedName(value: unknown, logicalId: string): boolean {
   return (
     typeof value === 'string' &&
-    value.startsWith(`${logicalId}-`) &&
+    (value.startsWith(`${logicalId}-`) || value.startsWith(`${logicalId}_`)) &&
     CFN_LOGICALID_RANDOM.test(value)
   );
 }

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9377,6 +9377,56 @@ describe('Face-stack false-positive folds', () => {
     expect(userSet.generated).toEqual([]);
   });
 
+  it('Cognito IdentityPool undeclared IdentityPoolName (<logicalId>_<random>) folds to generated', () => {
+    // An IdentityPool with no explicit IdentityPoolName reads back `<logicalId>_<random>` —
+    // note the UNDERSCORE separator, unlike UserPoolClient's `<logicalId>-<random>`. It folds
+    // via GENERATED_LOGICALID_PREFIX_PATHS, NOT a value-independent fold that would also hide a
+    // user-set name. Observed live: logical id "IdPool" → "IdPool_r5WzZ9554da2".
+    const poolResource = {
+      logicalId: 'IdPool',
+      resourceType: 'AWS::Cognito::IdentityPool',
+      physicalId: 'us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792',
+      constructPath: 'Stack/IdPool',
+      declared: {},
+    };
+    const pool = tiers(
+      classifyResource(poolResource, { IdentityPoolName: 'IdPool_r5WzZ9554da2' }, emptySchema)
+    );
+    expect(pool.generated).toEqual(['IdentityPoolName']);
+    expect(pool.undeclared).toEqual([]);
+    // A user-SET IdentityPoolName (no logical-id prefix) is NOT folded — it surfaces as real
+    // undeclared drift.
+    const userSetPool = tiers(
+      classifyResource(poolResource, { IdentityPoolName: 'my-app-identities' }, emptySchema)
+    );
+    expect(userSetPool.undeclared).toEqual(['IdentityPoolName']);
+    expect(userSetPool.generated).toEqual([]);
+  });
+
+  it('Cognito UserPool undeclared UserPoolName (<logicalId>-<random>) folds to generated', () => {
+    // A UserPool with no explicit UserPoolName reads back `<logicalId>-<random>` (the same
+    // sibling class as UserPoolClient.ClientName). It folds via GENERATED_LOGICALID_PREFIX_PATHS,
+    // NOT a value-independent fold. Observed live across corpus: "Pool88FC4FF9F-jVGU9rNojAd7".
+    const poolResource = {
+      logicalId: 'Pool88FC4FF9F',
+      resourceType: 'AWS::Cognito::UserPool',
+      physicalId: 'us-east-1_BUaNF3GfH',
+      constructPath: 'Stack/Pool8',
+      declared: {},
+    };
+    const pool = tiers(
+      classifyResource(poolResource, { UserPoolName: 'Pool88FC4FF9F-jVGU9rNojAd7' }, emptySchema)
+    );
+    expect(pool.generated).toEqual(['UserPoolName']);
+    expect(pool.undeclared).toEqual([]);
+    // A user-SET UserPoolName (no logical-id prefix) still surfaces as real undeclared drift.
+    const userSetPool = tiers(
+      classifyResource(poolResource, { UserPoolName: 'my-production-pool' }, emptySchema)
+    );
+    expect(userSetPool.undeclared).toEqual(['UserPoolName']);
+    expect(userSetPool.generated).toEqual([]);
+  });
+
   it('WAF WebACL ByteMatch SearchStringBase64 echo folds; a changed pattern is real drift', () => {
     const declared = {
       Rules: [

--- a/tests/corpus/AWS__Cognito__IdentityPool.IdPool.json
+++ b/tests/corpus/AWS__Cognito__IdentityPool.IdPool.json
@@ -1,0 +1,80 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "IdPool",
+    "resourceType": "AWS::Cognito::IdentityPool",
+    "physicalId": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+    "constructPath": "CdkRealDriftIntegCognitoIdPoolRich/IdPool",
+    "declared": {
+      "AllowUnauthenticatedIdentities": true
+    }
+  },
+  "liveRaw": {
+    "CognitoIdentityProviders": [],
+    "Id": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+    "IdentityPoolName": "IdPool_r5WzZ9554da2",
+    "SupportedLoginProviders": {},
+    "AllowUnauthenticatedIdentities": true,
+    "Name": "IdPool_r5WzZ9554da2",
+    "SamlProviderARNs": [],
+    "OpenIdConnectProviderARNs": [],
+    "AllowClassicFlow": false,
+    "IdentityPoolTags": [
+      {
+        "Value": "CdkRealDriftIntegCognitoIdPoolRich",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftIntegCognitoIdPoolRich/56fcf3c0-7a26-11f1-9625-0e573fd48a13",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "IdPool",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Id", "Name"],
+    "writeOnly": ["CognitoStreams", "PushSync"],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "Name"],
+    "writeOnlyPaths": ["CognitoStreams", "PushSync"],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [
+      "OpenIdConnectProviderARNs",
+      "PushSync.ApplicationArns",
+      "SamlProviderARNs"
+    ],
+    "unorderedObjectArrayPaths": ["CognitoIdentityProviders"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "IdPool",
+      "resourceType": "AWS::Cognito::IdentityPool",
+      "path": "IdentityPoolName",
+      "actual": "IdPool_r5WzZ9554da2",
+      "physicalId": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+      "constructPath": "CdkRealDriftIntegCognitoIdPoolRich/IdPool"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "IdPool",
+      "resourceType": "AWS::Cognito::IdentityPool",
+      "path": "AllowClassicFlow",
+      "actual": false,
+      "physicalId": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+      "constructPath": "CdkRealDriftIntegCognitoIdPoolRich/IdPool"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Cognito__IdentityPoolRoleAttachment.RoleAttachment.json
+++ b/tests/corpus/AWS__Cognito__IdentityPoolRoleAttachment.RoleAttachment.json
@@ -1,0 +1,43 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RoleAttachment",
+    "resourceType": "AWS::Cognito::IdentityPoolRoleAttachment",
+    "physicalId": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+    "constructPath": "CdkRealDriftIntegCognitoIdPoolRich/RoleAttachment",
+    "declared": {
+      "IdentityPoolId": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+      "Roles": {
+        "unauthenticated": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCognitoIdPoolRi-UnauthRole74358E81-E6KC6lALv81k"
+      }
+    }
+  },
+  "liveRaw": {
+    "RoleMappings": {},
+    "IdentityPoolId": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792",
+    "Roles": {
+      "unauthenticated": "arn:aws:iam::111111111111:role/CdkRealDriftIntegCognitoIdPoolRi-UnauthRole74358E81-E6KC6lALv81k"
+    },
+    "Id": "us-east-1:e04800fe-e59f-4a8a-adba-6d2b1bf9f792"
+  },
+  "schema": {
+    "readOnly": ["Id"],
+    "writeOnly": [],
+    "createOnly": ["IdentityPoolId"],
+    "readOnlyPaths": ["Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["IdentityPoolId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Pool88FC4FF9F.json
@@ -609,7 +609,7 @@
       "constructPath": "CdkdriftIntegHarvest8/Pool8"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Pool88FC4FF9F",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8.json
@@ -610,7 +610,7 @@
       "constructPath": "CdkrdIntegHarvest6/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",

--- a/tests/corpus/AWS__Cognito__UserPool.RecoveryMechanisms.json
+++ b/tests/corpus/AWS__Cognito__UserPool.RecoveryMechanisms.json
@@ -611,7 +611,7 @@
       "constructPath": "CdkRealDriftIntegCognitoRecoverySubset/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -589,7 +589,7 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "UserPoolName",

--- a/tests/integration/cloudwatch-compositealarm-rich/app.ts
+++ b/tests/integration/cloudwatch-compositealarm-rich/app.ts
@@ -1,0 +1,57 @@
+// Minimal CDK app for the cdk-real-drift CloudWatch CompositeAlarm integration test.
+//
+// Stack CdkRealDriftIntegCompositeAlarmRich exercises AWS::CloudWatch::CompositeAlarm —
+// the "alarm of alarms" pattern (combine several metric alarms with a boolean rule)
+// that ops teams deploy for aggregate health. Two child metric alarms feed one
+// composite alarm.
+//
+// A freshly deployed, un-mutated stack must produce ZERO [Potential Drift] on a first
+// `check`. Every value AWS assigns undeclared (ActionsEnabled default true, etc.) must
+// fold to atDefault.
+import { App, Duration, Stack } from "aws-cdk-lib";
+import {
+  Alarm,
+  AlarmRule,
+  ComparisonOperator,
+  CompositeAlarm,
+  Metric,
+  TreatMissingData,
+} from "aws-cdk-lib/aws-cloudwatch";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCompositeAlarmRich");
+
+const cpu = new Alarm(stack, "CpuAlarm", {
+  metric: new Metric({
+    namespace: "AWS/EC2",
+    metricName: "CPUUtilization",
+    period: Duration.minutes(5),
+    statistic: "Average",
+  }),
+  threshold: 80,
+  evaluationPeriods: 2,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+  treatMissingData: TreatMissingData.NOT_BREACHING,
+});
+
+const net = new Alarm(stack, "NetAlarm", {
+  metric: new Metric({
+    namespace: "AWS/EC2",
+    metricName: "NetworkIn",
+    period: Duration.minutes(5),
+    statistic: "Average",
+  }),
+  threshold: 1_000_000,
+  evaluationPeriods: 2,
+  comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+});
+
+new CompositeAlarm(stack, "Composite", {
+  alarmRule: AlarmRule.anyOf(cpu, net),
+  compositeAlarmName: "cdkrd-integ-composite",
+  actionsSuppressor: cpu,
+  actionsSuppressorExtensionPeriod: Duration.minutes(1),
+  actionsSuppressorWaitPeriod: Duration.minutes(1),
+});
+
+app.synth();

--- a/tests/integration/cloudwatch-compositealarm-rich/cdk.json
+++ b/tests/integration/cloudwatch-compositealarm-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cloudwatch-compositealarm-rich/package.json
+++ b/tests/integration/cloudwatch-compositealarm-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cloudwatch-compositealarm-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift CloudWatch CompositeAlarm integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cloudwatch-compositealarm-rich/verify.sh
+++ b/tests/integration/cloudwatch-compositealarm-rich/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# cdk-real-drift integration test (real AWS) for CdkRealDriftIntegCompositeAlarmRich.
+#   deploy fixture -> check BEFORE record (must be CLEAN: zero potential drift on a
+#   fresh un-mutated deploy) -> record (baseline) -> check --fail must be CLEAN.
+# A cleanup trap force-deletes the stack even on failure (delstack, not cdk destroy).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCompositeAlarmRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check BEFORE record (must be CLEAN — zero potential drift) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-$STACK-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected CLEAN before record (exit 0), got $rc — fold gap (FP)"
+
+echo "=== record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check should be CLEAN after record ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record"
+
+echo "INTEG PASS"

--- a/tests/integration/cognito-identitypool-rich/app.ts
+++ b/tests/integration/cognito-identitypool-rich/app.ts
@@ -1,0 +1,45 @@
+// Minimal CDK app for the cdk-real-drift Cognito Identity Pool integration test.
+//
+// Stack CdkRealDriftIntegCognitoIdPoolRich exercises AWS::Cognito::IdentityPool +
+// AWS::Cognito::IdentityPoolRoleAttachment — the federated-identity pattern web/mobile
+// apps deploy alongside a User Pool. Uses the L1 Cfn* constructs so the native CFn
+// types are exercised.
+//
+// A freshly deployed, un-mutated stack must produce ZERO [Potential Drift] on a first
+// `check`. Every value AWS assigns undeclared (e.g. an AllowClassicFlow default) must
+// fold to atDefault.
+import { App, Stack } from "aws-cdk-lib";
+import { CfnIdentityPool, CfnIdentityPoolRoleAttachment } from "aws-cdk-lib/aws-cognito";
+import { FederatedPrincipal, PolicyStatement, Role } from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCognitoIdPoolRich");
+
+const pool = new CfnIdentityPool(stack, "IdPool", {
+  allowUnauthenticatedIdentities: true,
+});
+
+// Unauthenticated role assumable by the identity pool (the classic guest-access role).
+const unauthRole = new Role(stack, "UnauthRole", {
+  assumedBy: new FederatedPrincipal(
+    "cognito-identity.amazonaws.com",
+    {
+      StringEquals: { "cognito-identity.amazonaws.com:aud": pool.ref },
+      "ForAnyValue:StringLike": { "cognito-identity.amazonaws.com:amr": "unauthenticated" },
+    },
+    "sts:AssumeRoleWithWebIdentity",
+  ),
+});
+unauthRole.addToPolicy(
+  new PolicyStatement({
+    actions: ["mobileanalytics:PutEvents", "cognito-sync:*"],
+    resources: ["*"],
+  }),
+);
+
+new CfnIdentityPoolRoleAttachment(stack, "RoleAttachment", {
+  identityPoolId: pool.ref,
+  roles: { unauthenticated: unauthRole.roleArn },
+});
+
+app.synth();

--- a/tests/integration/cognito-identitypool-rich/cdk.json
+++ b/tests/integration/cognito-identitypool-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cognito-identitypool-rich/package.json
+++ b/tests/integration/cognito-identitypool-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cognito-identitypool-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift Cognito Identity Pool integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cognito-identitypool-rich/verify.sh
+++ b/tests/integration/cognito-identitypool-rich/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# cdk-real-drift integration test (real AWS) for CdkRealDriftIntegCognitoIdPoolRich.
+#   deploy fixture -> check BEFORE record (must be CLEAN: zero potential drift on a
+#   fresh un-mutated deploy) -> record (baseline) -> check --fail must be CLEAN.
+# A cleanup trap force-deletes the stack even on failure (delstack, not cdk destroy).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCognitoIdPoolRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check BEFORE record (must be CLEAN — zero potential drift) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-$STACK-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected CLEAN before record (exit 0), got $rc — fold gap (FP)"
+
+echo "=== record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check should be CLEAN after record ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record"
+
+echo "INTEG PASS"

--- a/tests/integration/iam-identity-rich/app.ts
+++ b/tests/integration/iam-identity-rich/app.ts
@@ -1,0 +1,42 @@
+// Minimal CDK app for the cdk-real-drift IAM-identity integration test.
+//
+// Stack CdkRealDriftIntegIamIdentityRich exercises two common, previously-untested
+// IAM identity resource types deployed by a large fraction of CDK users:
+//   * AWS::IAM::OIDCProvider   — the GitHub Actions OIDC federation pattern
+//                                (token.actions.githubusercontent.com). Uses the L1
+//                                CfnOIDCProvider so the NATIVE CFn type is exercised,
+//                                not the custom-resource-backed L2.
+//   * AWS::IAM::InstanceProfile — the EC2 instance-profile pattern (role attached to
+//                                an instance).
+//
+// A freshly deployed, un-mutated stack must produce ZERO [Potential Drift] on a first
+// `check` (before `record`) — every value AWS assigns undeclared (a ThumbprintList
+// AWS may materialize, an InstanceProfile Path default of "/") must fold to atDefault.
+import { App, Stack } from "aws-cdk-lib";
+import {
+  CfnInstanceProfile,
+  CfnOIDCProvider,
+  Role,
+  ServicePrincipal,
+} from "aws-cdk-lib/aws-iam";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegIamIdentityRich");
+
+// The GitHub Actions OIDC provider — the single most common OIDCProvider in the wild.
+new CfnOIDCProvider(stack, "GitHubOidc", {
+  url: "https://token.actions.githubusercontent.com",
+  clientIdList: ["sts.amazonaws.com"],
+  thumbprintList: ["6938fd4d98bab03faadb97b34396831e3780aea1"],
+});
+
+// An EC2 instance profile wrapping a role.
+const instanceRole = new Role(stack, "InstanceRole", {
+  assumedBy: new ServicePrincipal("ec2.amazonaws.com"),
+  description: "cdk-real-drift instance-profile integration test role",
+});
+new CfnInstanceProfile(stack, "InstanceProfile", {
+  roles: [instanceRole.roleName],
+});
+
+app.synth();

--- a/tests/integration/iam-identity-rich/cdk.json
+++ b/tests/integration/iam-identity-rich/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/iam-identity-rich/package.json
+++ b/tests/integration/iam-identity-rich/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-iam-identity-rich",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift IAM-identity integration test. Run via verify.sh.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/iam-identity-rich/verify.sh
+++ b/tests/integration/iam-identity-rich/verify.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# cdk-real-drift integration test (real AWS) for CdkRealDriftIntegIamIdentityRich.
+#   deploy fixture -> check BEFORE record (must be CLEAN: zero potential drift on a
+#   fresh un-mutated deploy) -> record (baseline) -> check --fail must be CLEAN.
+# A cleanup trap force-deletes the stack even on failure (delstack, not cdk destroy).
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegIamIdentityRich
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL: $*"; exit 1; }
+
+echo "=== build cdk-real-drift ==="
+(cd "$ROOT" && vp run build) || fail "build"
+
+echo "=== deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== check BEFORE record (must be CLEAN — zero potential drift) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-$STACK-pre.out
+rc=${PIPESTATUS[0]}
+[ "$rc" -eq 0 ] || fail "expected CLEAN before record (exit 0), got $rc — fold gap (FP)"
+
+echo "=== record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== check should be CLEAN after record ==="
+$CLI check "$STACK" --region "$REGION" --fail
+[ $? -eq 0 ] || fail "expected CLEAN (exit 0) right after record"
+
+echo "INTEG PASS"


### PR DESCRIPTION
## Bug hunt: identity-obs

Deployed 3 previously-untested, high-frequency fixtures against real AWS and ran
`check` **before** `record` to catch first-run false positives.

### Finding — Cognito IdentityPool `IdentityPoolName` FP (fixed)

A fresh `AWS::Cognito::IdentityPool` that declares no `IdentityPoolName` reads its
live name back as the CFn auto-generated `<logicalId>_<random>` form — observed
live as `IdPool_r5WzZ9554da2` — and it surfaced as a first-run `[Potential Drift]`,
violating the **zero-potential-drift-on-a-clean-deploy** invariant.

The existing generated-name fold (`GENERATED_LOGICALID_PREFIX_PATHS` +
`isLogicalIdPrefixedGeneratedName`) only matched the **hyphen**-separated
`<logicalId>-<random>` form of the sibling `UserPoolClient.ClientName` (#537).

**Fix:** accept `_` as well as `-` as the separator, and register
`AWS::Cognito::IdentityPool.IdentityPoolName`.

### Sibling audit — Cognito UserPool `UserPoolName` (same latent FP, fixed)

Auditing the sibling class (the "fold for SOME → audit ALL siblings" lesson)
surfaced the identical latent FP on `AWS::Cognito::UserPool.UserPoolName`, which
reads back `<logicalId>-<random>` (e.g. `Pool88FC4FF9F-jVGU9rNojAd7`) when
undeclared. Present in 4 golden-corpus cases as `undeclared` — first-run noise.
Folded in; those 4 cases' `expected` updated `undeclared` → `generated`.

The fold stays **value-dependent**: a user-SET name (no logical-id prefix) still
surfaces as real undeclared drift — detection is preserved.

### Live verification

- Clean deploy → `check` (before record) **CLEAN** (FP gone).
- FN half: mutate declared `AllowUnauthenticatedIdentities` out of band →
  `check` **DETECTS** (declared drift, exit 1) → `revert` → live value restored →
  `check` **CLEAN**.

### Clean fixtures kept as regression

`iam-identity-rich` (`OIDCProvider` GitHub-Actions pattern + `InstanceProfile`) and
`cloudwatch-compositealarm-rich` deployed **CLEAN** (zero FP) — kept as clean-FP
regression fixtures.

### Tests

- `tests/classify.test.ts`: IdentityPool (underscore) + UserPool generated-name
  folds, each with the user-set-name-still-surfaces negative.
- `tests/corpus`: new `IdentityPool` (undeclared-name generated fold) +
  `IdentityPoolRoleAttachment` cases; 4 `UserPool` cases updated.
- Full suite: 2929 passing.
