### PR TITLE
fix(revert): Subnet EnableDns64 set-default + Lambda EventInvokeConfig husk strip (#651, #650)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -154,7 +154,25 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // whole default attribute-mapping array (from KNOWN_DEFAULTS) back explicitly so revert
   // converges — the whole-array-valued twin of DurationSeconds above.
   'AWS::RolesAnywhere::Profile\0AttributeMappings',
+  // EC2 ModifySubnetAttribute IGNORES an omitted EnableDns64 (live-proven on a dual-stack
+  // VPC 2026-07-08: EnableDns64 flipped `true` out of band, then `revert` planned a `remove`,
+  // Cloud Control reported the update applied, yet `describe-subnets` stayed `True` — the
+  // revert looped forever, #651). The subnet's `EnableDns64` default is the plain constant
+  // `false`, but it folds `atDefault` via the CFn SCHEMA default (not KNOWN_DEFAULTS), so the
+  // set-default value comes from REVERT_SET_DEFAULT_VALUES below rather than KNOWN_DEFAULTS.
+  // (The issue also flags sibling booleans AssignIpv6AddressOnCreation / Ipv6Native /
+  // PrivateDnsNameOptionsOnLaunch as candidates for the same silent no-op — left UNVERIFIED
+  // pending a live repro, so not added here.)
+  'AWS::EC2::Subnet\0EnableDns64',
 ]);
+
+// Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant
+// that folds `atDefault` via the CFn SCHEMA default rather than KNOWN_DEFAULTS (so it is
+// absent from that table). Consulted as a FALLBACK when KNOWN_DEFAULTS carries no value for
+// the path — KNOWN_DEFAULTS stays the primary source. Keyed `${resourceType}\0${path}`.
+const REVERT_SET_DEFAULT_VALUES: Record<string, unknown> = {
+  'AWS::EC2::Subnet\0EnableDns64': false,
+};
 
 /**
  * A nested undeclared value (a live sub-key inside a declared object, R96/R98) — a dotted
@@ -701,8 +719,10 @@ function revertOp(f: Finding, recorded: BaselineFile['recorded']): PatchOp {
   // known AWS default explicitly instead of a no-op `remove` (e.g. IAM Role
   // MaxSessionDuration). The value is the same KNOWN_DEFAULTS default that mutes an
   // at-default first sighting; if it is somehow absent we fall through to `remove`.
-  const knownDefault = KNOWN_DEFAULTS[f.resourceType]?.[f.path];
-  if (knownDefault !== undefined && REVERT_SET_DEFAULT_PATHS.has(`${f.resourceType}\0${f.path}`)) {
+  const setDefaultKey = `${f.resourceType}\0${f.path}`;
+  const knownDefault =
+    KNOWN_DEFAULTS[f.resourceType]?.[f.path] ?? REVERT_SET_DEFAULT_VALUES[setDefaultKey];
+  if (knownDefault !== undefined && REVERT_SET_DEFAULT_PATHS.has(setDefaultKey)) {
     return {
       op: 'add',
       path: pointer,
@@ -920,6 +940,20 @@ export const CC_UPDATE_REJECTED_EMPTY_PATHS: Record<string, readonly string[]> =
     '/Distributions/*/FastLaunchConfigurations',
     '/Distributions/*/LaunchTemplateConfigurations',
   ],
+  // Lambda EventInvokeConfig with no destinations configured (the common
+  // `configureAsyncInvoke({ retryAttempts, maxEventAge })` shape): Cloud Control's read
+  // echoes empty destination HUSKS `DestinationConfig: {OnSuccess: {}, OnFailure: {}}`, and
+  // the CC update handler folds its own read-back state into the update — but the schema
+  // requires a `Destination` inside each OnSuccess/OnFailure, so ANY patch (even a
+  // MaximumRetryAttempts-only revert) failed with "required key [Destination] not found"
+  // (#650, live-proven 2026-07-08). Unlike the array husks above these are empty OBJECTS
+  // `{}`, so the strip gate below also drops an empty PLAIN OBJECT (not just an empty array).
+  // Dropping the husk lets the handler treat the destination as absent (no destination),
+  // which is exactly what the `{}` echo meant.
+  'AWS::Lambda::EventInvokeConfig': [
+    '/DestinationConfig/OnSuccess',
+    '/DestinationConfig/OnFailure',
+  ],
 };
 // Expand a JSON pointer that MAY contain `*` array-wildcard segments into a {pointer, value}
 // pair for every matching live node. A `*` matches each index of an array node; a normal
@@ -941,12 +975,22 @@ function expandPointer(model: unknown, pointer: string): { pointer: string; valu
   }
   return frontier.map(({ path, node }) => ({ pointer: `/${path.join('/')}`, value: node }));
 }
+// A schema-invalid EMPTY husk the service echoes on read but rejects when re-sent on an
+// update: an empty ARRAY `[]` (VpcLattice / ImageBuilder above) or an empty PLAIN OBJECT
+// `{}` (Lambda EventInvokeConfig DestinationConfig husks, #650). A populated array/object is
+// real data and is NEVER dropped; an absent pointer needs no strip.
+function isEmptyHusk(value: unknown): boolean {
+  if (Array.isArray(value)) return value.length === 0;
+  if (value !== null && typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
+}
+
 // Extra `remove` ops for a cc-kind item on a type in the table above. Fail-safe gates:
-// the LIVE model must carry the pointer as an EMPTY array (a populated array is real
-// data and is never dropped; an absent pointer needs no strip and a `remove` on it
-// would itself fail), and no planned op may already rewrite the pointer or an ANCESTOR
-// of it (such a rewrite replaces what lives there, so a trailing remove would target a
-// path the patch may have just dropped).
+// the LIVE model must carry the pointer as an EMPTY husk (an empty array `[]` or empty
+// object `{}` — a populated one is real data and is never dropped; an absent pointer needs
+// no strip and a `remove` on it would itself fail), and no planned op may already rewrite
+// the pointer or an ANCESTOR of it (such a rewrite replaces what lives there, so a trailing
+// remove would target a path the patch may have just dropped).
 export function rejectedEmptyStripOps(
   resourceType: string,
   ops: PatchOp[],
@@ -957,13 +1001,13 @@ export function rejectedEmptyStripOps(
   const out: PatchOp[] = [];
   for (const pointer of pointers) {
     for (const { pointer: concrete, value } of expandPointer(liveRaw, pointer)) {
-      if (!Array.isArray(value) || value.length > 0) continue;
+      if (!isEmptyHusk(value)) continue;
       const covered = ops.some((o) => concrete === o.path || concrete.startsWith(`${o.path}/`));
       if (covered) continue;
       out.push({
         op: 'remove',
         path: concrete,
-        human: `${concrete.slice(1).replaceAll('/', '.')} -> drop service-echoed empty array (service rejects [] on update)`,
+        human: `${concrete.slice(1).replaceAll('/', '.')} -> drop service-echoed empty husk (service rejects it on update)`,
       });
     }
   }

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -361,6 +361,28 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#651: appeared-since-record undeclared EC2 Subnet EnableDns64 -> add op writing the false default', () => {
+    // AWS::EC2::Subnet EnableDns64 is in REVERT_SET_DEFAULT_PATHS: EC2 ModifySubnetAttribute
+    // leaves an OMITTED EnableDns64 UNCHANGED, so a bare `remove` of an out-of-band `true` is
+    // a silent no-op (Cloud Control reports the update applied yet describe-subnets stays True
+    // — the revert loops forever; live-proven on a dual-stack VPC 2026-07-08). The `false`
+    // default folds atDefault via the CFn SCHEMA default (not KNOWN_DEFAULTS), so it is sourced
+    // from REVERT_SET_DEFAULT_VALUES. Revert must write `false` explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::Subnet',
+      path: 'EnableDns64',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/EnableDns64',
+      value: false,
+      prior: true,
+    });
+  });
+
   it('Transfer Server SecurityPolicyName (SET-DEFAULT) -> add op writing the default policy, not a no-op remove', () => {
     // AWS::Transfer::Server SecurityPolicyName is in REVERT_SET_DEFAULT_PATHS: UpdateServer
     // leaves the policy UNCHANGED when it is OMITTED, so a bare `remove` of an out-of-band
@@ -2366,6 +2388,80 @@ describe('rejectedEmptyStripOps — array-WILDCARD husk inside array elements (#
 
   it('no Distributions array -> nothing to expand', () => {
     expect(rejectedEmptyStripOps(T, [descOp], { Name: 'dist' })).toEqual([]);
+  });
+});
+
+describe('rejectedEmptyStripOps — service-rejected empty-OBJECT husk (#650 Lambda EventInvokeConfig)', () => {
+  const T = 'AWS::Lambda::EventInvokeConfig';
+  const retryOp: PatchOp = {
+    op: 'add',
+    path: '/MaximumRetryAttempts',
+    value: 1,
+    human: 'MaximumRetryAttempts -> deployed-template value',
+  };
+  // The exact live model from the issue: no destinations configured, so the CC read echoes
+  // empty destination HUSKS {OnSuccess: {}, OnFailure: {}}; the schema requires a Destination
+  // inside each, so ANY patch (even a MaximumRetryAttempts-only revert) was rejected with
+  // "required key [Destination] not found", poisoning the unrelated retry revert.
+  const liveWithHusks = {
+    FunctionName: 'cdkrd-hunt0708i-fn',
+    MaximumRetryAttempts: 2,
+    DestinationConfig: { OnSuccess: {}, OnFailure: {} },
+    Qualifier: '$LATEST',
+    MaximumEventAgeInSeconds: 3600,
+  };
+
+  it('appends a remove op for each empty destination husk on a MaximumRetryAttempts-only revert', () => {
+    const strip = rejectedEmptyStripOps(T, [retryOp], liveWithHusks);
+    expect(strip.map((o) => `${o.op} ${o.path}`)).toEqual([
+      'remove /DestinationConfig/OnSuccess',
+      'remove /DestinationConfig/OnFailure',
+    ]);
+    // The serialized update document reverts MaximumRetryAttempts but no longer carries the
+    // empty husks, so the service would not reject it (it treats the absent destinations as
+    // "no destination", which is what the {} echo meant).
+    expect(
+      toPatchDocument({
+        logicalId: 'Async',
+        displayId: 'Async',
+        resourceType: T,
+        physicalId: 'cdkrd-hunt0708i-fn:$LATEST',
+        kind: 'cc',
+        ops: [retryOp, ...strip],
+      })
+    ).toBe(
+      JSON.stringify([
+        { op: 'add', path: '/MaximumRetryAttempts', value: 1 },
+        { op: 'remove', path: '/DestinationConfig/OnSuccess' },
+        { op: 'remove', path: '/DestinationConfig/OnFailure' },
+      ])
+    );
+  });
+
+  it('a POPULATED destination is real data — never stripped', () => {
+    const live = structuredClone(liveWithHusks) as unknown as {
+      DestinationConfig: { OnSuccess: unknown; OnFailure: unknown };
+    };
+    live.DestinationConfig.OnSuccess = { Destination: 'arn:aws:sqs:...:success' };
+    // OnFailure stays an empty husk, so only it is stripped.
+    const strip = rejectedEmptyStripOps(T, [retryOp], live);
+    expect(strip.map((o) => `${o.op} ${o.path}`)).toEqual(['remove /DestinationConfig/OnFailure']);
+  });
+
+  it('an ABSENT DestinationConfig needs no strip', () => {
+    expect(
+      rejectedEmptyStripOps(T, [retryOp], { FunctionName: 'fn', MaximumRetryAttempts: 2 })
+    ).toEqual([]);
+  });
+
+  it('an op already rewriting DestinationConfig (an ancestor) suppresses the strip', () => {
+    const wholeOp: PatchOp = {
+      op: 'add',
+      path: '/DestinationConfig',
+      value: {},
+      human: 'DestinationConfig -> deployed-template value',
+    };
+    expect(rejectedEmptyStripOps(T, [wholeOp], liveWithHusks)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Two revert bugs, both landing in `src/revert/plan.ts` (offline fix backed by unit tests; both issues are already live-proven).

### #651 — EC2 Subnet `EnableDns64` remove-revert is a silent no-op

EC2 `ModifySubnetAttribute` IGNORES an omitted `EnableDns64`, so a bare `remove` revert of an out-of-band `true` reports the update applied yet `describe-subnets` stays `True` — the revert loops forever.

Fix: add `AWS::EC2::Subnet\0EnableDns64` to `REVERT_SET_DEFAULT_PATHS` so revert writes the `false` default explicitly instead of omitting the property. `EnableDns64` folds `atDefault` via the CFn **schema** default (not `KNOWN_DEFAULTS`), so the set-default value is sourced from a new small local `REVERT_SET_DEFAULT_VALUES` fallback table in `plan.ts` (`KNOWN_DEFAULTS` stays the primary source; the fallback is consulted only when it carries no value for the path).

**Follow-up (unverified):** the issue flags sibling subnet booleans/objects handled by the same provider on the omit path — `AssignIpv6AddressOnCreation`, `Ipv6Native`, `PrivateDnsNameOptionsOnLaunch` — as candidates for the same silent no-op. These are marked UNVERIFIED / needs-live in the issue and are **not** added here; they need a live repro per the skill's revert-of-folded-mutable-prop rule before being added.

### #650 — Lambda `EventInvokeConfig` empty `DestinationConfig` husk poisons revert

When no destinations are configured (the common `configureAsyncInvoke({ retryAttempts, maxEventAge })` shape), Cloud Control's read echoes empty destination husks `DestinationConfig: {OnSuccess: {}, OnFailure: {}}`. The schema requires a `Destination` inside each, so the CC update handler rejects ANY patch (even a `MaximumRetryAttempts`-only revert) with `ValidationException: required key [Destination] not found`, poisoning the revert of the unrelated property.

Fix: add an `AWS::Lambda::EventInvokeConfig` entry to `CC_UPDATE_REJECTED_EMPTY_PATHS` covering `/DestinationConfig/OnSuccess` and `/DestinationConfig/OnFailure`. These husks are empty **objects** `{}` (not empty arrays like the prior `#481` / `#506` entries), so the strip fail-safe gate is generalized from "empty array only" to "empty husk" via a small `isEmptyHusk` helper that also treats an empty plain object as strippable. All existing fail-safe gates are preserved (a populated array/object is real data and is never dropped; an absent pointer needs no strip; an op rewriting the pointer or an ancestor suppresses the strip).

## Tests

`tests/revert-plan.test.ts` — 5 new regression tests:
- #651: appeared-since-record undeclared `EnableDns64=true` → `add /EnableDns64 false`.
- #650: the exact live model from the issue proves the update document reverts `MaximumRetryAttempts` while dropping both empty husks (so the update would no longer be rejected), plus populated-destination / absent-config / ancestor-rewrite fail-safe cases.

All gates green: `vp run typecheck`, `vp check --fix` (0 errors), `vp pack`, `vp test run` (48 files, 3017 tests pass; revert-plan.test.ts = 126 tests).

Closes #651
Closes #650
