### PR TITLE
fix(noise): fold VPCCidrBlock AmazonProvided ipv6 block + border group value-independent (#684)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2489,6 +2489,15 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::EC2::EIP': new Set(['NetworkBorderGroup']),
   'AWS::EC2::VPCEndpoint': new Set(['ServiceRegion', 'DnsOptions']),
   'AWS::EC2::VPCPeeringConnection': new Set(['PeerRegion']),
+  //     * EC2 VPCCidrBlock `Ipv6CidrBlock` + `Ipv6CidrBlockNetworkBorderGroup` — a
+  //       dual-stack / secondary-CIDR association that declares `AmazonProvidedIpv6CidrBlock`
+  //       (no explicit block) reads back the /56 AWS allocates plus its border group
+  //       (defaulting to the region), both AWS-assigned at creation, create-only, and per-VPC
+  //       (the block AWS picks differs every deploy). A user who brings their own CIDR DECLARES
+  //       `Ipv6CidrBlock` (compared in the declared loop); undeclared, these are AWS's choice,
+  //       never user intent. First-run FP on every clean dual-stack VPC (#684, live 2026-07-08);
+  //       mirrors EIP `NetworkBorderGroup` / `PrivateIpAddress`.
+  'AWS::EC2::VPCCidrBlock': new Set(['Ipv6CidrBlock', 'Ipv6CidrBlockNetworkBorderGroup']),
   //   AWS::Grafana::Workspace.GrafanaVersion — a workspace that pins no explicit version reads
   //   back the concrete Grafana version AWS provisioned ("10.4" today). AWS assigns the current
   //   GA default at creation, and that default moves over time (a fresh deploy next year reads a

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -770,6 +770,21 @@ describe('noise suppressors', () => {
     ); // #633
   });
 
+  it('VPCCidrBlock AmazonProvided ipv6 block + border group fold value-independent (#684)', () => {
+    // A dual-stack / secondary-CIDR association that declares AmazonProvidedIpv6CidrBlock (no
+    // explicit block) reads back the /56 AWS allocates plus its NetworkBorderGroup — both
+    // AWS-assigned at creation, create-only, per-VPC. First-run [Potential Drift] FP on every
+    // clean dual-stack VPC until folded (live-verified 2026-07-08, us-east-1: check went from
+    // 2 potential drift to CLEAN). A user who brings their own CIDR DECLARES Ipv6CidrBlock,
+    // which is then compared in the declared dimension (detection preserved).
+    expect(VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::EC2::VPCCidrBlock']).toContain(
+      'Ipv6CidrBlock'
+    ); // #684
+    expect(VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS['AWS::EC2::VPCCidrBlock']).toContain(
+      'Ipv6CidrBlockNetworkBorderGroup'
+    ); // #684
+  });
+
   it('ResourceExplorer2 View undeclared Scope folds via the context-ARN default (#626)', () => {
     // The account-root Scope is a tier-2 DERIVED default (arn:<partition>:iam::<account>:root),
     // built from the read context and equality-gated so a view scoped elsewhere still surfaces.


### PR DESCRIPTION
Fixes #684. A clean deploy of a dual-stack VPC (`ec2.Vpc({ ipProtocol: DUAL_STACK })`) surfaced **2 first-run `[Potential Drift]`** on `AWS::EC2::VPCCidrBlock`:
- `Ipv6CidrBlock` — the /56 AWS allocates for AmazonProvidedIpv6CidrBlock
- `Ipv6CidrBlockNetworkBorderGroup` — defaults to the region

Both are AWS-assigned at creation, create-only, and per-VPC (the block AWS picks differs every deploy), so they can be neither pinned as a constant nor derived — **tier-3 value-independent**, mirroring the established `EIP.NetworkBorderGroup` / `PrivateIpAddress` precedents. Detection is preserved: a user who brings their own CIDR **declares** `Ipv6CidrBlock`, which is then compared in the declared dimension.

## Verification
Live-verified us-east-1: deployed a dual-stack VPC, `check` went from **2 potential drift → CLEAN** (the 2 values now fold `atDefault`), then torn down with `delstack` (swept clean). Unit test asserts both folds (3068 tests pass).

Found during #651 sibling verification; scoped to `src/normalize/noise.ts` + its test.