### PR TITLE
docs(hunt-bugs): warn a covered type may still hide an undeclared-default FP

### DIFF
--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -75,7 +75,15 @@ non-negotiable", which is enforced by a gate, not by trust.
    ```bash
    grep -rln "Kinesis\|Dashboard\|Secret\|intelligentTiering\|FunctionUrl" tests/integration/*/app.ts
    ```
-   Empty hits = untested = good hunting ground.
+   Empty hits = untested = good hunting ground. But a NON-empty hit does **NOT** mean
+   the type's undeclared-default scenario is covered: an existing fixture/corpus case
+   that **DECLARES** the suspect property never exercises the undeclared-default fold,
+   so a first-run FP on that property stays latent under apparent coverage (observed on
+   `Events::ApiDestination` `InvocationRateLimitPerSecond` — the pre-existing corpus case
+   declared it, hiding the undeclared-300 FP; #615). Before skipping a "covered" type,
+   check whether any existing case leaves the suspect property **UNDECLARED** — `grep`
+   the fixture `app.ts` / the corpus case's `declared` block for it; if every case
+   declares it, the undeclared-default path is still open hunting ground.
 4. **Probe CC support BEFORE an expensive deploy — skip the CC-gap tail.** For a
    high-cost or slow stateful/niche type (RDS-family, OpenSearch, MSK, Neptune,
    DocumentDB, Cloud Map, …), first check whether Cloud Control can even READ it —


### PR DESCRIPTION
Refine the hunt-bugs skill's **principle 3 "Check coverage first"**.

A NON-empty `grep` hit does **not** mean the type's undeclared-default scenario is
covered: an existing fixture/corpus case that **DECLARES** the suspect property never
exercises the undeclared-default fold, so a first-run FP on that property stays latent
under apparent coverage.

Observed this round on `Events::ApiDestination` `InvocationRateLimitPerSecond` (#615):
the pre-existing corpus case declared the rate limit, hiding the undeclared-300 FP.
Now the skill tells the hunter to check whether any existing case leaves the suspect
property UNDECLARED before skipping a "covered" type.

Docs/tooling-only (no `src/**`) → verify-pr-gate exempt.
