### PR TITLE
fix(noise): fold 2026-07-08 bug-hunt first-run FPs across 12 zero/low-coverage types (#619 #622 #625 #626 #628 #633)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -55,6 +55,7 @@ import {
   TRAILING_SLASH_PATHS,
   GENERATED_PATHS,
   CONTEXT_DEFAULTS,
+  CONTEXT_ARN_DEFAULTS,
   DEFAULT_MANAGED_NAME_PATHS,
   DESCEND_UNDECLARED_OBJECT_PATHS,
   ebOptionSettingTier,
@@ -1884,6 +1885,32 @@ export function classifyResource(
     if (ctxKind !== undefined && opts.region !== undefined) {
       const ctxDefault = ctxKind === 'region' ? opts.region : [opts.region];
       if (deepEqual(v, ctxDefault)) {
+        findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
+        continue;
+      }
+    }
+    // A live value EQUAL to its CONTEXT-DERIVED ARN default — an ARN whose VALUE is built from
+    // this resource's own account/region/partition (a ResourceExplorer2 View's account-root
+    // Scope), which neither a constant nor the region-only CONTEXT_DEFAULTS can express.
+    // Equality-gated (a view scoped elsewhere still surfaces); with no resolved account/region
+    // it falls through to plain `undeclared` (recordable), never a wrong fold.
+    const ctxArnTemplate = CONTEXT_ARN_DEFAULTS[resourceType]?.[k];
+    if (
+      ctxArnTemplate !== undefined &&
+      opts.region !== undefined &&
+      opts.accountId !== undefined &&
+      typeof v === 'string'
+    ) {
+      const partition = opts.region.startsWith('cn-')
+        ? 'aws-cn'
+        : opts.region.startsWith('us-gov-')
+          ? 'aws-us-gov'
+          : 'aws';
+      const ctxArnDefault = ctxArnTemplate
+        .replace('{partition}', partition)
+        .replace('{region}', opts.region)
+        .replace('{accountId}', opts.accountId);
+      if (v === ctxArnDefault) {
         findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
         continue;
       }

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -997,6 +997,52 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Bedrock::Agent': {
     AgentCollaboration: 'DISABLED',
     OrchestrationType: 'DEFAULT',
+    // An agent that declares no idle-session TTL reads back AWS's 600-second default
+    // (observed live, hunt 2026-07-08, #619). A user-settable knob — equality-gated, so an
+    // agent that raises/lowers it surfaces as real undeclared drift. (Live: an out-of-band
+    // 600->1200 re-surfaced correctly after record.)
+    IdleSessionTTLInSeconds: 600,
+  },
+  // A Site-to-Site VPN gateway that declares no ASN reads back AWS's 64512 default private
+  // ASN (observed live, hunt 2026-07-08, #619). createOnly, so it never drifts; equality-
+  // gated all the same (a gateway created with a custom ASN declares it, compared).
+  'AWS::EC2::VPNGateway': {
+    AmazonSideAsn: 64512,
+  },
+  // A CodeGuru Profiler group that declares no compute platform reads back the constant
+  // "Default" (enum Default|AWSLambda; the CFn schema annotates no default). createOnly.
+  // Equality-gated (an AWSLambda group is declared, compared). Live, hunt 2026-07-08 (#622).
+  'AWS::CodeGuruProfiler::ProfilingGroup': {
+    ComputePlatform: 'Default',
+  },
+  // A Service Catalog product that declares no product type reads back the constant
+  // "CLOUD_FORMATION_TEMPLATE" AWS materializes (observed live, hunt 2026-07-08, #625).
+  // Equality-gated, so a MARKETPLACE/EXTERNAL product (declared) still surfaces. The nested
+  // per-artifact Type echo folds via KNOWN_DEFAULT_PATHS below.
+  'AWS::ServiceCatalog::CloudFormationProduct': {
+    ProductType: 'CLOUD_FORMATION_TEMPLATE',
+  },
+  // An Internet Monitor that declares no Status reads back "ACTIVE" (observed live, hunt
+  // 2026-07-08 round F, #626). A user-settable knob (a user pausing a monitor sets INACTIVE)
+  // — equality-gated, so a paused monitor surfaces as real undeclared drift.
+  'AWS::InternetMonitor::Monitor': {
+    Status: 'ACTIVE',
+  },
+  // A Roles Anywhere profile that declares neither a session duration nor attribute mappings
+  // reads back AWS's 3600-second default and the constant default attribute-mapping set
+  // (observed live, hunt 2026-07-08, #619). DurationSeconds is a user-settable knob (equality-
+  // gated, a custom TTL surfaces); AttributeMappings is the whole-array constant AWS seeds
+  // (same shape family as the TrustAnchor NotificationSettings whole-array default).
+  'AWS::RolesAnywhere::Profile': {
+    DurationSeconds: 3600,
+    AttributeMappings: [
+      { CertificateField: 'x509Issuer', MappingRules: [{ Specifier: '*' }] },
+      {
+        CertificateField: 'x509SAN',
+        MappingRules: [{ Specifier: 'DNS' }, { Specifier: 'URI' }, { Specifier: 'Name/*' }],
+      },
+      { CertificateField: 'x509Subject', MappingRules: [{ Specifier: '*' }] },
+    ],
   },
   // A CodeStar notification rule / Recycle Bin rule read back the "on" default status when
   // the template declares none (observed live on hunt 2026-07-03, #492). These ARE
@@ -1187,6 +1233,13 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A Service Catalog product's provisioning artifact that declares no Type reads back the
+  // constant "CLOUD_FORMATION_TEMPLATE" (observed live, hunt 2026-07-08, #625) — the nested
+  // twin of the top-level ProductType fold above. Equality-gated, so an artifact created as a
+  // different type still surfaces.
+  'AWS::ServiceCatalog::CloudFormationProduct': {
+    'ProvisioningArtifactParameters.*.Type': 'CLOUD_FORMATION_TEMPLATE',
+  },
   // A Managed Service for Apache Flink application that declares no encryption config
   // reads back the AWS-owned-key default. Constant (a customer CMK is set explicitly).
   // Equality-gated: an out-of-band switch to a customer key no longer matches. Observed
@@ -1660,6 +1713,21 @@ export const CONTEXT_DEFAULTS: Record<string, Record<string, 'region' | 'regionL
   'AWS::EC2::VPCEndpointService': { SupportedRegions: 'regionList' },
 };
 
+// Top-level UNDECLARED keys whose default VALUE is an ARN derived from the resource's own
+// deploy context — partition, region, account id — which neither a constant KNOWN_DEFAULTS
+// entry nor the region-only CONTEXT_DEFAULTS above can express. The template uses the
+// placeholders {partition}/{region}/{accountId}, substituted from the read opts and equality-
+// gated against the live value: a resource that points the property at a DIFFERENT scope / key
+// still surfaces as real undeclared drift (detection preserved, unlike a value-independent
+// fold). With no resolved account/region the substitution is skipped and the value stays
+// `undeclared` (recordable), never a wrong fold.
+export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string>> = {
+  // A ResourceExplorer2 View that declares no Scope reads back the account-root ARN — the
+  // whole-account default scope. createOnly (never drifts), but derived rather than value-
+  // independent per the fold-strategy order. Live, hunt 2026-07-08 round F (#626).
+  'AWS::ResourceExplorer2::View': { Scope: 'arn:{partition}:iam::{accountId}:root' },
+};
+
 // Top-level UNDECLARED keys whose service default VALUE is derived from the resource's own
 // live ENGINE (RDS) — the engine-conditional twin of CONTEXT_DEFAULTS (region-derived) and
 // KNOWN_DEFAULTS (constant). A single constant cannot express these because the default
@@ -1918,6 +1986,12 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   // (a GUID) inside EncryptionAtRestOptions — never a constant, never user intent when undeclared
   // (like RDS KmsKeyId). Live-verified undeclared on a fresh opensearch-rich deploy.
   'AWS::OpenSearchService::Domain': new Set(['EncryptionAtRestOptions.KmsKeyId']),
+  // A stage with a declared canary reads back a CanarySetting.DeploymentId AWS materializes at
+  // creation — the canary starts pointed at the stage's current deployment, so AWS fills the id
+  // the template's CanarySetting omits. Per-resource AWS-assigned identifier (the canary-nested
+  // twin of the stage's own top-level DeploymentId, which already folds `generated`), so fold it
+  // value-independently. Live, hunt 2026-07-08 round G (#633).
+  'AWS::ApiGateway::Stage': new Set(['CanarySetting.DeploymentId']),
 };
 
 // Elastic Beanstalk ConfigurationTemplate `OptionSettings` first-run default fold. A template
@@ -2290,6 +2364,38 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   Same shape as AWS::Redshift::Cluster.ClusterVersion / AWS::ECS::Service.PlatformVersion
   //   above. Live-verified undeclared on a fresh grafana-rich deploy ("10.4"), no out-of-band edit.
   'AWS::Grafana::Workspace': new Set(['GrafanaVersion']),
+  //   AWS::Bedrock::AgentAlias.RoutingConfiguration — an alias that declares no routing reads
+  //   back an AWS-assigned pointer to the auto-created agent version ([{"AgentVersion":"1"}]).
+  //   The version number moves as the agent is updated/re-prepared, so it is not a constant we
+  //   can pin and is not user intent when undeclared (a user who pins a version DECLARES
+  //   routingConfiguration → compared in the declared loop). Live, hunt 2026-07-08 (#619).
+  'AWS::Bedrock::AgentAlias': new Set(['RoutingConfiguration']),
+  //   AWS::AppSync::ApiKey.Expires (UNDECLARED) — a key that declares no expiry reads back
+  //   AWS's creation-time + 7 days (rounded down to the hour): creation-time-relative, not a
+  //   constant and not derivable from any declared prop. A DECLARED Expires goes through the
+  //   declared loop with EPOCH_HOUR_PATHS rounding (unaffected). The existing corpus ApiKey
+  //   case DECLARES Expires, which is why this undeclared scenario stayed latent (#615 lesson).
+  //   Live, hunt 2026-07-08 (#619).
+  'AWS::AppSync::ApiKey': new Set(['Expires']),
+  //   AWS::AppConfig::ExtensionAssociation.ExtensionVersionNumber — an association reads back
+  //   the bound extension's current version at creation (1 here). Not declared, not a stable
+  //   constant (it equals whatever version the referenced extension is at), and not derivable
+  //   from the association's own declared props (ExtensionIdentifier is write-only and carries
+  //   no version). A per-association AWS-assigned pointer; a user who pins the version DECLARES
+  //   it → compared in the declared loop. Live, hunt 2026-07-08 round D (#622).
+  'AWS::AppConfig::ExtensionAssociation': new Set(['ExtensionVersionNumber']),
+  //   AWS::StepFunctions::StateMachineVersion.StateMachineRevisionId — a version reads back the
+  //   AWS-assigned revision pointer ("INITIAL" for a never-updated machine's first version; a
+  //   UUID for a version cut from a later revision). It is a per-resource AWS-assigned identifier
+  //   the user cannot meaningfully set, and the value legitimately varies (INITIAL vs a UUID), so
+  //   neither a constant nor a derivation fits — value-independent. Live, hunt 2026-07-08 (#628).
+  'AWS::StepFunctions::StateMachineVersion': new Set(['StateMachineRevisionId']),
+  //   AWS::StepFunctions::StateMachineAlias.StateMachineArn — an alias reads back the ARN of the
+  //   state machine it belongs to (an AWS-assigned echo derivable from the declared
+  //   RoutingConfiguration's version ARN, but an alias is bound to exactly one state machine and
+  //   the ARN carries the machine's generated name segment). Not user intent when undeclared —
+  //   fold value-independent. Live, hunt 2026-07-08 (#628).
+  'AWS::StepFunctions::StateMachineAlias': new Set(['StateMachineArn']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1019,6 +1019,25 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t({ VisibilityTimeout: 60 }).undeclared).toEqual(['VisibilityTimeout']);
   });
 
+  it('#626: ResourceExplorer2 View undeclared Scope folds via the context-ARN default', () => {
+    const t = (live: Record<string, unknown>, opts?: Parameters<typeof classifyResource>[3]) =>
+      tiers(classifyResource(bare('AWS::ResourceExplorer2::View'), live, emptySchema, opts));
+    const opts = { accountId: '111111111111', region: 'us-east-1' };
+    // the account-root ARN, derived from account+region+partition, folds atDefault
+    expect(t({ Scope: 'arn:aws:iam::111111111111:root' }, opts).atDefault).toEqual(['Scope']);
+    // a view scoped elsewhere (an OU) is NOT the default and still surfaces (equality-gated)
+    expect(
+      t({ Scope: 'arn:aws:organizations::111111111111:ou/o-x/ou-x' }, opts).undeclared
+    ).toEqual(['Scope']);
+    // China / GovCloud partitions are derived from the region prefix
+    expect(
+      t({ Scope: 'arn:aws-cn:iam::111111111111:root' }, { ...opts, region: 'cn-north-1' }).atDefault
+    ).toEqual(['Scope']);
+    // with no resolved account/region the substitution is skipped → stays undeclared, never a
+    // wrong fold
+    expect(t({ Scope: 'arn:aws:iam::111111111111:root' }).undeclared).toEqual(['Scope']);
+  });
+
   it('noise-sweep batch: the default folds, a flipped (security-relevant) value surfaces', () => {
     const t = (rt: string, live: Record<string, unknown>) =>
       tiers(classifyResource(bare(rt), live, emptySchema));

--- a/tests/corpus/AWS__ApiGateway__Stage.CanaryStage.json
+++ b/tests/corpus/AWS__ApiGateway__Stage.CanaryStage.json
@@ -1,0 +1,75 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "ApiDeploymentStageprod3EB9684E",
+    "resourceType": "AWS::ApiGateway::Stage",
+    "physicalId": "prod",
+    "constructPath": "CdkRealDriftHunt0708gApigwCanary/Api/DeploymentStage.prod",
+    "declared": {
+      "CanarySetting": {
+        "PercentTraffic": 10,
+        "UseStageCache": false
+      },
+      "DeploymentId": "xn6iv8",
+      "RestApiId": "lzniau0ph2",
+      "StageName": "prod"
+    }
+  },
+  "liveRaw": {
+    "DeploymentId": "xn6iv8",
+    "StageName": "prod",
+    "TracingEnabled": false,
+    "RestApiId": "lzniau0ph2",
+    "CanarySetting": {
+      "DeploymentId": "xn6iv8",
+      "PercentTraffic": 10,
+      "UseStageCache": false
+    },
+    "Tags": [
+      {
+        "Value": "ApiDeploymentStageprod3EB9684E",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708gApigwCanary/c9d3cea0-7a80-11f1-a1d0-0affcfb358e5",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708gApigwCanary",
+        "Key": "aws:cloudformation:stack-name"
+      }
+    ],
+    "CacheClusterEnabled": false
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": [],
+    "createOnly": ["RestApiId", "StageName"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["RestApiId", "StageName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["MethodSettings"],
+    "freeFormMapPaths": ["CanarySetting.StageVariableOverrides", "Variables"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "generated",
+      "logicalId": "ApiDeploymentStageprod3EB9684E",
+      "resourceType": "AWS::ApiGateway::Stage",
+      "path": "CanarySetting.DeploymentId",
+      "actual": "xn6iv8",
+      "nested": true,
+      "physicalId": "prod",
+      "constructPath": "CdkRealDriftHunt0708gApigwCanary/Api/DeploymentStage.prod"
+    }
+  ]
+}

--- a/tests/corpus/AWS__AppConfig__Application.HuntAppCfgApp.json
+++ b/tests/corpus/AWS__AppConfig__Application.HuntAppCfgApp.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntAppCfgApp",
+    "resourceType": "AWS::AppConfig::Application",
+    "physicalId": "5p56psc",
+    "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntAppCfgApp",
+    "declared": {
+      "Name": "cdkrd-hunt-0708d-app"
+    }
+  },
+  "liveRaw": {
+    "ApplicationId": "5p56psc",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftHunt0708DVpMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntAppCfgApp",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708DVpMisc/ed11d250-7a70-11f1-85fb-0ecb5367f463",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "cdkrd-hunt-0708d-app"
+  },
+  "schema": {
+    "readOnly": ["ApplicationId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["ApplicationId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppConfig__Extension.HuntExtension.json
+++ b/tests/corpus/AWS__AppConfig__Extension.HuntExtension.json
@@ -1,0 +1,83 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntExtension",
+    "resourceType": "AWS::AppConfig::Extension",
+    "physicalId": "5s8opx5",
+    "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtension",
+    "declared": {
+      "Actions": {
+        "ON_DEPLOYMENT_START": [
+          {
+            "Name": "hunt-notify",
+            "Uri": "arn:aws:events:us-east-1:111111111111:event-bus/default"
+          }
+        ]
+      },
+      "Description": "cdkrd hunt extension",
+      "Name": "cdkrd-hunt-0708d-ext",
+      "Parameters": {
+        "huntParam": {
+          "Description": "optional hunt parameter",
+          "Required": false
+        }
+      }
+    }
+  },
+  "liveRaw": {
+    "Description": "cdkrd hunt extension",
+    "Parameters": {
+      "huntParam": {
+        "Dynamic": false,
+        "Description": "optional hunt parameter",
+        "Required": false
+      }
+    },
+    "Actions": {
+      "ON_DEPLOYMENT_START": [
+        {
+          "Uri": "arn:aws:events:us-east-1:111111111111:event-bus/default",
+          "Name": "hunt-notify"
+        }
+      ]
+    },
+    "Id": "5s8opx5",
+    "Arn": "arn:aws:appconfig:us-east-1:111111111111:extension/5s8opx5/1",
+    "VersionNumber": 1,
+    "Tags": [
+      {
+        "Value": "CdkRealDriftHunt0708DVpMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntExtension",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708DVpMisc/ed11d250-7a70-11f1-85fb-0ecb5367f463",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ],
+    "Name": "cdkrd-hunt-0708d-ext"
+  },
+  "schema": {
+    "readOnly": ["Arn", "Id", "VersionNumber"],
+    "writeOnly": ["LatestVersionNumber"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn", "Id", "VersionNumber"],
+    "writeOnlyPaths": ["LatestVersionNumber"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Actions", "Parameters"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppConfig__ExtensionAssociation.HuntExtAssoc.json
+++ b/tests/corpus/AWS__AppConfig__ExtensionAssociation.HuntExtAssoc.json
@@ -1,0 +1,88 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntExtAssoc",
+    "resourceType": "AWS::AppConfig::ExtensionAssociation",
+    "physicalId": "qza1zzu",
+    "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc",
+    "declared": {
+      "ExtensionIdentifier": "5s8opx5",
+      "Parameters": {
+        "huntParam": "v1"
+      },
+      "ResourceIdentifier": "arn:aws:appconfig:us-east-1:111111111111:application/5p56psc"
+    }
+  },
+  "liveRaw": {
+    "ResourceArn": "arn:aws:appconfig:us-east-1:111111111111:application/5p56psc",
+    "Parameters": {
+      "huntParam": "v1"
+    },
+    "ExtensionArn": "arn:aws:appconfig:us-east-1:111111111111:extension/5s8opx5/1",
+    "Id": "qza1zzu",
+    "Arn": "arn:aws:appconfig:us-east-1:111111111111:extensionassociation/qza1zzu",
+    "ExtensionVersionNumber": 1,
+    "Tags": [
+      {
+        "Value": "CdkRealDriftHunt0708DVpMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "HuntExtAssoc",
+        "Key": "aws:cloudformation:logical-id"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708DVpMisc/ed11d250-7a70-11f1-85fb-0ecb5367f463",
+        "Key": "aws:cloudformation:stack-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["Arn", "ExtensionArn", "Id", "ResourceArn"],
+    "writeOnly": ["ExtensionIdentifier", "ResourceIdentifier"],
+    "createOnly": ["ExtensionIdentifier", "ExtensionVersionNumber", "ResourceIdentifier"],
+    "readOnlyPaths": ["Arn", "ExtensionArn", "Id", "ResourceArn"],
+    "writeOnlyPaths": ["ExtensionIdentifier", "ResourceIdentifier"],
+    "createOnlyPaths": ["ExtensionIdentifier", "ExtensionVersionNumber", "ResourceIdentifier"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": ["Parameters"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "HuntExtAssoc",
+      "resourceType": "AWS::AppConfig::ExtensionAssociation",
+      "path": "ExtensionIdentifier",
+      "note": "write-only — cannot be read back",
+      "physicalId": "qza1zzu",
+      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc"
+    },
+    {
+      "tier": "readGap",
+      "logicalId": "HuntExtAssoc",
+      "resourceType": "AWS::AppConfig::ExtensionAssociation",
+      "path": "ResourceIdentifier",
+      "note": "write-only — cannot be read back",
+      "physicalId": "qza1zzu",
+      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntExtAssoc",
+      "resourceType": "AWS::AppConfig::ExtensionAssociation",
+      "path": "ExtensionVersionNumber",
+      "actual": 1,
+      "physicalId": "qza1zzu",
+      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntExtAssoc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__AppSync__Api.EventsApi.json
+++ b/tests/corpus/AWS__AppSync__Api.EventsApi.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EventsApi",
+    "resourceType": "AWS::AppSync::Api",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/q6ihygkfmzfwjimciq5wgoeuky",
+    "constructPath": "CdkRealDriftHunt0708AppSyncEvents/EventsApi",
+    "declared": {
+      "EventConfig": {
+        "AuthProviders": [
+          {
+            "AuthType": "API_KEY"
+          }
+        ],
+        "ConnectionAuthModes": [
+          {
+            "AuthType": "API_KEY"
+          }
+        ],
+        "DefaultPublishAuthModes": [
+          {
+            "AuthType": "API_KEY"
+          }
+        ],
+        "DefaultSubscribeAuthModes": [
+          {
+            "AuthType": "API_KEY"
+          }
+        ]
+      },
+      "Name": "cdkrd-hunt0708-events-api"
+    }
+  },
+  "liveRaw": {
+    "ApiArn": "arn:aws:appsync:us-east-1:111111111111:apis/q6ihygkfmzfwjimciq5wgoeuky",
+    "Dns": {
+      "Http": "ff75znegl5fsje723tgmqp2j7m.appsync-api.us-east-1.amazonaws.com",
+      "Realtime": "ff75znegl5fsje723tgmqp2j7m.appsync-realtime-api.us-east-1.amazonaws.com"
+    },
+    "EventConfig": {
+      "AuthProviders": [
+        {
+          "AuthType": "API_KEY"
+        }
+      ],
+      "ConnectionAuthModes": [
+        {
+          "AuthType": "API_KEY"
+        }
+      ],
+      "DefaultPublishAuthModes": [
+        {
+          "AuthType": "API_KEY"
+        }
+      ],
+      "DefaultSubscribeAuthModes": [
+        {
+          "AuthType": "API_KEY"
+        }
+      ]
+    },
+    "ApiId": "q6ihygkfmzfwjimciq5wgoeuky",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftHunt0708AppSyncEvents",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708AppSyncEvents/32739bd0-7a6c-11f1-964a-12bd8434d3df",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "EventsApi",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-hunt0708-events-api"
+  },
+  "schema": {
+    "readOnly": ["ApiArn", "ApiId", "Dns"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["ApiArn", "ApiId", "Dns", "Dns.Http", "Dns.Realtime"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [
+      "EventConfig.AuthProviders",
+      "EventConfig.ConnectionAuthModes",
+      "EventConfig.DefaultPublishAuthModes",
+      "EventConfig.DefaultSubscribeAuthModes"
+    ],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__AppSync__ApiKey.EventsApiKey.json
+++ b/tests/corpus/AWS__AppSync__ApiKey.EventsApiKey.json
@@ -1,0 +1,48 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "EventsApiKey",
+    "resourceType": "AWS::AppSync::ApiKey",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/q6ihygkfmzfwjimciq5wgoeuky/apikeys/da2-gonknqlfcvg4rbmzc4rhtnuzki",
+    "constructPath": "CdkRealDriftHunt0708AppSyncEvents/EventsApiKey",
+    "declared": {
+      "ApiId": "q6ihygkfmzfwjimciq5wgoeuky",
+      "Description": "cdkrd bug-hunt events api key"
+    }
+  },
+  "liveRaw": {
+    "ApiId": "q6ihygkfmzfwjimciq5wgoeuky",
+    "Description": "cdkrd bug-hunt events api key",
+    "Expires": 1784077200
+  },
+  "schema": {
+    "readOnly": ["ApiKey", "ApiKeyId", "Arn"],
+    "writeOnly": [],
+    "createOnly": ["ApiId"],
+    "readOnlyPaths": ["ApiKey", "ApiKeyId", "Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ApiId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "EventsApiKey",
+      "resourceType": "AWS::AppSync::ApiKey",
+      "path": "Expires",
+      "actual": 1784077200,
+      "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/q6ihygkfmzfwjimciq5wgoeuky/apikeys/da2-gonknqlfcvg4rbmzc4rhtnuzki",
+      "constructPath": "CdkRealDriftHunt0708AppSyncEvents/EventsApiKey"
+    }
+  ]
+}

--- a/tests/corpus/AWS__AppSync__ChannelNamespace.DefaultNs.json
+++ b/tests/corpus/AWS__AppSync__ChannelNamespace.DefaultNs.json
@@ -1,0 +1,55 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "DefaultNs",
+    "resourceType": "AWS::AppSync::ChannelNamespace",
+    "physicalId": "arn:aws:appsync:us-east-1:111111111111:apis/q6ihygkfmzfwjimciq5wgoeuky/channelNamespace/default",
+    "constructPath": "CdkRealDriftHunt0708AppSyncEvents/DefaultNs",
+    "declared": {
+      "ApiId": "q6ihygkfmzfwjimciq5wgoeuky",
+      "Name": "default"
+    }
+  },
+  "liveRaw": {
+    "SubscribeAuthModes": [],
+    "PublishAuthModes": [],
+    "HandlerConfigs": {},
+    "ApiId": "q6ihygkfmzfwjimciq5wgoeuky",
+    "ChannelNamespaceArn": "arn:aws:appsync:us-east-1:111111111111:apis/q6ihygkfmzfwjimciq5wgoeuky/channelNamespace/default",
+    "Tags": [
+      {
+        "Value": "CdkRealDriftHunt0708AppSyncEvents",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708AppSyncEvents/32739bd0-7a6c-11f1-964a-12bd8434d3df",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "DefaultNs",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "default"
+  },
+  "schema": {
+    "readOnly": ["ChannelNamespaceArn"],
+    "writeOnly": ["CodeS3Location"],
+    "createOnly": ["ApiId", "Name"],
+    "readOnlyPaths": ["ChannelNamespaceArn"],
+    "writeOnlyPaths": ["CodeS3Location"],
+    "createOnlyPaths": ["ApiId", "Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["PublishAuthModes", "SubscribeAuthModes"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__Bedrock__Agent.Agent.json
+++ b/tests/corpus/AWS__Bedrock__Agent.Agent.json
@@ -1,0 +1,141 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Agent",
+    "resourceType": "AWS::Bedrock::Agent",
+    "physicalId": "9W8IFJ9ZK0",
+    "constructPath": "CdkRealDriftHunt0708Bedrock/Agent",
+    "declared": {
+      "AgentName": "cdkrd-hunt0708-agent",
+      "AgentResourceRoleArn": "arn:aws:iam::111111111111:role/cdkrd-hunt0708-bedrock-agent-role",
+      "AutoPrepare": true,
+      "Description": "cdkrd bug-hunt agent",
+      "FoundationModel": "anthropic.claude-3-haiku-20240307-v1:0",
+      "Instruction": "You are a placeholder integration-test agent for cdk-real-drift. Reply politely."
+    }
+  },
+  "liveRaw": {
+    "AgentCollaborators": [],
+    "Description": "cdkrd bug-hunt agent",
+    "AgentVersion": "DRAFT",
+    "PromptOverrideConfiguration": {
+      "PromptConfigurations": []
+    },
+    "CreatedAt": "2026-07-08T01:28:05.585469689Z",
+    "AgentCollaboration": "DISABLED",
+    "PreparedAt": "2026-07-08T01:28:21.106919716Z",
+    "Instruction": "You are a placeholder integration-test agent for cdk-real-drift. Reply politely.",
+    "FailureReasons": [],
+    "UpdatedAt": "2026-07-08T01:28:24.079611921Z",
+    "TestAliasTags": {},
+    "AgentResourceRoleArn": "arn:aws:iam::111111111111:role/cdkrd-hunt0708-bedrock-agent-role",
+    "AgentArn": "arn:aws:bedrock:us-east-1:111111111111:agent/9W8IFJ9ZK0",
+    "AgentStatus": "PREPARED",
+    "OrchestrationType": "DEFAULT",
+    "FoundationModel": "anthropic.claude-3-haiku-20240307-v1:0",
+    "IdleSessionTTLInSeconds": 600,
+    "AgentId": "9W8IFJ9ZK0",
+    "AgentName": "cdkrd-hunt0708-agent",
+    "KnowledgeBases": [],
+    "ActionGroups": [],
+    "RecommendedActions": [],
+    "Tags": {}
+  },
+  "schema": {
+    "readOnly": [
+      "AgentArn",
+      "AgentId",
+      "AgentStatus",
+      "AgentVersion",
+      "CreatedAt",
+      "FailureReasons",
+      "PreparedAt",
+      "RecommendedActions",
+      "UpdatedAt"
+    ],
+    "writeOnly": ["AutoPrepare", "SkipResourceInUseCheckOnDelete"],
+    "createOnly": [],
+    "readOnlyPaths": [
+      "AgentArn",
+      "AgentId",
+      "AgentStatus",
+      "AgentVersion",
+      "CreatedAt",
+      "FailureReasons",
+      "PreparedAt",
+      "RecommendedActions",
+      "UpdatedAt"
+    ],
+    "writeOnlyPaths": [
+      "ActionGroups.*.SkipResourceInUseCheckOnDelete",
+      "AutoPrepare",
+      "SkipResourceInUseCheckOnDelete"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {
+      "AutoPrepare": false,
+      "SkipResourceInUseCheckOnDelete": false
+    },
+    "defaultPaths": {
+      "ActionGroups.*.SkipResourceInUseCheckOnDelete": false,
+      "AutoPrepare": false,
+      "SkipResourceInUseCheckOnDelete": false
+    },
+    "unorderedScalarPaths": [
+      "FailureReasons",
+      "MemoryConfiguration.EnabledMemoryTypes",
+      "RecommendedActions"
+    ],
+    "unorderedObjectArrayPaths": [
+      "ActionGroups",
+      "AgentCollaborators",
+      "KnowledgeBases",
+      "PromptOverrideConfiguration.PromptConfigurations"
+    ],
+    "freeFormMapPaths": ["ActionGroups.*.FunctionSchema.Functions.*.Parameters", "TestAliasTags"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Agent",
+      "resourceType": "AWS::Bedrock::Agent",
+      "path": "AutoPrepare",
+      "note": "write-only — cannot be read back",
+      "physicalId": "9W8IFJ9ZK0",
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Agent"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Agent",
+      "resourceType": "AWS::Bedrock::Agent",
+      "path": "AgentCollaboration",
+      "actual": "DISABLED",
+      "physicalId": "9W8IFJ9ZK0",
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Agent"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Agent",
+      "resourceType": "AWS::Bedrock::Agent",
+      "path": "OrchestrationType",
+      "actual": "DEFAULT",
+      "physicalId": "9W8IFJ9ZK0",
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Agent"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Agent",
+      "resourceType": "AWS::Bedrock::Agent",
+      "path": "IdleSessionTTLInSeconds",
+      "actual": 600,
+      "physicalId": "9W8IFJ9ZK0",
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Agent"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Bedrock__AgentAlias.AgentAlias.json
+++ b/tests/corpus/AWS__Bedrock__AgentAlias.AgentAlias.json
@@ -1,0 +1,93 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AgentAlias",
+    "resourceType": "AWS::Bedrock::AgentAlias",
+    "physicalId": "9W8IFJ9ZK0|RNIIBZI1I2",
+    "constructPath": "CdkRealDriftHunt0708Bedrock/AgentAlias",
+    "declared": {
+      "AgentAliasName": "live",
+      "AgentId": "9W8IFJ9ZK0",
+      "Description": "cdkrd bug-hunt agent alias"
+    }
+  },
+  "liveRaw": {
+    "AgentAliasStatus": "PREPARED",
+    "AgentAliasName": "live",
+    "AgentAliasArn": "arn:aws:bedrock:us-east-1:111111111111:agent-alias/9W8IFJ9ZK0/RNIIBZI1I2",
+    "Description": "cdkrd bug-hunt agent alias",
+    "RoutingConfiguration": [
+      {
+        "AgentVersion": "1"
+      }
+    ],
+    "AgentAliasHistoryEvents": [
+      {
+        "StartDate": "2026-07-08T01:28:25.754226239Z",
+        "RoutingConfiguration": [
+          {
+            "AgentVersion": "1"
+          }
+        ],
+        "EndDate": ""
+      }
+    ],
+    "CreatedAt": "2026-07-08T01:28:22.433897279Z",
+    "AgentAliasId": "RNIIBZI1I2",
+    "AgentId": "9W8IFJ9ZK0",
+    "UpdatedAt": "2026-07-08T01:28:22.433897279Z",
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftHunt0708Bedrock",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708Bedrock/327a79a0-7a6c-11f1-b5f6-0e169744b13b",
+      "aws:cloudformation:logical-id": "AgentAlias"
+    }
+  },
+  "schema": {
+    "readOnly": [
+      "AgentAliasArn",
+      "AgentAliasHistoryEvents",
+      "AgentAliasId",
+      "AgentAliasStatus",
+      "CreatedAt",
+      "UpdatedAt"
+    ],
+    "writeOnly": [],
+    "createOnly": ["AgentId"],
+    "readOnlyPaths": [
+      "AgentAliasArn",
+      "AgentAliasHistoryEvents",
+      "AgentAliasId",
+      "AgentAliasStatus",
+      "CreatedAt",
+      "UpdatedAt"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AgentId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["AgentAliasHistoryEvents", "RoutingConfiguration"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AgentAlias",
+      "resourceType": "AWS::Bedrock::AgentAlias",
+      "path": "RoutingConfiguration",
+      "actual": [
+        {
+          "AgentVersion": "1"
+        }
+      ],
+      "physicalId": "9W8IFJ9ZK0|RNIIBZI1I2",
+      "constructPath": "CdkRealDriftHunt0708Bedrock/AgentAlias"
+    }
+  ]
+}

--- a/tests/corpus/AWS__Bedrock__ApplicationInferenceProfile.Aip.json
+++ b/tests/corpus/AWS__Bedrock__ApplicationInferenceProfile.Aip.json
@@ -1,0 +1,94 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Aip",
+    "resourceType": "AWS::Bedrock::ApplicationInferenceProfile",
+    "physicalId": "arn:aws:bedrock:us-east-1:111111111111:application-inference-profile/dgsnhongtx0l",
+    "constructPath": "CdkRealDriftHunt0708Bedrock/Aip",
+    "declared": {
+      "Description": "cdkrd bug-hunt application inference profile",
+      "InferenceProfileName": "cdkrd-hunt0708-aip",
+      "ModelSource": {
+        "CopyFrom": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+      }
+    }
+  },
+  "liveRaw": {
+    "Status": "ACTIVE",
+    "Type": "APPLICATION",
+    "Description": "cdkrd bug-hunt application inference profile",
+    "InferenceProfileArn": "arn:aws:bedrock:us-east-1:111111111111:application-inference-profile/dgsnhongtx0l",
+    "InferenceProfileIdentifier": "arn:aws:bedrock:us-east-1:111111111111:application-inference-profile/dgsnhongtx0l",
+    "CreatedAt": "2026-07-08T01:27:46.011470324Z",
+    "InferenceProfileName": "cdkrd-hunt0708-aip",
+    "Models": [
+      {
+        "ModelArn": "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-haiku-20240307-v1:0"
+      }
+    ],
+    "InferenceProfileId": "dgsnhongtx0l",
+    "UpdatedAt": "2026-07-08T01:27:46.011470324Z",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708Bedrock/327a79a0-7a6c-11f1-b5f6-0e169744b13b",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708Bedrock",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Aip",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CreatedAt",
+      "InferenceProfileArn",
+      "InferenceProfileId",
+      "InferenceProfileIdentifier",
+      "Models",
+      "Status",
+      "Type",
+      "UpdatedAt"
+    ],
+    "writeOnly": ["ModelSource"],
+    "createOnly": ["Description", "InferenceProfileName", "ModelSource"],
+    "readOnlyPaths": [
+      "CreatedAt",
+      "InferenceProfileArn",
+      "InferenceProfileId",
+      "InferenceProfileIdentifier",
+      "Models",
+      "Status",
+      "Type",
+      "UpdatedAt"
+    ],
+    "writeOnlyPaths": ["ModelSource"],
+    "createOnlyPaths": ["Description", "InferenceProfileName", "ModelSource"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "readGap",
+      "logicalId": "Aip",
+      "resourceType": "AWS::Bedrock::ApplicationInferenceProfile",
+      "path": "ModelSource",
+      "note": "write-only — cannot be read back",
+      "physicalId": "arn:aws:bedrock:us-east-1:111111111111:application-inference-profile/dgsnhongtx0l",
+      "constructPath": "CdkRealDriftHunt0708Bedrock/Aip"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeGuruProfiler__ProfilingGroup.HuntPgMinimal.json
+++ b/tests/corpus/AWS__CodeGuruProfiler__ProfilingGroup.HuntPgMinimal.json
@@ -1,0 +1,52 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPgMinimal",
+    "resourceType": "AWS::CodeGuruProfiler::ProfilingGroup",
+    "physicalId": "cdkrd-hunt-0708d-pg-min",
+    "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntPgMinimal",
+    "declared": {
+      "ProfilingGroupName": "cdkrd-hunt-0708d-pg-min"
+    }
+  },
+  "liveRaw": {
+    "AnomalyDetectionNotificationConfiguration": [],
+    "AgentPermissions": {
+      "Principals": []
+    },
+    "ComputePlatform": "Default",
+    "ProfilingGroupName": "cdkrd-hunt-0708d-pg-min",
+    "Arn": "arn:aws:codeguru-profiler:us-east-1:111111111111:profilingGroup/cdkrd-hunt-0708d-pg-min",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["ComputePlatform", "ProfilingGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ComputePlatform", "ProfilingGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "HuntPgMinimal",
+      "resourceType": "AWS::CodeGuruProfiler::ProfilingGroup",
+      "path": "ComputePlatform",
+      "actual": "Default",
+      "physicalId": "cdkrd-hunt-0708d-pg-min",
+      "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntPgMinimal"
+    }
+  ]
+}

--- a/tests/corpus/AWS__CodeGuruProfiler__ProfilingGroup.HuntPgRich.json
+++ b/tests/corpus/AWS__CodeGuruProfiler__ProfilingGroup.HuntPgRich.json
@@ -1,0 +1,50 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "HuntPgRich",
+    "resourceType": "AWS::CodeGuruProfiler::ProfilingGroup",
+    "physicalId": "cdkrd-hunt-0708d-pg-rich",
+    "constructPath": "CdkRealDriftHunt0708DVpMisc/HuntPgRich",
+    "declared": {
+      "AgentPermissions": {
+        "Principals": [
+          "arn:aws:iam::111111111111:role/CdkRealDriftHunt0708DVpMisc-HuntAgentRole32F54652-JiH9SVu0cEMp"
+        ]
+      },
+      "ComputePlatform": "Default",
+      "ProfilingGroupName": "cdkrd-hunt-0708d-pg-rich"
+    }
+  },
+  "liveRaw": {
+    "AnomalyDetectionNotificationConfiguration": [],
+    "AgentPermissions": {
+      "Principals": [
+        "arn:aws:iam::111111111111:role/CdkRealDriftHunt0708DVpMisc-HuntAgentRole32F54652-JiH9SVu0cEMp"
+      ]
+    },
+    "ComputePlatform": "Default",
+    "ProfilingGroupName": "cdkrd-hunt-0708d-pg-rich",
+    "Arn": "arn:aws:codeguru-profiler:us-east-1:111111111111:profilingGroup/cdkrd-hunt-0708d-pg-rich",
+    "Tags": []
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["ComputePlatform", "ProfilingGroupName"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["ComputePlatform", "ProfilingGroupName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__EC2__VPNGateway.Vgw.json
+++ b/tests/corpus/AWS__EC2__VPNGateway.Vgw.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Vgw",
+    "resourceType": "AWS::EC2::VPNGateway",
+    "physicalId": "vgw-02dd4c8424294bb56",
+    "constructPath": "CdkRealDriftHunt0708Vpn/Vgw",
+    "declared": {
+      "Type": "ipsec.1"
+    }
+  },
+  "liveRaw": {
+    "VPNGatewayId": "vgw-02dd4c8424294bb56",
+    "Type": "ipsec.1",
+    "AmazonSideAsn": 64512,
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708Vpn/3274d451-7a6c-11f1-b1b4-0e54e818a535",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708Vpn",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Vgw",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["VPNGatewayId"],
+    "writeOnly": [],
+    "createOnly": ["AmazonSideAsn", "Type"],
+    "readOnlyPaths": ["VPNGatewayId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["AmazonSideAsn", "Type"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Vgw",
+      "resourceType": "AWS::EC2::VPNGateway",
+      "path": "AmazonSideAsn",
+      "actual": 64512,
+      "physicalId": "vgw-02dd4c8424294bb56",
+      "constructPath": "CdkRealDriftHunt0708Vpn/Vgw"
+    }
+  ]
+}

--- a/tests/corpus/AWS__InternetMonitor__Monitor.NetMonitor.json
+++ b/tests/corpus/AWS__InternetMonitor__Monitor.NetMonitor.json
@@ -1,0 +1,90 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "NetMonitor",
+    "resourceType": "AWS::InternetMonitor::Monitor",
+    "physicalId": "cdkrd-hunt-0708f-monitor",
+    "constructPath": "CdkRealDriftHunt0708FMisc/NetMonitor",
+    "declared": {
+      "MaxCityNetworksToMonitor": 1,
+      "MonitorName": "cdkrd-hunt-0708f-monitor"
+    }
+  },
+  "liveRaw": {
+    "ModifiedAt": "2026-07-08T03:29:49Z",
+    "Status": "ACTIVE",
+    "MonitorArn": "arn:aws:internetmonitor:us-east-1:111111111111:monitor/cdkrd-hunt-0708f-monitor",
+    "CreatedAt": "2026-07-08T03:29:49Z",
+    "MonitorName": "cdkrd-hunt-0708f-monitor",
+    "Resources": [],
+    "ProcessingStatusInfo": "The monitor is OK and is collecting data-points to produce insights",
+    "MaxCityNetworksToMonitor": 1,
+    "ProcessingStatus": "COLLECTING_DATA",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708FMisc/3f8c8370-7a7d-11f1-9dca-0ef759634907",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708FMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "NetMonitor",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": [
+      "CreatedAt",
+      "ModifiedAt",
+      "MonitorArn",
+      "ProcessingStatus",
+      "ProcessingStatusInfo"
+    ],
+    "writeOnly": [
+      "IncludeLinkedAccounts",
+      "LinkedAccountId",
+      "ResourcesToAdd",
+      "ResourcesToRemove"
+    ],
+    "createOnly": ["MonitorName"],
+    "readOnlyPaths": [
+      "CreatedAt",
+      "ModifiedAt",
+      "MonitorArn",
+      "ProcessingStatus",
+      "ProcessingStatusInfo"
+    ],
+    "writeOnlyPaths": [
+      "IncludeLinkedAccounts",
+      "LinkedAccountId",
+      "ResourcesToAdd",
+      "ResourcesToRemove"
+    ],
+    "createOnlyPaths": ["MonitorName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["Resources", "ResourcesToAdd", "ResourcesToRemove"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "NetMonitor",
+      "resourceType": "AWS::InternetMonitor::Monitor",
+      "path": "Status",
+      "actual": "ACTIVE",
+      "physicalId": "cdkrd-hunt-0708f-monitor",
+      "constructPath": "CdkRealDriftHunt0708FMisc/NetMonitor"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ResourceExplorer2__View.RexView.json
+++ b/tests/corpus/AWS__ResourceExplorer2__View.RexView.json
@@ -1,0 +1,56 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "RexView",
+    "resourceType": "AWS::ResourceExplorer2::View",
+    "physicalId": "arn:aws:resource-explorer-2:us-east-1:111111111111:view/cdkrd-hunt-0708f-view/f1851768-efa7-422c-a5fe-501bcc4242ce",
+    "constructPath": "CdkRealDriftHunt0708FMisc/RexView",
+    "declared": {
+      "ViewName": "cdkrd-hunt-0708f-view"
+    }
+  },
+  "liveRaw": {
+    "Filters": {
+      "FilterString": ""
+    },
+    "ViewArn": "arn:aws:resource-explorer-2:us-east-1:111111111111:view/cdkrd-hunt-0708f-view/f1851768-efa7-422c-a5fe-501bcc4242ce",
+    "Scope": "arn:aws:iam::111111111111:root",
+    "IncludedProperties": [],
+    "Tags": {
+      "aws:cloudformation:stack-name": "CdkRealDriftHunt0708FMisc",
+      "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708FMisc/3f8c8370-7a7d-11f1-9dca-0ef759634907",
+      "aws:cloudformation:logical-id": "RexView"
+    },
+    "ViewName": "cdkrd-hunt-0708f-view"
+  },
+  "schema": {
+    "readOnly": ["ViewArn"],
+    "writeOnly": [],
+    "createOnly": ["Scope", "ViewName"],
+    "readOnlyPaths": ["ViewArn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Scope", "ViewName"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "RexView",
+      "resourceType": "AWS::ResourceExplorer2::View",
+      "path": "Scope",
+      "actual": "arn:aws:iam::111111111111:root",
+      "physicalId": "arn:aws:resource-explorer-2:us-east-1:111111111111:view/cdkrd-hunt-0708f-view/f1851768-efa7-422c-a5fe-501bcc4242ce",
+      "constructPath": "CdkRealDriftHunt0708FMisc/RexView"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RolesAnywhere__Profile.Profile.json
+++ b/tests/corpus/AWS__RolesAnywhere__Profile.Profile.json
@@ -1,0 +1,140 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Profile",
+    "resourceType": "AWS::RolesAnywhere::Profile",
+    "physicalId": "b1265716-d00d-4616-b0f2-6c5bdcc77e75",
+    "constructPath": "CdkRealDriftHunt0708RolesAnywhere/Profile",
+    "declared": {
+      "Enabled": true,
+      "Name": "cdkrd-hunt0708-profile",
+      "RoleArns": ["arn:aws:iam::111111111111:role/cdkrd-hunt0708-rolesanywhere-role"]
+    }
+  },
+  "liveRaw": {
+    "ProfileId": "b1265716-d00d-4616-b0f2-6c5bdcc77e75",
+    "ManagedPolicyArns": [],
+    "RoleArns": ["arn:aws:iam::111111111111:role/cdkrd-hunt0708-rolesanywhere-role"],
+    "AcceptRoleSessionName": false,
+    "AttributeMappings": [
+      {
+        "MappingRules": [
+          {
+            "Specifier": "*"
+          }
+        ],
+        "CertificateField": "x509Issuer"
+      },
+      {
+        "MappingRules": [
+          {
+            "Specifier": "DNS"
+          },
+          {
+            "Specifier": "URI"
+          },
+          {
+            "Specifier": "Name/*"
+          }
+        ],
+        "CertificateField": "x509SAN"
+      },
+      {
+        "MappingRules": [
+          {
+            "Specifier": "*"
+          }
+        ],
+        "CertificateField": "x509Subject"
+      }
+    ],
+    "Enabled": true,
+    "DurationSeconds": 3600,
+    "ProfileArn": "arn:aws:rolesanywhere:us-east-1:111111111111:profile/b1265716-d00d-4616-b0f2-6c5bdcc77e75",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708RolesAnywhere/9e8f3cc0-7a6c-11f1-936b-1209b76a853f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708RolesAnywhere",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "Profile",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "cdkrd-hunt0708-profile"
+  },
+  "schema": {
+    "readOnly": ["ProfileArn", "ProfileId"],
+    "writeOnly": ["RequireInstanceProperties"],
+    "createOnly": ["RequireInstanceProperties"],
+    "readOnlyPaths": ["ProfileArn", "ProfileId"],
+    "writeOnlyPaths": ["RequireInstanceProperties"],
+    "createOnlyPaths": ["RequireInstanceProperties"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Profile",
+      "resourceType": "AWS::RolesAnywhere::Profile",
+      "path": "AttributeMappings",
+      "actual": [
+        {
+          "MappingRules": [
+            {
+              "Specifier": "*"
+            }
+          ],
+          "CertificateField": "x509Issuer"
+        },
+        {
+          "MappingRules": [
+            {
+              "Specifier": "DNS"
+            },
+            {
+              "Specifier": "URI"
+            },
+            {
+              "Specifier": "Name/*"
+            }
+          ],
+          "CertificateField": "x509SAN"
+        },
+        {
+          "MappingRules": [
+            {
+              "Specifier": "*"
+            }
+          ],
+          "CertificateField": "x509Subject"
+        }
+      ],
+      "physicalId": "b1265716-d00d-4616-b0f2-6c5bdcc77e75",
+      "constructPath": "CdkRealDriftHunt0708RolesAnywhere/Profile"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Profile",
+      "resourceType": "AWS::RolesAnywhere::Profile",
+      "path": "DurationSeconds",
+      "actual": 3600,
+      "physicalId": "b1265716-d00d-4616-b0f2-6c5bdcc77e75",
+      "constructPath": "CdkRealDriftHunt0708RolesAnywhere/Profile"
+    }
+  ]
+}

--- a/tests/corpus/AWS__RolesAnywhere__TrustAnchor.TrustAnchor.json
+++ b/tests/corpus/AWS__RolesAnywhere__TrustAnchor.TrustAnchor.json
@@ -1,0 +1,102 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "TrustAnchor",
+    "resourceType": "AWS::RolesAnywhere::TrustAnchor",
+    "physicalId": "400fbb64-0009-4231-a9f5-02553e62c6c8",
+    "constructPath": "CdkRealDriftHunt0708RolesAnywhere/TrustAnchor",
+    "declared": {
+      "Enabled": true,
+      "Name": "cdkrd-hunt0708-anchor",
+      "Source": {
+        "SourceData": {
+          "X509CertificateData": "-----BEGIN CERTIFICATE-----\nMIIBnTCCAUOgAwIBAgIUB6w5GVsiPA98IQknPXbDCfBYuvYwCgYIKoZIzj0EAwIw\nHDEaMBgGA1UEAwwRY2RrcmQtaHVudDA3MDgtY2EwHhcNMjYwNzA4MDEyODMyWhcN\nMjYwODA3MDEyODMyWjAcMRowGAYDVQQDDBFjZGtyZC1odW50MDcwOC1jYTBZMBMG\nByqGSM49AgEGCCqGSM49AwEHA0IABKWZ40lCqvvvGgZy+bvbEEmDRZCh5C4mcI9k\nIUGlPgfeZfSgtTzoF3lVKt4feJr80ZoqF7j28pX63+Nz/1AVDMujYzBhMB0GA1Ud\nDgQWBBT5l2Nhv3ZffQyT4nMyEwo3/91+gDAfBgNVHSMEGDAWgBT5l2Nhv3ZffQyT\n4nMyEwo3/91+gDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAKBggq\nhkjOPQQDAgNIADBFAiB93vdN1cDo6Y/s2coogwkpbyzG07MWJWcdn2wMLZ9NcQIh\nAMGswXhJ2OZ3HBSDnt4Nk0m8pAo02S5Ngs8vwdLtb2oy\n-----END CERTIFICATE-----"
+        },
+        "SourceType": "CERTIFICATE_BUNDLE"
+      }
+    }
+  },
+  "liveRaw": {
+    "TrustAnchorArn": "arn:aws:rolesanywhere:us-east-1:111111111111:trust-anchor/400fbb64-0009-4231-a9f5-02553e62c6c8",
+    "NotificationSettings": [
+      {
+        "Channel": "ALL",
+        "Enabled": true,
+        "Event": "CA_CERTIFICATE_EXPIRY",
+        "Threshold": 45
+      },
+      {
+        "Channel": "ALL",
+        "Enabled": true,
+        "Event": "END_ENTITY_CERTIFICATE_EXPIRY",
+        "Threshold": 45
+      }
+    ],
+    "Enabled": true,
+    "Source": {
+      "SourceType": "CERTIFICATE_BUNDLE",
+      "SourceData": {
+        "X509CertificateData": "-----BEGIN CERTIFICATE-----\nMIIBnTCCAUOgAwIBAgIUB6w5GVsiPA98IQknPXbDCfBYuvYwCgYIKoZIzj0EAwIw\nHDEaMBgGA1UEAwwRY2RrcmQtaHVudDA3MDgtY2EwHhcNMjYwNzA4MDEyODMyWhcN\nMjYwODA3MDEyODMyWjAcMRowGAYDVQQDDBFjZGtyZC1odW50MDcwOC1jYTBZMBMG\nByqGSM49AgEGCCqGSM49AwEHA0IABKWZ40lCqvvvGgZy+bvbEEmDRZCh5C4mcI9k\nIUGlPgfeZfSgtTzoF3lVKt4feJr80ZoqF7j28pX63+Nz/1AVDMujYzBhMB0GA1Ud\nDgQWBBT5l2Nhv3ZffQyT4nMyEwo3/91+gDAfBgNVHSMEGDAWgBT5l2Nhv3ZffQyT\n4nMyEwo3/91+gDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAKBggq\nhkjOPQQDAgNIADBFAiB93vdN1cDo6Y/s2coogwkpbyzG07MWJWcdn2wMLZ9NcQIh\nAMGswXhJ2OZ3HBSDnt4Nk0m8pAo02S5Ngs8vwdLtb2oy\n-----END CERTIFICATE-----"
+      }
+    },
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708RolesAnywhere/9e8f3cc0-7a6c-11f1-936b-1209b76a853f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708RolesAnywhere",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "TrustAnchor",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "TrustAnchorId": "400fbb64-0009-4231-a9f5-02553e62c6c8",
+    "Name": "cdkrd-hunt0708-anchor"
+  },
+  "schema": {
+    "readOnly": ["TrustAnchorArn", "TrustAnchorId"],
+    "writeOnly": [],
+    "createOnly": [],
+    "readOnlyPaths": ["TrustAnchorArn", "TrustAnchorId"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "TrustAnchor",
+      "resourceType": "AWS::RolesAnywhere::TrustAnchor",
+      "path": "NotificationSettings",
+      "actual": [
+        {
+          "Channel": "ALL",
+          "Enabled": true,
+          "Event": "CA_CERTIFICATE_EXPIRY",
+          "Threshold": 45
+        },
+        {
+          "Channel": "ALL",
+          "Enabled": true,
+          "Event": "END_ENTITY_CERTIFICATE_EXPIRY",
+          "Threshold": 45
+        }
+      ],
+      "physicalId": "400fbb64-0009-4231-a9f5-02553e62c6c8",
+      "constructPath": "CdkRealDriftHunt0708RolesAnywhere/TrustAnchor"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceCatalog__CloudFormationProduct.Product.json
+++ b/tests/corpus/AWS__ServiceCatalog__CloudFormationProduct.Product.json
@@ -1,0 +1,92 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Product",
+    "resourceType": "AWS::ServiceCatalog::CloudFormationProduct",
+    "physicalId": "prod-bme7axqm2leri",
+    "constructPath": "CdkRealDriftHunt0708ESvcCat/Product",
+    "declared": {
+      "Description": "hunt fixture product",
+      "Distributor": "cdkrd",
+      "Name": "cdkrd-hunt0708e-product",
+      "Owner": "cdkrd-hunt",
+      "ProvisioningArtifactParameters": [
+        {
+          "Description": "initial version",
+          "Info": {
+            "LoadTemplateFromURL": "https://s3.us-east-1.amazonaws.com/cdk-hnb659fds-assets-111111111111-us-east-1/180f7f4d71098d3cbe88f73ce42dd66b715e7d758132a546662be423d5b015b0.json"
+          },
+          "Name": "v1"
+        }
+      ],
+      "SupportEmail": "hunt@example.com"
+    }
+  },
+  "liveRaw": {
+    "Owner": "cdkrd-hunt",
+    "Description": "hunt fixture product",
+    "Distributor": "cdkrd",
+    "ProductName": "cdkrd-hunt0708e-product",
+    "SupportEmail": "hunt@example.com",
+    "ProductType": "CLOUD_FORMATION_TEMPLATE",
+    "ProvisioningArtifactIds": "pa-vq3vgxf4pmfzm",
+    "ProvisioningArtifactNames": "v1",
+    "Id": "prod-bme7axqm2leri",
+    "Tags": [],
+    "ProvisioningArtifactParameters": [
+      {
+        "Type": "CLOUD_FORMATION_TEMPLATE",
+        "Description": "initial version",
+        "Info": {
+          "LoadTemplateFromURL": "https://s3.us-east-1.amazonaws.com/cdk-hnb659fds-assets-111111111111-us-east-1/180f7f4d71098d3cbe88f73ce42dd66b715e7d758132a546662be423d5b015b0.json"
+        },
+        "Name": "v1"
+      }
+    ],
+    "Name": "cdkrd-hunt0708e-product"
+  },
+  "schema": {
+    "readOnly": ["Id", "ProductName", "ProvisioningArtifactIds", "ProvisioningArtifactNames"],
+    "writeOnly": ["AcceptLanguage", "ReplaceProvisioningArtifacts"],
+    "createOnly": [],
+    "readOnlyPaths": ["Id", "ProductName", "ProvisioningArtifactIds", "ProvisioningArtifactNames"],
+    "writeOnlyPaths": [
+      "AcceptLanguage",
+      "ProvisioningArtifactParameters.*.DisableTemplateValidation",
+      "ReplaceProvisioningArtifacts"
+    ],
+    "createOnlyPaths": [],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "Product",
+      "resourceType": "AWS::ServiceCatalog::CloudFormationProduct",
+      "path": "ProductType",
+      "actual": "CLOUD_FORMATION_TEMPLATE",
+      "physicalId": "prod-bme7axqm2leri",
+      "constructPath": "CdkRealDriftHunt0708ESvcCat/Product"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Product",
+      "resourceType": "AWS::ServiceCatalog::CloudFormationProduct",
+      "path": "ProvisioningArtifactParameters[v1].Type",
+      "actual": "CLOUD_FORMATION_TEMPLATE",
+      "nested": true,
+      "physicalId": "prod-bme7axqm2leri",
+      "constructPath": "CdkRealDriftHunt0708ESvcCat/Product"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ServiceCatalog__PortfolioProductAssociation.Assoc.json
+++ b/tests/corpus/AWS__ServiceCatalog__PortfolioProductAssociation.Assoc.json
@@ -1,0 +1,37 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "Assoc",
+    "resourceType": "AWS::ServiceCatalog::PortfolioProductAssociation",
+    "physicalId": "port-l27sc3bcj4xe6|prod-bme7axqm2leri",
+    "constructPath": "CdkRealDriftHunt0708ESvcCat/Assoc",
+    "declared": {
+      "PortfolioId": "port-l27sc3bcj4xe6",
+      "ProductId": "prod-bme7axqm2leri"
+    }
+  },
+  "liveRaw": {
+    "PortfolioId": "port-l27sc3bcj4xe6",
+    "ProductId": "prod-bme7axqm2leri"
+  },
+  "schema": {
+    "readOnly": [],
+    "writeOnly": ["AcceptLanguage", "SourcePortfolioId"],
+    "createOnly": ["AcceptLanguage", "PortfolioId", "ProductId", "SourcePortfolioId"],
+    "readOnlyPaths": [],
+    "writeOnlyPaths": ["AcceptLanguage", "SourcePortfolioId"],
+    "createOnlyPaths": ["AcceptLanguage", "PortfolioId", "ProductId", "SourcePortfolioId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": []
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.SmCEE63372.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.SmCEE63372.json
@@ -1,0 +1,108 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SmCEE63372",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+    "constructPath": "CdkRealDriftHunt0708gSfn/Sm",
+    "declared": {
+      "DefinitionString": "{\"StartAt\":\"P\",\"States\":{\"P\":{\"Type\":\"Pass\",\"End\":true}}}",
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftHunt0708gSfn-SmRole9B0BB922-My6Pbo9sFDA4"
+    }
+  },
+  "liveRaw": {
+    "DefinitionString": "{\"StartAt\":\"P\",\"States\":{\"P\":{\"Type\":\"Pass\",\"End\":true}}}",
+    "EncryptionConfiguration": {
+      "Type": "AWS_OWNED_KEY"
+    },
+    "LoggingConfiguration": {
+      "IncludeExecutionData": false,
+      "Level": "OFF"
+    },
+    "StateMachineRevisionId": "INITIAL",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+    "StateMachineName": "SmCEE63372-Km6uaQv7cFLv",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftHunt0708gSfn-SmRole9B0BB922-My6Pbo9sFDA4",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708gSfn/585cd470-7a7f-11f1-b37a-124616eb4d5f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708gSfn",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SmCEE63372",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "SmCEE63372-Km6uaQv7cFLv",
+    "StateMachineType": "STANDARD",
+    "TracingConfiguration": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnly": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnly": ["StateMachineName", "StateMachineType"],
+    "readOnlyPaths": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnlyPaths": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnlyPaths": ["StateMachineName", "StateMachineType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["LoggingConfiguration.Destinations"],
+    "freeFormMapPaths": ["DefinitionSubstitutions"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SmCEE63372",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "EncryptionConfiguration",
+      "actual": {
+        "Type": "AWS_OWNED_KEY"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+      "constructPath": "CdkRealDriftHunt0708gSfn/Sm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SmCEE63372",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "LoggingConfiguration",
+      "actual": {
+        "IncludeExecutionData": false,
+        "Level": "OFF"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+      "constructPath": "CdkRealDriftHunt0708gSfn/Sm"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "SmCEE63372",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineName",
+      "actual": "SmCEE63372-Km6uaQv7cFLv",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+      "constructPath": "CdkRealDriftHunt0708gSfn/Sm"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SmCEE63372",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineType",
+      "actual": "STANDARD",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+      "constructPath": "CdkRealDriftHunt0708gSfn/Sm"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachine.SmEnc6D9DFB84.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachine.SmEnc6D9DFB84.json
@@ -1,0 +1,104 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "SmEnc6D9DFB84",
+    "resourceType": "AWS::StepFunctions::StateMachine",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmEnc6D9DFB84-urARXFvJYAXu",
+    "constructPath": "CdkRealDriftHunt0708gSfn/SmEnc",
+    "declared": {
+      "DefinitionString": "{\"StartAt\":\"P2\",\"States\":{\"P2\":{\"Type\":\"Pass\",\"End\":true}}}",
+      "EncryptionConfiguration": {
+        "KmsDataKeyReusePeriodSeconds": 300,
+        "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/1c68fba3-c16d-4227-8368-5b9ec888e43b",
+        "Type": "CUSTOMER_MANAGED_KMS_KEY"
+      },
+      "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftHunt0708gSfn-SmEncRoleEC17B84F-STKSWVTmAXLf"
+    }
+  },
+  "liveRaw": {
+    "DefinitionString": "{\"StartAt\":\"P2\",\"States\":{\"P2\":{\"Type\":\"Pass\",\"End\":true}}}",
+    "EncryptionConfiguration": {
+      "Type": "CUSTOMER_MANAGED_KMS_KEY",
+      "KmsKeyId": "arn:aws:kms:us-east-1:111111111111:key/1c68fba3-c16d-4227-8368-5b9ec888e43b",
+      "KmsDataKeyReusePeriodSeconds": 300
+    },
+    "LoggingConfiguration": {
+      "IncludeExecutionData": false,
+      "Level": "OFF"
+    },
+    "StateMachineRevisionId": "INITIAL",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmEnc6D9DFB84-urARXFvJYAXu",
+    "StateMachineName": "SmEnc6D9DFB84-urARXFvJYAXu",
+    "RoleArn": "arn:aws:iam::111111111111:role/CdkRealDriftHunt0708gSfn-SmEncRoleEC17B84F-STKSWVTmAXLf",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708gSfn/585cd470-7a7f-11f1-b37a-124616eb4d5f",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708gSfn",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "SmEnc6D9DFB84",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ],
+    "Name": "SmEnc6D9DFB84-urARXFvJYAXu",
+    "StateMachineType": "STANDARD",
+    "TracingConfiguration": {
+      "Enabled": false
+    }
+  },
+  "schema": {
+    "readOnly": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnly": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnly": ["StateMachineName", "StateMachineType"],
+    "readOnlyPaths": ["Arn", "Name", "StateMachineRevisionId"],
+    "writeOnlyPaths": ["Definition", "DefinitionS3Location", "DefinitionSubstitutions"],
+    "createOnlyPaths": ["StateMachineName", "StateMachineType"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": ["LoggingConfiguration.Destinations"],
+    "freeFormMapPaths": ["DefinitionSubstitutions"]
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "SmEnc6D9DFB84",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "LoggingConfiguration",
+      "actual": {
+        "IncludeExecutionData": false,
+        "Level": "OFF"
+      },
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmEnc6D9DFB84-urARXFvJYAXu",
+      "constructPath": "CdkRealDriftHunt0708gSfn/SmEnc"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "SmEnc6D9DFB84",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineName",
+      "actual": "SmEnc6D9DFB84-urARXFvJYAXu",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmEnc6D9DFB84-urARXFvJYAXu",
+      "constructPath": "CdkRealDriftHunt0708gSfn/SmEnc"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "SmEnc6D9DFB84",
+      "resourceType": "AWS::StepFunctions::StateMachine",
+      "path": "StateMachineType",
+      "actual": "STANDARD",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmEnc6D9DFB84-urARXFvJYAXu",
+      "constructPath": "CdkRealDriftHunt0708gSfn/SmEnc"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachineAlias.AliasLive.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachineAlias.AliasLive.json
@@ -1,0 +1,61 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "AliasLive",
+    "resourceType": "AWS::StepFunctions::StateMachineAlias",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:hunt0708g-live",
+    "constructPath": "CdkRealDriftHunt0708gSfn/AliasLive",
+    "declared": {
+      "Description": "hunt alias",
+      "Name": "hunt0708g-live",
+      "RoutingConfiguration": [
+        {
+          "StateMachineVersionArn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:1",
+          "Weight": 100
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "Description": "hunt alias",
+    "RoutingConfiguration": [
+      {
+        "StateMachineVersionArn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:1",
+        "Weight": 100
+      }
+    ],
+    "StateMachineArn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:hunt0708g-live",
+    "Name": "hunt0708g-live"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": ["DeploymentPreference"],
+    "createOnly": ["Name"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": ["DeploymentPreference"],
+    "createOnlyPaths": ["Name"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["DeploymentPreference.Alarms"],
+    "unorderedObjectArrayPaths": ["RoutingConfiguration"],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "AliasLive",
+      "resourceType": "AWS::StepFunctions::StateMachineAlias",
+      "path": "StateMachineArn",
+      "actual": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:hunt0708g-live",
+      "constructPath": "CdkRealDriftHunt0708gSfn/AliasLive"
+    }
+  ]
+}

--- a/tests/corpus/AWS__StepFunctions__StateMachineVersion.V1.json
+++ b/tests/corpus/AWS__StepFunctions__StateMachineVersion.V1.json
@@ -1,0 +1,49 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "V1",
+    "resourceType": "AWS::StepFunctions::StateMachineVersion",
+    "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:1",
+    "constructPath": "CdkRealDriftHunt0708gSfn/V1",
+    "declared": {
+      "Description": "hunt v1",
+      "StateMachineArn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv"
+    }
+  },
+  "liveRaw": {
+    "Description": "hunt v1",
+    "StateMachineRevisionId": "INITIAL",
+    "StateMachineArn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv",
+    "Arn": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:1"
+  },
+  "schema": {
+    "readOnly": ["Arn"],
+    "writeOnly": [],
+    "createOnly": ["Description", "StateMachineArn", "StateMachineRevisionId"],
+    "readOnlyPaths": ["Arn"],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": ["Description", "StateMachineArn", "StateMachineRevisionId"],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": [],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "V1",
+      "resourceType": "AWS::StepFunctions::StateMachineVersion",
+      "path": "StateMachineRevisionId",
+      "actual": "INITIAL",
+      "physicalId": "arn:aws:states:us-east-1:111111111111:stateMachine:SmCEE63372-Km6uaQv7cFLv:1",
+      "constructPath": "CdkRealDriftHunt0708gSfn/V1"
+    }
+  ]
+}

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -22,6 +22,8 @@ import {
   INTELLIGENT_TIERING_PATHS,
   KNOWN_DEFAULTS,
   KNOWN_DEFAULT_PATHS,
+  GENERATED_NESTED_PATHS,
+  CONTEXT_ARN_DEFAULTS,
   VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS,
   stripAwsTagsDeep,
   VERSION_PREFIX_PATHS,
@@ -715,6 +717,62 @@ describe('noise suppressors', () => {
     // ApiDestination.ApiDestination corpus-replay case).
     expect(KNOWN_DEFAULTS['AWS::Events::ApiDestination']).toEqual({
       InvocationRateLimitPerSecond: 300,
+    });
+  });
+
+  it('bug-hunt 2026-07-08 first-run constant/derived/value-independent folds (#619/#622/#625/#626/#628/#633)', () => {
+    // Tier-1 equality-gated constants: undeclared values AWS materializes at creation that
+    // surfaced as first-run [Potential Drift] FPs until folded (exercised end-to-end by the
+    // matching corpus-replay cases). Equality-gated, so an out-of-band change re-surfaces.
+    expect(KNOWN_DEFAULTS['AWS::EC2::VPNGateway']).toEqual({ AmazonSideAsn: 64512 }); // #619
+    expect(KNOWN_DEFAULTS['AWS::Bedrock::Agent']?.IdleSessionTTLInSeconds).toBe(600); // #619
+    expect(KNOWN_DEFAULTS['AWS::CodeGuruProfiler::ProfilingGroup']).toEqual({
+      ComputePlatform: 'Default',
+    }); // #622
+    expect(KNOWN_DEFAULTS['AWS::ServiceCatalog::CloudFormationProduct']).toEqual({
+      ProductType: 'CLOUD_FORMATION_TEMPLATE',
+    }); // #625
+    expect(KNOWN_DEFAULTS['AWS::InternetMonitor::Monitor']).toEqual({ Status: 'ACTIVE' }); // #626
+    expect(KNOWN_DEFAULTS['AWS::RolesAnywhere::Profile']?.DurationSeconds).toBe(3600); // #619
+    expect(KNOWN_DEFAULTS['AWS::RolesAnywhere::Profile']?.AttributeMappings).toEqual([
+      { CertificateField: 'x509Issuer', MappingRules: [{ Specifier: '*' }] },
+      {
+        CertificateField: 'x509SAN',
+        MappingRules: [{ Specifier: 'DNS' }, { Specifier: 'URI' }, { Specifier: 'Name/*' }],
+      },
+      { CertificateField: 'x509Subject', MappingRules: [{ Specifier: '*' }] },
+    ]); // #619
+    // Nested constant: a product's per-artifact Type echo.
+    expect(KNOWN_DEFAULT_PATHS['AWS::ServiceCatalog::CloudFormationProduct']).toEqual({
+      'ProvisioningArtifactParameters.*.Type': 'CLOUD_FORMATION_TEMPLATE',
+    }); // #625
+    // Tier-3 value-independent: per-resource AWS-assigned pointers/echoes the user cannot
+    // meaningfully pin, folded only when UNDECLARED (a DECLARED value is compared).
+    expect(VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::Bedrock::AgentAlias']).toContain(
+      'RoutingConfiguration'
+    ); // #619
+    expect(VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::AppSync::ApiKey']).toContain('Expires'); // #619
+    expect(
+      VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::AppConfig::ExtensionAssociation']
+    ).toContain('ExtensionVersionNumber'); // #622
+    expect(
+      VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::StepFunctions::StateMachineVersion']
+    ).toContain('StateMachineRevisionId'); // #628
+    expect(
+      VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::StepFunctions::StateMachineAlias']
+    ).toContain('StateMachineArn'); // #628
+    // Value-independent nested generated id: the canary's AWS-assigned DeploymentId.
+    expect(GENERATED_NESTED_PATHS['AWS::ApiGateway::Stage']).toContain(
+      'CanarySetting.DeploymentId'
+    ); // #633
+  });
+
+  it('ResourceExplorer2 View undeclared Scope folds via the context-ARN default (#626)', () => {
+    // The account-root Scope is a tier-2 DERIVED default (arn:<partition>:iam::<account>:root),
+    // built from the read context and equality-gated so a view scoped elsewhere still surfaces.
+    // Exercised end-to-end by the AWS__ResourceExplorer2__View.RexView corpus-replay case.
+    expect(CONTEXT_ARN_DEFAULTS['AWS::ResourceExplorer2::View']).toEqual({
+      Scope: 'arn:{partition}:iam::{accountId}:root',
     });
   });
 


### PR DESCRIPTION
Folds the first-run `[Potential Drift]` false positives found by the 2026-07-08 bug hunt across 12 zero/low-coverage types (the corpus-harvested, mechanical batch). A clean deploy of each now shows ZERO potential drift (core invariant), while an out-of-band change to any equality-gated/derived value still surfaces.

## Folds (per CLAUDE.md fold-strategy order)

**Tier 1 — equality-gated constants (`KNOWN_DEFAULTS` / `KNOWN_DEFAULT_PATHS`)**
- `AWS::EC2::VPNGateway` `AmazonSideAsn` = 64512 (#619)
- `AWS::Bedrock::Agent` `IdleSessionTTLInSeconds` = 600 (#619)
- `AWS::RolesAnywhere::Profile` `DurationSeconds` = 3600 + `AttributeMappings` (whole-array constant) (#619)
- `AWS::CodeGuruProfiler::ProfilingGroup` `ComputePlatform` = "Default" (#622)
- `AWS::ServiceCatalog::CloudFormationProduct` `ProductType` + `ProvisioningArtifactParameters.*.Type` = "CLOUD_FORMATION_TEMPLATE" (#625)
- `AWS::InternetMonitor::Monitor` `Status` = "ACTIVE" (#626)

**Tier 2 — derived default (new `CONTEXT_ARN_DEFAULTS` mechanism)**
- `AWS::ResourceExplorer2::View` `Scope` = `arn:{partition}:iam::{accountId}:root` — account-root ARN built from the read context, equality-gated (a view scoped elsewhere still surfaces) (#626)

**Tier 3 — value-independent (per-resource AWS-assigned pointer/echo, folded only when UNDECLARED)**
- `AWS::Bedrock::AgentAlias` `RoutingConfiguration` (#619)
- `AWS::AppSync::ApiKey` `Expires` (undeclared; declared Expires still goes through EPOCH_HOUR_PATHS) (#619)
- `AWS::AppConfig::ExtensionAssociation` `ExtensionVersionNumber` (#622)
- `AWS::StepFunctions::StateMachineVersion` `StateMachineRevisionId` (#628)
- `AWS::StepFunctions::StateMachineAlias` `StateMachineArn` (#628)
- `AWS::ApiGateway::Stage` `CanarySetting.DeploymentId` (value-independent nested generated id) (#633)

## Tests
- 23 harvested corpus cases added (golden-replay proves each FP path now folds to `atDefault`/`generated`, and clean siblings stay clean).
- Focused unit tests for the fold tables + the new `CONTEXT_ARN_DEFAULTS` mechanism (match / mismatch-surfaces / cn+gov partition / no-context-skip).

All local gates green: typecheck, `vp test run` (2972 tests), build, `vp check` (0 errors).

Closes #619, #622, #625, #626, #628, #633.

Note: the derived/mechanism changes touch `src/**`, so a full `/verify-pr` live-test is still the pre-release gate before merge; the folds themselves are corpus-harvested from live deploys and offline-verified here.