### PR TITLE
fix(revert): converge #651 sibling subnet attrs (PrivateDnsNameOptionsOnLaunch + AssignIpv6AddressOnCreation)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -160,9 +160,22 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   // revert looped forever, #651). The subnet's `EnableDns64` default is the plain constant
   // `false`, but it folds `atDefault` via the CFn SCHEMA default (not KNOWN_DEFAULTS), so the
   // set-default value comes from REVERT_SET_DEFAULT_VALUES below rather than KNOWN_DEFAULTS.
-  // (The issue also flags sibling booleans AssignIpv6AddressOnCreation / Ipv6Native /
-  // PrivateDnsNameOptionsOnLaunch as candidates for the same silent no-op — left UNVERIFIED
-  // pending a live repro, so not added here.)
+  // Sibling undeclared subnet attributes hit by the same EC2 ModifySubnetAttribute
+  // omit-is-ignored no-op the #651 issue flagged — each folds `atDefault` from
+  // KNOWN_DEFAULTS (AWS::EC2::Subnet), so writing that default explicitly converges
+  // where a `remove` silently no-ops.
+  //   - PrivateDnsNameOptionsOnLaunch: LIVE-VERIFIED 2026-07-08 on a dual-stack VPC —
+  //     enabled a resource-name DNS record out of band, `revert`'s `remove` left it
+  //     unchanged ("1 drift(s) remain"), the set-default (whole default object)
+  //     converges (CLEAN after revert). This is the object-valued twin of EnableDns64.
+  //   - AssignIpv6AddressOnCreation: CDK DECLARES it on every dual-stack subnet, so it is
+  //     not reachable as undeclared drift through CDK (a declared revert already
+  //     converges); this entry defensively covers the raw-CFn case where the attribute is
+  //     left undeclared and flipped out of band — same provider omit-no-op, same fix.
+  //   - Ipv6Native is create-only (not settable by ModifySubnetAttribute), so it cannot
+  //     drift out of band and needs no revert entry — it folds fine as `atDefault`.
+  'AWS::EC2::Subnet\0AssignIpv6AddressOnCreation',
+  'AWS::EC2::Subnet\0PrivateDnsNameOptionsOnLaunch',
   'AWS::EC2::Subnet\0EnableDns64',
 ]);
 

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -383,6 +383,52 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#651 sibling: undeclared EC2 Subnet PrivateDnsNameOptionsOnLaunch -> add op writing the default object', () => {
+    // LIVE-VERIFIED 2026-07-08: same EC2 ModifySubnetAttribute omit-no-op as EnableDns64 —
+    // enabling a resource-name DNS record out of band then reverting via `remove` left the
+    // live value unchanged ("1 drift(s) remain"); writing the whole KNOWN_DEFAULTS default
+    // object converged (CLEAN after revert). The object-valued twin of EnableDns64.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::Subnet',
+      path: 'PrivateDnsNameOptionsOnLaunch',
+      actual: {
+        EnableResourceNameDnsARecord: true,
+        HostnameType: 'ip-name',
+        EnableResourceNameDnsAAAARecord: false,
+      },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/PrivateDnsNameOptionsOnLaunch',
+      value: {
+        EnableResourceNameDnsARecord: false,
+        HostnameType: 'ip-name',
+        EnableResourceNameDnsAAAARecord: false,
+      },
+    });
+  });
+
+  it('#651 sibling: undeclared EC2 Subnet AssignIpv6AddressOnCreation -> add op writing the false default', () => {
+    // Same provider omit-no-op class; defensively covers the raw-CFn case where the
+    // attribute is left undeclared (CDK always declares it on dual-stack subnets) and
+    // flipped out of band. The `false` default is sourced from KNOWN_DEFAULTS.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::Subnet',
+      path: 'AssignIpv6AddressOnCreation',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AssignIpv6AddressOnCreation',
+      value: false,
+      prior: true,
+    });
+  });
+
   it('Transfer Server SecurityPolicyName (SET-DEFAULT) -> add op writing the default policy, not a no-op remove', () => {
     // AWS::Transfer::Server SecurityPolicyName is in REVERT_SET_DEFAULT_PATHS: UpdateServer
     // leaves the policy UNCHANGED when it is OMITTED, so a bare `remove` of an out-of-band


### PR DESCRIPTION
Follow-up to #651 (EnableDns64, PR #669). The issue flagged sibling subnet attributes as candidates for the same silent-no-op revert (EC2 `ModifySubnetAttribute` ignores an omitted attribute). Verified live 2026-07-08 on a dual-stack VPC and fixed the reachable one.

## Findings
- **PrivateDnsNameOptionsOnLaunch** — CONFIRMED same bug. Enabled a resource-name DNS record out of band → `check` detected it (undeclared) → `revert`'s `remove` left the live value unchanged (`1 drift(s) remain`). Added to `REVERT_SET_DEFAULT_PATHS`; the set-default now writes the whole default object from `KNOWN_DEFAULTS` → **CLEAN after revert** (live-confirmed). This is the object-valued twin of EnableDns64.
- **AssignIpv6AddressOnCreation** — CDK **always declares** it on dual-stack subnets, so it is not reachable as undeclared drift through CDK (a declared revert already converges). Added defensively for the raw-CFn case where it's left undeclared and flipped out of band — same provider omit-no-op, same `KNOWN_DEFAULTS`-backed fix.
- **Ipv6Native** — create-only (not settable by `ModifySubnetAttribute`), cannot drift out of band → no revert entry needed; folds fine as `atDefault`.

## Verification
Deployed a dual-stack VPC (+ an isolated-only variant), mutated out of band, confirmed the pre-fix silent no-op, applied the fix, confirmed convergence, then tore both down with `delstack` (swept clean). Unit tests added for both new set-default paths (revert-plan.test.ts, 3045 tests pass).

Scoped to `src/revert/plan.ts` + its test. (Separately spotted an unrelated first-run FP — VPCCidrBlock ipv6 CIDR / NetworkBorderGroup surface as potential drift on a clean isolated dual-stack VPC — filing as its own issue.)