### PR TITLE
fix(diff): surface an undeclared switch disabled out of band — isTrivialEmpty swallowed the false before the KNOWN_DEFAULTS gate (#632)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -595,7 +595,18 @@ non-trivial value is recorded and then changes to `false`/empty out of band, the
 baseline removal-detection (§8) DOES surface it. We deliberately do NOT skip
 `isTrivialEmpty` under `--show-all` — that would re-flood inventory with the very
 `false`/empty noise the subtractive model exists to remove. (Considered and rejected;
-see [redesign-notes.md](redesign-notes.md).)
+see [redesign-notes.md](redesign-notes.md).) **Carve-out (#632):** the
+self-correction above fails for an UNDECLARED switch AWS materialized ON at
+creation that a user later disables out of band — the `false` never had a
+non-trivial baseline value to be removed, so `isTrivialEmpty` swallowed it BEFORE
+the fold table was consulted, making the disable invisible (undetectable,
+unrecordable, unrevertable — proven live for SQS SSE-SQS + KMS key disable). The
+curated `MEANINGFUL_WHEN_OFF` allowlist in `classify.ts` names the exact
+`(type, path)` pairs whose OFF state is a real divergence from a `KNOWN_DEFAULTS`
+pin and surfaces them even on a first run; it is predicate-gated (NOT a blanket
+"any diverging `false` surfaces") because most "default true" booleans are
+CONDITIONAL — an SSE-KMS queue reads `SqsManagedSseEnabled:false` legitimately,
+so the predicate surfaces the OFF state only when the queue uses no KMS key.
 
 ## 7. Revert (the only AWS-mutating path)
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -106,6 +106,33 @@ const ELB_ATTRIBUTE_BAGS: Record<string, string> = {
   'AWS::ElasticLoadBalancingV2::Listener': 'ListenerAttributes',
 };
 
+// #632: undeclared KNOWN_DEFAULTS pins whose OFF state (a live `false`/`""` that DIVERGES
+// from the pinned default) is a REAL, detectable divergence — an out-of-band DISABLE of a
+// switch AWS materialized ON at creation. The undeclared loop otherwise drops any `false`/`""`
+// via isTrivialEmpty BEFORE the fold table is consulted ("false does not stay meaningful",
+// which keeps feature-off husks quiet), so a `true→false` flip of such a switch was
+// completely invisible — undetectable, unbaselineable by `record`, unrevertable (SQS SSE-SQS
+// disable + KMS key disable both proven live 2026-07-08). This is CURATED + predicate-gated,
+// NOT a blanket "any diverging false surfaces": most "default true" booleans are CONDITIONAL
+// (true only in a specific config, legitimately `false` otherwise), so a blanket rule would
+// false-positive on every such clean deploy — e.g. an SSE-KMS SQS queue reads
+// SqsManagedSseEnabled=false legitimately (mutually exclusive with SSE-SQS), and a non-HTTPS
+// Route53 HealthCheck reads EnableSNI=false. The predicate returns true only when the OFF
+// state is a genuine divergence in THIS resource's config. Add an entry ONLY after a live
+// confirm that the OFF state is meaningful in EVERY clean-deploy configuration of the type.
+type OffStateContext = { declared: Record<string, unknown>; live: Record<string, unknown> };
+const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) => boolean>> = {
+  // A KMS key is always created enabled; `disable-key` (Enabled=false) is always meaningful.
+  'AWS::KMS::Key': { Enabled: () => true },
+  // SSE-SQS defaults ON, but is mutually exclusive with SSE-KMS: a queue that uses a KMS key
+  // reads SqsManagedSseEnabled=false legitimately. Surface the OFF state only when the queue
+  // uses no KMS key — i.e. encryption was genuinely disabled out of band.
+  'AWS::SQS::Queue': {
+    SqsManagedSseEnabled: ({ declared, live }) =>
+      declared['KmsMasterKeyId'] === undefined && live['KmsMasterKeyId'] === undefined,
+  },
+};
+
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
 // AWS always returns — keyed by the property -> the element's identity field. Cognito
 // UserPool `Schema` is the case: AWS returns all ~21 standard attributes (sub, email,
@@ -1980,7 +2007,20 @@ export function classifyResource(
     // and trivially-empty {}/[]. These carry no inventory value, so they are not folded.
     if (isAllAwsTags(v)) continue;
     if (physicalId !== undefined && v === physicalId) continue;
-    if (isTrivialEmpty(v) || isSelfEchoTrivialEmpty(v, physicalId) || isEmptyPolicyShell(v))
+    // #632: an OFF state (a live `false`/`""` diverging from a KNOWN_DEFAULTS pin) that is a
+    // REAL divergence per the curated MEANINGFUL_WHEN_OFF predicate must NOT be swallowed by
+    // the trivial-empty drop below — surface it so an out-of-band disable is detected,
+    // recorded, and revertible. The atDefault gate above already `continue`d when the value
+    // MATCHED the pin, so reaching here with a pin means it diverges; the predicate gates the
+    // narrow set of paths whose OFF state is genuinely meaningful in this resource's config.
+    const offStateIsMeaningful =
+      k in knownDef &&
+      !matchesKnownDefault(v, knownDef[k]) &&
+      (MEANINGFUL_WHEN_OFF[resourceType]?.[k]?.({ declared, live }) ?? false);
+    if (
+      !offStateIsMeaningful &&
+      (isTrivialEmpty(v) || isSelfEchoTrivialEmpty(v, physicalId) || isEmptyPolicyShell(v))
+    )
       continue;
     // #555: a FULLY-undeclared OBJECT listed in DESCEND_UNDECLARED_OBJECT_PATHS is descended
     // leaf-by-leaf (via the SAME emitNested classification the declared-nested loop uses)

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1093,7 +1093,10 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ).toEqual(['WarmThroughput']);
 
     // ESM created enabled → folds. (Enabled:false is dropped upstream as trivially-empty,
-    // like the KMS Key Enabled case — neither undeclared nor atDefault.)
+    // like the KMS Key Enabled case — neither undeclared nor atDefault.) #632 fixed the
+    // KMS/SQS twins of this via the curated MEANINGFUL_WHEN_OFF allowlist; ESM is left
+    // unchanged here pending a live confirm that an undeclared ESM Enabled=false is
+    // unconditionally a real out-of-band disable.
     expect(t('AWS::Lambda::EventSourceMapping', { Enabled: true }).atDefault).toEqual(['Enabled']);
     const disabled = t('AWS::Lambda::EventSourceMapping', { Enabled: false });
     expect(disabled.undeclared).toEqual([]);
@@ -10077,5 +10080,65 @@ describe('#555: descend a fully-undeclared object (DESCEND_UNDECLARED_OBJECT_PAT
     expect(t.map((f) => f.path)).toEqual(['AccessConfig']);
     expect(t[0]!.tier).toBe('undeclared');
     expect(t[0]!.actual).toEqual({ AuthenticationMode: 'CONFIG_MAP' });
+  });
+});
+
+// #632: an undeclared boolean/empty value that DIVERGES from its KNOWN_DEFAULTS pin must
+// surface (undeclared) instead of being swallowed by the trivial-empty drop. Before the fix
+// the top-level undeclared loop dropped any `false`/`""` via isTrivialEmpty BEFORE consulting
+// the fold table, so a `true→false` flip of a switch whose pinned default is `true` (SQS
+// SSE-SQS, KMS key Enabled) was completely invisible — undetectable, unrecordable, unrevertable
+// (both proven live 2026-07-08). The nested twin (KNOWN_DEFAULT_PATHS) had the same gap.
+describe('#632 undeclared boolean flipped off is not swallowed by trivial-empty', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const classify = (
+    type: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    classifyResource({ logicalId: 'R', resourceType: type, physicalId: 'p', declared }, live, bare);
+
+  it('SQS SqsManagedSseEnabled=false (KNOWN_DEFAULTS true) surfaces as undeclared', () => {
+    const f = classify('AWS::SQS::Queue', {}, { SqsManagedSseEnabled: false });
+    const hit = f.find((x) => x.path === 'SqsManagedSseEnabled');
+    expect(hit?.tier).toBe('undeclared');
+    expect(hit?.actual).toBe(false);
+  });
+
+  it('SQS SqsManagedSseEnabled=true (the pin) still folds atDefault (no new FP)', () => {
+    const f = classify('AWS::SQS::Queue', {}, { SqsManagedSseEnabled: true });
+    expect(f.find((x) => x.path === 'SqsManagedSseEnabled')?.tier).toBe('atDefault');
+  });
+
+  it('KMS Key Enabled=false (KNOWN_DEFAULTS true) surfaces as undeclared', () => {
+    const f = classify('AWS::KMS::Key', {}, { Enabled: false });
+    const hit = f.find((x) => x.path === 'Enabled');
+    expect(hit?.tier).toBe('undeclared');
+    expect(hit?.actual).toBe(false);
+  });
+
+  it('a false value with NO fold entry is still dropped (feature-off husk stays quiet)', () => {
+    const f = classify('AWS::SQS::Queue', {}, { SomeUnpinnedFlag: false });
+    expect(f.find((x) => x.path === 'SomeUnpinnedFlag')).toBeUndefined();
+  });
+
+  it('SSE-KMS queue SqsManagedSseEnabled=false is NOT surfaced (conditional default, no FP)', () => {
+    // SSE-SQS and SSE-KMS are mutually exclusive: a queue that declares a KMS key reads
+    // SqsManagedSseEnabled=false legitimately on a clean deploy — must stay dropped.
+    const f = classify(
+      'AWS::SQS::Queue',
+      { KmsMasterKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc' },
+      { KmsMasterKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc', SqsManagedSseEnabled: false }
+    );
+    expect(f.find((x) => x.path === 'SqsManagedSseEnabled')).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #632.

## Problem
An **undeclared boolean flipped to `false` out of band was completely invisible** to cdkrd. The top-level undeclared loop dropped any `false`/`""` via `isTrivialEmpty` **before** the `KNOWN_DEFAULTS` equality gate could observe the divergence, so a `true→false` disable of a switch whose pinned default is `true` never surfaced — **undetectable, unbaselineable by `record`, unrevertable**. A false-negative class on security-relevant switches.

Proven live 2026-07-08 (us-east-1):
- **SQS SSE-SQS disabled** (`SqsManagedSseEnabled=false`, pin `true`) → `check` showed no finding.
- **KMS key disabled** (`Enabled=false`, pin `true`) → a disabled encryption key was undetectable.

## Fix
A curated, **predicate-gated** `MEANINGFUL_WHEN_OFF` allowlist in `classify.ts`. When a live value diverges from its `KNOWN_DEFAULTS` pin **and** the path's predicate says the OFF state is a real divergence in this resource's config, the trivial-empty drop is skipped and the value surfaces as `undeclared`.

Deliberately **NOT** a blanket "any diverging `false` surfaces" rule — most "default true" booleans are **conditional** and a blanket rule would false-positive on every clean deploy. Corpus replay caught exactly that during development:
- SSE-KMS queues (`MainRedrive`/`DlqRedrive`) read `SqsManagedSseEnabled=false` legitimately (mutually exclusive with SSE-KMS).
- A non-HTTPS Route53 `HealthCheck` reads `EnableSNI=false` legitimately.

Seeded with the two **live-proven top-level** cases:
- `AWS::KMS::Key` `Enabled` — unconditional.
- `AWS::SQS::Queue` `SqsManagedSseEnabled` — only when the queue uses no KMS key.

Other blast-radius candidates (ESM `Enabled`, nested `EnableSNI`/`EndpointPublicAccess`, …) are **deferred** pending a live confirm that their OFF state is unconditionally meaningful — per the core invariant, ship only what's verified.

## Tests / docs
- `classify.test.ts`: SQS + KMS disable surface; clean-state `true` still folds `atDefault`; SSE-KMS negative (`false` NOT surfaced); unpinned `false` still dropped.
- Full suite green (2951 tests), incl. corpus replay.
- `docs/ARCHITECTURE.md`: the `isTrivialEmpty`-asymmetry section documents the carve-out.

## Verification note
Offline-verified (unit + corpus replay). No shared-name live fixtures were deployed (parallel agents active). The two repros were already live-proven in the originating bug hunt.
