### PR TITLE
fix(revert): REVERT_SET_DEFAULT_PATHS gaps — Cognito UserPool + SNS Subscription (#630)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -119,6 +119,22 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // 50 reported SUCCESS yet the live value stayed 50 — "1 drift remain"). Write the 300
   // default (from KNOWN_DEFAULTS) back explicitly so revert converges.
   'AWS::Events::ApiDestination\0InvocationRateLimitPerSecond',
+  // Cognito UpdateUserPool is a FULL-PUT provider: it IGNORES an omitted property and keeps
+  // the existing live value, so a bare `remove` revert of an out-of-band change is a silent
+  // no-op. Live-proven for DeletionProtection (#630, reproduced twice: a bare pool set to
+  // ACTIVE out of band, then `revert --remove-unrecorded` planned a `remove`, reported
+  // CLEAN, yet the live pool stayed ACTIVE). MfaConfiguration and UserPoolTier are the same
+  // provider family (same UpdateUserPool omit-ignored behavior), so write their KNOWN_DEFAULTS
+  // defaults (INACTIVE / OFF / ESSENTIALS) back explicitly — idempotent and safe.
+  'AWS::Cognito::UserPool\0DeletionProtection',
+  'AWS::Cognito::UserPool\0MfaConfiguration',
+  'AWS::Cognito::UserPool\0UserPoolTier',
+  // SNS SetSubscriptionAttributes HARD-FAILS a `remove` of FilterPolicyScope (#630,
+  // live-proven: setting it to MessageBody out of band, then reverting via `remove` fails with
+  // InvalidRequest "FilterPolicyScope: Invalid value [null]. Please use either MessageBody or
+  // MessageAttributes"). SNS refuses to clear the attribute, so revert can only converge by
+  // SETTING the "MessageAttributes" default (from KNOWN_DEFAULTS) explicitly.
+  'AWS::SNS::Subscription\0FilterPolicyScope',
 ]);
 
 /**

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -478,6 +478,85 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('Cognito UserPool DeletionProtection (SET-DEFAULT) -> add op writing INACTIVE, not a no-op remove', () => {
+    // #630: AWS::Cognito::UserPool DeletionProtection is in REVERT_SET_DEFAULT_PATHS:
+    // UpdateUserPool is a full-PUT provider that IGNORES an omitted property, so a bare
+    // `remove` of an out-of-band ACTIVE is a silent no-op (live-proven twice: check surfaced
+    // it, revert reported CLEAN, yet the live pool stayed ACTIVE). Revert must write the
+    // "INACTIVE" default (from KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Cognito::UserPool',
+      path: 'DeletionProtection',
+      actual: 'ACTIVE',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DeletionProtection',
+      value: 'INACTIVE',
+      prior: 'ACTIVE',
+    });
+  });
+
+  it('Cognito UserPool MfaConfiguration (SET-DEFAULT) -> add op writing OFF, not a no-op remove', () => {
+    // #630: same Cognito UpdateUserPool full-PUT provider family as DeletionProtection —
+    // an omitted MfaConfiguration is ignored, so revert must write the "OFF" default
+    // (from KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Cognito::UserPool',
+      path: 'MfaConfiguration',
+      actual: 'ON',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/MfaConfiguration',
+      value: 'OFF',
+      prior: 'ON',
+    });
+  });
+
+  it('Cognito UserPool UserPoolTier (SET-DEFAULT) -> add op writing ESSENTIALS, not a no-op remove', () => {
+    // #630: same Cognito UpdateUserPool full-PUT provider family — an omitted UserPoolTier
+    // is ignored, so revert must write the "ESSENTIALS" default (from KNOWN_DEFAULTS)
+    // explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Cognito::UserPool',
+      path: 'UserPoolTier',
+      actual: 'PLUS',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/UserPoolTier',
+      value: 'ESSENTIALS',
+      prior: 'PLUS',
+    });
+  });
+
+  it('SNS Subscription FilterPolicyScope (SET-DEFAULT) -> add op writing MessageAttributes, not a no-op remove', () => {
+    // #630: AWS::SNS::Subscription FilterPolicyScope is in REVERT_SET_DEFAULT_PATHS:
+    // SetSubscriptionAttributes HARD-FAILS a `remove` (live-proven InvalidRequest "Invalid
+    // value [null]. Please use either MessageBody or MessageAttributes"), so revert must
+    // write the "MessageAttributes" default (from KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::SNS::Subscription',
+      path: 'FilterPolicyScope',
+      actual: 'MessageBody',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/FilterPolicyScope',
+      value: 'MessageAttributes',
+      prior: 'MessageBody',
+    });
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.


### PR DESCRIPTION
Closes #630.

Two live-proven `REVERT_SET_DEFAULT_PATHS` gaps (the #597 class): a
KNOWN_DEFAULTS-folded MUTABLE prop is changed out of band, `check` surfaces it,
but the default `remove`-style revert does NOT converge. The fix adds entries to
`REVERT_SET_DEFAULT_PATHS` in `src/revert/plan.ts` so revert writes the
KNOWN_DEFAULTS default value back explicitly (an `add` op) instead of a no-op
`remove`.

Added entries:

- `AWS::Cognito::UserPool` — `DeletionProtection`, `MfaConfiguration`,
  `UserPoolTier`. Cognito `UpdateUserPool` is a full-PUT provider that IGNORES an
  omitted property, so a bare `remove` is a silent no-op. Live-proven for
  `DeletionProtection` (reproduced twice: bare pool set to `ACTIVE` out of band →
  `revert --remove-unrecorded` planned `remove`, reported CLEAN, yet live stayed
  `ACTIVE`). `MfaConfiguration`/`UserPoolTier` are the same provider family;
  writing their known defaults (`INACTIVE`/`OFF`/`ESSENTIALS`) back is idempotent
  and safe.
- `AWS::SNS::Subscription` — `FilterPolicyScope`. `SetSubscriptionAttributes`
  HARD-FAILS a `remove` with `InvalidRequest: Invalid parameter:
  FilterPolicyScope: Invalid value [null]. Please use either MessageBody or
  MessageAttributes`. Revert can only converge by SETTING the `MessageAttributes`
  default explicitly.

All defaults come from the existing `KNOWN_DEFAULTS` table (single source of
truth) — verified present. Live repro is documented in issue #630.

Unit tests added in `tests/revert-plan.test.ts` (one per path) mirroring the
existing Transfer `SecurityPolicyName` SET-DEFAULT test: each asserts the first
op is an `add` writing the KNOWN_DEFAULTS default (not a `remove`).

Gates: `vp run typecheck`, `vp run test` (2950 pass), `vp run build`, `vp check`
(0 errors) — all green.
