### PR TITLE
fix(read,noise): ApiGatewayV2 WebSocket RouteResponse read-gap + first-run folds (#664, #665)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -67,6 +67,7 @@ import {
   EPOCH_HOUR_PATHS,
   IDENTITY_KEYED_DEFAULT_ELEMENTS,
   isEpochHourEqual,
+  KNOWN_DEFAULT_ONE_OF,
   KNOWN_DEFAULT_PATHS,
   KNOWN_DEFAULTS,
   ORDER_SIGNIFICANT_ARRAY_KEYS,
@@ -2061,6 +2062,11 @@ export function classifyResource(
     if (
       (k in schema.defaults && matchesKnownDefault(v, schema.defaults[k])) ||
       (k in knownDef && matchesKnownDefault(v, knownDef[k])) ||
+      // A live value equal to ONE OF several stable-constant AWS defaults for this key (e.g.
+      // an ApiGatewayV2 Integration's protocol-specific TimeoutInMillis, 29000 for WebSocket
+      // vs 30000 for HTTP). Still equality-gated — a declared value or any value outside the
+      // set falls through to `undeclared`.
+      KNOWN_DEFAULT_ONE_OF[resourceType]?.[k]?.some((d) => matchesKnownDefault(v, d)) ||
       // A top-level key whose AWS default is NON-DETERMINISTIC (ECS
       // AvailabilityZoneRebalancing reads back ENABLED or DISABLED depending on the
       // service) — folded atDefault regardless of value: undeclared, so any value is

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -442,10 +442,38 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     RouteSelectionExpression: '$request.method $request.path',
     IpAddressType: 'ipv4', // R-noise-sweep: default; flipping to dualstack no longer matches and surfaces
     DisableExecuteApiEndpoint: false,
+    // A WebSocket (and HTTP) API that declares no ApiKeySelectionExpression reads back the
+    // documented service default `$request.header.x-api-key`. Equality-gated so a declared /
+    // other selection expression still surfaces — this type covers HTTP APIs too, but the
+    // gate means only an UNDECLARED value exactly equal to this constant folds; any custom
+    // value (or an out-of-band change) no longer matches and re-surfaces as real undeclared
+    // drift. WebSocket API, live-proven 2026-07-08 #664.
+    ApiKeySelectionExpression: '$request.header.x-api-key',
   },
   'AWS::ApiGatewayV2::Integration': {
     ConnectionType: 'INTERNET',
+    // The WebSocket default (29000) is protocol-derived, NOT a single constant: an HTTP-API
+    // integration reads 30000, a WebSocket one reads 29000 (per the CFn schema description).
+    // This pin folds the HTTP 30000; the WebSocket 29000 cannot be equality-gated by a single
+    // constant here without breaking the HTTP fold, and the discriminator (the parent Api's
+    // ProtocolType) is not on the Integration model — folding it needs a tier-2 derivation in
+    // classify.ts, DEFERRED to a follow-up (#664). Until then a WebSocket integration's
+    // undeclared TimeoutInMillis=29000 still surfaces (the residual first-run FP tracked below).
     TimeoutInMillis: 30000,
+    // WebSocket integration constant service defaults, materialized on every route created
+    // with CDK's WebSocketLambdaIntegration when the template declares none of them. All are
+    // equality-gated so a declared / out-of-band-changed value still surfaces. This type ALSO
+    // covers HTTP-API integrations, but the gate makes the fold HTTP-safe:
+    //   - PayloadFormatVersion "1.0" — HTTP-API CDK L2 ALWAYS declares "2.0" (a declared value
+    //     is never folded), and HTTP_PROXY declares "1.0" explicitly (also declared), so an
+    //     equality-gated "1.0" fold can only match an UNDECLARED WebSocket integration.
+    //   - IntegrationMethod "POST" — the AWS_PROXY default method for both protocols; a custom
+    //     declared method (e.g. HTTP_PROXY "ANY") is compared in the declared dimension.
+    //   - PassthroughBehavior "WHEN_NO_MATCH" — the documented default; any other value surfaces.
+    // WebSocket API, live-proven 2026-07-08 #664.
+    PayloadFormatVersion: '1.0',
+    IntegrationMethod: 'POST',
+    PassthroughBehavior: 'WHEN_NO_MATCH',
   },
   'AWS::CodeBuild::Project': {
     TimeoutInMinutes: 60,
@@ -1246,6 +1274,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A WebSocket API Stage whose DefaultRouteSettings declares only throttling (CDK's
+  // WebSocketStage renders just ThrottlingRateLimit / ThrottlingBurstLimit) reads back the
+  // sibling `LoggingLevel: "OFF"` — the documented service default AWS fills into
+  // DefaultRouteSettings. Equality-gated so turning logging on out of band (INFO/ERROR) no
+  // longer matches and re-surfaces as real undeclared drift. (The `DataTraceEnabled` /
+  // `DetailedMetricsEnabled` false siblings fold via isTrivialEmpty and do not surface.)
+  // WebSocket API, live-proven 2026-07-08 #664.
+  'AWS::ApiGatewayV2::Stage': {
+    'DefaultRouteSettings.LoggingLevel': 'OFF',
+  },
   // A Service Catalog product's provisioning artifact that declares no Type reads back the
   // constant "CLOUD_FORMATION_TEMPLATE" (observed live, hunt 2026-07-08, #625) — the nested
   // twin of the top-level ProductType fold above. Equality-gated, so an artifact created as a

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -452,14 +452,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::ApiGatewayV2::Integration': {
     ConnectionType: 'INTERNET',
-    // The WebSocket default (29000) is protocol-derived, NOT a single constant: an HTTP-API
-    // integration reads 30000, a WebSocket one reads 29000 (per the CFn schema description).
-    // This pin folds the HTTP 30000; the WebSocket 29000 cannot be equality-gated by a single
-    // constant here without breaking the HTTP fold, and the discriminator (the parent Api's
-    // ProtocolType) is not on the Integration model — folding it needs a tier-2 derivation in
-    // classify.ts, DEFERRED to a follow-up (#664). Until then a WebSocket integration's
-    // undeclared TimeoutInMillis=29000 still surfaces (the residual first-run FP tracked below).
-    TimeoutInMillis: 30000,
+    // TimeoutInMillis is NOT a single constant on this shared type — its undeclared default is
+    // protocol-specific: a WebSocket-API integration reads back 29000, an HTTP-API one reads
+    // 30000 (per the CFn schema description). Both are stable constants, so both fold as tier-1
+    // equality-gated defaults — but a single KNOWN_DEFAULTS key holds only one value, so the
+    // pair lives in KNOWN_DEFAULT_ONE_OF below (a live value equal to EITHER folds; any other
+    // value, or a declared timeout, still surfaces). See that entry for the full reasoning.
     // WebSocket integration constant service defaults, materialized on every route created
     // with CDK's WebSocketLambdaIntegration when the template declares none of them. All are
     // equality-gated so a declared / out-of-band-changed value still surfaces. This type ALSO
@@ -1238,6 +1236,30 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::CodeStarConnections::Connection': {
     HostArn:
       'arn:aws:codestar-connections:us-west-2:000000000000:host/00000000-0000-0000-0000-000000000000',
+  },
+};
+
+// A top-level twin of KNOWN_DEFAULTS for the rare property whose undeclared AWS default is a
+// stable constant but takes ONE OF SEVERAL values depending on a sibling the value itself does
+// not carry. Each entry lists the full SET of accepted defaults; a live value that deep-equals
+// ANY member folds to `atDefault`, and anything else — including a declared value — still
+// surfaces. This is still tier-1 (equality-gated constants), just against a small closed set
+// rather than a single value; it is NOT a tier-2 derivation (no value is computed from the
+// declared inputs). Reach for it ONLY when the two-plus defaults are genuine, stable constants
+// and the discriminator (e.g. the parent's protocol) is off the resource's own model.
+export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknown[]>> = {
+  // AWS::ApiGatewayV2::Integration is shared by HTTP and WebSocket APIs, and its undeclared
+  // TimeoutInMillis default is protocol-specific: a WebSocket integration reads back 29000, an
+  // HTTP integration reads back 30000 (per the CFn schema description). Both are stable
+  // constants, but the discriminator — the parent Api's ProtocolType — is not on the Integration
+  // model, so a single KNOWN_DEFAULTS constant cannot cover both without breaking the other.
+  // Folding the SET {29000, 30000} keeps a clean deploy of EITHER protocol at zero first-run
+  // drift, while equality-gating preserves detection: a user who DECLARES a timeout is compared
+  // in the declared dimension (never folded), and an out-of-band change to any value outside the
+  // set (e.g. 10000) re-surfaces as real undeclared drift. HTTP's 30000 and WebSocket's 29000
+  // are folded as PEERS here — neither masks the other, and neither masks a custom value.
+  'AWS::ApiGatewayV2::Integration': {
+    TimeoutInMillis: [29000, 30000],
   },
 };
 

--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -279,6 +279,30 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
     const vpcId = declared.VpcId;
     return typeof vpcId === 'string' && vpcId.length > 0 ? `${pid}|${vpcId}` : undefined;
   },
+  // ApiGatewayV2 RouteResponse primaryIdentifier is the 3-SEGMENT composite
+  // [ApiId, RouteId, RouteResponseId] — parent-first (Api, then Route, then the child
+  // RouteResponse), like the AppConfig HostedConfigurationVersion/Deployment 3-segment
+  // adapters above. The CFn physical id is only the LAST segment (RouteResponseId), so a
+  // bare-id CC GetResource ValidationException-skips it (read-gap) on every WebSocket route
+  // created with CDK's `returnResponse: true` — the RouteResponse goes entirely unwatched
+  // (surfaced only as `skipped=1` in the info footer). BOTH parent segments are resolvable
+  // from the declared model: `ApiId` is a Ref to the Api, and `RouteId` is a Ref to the
+  // Route (the Route's own physical id IS the RouteId). Verified live (#665, us-east-1):
+  // `ApiId|RouteId|RouteResponseId` reads; the reversed order returns NotFound ("Invalid
+  // API identifier") and the bare id ValidationExceptions. An unresolved parent → fall back
+  // to the bare physical id (honest skip). Not `compositeWith` (which is a single-parent
+  // helper); this is a two-parent, parent-first composite.
+  'AWS::ApiGatewayV2::RouteResponse': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const apiId = declared.ApiId;
+    const routeId = declared.RouteId;
+    return typeof apiId === 'string' &&
+      apiId.length > 0 &&
+      typeof routeId === 'string' &&
+      routeId.length > 0
+      ? `${apiId}|${routeId}|${pid}`
+      : undefined;
+  },
 };
 
 // `${PolicyARN}|${ScalableDimension}` for a ScalingPolicy, extracting the

--- a/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
+++ b/tests/corpus/AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524.json
@@ -59,7 +59,7 @@
       "constructPath": "CdkrdIntegHarvest4/Api/ANY--ping/Ping"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "ApiANYpingPingA3011524",
       "resourceType": "AWS::ApiGatewayV2::Integration",
       "path": "IntegrationMethod",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -2007,3 +2007,155 @@ describe('isCaseInsensitiveKeyMapEqual — free-form map key-case fold (#494)', 
     ).toBe(true);
   });
 });
+
+describe('#664 ApiGatewayV2 WebSocket first-run undeclared folds', () => {
+  const emptySchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const bare = (resourceType: string, declared: Record<string, unknown> = {}): DesiredResource => ({
+    logicalId: 'WsApi',
+    resourceType,
+    physicalId: 'ws-phys',
+    declared,
+  });
+  const t = (
+    resourceType: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ): { atDefault: string[]; undeclared: string[] } => {
+    const findings: Finding[] = classifyResource(bare(resourceType, declared), live, emptySchema);
+    const by = (tier: string) =>
+      findings
+        .filter((f) => f.tier === tier)
+        .map((f) => f.path)
+        .sort();
+    return { atDefault: by('atDefault'), undeclared: by('undeclared') };
+  };
+
+  it('the WebSocket defaults are registered in the fold tables', () => {
+    expect(KNOWN_DEFAULTS['AWS::ApiGatewayV2::Api'].ApiKeySelectionExpression).toBe(
+      '$request.header.x-api-key'
+    );
+    expect(KNOWN_DEFAULTS['AWS::ApiGatewayV2::Integration'].PayloadFormatVersion).toBe('1.0');
+    expect(KNOWN_DEFAULTS['AWS::ApiGatewayV2::Integration'].IntegrationMethod).toBe('POST');
+    expect(KNOWN_DEFAULTS['AWS::ApiGatewayV2::Integration'].PassthroughBehavior).toBe(
+      'WHEN_NO_MATCH'
+    );
+    expect(
+      KNOWN_DEFAULT_PATHS['AWS::ApiGatewayV2::Stage']['DefaultRouteSettings.LoggingLevel']
+    ).toBe('OFF');
+  });
+
+  it('Api: an undeclared ApiKeySelectionExpression at the default folds to atDefault', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Api',
+      { RouteSelectionExpression: '$request.body.action' },
+      {
+        RouteSelectionExpression: '$request.body.action',
+        ApiKeySelectionExpression: '$request.header.x-api-key',
+      }
+    );
+    expect(r.atDefault).toContain('ApiKeySelectionExpression');
+    expect(r.undeclared).not.toContain('ApiKeySelectionExpression');
+  });
+
+  it('Api: a CHANGED ApiKeySelectionExpression still surfaces (equality-gated)', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Api',
+      {},
+      { ApiKeySelectionExpression: '$request.querystring.api_key' }
+    );
+    expect(r.undeclared).toContain('ApiKeySelectionExpression');
+    expect(r.atDefault).not.toContain('ApiKeySelectionExpression');
+  });
+
+  it('Integration: undeclared WebSocket defaults (PayloadFormatVersion/IntegrationMethod/PassthroughBehavior) fold to atDefault', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY', IntegrationUri: 'arn:aws:lambda:...' },
+      {
+        ApiId: 'api1',
+        IntegrationType: 'AWS_PROXY',
+        IntegrationUri: 'arn:aws:lambda:...',
+        PayloadFormatVersion: '1.0',
+        IntegrationMethod: 'POST',
+        PassthroughBehavior: 'WHEN_NO_MATCH',
+      }
+    );
+    expect(r.atDefault).toContain('PayloadFormatVersion');
+    expect(r.atDefault).toContain('IntegrationMethod');
+    expect(r.atDefault).toContain('PassthroughBehavior');
+    expect(r.undeclared).toEqual([]);
+  });
+
+  it('Integration: a DECLARED PayloadFormatVersion is never folded (HTTP-API 2.0 safety)', () => {
+    // An HTTP-API L2 always DECLARES PayloadFormatVersion "2.0"; a declared value is compared
+    // in the declared dimension, never folded by the equality-gated "1.0" KNOWN_DEFAULTS entry.
+    const r = t(
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY', PayloadFormatVersion: '2.0' },
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY', PayloadFormatVersion: '2.0' }
+    );
+    // PayloadFormatVersion is declared+equal → no undeclared/atDefault finding for it at all.
+    expect(r.atDefault).not.toContain('PayloadFormatVersion');
+    expect(r.undeclared).not.toContain('PayloadFormatVersion');
+  });
+
+  it('Integration: a CHANGED PassthroughBehavior still surfaces (equality-gated)', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY' },
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY', PassthroughBehavior: 'WHEN_NO_TEMPLATES' }
+    );
+    expect(r.undeclared).toContain('PassthroughBehavior');
+    expect(r.atDefault).not.toContain('PassthroughBehavior');
+  });
+
+  it('Stage: an undeclared DefaultRouteSettings.LoggingLevel at the default folds to atDefault', () => {
+    // CDK renders only the throttling knobs inside DefaultRouteSettings; AWS fills LoggingLevel "OFF".
+    const r = t(
+      'AWS::ApiGatewayV2::Stage',
+      {
+        ApiId: 'api1',
+        StageName: 'dev',
+        DefaultRouteSettings: { ThrottlingRateLimit: 100, ThrottlingBurstLimit: 50 },
+      },
+      {
+        ApiId: 'api1',
+        StageName: 'dev',
+        DefaultRouteSettings: {
+          ThrottlingRateLimit: 100,
+          ThrottlingBurstLimit: 50,
+          LoggingLevel: 'OFF',
+        },
+      }
+    );
+    expect(r.atDefault).toContain('DefaultRouteSettings.LoggingLevel');
+    expect(r.undeclared).not.toContain('DefaultRouteSettings.LoggingLevel');
+  });
+
+  it('Stage: LoggingLevel turned on out of band still surfaces (equality-gated)', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Stage',
+      {
+        ApiId: 'api1',
+        StageName: 'dev',
+        DefaultRouteSettings: { ThrottlingRateLimit: 100 },
+      },
+      {
+        ApiId: 'api1',
+        StageName: 'dev',
+        DefaultRouteSettings: { ThrottlingRateLimit: 100, LoggingLevel: 'INFO' },
+      }
+    );
+    expect(r.undeclared).toContain('DefaultRouteSettings.LoggingLevel');
+    expect(r.atDefault).not.toContain('DefaultRouteSettings.LoggingLevel');
+  });
+});

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -22,6 +22,7 @@ import {
   isIntelligentTieringMatch,
   INTELLIGENT_TIERING_PATHS,
   KNOWN_DEFAULTS,
+  KNOWN_DEFAULT_ONE_OF,
   KNOWN_DEFAULT_PATHS,
   GENERATED_NESTED_PATHS,
   DESCEND_UNDECLARED_OBJECT_PATHS,
@@ -2116,6 +2117,47 @@ describe('#664 ApiGatewayV2 WebSocket first-run undeclared folds', () => {
     );
     expect(r.undeclared).toContain('PassthroughBehavior');
     expect(r.atDefault).not.toContain('PassthroughBehavior');
+  });
+
+  it('Integration: TimeoutInMillis one-of defaults {29000, 30000} are registered', () => {
+    expect(KNOWN_DEFAULT_ONE_OF['AWS::ApiGatewayV2::Integration'].TimeoutInMillis).toEqual([
+      29000, 30000,
+    ]);
+  });
+
+  it('Integration: an undeclared WebSocket TimeoutInMillis=29000 folds to atDefault', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY', IntegrationUri: 'arn:aws:lambda:...' },
+      {
+        ApiId: 'api1',
+        IntegrationType: 'AWS_PROXY',
+        IntegrationUri: 'arn:aws:lambda:...',
+        TimeoutInMillis: 29000,
+      }
+    );
+    expect(r.atDefault).toContain('TimeoutInMillis');
+    expect(r.undeclared).not.toContain('TimeoutInMillis');
+  });
+
+  it('Integration: an undeclared HTTP TimeoutInMillis=30000 also folds to atDefault (the peer default)', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: 'api1', IntegrationType: 'HTTP_PROXY' },
+      { ApiId: 'api1', IntegrationType: 'HTTP_PROXY', TimeoutInMillis: 30000 }
+    );
+    expect(r.atDefault).toContain('TimeoutInMillis');
+    expect(r.undeclared).not.toContain('TimeoutInMillis');
+  });
+
+  it('Integration: an undeclared TimeoutInMillis OUTSIDE the set (10000) still surfaces (equality-gated)', () => {
+    const r = t(
+      'AWS::ApiGatewayV2::Integration',
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY' },
+      { ApiId: 'api1', IntegrationType: 'AWS_PROXY', TimeoutInMillis: 10000 }
+    );
+    expect(r.undeclared).toContain('TimeoutInMillis');
+    expect(r.atDefault).not.toContain('TimeoutInMillis');
   });
 
   it('Stage: an undeclared DefaultRouteSettings.LoggingLevel at the default folds to atDefault', () => {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -774,6 +774,55 @@ describe('readLive (CC identifier adapters, R74)', () => {
     }
   });
 
+  // #665: ApiGatewayV2 RouteResponse is a 3-SEGMENT composite [ApiId, RouteId,
+  // RouteResponseId] — parent-first, the CFn physical id is only the child
+  // RouteResponseId. Both parents come from the declared Refs (ApiId → Api,
+  // RouteId → Route).
+  it('ApiGatewayV2 RouteResponse: builds the ApiId|RouteId|RouteResponseId 3-seg composite', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::RouteResponse',
+        physicalId: 'pzrk3r',
+        declared: { ApiId: 'hlc1jtf6ml', RouteId: 'r7d6lvr' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('hlc1jtf6ml|r7d6lvr|pzrk3r');
+  });
+
+  it('ApiGatewayV2 RouteResponse: an already-composite physical id is not double-prefixed', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::RouteResponse',
+        physicalId: 'hlc1jtf6ml|r7d6lvr|pzrk3r',
+        declared: { ApiId: 'hlc1jtf6ml', RouteId: 'r7d6lvr' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('hlc1jtf6ml|r7d6lvr|pzrk3r');
+  });
+
+  it('ApiGatewayV2 RouteResponse: an unresolved parent (missing RouteId) falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::RouteResponse',
+        physicalId: 'pzrk3r',
+        declared: { ApiId: 'hlc1jtf6ml' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('pzrk3r');
+  });
+
   // R79: ApplicationAutoScaling ScalingPolicy [Arn, ScalableDimension] — the
   // dimension is parsed from the resolved ScalingTargetId (the ScalableTarget
   // physical id `resourceId|scalableDimension|serviceNamespace`).


### PR DESCRIPTION
Closes #664
Closes #665

One PR closing both WebSocket (ApiGatewayV2) issues. Scoped to two source files
(`src/read/router.ts`, `src/normalize/noise.ts`) + their tests, plus one
sanctioned corpus-expectation update.

## Root causes

- **#665** — `AWS::ApiGatewayV2::RouteResponse` has a 3-segment composite
  `primaryIdentifier` `[ApiId, RouteId, RouteResponseId]`, but the CFn physical id
  is only the child `RouteResponseId`. A bare-id CC `GetResource` throws
  `ValidationException`, so the resource is silently `skipped` on every WebSocket
  route created with CDK's `returnResponse: true` (surfaced only as `skipped=1` in
  the info footer). It was missing from `CC_IDENTIFIER_ADAPTERS`.
- **#664** — the WEBSOCKET protocol materializes a set of undeclared defaults that
  all existing (HTTP-protocol) ApiGatewayV2 folds don't cover, so a clean minimal
  WebSocket API surfaced first-run `[Potential Drift]` on values the template never
  declared.

## Fixes

### #665 — RouteResponse composite read-gap (`router.ts`)
Added a `CC_IDENTIFIER_ADAPTERS` entry building `ApiId|RouteId|RouteResponseId`
(parent-first), resolving BOTH parent segments from the declared Refs (`ApiId` →
Api, `RouteId` → Route). Mirrors the AppConfig `HostedConfigurationVersion` /
`Deployment` 3-segment inline pattern already in the table. Live-verified order in
the issue: `ApiId|RouteId|RouteResponseId` reads; reversed → NotFound; bare →
ValidationException.

**`compositeWith` was NOT extended.** It is a single-parent helper; the 3-segment
adapter is written inline (like the AppConfig 3-seg adapters), so the existing
2-segment adapters (Stage/Route/Integration/Authorizer) are byte-for-byte
unchanged. Their existing unit tests (building `ApiId|<child>`) continue to pass,
proving no behavior change.

### #664 — first-run undeclared folds (`noise.ts`)
Equality-gated tier-1 constants (a change away from the default still surfaces):

| Type | Path | Value | Table |
| --- | --- | --- | --- |
| `ApiGatewayV2::Api` | `ApiKeySelectionExpression` | `$request.header.x-api-key` | KNOWN_DEFAULTS (added to existing Api entry) |
| `ApiGatewayV2::Integration` | `PayloadFormatVersion` | `1.0` | KNOWN_DEFAULTS |
| `ApiGatewayV2::Integration` | `IntegrationMethod` | `POST` | KNOWN_DEFAULTS |
| `ApiGatewayV2::Integration` | `PassthroughBehavior` | `WHEN_NO_MATCH` | KNOWN_DEFAULTS |
| `ApiGatewayV2::Stage` | `DefaultRouteSettings.LoggingLevel` | `OFF` | KNOWN_DEFAULT_PATHS |

The 16 Integration findings are 4 paths × 4 routes — a single per-type
KNOWN_DEFAULTS entry covers all routes.

## HTTP-safety reasoning

`ApiGatewayV2::Api` and `ApiGatewayV2::Integration` are shared between HTTP and
WebSocket APIs. Every fold is **equality-gated**, so it only ever folds an
UNDECLARED value that exactly equals the constant; a declared value is compared in
the declared dimension and is never folded.

- `PayloadFormatVersion "1.0"` — HTTP-API CDK L2 **always DECLARES** `"2.0"`
  (declared, never folded), and HTTP_PROXY declares `"1.0"` explicitly (also
  declared). So the equality-gated `"1.0"` fold can only match an UNDECLARED
  WebSocket integration.
- `IntegrationMethod "POST"` — the AWS_PROXY default method for both protocols; a
  custom declared method (e.g. HTTP_PROXY `"ANY"`) is compared as declared.
- `ApiKeySelectionExpression` — the documented service default for both protocols;
  any custom selection expression surfaces.

## Corpus-replay result

`vp test run corpus-replay` — **675/675 pass**. One existing HTTP-API Integration
corpus case (`AWS__ApiGatewayV2__Integration.ApiANYpingPingA3011524`, an AWS_PROXY
integration declaring `PayloadFormatVersion "2.0"`) had `IntegrationMethod: POST`
recorded as `undeclared` — a latent HTTP first-run FP. The new `IntegrationMethod:
"POST"` constant correctly reclassifies it to `atDefault`, so that case's
`expected` tier was updated in this PR (the sanctioned corpus-change workflow — a
semantic change made visible in review). No other ApiGatewayV2 HTTP case regresses;
the second HTTP Integration corpus case declares both `PayloadFormatVersion` and
`IntegrationMethod`, so nothing is folded there.

### TimeoutInMillis — now folded (true zero first-run drift)

The earlier residual — a WebSocket integration's undeclared `TimeoutInMillis=29000`
surfacing on a clean deploy — is **now folded**. `AWS::ApiGatewayV2::Integration`
is shared by HTTP and WebSocket APIs and its undeclared `TimeoutInMillis` default is
protocol-specific: **WebSocket reads back 29000, HTTP reads back 30000** (per the CFn
schema description). Both are stable constants, so both fold as **tier-1
equality-gated** defaults — the DEFAULT choice for a stable-constant default. A single
`KNOWN_DEFAULTS` key holds only one value, so the pair `{29000, 30000}` lives in a new
`KNOWN_DEFAULT_ONE_OF` table (a top-level twin of `KNOWN_DEFAULTS` for the rare
property with several valid constant defaults) and both are folded as **peers** — no
tier-2 derivation in `classify.ts` is needed.

Equality-gating preserves detection: a user who **declares** a timeout is compared in
the declared dimension (never folded), and an out-of-band change to any value outside
the set (e.g. 10000) re-surfaces as real undeclared drift. HTTP's 30000 and
WebSocket's 29000 never mask each other, and neither masks a custom value. HTTP's own
30000 default (a pre-existing, separate concern) is unaffected — both existing HTTP
`AWS::ApiGatewayV2::Integration` corpus cases (which read 30000) still fold via the
set, so `vp test run corpus-replay` stays **675/675** with **no corpus `expected`
change** required.

Net effect: a clean minimal WebSocket API deploy now folds **all** first-run
undeclared paths — **true zero** first-run `[Potential Drift]`.

## Deferred follow-up (not fixed here)

- **RouteResponse husks**: the CC read returns `ResponseParameters:{}` /
  `ResponseModels:{}` empty husks. The existing trivial-empty drop is expected to
  handle them; if they surface, that is a separate husk-logic follow-up (another
  area), not addressed here.

## Verification

- `vp run typecheck` — pass
- `vp pack` — pass
- `vp test run` — 48 files, 3035 tests pass (incl. new router + noise WebSocket tests, plus the TimeoutInMillis one-of fold tests)
- `vp test run corpus-replay` — 675 pass
- `vp run check` — 0 errors

