### PR TITLE
fix(noise): fold ASG first-run undeclared batch + EC2 LaunchTemplate generated-name echo (#639)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -885,6 +885,16 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Cooldown: '300', // default cooldown 300s (CC returns it as a string)
     HealthCheckType: 'EC2',
     HealthCheckGracePeriod: 0,
+    // Constant defaults AWS materializes into a fresh ASG that declares none of them
+    // (live-verified on a minimal Min/Max/Desired ASG, hunt 2026-07-08 #639). Each is a
+    // stable documented default, so equality-gate it: change one out of band (e.g. a real
+    // TerminationPolicies list, disabling capacity rebalancing) and it no longer matches,
+    // surfacing as real undeclared drift. `TerminationPolicies` is create-time-defaulted to
+    // ["Default"]; a declared list is compared in the declared loop and never reaches here.
+    TerminationPolicies: ['Default'],
+    AvailabilityZoneDistribution: { CapacityDistributionStrategy: 'balanced-best-effort' },
+    InstanceLifecyclePolicy: { RetentionTriggers: { TerminateHookAbandon: 'terminate' } },
+    CapacityReservationSpecification: { CapacityReservationPreference: 'default' },
   },
   // A warm pool that declares no MinSize reads back MinSize:0 — the documented
   // constant default ("minimum 0 warmed instances"). Observed undeclared on a fresh
@@ -1840,6 +1850,14 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string>> = {
   'AWS::KinesisVideo::Stream': {
     KmsKeyId: 'arn:{partition}:kms:{region}:{accountId}:alias/aws/kinesisvideo',
   },
+  // An AutoScalingGroup that declares no ServiceLinkedRoleARN reads back the account's
+  // AWS-managed service-linked role ARN — f(partition, accountId) (IAM ARNs carry no region).
+  // Derived, not value-independent: a user who passes a CUSTOM service-linked role declares it
+  // and it is compared in the declared loop (detection preserved). Live, hunt 2026-07-08 #639.
+  'AWS::AutoScaling::AutoScalingGroup': {
+    ServiceLinkedRoleARN:
+      'arn:{partition}:iam::{accountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling',
+  },
 };
 
 // Top-level UNDECLARED keys whose service default VALUE is derived from the resource's own
@@ -2067,6 +2085,12 @@ export const GENERATED_LOGICALID_PREFIX_PATHS: Record<string, ReadonlySet<string
   'AWS::Cognito::IdentityPool': new Set(['IdentityPoolName']),
   'AWS::Cognito::UserPool': new Set(['UserPoolName']),
   'AWS::Batch::JobDefinition': new Set(['JobDefinitionName']),
+  // A LaunchTemplate that declares no LaunchTemplateName reads back CFn's
+  // `<logicalId>_<random>` minted name (e.g. "LtFD2A8520_TE2V74FxIYEe") — the same
+  // generated-name class as the Cognito/Batch names above (hash suffix present, so the
+  // #525/#537 over-fold concern does not apply). A user-SET name has no logical-id prefix
+  // and still surfaces. Live, hunt 2026-07-08 #639.
+  'AWS::EC2::LaunchTemplate': new Set(['LaunchTemplateName']),
 };
 
 // True when `value` is the `<logicalId><sep><random>` CFn auto-generated-name form: the logical
@@ -2125,6 +2149,13 @@ export const GENERATED_NESTED_PATHS: Record<string, ReadonlySet<string>> = {
   // `Replicas.*.SSESpecification.KMSMasterKeyId`. Live-proven 2026-07-08 #649.
   'AWS::DynamoDB::Table': new Set(['SSESpecification.KMSMasterKeyId']),
   'AWS::DynamoDB::GlobalTable': new Set(['Replicas.*.SSESpecification.KMSMasterKeyId']),
+  // An ASG references its LaunchTemplate by the declared Id + Version; AWS echoes the LT's
+  // minted NAME alongside them inside the live `LaunchTemplate` object. The name is the LT's
+  // own `<logicalId>_<random>` generated value (a different resource's logical id, so the
+  // top-level GENERATED_LOGICALID gate can't derive it from THIS resource) — a per-resource
+  // AWS-assigned identifier, never user intent when undeclared. Fold value-independent. Live,
+  // hunt 2026-07-08 #639.
+  'AWS::AutoScaling::AutoScalingGroup': new Set(['LaunchTemplate.LaunchTemplateName']),
 };
 
 // Elastic Beanstalk ConfigurationTemplate `OptionSettings` first-run default fold. A template
@@ -2334,6 +2365,15 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   `Policies`, which is then compared in the declared loop. Observed live on a fresh
   //   internet-facing CLB with an HTTPS listener (elb-classic-https, 2026-07-07).
   'AWS::ElasticLoadBalancing::LoadBalancer': new Set(['AvailabilityZones', 'Policies']),
+  //   AWS::AutoScaling::AutoScalingGroup.AvailabilityZones / .AvailabilityZoneIds — an ASG
+  //   declares `VPCZoneIdentifier` (subnets); AWS reads back the AZs it PLACED the group in —
+  //   the AZs of those subnets (["us-east-1a","us-east-1b"]) plus their per-account zone IDs
+  //   (["use1-az1","use1-az2"]). Both are a pure reflection of where the declared subnets live
+  //   (the subnet-id → AZ mapping is not resolvable offline), so they cannot be pinned to a
+  //   constant nor derived. Undeclared → whatever AZs AWS chose are not user intent; a user who
+  //   wants specific AZs declares `AvailabilityZones` instead, compared in the declared loop.
+  //   Exact twin of the classic-ELB AvailabilityZones fold above. Live, hunt 2026-07-08 #639.
+  'AWS::AutoScaling::AutoScalingGroup': new Set(['AvailabilityZones', 'AvailabilityZoneIds']),
   //   AWS::ApiGateway::Authorizer.AuthType — a REST-API authorizer's schema carries NO
   //   `AuthType` property (the template declares `Type`: TOKEN / REQUEST /
   //   COGNITO_USER_POOLS); AWS DERIVES and reads back AuthType from it ("custom" for

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9627,6 +9627,85 @@ describe('Face-stack false-positive folds', () => {
     expect(userSetJob.generated).toEqual([]);
   });
 
+  it('EC2 LaunchTemplate undeclared LaunchTemplateName (<logicalId>_<random>) folds to generated (#639)', () => {
+    // A LaunchTemplate with no explicit LaunchTemplateName reads back CFn's `<logicalId>_<random>`
+    // minted name. It folds via GENERATED_LOGICALID_PREFIX_PATHS, NOT a value-independent fold that
+    // would also hide a user-set name. Observed live: logical id "Lt" -> "LtFD2A8520_TE2V74FxIYEe".
+    const ltResource = {
+      logicalId: 'LtFD2A8520',
+      resourceType: 'AWS::EC2::LaunchTemplate',
+      physicalId: 'lt-024b5f274d171865a',
+      constructPath: 'Stack/Lt',
+      declared: {},
+    };
+    const lt = tiers(
+      classifyResource(ltResource, { LaunchTemplateName: 'LtFD2A8520_TE2V74FxIYEe' }, emptySchema)
+    );
+    expect(lt.generated).toEqual(['LaunchTemplateName']);
+    expect(lt.undeclared).toEqual([]);
+    // A user-SET LaunchTemplateName (no logical-id prefix) still surfaces as real undeclared drift.
+    const userSet = tiers(
+      classifyResource(ltResource, { LaunchTemplateName: 'my-web-tier-lt' }, emptySchema)
+    );
+    expect(userSet.undeclared).toEqual(['LaunchTemplateName']);
+    expect(userSet.generated).toEqual([]);
+  });
+
+  it('ASG first-run undeclared batch folds (constants + SLR ARN + AZs + nested LT name) (#639)', () => {
+    // A clean, un-mutated ASG that declares only VPCZoneIdentifier + a LaunchTemplate ref reads
+    // back a batch of AWS-materialized defaults; every one must fold (zero-potential-drift).
+    const asgResource = {
+      logicalId: 'Asg',
+      resourceType: 'AWS::AutoScaling::AutoScalingGroup',
+      physicalId: 'cdkrd-asg',
+      constructPath: 'Stack/Asg',
+      declared: { LaunchTemplate: { LaunchTemplateId: 'lt-024b5f274d171865a', Version: '1' } },
+    };
+    const opts = { accountId: '111111111111', region: 'us-east-1' };
+    const live = {
+      ServiceLinkedRoleARN:
+        'arn:aws:iam::111111111111:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling',
+      AvailabilityZones: ['us-east-1a', 'us-east-1b'],
+      AvailabilityZoneIds: ['use1-az1', 'use1-az2'],
+      AvailabilityZoneDistribution: { CapacityDistributionStrategy: 'balanced-best-effort' },
+      InstanceLifecyclePolicy: { RetentionTriggers: { TerminateHookAbandon: 'terminate' } },
+      TerminationPolicies: ['Default'],
+      CapacityReservationSpecification: { CapacityReservationPreference: 'default' },
+      LaunchTemplate: {
+        LaunchTemplateId: 'lt-024b5f274d171865a',
+        Version: '1',
+        LaunchTemplateName: 'LtFD2A8520_TE2V74FxIYEe',
+      },
+    };
+    const t = tiers(classifyResource(asgResource, live, emptySchema, opts));
+    expect(t.undeclared).toEqual([]);
+    expect(t.atDefault).toEqual([
+      'AvailabilityZoneDistribution',
+      'AvailabilityZoneIds',
+      'AvailabilityZones',
+      'CapacityReservationSpecification',
+      'InstanceLifecyclePolicy',
+      'ServiceLinkedRoleARN',
+      'TerminationPolicies',
+    ]);
+    expect(t.generated).toEqual(['LaunchTemplate.LaunchTemplateName']);
+    // Detection preserved: a TerminationPolicies list changed away from the default surfaces,
+    // and a custom (non-account) service-linked role ARN surfaces.
+    const mutated = tiers(
+      classifyResource(
+        asgResource,
+        {
+          ...live,
+          TerminationPolicies: ['OldestInstance'],
+          ServiceLinkedRoleARN: 'arn:aws:iam::111111111111:role/my-custom-asg-role',
+        },
+        emptySchema,
+        opts
+      )
+    );
+    expect(mutated.undeclared.sort()).toEqual(['ServiceLinkedRoleARN', 'TerminationPolicies']);
+  });
+
   it('WAF WebACL ByteMatch SearchStringBase64 echo folds; a changed pattern is real drift', () => {
     const declared = {
       Rules: [

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgLifecycleHookInline.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgLifecycleHookInline.json
@@ -149,7 +149,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "ServiceLinkedRoleARN",
@@ -158,7 +158,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneIds",
@@ -176,7 +176,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZones",
@@ -185,7 +185,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneDistribution",
@@ -205,7 +205,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "InstanceLifecyclePolicy",
@@ -218,7 +218,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "TerminationPolicies",
@@ -227,7 +227,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "CapacityReservationSpecification",
@@ -247,7 +247,7 @@
       "constructPath": "CdkRealDriftIntegAsgLifecycleHookInline/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "LaunchTemplate.LaunchTemplateName",

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgNotifMetrics.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AsgNotifMetrics.json
@@ -152,7 +152,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "ServiceLinkedRoleARN",
@@ -161,7 +161,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneIds",
@@ -179,7 +179,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZones",
@@ -188,7 +188,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneDistribution",
@@ -208,7 +208,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "InstanceLifecyclePolicy",
@@ -221,7 +221,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "TerminationPolicies",
@@ -230,7 +230,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "CapacityReservationSpecification",
@@ -250,7 +250,7 @@
       "constructPath": "CdkRealDriftIntegAsgNotificationMetrics/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "LaunchTemplate.LaunchTemplateName",

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AutoScalingGroupASG804C35BE.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AutoScalingGroupASG804C35BE.json
@@ -110,7 +110,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "ServiceLinkedRoleARN",
@@ -119,7 +119,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneIds",
@@ -137,7 +137,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZones",
@@ -146,7 +146,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneDistribution",
@@ -166,7 +166,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "InstanceLifecyclePolicy",
@@ -179,7 +179,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "CapacityReservationSpecification",
@@ -190,7 +190,7 @@
       "constructPath": "CdkdriftIntegHarvest12/AutoScalingGroup/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "AutoScalingGroupASG804C35BE",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "LaunchTemplate.LaunchTemplateName",

--- a/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AzReorder.json
+++ b/tests/corpus/AWS__AutoScaling__AutoScalingGroup.AzReorder.json
@@ -114,7 +114,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "ServiceLinkedRoleARN",
@@ -123,7 +123,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneIds",
@@ -141,7 +141,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZones",
@@ -150,7 +150,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "AvailabilityZoneDistribution",
@@ -170,7 +170,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "InstanceLifecyclePolicy",
@@ -183,7 +183,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "TerminationPolicies",
@@ -192,7 +192,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "CapacityReservationSpecification",
@@ -212,7 +212,7 @@
       "constructPath": "CdkRealDriftIntegAsgAzReorder/Asg/ASG"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "AsgASGD1D7B4E2",
       "resourceType": "AWS::AutoScaling::AutoScalingGroup",
       "path": "LaunchTemplate.LaunchTemplateName",

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -624,6 +624,10 @@ describe('noise suppressors', () => {
       Cooldown: '300',
       HealthCheckType: 'EC2',
       HealthCheckGracePeriod: 0,
+      TerminationPolicies: ['Default'],
+      AvailabilityZoneDistribution: { CapacityDistributionStrategy: 'balanced-best-effort' },
+      InstanceLifecyclePolicy: { RetentionTriggers: { TerminateHookAbandon: 'terminate' } },
+      CapacityReservationSpecification: { CapacityReservationPreference: 'default' },
     });
     // CloudWatch alarms (Alarm.ActionsEnabled already folds via its schema default).
     expect(KNOWN_DEFAULTS['AWS::CloudWatch::Alarm'].TreatMissingData).toBe('missing');


### PR DESCRIPTION
fix(noise): fold ASG first-run undeclared batch + EC2 LaunchTemplate generated-name echo (#639)

A clean, un-mutated AutoScalingGroup surfaced 8 first-run [Potential Drift]
entries for values AWS materializes at creation, plus the EC2 LaunchTemplate's
CFn-minted logicalId_random name — all fold gaps against the zero-potential-drift
invariant. Fold each per the CLAUDE.md decision order:

- KNOWN_DEFAULTS constants (ASG): TerminationPolicies ["Default"],
  AvailabilityZoneDistribution, InstanceLifecyclePolicy,
  CapacityReservationSpecification — equality-gated, so a real change surfaces.
- CONTEXT_ARN_DEFAULTS (ASG): ServiceLinkedRoleARN derived from
  partition/accountId (a custom SLR is declared → still detected).
- VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS (ASG): AvailabilityZones /
  AvailabilityZoneIds — a pure reflection of the declared subnets' placement,
  not resolvable offline (twin of the classic-ELB AvailabilityZones fold).
- GENERATED_NESTED_PATHS (ASG): LaunchTemplate.LaunchTemplateName — the LT's own
  minted name echoed alongside the declared Id/Version.
- GENERATED_LOGICALID_PREFIX_PATHS (EC2::LaunchTemplate): LaunchTemplateName —
  the same generated-name class as the Cognito/Batch names (hash suffix present,
  so a user-set name still surfaces).

Regenerated the 4 committed ASG corpus cases (undeclared to atDefault/generated)
plus added focused classify tests for the LaunchTemplate and ASG batch folds.

Closes #639
