### PR TITLE
fix(baseline): fold stale recorded entries on resource replacement + template removal (#674, #675)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -852,8 +852,16 @@ replace it — lives in [why-a-baseline-file.md](why-a-baseline-file.md).
   "accountId": "<aws account the baseline was captured in>",
   "capturedAt": "<iso>", "templateHash": "<hash of deployed template>",
   "recorded": [ { "logicalId", "resourceType", "path", "value" }, ... ],
-  "completeResources": [ "<logicalIds the record snapshot fully covered>" ] }
+  "completeResources": [ "<logicalIds the record snapshot fully covered>" ],
+  "recordedPhysicalIds": { "<logicalId>": "<physical id at record>", ... } }
 ```
+
+`recordedPhysicalIds` (additive, optional — #674) records the PHYSICAL id each
+resource's entries were snapshot against, so a later deploy that **replaces** a
+resource (new physical id) can void the now-stale entries (see the lifecycle
+paragraph below). Old committed baselines have no such field; a resource whose
+physical id was unknown at record time is simply absent — both fall back to the
+pre-#674 behavior (never void).
 
 **Per-entry classification (R62).** The unit of "recorded" is the ENTRY, not the
 file: an undeclared finding with a matching entry is suppressed; with an entry
@@ -906,6 +914,27 @@ removed since record". `applyBaseline` is passed the set of currently-declared k
 (`declaredKeysByLogical`) and suppresses that false removal, emitting a one-line
 stderr note ("now declared in the template — re-run `cdkrd record`") instead. So the
 behavior we recommend is never punished as drift.
+
+**Lifecycle folds (a normal deploy never re-surfaces stale entries).** Two IaC
+lifecycle events leave recorded entries pointing at state that no longer exists;
+both fold into a one-line stderr nudge (mirroring the promotion note), never drift:
+
+- **Removed from the template (#675).** A resource legitimately deleted from the
+  CDK app is in neither the template nor live AWS. `applyBaseline` is passed the
+  current template's logical-id set (`allLogicalIds`); a recorded entry whose
+  logicalId is absent from it is folded ("N baseline entries belong to resources no
+  longer in the template — re-run `cdkrd record`"), not reported as "baseline value
+  removed since record".
+- **Replaced by a deploy (#674).** A property change that forces a
+  create-before-delete replacement (e.g. adding an explicit `QueueName`) gives the
+  resource a NEW physical id; its recorded entries belong to the old, deleted
+  resource. `applyBaseline` compares the entry's `recordedPhysicalIds` value to
+  the LIVE physical id (`physicalIdByLogical`); when they DIFFER it voids every
+  entry for that logicalId — the fresh AWS default folds to `atDefault`, never as
+  "changed from your .cdkrd baseline", and revert never offers the stale value.
+  Backward compatible: it only voids when a recorded physical id EXISTS and DIFFERS
+  from a KNOWN live id (an old baseline with no recorded id, or an unread resource,
+  keeps prior behavior).
 
 **Stale-baseline warning.** `templateHash` (sha256 of the deployed template at
 capture) is verified on load (`warnTemplateHashDrift`): a mismatch prints a non-fatal

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -52,6 +52,15 @@ export interface BaselineFile {
   // is UNRECORDED (never decided). Monotonic: once complete, a resource stays
   // complete (declining to record a new appeared value must not demote it back).
   completeResources?: string[];
+  // #674: logicalId -> the PHYSICAL id the recorded entries were snapshot against.
+  // Additive & OPTIONAL — old committed baselines have none, and a resource whose
+  // physical id was unknown at record time is simply absent. At `applyBaseline` time
+  // an entry's recorded physical id (if present) is compared to the LIVE physical id:
+  // when they DIFFER, the resource was REPLACED by a deploy (create-before-delete,
+  // new physical id, fresh AWS defaults), so its recorded entries belong to the old,
+  // deleted resource and must NOT surface as drift against the new one. Absent/unknown
+  // recorded id -> fall back to today's behavior (never void).
+  recordedPhysicalIds?: Record<string, string>;
 }
 
 export function baselinePath(stackName: string, accountId: string, region: string): string {
@@ -117,6 +126,19 @@ function sortRecorded(recorded: RecordedEntry[]): RecordedEntry[] {
   );
 }
 
+/** #674: keep only physical ids for logicalIds that still carry a recorded entry, with
+ *  sorted keys, so the baseline JSON is byte-stable and free of dead entries. */
+function sortedPhysicalIds(
+  ids: Record<string, string>,
+  recorded: RecordedEntry[]
+): Record<string, string> {
+  const live = new Set(recorded.map((e) => e.logicalId));
+  const out: Record<string, string> = {};
+  for (const key of Object.keys(ids).sort())
+    if (live.has(key) && ids[key] !== undefined) out[key] = ids[key];
+  return out;
+}
+
 export async function writeBaselineFile(b: BaselineFile): Promise<string> {
   const p = baselinePath(b.stackName, b.accountId, b.region);
   await mkdir(dirname(p), { recursive: true });
@@ -126,6 +148,13 @@ export async function writeBaselineFile(b: BaselineFile): Promise<string> {
     ...b,
     recorded: sortRecorded(b.recorded),
     ...(b.completeResources ? { completeResources: [...b.completeResources].sort() } : {}),
+    // #674: write the physical-id map with sorted keys so the JSON stays byte-stable
+    // across machines (same clean-PR-diff goal as sortRecorded). Only for logicalIds
+    // that still have at least one recorded entry — a stray id for a resource with no
+    // entries would be dead weight.
+    ...(b.recordedPhysicalIds
+      ? { recordedPhysicalIds: sortedPhysicalIds(b.recordedPhysicalIds, b.recorded) }
+      : {}),
   };
   await writeFile(p, JSON.stringify(stable, null, 2) + '\n', 'utf8'); // pretty + stable for clean PR diffs
   return p;
@@ -174,7 +203,14 @@ export async function writeBaseline(
   findings: Finding[],
   rawTemplate: string,
   recorded: RecordedEntry[] = buildRecorded(findings),
-  opts: { allLogicalIds?: string[] | undefined; previous?: BaselineFile | undefined } = {}
+  opts: {
+    allLogicalIds?: string[] | undefined;
+    previous?: BaselineFile | undefined;
+    // #674: logicalId -> live physical id at record time, so a later deploy that
+    // REPLACES a resource (new physical id) can void its stale recorded entries.
+    // Optional: an omitting caller keeps today's (physical-id-less) behavior.
+    physicalIdByLogical?: Map<string, string> | undefined;
+  } = {}
 ): Promise<{ path: string; count: number }> {
   const allIds = opts.allLogicalIds ?? [
     ...new Set([...findings.map((f) => f.logicalId), ...recorded.map((a) => a.logicalId)]),
@@ -193,8 +229,35 @@ export async function writeBaseline(
       recorded,
       opts.previous?.completeResources ?? []
     ),
+    // #674: capture the physical id per recorded logicalId. writeBaselineFile prunes
+    // this to ids that still have an entry. Carry forward the previous baseline's map
+    // for ids this run did not resolve a physical id for, so a re-record does not drop
+    // a previously-captured id (symmetric with carryForwardUnreadable on `recorded`).
+    ...buildRecordedPhysicalIds(recorded, opts.physicalIdByLogical, opts.previous),
   });
   return { path, count: recorded.length };
+}
+
+/**
+ * #674: build the `recordedPhysicalIds` map (logicalId -> physical id) for the entries
+ * being written. Prefers the physical id resolved THIS run; falls back to the previous
+ * baseline's stored id when this run did not resolve one (a resource skipped / with no
+ * physical id must not lose its previously-captured id on re-record — else a later
+ * replacement could not be detected). Returns `{}` (spread to nothing) when no id is
+ * known, so the field stays absent on baselines with no physical ids at all.
+ */
+function buildRecordedPhysicalIds(
+  recorded: RecordedEntry[],
+  live: Map<string, string> | undefined,
+  previous: BaselineFile | undefined
+): { recordedPhysicalIds?: Record<string, string> } {
+  const prior = previous?.recordedPhysicalIds ?? {};
+  const out: Record<string, string> = {};
+  for (const e of recorded) {
+    const id = live?.get(e.logicalId) ?? prior[e.logicalId];
+    if (id !== undefined) out[e.logicalId] = id;
+  }
+  return Object.keys(out).length > 0 ? { recordedPhysicalIds: out } : {};
 }
 
 /**
@@ -425,6 +488,12 @@ export interface ApplyBaselineOptions {
   // making a recorded value removed out of band UN-revertable (a real revert FN: the
   // value the user chose to keep disappeared, yet `revert` refuses to restore it).
   physicalIdByLogical?: Map<string, string>;
+  // #675: the CURRENT template's full logical-id set. A recorded entry whose logicalId
+  // is absent from it belongs to a resource legitimately REMOVED from the template (and
+  // deleted by the deploy) — nothing drifted, so it must be folded into a nudge, never
+  // surfaced as "baseline value removed since record". Optional: when omitted, the
+  // absent-from-template check is skipped (today's behavior).
+  allLogicalIds?: Set<string> | string[];
   warn?: (s: string) => void; // stderr note channel for the promotion case
 }
 
@@ -463,6 +532,27 @@ export function applyBaseline(
   const recorded = baseline.recorded;
   const complete = new Set(baseline.completeResources ?? []); // v1 file: nothing complete
   const kept: Finding[] = [];
+  // #675: current template's logical-id set (optional). Recorded entries for a logicalId
+  // NOT in it belong to a resource removed from the template — folded, never surfaced.
+  const currentLogicalIds =
+    opts.allLogicalIds === undefined
+      ? undefined
+      : Array.isArray(opts.allLogicalIds)
+        ? new Set(opts.allLogicalIds)
+        : opts.allLogicalIds;
+  // #674: a logicalId whose RECORDED physical id differs from the LIVE physical id was
+  // REPLACED by a deploy (create-before-delete → new physical id, fresh AWS defaults).
+  // Its recorded entries belong to the old, deleted resource, so treat them all as VOID:
+  // never a suppression MATCH, never surfaced as "changed since record" drift, never a
+  // "removed since record" finding — just a folded nudge. Backward compatible: only void
+  // when a recorded id EXISTS and DIFFERS from a KNOWN live id (absent recorded id = old
+  // baseline; absent live id = unread this run → fall back to today's behavior).
+  const recordedPhysIds = baseline.recordedPhysicalIds ?? {};
+  const replacedLogical = new Set<string>();
+  for (const [logicalId, recordedId] of Object.entries(recordedPhysIds)) {
+    const liveId = opts.physicalIdByLogical?.get(logicalId);
+    if (liveId !== undefined && liveId !== recordedId) replacedLogical.add(logicalId);
+  }
   for (const f of findings) {
     // PR4: reconcile `added` against the baseline as a full mirror of undeclared — but on
     // the WHOLE resource (path ''), not a property. A matching entry whose value is equal
@@ -505,7 +595,14 @@ export function applyBaseline(
       kept.push(f);
       continue;
     }
-    const entry = recorded.find((a) => a.logicalId === f.logicalId && a.path === f.path);
+    // #674: on a REPLACED resource treat every recorded entry as absent — the snapshot
+    // was taken against the old, deleted physical resource, so it must not match/suppress
+    // or surface as "changed" against the brand-new one's fresh AWS defaults. The value
+    // then folds through the tiers below (an at-default value folds; a genuine non-default
+    // value on the new resource is unrecorded, not drift — the user never recorded IT).
+    const entry = replacedLogical.has(f.logicalId)
+      ? undefined
+      : recorded.find((a) => a.logicalId === f.logicalId && a.path === f.path);
     // re-canonicalize the baseline value through the CURRENT pipeline before comparing
     // (f.actual is already canonical from classify): a baseline recorded under older
     // normalization rules still matches today's live, so a cdkrd version bump alone
@@ -534,8 +631,11 @@ export function applyBaseline(
       kept.push(f);
       continue;
     }
-    if (complete.has(f.logicalId)) {
-      // the record snapshot covered this whole resource, so this value is new
+    if (complete.has(f.logicalId) && !replacedLogical.has(f.logicalId)) {
+      // the record snapshot covered this whole resource, so this value is new. #674: a
+      // REPLACED resource's completeness belongs to the OLD physical resource, so an
+      // undeclared value on the new one is NOT "appeared since record" — fall through to
+      // unrecorded (the user never recorded the replacement).
       kept.push({
         ...f,
         note: f.note ? `${f.note}; appeared since record` : 'appeared since record',
@@ -601,16 +701,33 @@ export function applyBaseline(
       (p) => path === p || path.startsWith(`${p}.`) || path.startsWith(`${p}[`)
     );
   const promotedStale: string[] = [];
+  const removedFromTemplate: string[] = []; // #675
+  const replacedStale: string[] = []; // #674
   for (const a of recorded) {
     // PR4: an `added`-resource entry has an empty path (the whole resource is the value)
     // and is reconciled in the loop above, never here. If its live resource is gone the
     // out-of-band addition was simply removed — nothing to "restore", so skip it (a
     // property-removal note against a synthesized child id would be meaningless).
     if (a.path === '') continue;
+    // #674: the resource was REPLACED by a deploy — this entry belongs to the old,
+    // deleted physical resource, so it is void, not "removed since record". Fold it.
+    if (replacedLogical.has(a.logicalId)) {
+      replacedStale.push(`${a.logicalId}.${a.path}`);
+      continue;
+    }
     if (currentPaths.has(`${a.logicalId}.${a.path}`)) continue;
     if (skippedLogical.has(a.logicalId)) continue; // unread this run -> not "removed"
     if (deletedLogical.has(a.logicalId)) continue; // subsumed by the `deleted` finding
     if (underDeclaredDrift(a.logicalId, a.path)) continue; // subsumed by parent declared drift
+    // #675: the resource is gone from the CURRENT template entirely (legitimately removed
+    // from IaC and deleted by the deploy). It is in neither template nor live AWS —
+    // nothing drifted, so fold into a nudge instead of a synthetic "removed since record"
+    // finding. Gated on a KNOWN logical-id set (opts.allLogicalIds present) so a caller
+    // that does not pass it keeps today's behavior.
+    if (currentLogicalIds !== undefined && !currentLogicalIds.has(a.logicalId)) {
+      removedFromTemplate.push(`${a.logicalId}.${a.path}`);
+      continue;
+    }
     // promoted into the template since record → not a removal, just stale baseline
     if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
       promotedStale.push(`${a.logicalId}.${a.path}`);
@@ -640,6 +757,9 @@ export function applyBaseline(
     });
   }
   if (promotedStale.length > 0) opts.warn?.(formatPromotedStaleNote(promotedStale));
+  if (removedFromTemplate.length > 0)
+    opts.warn?.(formatRemovedFromTemplateNote(removedFromTemplate));
+  if (replacedStale.length > 0) opts.warn?.(formatReplacedStaleNote(replacedStale));
   return kept;
 }
 
@@ -653,6 +773,28 @@ export function formatPromotedStaleNote(paths: string[]): string {
   const subject = n === 1 ? `baseline entry (${paths[0]}) is` : `${n} baseline entries are`;
   const them = n === 1 ? 'it' : 'them';
   return `note: ${subject} now declared in the template — re-run \`cdkrd record\` to clean ${them} up.`;
+}
+
+/**
+ * #675: the folded one-line note for baseline entries whose resource is no longer in
+ * the template at all (legitimately removed from IaC and deleted by the deploy). Mirror
+ * of formatPromotedStaleNote. Pure + exported for unit tests.
+ */
+export function formatRemovedFromTemplateNote(paths: string[]): string {
+  const n = paths.length;
+  const subject = n === 1 ? `baseline entry (${paths[0]}) belongs` : `${n} baseline entries belong`;
+  return `note: ${subject} to resources no longer in the template — re-run \`cdkrd record\` to clean them up.`;
+}
+
+/**
+ * #674: the folded one-line note for baseline entries recorded against a resource that a
+ * deploy has since REPLACED (new physical id). Mirror of formatPromotedStaleNote. Pure +
+ * exported for unit tests.
+ */
+export function formatReplacedStaleNote(paths: string[]): string {
+  const n = paths.length;
+  const subject = n === 1 ? `baseline entry (${paths[0]}) was` : `${n} baseline entries were`;
+  return `note: ${subject} recorded against a resource since REPLACED by a deploy — re-run \`cdkrd record\`.`;
 }
 
 /** logicalId -> set of declared top-level keys, for applyBaseline's promotion check. */

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -381,6 +381,9 @@ export async function runCheck(args: string[]): Promise<number> {
             declaredByLogical: declaredKeysByLogical(desired.resources),
             constructPathByLogical: constructPathsByLogical(desired.resources),
             physicalIdByLogical: physicalIdsByLogical(desired.resources),
+            // #675: current template's logical-id set so recorded entries for a resource
+            // removed from the template fold into a nudge (not phantom "removed" drift).
+            allLogicalIds: desired.resources.map((r) => r.logicalId),
             warn: (s: string) => {
               if (!a.json) console.error(s);
             },

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -10,6 +10,7 @@ import {
   checkBaselineAccount,
   declaredKeysByLogical,
   loadBaseline,
+  physicalIdsByLogical,
 } from '../baseline/baseline-file.js';
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
@@ -68,6 +69,8 @@ export async function runIgnore(args: string[]): Promise<number> {
       const reconciled = applyIgnores(
         applyBaseline(findings, baseline, {
           declaredByLogical: declaredKeysByLogical(desired.resources),
+          physicalIdByLogical: physicalIdsByLogical(desired.resources),
+          allLogicalIds: desired.resources.map((r) => r.logicalId),
           warn: console.error,
         }),
         { stackName, accountId: desired.accountId, region },

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -172,6 +172,8 @@ const baselineOpts = (p: ResolveParams): ApplyBaselineOptions => ({
   declaredByLogical: declaredKeysByLogical(p.desired.resources),
   constructPathByLogical: constructPathsByLogical(p.desired.resources),
   physicalIdByLogical: physicalIdsByLogical(p.desired.resources),
+  // #675: fold recorded entries whose resource was removed from the template.
+  allLogicalIds: p.desired.resources.map((r) => r.logicalId),
 });
 
 /**

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -386,8 +386,13 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
     desired.rawTemplate,
     recorded,
     // full resource list (read-clean resources are snapshot-complete too) +
-    // previous baseline so completeness stays monotonic across re-records (R62)
-    { allLogicalIds: desired.resources.map((r) => r.logicalId), previous: existing }
+    // previous baseline so completeness stays monotonic across re-records (R62) +
+    // #674: per-resource physical id so a later REPLACING deploy can void stale entries
+    {
+      allLogicalIds: desired.resources.map((r) => r.logicalId),
+      previous: existing,
+      physicalIdByLogical: physicalIdsByLogical(desired.resources),
+    }
   );
   console.log(style.ok(recordOutcomeMessage(stackName, path, count, refreshedOnly, !!existing)));
   // record's scope excludes declared/deleted: if such drift is present, say so —
@@ -753,7 +758,16 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // lets a constructPath-form ignore rule match it during applyIgnores.
   const physicalIdByLogical = physicalIdsByLogical(gathered.desired.resources);
   const constructPathByLogical = constructPathsByLogical(gathered.desired.resources);
-  const baselineOpts = { declaredByLogical, physicalIdByLogical, constructPathByLogical };
+  // #675: the current template's logical-id set so applyBaseline can fold recorded
+  // entries whose resource was removed from the template. #674 reuses physicalIdByLogical
+  // (LIVE physical ids) to void entries recorded against a since-REPLACED resource.
+  const allLogicalIds = gathered.desired.resources.map((r) => r.logicalId);
+  const baselineOpts = {
+    declaredByLogical,
+    physicalIdByLogical,
+    constructPathByLogical,
+    allLogicalIds,
+  };
   const drifted = applyIgnores(
     applyBaseline(gathered.findings, baseline, { ...baselineOpts, warn: console.error }),
     { stackName, accountId: gathered.desired.accountId, region },

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -13,6 +13,8 @@ import {
   constructPathsByLogical,
   physicalIdsByLogical,
   formatPromotedStaleNote,
+  formatRemovedFromTemplateNote,
+  formatReplacedStaleNote,
   identityArrayDelta,
   checkBaselineAccount,
   computeCompleteResources,
@@ -901,6 +903,224 @@ describe('baseline', () => {
     const out = applyBaseline([], b, { declaredByLogical: new Map([['A', new Set(['Other'])]]) });
     expect(out).toHaveLength(1);
     expect(out[0]).toMatchObject({ note: 'baseline value removed since record' });
+  });
+
+  describe('#675 — resource REMOVED from the template (baseline entries folded, not phantom drift)', () => {
+    it('folds a recorded entry whose logicalId is absent from the current template', () => {
+      // 'A' was removed from the template and deleted by the deploy. It is in neither the
+      // template nor live AWS — its recorded entry must not surface as "removed since record".
+      const b = baseline([
+        { logicalId: 'A', resourceType: 'AWS::S3::Bucket', path: 'P', value: ['x'] },
+      ]);
+      const warnings: string[] = [];
+      const out = applyBaseline([], b, {
+        allLogicalIds: ['B', 'C'], // 'A' gone from the template
+        warn: (m) => warnings.push(m),
+      });
+      expect(out).toHaveLength(0); // never surfaced as drift
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('no longer in the template');
+      expect(warnings[0]).toContain('re-run `cdkrd record`');
+    });
+
+    it('folds MANY removed-from-template entries into ONE warn line', () => {
+      const b = baseline([
+        { logicalId: 'A', resourceType: 'AWS::S3::Bucket', path: 'P1', value: 1 },
+        { logicalId: 'A', resourceType: 'AWS::S3::Bucket', path: 'P2', value: 2 },
+      ]);
+      const warnings: string[] = [];
+      const out = applyBaseline([], b, { allLogicalIds: ['Other'], warn: (m) => warnings.push(m) });
+      expect(out).toHaveLength(0);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain(
+        '2 baseline entries belong to resources no longer in the template'
+      );
+    });
+
+    it('a still-present logicalId behaves as before (genuine removal still surfaces)', () => {
+      // 'A' is STILL in the template, so a recorded path now absent is a genuine removal.
+      const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+      const out = applyBaseline([], b, { allLogicalIds: ['A'] });
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ note: 'baseline value removed since record' });
+    });
+
+    it('with NO allLogicalIds passed, keeps today’s behavior (surfaces the removal)', () => {
+      const b = baseline([{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: ['x'] }]);
+      const out = applyBaseline([], b); // no allLogicalIds
+      expect(out).toHaveLength(1);
+      expect(out[0]).toMatchObject({ note: 'baseline value removed since record' });
+    });
+  });
+
+  describe('#674 — resource REPLACED by a deploy (stale entries voided when live physId differs)', () => {
+    const atDef = (logicalId: string, path: string, value: unknown): Finding => ({
+      tier: 'atDefault',
+      logicalId,
+      resourceType: 'AWS::SQS::Queue',
+      path,
+      actual: value,
+    });
+    // helper: a baseline carrying a recorded physical id for the logicalId
+    const withPhys = (
+      recorded: BaselineFile['recorded'],
+      recordedPhysicalIds: Record<string, string>
+    ): BaselineFile => ({ ...baseline(recorded), recordedPhysicalIds });
+
+    it('voids a changed-from-baseline entry when the live physical id DIFFERS (replacement)', () => {
+      // Recorded VisibilityTimeout=120 against the OLD queue (phys-old). The new (replaced)
+      // queue reads the fresh AWS default 30 (atDefault). Without the fix this surfaces as
+      // "changed from your .cdkrd baseline" drift; the recorded 120 belongs to a deleted queue.
+      const b = withPhys(
+        [
+          {
+            logicalId: 'Q',
+            resourceType: 'AWS::SQS::Queue',
+            path: 'VisibilityTimeout',
+            value: 120,
+          },
+        ],
+        { Q: 'phys-old' }
+      );
+      const warnings: string[] = [];
+      const out = applyBaseline([atDef('Q', 'VisibilityTimeout', 30)], b, {
+        physicalIdByLogical: new Map([['Q', 'phys-new']]),
+        warn: (m) => warnings.push(m),
+      });
+      // the fresh default folds (atDefault passes through as folded inventory, not drift)
+      expect(out.some((f) => f.tier === 'undeclared')).toBe(false);
+      // and a folded nudge is emitted
+      expect(warnings.some((w) => w.includes('since REPLACED by a deploy'))).toBe(true);
+    });
+
+    it('does NOT surface a "removed since record" finding for a replaced resource', () => {
+      // The recorded path is gone from the (new) resource's findings — but because the
+      // resource was replaced, it is void, not "removed since record".
+      const b = withPhys(
+        [
+          {
+            logicalId: 'Q',
+            resourceType: 'AWS::SQS::Queue',
+            path: 'VisibilityTimeout',
+            value: 120,
+          },
+        ],
+        { Q: 'phys-old' }
+      );
+      const warnings: string[] = [];
+      const out = applyBaseline([], b, {
+        physicalIdByLogical: new Map([['Q', 'phys-new']]),
+        warn: (m) => warnings.push(m),
+      });
+      expect(out.some((f) => f.note === 'baseline value removed since record')).toBe(false);
+      expect(warnings.some((w) => w.includes('since REPLACED by a deploy'))).toBe(true);
+    });
+
+    it('a MATCHING physical id behaves as before (recorded value still compared → drift)', () => {
+      // Same physical id -> not replaced. A changed live value is real drift.
+      const b = withPhys(
+        [
+          {
+            logicalId: 'Q',
+            resourceType: 'AWS::SQS::Queue',
+            path: 'VisibilityTimeout',
+            value: 120,
+          },
+        ],
+        { Q: 'phys-same' }
+      );
+      const out = applyBaseline([atDef('Q', 'VisibilityTimeout', 30)], b, {
+        physicalIdByLogical: new Map([['Q', 'phys-same']]),
+      });
+      // recorded 120 vs live 30 -> surfaces as drift (forced to undeclared)
+      expect(out.some((f) => f.tier === 'undeclared' && f.path === 'VisibilityTimeout')).toBe(true);
+    });
+
+    it('a MISSING recorded physical id (old baseline) falls back to today’s behavior (no void)', () => {
+      // Old committed baseline: no recordedPhysicalIds. Even if the live id "differs", there
+      // is nothing to compare, so the recorded value is compared as usual (→ drift).
+      const b = baseline([
+        { logicalId: 'Q', resourceType: 'AWS::SQS::Queue', path: 'VisibilityTimeout', value: 120 },
+      ]);
+      const out = applyBaseline([atDef('Q', 'VisibilityTimeout', 30)], b, {
+        physicalIdByLogical: new Map([['Q', 'phys-new']]),
+      });
+      expect(out.some((f) => f.tier === 'undeclared' && f.path === 'VisibilityTimeout')).toBe(true);
+    });
+
+    it('an UNKNOWN live physical id (unread this run) does NOT void — fall back to today’s behavior', () => {
+      const b = withPhys(
+        [
+          {
+            logicalId: 'Q',
+            resourceType: 'AWS::SQS::Queue',
+            path: 'VisibilityTimeout',
+            value: 120,
+          },
+        ],
+        { Q: 'phys-old' }
+      );
+      const out = applyBaseline([atDef('Q', 'VisibilityTimeout', 30)], b, {
+        physicalIdByLogical: new Map(), // no live id resolved
+      });
+      expect(out.some((f) => f.tier === 'undeclared' && f.path === 'VisibilityTimeout')).toBe(true);
+    });
+  });
+
+  describe('formatRemovedFromTemplateNote (#675 — folded one-liner)', () => {
+    it('singular names the one entry', () => {
+      expect(formatRemovedFromTemplateNote(['A.P'])).toBe(
+        'note: baseline entry (A.P) belongs to resources no longer in the template — re-run `cdkrd record` to clean them up.'
+      );
+    });
+    it('plural folds to a count (no per-entry list)', () => {
+      const note = formatRemovedFromTemplateNote(['A.P1', 'A.P2', 'B.Q']);
+      expect(note).toContain('3 baseline entries belong to resources no longer in the template');
+      expect(note).not.toContain('A.P1');
+    });
+  });
+
+  describe('formatReplacedStaleNote (#674 — folded one-liner)', () => {
+    it('singular names the one entry', () => {
+      expect(formatReplacedStaleNote(['Q.VisibilityTimeout'])).toBe(
+        'note: baseline entry (Q.VisibilityTimeout) was recorded against a resource since REPLACED by a deploy — re-run `cdkrd record`.'
+      );
+    });
+    it('plural folds to a count (no per-entry list)', () => {
+      const note = formatReplacedStaleNote(['Q.A', 'Q.B']);
+      expect(note).toContain('2 baseline entries were recorded against a resource since REPLACED');
+      expect(note).not.toContain('Q.A');
+    });
+  });
+
+  describe('writeBaseline captures recordedPhysicalIds (#674)', () => {
+    it('stores per-resource physical id, pruned to logicalIds with an entry, sorted', () => {
+      const recorded: BaselineFile['recorded'] = [
+        { logicalId: 'Q', resourceType: 'AWS::SQS::Queue', path: 'VisibilityTimeout', value: 30 },
+      ];
+      // exercise sortedPhysicalIds directly via writeBaselineFile to keep this pure (no fs
+      // in this assertion; the round-trip fs test lives in the writeBaselineFile block).
+      const file: BaselineFile = {
+        ...baseline(recorded),
+        schemaVersion: 2,
+        recordedPhysicalIds: { Z: 'phys-Z-noentry', Q: 'phys-Q' },
+      };
+      // sortedPhysicalIds is internal; assert its effect through a fs round-trip.
+      return (async () => {
+        const dir = await mkdtemp(join(tmpdir(), 'cdkrd-phys-'));
+        const cwd = process.cwd();
+        process.chdir(dir);
+        try {
+          const p = await writeBaselineFile(file);
+          const reread = JSON.parse(await readFile(p, 'utf8')) as BaselineFile;
+          // 'Z' has no recorded entry -> pruned; only 'Q' remains
+          expect(reread.recordedPhysicalIds).toEqual({ Q: 'phys-Q' });
+        } finally {
+          process.chdir(cwd);
+          await rm(dir, { recursive: true, force: true });
+        }
+      })();
+    });
   });
 
   describe('writeBaselineFile (deterministic order, R40)', () => {


### PR DESCRIPTION
## Summary

Two baseline-lifecycle **false positives** on normal IaC deploys — both would make
CI `check --fail` exit 1 on a stack the user only touched through CDK/CloudFormation.
One PR closes both.

Closes #674
Closes #675

## #675 — resource REMOVED from the template (phantom "removed since record")

**Root cause.** When a resource with recorded baseline entries is legitimately
deleted from the CDK app and the removal is deployed, its logicalId is absent from
the current template entirely. `applyBaseline`'s removal walk suppressed recorded
entries only for `skipped` / out-of-band `deleted` / under-declared-drift /
promoted-into-template — none of which match a resource simply gone from the
template — so every entry fell through to the synthetic `baseline value removed
since record` undeclared finding (`actual=undefined`). The resource is in neither
the template nor live AWS: nothing drifted.

**Fix.** `applyBaseline` now receives the current template's logical-id set
(`allLogicalIds`, already threaded to the caller). A recorded entry whose logicalId
is absent from it is folded into a one-line nudge instead of surfaced:

> note: N baseline entries belong to resources no longer in the template — re-run `cdkrd record` to clean them up.

## #674 — resource REPLACED by a deploy (stale entries resurrected)

**Root cause.** A property change that forces a create-before-delete replacement
(e.g. adding an explicit `QueueName` to an `AWS::SQS::Queue`) gives the resource a
NEW physical id. A `RecordedEntry` stored no physical id, so `applyBaseline` matched
entries by `(logicalId, path)` only — the entries recorded against the OLD, deleted
resource applied verbatim to the brand-new one. Its fresh AWS default then read as
`CFn-Undeclared Drift ("changed from your .cdkrd baseline")`, and `revert` offered
to write the stale value onto the new resource.

**Fix.** `record` now captures the resource's physical id per logicalId; at
`applyBaseline` time, when the LIVE physical id differs from the recorded one, all
that resource's entries are treated as VOID for drift purposes — the fresh default
folds to `atDefault`, never surfaces as drift, and revert never offers the stale
value. A one-line nudge is emitted:

> note: N baseline entries were recorded against a resource since REPLACED by a deploy — re-run `cdkrd record`.

## Baseline file-format addition (additive, backward-compatible)

New OPTIONAL field on the baseline JSON:

```jsonc
"recordedPhysicalIds": { "<logicalId>": "<physical id at record>", ... }
```

- Keys pruned to logicalIds that still carry a recorded entry, sorted for
  byte-stable clean PR diffs.
- Carried forward on re-record for resources this run did not resolve a physical id
  for (symmetric with `carryForwardUnreadable`), so a re-record never drops a
  previously-captured id.
- **Backward compat:** old committed baselines have no such field; a resource whose
  physical id was unknown is simply absent. The replacement check **only voids when a
  recorded id EXISTS and DIFFERS from a KNOWN live id** — an old baseline, or an
  unread resource, falls back to today's behavior (never void). Old baselines load
  unchanged.

## Threading

`applyBaseline` gained two optional, backward-compatible options: `allLogicalIds`
(#675) and reuse of the existing live `physicalIdByLogical` map (#674). Both are
threaded from values already computed at each caller (`desired.resources`) —
`check.ts`, `stack-actions.ts` (check + revert), `ignore.ts`,
`interactive-resolve.ts`. `writeBaseline` gained an optional `physicalIdByLogical`
so `record` captures the ids. The core logic is confined to
`src/baseline/baseline-file.ts`.

## Tests

Added to `tests/baseline.test.ts`:
- #675: an entry whose logicalId is absent from `allLogicalIds` is folded (single +
  many-into-one-line); a still-present logicalId's genuine removal still surfaces;
  with no `allLogicalIds` passed, prior behavior is kept.
- #674: a differing recorded physical id voids the entries with a nudge (both the
  "changed" and "removed" paths); a matching id behaves as before; a missing recorded
  id (old baseline) and an unknown live id both fall back to prior behavior.
- Both new folded-nudge formatters (singular + plural fold), and `writeBaseline`
  physical-id capture / pruning.

All 3057 unit tests pass; typecheck / lint+format / build clean.
