### PR TITLE
fix(revert): converge revert for InternetMonitor Status + RolesAnywhere DurationSeconds + KinesisVideo retention/TTL (#597-class follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@aws-sdk/client-glue": "^3.1066.0",
     "@aws-sdk/client-iam": "^3.1065.0",
     "@aws-sdk/client-kafka": "^3.1079.0",
+    "@aws-sdk/client-kinesis-video": "^3.1081.0",
     "@aws-sdk/client-kms": "^3.1066.0",
     "@aws-sdk/client-lambda": "^3.1065.0",
     "@aws-sdk/client-lex-models-v2": "^3.1079.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       '@aws-sdk/client-kafka':
         specifier: ^3.1079.0
         version: 3.1079.0
+      '@aws-sdk/client-kinesis-video':
+        specifier: ^3.1081.0
+        version: 3.1081.0
       '@aws-sdk/client-kms':
         specifier: ^3.1066.0
         version: 3.1066.0
@@ -430,6 +433,10 @@ packages:
     resolution: {integrity: sha512-jjl2t1GTmgJHMLuKuSpgk6h/9F8nX3nAZQxljxWBRWQq1448AzhgPiVEqx2n3Vp1TcwIOHaHFtH9mEwt9gi/4Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-kinesis-video@3.1081.0':
+    resolution: {integrity: sha512-pmf5OGYhGn6qVBOwd0Picpvcy4suJvl7/pO0Z6Yu+EJ/ekT4xYSOQKV1qmd0jgNkIedG6E3DEnmuP48WibosFw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-kms@3.1066.0':
     resolution: {integrity: sha512-qaSA4aFdmh0HX8/1tjYX6oZoFV3ylL9mUgjZhlMkX6P9K4c6Cw8H0B9f4Ap2zMIKpgpvYBMBh/1c8XC/OiQk8Q==}
     engines: {node: '>=20.0.0'}
@@ -542,6 +549,10 @@ packages:
     resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.29':
+    resolution: {integrity: sha512-yqKcltLbtRh1ubzhRSldIs8jFHNZlyMlgoIccCC0aDVbrB99nXaBdmfr89mK7obWX/NVg4rAMpCpZ6dCDiVBtA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     resolution: {integrity: sha512-4L/REssieLON1hVsTzZucP1p2u5jmPNejyh/9BCGZXr93IalBbhRPCrtKIKwMTu9yRGr/bcKzhrQocByKLSzLQ==}
     engines: {node: '>=20.0.0'}
@@ -558,6 +569,10 @@ packages:
     resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.55':
+    resolution: {integrity: sha512-Ah36tYkqyaVnaHkx7VseoTYrHUmwgBps3V+wnrC1idhIIMGlviH0FtrX9EIPdAlVHvXC7FQZLhmHBRz+pLaiWg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.48':
     resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
@@ -568,6 +583,10 @@ packages:
 
   '@aws-sdk/credential-provider-http@3.972.56':
     resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.57':
+    resolution: {integrity: sha512-/vp6i5YEliJqRm5k/BDmYjAyRAMTdkjW6UciVRk9oh/0OfDCWeb/ih7hqte4lFvKXkIbsqe9AdK9LQK6NGardw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.53':
@@ -582,6 +601,10 @@ packages:
     resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.62':
+    resolution: {integrity: sha512-pQIRiQQs+MUlVnJdWJ7/6KS0WxcLRVfut57OFgwC3cnM1F8mXw3Kh4gAVwj6AtvD6CWx8x6+po4ENRcqe64XrQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.52':
     resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
@@ -592,6 +615,10 @@ packages:
 
   '@aws-sdk/credential-provider-login@3.972.60':
     resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.61':
+    resolution: {integrity: sha512-jtrxWwC7slqxh7DnAWHrwsA3UwCsnlypdYtavGT7EX5p791wxWQys7QzkCZ7JvOMAyylDtPoxyV+ic0zg3rV9g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.55':
@@ -626,6 +653,10 @@ packages:
     resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.64':
+    resolution: {integrity: sha512-zyKVYDyMR9VQL/kPi03ygN2vtD9uLMuWRLoJ77KxgZZaS1VlJloI+SzleF9Zg4HWUI+AIu+ZRs8zsJFNqbrxsw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.46':
     resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
     engines: {node: '>=20.0.0'}
@@ -636,6 +667,10 @@ packages:
 
   '@aws-sdk/credential-provider-process@3.972.54':
     resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.55':
+    resolution: {integrity: sha512-x0XjjF0l1WGRtK2vEhTZqCguQuAIZLep9l2+eeEmuxQQjjD3BlGQXY5xADR+l3t576UX+dxRkRtTjEu40l81Vw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.52':
@@ -650,6 +685,10 @@ packages:
     resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.61':
+    resolution: {integrity: sha512-d/V0VRsz73i+PHhbult/tx0Y1+de1SNQVsXkcQCmpfeBq7uODy/RTxNsOLpT9ZVHxcRNzbQFuywLKC33fUMIxA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
@@ -660,6 +699,10 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.61':
+    resolution: {integrity: sha512-Bv4n3NOI6hPy+rmr6Bw9R6LnBVRkcp3ncj2E2IKSYJG+0UkysSitWMvbgndNvMxDw7gE1pQ/ErwkNceuKwj7zQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.1066.0':
@@ -720,6 +763,10 @@ packages:
     resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.29':
+    resolution: {integrity: sha512-ot6v8J5W8P0w6ryyuIkXP1bHZHTlvwtn83mVCYaBE0GJ6tJX4vPSBx7M98w9O4wmmDruFsDBUMjhEHA+OosUFQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
@@ -742,6 +789,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1080.0':
     resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1081.0':
+    resolution: {integrity: sha512-kduAeI6cL+zqwj3gjPh9LhuX7kBZ83msYxutavaR+UPm5K8J7iThJBvNRAsFNyWTji92CSU8dogUgvi9T0BehA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.12':
@@ -4210,6 +4261,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-kinesis-video@3.1081.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/credential-provider-node': 3.972.64
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-kms@3.1066.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4558,6 +4620,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.29':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.0
+      '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     dependencies:
       '@aws-sdk/nested-clients': 3.997.20
@@ -4590,6 +4663,14 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.48':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4613,6 +4694,16 @@ snapshots:
   '@aws-sdk/credential-provider-http@3.972.56':
     dependencies:
       '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/fetch-http-handler': 5.6.2
@@ -4668,6 +4759,22 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/credential-provider-env': 3.972.55
+      '@aws-sdk/credential-provider-http': 3.972.57
+      '@aws-sdk/credential-provider-login': 3.972.61
+      '@aws-sdk/credential-provider-process': 3.972.55
+      '@aws-sdk/credential-provider-sso': 3.972.61
+      '@aws-sdk/credential-provider-web-identity': 3.972.61
+      '@aws-sdk/nested-clients': 3.997.29
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.52':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4690,6 +4797,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/nested-clients': 3.997.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
@@ -4807,6 +4923,20 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.64':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.55
+      '@aws-sdk/credential-provider-http': 3.972.57
+      '@aws-sdk/credential-provider-ini': 3.972.62
+      '@aws-sdk/credential-provider-process': 3.972.55
+      '@aws-sdk/credential-provider-sso': 3.972.61
+      '@aws-sdk/credential-provider-web-identity': 3.972.61
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/credential-provider-imds': 4.4.5
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.46':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4826,6 +4956,14 @@ snapshots:
   '@aws-sdk/credential-provider-process@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.55':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
@@ -4861,6 +4999,16 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/nested-clients': 3.997.29
+      '@aws-sdk/token-providers': 3.1081.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4883,6 +5031,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/nested-clients': 3.997.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0
@@ -5022,6 +5179,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.29':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/fetch-http-handler': 5.6.2
+      '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -5065,6 +5233,15 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1081.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.29
+      '@aws-sdk/nested-clients': 3.997.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
       '@smithy/types': 4.15.0

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -135,6 +135,19 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // MessageAttributes"). SNS refuses to clear the attribute, so revert can only converge by
   // SETTING the "MessageAttributes" default (from KNOWN_DEFAULTS) explicitly.
   'AWS::SNS::Subscription\0FilterPolicyScope',
+  // InternetMonitor UpdateMonitor IGNORES an omitted Status (live-proven follow-up to the
+  // #626 fold: a monitor paused out of band to INACTIVE, then `revert --remove-unrecorded`
+  // planned a `remove`, reported CLEAN, yet live `get-monitor` stayed INACTIVE). Write the
+  // "ACTIVE" default (from KNOWN_DEFAULTS) back explicitly so revert converges.
+  'AWS::InternetMonitor::Monitor\0Status',
+  // RolesAnywhere UpdateProfile IGNORES an omitted DurationSeconds (live-proven follow-up to
+  // the #619 fold: a profile's session duration changed out of band to 7200, then
+  // `revert --remove-unrecorded` planned a `remove`, reported reverted, yet live `get-profile`
+  // stayed 7200). Write the 3600 default (from KNOWN_DEFAULTS) back explicitly so revert
+  // converges. (Contrast AWS::Bedrock::Agent IdleSessionTTLInSeconds, verified same session to
+  // CONVERGE via a plain `remove` — UpdateAgent re-materializes the 600 default on omit — so it
+  // needs NO entry here.)
+  'AWS::RolesAnywhere::Profile\0DurationSeconds',
 ]);
 
 /**

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -51,6 +51,13 @@ import {
   PutMetricFilterCommand,
 } from '@aws-sdk/client-cloudwatch-logs';
 import {
+  DescribeSignalingChannelCommand,
+  DescribeStreamCommand,
+  KinesisVideoClient,
+  UpdateDataRetentionCommand,
+  UpdateSignalingChannelCommand,
+} from '@aws-sdk/client-kinesis-video';
+import {
   ElasticBeanstalkClient,
   UpdateApplicationCommand,
   UpdateEnvironmentCommand,
@@ -2126,6 +2133,71 @@ const writeElasticBeanstalkEnvironment: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// Kinesis Video Stream / SignalingChannel: Cloud Control UpdateResource REJECTS ANY patch
+// with `ValidationException: #/Tags: expected minimum item count: 1, found: 0` — the KVS CFn
+// schema requires a non-empty Tags array in the model CC reconstructs — so a folded MUTABLE
+// prop (#624: DataRetentionInHours / MessageTtlSeconds) cannot be reverted through Cloud
+// Control at all. Revert via the service's own granular update API instead. The revert TARGET
+// is the KNOWN_DEFAULTS default (a plain `remove` back to default); an explicit `add`/replace
+// carries the value. Live-proven follow-up (a `remove` revert of an out-of-band retention/TTL
+// FAILED on the Tags validation until routed here).
+const KVS_STREAM_RETENTION_DEFAULT = 0;
+const KVS_CHANNEL_MESSAGE_TTL_DEFAULT = 60;
+// DescribeStream / UpdateDataRetention accept EITHER StreamName or StreamARN — pick by shape
+// (the CFn physical id may be an ARN).
+const kvsStreamRef = (id: string): { StreamName: string } | { StreamARN: string } =>
+  id.startsWith('arn:') ? { StreamARN: id } : { StreamName: id };
+const kvsChannelDescribeRef = (id: string): { ChannelName: string } | { ChannelARN: string } =>
+  id.startsWith('arn:') ? { ChannelARN: id } : { ChannelName: id };
+
+const writeKinesisVideoStreamRetention: SdkWriter = async (ctx, ops) => {
+  const id = str(ctx.physicalId) ?? str(ctx.declared['Name']);
+  if (!id) throw new Error('cannot resolve Kinesis Video stream for revert');
+  const op = ops.find((o) => o.path.replace(/^\//, '') === 'DataRetentionInHours');
+  if (!op) return;
+  const target =
+    op.op === 'add' && typeof op.value === 'number' ? op.value : KVS_STREAM_RETENTION_DEFAULT;
+  const kv = new KinesisVideoClient({ region: ctx.region });
+  const desc = await kv.send(new DescribeStreamCommand(kvsStreamRef(id)));
+  const current = desc.StreamInfo?.DataRetentionInHours ?? 0;
+  const version = desc.StreamInfo?.Version;
+  if (version === undefined) throw new Error(`cannot resolve stream version for ${id}`);
+  if (target === current) return;
+  // UpdateDataRetention is a DELTA API (increase/decrease by N hours), so translate the
+  // absolute target into the signed change from the current live value.
+  await kv.send(
+    new UpdateDataRetentionCommand({
+      ...kvsStreamRef(id),
+      CurrentVersion: version,
+      Operation: target > current ? 'INCREASE_DATA_RETENTION' : 'DECREASE_DATA_RETENTION',
+      DataRetentionChangeInHours: Math.abs(target - current),
+    })
+  );
+};
+
+const writeKinesisVideoSignalingChannel: SdkWriter = async (ctx, ops) => {
+  const id = str(ctx.physicalId) ?? str(ctx.declared['Name']);
+  if (!id) throw new Error('cannot resolve Kinesis Video signaling channel for revert');
+  const op = ops.find((o) => o.path.replace(/^\//, '') === 'MessageTtlSeconds');
+  if (!op) return;
+  const target =
+    op.op === 'add' && typeof op.value === 'number' ? op.value : KVS_CHANNEL_MESSAGE_TTL_DEFAULT;
+  const kv = new KinesisVideoClient({ region: ctx.region });
+  const desc = await kv.send(new DescribeSignalingChannelCommand(kvsChannelDescribeRef(id)));
+  const arn = desc.ChannelInfo?.ChannelARN;
+  const version = desc.ChannelInfo?.Version;
+  if (arn === undefined || version === undefined)
+    throw new Error(`cannot resolve signaling channel ARN/version for ${id}`);
+  // UpdateSignalingChannel addresses the channel by ARN and takes the absolute TTL.
+  await kv.send(
+    new UpdateSignalingChannelCommand({
+      ChannelARN: arn,
+      CurrentVersion: version,
+      SingleMasterConfiguration: { MessageTtlSeconds: target },
+    })
+  );
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::ElasticBeanstalk::Application': writeElasticBeanstalkApplication,
   'AWS::ElasticBeanstalk::Environment': writeElasticBeanstalkEnvironment,
@@ -2166,6 +2238,10 @@ export const SDK_WRITERS: Record<string, SdkWriter> = {
 export const SDK_PROP_WRITERS: Record<string, Record<string, SdkWriter>> = {
   'AWS::Cognito::IdentityPool': { CognitoEvents: writeCognitoIdentityPoolEvents },
   'AWS::Config::ConfigRule': { InputParameters: writeConfigRuleInputParameters },
+  'AWS::KinesisVideo::Stream': { DataRetentionInHours: writeKinesisVideoStreamRetention },
+  'AWS::KinesisVideo::SignalingChannel': {
+    MessageTtlSeconds: writeKinesisVideoSignalingChannel,
+  },
   'AWS::MSK::Configuration': { ServerProperties: writeMskConfiguration },
   'AWS::IAM::Role': { Policies: writeIamRoleInlinePolicies },
   'AWS::Logs::LogGroup': { BearerTokenAuthenticationEnabled: writeLogGroupBearerTokenAuth },

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -557,6 +557,73 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('InternetMonitor Status (SET-DEFAULT) -> add op writing ACTIVE, not a no-op remove', () => {
+    // Follow-up to #626: UpdateMonitor IGNORES an omitted Status (live-proven — a monitor
+    // paused to INACTIVE, then `revert --remove-unrecorded` reported CLEAN, yet live stayed
+    // INACTIVE). Revert must write the "ACTIVE" default (from KNOWN_DEFAULTS) explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::InternetMonitor::Monitor',
+      path: 'Status',
+      actual: 'INACTIVE',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Status',
+      value: 'ACTIVE',
+      prior: 'INACTIVE',
+    });
+  });
+
+  it('RolesAnywhere Profile DurationSeconds (SET-DEFAULT) -> add op writing 3600, not a no-op remove', () => {
+    // Follow-up to #619: UpdateProfile IGNORES an omitted DurationSeconds (live-proven — a
+    // profile duration changed to 7200, then `revert --remove-unrecorded` reported reverted,
+    // yet live stayed 7200). Revert must write the 3600 default (from KNOWN_DEFAULTS)
+    // explicitly. (Contrast Bedrock Agent IdleSessionTTLInSeconds, verified same session to
+    // converge via a plain `remove`, so it is deliberately NOT in the set.)
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RolesAnywhere::Profile',
+      path: 'DurationSeconds',
+      actual: 7200,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DurationSeconds',
+      value: 3600,
+      prior: 7200,
+    });
+  });
+
+  it('KinesisVideo Stream/SignalingChannel folded props -> prop-scoped SDK item (CC UpdateResource rejects them on a Tags-min-items validation)', () => {
+    // Follow-up to #624: Cloud Control UpdateResource FAILS any KVS patch on
+    // "#/Tags: expected minimum item count: 1", so the folded MUTABLE props revert via the
+    // service's own UpdateDataRetention / UpdateSignalingChannel APIs (SDK_PROP_WRITERS)
+    // instead of a CC patch. Live-proven to converge (24->0, 120->60).
+    const retention = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::KinesisVideo::Stream',
+      path: 'DataRetentionInHours',
+      actual: 24,
+      physicalId: 'my-stream',
+    });
+    const ttl = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::KinesisVideo::SignalingChannel',
+      path: 'MessageTtlSeconds',
+      actual: 120,
+      physicalId: 'my-channel',
+    });
+    const plan = buildRevertPlan([retention, ttl], baseline([]));
+    expect(plan.notRevertable).toHaveLength(0);
+    const r = plan.items.find((i) => i.ops.some((o) => o.path === '/DataRetentionInHours'))!;
+    const t = plan.items.find((i) => i.ops.some((o) => o.path === '/MessageTtlSeconds'))!;
+    expect(r.kind).toBe('sdk');
+    expect(t.kind).toBe('sdk');
+  });
+
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {
     // S3 OwnershipControls is in KNOWN_DEFAULTS but NOT in REVERT_SET_DEFAULT_PATHS:
     // DeleteBucketOwnershipControls resets it to the AWS default, so `remove` converges.


### PR DESCRIPTION
Live-verified revert-convergence follow-up to the 2026-07-08 fold batch: the newly-folded MUTABLE props were fold-tested but their `remove`-style revert was not, and several silently no-op or hard-fail (the #597 class the #630 fix addressed). Each case below was deployed to real AWS (us-east-1), mutated out of band, `revert --remove-unrecorded`-ed, and the LIVE state re-read to confirm convergence.

## Findings + fixes (all live-verified)

| Prop | Live behavior of a plain `remove` revert | Fix |
|---|---|---|
| `AWS::InternetMonitor::Monitor` `Status` | silent no-op (UpdateMonitor ignores omitted Status; stayed INACTIVE) | `REVERT_SET_DEFAULT_PATHS` → writes `ACTIVE` |
| `AWS::RolesAnywhere::Profile` `DurationSeconds` | silent no-op (UpdateProfile ignores omitted duration; stayed 7200) | `REVERT_SET_DEFAULT_PATHS` → writes `3600` |
| `AWS::KinesisVideo::Stream` `DataRetentionInHours` | CC `UpdateResource` HARD-FAILS `ValidationException: #/Tags: expected minimum item count: 1` | `SDK_WRITERS` → `UpdateDataRetention` (delta API) |
| `AWS::KinesisVideo::SignalingChannel` `MessageTtlSeconds` | same CC Tags hard-fail | `SDK_WRITERS` → `UpdateSignalingChannel` |
| `AWS::Bedrock::Agent` `IdleSessionTTLInSeconds` | **CONVERGES** (UpdateAgent re-materializes 600 on omit) | **no change** — deliberately NOT added |

Post-fix live convergence confirmed: Status INACTIVE→ACTIVE, DurationSeconds 7200→3600, retention 24→0, MessageTtlSeconds 120→60.

## Notes
- Adds `@aws-sdk/client-kinesis-video` (the KVS CC path is unusable for revert — CC rebuilds the model with an empty Tags array the KVS schema rejects — so the two folded mutable KVS props route to the service's own granular update APIs, like the existing DAX/EB/CloudFront SDK writers).
- Bedrock Agent shows why live-testing matters: a defensive `REVERT_SET_DEFAULT_PATHS` entry there would have been wrong (it already converges).
- Unit tests: 2 SET-DEFAULT `add`-op tests + 1 KVS prop-scoped SDK-routing test. All local gates green (typecheck, `vp test run` 2995 tests, build, `vp check` 0 errors).

Follow-up to #619 / #624 / #626 (the folds) and the #630 REVERT_SET_DEFAULT_PATHS pattern.
