### PR TITLE
fix(diff): fold a fully-undeclared object atDefault when every leaf matches a schema nested default (#624 general improvement)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1224,6 +1224,27 @@ export function classifyResource(
       ...(freeFormKey && { freeFormKey: true }),
     });
   };
+  // #624 (general, fail-closed): true when a FULLY-undeclared OBJECT is entirely AWS-materialized
+  // defaults — every scalar leaf equality-matches the schema's nested `default` (schema.defaultPaths)
+  // or the hand-coded KNOWN_DEFAULT_PATHS twin, and any empty sub-value is trivially empty. A single
+  // leaf that is a real (non-default) value — or an ARRAY, which this rule does not attempt to fold —
+  // makes it false, so the whole object surfaces. Lets a fully-undeclared object whose only leaves are
+  // schema-annotated defaults (e.g. KinesisVideo StreamStorageConfiguration `{DefaultStorageTier:"HOT"}`)
+  // fold whole atDefault WITHOUT a per-type DESCEND_UNDECLARED_OBJECT_PATHS entry.
+  const allLeavesAtSchemaDefault = (value: unknown, basePath: string): boolean => {
+    if (isTrivialEmpty(value)) return true;
+    if (Array.isArray(value)) return false;
+    if (isNestedObject(value))
+      return Object.entries(value).every(([sk, sv]) =>
+        allLeavesAtSchemaDefault(sv, `${basePath}.${sk}`)
+      );
+    const schemaPath = basePath.replace(/\[[^\]]*\]/g, '.*');
+    return (
+      (schemaPath in schema.defaultPaths &&
+        matchesKnownDefault(value, schema.defaultPaths[schemaPath])) ||
+      (schemaPath in knownDefPaths && matchesKnownDefault(value, knownDefPaths[schemaPath]))
+    );
+  };
   // ----------------------------------------------------------------------------------------
 
   for (const [k, v] of Object.entries(declared)) {
@@ -2140,6 +2161,14 @@ export function classifyResource(
           nested: true,
         });
       }
+      continue;
+    }
+    // #624 (general): a fully-undeclared OBJECT whose every leaf is a schema/known nested default
+    // is entirely AWS-materialized — fold the WHOLE object atDefault. Fail-closed: a single
+    // non-default leaf (or any array) leaves it surfacing whole. Runs AFTER the per-type descends
+    // above, so a type curated to fragment (Athena WorkGroupConfiguration) keeps that behavior.
+    if (isNestedObject(v) && Object.keys(v).length > 0 && allLeavesAtSchemaDefault(v, k)) {
+      findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;
     }
     findings.push({ tier: 'undeclared', logicalId, resourceType, path: k, actual: v });

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1020,6 +1020,26 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t({ VisibilityTimeout: 60 }).undeclared).toEqual(['VisibilityTimeout']);
   });
 
+  it('#624 general: a fully-undeclared object whose every leaf is a schema nested default folds whole atDefault; anything else surfaces', () => {
+    // The general fail-closed rule that closes the fully-undeclared-object gap (KinesisVideo
+    // StreamStorageConfiguration, Lambda CodeSigningConfig CodeSigningPolicies) for ANY type
+    // whose schema annotates the nested defaults — no per-type DESCEND entry needed.
+    const schema: SchemaInfo = {
+      ...emptySchema,
+      defaultPaths: { 'Conf.Tier': 'HOT', 'Conf.Nested.Mode': 'A' },
+    };
+    const t = (live: Record<string, unknown>) =>
+      tiers(classifyResource(bare('AWS::X::Y'), live, schema));
+    // every leaf (incl. a deeper nested one) at its schema default -> WHOLE object folds atDefault
+    expect(t({ Conf: { Tier: 'HOT', Nested: { Mode: 'A' } } }).atDefault).toEqual(['Conf']);
+    // one leaf off its default -> the whole object surfaces (fail-closed)
+    expect(t({ Conf: { Tier: 'WARM', Nested: { Mode: 'A' } } }).undeclared).toEqual(['Conf']);
+    // a leaf with NO schema default -> surfaces (never fold an object with a real settable value)
+    expect(t({ Conf: { Tier: 'HOT', Extra: 'x' } }).undeclared).toEqual(['Conf']);
+    // an array member -> not folded by this rule (conservative), surfaces
+    expect(t({ Conf: { Tier: 'HOT', List: [1] } }).undeclared).toEqual(['Conf']);
+  });
+
   it('#627: DynamoDB top-level WarmThroughput derives from ProvisionedThroughput / on-demand constant', () => {
     // a provisioned table's undeclared WarmThroughput echoes its own ProvisionedThroughput
     const t = (live: Record<string, unknown>) =>

--- a/tests/corpus/AWS__Lambda__CodeSigningConfig.Csc.json
+++ b/tests/corpus/AWS__Lambda__CodeSigningConfig.Csc.json
@@ -61,7 +61,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Csc",
       "resourceType": "AWS::Lambda::CodeSigningConfig",
       "path": "CodeSigningPolicies",


### PR DESCRIPTION
Generalizes the #624 fully-undeclared-object fold: a fully-undeclared OBJECT whose every scalar leaf equality-matches the schema nested `default` (`schema.defaultPaths`) or its `KNOWN_DEFAULT_PATHS` twin — with any empty sub-value trivially empty — is entirely AWS-materialized, so it folds WHOLE `atDefault`. Fail-closed: a single non-default leaf, a leaf with no schema default, or ANY array leaves the object surfacing whole.

This closes the object-descend gap for ANY type whose schema annotates its nested defaults, WITHOUT a per-type `DESCEND_UNDECLARED_OBJECT_PATHS` entry (the #624 fix noted this general candidate alongside the KVS-specific per-type descend, which stays for its per-leaf granularity).

## Impact (corpus)
Exactly ONE latent FP folds: `AWS__Lambda__CodeSigningConfig` `CodeSigningPolicies` (`{UntrustedArtifactOnDeployment:"Warn"}`, whose sole leaf matches `schema.defaultPaths[CodeSigningPolicies.UntrustedArtifactOnDeployment]="Warn"`) undeclared→atDefault. Only one flip = well-scoped, no over-folding.

## Verification
- Unit test: whole-object fold when every (incl. deeper-nested) leaf is at its schema default; a non-default leaf surfaces; a leaf with no schema default surfaces (fail-closed); an array member is not folded.
- **Live-tested**: a bare Lambda `CodeSigningConfig` (no `CodeSigningPolicies` declared) deployed to real AWS → `cdkrd check` CLEAN (the object folds atDefault; live value confirmed `{UntrustedArtifactOnDeployment:"Warn"}`). Fixture torn down, orphans swept clean.
- All local gates green: typecheck, `vp test run` (2993), build, `vp check` (0 errors).

General improvement noted in #624.
