### PR TITLE
fix(diff): extend MEANINGFUL_WHEN_OFF to the unconditional top-level #632 blast-radius switches

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -132,6 +132,24 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
     SqsManagedSseEnabled: ({ declared, live }) =>
       declared['KmsMasterKeyId'] === undefined && live['KmsMasterKeyId'] === undefined,
   },
+  // #632 follow-up — the UNCONDITIONAL top-level members of the blast radius: a fresh deploy
+  // ALWAYS reads these `true` (confirmed across the committed corpus, no false-on-clean case,
+  // no restore/import/legacy path that yields an untouched `false`), so an undeclared `false`
+  // is unambiguously an out-of-band disable. (The DB `AutoMinorVersionUpgrade` /
+  // `AllowVersionUpgrade`, ELBv2 TargetGroup `HealthCheckEnabled` (Lambda-target conditional),
+  // and the nested Athena/EKS/Cognito-password/EnableSNI switches are DEFERRED to a live-verified
+  // follow-up — a snapshot-restored DB / a Lambda target group can read `false` legitimately.)
+  //
+  // A VPC always resolves DNS by default; disabling it out of band breaks name resolution.
+  'AWS::EC2::VPC': { EnableDnsSupport: () => true },
+  // Source/dest checking is ON for every ENI/instance at launch (a NAT declares `false`); an
+  // undeclared `false` means it was turned into a router out of band.
+  'AWS::EC2::Instance': { SourceDestCheck: () => true },
+  'AWS::EC2::NetworkInterface': { SourceDestCheck: () => true },
+  // A user-pool client is created with token revocation ON; an undeclared `false` disables it.
+  'AWS::Cognito::UserPoolClient': { EnableTokenRevocation: () => true },
+  // A composite alarm is created with its actions ON; an undeclared `false` silences them.
+  'AWS::CloudWatch::CompositeAlarm': { ActionsEnabled: () => true },
 };
 
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10356,3 +10356,41 @@ describe('#618 VPNConnection VpnTunnelOptionsSpecifications subset + husk fold',
     expect(t.undeclared).toEqual(['VpnTunnelOptionsSpecifications[169.254.234.232/30]']);
   });
 });
+
+// #632 follow-up: extend MEANINGFUL_WHEN_OFF to the UNCONDITIONAL top-level members of the
+// blast radius (a fresh deploy always reads them true; no restore/conditional path yields an
+// untouched false — corpus-mined, no false-on-clean case). An undeclared false is a real
+// out-of-band disable and must surface instead of being swallowed by the trivial-empty drop.
+describe('#632 follow-up: unconditional boolean disables surface (undeclared)', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const tierOf = (type: string, key: string, val: unknown) => {
+    const f = classifyResource(
+      { logicalId: 'R', resourceType: type, physicalId: 'p', declared: {} },
+      { [key]: val },
+      bare
+    );
+    return f.find((x) => x.path === key)?.tier;
+  };
+  const cases: [string, string][] = [
+    ['AWS::EC2::VPC', 'EnableDnsSupport'],
+    ['AWS::EC2::Instance', 'SourceDestCheck'],
+    ['AWS::EC2::NetworkInterface', 'SourceDestCheck'],
+    ['AWS::Cognito::UserPoolClient', 'EnableTokenRevocation'],
+    ['AWS::CloudWatch::CompositeAlarm', 'ActionsEnabled'],
+  ];
+  for (const [type, key] of cases) {
+    it(`${type} ${key}=false surfaces undeclared; =true folds atDefault`, () => {
+      expect(tierOf(type, key, false)).toBe('undeclared');
+      expect(tierOf(type, key, true)).toBe('atDefault');
+    });
+  }
+});


### PR DESCRIPTION
Follow-up to #632 (the invisible-disable false-negative class).

#632 closed the class only for `KMS::Key.Enabled` + `SQS::Queue.SqsManagedSseEnabled`. This adds the **unconditional top-level** members of the blast radius — an undeclared `false` on any of these is unambiguously an out-of-band disable (currently swallowed by the trivial-empty drop → undetectable/unrecordable/unrevertable):

- `AWS::EC2::VPC` `EnableDnsSupport`
- `AWS::EC2::Instance` `SourceDestCheck`
- `AWS::EC2::NetworkInterface` `SourceDestCheck`
- `AWS::Cognito::UserPoolClient` `EnableTokenRevocation`
- `AWS::CloudWatch::CompositeAlarm` `ActionsEnabled`

## How "unconditional" was established (offline)
Corpus-mined across every committed case: each reads `true` on a clean deploy (multiple true-cases each), **no false-on-clean case**, and no restore/import/legacy path that yields an untouched `false`. Corpus replay is the safety net — a committed clean-deploy case reading any of these `false` would fail the replay. Each entry stays equality-gated to its `KNOWN_DEFAULTS` `true` pin.

## Deferred (tracked in the follow-up issue — need live verification)
- DB `AutoMinorVersionUpgrade` (6 types) + Redshift `AllowVersionUpgrade` — a **snapshot-restored** DB can read `false` untouched (ELS-restore lesson).
- ELBv2 `TargetGroup.HealthCheckEnabled` — **Lambda-target conditional** (overlaps #648).
- Lambda `EventSourceMapping.Enabled` — some ESM types may be created disabled.
- **Nested** switches (Athena `WorkGroupConfiguration.*`, EKS `...EndpointPublicAccess`, Cognito password-policy `Require*`, Route53 `HealthCheckConfig.EnableSNI`) — need a nested `MEANINGFUL_WHEN_OFF` mechanism (the current one is top-level only).

## Tests
Unit coverage (false→undeclared / true→atDefault) for each of the 5; full suite + corpus replay green (3010 tests).
