### PR TITLE
fix(normalize): drop bare null array-element husks in CC read (S3 TagFilters:[null], #641)

### DIFF
--- a/src/normalize/cc-api-strip.ts
+++ b/src/normalize/cc-api-strip.ts
@@ -60,7 +60,20 @@ export function stripCcApiAwsManagedFields(
 // so this is a defensive hardening to keep the two free-form guards consistent.
 function stripWalk(value: unknown, freeForm: boolean): unknown {
   if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map((v) => stripWalk(v, freeForm));
+  if (Array.isArray(value)) {
+    const mapped = value.map((v) => stripWalk(v, freeForm));
+    // A bare JSON `null` array ELEMENT is never a meaningful user value — it is a
+    // service read artifact. S3, for one, echoes `TagFilters: [null]` inside every
+    // prefix-scoped IntelligentTiering / Metrics config element that declares no
+    // tag filter (#641), which then surfaces as a first-run undeclared FP on a
+    // clean deploy. Drop null/undefined elements so the husk never surfaces; a REAL
+    // out-of-band edit produces non-null objects, which still surface. Only outside
+    // free-form USER maps (Lambda env Variables, Glue Parameters, …), where an array
+    // value would be the user's own data and must be preserved verbatim. (This is
+    // the safe complement to the #632 lesson: a null husk is droppable; a meaningful
+    // scalar like `false` is not — and this drops only nulls, never scalars.)
+    return freeForm ? mapped : mapped.filter((v) => v !== null && v !== undefined);
+  }
   if (typeof value === 'object') {
     const out: Record<string, unknown> = {};
     for (const [k, child] of Object.entries(value as Record<string, unknown>)) {

--- a/tests/corpus/AWS__S3__Bucket.Data666C94C7_s3extras.json
+++ b/tests/corpus/AWS__S3__Bucket.Data666C94C7_s3extras.json
@@ -321,36 +321,6 @@
       },
       "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
       "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Data666C94C7",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "IntelligentTieringConfigurations[dataTier].TagFilters",
-      "actual": [null],
-      "nested": true,
-      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
-      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Data666C94C7",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "IntelligentTieringConfigurations[logsTier].TagFilters",
-      "actual": [null],
-      "nested": true,
-      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
-      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Data666C94C7",
-      "resourceType": "AWS::S3::Bucket",
-      "path": "MetricsConfigurations[LogsOnly].TagFilters",
-      "actual": [null],
-      "nested": true,
-      "physicalId": "cdkrealdriftintegs3richextras-data666c94c7-45yg6ntha7ln",
-      "constructPath": "CdkRealDriftIntegS3RichExtras/Data"
     }
   ]
 }

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -1345,6 +1345,45 @@ describe('cc-api strip', () => {
     });
     expect(out).toEqual({ LoggingConfiguration: { Level: 'OFF' } });
   });
+
+  it('drops bare null array-element husks (S3 TagFilters:[null], #641)', () => {
+    // S3 echoes `TagFilters: [null]` inside every prefix-scoped IntelligentTiering /
+    // Metrics config element that declares no tag filter — a service read artifact, not
+    // a user value. The null husk is dropped so it never surfaces as first-run undeclared
+    // drift; a REAL out-of-band edit produces non-null objects, which are preserved.
+    const out = stripCcApiAwsManagedFields({
+      IntelligentTieringConfigurations: [{ Id: 'dataTier', Prefix: 'data/', TagFilters: [null] }],
+      MetricsConfigurations: [
+        { Id: 'EntireBucket' },
+        { Id: 'LogsOnly', Prefix: 'logs/', TagFilters: [null] },
+      ],
+    });
+    expect(out).toEqual({
+      IntelligentTieringConfigurations: [{ Id: 'dataTier', Prefix: 'data/', TagFilters: [] }],
+      MetricsConfigurations: [
+        { Id: 'EntireBucket' },
+        { Id: 'LogsOnly', Prefix: 'logs/', TagFilters: [] },
+      ],
+    });
+  });
+
+  it('keeps a real (non-null) array element, dropping only the null husk', () => {
+    // a genuine out-of-band TagFilter is a non-null object and must keep surfacing —
+    // only the interleaved null artifact is removed.
+    const out = stripCcApiAwsManagedFields({
+      TagFilters: [{ Key: 'team', Value: 'a' }, null],
+    });
+    expect(out).toEqual({ TagFilters: [{ Key: 'team', Value: 'a' }] });
+  });
+
+  it('does NOT drop null array elements under a free-form USER map (user data preserved)', () => {
+    // inside a free-form map the array is the user's own data; a null there is the user's,
+    // not a service artifact, so it is left verbatim (consistent with the sticky free-form guard).
+    const out = stripCcApiAwsManagedFields({
+      Environment: { Variables: { list: [null, 'v'] } },
+    });
+    expect(out).toEqual({ Environment: { Variables: { list: [null, 'v'] } } });
+  });
 });
 
 describe('parseSchema', () => {


### PR DESCRIPTION
## What

S3 echoes `TagFilters: [null]` inside every **prefix-scoped** IntelligentTiering / Metrics config element that declares no tag filter — a JSON `null` array element, a service read artifact rather than a user value. On a clean, un-mutated deploy this surfaced on the very first `check` as first-run undeclared `[Potential Drift]` (symptom 1 of #641), violating the core invariant that a clean deploy has ZERO potential drift.

## Fix

Strip `null`/`undefined` **array elements** at CC-strip time (`stripCcApiAwsManagedFields`), outside free-form USER maps (Lambda env `Variables`, Glue `Parameters`, …) where an array value would be the user's own data and is preserved verbatim. A REAL out-of-band TagFilter edit produces non-null objects, which still surface — out-of-band detection is preserved. This is the safe complement to the #632 lesson: a null husk is droppable; a meaningful scalar like `false` is not, and this drops only nulls.

## Scope

- **Symptom 1 (first-run FP) — fixed here.** `[null]` → `[]` folds cleanly (empty array is trivial-empty), so the three findings vanish.
- **Symptom 2 (revert poison) — follow-up, NOT in this PR.** The `[null]` husk that breaks a Cloud Control read-modify-write revert of an *unrelated* property lives in Cloud Control's **own server-side model** (S3's read handler returns what S3's update handler rejects). `cc-api-strip` runs only in the diff view (`classify.ts`), never in the revert path, which sends an RFC6902 patch that CC applies to its own model. Closing symptom 2 needs husk-removal patch ops emitted from `revert/plan.ts` + a live S3 deploy — tracked as a follow-up on #641.

## Tests

- `tests/noise-and-strip.test.ts`: drops the `[null]` husk, keeps a real non-null element, and leaves null array elements under a free-form map untouched.
- `tests/corpus/AWS__S3__Bucket.Data666C94C7_s3extras.json`: the 3 `TagFilters` undeclared findings removed; `corpus-replay` reproduces the clean output offline (this corpus case was live-harvested 2026-07-08, us-east-1 — the authoritative live evidence for this fold fix).

Refs #641 (kept open for symptom 2).
