### PR TITLE
fix(noise): fold ELBv2 TargetGroup first-run health-check + attribute + husk defaults (#648)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1244,6 +1244,32 @@ export function classifyResource(
   ) {
     knownDef = { ...knownDef, Encrypted: true, AvailabilityZoneRelocationStatus: 'enabled' };
   }
+  // A TargetGroup's undeclared health-check defaults are a deterministic function of the
+  // declared TargetType and ProtocolVersion — a single KNOWN_DEFAULTS constant covers only the
+  // HTTP/instance case, so a clean gRPC / instance / lambda group floods first-run potential
+  // drift (#648). Derive the per-type default and equality-gate it (a real out-of-band change to
+  // any still surfaces). Live-verified across all three variants (hunt 2026-07-08 #648):
+  //   - HealthCheckIntervalSeconds: lambda -> 35, else 30.
+  //   - HealthCheckPath: GRPC -> "/AWS.ALB/healthcheck", else "/" (only present for HTTP-family
+  //     health checks; a TCP group returns none so the default is inert there).
+  //   - HealthCheckTimeoutSeconds: lambda -> 30 (the base 5 constant covers instance/ip/gRPC).
+  //   - Matcher: GRPC -> {GrpcCode:"12"} (the base {HttpCode:"200"} constant covers the rest).
+  //   - HealthyThresholdCount: 5 for every undeclared group.
+  // A group that DECLARES any of these carries it in the template and is compared there.
+  if (resourceType === 'AWS::ElasticLoadBalancingV2::TargetGroup') {
+    const targetType = declaredIn?.['TargetType'];
+    // gRPC groups declare ProtocolVersion: GRPC; instance/ip groups read it back HTTP1 from
+    // live; a lambda group has neither (so the "/" path default applies).
+    const protocolVersion = declaredIn?.['ProtocolVersion'] ?? live['ProtocolVersion'];
+    knownDef = {
+      ...knownDef,
+      HealthyThresholdCount: 5,
+      HealthCheckIntervalSeconds: targetType === 'lambda' ? 35 : 30,
+      HealthCheckPath: protocolVersion === 'GRPC' ? '/AWS.ALB/healthcheck' : '/',
+      ...(targetType === 'lambda' ? { HealthCheckTimeoutSeconds: 30 } : {}),
+      ...(protocolVersion === 'GRPC' ? { Matcher: { GrpcCode: '12' } } : {}),
+    };
+  }
   // AWS/CDK-generated values for THIS resource (its minted name, a default log group
   // derived from the physical id), with the live physical id substituted in — keyed
   // by property, consulted by the undeclared loop below. Empty when the type has no

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1306,6 +1306,14 @@ export const KNOWN_DEFAULT_ONE_OF: Record<string, Record<string, readonly unknow
 // constant first-run default (12000/4000) and folds via KNOWN_DEFAULTS above —
 // equality-gated, so a warmed-up table still surfaces.
 export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
+  // A lambda TargetGroup's declared `Targets` element reads back an AWS-filled
+  // `AvailabilityZone: "all"` husk (a lambda target has no AZ) that the template never declares —
+  // the #618 in-element husk class. Equality-gated: a real target with a specific AZ still
+  // surfaces. `Targets` is identity-keyed by target Id, so the path crosses the array (`*`).
+  // Live-verified on a fresh lambda target group (hunt 2026-07-08 #648).
+  'AWS::ElasticLoadBalancingV2::TargetGroup': {
+    'Targets.*.AvailabilityZone': 'all',
+  },
   // A WebSocket API Stage whose DefaultRouteSettings declares only throttling (CDK's
   // WebSocketStage renders just ThrottlingRateLimit / ThrottlingBurstLimit) reads back the
   // sibling `LoggingLevel: "OFF"` — the documented service default AWS fills into
@@ -2874,6 +2882,10 @@ export const ELB_ATTRIBUTE_DEFAULTS: Record<string, Record<string, string>> = {
     'routing.http.response.server.enabled': 'true',
   },
   'AWS::ElasticLoadBalancingV2::TargetGroup': {
+    // A group that declares no deregistration delay reads back the 300s default; a lambda group
+    // additionally reads back the multi-value-headers "false" default (live-verified #648).
+    'deregistration_delay.timeout_seconds': '300',
+    'lambda.multi_value_headers.enabled': 'false',
     'load_balancing.algorithm.anomaly_mitigation': 'off',
     'load_balancing.algorithm.type': 'round_robin',
     'load_balancing.cross_zone.enabled': 'use_load_balancer_configuration',

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9706,6 +9706,71 @@ describe('Face-stack false-positive folds', () => {
     expect(mutated.undeclared.sort()).toEqual(['ServiceLinkedRoleARN', 'TerminationPolicies']);
   });
 
+  it('ELBv2 TargetGroup health-check defaults derive from TargetType/ProtocolVersion (#648)', () => {
+    // gRPC group: interval 30, path /AWS.ALB/healthcheck, Matcher {GrpcCode:12}, threshold 5.
+    const grpc = tiers(
+      classifyResource(
+        {
+          logicalId: 'GrpcTg',
+          resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+          physicalId: 'grpc',
+          declared: { TargetType: 'ip', Protocol: 'HTTP', ProtocolVersion: 'GRPC' },
+        },
+        {
+          HealthCheckIntervalSeconds: 30,
+          HealthCheckPath: '/AWS.ALB/healthcheck',
+          Matcher: { GrpcCode: '12' },
+          HealthyThresholdCount: 5,
+        },
+        emptySchema
+      )
+    );
+    expect(grpc.undeclared).toEqual([]);
+    expect(grpc.atDefault.sort()).toEqual([
+      'HealthCheckIntervalSeconds',
+      'HealthCheckPath',
+      'HealthyThresholdCount',
+      'Matcher',
+    ]);
+
+    // lambda group: interval 35, timeout 30, path / (no ProtocolVersion). ProtocolVersion read
+    // from live for an instance group; a lambda group has none.
+    const lambda = tiers(
+      classifyResource(
+        {
+          logicalId: 'LamTg',
+          resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+          physicalId: 'lam',
+          declared: { TargetType: 'lambda' },
+        },
+        {
+          HealthCheckIntervalSeconds: 35,
+          HealthCheckTimeoutSeconds: 30,
+          HealthCheckPath: '/',
+          HealthyThresholdCount: 5,
+        },
+        emptySchema
+      )
+    );
+    expect(lambda.undeclared).toEqual([]);
+
+    // Detection preserved: an out-of-band interval change (a group that never declared it)
+    // away from the derived default surfaces as real undeclared drift.
+    const drifted = tiers(
+      classifyResource(
+        {
+          logicalId: 'InstTg',
+          resourceType: 'AWS::ElasticLoadBalancingV2::TargetGroup',
+          physicalId: 'inst',
+          declared: { TargetType: 'instance', Protocol: 'HTTP' },
+        },
+        { HealthCheckIntervalSeconds: 60, HealthCheckPath: '/', HealthyThresholdCount: 5 },
+        emptySchema
+      )
+    );
+    expect(drifted.undeclared).toEqual(['HealthCheckIntervalSeconds']);
+  });
+
   it('WAF WebACL ByteMatch SearchStringBase64 echo folds; a changed pattern is real drift', () => {
     const declared = {
       Rules: [

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.GrpcTgF27A0024.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.GrpcTgF27A0024.json
@@ -1,0 +1,383 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "GrpcTgF27A0024",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+    "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg",
+    "declared": {
+      "Name": "cdkrd-hunt0708i-grpc",
+      "Port": 50051,
+      "Protocol": "HTTP",
+      "ProtocolVersion": "GRPC",
+      "TargetGroupAttributes": [
+        {
+          "Key": "stickiness.enabled",
+          "Value": "false"
+        }
+      ],
+      "TargetType": "ip",
+      "VpcId": "vpc-024ce3500f00b6155"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Matcher": {
+      "GrpcCode": "12"
+    },
+    "HealthCheckPath": "/AWS.ALB/healthcheck",
+    "Port": 50051,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "ProtocolVersion": "GRPC",
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 5,
+    "Name": "cdkrd-hunt0708i-grpc",
+    "VpcId": "vpc-024ce3500f00b6155",
+    "TargetGroupFullName": "targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "HTTP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "lb_cookie",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.app_cookie.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.lb_cookie.duration_seconds"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "slow_start.duration_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "off",
+        "Key": "load_balancing.algorithm.anomaly_mitigation"
+      },
+      {
+        "Value": "",
+        "Key": "stickiness.app_cookie.cookie_name"
+      },
+      {
+        "Value": "round_robin",
+        "Key": "load_balancing.algorithm.type"
+      }
+    ],
+    "TargetType": "ip",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "HTTP",
+    "TargetGroupName": "cdkrd-hunt0708i-grpc",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708iMisc/04e5b890-7a8c-11f1-a555-0e325c63a7c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708iMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "GrpcTgF27A0024",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.algorithm.anomaly_mitigation]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.algorithm.type]",
+      "actual": "round_robin",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[slow_start.duration_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.app_cookie.duration_seconds]",
+      "actual": "86400",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.lb_cookie.duration_seconds]",
+      "actual": "86400",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "lb_cookie",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Matcher",
+      "actual": {
+        "GrpcCode": "12"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPath",
+      "actual": "/AWS.ALB/healthcheck",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Targets",
+      "actual": [],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "HTTP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "GrpcTgF27A0024",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-grpc/1165a745b9786029",
+      "constructPath": "CdkRealDriftHunt0708iMisc/GrpcTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.InstTg162F7452.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.InstTg162F7452.json
@@ -1,0 +1,391 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "InstTg162F7452",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+    "constructPath": "CdkRealDriftHunt0708iMisc/InstTg",
+    "declared": {
+      "Name": "cdkrd-hunt0708i-inst",
+      "Port": 80,
+      "Protocol": "HTTP",
+      "TargetGroupAttributes": [
+        {
+          "Key": "stickiness.enabled",
+          "Value": "false"
+        }
+      ],
+      "TargetType": "instance",
+      "VpcId": "vpc-024ce3500f00b6155"
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+    "HealthCheckIntervalSeconds": 30,
+    "LoadBalancerArns": [],
+    "Matcher": {
+      "HttpCode": "200"
+    },
+    "HealthCheckPath": "/",
+    "Port": 80,
+    "Targets": [],
+    "HealthCheckEnabled": true,
+    "ProtocolVersion": "HTTP1",
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 5,
+    "Name": "cdkrd-hunt0708i-inst",
+    "VpcId": "vpc-024ce3500f00b6155",
+    "TargetGroupFullName": "targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+    "HealthyThresholdCount": 5,
+    "HealthCheckProtocol": "HTTP",
+    "TargetGroupAttributes": [
+      {
+        "Value": "lb_cookie",
+        "Key": "stickiness.type"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.app_cookie.duration_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "use_load_balancer_configuration",
+        "Key": "load_balancing.cross_zone.enabled"
+      },
+      {
+        "Value": "86400",
+        "Key": "stickiness.lb_cookie.duration_seconds"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.dns_failover.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "false",
+        "Key": "stickiness.enabled"
+      },
+      {
+        "Value": "off",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage"
+      },
+      {
+        "Value": "0",
+        "Key": "slow_start.duration_seconds"
+      },
+      {
+        "Value": "300",
+        "Key": "deregistration_delay.timeout_seconds"
+      },
+      {
+        "Value": "1",
+        "Key": "target_group_health.unhealthy_state_routing.minimum_healthy_targets.count"
+      },
+      {
+        "Value": "off",
+        "Key": "load_balancing.algorithm.anomaly_mitigation"
+      },
+      {
+        "Value": "",
+        "Key": "stickiness.app_cookie.cookie_name"
+      },
+      {
+        "Value": "round_robin",
+        "Key": "load_balancing.algorithm.type"
+      }
+    ],
+    "TargetType": "instance",
+    "HealthCheckPort": "traffic-port",
+    "Protocol": "HTTP",
+    "TargetGroupName": "cdkrd-hunt0708i-inst",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708iMisc/04e5b890-7a8c-11f1-a555-0e325c63a7c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708iMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "InstTg162F7452",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[deregistration_delay.timeout_seconds]",
+      "actual": "300",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.algorithm.anomaly_mitigation]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.algorithm.type]",
+      "actual": "round_robin",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[load_balancing.cross_zone.enabled]",
+      "actual": "use_load_balancer_configuration",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[slow_start.duration_seconds]",
+      "actual": "0",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.app_cookie.duration_seconds]",
+      "actual": "86400",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.lb_cookie.duration_seconds]",
+      "actual": "86400",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[stickiness.type]",
+      "actual": "lb_cookie",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.dns_failover.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.count]",
+      "actual": "1",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[target_group_health.unhealthy_state_routing.minimum_healthy_targets.percentage]",
+      "actual": "off",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Matcher",
+      "actual": {
+        "HttpCode": "200"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPath",
+      "actual": "/",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "generated",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Targets",
+      "actual": [],
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckEnabled",
+      "actual": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "ProtocolVersion",
+      "actual": "HTTP1",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckProtocol",
+      "actual": "HTTP",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "InstTg162F7452",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPort",
+      "actual": "traffic-port",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-inst/260e8a45e360c142",
+      "constructPath": "CdkRealDriftHunt0708iMisc/InstTg"
+    }
+  ]
+}

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.LamTgA990B741.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__TargetGroup.LamTgA990B741.json
@@ -1,0 +1,189 @@
+{
+  "corpusVersion": 1,
+  "resource": {
+    "logicalId": "LamTgA990B741",
+    "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+    "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+    "constructPath": "CdkRealDriftHunt0708iMisc/LamTg",
+    "declared": {
+      "Name": "cdkrd-hunt0708i-lam",
+      "TargetType": "lambda",
+      "Targets": [
+        {
+          "Id": "arn:aws:lambda:us-east-1:111111111111:function:cdkrd-hunt0708i-tgfn"
+        }
+      ]
+    }
+  },
+  "liveRaw": {
+    "IpAddressType": "ipv4",
+    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+    "HealthCheckIntervalSeconds": 35,
+    "LoadBalancerArns": [],
+    "Matcher": {
+      "HttpCode": "200"
+    },
+    "HealthCheckPath": "/",
+    "Targets": [
+      {
+        "AvailabilityZone": "all",
+        "Id": "arn:aws:lambda:us-east-1:111111111111:function:cdkrd-hunt0708i-tgfn"
+      }
+    ],
+    "HealthCheckEnabled": false,
+    "UnhealthyThresholdCount": 2,
+    "HealthCheckTimeoutSeconds": 30,
+    "Name": "cdkrd-hunt0708i-lam",
+    "TargetGroupFullName": "targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+    "HealthyThresholdCount": 5,
+    "TargetGroupAttributes": [
+      {
+        "Value": "false",
+        "Key": "lambda.multi_value_headers.enabled"
+      }
+    ],
+    "TargetType": "lambda",
+    "TargetGroupName": "cdkrd-hunt0708i-lam",
+    "Tags": [
+      {
+        "Value": "arn:aws:cloudformation:us-east-1:111111111111:stack/CdkRealDriftHunt0708iMisc/04e5b890-7a8c-11f1-a555-0e325c63a7c3",
+        "Key": "aws:cloudformation:stack-id"
+      },
+      {
+        "Value": "CdkRealDriftHunt0708iMisc",
+        "Key": "aws:cloudformation:stack-name"
+      },
+      {
+        "Value": "LamTgA990B741",
+        "Key": "aws:cloudformation:logical-id"
+      }
+    ]
+  },
+  "schema": {
+    "readOnly": ["LoadBalancerArns", "TargetGroupArn", "TargetGroupFullName", "TargetGroupName"],
+    "writeOnly": [],
+    "createOnly": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "readOnlyPaths": [
+      "LoadBalancerArns",
+      "TargetGroupArn",
+      "TargetGroupFullName",
+      "TargetGroupName"
+    ],
+    "writeOnlyPaths": [],
+    "createOnlyPaths": [
+      "IpAddressType",
+      "Name",
+      "Port",
+      "Protocol",
+      "ProtocolVersion",
+      "TargetType",
+      "VpcId"
+    ],
+    "defaults": {},
+    "defaultPaths": {},
+    "unorderedScalarPaths": ["LoadBalancerArns"],
+    "unorderedObjectArrayPaths": [],
+    "freeFormMapPaths": []
+  },
+  "opts": {
+    "accountId": "111111111111",
+    "region": "us-east-1",
+    "kmsAliasTargets": {},
+    "oaiCanonicalIds": {}
+  },
+  "expected": [
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "IpAddressType",
+      "actual": "ipv4",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckIntervalSeconds",
+      "actual": 35,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Matcher",
+      "actual": {
+        "HttpCode": "200"
+      },
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckPath",
+      "actual": "/",
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "UnhealthyThresholdCount",
+      "actual": 2,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthCheckTimeoutSeconds",
+      "actual": 30,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "HealthyThresholdCount",
+      "actual": 5,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "TargetGroupAttributes[lambda.multi_value_headers.enabled]",
+      "actual": "false",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "LamTgA990B741",
+      "resourceType": "AWS::ElasticLoadBalancingV2::TargetGroup",
+      "path": "Targets[arn:aws:lambda:us-east-1:111111111111:function:cdkrd-hunt0708i-tgfn].AvailabilityZone",
+      "actual": "all",
+      "nested": true,
+      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:targetgroup/cdkrd-hunt0708i-lam/623fa64bdebe4639",
+      "constructPath": "CdkRealDriftHunt0708iMisc/LamTg"
+    }
+  ]
+}


### PR DESCRIPTION
fix(noise): fold ELBv2 TargetGroup first-run health-check + attribute + husk defaults (#648)

A clean deploy of gRPC / instance / lambda TargetGroups surfaced 15 first-run
[Potential Drift] entries for values AWS materializes at creation — fold gaps
against the zero-potential-drift invariant. The existing TG coverage all DECLARED
its health-check props, so the bare-group default scenario was never exercised.
Fold each per the CLAUDE.md decision order (live-verified across all 3 variants,
hunt 2026-07-08 #648):

- Derived (classify.ts, f(TargetType, ProtocolVersion)): a single KNOWN_DEFAULTS
  constant only covered the HTTP/instance case, so derive the per-type default and
  equality-gate it (a real change still surfaces):
  - HealthCheckIntervalSeconds: lambda 35, else 30
  - HealthCheckPath: GRPC "/AWS.ALB/healthcheck", else "/"
  - HealthCheckTimeoutSeconds: lambda 30 (base 5 covers instance/ip/gRPC)
  - Matcher: GRPC {GrpcCode:"12"} (base {HttpCode:"200"} covers the rest)
  - HealthyThresholdCount: 5
- Attribute constants (ELB_ATTRIBUTE_DEFAULTS): deregistration_delay.timeout_seconds
  "300", lambda.multi_value_headers.enabled "false".
- In-element husk (KNOWN_DEFAULT_PATHS): Targets.*.AvailabilityZone "all" — the
  AWS-filled AZ on a declared lambda target element (#618 class), equality-gated.

Added the 3 harvested corpus cases (authoritative live data, pinned by
corpus-replay) + a focused classify test asserting the derivation and that an
out-of-band interval change still surfaces (detection preserved).

Closes #648
