### PR TITLE
fix(noise): fold DynamoDB Table first-run FPs — ContributorInsights Mode + SSE type/KMS echoes (#649)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1425,6 +1425,40 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   },
   'AWS::DynamoDB::Table': {
     'PointInTimeRecoverySpecification.RecoveryPeriodInDays': 35,
+    // A table that declares only `ContributorInsightsSpecification.Enabled: true` reads back
+    // the service-default Mode `ACCESSED_AND_THROTTLED_KEYS` (the mode AWS applies when
+    // Contributor Insights is enabled without an explicit Mode) — the template never carries
+    // it, so it floods the first check as an undeclared sibling of the declared `Enabled`.
+    // Equality-gated: a table that pins the other mode (`THROTTLED_KEYS`) or one AWS changes
+    // out of band no longer matches and re-surfaces. The same spec can also sit on each GSI
+    // (`GlobalSecondaryIndexes.*.ContributorInsightsSpecification`), so fold the Mode there
+    // too. Live-proven 2026-07-08 #649.
+    'ContributorInsightsSpecification.Mode': 'ACCESSED_AND_THROTTLED_KEYS',
+    'GlobalSecondaryIndexes.*.ContributorInsightsSpecification.Mode': 'ACCESSED_AND_THROTTLED_KEYS',
+    // A table with `SSESpecification.SSEEnabled: true` and no explicit `SSEType` reads back
+    // `SSEType: 'KMS'` — the only value AWS assigns when server-side encryption is enabled
+    // without a type (the AWS-managed / customer-managed KMS path). The template omits it, so
+    // it is undeclared first-run noise. Equality-gated so a future/other SSEType still
+    // surfaces. Live-proven 2026-07-08 #649.
+    'SSESpecification.SSEType': 'KMS',
+  },
+  // AWS::DynamoDB::GlobalTable shares the SSE/ContributorInsights shapes with the classic
+  // ::Table (#523 twin-type), but with GlobalTable's own nesting: SSESpecification (the
+  // SSEEnabled/SSEType pair) is top-level, while ContributorInsightsSpecification lives per
+  // replica (`Replicas.*.ContributorInsightsSpecification`) and per replica GSI
+  // (`Replicas.*.GlobalSecondaryIndexes.*.ContributorInsightsSpecification`). Register the
+  // same equality-gated Mode/SSEType folds at those paths so a GlobalTable deployed with the
+  // same common flags is CLEAN first-run too. The top-level SSEType fold is reachable today;
+  // the per-replica Mode/KMSMasterKeyId folds additionally need the `Replicas` array keyed by
+  // `Region` in NESTED_ARRAY_IDENTITY (classify.ts) for the undeclared descent to align each
+  // replica — the entries here are the noise-side twin, forward-compatible and equality-gated.
+  // (GlobalTable's KMSMasterKeyId lives per replica under `Replicas.*.SSESpecification` and is
+  // folded value-independently via GENERATED_NESTED_PATHS below.) Mirrors #649.
+  'AWS::DynamoDB::GlobalTable': {
+    'SSESpecification.SSEType': 'KMS',
+    'Replicas.*.ContributorInsightsSpecification.Mode': 'ACCESSED_AND_THROTTLED_KEYS',
+    'Replicas.*.GlobalSecondaryIndexes.*.ContributorInsightsSpecification.Mode':
+      'ACCESSED_AND_THROTTLED_KEYS',
   },
   'AWS::ECS::TaskDefinition': {
     // A container that does not reserve CPU reads back Cpu: 0 (the documented "no
@@ -2019,6 +2053,18 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   // twin of the stage's own top-level DeploymentId, which already folds `generated`), so fold it
   // value-independently. Live, hunt 2026-07-08 round G (#633).
   'AWS::ApiGateway::Stage': new Set(['CanarySetting.DeploymentId']),
+  // A DynamoDB table with `SSESpecification.SSEEnabled: true` and no explicit KMS key reads
+  // back `SSESpecification.KMSMasterKeyId` = the account's AWS-managed `alias/aws/dynamodb`
+  // key ARN (a per-account, AWS-assigned GUID — the account-default-KMS echo class, exactly
+  // like the RDS/OpenSearch `KmsKeyId` folds above). It is never a constant we can pin (it
+  // embeds the per-account key id) and never user intent when undeclared: the CFn schema note
+  // says to set KMSMasterKeyId "only if the key is different from the default DynamoDB key
+  // alias/aws/dynamodb". Fold value-independent — a user who wants a customer-managed key
+  // DECLARES KMSMasterKeyId, which is then compared in the declared loop (detected) and never
+  // reaches here. For GlobalTable the key sits per replica under
+  // `Replicas.*.SSESpecification.KMSMasterKeyId`. Live-proven 2026-07-08 #649.
+  'AWS::DynamoDB::Table': new Set(['SSESpecification.KMSMasterKeyId']),
+  'AWS::DynamoDB::GlobalTable': new Set(['Replicas.*.SSESpecification.KMSMasterKeyId']),
 };
 
 // Elastic Beanstalk ConfigurationTemplate `OptionSettings` first-run default fold. A template

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { matchesKnownDefault } from '../src/diff/classify.js';
+import { classifyResource, matchesKnownDefault } from '../src/diff/classify.js';
 import { stripCcApiAwsManagedFields } from '../src/normalize/cc-api-strip.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
 import {
   awsManagedTags,
   canonicalizeIdArraysDeep,
@@ -1118,6 +1119,179 @@ describe('noise suppressors', () => {
     // non-strings never match
     expect(isCfnTemplateNonAsciiMask(1, 1)).toBe(false);
     expect(isCfnTemplateNonAsciiMask('?', undefined)).toBe(false);
+  });
+});
+
+describe('#649 DynamoDB first-run FPs: ContributorInsights Mode + SSE type/KMS echoes', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const bare = (resourceType: string, declared: Record<string, unknown> = {}): DesiredResource => ({
+    logicalId: 'Tbl',
+    resourceType,
+    physicalId: 'my-table-phys',
+    declared,
+  });
+  const t = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ): { atDefault: string[]; generated: string[]; undeclared: string[] } => {
+    const findings: Finding[] = classifyResource(bare(resourceType, declared), live, emptySchema);
+    const by = (tier: string) =>
+      findings
+        .filter((f) => f.tier === tier)
+        .map((f) => f.path)
+        .sort();
+    return { atDefault: by('atDefault'), generated: by('generated'), undeclared: by('undeclared') };
+  };
+  // The account's AWS-managed aws/dynamodb key ARN AWS echoes into SSESpecification.KMSMasterKeyId.
+  const accountKmsArn =
+    'arn:aws:kms:us-east-1:111122223333:key/e6ab85f6-1234-5678-9abc-def012345678';
+
+  it('table shapes: Mode/SSEType are equality-gated KNOWN_DEFAULT_PATHS, KMSMasterKeyId is value-independent', () => {
+    expect(
+      KNOWN_DEFAULT_PATHS['AWS::DynamoDB::Table']['ContributorInsightsSpecification.Mode']
+    ).toBe('ACCESSED_AND_THROTTLED_KEYS');
+    expect(
+      KNOWN_DEFAULT_PATHS['AWS::DynamoDB::Table'][
+        'GlobalSecondaryIndexes.*.ContributorInsightsSpecification.Mode'
+      ]
+    ).toBe('ACCESSED_AND_THROTTLED_KEYS');
+    expect(KNOWN_DEFAULT_PATHS['AWS::DynamoDB::Table']['SSESpecification.SSEType']).toBe('KMS');
+    expect(
+      GENERATED_NESTED_PATHS['AWS::DynamoDB::Table'].has('SSESpecification.KMSMasterKeyId')
+    ).toBe(true);
+    // GlobalTable twin (#523): SSEType top-level, CI per-replica + per-replica-GSI, KMS per-replica.
+    expect(KNOWN_DEFAULT_PATHS['AWS::DynamoDB::GlobalTable']['SSESpecification.SSEType']).toBe(
+      'KMS'
+    );
+    expect(
+      KNOWN_DEFAULT_PATHS['AWS::DynamoDB::GlobalTable'][
+        'Replicas.*.ContributorInsightsSpecification.Mode'
+      ]
+    ).toBe('ACCESSED_AND_THROTTLED_KEYS');
+    expect(
+      KNOWN_DEFAULT_PATHS['AWS::DynamoDB::GlobalTable'][
+        'Replicas.*.GlobalSecondaryIndexes.*.ContributorInsightsSpecification.Mode'
+      ]
+    ).toBe('ACCESSED_AND_THROTTLED_KEYS');
+    expect(
+      GENERATED_NESTED_PATHS['AWS::DynamoDB::GlobalTable'].has(
+        'Replicas.*.SSESpecification.KMSMasterKeyId'
+      )
+    ).toBe(true);
+  });
+
+  it('classic Table: a clean table with the declared flags surfaces ZERO undeclared drift', () => {
+    // The user DECLARED ContributorInsightsSpecification.Enabled + SSESpecification.SSEEnabled;
+    // AWS echoes the undeclared Mode / SSEType / KMSMasterKeyId siblings. All three must fold.
+    const r = t(
+      'AWS::DynamoDB::Table',
+      {
+        ContributorInsightsSpecification: { Enabled: true },
+        SSESpecification: { SSEEnabled: true },
+      },
+      {
+        ContributorInsightsSpecification: { Enabled: true, Mode: 'ACCESSED_AND_THROTTLED_KEYS' },
+        SSESpecification: { SSEEnabled: true, SSEType: 'KMS', KMSMasterKeyId: accountKmsArn },
+      }
+    );
+    expect(r.undeclared).toEqual([]);
+    expect(r.atDefault).toContain('ContributorInsightsSpecification.Mode');
+    expect(r.atDefault).toContain('SSESpecification.SSEType');
+    expect(r.generated).toContain('SSESpecification.KMSMasterKeyId');
+  });
+
+  it('classic Table: a GSI-nested ContributorInsights Mode default folds too', () => {
+    // GSIs are keyed by IndexName (IDENTITY_FIELDS), so the undeclared descent aligns the
+    // declared GSI to the live one and reports the finding path identity-keyed
+    // (GlobalSecondaryIndexes[gsi1]…), where the `.*` fold key matches.
+    const r = t(
+      'AWS::DynamoDB::Table',
+      {
+        GlobalSecondaryIndexes: [
+          { IndexName: 'gsi1', ContributorInsightsSpecification: { Enabled: true } },
+        ],
+      },
+      {
+        GlobalSecondaryIndexes: [
+          {
+            IndexName: 'gsi1',
+            ContributorInsightsSpecification: {
+              Enabled: true,
+              Mode: 'ACCESSED_AND_THROTTLED_KEYS',
+            },
+          },
+        ],
+      }
+    );
+    const gsiModePath = 'GlobalSecondaryIndexes[gsi1].ContributorInsightsSpecification.Mode';
+    expect(r.undeclared).not.toContain(gsiModePath);
+    expect(r.atDefault).toContain(gsiModePath);
+  });
+
+  it('detection preserved: a CHANGED Mode / SSEType still surfaces (equality-gated)', () => {
+    // ContributorInsights Mode flipped to the other enum value out of band → real undeclared drift.
+    const changedMode = t(
+      'AWS::DynamoDB::Table',
+      { ContributorInsightsSpecification: { Enabled: true } },
+      { ContributorInsightsSpecification: { Enabled: true, Mode: 'THROTTLED_KEYS' } }
+    );
+    expect(changedMode.undeclared).toContain('ContributorInsightsSpecification.Mode');
+    expect(changedMode.atDefault).not.toContain('ContributorInsightsSpecification.Mode');
+    // A hypothetical non-KMS SSEType would also surface (only 'KMS' folds).
+    const changedType = t(
+      'AWS::DynamoDB::Table',
+      { SSESpecification: { SSEEnabled: true } },
+      { SSESpecification: { SSEEnabled: true, SSEType: 'SOMETHING_ELSE' } }
+    );
+    expect(changedType.undeclared).toContain('SSESpecification.SSEType');
+    expect(changedType.atDefault).not.toContain('SSESpecification.SSEType');
+  });
+
+  it('a user-DECLARED KMSMasterKeyId is compared in the declared dimension (detection preserved)', () => {
+    // Declaring a customer-managed key sends KMSMasterKeyId through the DECLARED loop, so an
+    // out-of-band swap to a DIFFERENT key surfaces as declared drift — the value-independent
+    // undeclared fold only applies when the key is UNDECLARED (delegated to AWS).
+    const findings = classifyResource(
+      bare('AWS::DynamoDB::Table', {
+        SSESpecification: { SSEEnabled: true, KMSMasterKeyId: 'alias/my-key' },
+      }),
+      { SSESpecification: { SSEEnabled: true, KMSMasterKeyId: 'alias/attacker-key' } },
+      emptySchema
+    );
+    const declared = findings.filter((f) => f.tier === 'declared').map((f) => f.path);
+    expect(declared).toContain('SSESpecification.KMSMasterKeyId');
+  });
+
+  it('GlobalTable twin: top-level SSEType default folds clean, a changed type surfaces', () => {
+    // GlobalTable's SSESpecification is top-level (SSEEnabled/SSEType), so this end-to-end
+    // fold is reachable today. (The per-replica Mode/KMSMasterKeyId noise-side folds are
+    // asserted structurally in the shapes test above; their undeclared descent additionally
+    // needs the `Replicas` array keyed by Region in NESTED_ARRAY_IDENTITY, which lives in
+    // classify.ts and is out of scope for this noise-only change.)
+    const clean = t(
+      'AWS::DynamoDB::GlobalTable',
+      { SSESpecification: { SSEEnabled: true } },
+      { SSESpecification: { SSEEnabled: true, SSEType: 'KMS' } }
+    );
+    expect(clean.atDefault).toContain('SSESpecification.SSEType');
+    expect(clean.undeclared).not.toContain('SSESpecification.SSEType');
+    const changed = t(
+      'AWS::DynamoDB::GlobalTable',
+      { SSESpecification: { SSEEnabled: true } },
+      { SSESpecification: { SSEEnabled: true, SSEType: 'SOMETHING_ELSE' } }
+    );
+    expect(changed.undeclared).toContain('SSESpecification.SSEType');
+    expect(changed.atDefault).not.toContain('SSESpecification.SSEType');
   });
 });
 


### PR DESCRIPTION
Closes #649

## Problem

A clean, un-mutated `AWS::DynamoDB::Table` deployed with two very common production flags — `contributorInsightsEnabled: true` and `encryption: TableEncryption.AWS_MANAGED` — surfaced **three** first-run `[Potential Drift]` entries (live-proven 2026-07-08, us-east-1). All three are values AWS materializes next to the declared flags — not user intent — so per the zero-potential-drift invariant they must fold.

## The 3 folds

| Path | Value | Tier |
|---|---|---|
| `ContributorInsightsSpecification.Mode` | `ACCESSED_AND_THROTTLED_KEYS` | **tier-1** equality-gated constant (`KNOWN_DEFAULT_PATHS`) — the service default mode echoed next to the declared `Enabled: true` sibling. Also folded GSI-nested (`GlobalSecondaryIndexes.*.ContributorInsightsSpecification.Mode`). |
| `SSESpecification.SSEType` | `KMS` | **tier-1** equality-gated constant — the only value AWS assigns when SSE is enabled without a type. |
| `SSESpecification.KMSMasterKeyId` | account `aws/dynamodb` managed key ARN | **tier-3** value-independent (`GENERATED_NESTED_PATHS`) — the account-default-KMS echo class, mirroring the existing OpenSearch/RDS `KmsKeyId` folds. Undeclared → AWS-assigned per account, never user intent; a user who wants a customer-managed key **declares** `KMSMasterKeyId`, which is then detected in the declared dimension. |

## Twin-type coverage (#523)

Registered under **both** `AWS::DynamoDB::Table` and `AWS::DynamoDB::GlobalTable`, respecting GlobalTable's own nesting: `SSESpecification` (SSEEnabled/SSEType) is top-level, while `ContributorInsightsSpecification` and `KMSMasterKeyId` live per replica (`Replicas.*.…`) and per replica-GSI. The top-level GlobalTable `SSEType` fold is reachable today; the per-replica noise-side entries are forward-compatible and additionally need the `Replicas` array keyed by `Region` in `NESTED_ARRAY_IDENTITY` (which lives in `classify.ts`, out of scope for this noise-only change) for the undeclared descent to align each replica.

## Detection preserved

Every fold is equality-gated (constants) or scoped to the **undeclared** dimension (KMS). Tests assert the clean-deploy folds AND that a changed value still surfaces:
- a `ContributorInsightsSpecification.Mode` flipped to `THROTTLED_KEYS` → surfaces `undeclared`,
- a non-`KMS` `SSEType` → surfaces `undeclared`,
- a **declared** customer-managed `KMSMasterKeyId` swapped out of band → surfaces `declared`.

## Scope

Confined to `src/normalize/noise.ts` (fold tables) + `tests/noise-and-strip.test.ts`. typecheck / build / lint+format / 3016 unit tests all pass.
