### PR TITLE
fix(read): supplement MemoryDB ParameterGroup Parameters (writeOnly readGap) + surface the CFn-never-applied divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,11 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `AWS::ElastiCache::User` / `AWS::MemoryDB::User` with its writeOnly
   `AccessString` — the Redis/Valkey ACL; an out-of-band permission grant is
   otherwise invisible to the Cloud Control read),
+  `memorydb:DescribeParameters` + `memorydb:DescribeParameterGroups` (supplement an
+  `AWS::MemoryDB::ParameterGroup` with its writeOnly `Parameters` — folding the
+  family-default fill by diffing the managed `default.<family>` group; the MemoryDB
+  provider does not apply declared parameters on CREATE, so this surfaces the
+  never-applied tuning that was otherwise an invisible readGap),
   `redshift-serverless:GetWorkgroup` (supplements an
   `AWS::RedshiftServerless::Workgroup` with its writeOnly `ConfigParameters` /
   `SecurityGroupIds` / `SubnetIds`, which the Cloud Control read returns only
@@ -643,6 +648,10 @@ is refused, never overwritten, so the un-read credential is never cleared),
 `AWS::ElastiCache::ParameterGroup` — a changed declared parameter is modified back
 to its desired value; an out-of-band-added undeclared parameter is reset to the
 family default),
+`memorydb:UpdateParameterGroup` / `ResetParameterGroup` (revert an
+`AWS::MemoryDB::ParameterGroup` — a declared parameter is applied to its desired
+value, which also materializes tuning the provider never applied on CREATE; an
+out-of-band-added undeclared parameter is reset to the family default),
 `ses:UpdateReceiptRule` (reverts an `AWS::SES::ReceiptRule` — the whole rule is
 re-supplied in place, since Cloud Control has no handler for the type),
 `cloudwatch:PutAnomalyDetector` (reverts an `AWS::CloudWatch::AnomalyDetector`

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -80,6 +80,8 @@ import {
   ElastiCacheClient,
 } from '@aws-sdk/client-elasticache';
 import {
+  DescribeParameterGroupsCommand as DescribeMemoryDbParameterGroupsCommand,
+  DescribeParametersCommand as DescribeMemoryDbParametersCommand,
   DescribeUsersCommand as DescribeMemoryDbUsersCommand,
   MemoryDBClient,
 } from '@aws-sdk/client-memorydb';
@@ -2256,6 +2258,91 @@ const supplementMemoryDbUser: SupplementReader = async ({ physicalId, declared, 
   return access !== undefined ? { AccessString: access } : undefined;
 };
 
+// Read every parameter of a MemoryDB parameter group as a { name -> value } map (paginated).
+const readMemoryDbParamMap = async (
+  c: MemoryDBClient,
+  groupName: string
+): Promise<Record<string, string>> => {
+  const out: Record<string, string> = {};
+  let token: string | undefined;
+  do {
+    const r = await c.send(
+      new DescribeMemoryDbParametersCommand({ ParameterGroupName: groupName, NextToken: token })
+    );
+    for (const p of r.Parameters ?? []) {
+      const n = str(p.Name);
+      const v = str(p.Value);
+      if (n !== undefined && v !== undefined) out[n] = v;
+    }
+    token = str(r.NextToken);
+  } while (token !== undefined);
+  return out;
+};
+
+// The managed `default.<family>` parameter group carries the family's default parameter
+// values. Find it by listing parameter groups and matching the family on a `default.`-prefixed
+// name (the name transform — memorydb_redis7 -> default.memorydb-redis7 — is not reliable to
+// synthesize, so match on Family instead). Returns {} when it cannot be resolved.
+const readMemoryDbFamilyDefaults = async (
+  c: MemoryDBClient,
+  family: string
+): Promise<Record<string, string>> => {
+  let token: string | undefined;
+  do {
+    const r = await c.send(new DescribeMemoryDbParameterGroupsCommand({ NextToken: token }));
+    for (const g of r.ParameterGroups ?? []) {
+      const name = str(g.Name);
+      if (name?.startsWith('default.') && str(g.Family) === family) {
+        return readMemoryDbParamMap(c, name);
+      }
+    }
+    token = str(r.NextToken);
+  } while (token !== undefined);
+  return {};
+};
+
+// AWS::MemoryDB::ParameterGroup — `Parameters` is writeOnly in the registry schema, so Cloud
+// Control never echoes it and a declared parameter was an unverifiable readGap (out-of-band
+// changes silently invisible). Worse, the MemoryDB CloudFormation provider does NOT apply the
+// declared Parameters on CREATE (it applies them only on a later UPDATE — verified on a raw,
+// non-CDK template; AWS's own drift detection reports IN_SYNC because it too cannot read the
+// writeOnly Parameters), so a freshly created group silently runs the family defaults, not the
+// declared tuning. Project the live parameters (via memorydb:DescribeParameters — the twin of
+// ElastiCache #612, but MemoryDB has NO source=user filter and no modified flag) so the classify
+// pipeline compares them; schema-strip OVERRIDE_READABLE_WRITEONLY exempts `Parameters` from the
+// writeOnly strip. To avoid re-introducing a default-fill FP (a group reads back ALL ~40 family
+// parameters), fold undeclared parameters still at their family default by diffing against the
+// managed `default.<family>` group — projecting a parameter only when it DIVERGES from the family
+// default (a real modification, declared or out-of-band) OR the template DECLARES it (so a declared
+// parameter is always comparable, including the CFn-never-applied divergence we want to surface).
+// FP-safe: when the family defaults cannot be resolved, fall back to projecting only the declared
+// parameters (never the full effective set).
+const supplementMemoryDbParameterGroup: SupplementReader = async ({
+  physicalId,
+  declared,
+  region,
+}) => {
+  const name = str(declared.ParameterGroupName) ?? str(physicalId);
+  if (!name) return undefined;
+  const c = new MemoryDBClient({ region, ...READ_RETRY });
+  const live = await readMemoryDbParamMap(c, name);
+  if (Object.keys(live).length === 0) return undefined;
+  const family = str(declared.Family);
+  const defaults = family ? await readMemoryDbFamilyDefaults(c, family) : {};
+  const haveDefaults = Object.keys(defaults).length > 0;
+  const declaredParams =
+    typeof declared.Parameters === 'object' && declared.Parameters !== null
+      ? (declared.Parameters as Record<string, unknown>)
+      : {};
+  const projected: Record<string, string> = {};
+  for (const [k, v] of Object.entries(live)) {
+    const isDeclared = Object.prototype.hasOwnProperty.call(declaredParams, k);
+    const isModified = haveDefaults && v !== defaults[k];
+    if (isDeclared || isModified) projected[k] = v;
+  }
+  return Object.keys(projected).length > 0 ? { Parameters: projected } : undefined;
+};
+
 // AWS::RedshiftServerless::Workgroup — ConfigParameters / SecurityGroupIds / SubnetIds are
 // writeOnly in the registry schema and, unlike the hunt's harvested corpus suggested, the
 // Cloud Control GetResource does NOT return them at the top level (they live only inside the
@@ -2593,5 +2680,6 @@ export const SDK_SUPPLEMENTS: Record<string, SupplementReader> = {
   'AWS::ECS::Service': supplementEcsService,
   'AWS::ElastiCache::User': supplementElastiCacheUser,
   'AWS::MemoryDB::User': supplementMemoryDbUser,
+  'AWS::MemoryDB::ParameterGroup': supplementMemoryDbParameterGroup,
   'AWS::RedshiftServerless::Workgroup': supplementRedshiftServerlessWorkgroup,
 };

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -124,6 +124,11 @@ import {
   ModifyCacheParameterGroupCommand,
   ResetCacheParameterGroupCommand,
 } from '@aws-sdk/client-elasticache';
+import {
+  MemoryDBClient,
+  ResetParameterGroupCommand as ResetMemoryDbParameterGroupCommand,
+  UpdateParameterGroupCommand as UpdateMemoryDbParameterGroupCommand,
+} from '@aws-sdk/client-memorydb';
 import { EC2Client, ModifyClientVpnEndpointCommand } from '@aws-sdk/client-ec2';
 import {
   DescribeEventBusCommand,
@@ -1584,6 +1589,57 @@ const writeElastiCacheParameterGroup: SdkWriter = async (ctx, ops) => {
   }
 };
 
+// AWS::MemoryDB::ParameterGroup — the twin of the ElastiCache writer above, read via an
+// SDK_SUPPLEMENTS reader. The CFn `Parameters` is a { name → value } map. An `add` op reverts a
+// DECLARED parameter (including one the MemoryDB CFn provider never applied on create) to its
+// deployed-template value via UpdateParameterGroup — which is exactly the API call the provider
+// skips, so revert actually MATERIALIZES the declared intent. A `remove` op resets an
+// out-of-band-added undeclared parameter to the family default via ResetParameterGroup (which
+// takes bare `ParameterNames`, unlike ElastiCache's ParameterNameValues). Keyed on the
+// `/Parameters/<key>` path (or a whole-map `/Parameters` op → every desired key).
+const writeMemoryDbParameterGroup: SdkWriter = async (ctx, ops) => {
+  const name = str(ctx.physicalId) ?? str(ctx.declared['ParameterGroupName']);
+  if (!name) throw new Error('cannot resolve MemoryDB parameter-group name for revert');
+  const desired = await desiredModel('AWS::MemoryDB::ParameterGroup', ctx, ops);
+  const desiredValues = (desired.Parameters as Record<string, unknown> | undefined) ?? {};
+  const modifyKeys = new Set<string>();
+  const resetKeys = new Set<string>();
+  for (const op of ops) {
+    const segs = op.path.replace(/^\//, '').split('/');
+    if (segs[0] !== 'Parameters') continue;
+    const key = segs[1]?.replace(/~1/g, '/').replace(/~0/g, '~');
+    if (op.op === 'remove') {
+      if (key !== undefined) resetKeys.add(key);
+    } else if (key !== undefined) {
+      modifyKeys.add(key);
+    } else {
+      for (const k of Object.keys(desiredValues)) modifyKeys.add(k);
+    }
+  }
+  const c = new MemoryDBClient({ region: ctx.region });
+  const modify = [...modifyKeys]
+    .filter((k) => typeof desiredValues[k] === 'string')
+    .map((k) => ({ ParameterName: k, ParameterValue: desiredValues[k] as string }));
+  if (modify.length > 0) {
+    await c.send(
+      new UpdateMemoryDbParameterGroupCommand({
+        ParameterGroupName: name,
+        ParameterNameValues: modify,
+      })
+    );
+  }
+  const reset = [...resetKeys];
+  if (reset.length > 0) {
+    await c.send(
+      new ResetMemoryDbParameterGroupCommand({
+        ParameterGroupName: name,
+        AllParameters: false,
+        ParameterNames: reset,
+      })
+    );
+  }
+};
+
 // AWS::EC2::ClientVpnEndpoint — NON_PROVISIONABLE (read via DescribeClientVpnEndpoints; #534).
 // ec2:ModifyClientVpnEndpoint is a PARTIAL modify: send ONLY the drifted top-level props in the
 // mutable allowlist. Two props need reshaping vs the reader's projection: DnsServers (the read is
@@ -2077,6 +2133,7 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::DAX::Cluster': writeDaxCluster,
   'AWS::DAX::ParameterGroup': writeDaxParameterGroup,
   'AWS::ElastiCache::ParameterGroup': writeElastiCacheParameterGroup,
+  'AWS::MemoryDB::ParameterGroup': writeMemoryDbParameterGroup,
   'AWS::EC2::ClientVpnEndpoint': writeEc2ClientVpnEndpoint,
   'AWS::OpenSearchService::Domain': writeOpenSearchDomain,
   'AWS::CloudFront::Distribution': writeCloudFrontDistribution,

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -81,6 +81,13 @@ export const OVERRIDE_READABLE_WRITEONLY: Record<string, readonly string[]> = {
   // NoPasswordRequired stay writeOnly readGaps (read shape differs from CFn input).
   'AWS::ElastiCache::User': ['AccessString'],
   'AWS::MemoryDB::User': ['AccessString'],
+  // AWS::MemoryDB::ParameterGroup `Parameters` is writeOnly (CC never echoes the parameter
+  // map), so a declared parameter was an unverifiable readGap — and because the MemoryDB CFn
+  // provider does not apply declared Parameters on CREATE, the divergence was doubly invisible.
+  // The SDK_SUPPLEMENTS reader fetches the live parameters via memorydb:DescribeParameters and
+  // folds the undeclared family-default fill by diffing the managed default.<family> group, so
+  // compare it, don't readGap.
+  'AWS::MemoryDB::ParameterGroup': ['Parameters'],
   // AWS::RedshiftServerless::Workgroup ConfigParameters / SecurityGroupIds / SubnetIds
   // are writeOnly in the registry schema, so cdkrd filed them under the write-only readGap
   // bucket and an out-of-band change was silently invisible (#490 — a security-relevant FN

--- a/tests/corpus/AWS__MemoryDB__ParameterGroup.Pg.json
+++ b/tests/corpus/AWS__MemoryDB__ParameterGroup.Pg.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Pg",
+    "resourceType": "AWS::MemoryDB::ParameterGroup",
+    "physicalId": "cdkrd-integ-memorydb-pg",
+    "constructPath": "CdkRealDriftIntegMemoryDbParamGroup/Pg",
+    "declared": {
+      "Description": "cdkrd integ memorydb redis7 parameter group",
+      "Family": "memorydb_redis7",
+      "ParameterGroupName": "cdkrd-integ-memorydb-pg",
+      "Parameters": {
+        "maxmemory-policy": "allkeys-lru",
+        "timeout": "300"
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd integ memorydb redis7 parameter group",
+    "ParameterGroupName": "cdkrd-integ-memorydb-pg",
+    "Family": "memorydb_redis7",
+    "ARN": "arn:aws:memorydb:us-east-1:111111111111:parametergroup/cdkrd-integ-memorydb-pg",
+    "Parameters": {
+      "maxmemory-policy": "allkeys-lru",
+      "timeout": "300"
+    }
+  },
+  "schema": {
+    "readOnly": ["ARN"],
+    "writeOnly": [],
+    "createOnly": ["Description", "Family", "ParameterGroupName"],
+    "readOnlyPaths": ["ARN"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description", "Family", "ParameterGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/integration/memorydb-paramgroup/app.ts
+++ b/tests/integration/memorydb-paramgroup/app.ts
@@ -1,0 +1,11 @@
+import { App, Stack } from "aws-cdk-lib";
+import { CfnParameterGroup } from "aws-cdk-lib/aws-memorydb";
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegMemoryDbParamGroup");
+new CfnParameterGroup(stack, "Pg", {
+  family: "memorydb_redis7",
+  parameterGroupName: "cdkrd-integ-memorydb-pg",
+  description: "cdkrd integ memorydb redis7 parameter group",
+  parameters: { "maxmemory-policy": "allkeys-lru", timeout: "300" },
+});
+app.synth();

--- a/tests/integration/memorydb-paramgroup/cdk.json
+++ b/tests/integration/memorydb-paramgroup/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/memorydb-paramgroup/package.json
+++ b/tests/integration/memorydb-paramgroup/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cdk-real-drift-integ-memorydb-paramgroup",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "devDependencies": { "aws-cdk": "^2.0.0", "aws-cdk-lib": "^2.0.0", "constructs": "^10.0.0" }
+}

--- a/tests/integration/memorydb-paramgroup/verify.sh
+++ b/tests/integration/memorydb-paramgroup/verify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Integration test (real AWS): the MemoryDB CloudFormation provider does NOT apply a declared
+# ParameterGroup's Parameters on CREATE (it applies them only on a later UPDATE — verified on a
+# raw non-CDK template; AWS drift detection is blind because Parameters is writeOnly). The
+# SDK_SUPPLEMENTS reader makes cdkrd read the live parameters, so a fresh deploy DETECTS the
+# never-applied declared parameters (previously an invisible writeOnly readGap), and `revert`
+# materializes them via UpdateParameterGroup — the very call the provider skipped. Follow-up to
+# the ElastiCache ParameterGroup fix (#612). A ParameterGroup provisions nothing billable.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/../../.." && pwd)"; cd "$HERE"
+STACK=CdkRealDriftIntegMemoryDbParamGroup; REGION="${AWS_REGION:-us-east-1}"; CLI="node $ROOT/dist/cli.js"
+cleanup(){ echo "--- cleanup ($STACK) ---"; delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || true; rm -rf .cdkrd cdk.out; }
+trap cleanup EXIT; fail(){ echo "INTEG FAIL ($STACK): $*"; exit 1; }
+echo "=== build ==="; (cd "$ROOT" && vp pack) >/dev/null 2>&1 || fail build
+echo "=== deploy ==="; npx cdk deploy -f "$STACK" --require-approval never || fail deploy
+echo "=== harvest corpus (fresh deploy, no baseline) ==="
+CDKRD_CORPUS_DIR=/tmp/corpus-mdbpg $CLI check "$STACK" --region "$REGION" >/dev/null 2>&1 || true
+echo "=== check --fail MUST DETECT the CFn-never-applied declared params (previously readGap) ==="
+$CLI check "$STACK" --region "$REGION" --fail | tee /tmp/cdkrd-mdbpg.out
+rc=${PIPESTATUS[0]}
+grep -q "Parameters.maxmemory-policy" /tmp/cdkrd-mdbpg.out || fail "expected to detect the never-applied declared parameters"
+[ "$rc" -ne 0 ] || fail "expected drift exit (the never-applied params) but got 0"
+echo "=== revert --yes MUST apply the declared params (UpdateParameterGroup) and converge CLEAN ==="
+$CLI revert "$STACK" --region "$REGION" --yes || fail revert
+$CLI check "$STACK" --region "$REGION" --fail; [ $? -eq 0 ] || fail "expected CLEAN after revert applied the declared params"
+echo "INTEG PASS ($STACK)"

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -37,6 +37,11 @@ import {
   ElastiCacheClient,
 } from '@aws-sdk/client-elasticache';
 import {
+  DescribeParameterGroupsCommand as DescribeMemoryDbParameterGroupsCommand,
+  DescribeParametersCommand as DescribeMemoryDbParametersCommand,
+  MemoryDBClient,
+} from '@aws-sdk/client-memorydb';
+import {
   DescribeBotLocaleCommand,
   DescribeIntentCommand,
   DescribeSlotCommand,
@@ -119,6 +124,7 @@ const dms = mockClient(DatabaseMigrationServiceClient);
 const mediaconvert = mockClient(MediaConvertClient);
 const dax = mockClient(DAXClient);
 const elasticache = mockClient(ElastiCacheClient);
+const memorydb = mockClient(MemoryDBClient);
 const eb = mockClient(ElasticBeanstalkClient);
 const lex = mockClient(LexModelsV2Client);
 
@@ -155,6 +161,7 @@ beforeEach(() => {
     mediaconvert,
     dax,
     elasticache,
+    memorydb,
     lex,
     eb,
   ])
@@ -3131,5 +3138,95 @@ describe('SDK supplements', () => {
 
   it('Lex::Bot: undefined (skipped) when the physical id is empty', async () => {
     expect(await SDK_SUPPLEMENTS['AWS::Lex::Bot'](ctx({}))).toBeUndefined();
+  });
+
+  describe('MemoryDB::ParameterGroup', () => {
+    const stubGroups = (): void => {
+      memorydb.on(DescribeMemoryDbParameterGroupsCommand).resolves({
+        ParameterGroups: [
+          { Name: 'default.memorydb-redis7', Family: 'memorydb_redis7' },
+          { Name: 'pg', Family: 'memorydb_redis7' },
+        ],
+      } as never);
+    };
+    const params = (m: Record<string, string>): never =>
+      ({ Parameters: Object.entries(m).map(([Name, Value]) => ({ Name, Value })) }) as never;
+
+    it('projects declared params (even at the family default — the CFn-never-applied case) + out-of-band-modified, folding untouched defaults', async () => {
+      stubGroups();
+      // The declared maxmemory-policy/timeout read back at the family DEFAULT (the MemoryDB
+      // provider never applied them on create); maxmemory-samples was modified out of band;
+      // activedefrag is an untouched default.
+      memorydb.on(DescribeMemoryDbParametersCommand, { ParameterGroupName: 'pg' }).resolves(
+        params({
+          'maxmemory-policy': 'noeviction',
+          timeout: '0',
+          activedefrag: 'no',
+          'maxmemory-samples': '10',
+        })
+      );
+      memorydb
+        .on(DescribeMemoryDbParametersCommand, { ParameterGroupName: 'default.memorydb-redis7' })
+        .resolves(
+          params({
+            'maxmemory-policy': 'noeviction',
+            timeout: '0',
+            activedefrag: 'no',
+            'maxmemory-samples': '3',
+          })
+        );
+      const out = await SDK_SUPPLEMENTS['AWS::MemoryDB::ParameterGroup'](
+        ctx(
+          {
+            ParameterGroupName: 'pg',
+            Family: 'memorydb_redis7',
+            Parameters: { 'maxmemory-policy': 'allkeys-lru', timeout: '300' },
+          },
+          'pg'
+        )
+      );
+      // declared → always projected (surfaces the never-applied divergence); modified undeclared
+      // → projected; untouched undeclared default (activedefrag) → folded.
+      expect(out).toEqual({
+        Parameters: { 'maxmemory-policy': 'noeviction', timeout: '0', 'maxmemory-samples': '10' },
+      });
+    });
+
+    it('falls back to declared-only when the family default group cannot be resolved (no fill FP)', async () => {
+      memorydb
+        .on(DescribeMemoryDbParameterGroupsCommand)
+        .resolves({ ParameterGroups: [] } as never);
+      memorydb
+        .on(DescribeMemoryDbParametersCommand, { ParameterGroupName: 'pg' })
+        .resolves(
+          params({ 'maxmemory-policy': 'allkeys-lru', timeout: '300', activedefrag: 'no' })
+        );
+      const out = await SDK_SUPPLEMENTS['AWS::MemoryDB::ParameterGroup'](
+        ctx(
+          {
+            ParameterGroupName: 'pg',
+            Family: 'memorydb_redis7',
+            Parameters: { 'maxmemory-policy': 'allkeys-lru', timeout: '300' },
+          },
+          'pg'
+        )
+      );
+      // Without defaults, only the declared params project — the undeclared `activedefrag` is NOT
+      // surfaced (never a full-effective-set fill FP).
+      expect(out).toEqual({ Parameters: { 'maxmemory-policy': 'allkeys-lru', timeout: '300' } });
+    });
+
+    it('undefined when the group has no readable parameters', async () => {
+      memorydb.on(DescribeMemoryDbParametersCommand).resolves({ Parameters: [] } as never);
+      expect(
+        await SDK_SUPPLEMENTS['AWS::MemoryDB::ParameterGroup'](
+          ctx({ ParameterGroupName: 'pg', Family: 'memorydb_redis7' }, 'pg')
+        )
+      ).toBeUndefined();
+    });
+
+    it('undefined (skipped) when no name is resolvable', async () => {
+      expect(await SDK_SUPPLEMENTS['AWS::MemoryDB::ParameterGroup'](ctx({}))).toBeUndefined();
+    });
   });
 });

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -143,6 +143,11 @@ import {
   ResetCacheParameterGroupCommand,
 } from '@aws-sdk/client-elasticache';
 import {
+  MemoryDBClient,
+  ResetParameterGroupCommand as ResetMemoryDbParameterGroupCommand,
+  UpdateParameterGroupCommand as UpdateMemoryDbParameterGroupCommand,
+} from '@aws-sdk/client-memorydb';
+import {
   DescribeClientVpnEndpointsCommand,
   EC2Client,
   ModifyClientVpnEndpointCommand,
@@ -199,6 +204,7 @@ const kafka = mockClient(KafkaClient);
 const codebuild = mockClient(CodeBuildClient);
 const dax = mockClient(DAXClient);
 const elasticache = mockClient(ElastiCacheClient);
+const memorydb = mockClient(MemoryDBClient);
 const ec2 = mockClient(EC2Client);
 const lex = mockClient(LexModelsV2Client);
 
@@ -236,6 +242,7 @@ beforeEach(() => {
   sqs.reset();
   serviceDiscovery.reset();
   elasticache.reset();
+  memorydb.reset();
   docdb.reset();
   eb.reset();
   cloudfront.reset();
@@ -1776,6 +1783,58 @@ describe('ElastiCache ParameterGroup writer (source=user reader; Modify/Reset)',
     ]);
     expect(elasticache.commandCalls(ModifyCacheParameterGroupCommand)).toHaveLength(0);
     expect(elasticache.commandCalls(ResetCacheParameterGroupCommand)).toHaveLength(0);
+  });
+});
+
+describe('MemoryDB ParameterGroup writer (SDK_SUPPLEMENTS reader; Update/Reset)', () => {
+  const PGN = 'cdkrd-memorydb-params';
+  // No SDK_OVERRIDES reader for this type (it is a supplement), so desiredModel applies the ops to
+  // an empty base — the desired values come from each op's `value`, no read stub needed.
+
+  it('a declared param (incl. one the provider never applied) -> UpdateParameterGroup', async () => {
+    memorydb.on(UpdateMemoryDbParameterGroupCommand).resolves({});
+    await SDK_WRITERS['AWS::MemoryDB::ParameterGroup'](ctx({ physicalId: PGN }), [
+      {
+        op: 'add',
+        path: '/Parameters/maxmemory-policy',
+        value: 'allkeys-lru',
+        human: 'Parameters.maxmemory-policy -> deployed-template value',
+      },
+    ]);
+    const update = memorydb.commandCalls(UpdateMemoryDbParameterGroupCommand);
+    expect(update).toHaveLength(1);
+    expect(update[0]!.args[0].input).toEqual({
+      ParameterGroupName: PGN,
+      ParameterNameValues: [{ ParameterName: 'maxmemory-policy', ParameterValue: 'allkeys-lru' }],
+    });
+    expect(memorydb.commandCalls(ResetMemoryDbParameterGroupCommand)).toHaveLength(0);
+  });
+
+  it('an undeclared added param -> ResetParameterGroup with bare ParameterNames (no update)', async () => {
+    memorydb.on(ResetMemoryDbParameterGroupCommand).resolves({});
+    await SDK_WRITERS['AWS::MemoryDB::ParameterGroup'](ctx({ physicalId: PGN }), [
+      {
+        op: 'remove',
+        path: '/Parameters/maxmemory-samples',
+        human: 'Parameters.maxmemory-samples -> remove (undeclared, not in baseline)',
+      },
+    ]);
+    const reset = memorydb.commandCalls(ResetMemoryDbParameterGroupCommand);
+    expect(reset).toHaveLength(1);
+    expect(reset[0]!.args[0].input).toEqual({
+      ParameterGroupName: PGN,
+      AllParameters: false,
+      ParameterNames: ['maxmemory-samples'],
+    });
+    expect(memorydb.commandCalls(UpdateMemoryDbParameterGroupCommand)).toHaveLength(0);
+  });
+
+  it('sends nothing when no Parameters op is present', async () => {
+    await SDK_WRITERS['AWS::MemoryDB::ParameterGroup'](ctx({ physicalId: PGN }), [
+      { op: 'add', path: '/Description', value: 'x', human: 'x' },
+    ]);
+    expect(memorydb.commandCalls(UpdateMemoryDbParameterGroupCommand)).toHaveLength(0);
+    expect(memorydb.commandCalls(ResetMemoryDbParameterGroupCommand)).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## What

An `AWS::MemoryDB::ParameterGroup`'s `Parameters` is **writeOnly** in the registry schema, so Cloud Control never echoes it and a declared parameter was an unverifiable **readGap** — an out-of-band change was silently invisible.

Investigating (per the ElastiCache ParameterGroup twin #612) surfaced a second, larger issue: the **MemoryDB CloudFormation provider does NOT apply the declared `Parameters` on CREATE** — it applies them only on a later UPDATE. Verified on a **raw, non-CDK** template (so it is the AWS provider, not CDK), and AWS's own drift detection reports `IN_SYNC` because it too cannot read the writeOnly `Parameters`. So a freshly created group silently runs the family defaults, not the declared tuning — and nothing catches it.

## Fix

- **Reader** (`src/read/overrides.ts`): a new `SDK_SUPPLEMENTS` reader fetches the live parameters via `memorydb:DescribeParameters` (MemoryDB has no `source=user` filter, unlike ElastiCache #612) and folds the undeclared family-default fill by diffing the managed `default.<family>` group — projecting a parameter only when it **diverges from the family default** OR the **template declares it** (so a declared parameter is always comparable, including the never-applied divergence). FP-safe: falls back to declared-only when the defaults can't be resolved. `schema-strip` exempts `Parameters` from the writeOnly strip.
- **Writer** (`src/revert/writers.ts`): an `add` op applies a declared parameter via `UpdateParameterGroup` — the very call the provider skips, so **revert materializes the declared intent**; a `remove` op resets an out-of-band-added undeclared parameter to the family default via `ResetParameterGroup`.

## Live-verified (fresh redis7 group)

- **FN (never-applied)**: fresh deploy → `check` DETECTS the 2 never-applied declared params (previously an invisible readGap) → `revert` applies them via `UpdateParameterGroup` → CLEAN.
- **Undeclared**: out-of-band `maxmemory-samples=10` → detected → `revert --remove-unrecorded` resets to default → CLEAN.
- **Fold**: the ~39 untouched family defaults fold away (no fill FP).
- All 7 core integ fixtures (basic×3 / iam / lambda / revert / policies) re-run green.

## Tests / assets

- Reader + writer unit tests (fold-vs-default, declared-only fallback, Update/Reset).
- Harvested corpus case + new `memorydb-paramgroup` integ fixture (deploy → detect → revert → clean).
- README read/write IAM permission notes.

> Note: this makes cdkrd surface the provider's never-applied parameters as declared drift — a true positive that AWS's own drift detection misses (the differentiator), bounded to fresh-never-updated groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
