### PR TITLE
fix(revert): converge revert for RolesAnywhere AttributeMappings + KinesisVideo StreamStorageConfiguration (follow-up 2)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -148,6 +148,12 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // CONVERGE via a plain `remove` — UpdateAgent re-materializes the 600 default on omit — so it
   // needs NO entry here.)
   'AWS::RolesAnywhere::Profile\0DurationSeconds',
+  // RolesAnywhere ignores an omitted AttributeMappings on update the same way (live-proven:
+  // an out-of-band put-attribute-mapping changed x509Subject *->CN, then `revert` planned a
+  // `remove`, which the provider reported reverted yet left the live mapping CN). Write the
+  // whole default attribute-mapping array (from KNOWN_DEFAULTS) back explicitly so revert
+  // converges — the whole-array-valued twin of DurationSeconds above.
+  'AWS::RolesAnywhere::Profile\0AttributeMappings',
 ]);
 
 /**

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -54,8 +54,10 @@ import {
   DescribeSignalingChannelCommand,
   DescribeStreamCommand,
   KinesisVideoClient,
+  type DefaultStorageTier,
   UpdateDataRetentionCommand,
   UpdateSignalingChannelCommand,
+  UpdateStreamStorageConfigurationCommand,
 } from '@aws-sdk/client-kinesis-video';
 import {
   ElasticBeanstalkClient,
@@ -2198,6 +2200,35 @@ const writeKinesisVideoSignalingChannel: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// KVS Stream StreamStorageConfiguration.DefaultStorageTier — mutable via its own dedicated
+// UpdateStreamStorageConfiguration API, and (like the other KVS props) unrevertable through
+// Cloud Control (the Tags-min-items ValidationException). A nested-path writer: on a `remove`
+// it restores the "HOT" default; an explicit `add` carries the value. Live-proven follow-up (a
+// DefaultStorageTier changed to WARM out of band FAILED the CC Tags validation until routed here).
+const KVS_STREAM_STORAGE_TIER_DEFAULT = 'HOT';
+const writeKinesisVideoStreamStorage: SdkWriter = async (ctx, ops) => {
+  const id = str(ctx.physicalId) ?? str(ctx.declared['Name']);
+  if (!id) throw new Error('cannot resolve Kinesis Video stream for revert');
+  const op = ops.find((o) =>
+    o.path.replace(/^\//, '').replace(/\//g, '.').endsWith('DefaultStorageTier')
+  );
+  if (!op) return;
+  const target = (
+    op.op === 'add' && typeof op.value === 'string' ? op.value : KVS_STREAM_STORAGE_TIER_DEFAULT
+  ) as DefaultStorageTier;
+  const kv = new KinesisVideoClient({ region: ctx.region });
+  const desc = await kv.send(new DescribeStreamCommand(kvsStreamRef(id)));
+  const version = desc.StreamInfo?.Version;
+  if (version === undefined) throw new Error(`cannot resolve stream version for ${id}`);
+  await kv.send(
+    new UpdateStreamStorageConfigurationCommand({
+      ...kvsStreamRef(id),
+      CurrentVersion: version,
+      StreamStorageConfiguration: { DefaultStorageTier: target },
+    })
+  );
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
   'AWS::ElasticBeanstalk::Application': writeElasticBeanstalkApplication,
   'AWS::ElasticBeanstalk::Environment': writeElasticBeanstalkEnvironment,
@@ -2344,6 +2375,14 @@ export const SDK_NESTED_WRITERS: Record<string, NestedWriterSpec> = {
   'AWS::ApiGateway::Method': {
     match: isApiGatewayMethodKnobPath,
     writer: writeApiGatewayMethod,
+  },
+  // KVS Stream StreamStorageConfiguration is descended (a fully-undeclared object whose
+  // DefaultStorageTier folds to its schema default), so an out-of-band tier change surfaces at
+  // the nested path — unrevertable via CC (Tags validation), reverted via UpdateStreamStorage-
+  // Configuration instead.
+  'AWS::KinesisVideo::Stream': {
+    match: (p) => p === 'StreamStorageConfiguration' || p.startsWith('StreamStorageConfiguration.'),
+    writer: writeKinesisVideoStreamStorage,
   },
   // Any drift UNDER the writeOnly ServiceConnectConfiguration / VolumeConfigurations
   // re-supplies the whole declared prop via ecs:UpdateService (CC cannot sub-path patch

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vite-plus/test';
 import type { BaselineFile } from '../src/baseline/baseline-file.js';
 import { type CorpusCase, reviveSchema } from '../src/corpus/record.js';
 import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
+import { KNOWN_DEFAULTS } from '../src/normalize/noise.js';
 import {
   buildRevertPlan,
   type PatchOp,
@@ -622,6 +623,45 @@ describe('buildRevertPlan', () => {
     const t = plan.items.find((i) => i.ops.some((o) => o.path === '/MessageTtlSeconds'))!;
     expect(r.kind).toBe('sdk');
     expect(t.kind).toBe('sdk');
+  });
+
+  it('RolesAnywhere Profile AttributeMappings (SET-DEFAULT) -> add op writing the whole default array, not a no-op remove', () => {
+    // Follow-up 2: the whole-array twin of DurationSeconds — the provider ignores an omitted
+    // AttributeMappings, so a bare `remove` was a live-proven no-op (an out-of-band
+    // put-attribute-mapping x509Subject *->CN survived it). Revert writes the whole default
+    // array (from KNOWN_DEFAULTS) explicitly; live-proven to converge (x509Subject back to *).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::RolesAnywhere::Profile',
+      path: 'AttributeMappings',
+      actual: [{ CertificateField: 'x509Subject', MappingRules: [{ Specifier: 'CN' }] }],
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AttributeMappings',
+      value: KNOWN_DEFAULTS['AWS::RolesAnywhere::Profile']!.AttributeMappings,
+    });
+  });
+
+  it('KinesisVideo Stream StreamStorageConfiguration nested tier -> nested SDK item (CC Tags-min-items reject; UpdateStreamStorageConfiguration)', () => {
+    // Follow-up 2: StreamStorageConfiguration is descended, so an out-of-band DefaultStorageTier
+    // change surfaces at the nested path — unrevertable via CC (Tags validation), routed to the
+    // dedicated UpdateStreamStorageConfiguration API (SDK_NESTED_WRITERS). Live-proven WARM->HOT.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::KinesisVideo::Stream',
+      path: 'StreamStorageConfiguration.DefaultStorageTier',
+      actual: 'WARM',
+      nested: true,
+      physicalId: 'my-stream',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.notRevertable).toHaveLength(0);
+    const item = plan.items.find((i) =>
+      i.ops.some((o) => o.path === '/StreamStorageConfiguration/DefaultStorageTier')
+    )!;
+    expect(item.kind).toBe('sdk');
   });
 
   it('appeared-since-record undeclared drift on a KNOWN_DEFAULTS-but-not-SET-DEFAULT property still -> remove op', () => {


### PR DESCRIPTION
The two remaining MUTABLE folded props whose revert was untested — both live-verified to NOT converge, now fixed. Deployed to real AWS (us-east-1), mutated via each prop's dedicated API, reverted, and the LIVE state re-read to confirm convergence.

| Prop | Mutated via | Live behavior of plain `remove` revert | Fix | Post-fix |
|---|---|---|---|---|
| `AWS::RolesAnywhere::Profile` `AttributeMappings` | `put-attribute-mapping` (x509Subject `*`→`CN`) | silent no-op (provider ignored the omit; stayed `CN`) | `REVERT_SET_DEFAULT_PATHS` → writes the whole default array | x509Subject → `*` ✓ |
| `AWS::KinesisVideo::Stream` `StreamStorageConfiguration.DefaultStorageTier` | `update-stream-storage-configuration` (`HOT`→`WARM`) | CC `UpdateResource` hard-fails `#/Tags: expected minimum item count: 1` | `SDK_NESTED_WRITERS` → `UpdateStreamStorageConfiguration` | check CLEAN, back to `HOT` ✓ |

## Notes
- Both are the same classes the earlier follow-up (#656) fixed for sibling props: the RolesAnywhere silent-no-op (whole-array twin of `DurationSeconds`) and the KVS CC-Tags hard-fail (this one at a *nested* path, so it routes through `SDK_NESTED_WRITERS` rather than `SDK_PROP_WRITERS`).
- The new cdkrd (post-#631) correctly reported "NOT reverted — removal was a no-op" / the FAILED line instead of a false "CLEAN", which is how these were caught cleanly.
- Confirmed the OTHER folded props need nothing: value-independent folds (AgentAlias `RoutingConfiguration`, ApiKey `Expires`) never surface as drift; createOnly props (VPNGateway ASN, ProductType, RexView Scope, …) can't drift.
- Unit tests: 1 SET-DEFAULT whole-array `add`-op test + 1 nested-SDK-routing test. All local gates green (typecheck, `vp test run` 3007, build, `vp check` 0 errors). Fixture torn down, orphans swept clean.

Follow-up to #619 / #624 and the #656 revert-convergence work.
