### PR TITLE
fix(revert): converge revert for ApiGatewayV2 Stage autoDeploy + RestApi Policy JSON-string (#667, #677)

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,7 +663,13 @@ place, since Cloud Control has no handler for the type),
 `config:DescribeConfigRules` / `config:PutConfigRule`,
 `ecs:UpdateService` (reverts an `AWS::ECS::Service` `ServiceConnectConfiguration` /
 `VolumeConfigurations` drift — the whole writeOnly prop is re-supplied, since Cloud
-Control cannot sub-path patch it).
+Control cannot sub-path patch it),
+`apigateway:UpdateStage` (reverts an `AWS::ApiGatewayV2::Stage` — an `autoDeploy`
+stage rejects the `DeploymentId` the Cloud Control handler injects, so only the
+drifted stage properties are written directly, never `DeploymentId`),
+`apigateway:UpdateRestApi` (reverts an `AWS::ApiGateway::RestApi` `Policy` — the
+whole desired resource policy is re-serialized and replaced, since Cloud Control
+holds the policy as a JSON string it cannot sub-path patch).
 
 </details>
 

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -27,7 +27,13 @@ import {
   UpdateIntegrationCommand,
   UpdateIntegrationResponseCommand,
   UpdateMethodResponseCommand,
+  UpdateRestApiCommand,
 } from '@aws-sdk/client-api-gateway';
+import {
+  ApiGatewayV2Client,
+  type RouteSettings,
+  UpdateStageCommand as UpdateApiGatewayV2StageCommand,
+} from '@aws-sdk/client-apigatewayv2';
 import { CloudWatchClient, PutAnomalyDetectorCommand } from '@aws-sdk/client-cloudwatch';
 import {
   DLMClient,
@@ -2229,7 +2235,95 @@ const writeKinesisVideoStreamStorage: SdkWriter = async (ctx, ops) => {
   );
 };
 
+// AWS::ApiGatewayV2::Stage — Cloud Control CAN read this type, but its UpdateResource
+// REJECTS ANY patch on a stage with AutoDeploy=true: the CC handler applies our scoped
+// patch to the FULL current model — which includes the AWS-materialized DeploymentId — and
+// calls UpdateStage with DeploymentId set, and an auto-deploy stage rejects any explicit
+// DeploymentId write ("Deployment ID cannot be set on this stage because AutoDeploy is
+// enabled"). CDK's L2 WebSocketStage and the HTTP-API default stage BOTH set autoDeploy:true
+// by default, so in practice EVERY ApiGatewayV2 stage a CDK user deploys is un-revertable
+// via CC. The poison (DeploymentId) is injected by the CC handler itself, so stripping on our
+// side can't fix it → bypass CC and call apigatewayv2:UpdateStage DIRECTLY with ONLY the
+// drifted properties (NEVER DeploymentId). #667.
+//
+// The CFn Stage property names (DefaultRouteSettings / RouteSettings / AccessLogSettings /
+// Description / StageVariables / ClientCertificateId) map 1:1 onto UpdateStageRequest's typed
+// fields (same PascalCase, same nested RouteSettings shape), so reconstruct the desired value
+// from the DECLARED template + revert ops and send only the top-level properties the ops touch
+// — a partial update that leaves every other live stage setting untouched. Applies to WebSocket
+// AND HTTP API stages. The composite identifier is `ApiId|StageName` (ctx.identifier, resolved
+// by CC_IDENTIFIER_ADAPTERS on the read side); the bare CFn physical id is only the StageName.
+const APIGWV2_STAGE_UPDATE_FIELDS = new Set([
+  'DefaultRouteSettings',
+  'RouteSettings',
+  'AccessLogSettings',
+  'Description',
+  'StageVariables',
+  'ClientCertificateId',
+  'AutoDeploy',
+]);
+const writeApiGatewayV2Stage: SdkWriter = async (ctx, ops) => {
+  // Prefer the resolved composite identifier (`ApiId|StageName`); fall back to declared
+  // ApiId + the physical-id StageName when no identifier was threaded.
+  const [apiIdFromComposite, stageFromComposite] = (ctx.identifier ?? '').split('|');
+  const apiId = str(apiIdFromComposite) ?? str(ctx.declared['ApiId']);
+  const stageName =
+    str(stageFromComposite) ?? str(ctx.physicalId) ?? str(ctx.declared['StageName']);
+  if (!apiId || !stageName)
+    throw new Error('cannot resolve ApiId|StageName for ApiGatewayV2 Stage revert');
+  // Reconstruct the desired model = declared intent + revert ops. `remove` back to a
+  // default is expressed by the declared value's absence (the field is simply omitted).
+  const desired = applyOps({ ...ctx.declared }, ops);
+  const touched = new Set(
+    ops.map((o) => o.path.replace(/^\//, '').split('/')[0]).filter((p): p is string => !!p)
+  );
+  const input: Record<string, unknown> = { ApiId: apiId, StageName: stageName };
+  for (const p of touched) {
+    if (!APIGWV2_STAGE_UPDATE_FIELDS.has(p)) continue;
+    // Send the desired value (or `null`/absent -> the API clears it). NEVER DeploymentId.
+    input[p] = desired[p as keyof typeof desired] as unknown;
+  }
+  // Nothing settable touched (e.g. only DeploymentId drifted, which is never revertable) — no-op.
+  if (Object.keys(input).length <= 2) return;
+  await new ApiGatewayV2Client({ region: ctx.region }).send(
+    new UpdateApiGatewayV2StageCommand(
+      input as { ApiId: string; StageName: string; DefaultRouteSettings?: RouteSettings }
+    )
+  );
+};
+
+// AWS::ApiGateway::RestApi `Policy` — the RestApi resource policy is held in the Cloud
+// Control live model as a JSON STRING, while classify/diff parses it for comparison and
+// produces findings under object sub-paths (e.g. `Policy.Statement`). The revert planner's
+// sub-path patch (`/Policy/Statement`) is then rejected by the CC handler ("parent is not a
+// container in source" — the parent `Policy` is a string, not an object). The #389 JSON-string
+// class, but routed HERE (an SDK writer) rather than the noise.ts JSON_STRING_PROPS table.
+// apigateway:UpdateRestApi with a single `replace /policy` patchOperation carrying the WHOLE
+// desired policy document serialized to a compact JSON string is live-verified to converge.
+// The desired policy is the DECLARED template value (the object form); a revert to an ABSENT
+// declared policy clears it (empty string). The RestApi physical id IS its RestApiId. #677.
+const writeApiGatewayRestApiPolicy: SdkWriter = async (ctx) => {
+  const restApiId = str(ctx.physicalId) ?? str(ctx.declared['RestApiId']);
+  if (!restApiId) throw new Error('cannot resolve RestApiId for RestApi Policy revert');
+  const declaredPolicy = ctx.declared['Policy'];
+  // The declared policy is an object; serialize it whole. An absent declared policy reverts
+  // to the empty string (UpdateRestApi with `replace /policy value=""` clears it).
+  const value =
+    declaredPolicy === undefined || declaredPolicy === null
+      ? ''
+      : typeof declaredPolicy === 'string'
+        ? declaredPolicy
+        : JSON.stringify(declaredPolicy);
+  await new APIGatewayClient({ region: ctx.region }).send(
+    new UpdateRestApiCommand({
+      restApiId,
+      patchOperations: [{ op: 'replace', path: '/policy', value } satisfies PatchOperation],
+    })
+  );
+};
+
 export const SDK_WRITERS: Record<string, SdkWriter> = {
+  'AWS::ApiGatewayV2::Stage': writeApiGatewayV2Stage,
   'AWS::ElasticBeanstalk::Application': writeElasticBeanstalkApplication,
   'AWS::ElasticBeanstalk::Environment': writeElasticBeanstalkEnvironment,
   'AWS::CodeBuild::ReportGroup': writeCodeBuildReportGroup,
@@ -2420,6 +2514,15 @@ export const SDK_NESTED_WRITERS: Record<string, NestedWriterSpec> = {
   'AWS::ApiGateway::Stage': {
     match: (p) => p.startsWith('MethodSettings['),
     writer: writeCloudControlIndexNested,
+  },
+  // The RestApi resource `Policy` reads back from Cloud Control as a JSON STRING, so a
+  // sub-path patch (`/Policy/Statement`) is rejected ("parent is not a container"). Any drift
+  // under Policy re-serializes the WHOLE declared policy and replaces `/policy` via
+  // apigateway:UpdateRestApi. Scoped to Policy only — other RestApi props stay on Cloud
+  // Control. #677.
+  'AWS::ApiGateway::RestApi': {
+    match: (p) => p === 'Policy' || p.startsWith('Policy.') || p.startsWith('Policy['),
+    writer: writeApiGatewayRestApiPolicy,
   },
   // Any drift UNDER the writeOnly BotLocales (an utterance / slot / slot-type / prompt edit, OR a
   // whole intent / slot / slot type added or removed out of band) re-supplies the DECLARED

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -3,7 +3,12 @@ import {
   UpdateIntegrationCommand,
   UpdateIntegrationResponseCommand,
   UpdateMethodResponseCommand,
+  UpdateRestApiCommand,
 } from '@aws-sdk/client-api-gateway';
+import {
+  ApiGatewayV2Client,
+  UpdateStageCommand as UpdateApiGatewayV2StageCommand,
+} from '@aws-sdk/client-apigatewayv2';
 import {
   CloudWatchClient,
   DescribeAnomalyDetectorsCommand,
@@ -196,6 +201,7 @@ const route53 = mockClient(Route53Client);
 const configService = mockClient(ConfigServiceClient);
 const eventbridge = mockClient(EventBridgeClient);
 const apigw = mockClient(APIGatewayClient);
+const apigwv2 = mockClient(ApiGatewayV2Client);
 const ecs = mockClient(ECSClient);
 const cloudwatch = mockClient(CloudWatchClient);
 const dlm = mockClient(DLMClient);
@@ -256,6 +262,7 @@ beforeEach(() => {
   kafka.reset();
   eventbridge.reset();
   apigw.reset();
+  apigwv2.reset();
   ecs.reset();
   cloudwatch.reset();
   dlm.reset();
@@ -2940,5 +2947,140 @@ describe('Lex BotLocales writer (revert-by-rebuild via lexv2-models Update* APIs
         [utteranceOp]
       )
     ).rejects.toThrow(/Lex Bot id/);
+  });
+});
+
+describe('ApiGatewayV2 Stage writer (autoDeploy — bypass CC UpdateStage, issue #667)', () => {
+  const stageCtx = (over: Partial<OverrideCtx> = {}): OverrideCtx =>
+    ctx({
+      physicalId: 'prod', // the Ref (bare StageName)
+      identifier: 'abc123|prod', // ApiId|StageName resolved by CC_IDENTIFIER_ADAPTERS
+      declared: {
+        ApiId: 'abc123',
+        StageName: 'prod',
+        AutoDeploy: true,
+        DefaultRouteSettings: { ThrottlingRateLimit: 100, ThrottlingBurstLimit: 50 },
+      },
+      ...over,
+    });
+  // an out-of-band mutation dropped ThrottlingRateLimit 100 -> 50; revert restores the declared 100.
+  const op: PatchOp = {
+    op: 'add',
+    path: '/DefaultRouteSettings/ThrottlingRateLimit',
+    value: 100,
+    human: 'DefaultRouteSettings.ThrottlingRateLimit -> deployed-template value',
+  };
+
+  it('routes an ApiGatewayV2::Stage revert to the whole-type SDK writer', () => {
+    expect(SDK_WRITERS['AWS::ApiGatewayV2::Stage']).toBeDefined();
+    expect(resolveSdkWriter('AWS::ApiGatewayV2::Stage', [op])).toBe(
+      SDK_WRITERS['AWS::ApiGatewayV2::Stage']
+    );
+  });
+
+  it('calls UpdateStage with ONLY the drifted property and NEVER DeploymentId', async () => {
+    apigwv2.on(UpdateApiGatewayV2StageCommand).resolves({});
+    await SDK_WRITERS['AWS::ApiGatewayV2::Stage']!(stageCtx(), [op]);
+    const calls = apigwv2.commandCalls(UpdateApiGatewayV2StageCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input;
+    // identifier segments resolved from the composite ctx.identifier `ApiId|StageName`.
+    expect(input.ApiId).toBe('abc123');
+    expect(input.StageName).toBe('prod');
+    // ONLY the touched top-level property is sent (the declared desired value).
+    expect(input.DefaultRouteSettings).toEqual({
+      ThrottlingRateLimit: 100,
+      ThrottlingBurstLimit: 50,
+    });
+    // NEVER DeploymentId (the CC-injected poison auto-deploy stages reject).
+    expect(input).not.toHaveProperty('DeploymentId');
+    // untouched props are not re-sent.
+    expect(input).not.toHaveProperty('RouteSettings');
+    expect(input).not.toHaveProperty('AccessLogSettings');
+  });
+
+  it('falls back to declared ApiId + physical-id StageName when no composite identifier', async () => {
+    apigwv2.on(UpdateApiGatewayV2StageCommand).resolves({});
+    await SDK_WRITERS['AWS::ApiGatewayV2::Stage']!(stageCtx({ identifier: undefined }), [op]);
+    const input = apigwv2.commandCalls(UpdateApiGatewayV2StageCommand)[0]!.args[0].input;
+    expect(input.ApiId).toBe('abc123');
+    expect(input.StageName).toBe('prod');
+  });
+
+  it('throws when ApiId/StageName are unresolvable', async () => {
+    await expect(
+      SDK_WRITERS['AWS::ApiGatewayV2::Stage']!(
+        ctx({ physicalId: '', identifier: undefined, declared: {} }),
+        [op]
+      )
+    ).rejects.toThrow(/ApiId\|StageName/);
+  });
+});
+
+describe('ApiGateway RestApi Policy writer (JSON-string prop, issue #677)', () => {
+  const desiredPolicy = {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: '*',
+        Action: 'execute-api:Invoke',
+        Resource: 'arn:aws:execute-api:us-east-1:123456789012:wmvd2s08ng/*',
+      },
+      {
+        Effect: 'Deny',
+        Principal: '*',
+        Action: 'execute-api:Invoke',
+        Resource: 'arn:aws:execute-api:us-east-1:123456789012:wmvd2s08ng/*',
+        Condition: { StringNotEquals: { 'aws:SourceVpce': 'vpce-1234' } },
+      },
+    ],
+  };
+  const restApiCtx = (over: Partial<OverrideCtx> = {}): OverrideCtx =>
+    ctx({ physicalId: 'wmvd2s08ng', declared: { Policy: desiredPolicy }, ...over });
+  // the finding is a whole-statement declared drift under Policy (parsed object sub-path).
+  const op: PatchOp = {
+    op: 'add',
+    path: '/Policy/Statement',
+    value: desiredPolicy.Statement,
+    human: 'Policy.Statement -> deployed-template value',
+  };
+
+  it('routes a Policy sub-path drift to the nested RestApi SDK writer', () => {
+    const writer = resolveSdkWriter('AWS::ApiGateway::RestApi', [op]);
+    expect(writer).toBeDefined();
+    expect(writer).toBe(SDK_NESTED_WRITERS['AWS::ApiGateway::RestApi']!.writer);
+    // a non-Policy drift is NOT captured by this writer (stays on Cloud Control).
+    expect(SDK_NESTED_WRITERS['AWS::ApiGateway::RestApi']!.match('Description')).toBe(false);
+    expect(SDK_NESTED_WRITERS['AWS::ApiGateway::RestApi']!.match('Policy')).toBe(true);
+    expect(SDK_NESTED_WRITERS['AWS::ApiGateway::RestApi']!.match('Policy.Statement')).toBe(true);
+  });
+
+  it('replaces /policy with the WHOLE declared policy serialized to a compact JSON string', async () => {
+    apigw.on(UpdateRestApiCommand).resolves({});
+    await resolveSdkWriter('AWS::ApiGateway::RestApi', [op])!(restApiCtx(), [op]);
+    const calls = apigw.commandCalls(UpdateRestApiCommand);
+    expect(calls).toHaveLength(1);
+    const input = calls[0]!.args[0].input;
+    expect(input.restApiId).toBe('wmvd2s08ng'); // the RestApi physical id IS the RestApiId.
+    expect(input.patchOperations).toEqual([
+      { op: 'replace', path: '/policy', value: JSON.stringify(desiredPolicy) },
+    ]);
+  });
+
+  it('reverts an absent declared policy to the empty string (clears it)', async () => {
+    apigw.on(UpdateRestApiCommand).resolves({});
+    await resolveSdkWriter('AWS::ApiGateway::RestApi', [op])!(restApiCtx({ declared: {} }), [op]);
+    const input = apigw.commandCalls(UpdateRestApiCommand)[0]!.args[0].input;
+    expect(input.patchOperations).toEqual([{ op: 'replace', path: '/policy', value: '' }]);
+  });
+
+  it('throws when the RestApiId is unresolvable', async () => {
+    await expect(
+      resolveSdkWriter('AWS::ApiGateway::RestApi', [op])!(
+        ctx({ physicalId: '', declared: { Policy: desiredPolicy } }),
+        [op]
+      )
+    ).rejects.toThrow(/RestApiId/);
   });
 });


### PR DESCRIPTION
Closes #667
Closes #677

Two revert-convergence fixes of the same class — "the one AWS-mutating verb can't
fix a detected drift on this type". Both are confined to the SDK-writer path in
`src/revert/writers.ts` (+ its unit tests + a README permissions/limitations note).
No `plan.ts` routing tweak was needed — the existing `SDK_WRITERS` /
`SDK_NESTED_WRITERS` dispatch already routes both once the entries are added.

## #667 — ApiGatewayV2::Stage revert fails when AutoDeploy=true

**Root cause:** cdkrd's patch is correctly scoped (e.g. only
`/DefaultRouteSettings/ThrottlingRateLimit`), but the Cloud Control handler applies
it to the FULL current model — which includes the AWS-materialized `DeploymentId` —
and calls `UpdateStage` with `DeploymentId` set. An auto-deploy stage rejects any
explicit `DeploymentId` write (`Deployment ID cannot be set on this stage because
AutoDeploy is enabled`). CDK's L2 `WebSocketStage` and the HTTP-API default stage
both default `autoDeploy: true`, so in practice every ApiGatewayV2 stage is
un-revertable via CC. The poison is injected by the CC handler itself, so stripping
on our side can't fix it — we must bypass CC.

**Fix:** a whole-type `SDK_WRITERS['AWS::ApiGatewayV2::Stage']` writer that calls
`apigatewayv2:UpdateStage` directly with ONLY the drifted top-level properties
(DefaultRouteSettings / RouteSettings / AccessLogSettings / Description /
StageVariables / ClientCertificateId / AutoDeploy) reconstructed from the declared
template + revert ops — and NEVER `DeploymentId`. The CFn Stage property names map
1:1 onto `UpdateStageRequest`'s typed fields (same nested `RouteSettings` shape).
Applies to WebSocket AND HTTP API stages. The composite identifier `ApiId|StageName`
comes from `ctx.identifier` (resolved by `CC_IDENTIFIER_ADAPTERS` on the read side),
with a fallback to declared `ApiId` + the physical-id `StageName`.

## #677 — RestApi Policy revert always fails (JSON-string prop)

**Root cause:** the CC live model holds `Policy` as a JSON STRING, while classify/diff
parses it and produces findings under object sub-paths (e.g. `Policy.Statement`). The
revert planner's sub-path patch `/Policy/Statement` is then rejected
(`ValidationException: parent is not a container` — the parent `Policy` is a string,
not an object). The #389 JSON-string class.

**Fix (SDK writer, not the noise.ts `JSON_STRING_PROPS` route):** an
`SDK_NESTED_WRITERS['AWS::ApiGateway::RestApi']` entry matching any path under `Policy`
(`Policy` / `Policy.*` / `Policy[*]`) that calls `apigateway:UpdateRestApi` with a
single `patchOperations: [{ op: 'replace', path: '/policy', value: <WHOLE desired
policy serialized to a compact JSON string> }]`. The desired policy is the declared
template value; an absent declared policy reverts to the empty string (clears it).
Scoped to `Policy` only — every other RestApi property stays on Cloud Control. The
RestApi physical id IS the `RestApiId`.

**Live-test note:** #677's revert is live-testable standalone — write the resource
policy with a FULL explicit `execute-api` ARN resource (not the `execute-api:/*`
shorthand). The private-API shorthand echo-expansion FP is a SEPARATE issue (#676),
NOT in this PR's scope; using a full ARN isolates the revert path so an out-of-band
policy change detects -> this revert converges -> CLEAN.

## Tests

`tests/writers.test.ts` — new suites for both writers:
- #667: routes to the whole-type SDK writer; `UpdateStage` carries ONLY the drifted
  property and NO `DeploymentId`; identifier resolved from the composite `ApiId|StageName`
  (plus the declared/physical-id fallback); throws when unresolvable.
- #677: routes a `Policy.Statement` drift to the nested RestApi writer (a non-Policy
  path is NOT captured); `UpdateRestApi` replaces `/policy` with the full serialized
  desired policy; an absent declared policy clears it; throws when the RestApiId is
  unresolvable.

All 3051 unit tests pass; typecheck / lint+format / build clean.
