### PR TITLE
fix(read): add CC_IDENTIFIER_ADAPTERS entry for AWS::EC2::VPCCidrBlock composite id (#647)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -265,6 +265,20 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
       ? `${rtb}|${att}`
       : undefined;
   },
+  // VPCCidrBlock primaryIdentifier is [Id, VpcId] — CHILD (the vpc-cidr-assoc-... Id)
+  // FIRST, then VpcId. The CFn physical id is only the child segment (Id), so CC
+  // GetResource with the bare id ValidationException-skips it (read-gap) on every
+  // dual-stack (`IpProtocol.DUAL_STACK`) or secondary-CIDR VPC — its declared props
+  // (AmazonProvidedIpv6CidrBlock, CidrBlock, IPAM fields) go entirely unwatched. VpcId
+  // comes from the resolved declared Ref (the VPC is in the same template by
+  // construction). Verified live (#647, us-east-1): `<Id>|<VpcId>` reads; the reverse
+  // order (`VpcId|Id`) returns ResourceNotFoundException. Child-first like ECS Service,
+  // so not `compositeWith` (that is parent-first).
+  'AWS::EC2::VPCCidrBlock': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const vpcId = declared.VpcId;
+    return typeof vpcId === 'string' && vpcId.length > 0 ? `${pid}|${vpcId}` : undefined;
+  },
 };
 
 // `${PolicyARN}|${ScalableDimension}` for a ScalingPolicy, extracting the

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -672,6 +672,38 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('tgw-attach-aaa_tgw-rtb-bbb');
   });
 
+  // VPCCidrBlock: composite [Id, VpcId] — CHILD (vpc-cidr-assoc-... Id) first, then the
+  // VpcId from the declared Ref (the CFn physical id is only the child Id). (#647)
+  it('EC2 VPCCidrBlock: builds the Id|VpcId composite — CHILD first', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::EC2::VPCCidrBlock',
+        physicalId: 'vpc-cidr-assoc-0fb680f722ffd3d6b',
+        declared: { VpcId: 'vpc-099304131d588ddc1', AmazonProvidedIpv6CidrBlock: true },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('vpc-cidr-assoc-0fb680f722ffd3d6b|vpc-099304131d588ddc1');
+  });
+
+  it('EC2 VPCCidrBlock: an unresolved VpcId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::EC2::VPCCidrBlock',
+        physicalId: 'vpc-cidr-assoc-0fb680f722ffd3d6b',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('vpc-cidr-assoc-0fb680f722ffd3d6b');
+  });
+
   // R77: AppConfig Environment/ConfigurationProfile composite [ApplicationId, <child id>].
   for (const t of ['AWS::AppConfig::Environment', 'AWS::AppConfig::ConfigurationProfile']) {
     it(`${t}: builds the ApplicationId|<child> composite identifier`, async () => {


### PR DESCRIPTION
## Summary

Fixes the silent skip of `AWS::EC2::VPCCidrBlock` resources on every dual-stack / secondary-CIDR VPC.

## Root cause

`AWS::EC2::VPCCidrBlock` has a **composite** `primaryIdentifier`: `[ /properties/Id, /properties/VpcId ]`. Cloud Control API therefore expects the identifier as `<Id>|<VpcId>`, but cdkrd was passing the bare physical id (`Id` only). Cloud Control rejects the malformed identifier with a `ValidationException`, so the resource was **silently skipped** on read — every VPCCidrBlock (any dual-stack or secondary-CIDR VPC) fell out of the drift comparison entirely.

## Fix

Add a `CC_IDENTIFIER_ADAPTERS` entry for `AWS::EC2::VPCCidrBlock` that builds the composite identifier `<physicalId>|<VpcId>` **child-first**, matching the live Cloud Control identifier order (verified live). With the correct composite id, Cloud Control reads the resource and it participates in the drift comparison as expected.

## Deferred follow-up

The readOnly IPv6 properties on this type fold via the schema strip (readOnly props), not touched here.

Closes #647
