### PR TITLE
fix(revert): stop calling a stack CLEAN when a revert did not converge — count FAILED updates + detect no-op removals (#631)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -625,7 +625,19 @@ time by accident). When drift survives, each surviving finding is listed
 (id.path + tier) under the `N drift(s) remain.` line so the user doesn't have
 to re-run `check` to learn what failed to converge (R46); if unrecorded values
 remain after a clean revert, one pointer line names the count (they are not
-drift, but silence would read as "all decided" — R62). Exit semantics: no
+drift, but silence would read as "all decided" — R62). **Two verdict escapes
+are closed (#631):** a FAILED update/sdk op (not just a failed delete) now
+counts as UNCONFIRMED — so a `remove` the provider hard-rejects (SNS
+`FilterPolicyScope` InvalidRequest[null]) can never ride under a `CLEAN`
+summary; and a `remove`-style revert the provider SILENTLY IGNORED (the #597
+class — an omitted property left unchanged, e.g. Cognito UserPool
+`DeletionProtection`) on an UNRECORDED undeclared value is detected as a
+**no-op removal** (the exact path re-reads a non-drift finding carrying the
+SAME value) and reported `NOT reverted:` — before, that value re-read as
+"awaiting a baseline" (not drift) and the stack was falsely called CLEAN.
+Comparing the persisted VALUE (not mere presence) keeps a removal that
+converged by AWS re-materializing the default (#613 SLO `Goal`) correctly
+clean. Exit semantics: no
 drift at all → `no drift to revert.` + exit 0; findings exist but **nothing
 is revertable** →
 `nothing revertable — N drift(s) + M unrecorded value(s) remain.` (each part

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -39,6 +39,7 @@ import {
 } from '../revert/plan.js';
 import { errorText, type RetryOptions, retryTransient } from '../revert/transient.js';
 import { resolveSdkWriter } from '../revert/writers.js';
+import { deepEqual } from '../diff/drift-calculator.js';
 import type { Finding, SchemaInfo } from '../types.js';
 import { type Desired } from '../desired/template-adapter.js';
 import { buildSiblingSgRules, type GatherResult, regatherTouched } from './gather.js';
@@ -842,6 +843,11 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // correctly vanishes from `post`, but a FAILED one would vanish too (reading as CLEAN).
   // Track the failed ones and re-add their findings so they still count as drift.
   const failedDeleteIds = new Set<string>();
+  // #631: a FAILED update/sdk op (the SNS FilterPolicyScope `remove` that hard-fails
+  // InvalidRequest[null]) must count as UNCONFIRMED — the same "never claim convergence we
+  // could not verify" principle that already covers failed deletes. Without this a FAILED op
+  // printed alongside a `CLEAN after revert.` verdict (live-observed 2026-07-08).
+  const failedUpdateIds = new Set<string>();
   const applied: {
     logicalId: string;
     displayId: string;
@@ -940,6 +946,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       ...(r.hint !== undefined && { hint: r.hint }),
     });
     if (!r.ok) worst = Math.max(worst, 2);
+    // A failed NON-delete op (delete failures already tracked above) — feed the convergence
+    // verdict so a FAILED update never rides under a CLEAN summary.
+    if (!r.ok && item.kind !== 'delete') failedUpdateIds.add(item.logicalId);
   }
   // Print ONE outcome per resource (a resource that split into a `cc` + `sdk` item
   // produced two results) so a fully reverted resource never prints `reverted:` twice.
@@ -991,6 +1000,39 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   }
   const remainingDrift = post.filter(isDrift);
   const remaining = remainingDrift.length;
+  // #631: a `remove`-style revert the provider SILENTLY IGNORED (the #597 class — an
+  // omitted property not applied on UpdateResource; Cognito UserPool DeletionProtection,
+  // InternetMonitor Status, …) reports `reverted:` (ok) yet the value PERSISTS. When that
+  // value is UNRECORDED undeclared it re-reads as "awaiting a baseline" (not `isDrift`), so
+  // it escapes both `remaining` and the verdict, and the stack is falsely called CLEAN. A
+  // no-op removal = a `remove` op on a SUCCESSFULLY-applied item whose exact path still
+  // re-reads a NON-drift finding carrying the SAME value we tried to remove. Comparing the
+  // value (not just presence) is essential: a removal that CONVERGED by AWS re-materializing
+  // the DEFAULT (#613 SLO Goal) re-reads a DIFFERENT value / tier and is correctly NOT
+  // flagged. (Array-element removes, whose finding path is `[id]`-keyed, are not matched here
+  // — the reported cases are all top-level/nested scalar paths.)
+  const okIds = new Set(applied.filter((a) => a.ok).map((a) => a.logicalId));
+  const preActual = new Map<string, unknown>();
+  for (const f of gathered.findings) preActual.set(`${f.logicalId}\0${f.path}`, f.actual);
+  const noOpRemovals: { displayId: string; path: string }[] = [];
+  for (const item of plan.items) {
+    if (item.kind === 'delete' || !okIds.has(item.logicalId)) continue;
+    for (const op of item.ops) {
+      if (op.op !== 'remove') continue;
+      const dotted = op.path.replace(/^\//, '').replace(/\//g, '.');
+      const key = `${item.logicalId}\0${dotted}`;
+      if (!preActual.has(key)) continue;
+      const pre = preActual.get(key);
+      const persisted = post.some(
+        (f) =>
+          f.logicalId === item.logicalId &&
+          f.path === dotted &&
+          !isDrift(f) &&
+          deepEqual(f.actual, pre)
+      );
+      if (persisted) noOpRemovals.push({ displayId: item.displayId, path: dotted });
+    }
+  }
   // A touched resource whose verification RE-READ failed (skipped tier — a throttle /
   // transient CC or SDK-override read error) is NOT proof the write landed: a write CC
   // accepted (200) but silently rejected, followed by an unreadable re-read, would
@@ -999,15 +1041,24 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // (unrecorded), so it too would read as CLEAN though the resource still lives. Treat
   // both as UNCONFIRMED — never claim convergence we could not verify.
   const unverified = post.filter((f) => touched.has(f.logicalId) && f.tier === 'skipped').length;
-  const unconfirmed = unverified + failedDeleteIds.size;
-  const converged = remaining === 0 && unconfirmed === 0;
+  const unconfirmed = unverified + failedDeleteIds.size + failedUpdateIds.size;
+  const converged = remaining === 0 && unconfirmed === 0 && noOpRemovals.length === 0;
+  // Print the no-op removals FIRST so the "did not converge" verdict below has visible
+  // evidence above it, mirroring the FAILED: lines' relationship to the unconfirmed count.
+  for (const n of noOpRemovals)
+    console.log(
+      style.fail(
+        `  NOT reverted: ${n.displayId}.${n.path} — removal was a no-op (the provider ignored the omitted property; it needs an explicit default write — see #597 / REVERT_SET_DEFAULT_PATHS)`
+      )
+    );
+  const notConverged = unconfirmed + noOpRemovals.length;
   console.log(
     converged
       ? style.clean(`${stackName}: CLEAN after revert.`)
       : remaining > 0
         ? style.drift(`${stackName}: ${remaining} drift(s) remain.`)
         : style.drift(
-            `${stackName}: revert applied, but ${unconfirmed} resource(s) could not be confirmed converged (see above).`
+            `${stackName}: revert applied, but ${notConverged} value(s) could not be confirmed converged (see above).`
           )
   );
   // unrecorded values are not drift, but silently dropping them here would read
@@ -1032,9 +1083,10 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // learn what didn't converge (R46). A terse id-per-line pointer, not a report;
   // capped so a no-baseline partial revert doesn't re-list 100+ lines (R52).
   for (const line of formatSurvivingDrift(remainingDrift, stackName)) console.log(line);
-  // remaining drift OR an unverifiable re-read both mean "not confirmed clean" → exit 1
-  // (a failed delete already set 2). Never return 0 ("converged") when we could not check.
-  if (remaining > 0 || unverified > 0) worst = Math.max(worst, 1);
+  // remaining drift, an unverifiable re-read, OR a no-op removal all mean "not confirmed
+  // clean" → exit 1 (a failed delete/update already set 2). Never return 0 ("converged")
+  // when we could not verify convergence.
+  if (remaining > 0 || unverified > 0 || noOpRemovals.length > 0) worst = Math.max(worst, 1);
   return { exit: worst, aborted: false };
 }
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -687,6 +687,91 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     expect(logs).toContain('could not be re-read to verify');
   });
 
+  // #631: a FAILED update op must NOT ride under a CLEAN verdict even if the re-read
+  // happens to look converged — "never claim convergence we could not verify". The SNS
+  // FilterPolicyScope `remove` hard-failed (InvalidRequest[null]) yet the summary still
+  // said CLEAN. Here the write FAILS (non-transient) but the re-read returns the desired
+  // value; before the fix only failed DELETES fed the verdict, so this printed CLEAN.
+  it('a FAILED update op is unconfirmed, never CLEAN — even if the re-read looks converged', async () => {
+    const cc = mockClient(CloudControlClient);
+    cc.on(UpdateResourceCommand).resolves({
+      ProgressEvent: {
+        OperationStatus: 'FAILED',
+        RequestToken: 't',
+        StatusMessage: 'InvalidRequest: Invalid value [null]',
+      },
+    });
+    cc.on(GetResourceCommand).resolves(liveRead('Enabled')); // re-read LOOKS clean
+
+    const { outcome, logs } = await run();
+    expect(outcome.exit).toBe(2); // a failed apply bumps the exit to 2
+    expect(logs).not.toContain('CLEAN after revert');
+    expect(logs).toContain('FAILED:');
+    expect(logs).toContain('could not be confirmed converged');
+  });
+
+  // #631: a `remove`-style revert the provider SILENTLY IGNORED (reports ok, value
+  // persists) on an UNRECORDED undeclared value re-reads as "awaiting a baseline" (not
+  // isDrift), so it escaped the verdict and the stack was falsely called CLEAN (Cognito
+  // UserPool DeletionProtection remove-revert, live 2026-07-08). Now the persisted value is
+  // detected as a no-op removal and reported.
+  it('a no-op remove of an unrecorded undeclared value is NOT CLEAN (persisted value detected)', async () => {
+    const noopGathered = (): GatherResult =>
+      ({
+        desired: {
+          stackName: 's',
+          region: 'r',
+          accountId: '111122223333',
+          resources: [
+            { logicalId: 'B', resourceType: 'AWS::S3::Bucket', physicalId: 'b-phys', declared: {} },
+          ],
+          rawTemplate: '{}',
+          ctx: {
+            params: {},
+            pseudo: {},
+            conditions: {},
+            physIds: {},
+            liveAttrs: {},
+            mappings: {},
+            exports: {},
+            condCache: new Map(),
+          },
+        },
+        findings: [undeclared()], // AccelerateConfiguration, unrecorded (no baseline)
+        schemas: new Map([['AWS::S3::Bucket', EMPTY_SCHEMA]]),
+        liveByLogical: new Map(),
+      }) as GatherResult;
+
+    const cc = mockClient(CloudControlClient);
+    mockApplySuccess(cc); // the UpdateResource "succeeds"...
+    // ...but the value persists unchanged (the provider ignored the omitted property).
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Identifier: 'b-phys',
+        Properties: JSON.stringify({ AccelerateConfiguration: { AccelerationStatus: 'Enabled' } }),
+      },
+    });
+
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (s: unknown) => logs.push(String(s));
+    let outcome;
+    try {
+      outcome = await revertStack({
+        ...params(),
+        gathered: noopGathered(),
+        removeUnrecorded: true,
+      });
+    } finally {
+      console.log = orig;
+    }
+    const out = logs.join('\n');
+    expect(out).not.toContain('CLEAN after revert');
+    expect(out).toContain('NOT reverted:');
+    expect(out).toContain('AccelerateConfiguration');
+    expect(outcome!.exit).toBe(1);
+  });
+
   // issue #467 — the `revert --wait` path.
   const rslvrFailed = {
     ProgressEvent: {


### PR DESCRIPTION
Closes #631.

## Problem
The post-revert convergence check printed **`<stack>: CLEAN after revert.`** even when the revert demonstrably did **not** converge — live-observed twice (2026-07-08):

1. **Silent no-op** — a `remove`-style revert the provider ignored (Cognito `UserPool.DeletionProtection`, the #597 class) reports `reverted:` yet the value persists. When that value is **unrecorded undeclared** it re-reads as "awaiting a baseline" (not `isDrift`), so it escaped both `remaining` and the verdict. The stack was called CLEAN while `describe-user-pool` still showed `ACTIVE`.
2. **Hard failure** — a `remove` the provider rejected (SNS `Subscription.FilterPolicyScope`, `InvalidRequest: Invalid value [null]`) printed `FAILED:` — but only failed **deletes** fed `unconfirmed`, so a failed **update** still rode under the same-output `CLEAN` summary.

This is the damage-multiplier for every #597-class gap: a revert that silently no-ops **and** is summarized CLEAN gives false positive confirmation the change was undone.

## Fix (`stack-actions.ts` only — `plan.ts` untouched to avoid colliding with #630)
- **Count any FAILED update/sdk op** into `unconfirmed`, mirroring failed deletes ("never claim convergence we could not verify").
- **Detect a no-op removal**: a `remove` op on a **successfully-applied** item whose exact path still re-reads a **non-drift** finding carrying the **same value** we tried to remove → report `NOT reverted:` and mark the stack non-converged (exit 1). Comparing the persisted **value** (not mere presence) keeps a removal that converged by AWS re-materializing the default (#613 SLO `Goal`) correctly clean. (Array-element `[id]`-keyed removes aren't matched — the reported cases are top-level/nested scalar paths.)

## Tests / docs
- `stack-actions.test.ts`: a FAILED update op that re-reads clean is unconfirmed (never CLEAN, exit 2); a no-op remove of an unrecorded undeclared value is reported `NOT reverted:` (exit 1). Full suite green (2948).
- `docs/ARCHITECTURE.md` §7 documents both closed verdict escapes.

## Verification note
Offline-verified via unit tests over the mocked revert→re-read path. The two live repros (Cognito DeletionProtection, SNS FilterPolicyScope) were proven in the originating hunt; the sibling fix that makes those two *converge* is #630 (separate PR).
