### PR TITLE
fix(noise): fold Batch JobDefinition auto-generated JobDefinitionName (bug hunt follow-up)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1869,10 +1869,15 @@ export const DESCEND_UNDECLARED_OBJECT_PATHS: Record<string, ReadonlySet<string>
 //   AWS::Cognito::UserPool.UserPoolName — reads back `<logicalId>-<random>` when the template
 //   declares no UserPoolName (observed live across corpus: "Pool88FC4FF9F-jVGU9rNojAd7",
 //   "Users0A0EEA89-RYUoEBfJwQHo"). Same class as the sibling ClientName — audited in.
+//   AWS::Batch::JobDefinition.JobDefinitionName — reads back `<logicalId>-<random>` when the
+//   template declares no JobDefinitionName (observed live across corpus:
+//   "JobDef97B0969F-HFfibEW0TJakGN1M"). The logical id carries a CDK construct hash, so the
+//   `<logicalId>-<random>` gate cannot coincide with a genuine user-set name.
 export const GENERATED_LOGICALID_PREFIX_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::Cognito::UserPoolClient': new Set(['ClientName']),
   'AWS::Cognito::IdentityPool': new Set(['IdentityPoolName']),
   'AWS::Cognito::UserPool': new Set(['UserPoolName']),
+  'AWS::Batch::JobDefinition': new Set(['JobDefinitionName']),
 };
 
 // True when `value` is the `<logicalId><sep><random>` CFn auto-generated-name form: the logical

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9427,6 +9427,36 @@ describe('Face-stack false-positive folds', () => {
     expect(userSetPool.generated).toEqual([]);
   });
 
+  it('Batch JobDefinition undeclared JobDefinitionName (<logicalId>-<random>) folds to generated', () => {
+    // A JobDefinition with no explicit JobDefinitionName reads back `<logicalId>-<random>` — the
+    // same CFn auto-generated-name class as Cognito ClientName. The logical id carries a CDK
+    // construct hash, so the fold cannot coincide with a user-set name. Observed live across
+    // corpus: "JobDef97B0969F-HFfibEW0TJakGN1M".
+    const jobResource = {
+      logicalId: 'JobDef97B0969F',
+      resourceType: 'AWS::Batch::JobDefinition',
+      physicalId:
+        'arn:aws:batch:us-east-1:111111111111:job-definition/JobDef97B0969F-HFfibEW0TJakGN1M:1',
+      constructPath: 'Stack/JobDef',
+      declared: {},
+    };
+    const job = tiers(
+      classifyResource(
+        jobResource,
+        { JobDefinitionName: 'JobDef97B0969F-HFfibEW0TJakGN1M' },
+        emptySchema
+      )
+    );
+    expect(job.generated).toEqual(['JobDefinitionName']);
+    expect(job.undeclared).toEqual([]);
+    // A user-SET JobDefinitionName (no logical-id prefix) still surfaces as real undeclared drift.
+    const userSetJob = tiers(
+      classifyResource(jobResource, { JobDefinitionName: 'my-batch-job' }, emptySchema)
+    );
+    expect(userSetJob.undeclared).toEqual(['JobDefinitionName']);
+    expect(userSetJob.generated).toEqual([]);
+  });
+
   it('WAF WebACL ByteMatch SearchStringBase64 echo folds; a changed pattern is real drift', () => {
     const declared = {
       Rules: [

--- a/tests/corpus/AWS__Batch__JobDefinition.JobDef97B0969F.json
+++ b/tests/corpus/AWS__Batch__JobDefinition.JobDef97B0969F.json
@@ -111,7 +111,7 @@
       "constructPath": "CdkRealDriftIntegBatchRich/JobDef"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "JobDef97B0969F",
       "resourceType": "AWS::Batch::JobDefinition",
       "path": "JobDefinitionName",


### PR DESCRIPTION
## Bug hunt follow-up to #616

The `measure-noise` sweep run during the identity-obs hunt surfaced the **same
generated-name FP class** on `AWS::Batch::JobDefinition`.

A `JobDefinition` that declares no `JobDefinitionName` reads its live name back as
the CFn auto-generated `<logicalId>-<random>` form — observed live across the golden
corpus as `JobDef97B0969F-HFfibEW0TJakGN1M` — and surfaced as a first-run
`[Potential Drift]` false positive, violating the zero-potential-drift-on-a-clean-deploy
invariant.

### Fix

Add `AWS::Batch::JobDefinition.JobDefinitionName` to `GENERATED_LOGICALID_PREFIX_PATHS`
(the same mechanism extended for Cognito `IdentityPool`/`UserPool` in #616). The logical
id carries a CDK construct hash (`97B0969F`), so the `<logicalId>-<random>` gate cannot
coincide with a genuine user-set name. The fold stays **value-dependent** — a user-SET
`JobDefinitionName` (no logical-id prefix) still surfaces as real undeclared drift, so
detection is preserved.

### Verification

- `corpus-replay` reproduces the corrected classification on the **real harvested live
  read** (`JobDef97B0969F` case, `undeclared` → `generated`) — the offline authority.
- The identical fold mechanism was live-verified end-to-end in #616 (released 0.2.10):
  clean deploy → `check` CLEAN, and a user-set name still detected.
- No new deploy needed (offline-provable); WAFv2 `WebACL`/`RegexPatternSet` names were
  deliberately **not** folded (short raw construct ids with no hash → over-fold risk).

Full suite: 2931 passing.
