### PR TITLE
fix(added): fold cross-stack sibling children so they are not flagged out of band (#666)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -231,9 +231,15 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
                  Permission.FunctionName = GetAtt[fn, Arn]) — concurrent, once
    --- PASS 1.6: added-resource enumeration — for each declared PARENT type with a
                  CHILD_ENUMERATORS entry (read/child-enumerators.ts), list its LIVE
-                 child resources via the service SDK and emit an `added` finding for
-                 any not in the template (e.g. an API Gateway Method on `/`). Each
-                 added child is then read in FULL (CC GetResource) + normalized
+                 child resources via the service SDK and emit an `added` finding
+                 for any not in the template (e.g. an API Gateway Method on `/`)
+                 — EXCEPT a child CDK placed in a SIBLING stack of the app (a
+                 cross-stack ref, e.g. `topic.addSubscription(SqsSubscription)`
+                 puts the `AWS::SNS::Subscription` in the queue's stack), which
+                 `isManagedBySiblingStack` folds out by resolving its physical id
+                 via `DescribeStackResources` (owned by any CFn stack ⇒ managed,
+                 not out of band; #666). Each added child is then read in FULL
+                 (CC GetResource) + normalized
                  (normalizeLiveModel) so `record` can snapshot it and a later change
                  surfaces as drift. An enumeration failure is surfaced as a `skipped`
                  finding on the parent

--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -1,7 +1,10 @@
 // Shared read+classify pipeline used by both `check` and `record`.
 
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
-import { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import {
+  CloudFormationClient,
+  DescribeStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
 import { classifyResource, normalizeLiveModel } from '../diff/classify.js';
@@ -129,6 +132,58 @@ async function readAddedModel(
   } catch {
     return { model: c.live, ok: false };
   }
+}
+
+// A child enumerated off a declared parent but ABSENT from that parent's own template
+// is only "out of band" if NO CloudFormation stack manages it. The common false
+// positive is a cross-stack reference: a child resource CDK places in a SIBLING stack
+// of the same app (e.g. `topic.addSubscription(new SqsSubscription(queue))` puts the
+// `AWS::SNS::Subscription` in the QUEUE's stack to avoid a dependency cycle, so checking
+// the TOPIC's stack finds a live subscription not in that template) — it is fully
+// CFn-managed, just by a sibling (#666). DescribeStackResources resolves the owning stack
+// account-wide from the physical id alone, so this fixes both single-stack and multi-stack
+// (`--all`) runs. Only the child types whose CC primaryIdentifier IS the CFn physical id
+// (a bare ARN / UUID — the cross-stack class: SNS Subscription, ELBv2 Listener/Rule,
+// EventBus Rule, Lambda ESM/Alias/Version, AppSync …) are resolvable; the composite-id
+// children (`RestApiId|…`, `UserPoolId|…`) are within-stack API Gateway / Cognito
+// sub-resources that this class never covers, so they are left alone (skipped by the `|`
+// guard). Fails OPEN: any error (denied, throttled, or a physical id CFn does not accept)
+// keeps the current behavior — the child is still reported as `added` rather than silently
+// dropped. Results are memoized per physical id (added candidates are rare, but a shared
+// parent can enumerate the same live child under multiple declared parents).
+export async function isManagedBySiblingStack(
+  cfn: CloudFormationClient,
+  c: AddedChild,
+  cache: Map<string, boolean>
+): Promise<boolean> {
+  const physicalId = c.identifier;
+  // Pipe-composite CC identifiers (`RestApiId|…`, `UserPoolId|…`) are not CloudFormation
+  // physical resource ids — they belong to within-stack API Gateway / Cognito sub-resources
+  // outside this cross-stack class, so never spend a call on them. Bare ids that are ARNs
+  // (SNS Subscription, ELBv2 Listener/Rule, EventBus Rule, Lambda Alias/Version) contain
+  // `:` and ARE the class, so `:` is NOT a composite marker here; the lone `:`-joined
+  // composite (API Gateway GatewayResponse `RestApiId:ResponseType`) simply fails the
+  // DescribeStackResources lookup and falls through to "report as added" (fail open).
+  if (physicalId.includes('|')) return false;
+  const cached = cache.get(physicalId);
+  if (cached !== undefined) return cached;
+  let managed = false;
+  try {
+    const res = await cfn.send(
+      new DescribeStackResourcesCommand({ PhysicalResourceId: physicalId })
+    );
+    // DescribeStackResources(PhysicalResourceId) returns every resource of the OWNING
+    // stack; confirm the one matching this child's id + type is present (a stack owns it).
+    managed = (res.StackResources ?? []).some(
+      (r) => r.PhysicalResourceId === physicalId && r.ResourceType === c.resourceType
+    );
+  } catch {
+    // No stack owns this physical id (ValidationError "does not exist") -> genuinely out of
+    // band; or a permission/throttle error -> fail open to the current "report as added".
+    managed = false;
+  }
+  cache.set(physicalId, managed);
+  return managed;
 }
 
 interface ClassifyOpts {
@@ -397,6 +452,7 @@ export async function gatherFindings(
   // GetResource) and normalized so `record` can snapshot it and a later change surfaces
   // as drift (PR4). An enumeration failure is a coverage gap, not drift — surfaced as a
   // `skipped` finding on the parent so it is never silently lost.
+  const siblingStackCache = new Map<string, boolean>();
   for (const r of desired.resources) {
     const enumerate = CHILD_ENUMERATORS[r.resourceType];
     if (!enumerate || !r.physicalId) continue;
@@ -413,6 +469,10 @@ export async function gatherFindings(
     try {
       const children = await enumerate({ parent: r, desired, region });
       for (const c of children) {
+        // A child CDK placed in a SIBLING stack of the same app (cross-stack refs, #666)
+        // is fully CloudFormation-managed — not out of band. Skip it rather than false-flag
+        // it as `added` (fails open on any resolve error -> still reported).
+        if (await isManagedBySiblingStack(cfn, c, siblingStackCache)) continue;
         const read = await readAddedModel(cc, cfn, c, schemas, oaiCanonicalIds);
         findings.push(addedFinding(r, c, read));
       }

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -1,6 +1,7 @@
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
 import {
   CloudFormationClient,
+  DescribeStackResourcesCommand,
   DescribeStacksCommand,
   DescribeTypeCommand,
   GetTemplateCommand,
@@ -18,8 +19,10 @@ import {
   buildSiblingSgRules,
   type GatherResult,
   gatherFindings,
+  isManagedBySiblingStack,
   regatherTouched,
 } from '../src/commands/gather.js';
+import type { AddedChild } from '../src/read/child-enumerators.js';
 import type { Desired } from '../src/desired/template-adapter.js';
 import type { DesiredResource, Finding, ResolverContext, SchemaInfo } from '../src/types.js';
 
@@ -735,5 +738,104 @@ describe('buildBucketNotificationManaged', () => {
       ])
     );
     expect(managed.size).toBe(0);
+  });
+});
+
+describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
+  const child = (identifier: string, resourceType = 'AWS::SNS::Subscription'): AddedChild => ({
+    resourceType,
+    identifier,
+    label: identifier,
+    live: {},
+  });
+  const subArn = 'arn:aws:sns:us-east-1:111122223333:NotifTopic:0000-1111-2222';
+
+  it('folds a subscription CDK placed in a SIBLING stack (DescribeStackResources resolves it)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(DescribeStackResourcesCommand).resolves({
+      StackResources: [
+        {
+          StackName: 'Producer',
+          LogicalResourceId: 'NotifTopicSub',
+          PhysicalResourceId: subArn,
+          ResourceType: 'AWS::SNS::Subscription',
+          Timestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      new Map()
+    );
+    expect(managed).toBe(true);
+  });
+
+  it('does NOT fold a genuinely out-of-band subscription (no owning stack -> API throws)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const notFound = new Error(`Stack for ${subArn} does not exist`);
+    notFound.name = 'ValidationError';
+    cfn.on(DescribeStackResourcesCommand).rejects(notFound);
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      new Map()
+    );
+    expect(managed).toBe(false);
+  });
+
+  it('does NOT fold when the owning-stack resource type differs (id reuse guard)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(DescribeStackResourcesCommand).resolves({
+      StackResources: [
+        {
+          StackName: 'Other',
+          LogicalResourceId: 'SomethingElse',
+          PhysicalResourceId: subArn,
+          ResourceType: 'AWS::SNS::Topic',
+          Timestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      new Map()
+    );
+    expect(managed).toBe(false);
+  });
+
+  it('skips the API call for a pipe-composite CC identifier (within-stack sub-resource)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child('api123|res456|GET', 'AWS::ApiGateway::Method'),
+      new Map()
+    );
+    expect(managed).toBe(false);
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(0);
+  });
+
+  it('memoizes the resolution per physical id (one API call for a repeated child)', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(DescribeStackResourcesCommand).resolves({
+      StackResources: [
+        {
+          StackName: 'Producer',
+          LogicalResourceId: 'Sub',
+          PhysicalResourceId: subArn,
+          ResourceType: 'AWS::SNS::Subscription',
+          Timestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    const cache = new Map<string, boolean>();
+    await isManagedBySiblingStack(cfn as unknown as CloudFormationClient, child(subArn), cache);
+    await isManagedBySiblingStack(cfn as unknown as CloudFormationClient, child(subArn), cache);
+    expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
+    expect(cache.get(subArn)).toBe(true);
   });
 });


### PR DESCRIPTION
## What

A child resource CDK places in a **sibling stack of the same app** is fully CloudFormation-managed, but the `added` tier flagged it *"created out of band — not in your CloudFormation template"* — a first-run `[Potential Drift]` on one of the most common CDK patterns there is: **cross-stack references**. This violates the core invariant (a clean deploy has ZERO potential drift).

Live repro: `topic.addSubscription(new SqsSubscription(queue))` puts the `AWS::SNS::Subscription` in the **queue's** (producer) stack to avoid a dependency cycle, so checking the **topic's** (consumer) stack finds a live subscription absent from that template and reports it as added — though it is CFn-managed, just by the sibling.

## Fix

Before flagging an enumerated child as `added`, `isManagedBySiblingStack` resolves its physical id via `DescribeStackResources`: if **any** CloudFormation stack owns a resource with that physical id + type, it is managed (not out of band) and folded out. This resolves account-wide, so it fixes both single-stack and `--all` runs (issue fix directions 1 **and** 2 in one shot, without threading sibling templates through the per-stack `gatherFindings` signature).

Scoped to the cross-stack class — **bare-physical-id children** (ARN / UUID: SNS Subscription, ELBv2 Listener/Rule, EventBus Rule, Lambda ESM/Alias/Version, AppSync …). **Pipe-composite** CC identifiers (`RestApiId|…`, `UserPoolId|…` — within-stack API Gateway / Cognito sub-resources, outside this class) skip the call entirely. **Fails OPEN**: any resolve error (denied, throttled, or an id CFn does not accept) keeps the current "report as added" — a sibling FP is never traded for a silently-dropped real one. Memoized per physical id.

## Live verification (us-east-1, 2-stack fixture)

| case | before (released 0.2.29) | after (this PR) |
|---|---|---|
| sibling-stack subscription (producer owns it) | `[Potential Drift: 1]` "created out of band" | **CLEAN** |
| genuine out-of-band subscription (owned by no stack) | surfaces | **still surfaces** (no over-fold) |
| producer stack | — | CLEAN |

Fixture torn down with `delstack`; orphan sweep clean.

## Tests

`tests/gather.test.ts`: resolve→fold, no-owner→keep, resource-type-mismatch guard, pipe-composite skips the API call, per-id memoization. Plus an `ARCHITECTURE.md` pass-1.6 note.

Closes #666.
