### PR TITLE
fix(diff): fold IoT ThingType SearchableAttributes reorder — service re-sorts a schema-ordered set (#623)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3938,6 +3938,19 @@ export const UNORDERED_NESTED_OBJECT_ARRAY_PATHS: Record<string, ReadonlySet<str
   // reads back [wildcard, apex]), so a positional compare false-flags the identical
   // alias set as declared drift. Same nested-scalar-set treatment as CachePolicy Headers.
   'AWS::CloudFront::Distribution': new Set(['DistributionConfig.Aliases']),
+  // An IoT ThingType's `ThingTypeProperties.SearchableAttributes` is a nested SCALAR set
+  // (attribute names) that IoT stores as a set and returns in its OWN sorted order —
+  // declared ["serial","model"] reads back ["model","serial"], so a positional compare
+  // false-flags the identical set as a DECLARED drift on a freshly deployed stack. Because
+  // it is declared-tier it SURVIVES `record` (record snapshots only the undeclared
+  // dimension) and makes `revert` loop forever (the service re-sorts after every write), so
+  // `check --fail` stays red on a clean stack (#623). NOTE the CFn resource schema annotates
+  // this array `insertionOrder: true` (+ `uniqueItems: true`), so the schema-driven fold
+  // deliberately does NOT engage — but the live service reorders anyway: the classic
+  // "schema claims ordered, service re-sorts" case this curated allowlist exists for.
+  // sortNestedObjectArrays sorts scalar arrays by canonical JSON, so equal sets align and a
+  // genuine attribute add/remove still differs. Live-proven (hunt 2026-07-08 round E).
+  'AWS::IoT::ThingType': new Set(['ThingTypeProperties.SearchableAttributes']),
   // RULE-OUT (observed-only, NOT folded): a WAFv2 RuleGroup/WebACL rate-based rule's
   // `Rules[].Statement.RateBasedStatement.CustomKeys` is a SET of discriminated-union
   // aggregate-key objects ({UriPath:{}}, {Header:{Name,…}}, {HTTPMethod:{}}, …) with

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10205,3 +10205,48 @@ describe('#632 undeclared boolean flipped off is not swallowed by trivial-empty'
     expect(f.find((x) => x.path === 'SqsManagedSseEnabled')).toBeUndefined();
   });
 });
+
+// #623: IoT ThingType `ThingTypeProperties.SearchableAttributes` is a nested SCALAR set the
+// service re-sorts (declared ["serial","model"] reads back ["model","serial"]). The CFn
+// schema annotates it insertionOrder:true so the schema-driven fold does NOT engage — the
+// curated UNORDERED_NESTED_OBJECT_ARRAY_PATHS entry folds the reorder while a genuine
+// attribute add/remove still surfaces as declared drift. (Was a declared-tier FP that
+// survived record and looped revert forever.)
+describe('#623 IoT ThingType SearchableAttributes reorder folds (nested scalar set)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(['Arn', 'Id']),
+    writeOnly: new Set(),
+    createOnly: new Set(['ThingTypeName']),
+    readOnlyPaths: ['Arn', 'Id'],
+    writeOnlyPaths: [],
+    createOnlyPaths: ['ThingTypeName'],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const declaredPaths = (declared: Record<string, unknown>, live: Record<string, unknown>) =>
+    classifyResource(
+      { logicalId: 'ThingType', resourceType: 'AWS::IoT::ThingType', physicalId: 'p', declared },
+      live,
+      bare
+    )
+      .filter((f) => f.tier === 'declared')
+      .map((f) => f.path);
+
+  it('a reordered-but-identical attribute set is NOT declared drift', () => {
+    expect(
+      declaredPaths(
+        { ThingTypeProperties: { SearchableAttributes: ['serial', 'model'] } },
+        { ThingTypeProperties: { SearchableAttributes: ['model', 'serial'] } }
+      )
+    ).toEqual([]);
+  });
+
+  it('a genuine attribute change still surfaces as declared drift (fail-closed)', () => {
+    expect(
+      declaredPaths(
+        { ThingTypeProperties: { SearchableAttributes: ['serial', 'model'] } },
+        { ThingTypeProperties: { SearchableAttributes: ['model', 'firmware'] } }
+      )
+    ).toEqual(['ThingTypeProperties.SearchableAttributes']);
+  });
+});

--- a/tests/corpus/AWS__IoT__ThingType.ThingType.json
+++ b/tests/corpus/AWS__IoT__ThingType.ThingType.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ThingType",
+    "resourceType": "AWS::IoT::ThingType",
+    "physicalId": "cdkrd-hunt0708e-type",
+    "constructPath": "CdkRealDriftHunt0708EIot/ThingType",
+    "declared": {
+      "ThingTypeName": "cdkrd-hunt0708e-type",
+      "ThingTypeProperties": {
+        "SearchableAttributes": ["serial", "model"],
+        "ThingTypeDescription": "hunt fixture thing type"
+      }
+    }
+  },
+  "liveRaw": {
+    "DeprecateThingType": false,
+    "ThingTypeName": "cdkrd-hunt0708e-type",
+    "ThingTypeProperties": {
+      "ThingTypeDescription": "hunt fixture thing type",
+      "Mqtt5Configuration": {
+        "PropagatingAttributes": []
+      },
+      "SearchableAttributes": ["model", "serial"]
+    },
+    "Id": "4e3f5c9b-6fde-47e2-9aff-e0ae207352c9",
+    "Arn": "arn:aws:iot:us-east-1:111111111111:thingtype/cdkrd-hunt0708e-type",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id"],
+    "writeOnly": [],
+    "createOnly": ["ThingTypeName"],
+    "readOnlyPaths": ["Arn", "Id"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ThingTypeName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}


### PR DESCRIPTION
Closes #623.

## Problem
`AWS::IoT::ThingType` `ThingTypeProperties.SearchableAttributes` produced a **declared-tier false positive on a freshly deployed, un-mutated stack**. IoT stores the attribute names as a **set** and returns them in its own sorted order — declared `["serial","model"]` reads back `["model","serial"]` — so the positional compare false-flagged the identical set.

Because it is declared-tier the FP **survived `record`** (record snapshots only the undeclared dimension) and made **`revert` loop forever** (the service re-sorts after every write), so `check --fail` stayed red on a clean stack.

## Root cause
The CFn resource schema annotates this array `insertionOrder: true` (+ `uniqueItems: true`), so the schema-driven unordered fold deliberately does **not** engage — but the live service reorders anyway. This is the "schema claims ordered, service re-sorts" case the curated `UNORDERED_NESTED_OBJECT_ARRAY_PATHS` allowlist exists for.

## Fix
Add `AWS::IoT::ThingType` → `ThingTypeProperties.SearchableAttributes` to `UNORDERED_NESTED_OBJECT_ARRAY_PATHS`. `sortNestedObjectArrays` sorts scalar arrays by canonical JSON (identical treatment to CloudFront CachePolicy `Headers` / Distribution `Aliases`), so the reorder folds on both sides while a genuine attribute add/remove still surfaces as declared drift. Folding eliminates the finding entirely, so the revert loop disappears too.

## Tests
- `classify.test.ts`: reorder folds; a real attribute change still surfaces (fail-closed).
- Harvested **live corpus** case `tests/corpus/AWS__IoT__ThingType.ThingType.json` (real `liveRaw` from the hunt; `expected` now empty).
- Full suite green (2949 tests).

## Verification note
Offline-verified via corpus replay (real harvested live data is authoritative for classification). The reorder + record-survival + revert-loop were all live-proven in the originating 2026-07-08 round-E hunt.
