### PR TITLE
fix(noise): first-run fold gaps on ApiGateway/Cognito/Batch/ECR/SSM/CloudFront (#642, #643, #668, #678)

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -275,10 +275,10 @@ anything non-obvious you learned in memory.
   a worktree while `main` is checked out in the main tree, it exits 1 with
   `fatal: 'main' is already used by worktree …` — but the REMOTE merge AND remote
   branch delete already SUCCEEDED (gh only failed the post-merge local `checkout main`
-  + local branch delete). Confirm with `gh pr view <n> --json state,mergedAt`
-  (`MERGED`), then do the local cleanup yourself: `git checkout main && git pull`,
-  `git worktree remove …`, `git branch -D wt-…` (the `git push origin --delete` will
-  report "remote ref does not exist" — benign, gh already removed it).
+  - local branch delete). Confirm with `gh pr view <n> --json state,mergedAt`
+    (`MERGED`), then do the local cleanup yourself: `git checkout main && git pull`,
+    `git worktree remove …`, `git branch -D wt-…` (the `git push origin --delete` will
+    report "remote ref does not exist" — benign, gh already removed it).
 
 ## Important existing rules this skill leans on
 

--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1273,6 +1273,52 @@ export function classifyResource(
   if (resourceType === 'AWS::Lambda::Function' && 'DurableConfig' in declared) {
     knownDefPaths = { ...knownDefPaths, 'LoggingConfig.LogFormat': 'JSON' };
   }
+  // #678: a PRIVATE RestApi (declared EndpointConfiguration.Types includes 'PRIVATE') gets
+  // DIFFERENT AWS defaults than an EDGE/REGIONAL api — SecurityPolicy TLS_1_2 (not TLS_1_0)
+  // and EndpointConfiguration.IpAddressType 'dualstack' (not 'ipv4'), both live-verified.
+  // Derive the expected default from the declared endpoint type and equality-gate it (fold
+  // tier 2): an out-of-band flip of either value away from the PRIVATE default still
+  // surfaces. The base EDGE/REGIONAL constants stay for the other endpoint types.
+  if (resourceType === 'AWS::ApiGateway::RestApi') {
+    const types = (declared['EndpointConfiguration'] as Record<string, unknown> | undefined)?.[
+      'Types'
+    ];
+    if (Array.isArray(types) && types.includes('PRIVATE')) {
+      knownDef = { ...knownDef, SecurityPolicy: 'TLS_1_2' };
+      knownDefPaths = { ...knownDefPaths, 'EndpointConfiguration.IpAddressType': 'dualstack' };
+    }
+  }
+  // #642: a UserPool's undeclared AdminCreateUserConfig.UnusedAccountValidityDays is
+  // Cognito's legacy alias that always MIRRORS the declared
+  // Policies.PasswordPolicy.TemporaryPasswordValidityDays (7 when that too is unset). The
+  // base KNOWN_DEFAULT_PATHS pins the constant 7, so a pool declaring a non-7 temp-password
+  // lifetime false-drifts. Derive the expected value from the declared sibling and
+  // equality-gate it (fold tier 2): an out-of-band change still surfaces.
+  if (resourceType === 'AWS::Cognito::UserPool') {
+    const tpvd = (
+      (declared['Policies'] as Record<string, unknown> | undefined)?.['PasswordPolicy'] as
+        | Record<string, unknown>
+        | undefined
+    )?.['TemporaryPasswordValidityDays'];
+    knownDefPaths = {
+      ...knownDefPaths,
+      'AdminCreateUserConfig.UnusedAccountValidityDays': tpvd ?? 7,
+    };
+  }
+  // #643: a ResourceDataSync declares its destination NESTED (S3Destination.*), but the live
+  // read ALSO echoes BucketName / BucketRegion / SyncFormat as TOP-LEVEL twins (the schema's
+  // legacy flat shape). Fold each undeclared top-level twin against the declared S3Destination
+  // sibling (fold tier 2, equality-gated): a genuinely retargeted destination still surfaces.
+  if (resourceType === 'AWS::SSM::ResourceDataSync') {
+    const s3 = declared['S3Destination'] as Record<string, unknown> | undefined;
+    if (s3 && typeof s3 === 'object') {
+      const twins: Record<string, unknown> = {};
+      for (const key of ['BucketName', 'BucketRegion', 'SyncFormat'] as const) {
+        if (key in s3) twins[key] = s3[key];
+      }
+      knownDef = { ...knownDef, ...twins };
+    }
+  }
   // R140: nested paths that are always an AWS-assigned generated id (value-independent),
   // folded as `generated` like the top-level isGeneratedName/GENERATED_DEFAULTS cases.
   const generatedPaths = GENERATED_PATHS[resourceType] ?? [];

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -397,6 +397,15 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ApiGateway::DomainName': {
     SecurityPolicy: 'TLS_1_2',
   },
+  // A GatewayResponse that declares only its ResponseType (+ RestApiId, StatusCode)
+  // reads back AWS's stable default body template for that response type — the
+  // {"message":$context.error.messageString} passthrough (observed live on a fresh
+  // DEFAULT_4XX response). Users add gateway responses for CORS-on-4XX/5XX routinely,
+  // so this is everyday first-run noise. Equality-gated: a customized ResponseTemplates
+  // no longer matches and surfaces. (ResponseParameters:{} folds as trivial-empty.)
+  'AWS::ApiGateway::GatewayResponse': {
+    ResponseTemplates: { 'application/json': '{"message":$context.error.messageString}' },
+  },
   // NOTE: AWS::ApiGateway::Authorizer.AuthType is NOT a KNOWN_DEFAULTS entry — it is
   // folded value-independently via VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS below
   // (AuthType is a derived, non-declarable read-back of the declared Type).
@@ -501,6 +510,14 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     EncryptionConfiguration: { EncryptionType: 'AES256' },
     ImageTagMutability: 'MUTABLE', // R-noise-sweep: default; switching to IMMUTABLE no longer matches and surfaces
   },
+  // Same default family as AWS::ECR::Repository (above) — the template type was missed.
+  // A creation template that declares only {Prefix, AppliedFor, Description} reads back
+  // AES256 encryption + MUTABLE image tags (observed live). Equality-gated: a template
+  // switching to KMS encryption or IMMUTABLE tags no longer matches and surfaces.
+  'AWS::ECR::RepositoryCreationTemplate': {
+    EncryptionConfiguration: { EncryptionType: 'AES256' },
+    ImageTagMutability: 'MUTABLE',
+  },
   'AWS::Kinesis::Stream': {
     MaxRecordSizeInKiB: 1024,
   },
@@ -510,6 +527,15 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // projects it); folds an undeclared Standard so it is not noise. A real Advanced /
     // Intelligent-Tiering value still surfaces (undeclared) or compares (declared).
     Tier: 'Standard',
+  },
+  // A ResourceDataSync that declares only its nested S3Destination reads back the
+  // constant SyncType default "SyncToDestination" (observed live). The declared
+  // S3Destination.{BucketName,BucketRegion,SyncFormat} are ALSO echoed as top-level
+  // twins (the schema's legacy flat shape) — those are folded as declared-sibling
+  // echoes in classify.ts (equality-gated against the declared value). Equality-gated:
+  // a sync retargeted to SyncFromSource no longer matches SyncToDestination and surfaces.
+  'AWS::SSM::ResourceDataSync': {
+    SyncType: 'SyncToDestination',
   },
   'AWS::StepFunctions::Activity': {
     EncryptionConfiguration: { Type: 'AWS_OWNED_KEY' },
@@ -556,6 +582,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // longer matches and surfaces. Observed live.
     KeyConfiguration: { KeyType: 'AWS_OWNED_KEY' },
     IssuerConfiguration: { Type: 'ORIGINAL' },
+    // A pool that never configures WebAuthn reads back the constant default
+    // WebAuthnFactorConfiguration "SINGLE_FACTOR" (observed live). Equality-gated: a
+    // pool that enables MULTI_FACTOR WebAuthn no longer matches and surfaces.
+    WebAuthnFactorConfiguration: 'SINGLE_FACTOR',
   },
   // An identity pool that declares no allowClassicFlow reads back AllowClassicFlow=false
   // (the documented default). Equality-gated: switch it on out of band and the value no
@@ -2322,6 +2352,14 @@ export function ebOptionSettingTier(
 //   and "DISABLED" on others (both observed live), depending on how/when the service was
 //   created; neither is "the" default.
 export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
+  //   AWS::Batch::JobQueue.JobQueueType — a queue that declares no JobQueueType reads back
+  //   the type AWS DERIVES from its attached compute environment (ECS_FARGATE for a Fargate
+  //   CE, ECS for EC2, EKS for EKS). The value lives on a DIFFERENT resource (the CE), not in
+  //   the queue's own declared inputs, so it cannot be derived here; and JobQueueType is
+  //   createOnly (immutable — it can never drift out of band). Fold value-independent:
+  //   undeclared + immutable, so whatever type AWS derived is its default, never user intent
+  //   (a user who cares DECLARES it, and it is then compared in the declared loop).
+  'AWS::Batch::JobQueue': new Set(['JobQueueType']),
   //   AWS::ECS::Service.PlatformVersion — a service that declares no platform version reads
   //   back the concrete version AWS provisioned ("1.4.0" today); "use the default/latest" is
   //   satisfied by whatever concrete version is current, so any value is not user intent. (A
@@ -3733,6 +3771,18 @@ export function alignNameValueSubset(
 }
 
 export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
+  // Live-observed on a fresh cloudfront-georestriction deploy: a Distribution's
+  // GeoRestriction.Locations (ISO-3166 country codes for a geo allow/deny list) is
+  // semantically a SET — CloudFront renders it as a country set and does not guarantee
+  // echo order while the distribution propagates, so declared ["US","JP"] can read back
+  // ["JP","US"] on the first check right after deploy (an INTERMITTENT declared-tier FP
+  // that vanishes on re-check). The schema marks Locations uniqueItems:false with no
+  // insertionOrder, so neither the schema fold nor the uniqueItems heuristic catches it.
+  // A positional compare false-drifts the identical country set; a genuine membership
+  // change still changes the multiset. (Same set-reorder class as WAF IPSet / RecordSet.)
+  'AWS::CloudFront::Distribution': new Set([
+    'DistributionConfig.Restrictions.GeoRestriction.Locations',
+  ]),
   'AWS::Cognito::UserPoolClient': new Set([
     'AllowedOAuthFlows',
     'AllowedOAuthScopes',

--- a/tests/corpus/AWS__ApiGateway__GatewayResponse.GwResponse4E10BA47.json
+++ b/tests/corpus/AWS__ApiGateway__GatewayResponse.GwResponse4E10BA47.json
@@ -35,7 +35,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "GwResponse4E10BA47",
       "resourceType": "AWS::ApiGateway::GatewayResponse",
       "path": "ResponseTemplates",

--- a/tests/corpus/AWS__Batch__JobQueue.Queue4A7E3555.json
+++ b/tests/corpus/AWS__Batch__JobQueue.Queue4A7E3555.json
@@ -52,7 +52,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Queue4A7E3555",
       "resourceType": "AWS::Batch::JobQueue",
       "path": "JobQueueType",

--- a/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
+++ b/tests/corpus/AWS__Cognito__UserPool.PoolD3F588B8_userpool_rich.json
@@ -766,7 +766,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "WebAuthnFactorConfiguration",
@@ -775,7 +775,7 @@
       "constructPath": "CdkRealDriftIntegCognitoUserPoolRich/Pool"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "PoolD3F588B8",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "AdminCreateUserConfig.UnusedAccountValidityDays",

--- a/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
+++ b/tests/corpus/AWS__Cognito__UserPool.Users0A0EEA89.json
@@ -788,7 +788,7 @@
       "constructPath": "CdkrdIntegHarvest3/Users"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Users0A0EEA89",
       "resourceType": "AWS::Cognito::UserPool",
       "path": "AdminCreateUserConfig.UnusedAccountValidityDays",

--- a/tests/noise-firstrun-folds.test.ts
+++ b/tests/noise-firstrun-folds.test.ts
@@ -1,0 +1,275 @@
+// First-run fold gaps mined from clean, un-mutated deploys (issues #642, #643, #668,
+// #678). Each fold is equality-gated or derived, so a change away from the default
+// still surfaces — every test asserts BOTH the fold (atDefault / no declared drift on a
+// clean deploy) AND that a genuine divergence still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#642 ApiGateway GatewayResponse ResponseTemplates default', () => {
+  const res: DesiredResource = {
+    logicalId: 'GwResponse',
+    resourceType: 'AWS::ApiGateway::GatewayResponse',
+    physicalId: 'api:DEFAULT_4XX',
+    declared: { ResponseType: 'DEFAULT_4XX', RestApiId: 'api' },
+  };
+  it('folds the constant default template to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { ResponseTemplates: { 'application/json': '{"message":$context.error.messageString}' } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('ResponseTemplates');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('ResponseTemplates');
+  });
+  it('surfaces a customized template as undeclared', () => {
+    const f = classifyResource(
+      res,
+      { ResponseTemplates: { 'application/json': '{"custom":true}' } },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('ResponseTemplates');
+  });
+});
+
+describe('#642 Cognito UnusedAccountValidityDays mirrors declared TemporaryPasswordValidityDays', () => {
+  const mk = (tpvd: number): DesiredResource => ({
+    logicalId: 'Pool',
+    resourceType: 'AWS::Cognito::UserPool',
+    physicalId: 'pool',
+    declared: {
+      AdminCreateUserConfig: { AllowAdminCreateUserOnly: false },
+      Policies: { PasswordPolicy: { TemporaryPasswordValidityDays: tpvd } },
+    },
+  });
+  const live = (uavd: number) => ({
+    AdminCreateUserConfig: { AllowAdminCreateUserOnly: false, UnusedAccountValidityDays: uavd },
+  });
+  it('folds when the alias mirrors the declared non-7 lifetime', () => {
+    const f = classifyResource(mk(3), live(3), emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain(
+      'AdminCreateUserConfig.UnusedAccountValidityDays'
+    );
+    expect(pathsByTier(f, 'undeclared')).not.toContain(
+      'AdminCreateUserConfig.UnusedAccountValidityDays'
+    );
+  });
+  it('surfaces an out-of-band lifetime that diverges from the declared sibling', () => {
+    const f = classifyResource(mk(3), live(9), emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain(
+      'AdminCreateUserConfig.UnusedAccountValidityDays'
+    );
+  });
+});
+
+describe('#642 Cognito WebAuthnFactorConfiguration default', () => {
+  const res: DesiredResource = {
+    logicalId: 'Pool',
+    resourceType: 'AWS::Cognito::UserPool',
+    physicalId: 'pool',
+    declared: { MfaConfiguration: 'OFF' },
+  };
+  it('folds SINGLE_FACTOR to atDefault', () => {
+    const f = classifyResource(res, { WebAuthnFactorConfiguration: 'SINGLE_FACTOR' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('WebAuthnFactorConfiguration');
+  });
+  it('surfaces MULTI_FACTOR as undeclared', () => {
+    const f = classifyResource(res, { WebAuthnFactorConfiguration: 'MULTI_FACTOR' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('WebAuthnFactorConfiguration');
+  });
+});
+
+describe('#642 Batch JobQueueType (createOnly, derived from the attached CE)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Queue',
+    resourceType: 'AWS::Batch::JobQueue',
+    physicalId: 'queue',
+    declared: { Priority: 1, State: 'ENABLED' },
+  };
+  it('folds any AWS-derived queue type value-independent (undeclared + immutable)', () => {
+    for (const t of ['ECS_FARGATE', 'ECS', 'EKS']) {
+      const f = classifyResource(res, { JobQueueType: t }, emptySchema);
+      expect(pathsByTier(f, 'atDefault')).toContain('JobQueueType');
+      expect(pathsByTier(f, 'undeclared')).not.toContain('JobQueueType');
+    }
+  });
+});
+
+describe('#643 ECR RepositoryCreationTemplate constant defaults', () => {
+  const res: DesiredResource = {
+    logicalId: 'Rct',
+    resourceType: 'AWS::ECR::RepositoryCreationTemplate',
+    physicalId: 'rct',
+    declared: { Prefix: 'p', AppliedFor: ['PULL_THROUGH_CACHE'] },
+  };
+  it('folds AES256 encryption + MUTABLE tags to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { EncryptionConfiguration: { EncryptionType: 'AES256' }, ImageTagMutability: 'MUTABLE' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['EncryptionConfiguration', 'ImageTagMutability'])
+    );
+  });
+  it('surfaces IMMUTABLE tags as undeclared', () => {
+    const f = classifyResource(res, { ImageTagMutability: 'IMMUTABLE' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('ImageTagMutability');
+  });
+});
+
+describe('#643 SSM ResourceDataSync S3Destination top-level twins + SyncType', () => {
+  const res: DesiredResource = {
+    logicalId: 'Sync',
+    resourceType: 'AWS::SSM::ResourceDataSync',
+    physicalId: 'sync',
+    declared: {
+      S3Destination: { BucketName: 'b', BucketRegion: 'us-east-1', SyncFormat: 'JsonSerDe' },
+    },
+  };
+  it('folds the top-level twins against the declared S3Destination sibling + SyncType constant', () => {
+    const f = classifyResource(
+      res,
+      {
+        S3Destination: { BucketName: 'b', BucketRegion: 'us-east-1', SyncFormat: 'JsonSerDe' },
+        BucketName: 'b',
+        BucketRegion: 'us-east-1',
+        SyncFormat: 'JsonSerDe',
+        SyncType: 'SyncToDestination',
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['BucketName', 'BucketRegion', 'SyncFormat', 'SyncType'])
+    );
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+  it('surfaces a top-level twin retargeted to a different bucket', () => {
+    const f = classifyResource(
+      res,
+      {
+        S3Destination: { BucketName: 'b', BucketRegion: 'us-east-1', SyncFormat: 'JsonSerDe' },
+        BucketName: 'other',
+        BucketRegion: 'us-east-1',
+        SyncFormat: 'JsonSerDe',
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('BucketName');
+  });
+});
+
+describe('#668 CloudFront GeoRestriction.Locations is an unordered set', () => {
+  const res: DesiredResource = {
+    logicalId: 'Dist',
+    resourceType: 'AWS::CloudFront::Distribution',
+    physicalId: 'dist',
+    declared: {
+      DistributionConfig: {
+        Restrictions: { GeoRestriction: { RestrictionType: 'whitelist', Locations: ['US', 'JP'] } },
+      },
+    },
+  };
+  it('does not false-drift on a propagation reorder of the same country set', () => {
+    const f = classifyResource(
+      res,
+      {
+        DistributionConfig: {
+          Restrictions: {
+            GeoRestriction: { RestrictionType: 'whitelist', Locations: ['JP', 'US'] },
+          },
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).not.toContain(
+      'DistributionConfig.Restrictions.GeoRestriction.Locations'
+    );
+  });
+  it('still surfaces a genuine membership change as declared drift', () => {
+    const f = classifyResource(
+      res,
+      {
+        DistributionConfig: {
+          Restrictions: {
+            GeoRestriction: { RestrictionType: 'whitelist', Locations: ['US', 'GB'] },
+          },
+        },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toContain(
+      'DistributionConfig.Restrictions.GeoRestriction.Locations'
+    );
+  });
+});
+
+describe('#678 PRIVATE RestApi derives TLS_1_2 + dualstack from the declared endpoint type', () => {
+  const mk = (types: string[]): DesiredResource => ({
+    logicalId: 'Api',
+    resourceType: 'AWS::ApiGateway::RestApi',
+    physicalId: 'api',
+    declared: { Name: 'api', EndpointConfiguration: { Types: types } },
+  });
+  it('folds a PRIVATE api SecurityPolicy=TLS_1_2 + IpAddressType=dualstack', () => {
+    const f = classifyResource(
+      mk(['PRIVATE']),
+      {
+        SecurityPolicy: 'TLS_1_2',
+        EndpointConfiguration: { Types: ['PRIVATE'], IpAddressType: 'dualstack' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['SecurityPolicy', 'EndpointConfiguration.IpAddressType'])
+    );
+  });
+  it('still surfaces a PRIVATE api whose SecurityPolicy was flipped away from TLS_1_2', () => {
+    const f = classifyResource(
+      mk(['PRIVATE']),
+      {
+        SecurityPolicy: 'TLS_1_0',
+        EndpointConfiguration: { Types: ['PRIVATE'], IpAddressType: 'dualstack' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('SecurityPolicy');
+  });
+  it('keeps the EDGE/REGIONAL constants: TLS_1_0 folds, TLS_1_2 surfaces', () => {
+    const folds = classifyResource(
+      mk(['REGIONAL']),
+      {
+        SecurityPolicy: 'TLS_1_0',
+        EndpointConfiguration: { Types: ['REGIONAL'], IpAddressType: 'ipv4' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(folds, 'atDefault')).toContain('SecurityPolicy');
+    const surfaces = classifyResource(
+      mk(['REGIONAL']),
+      {
+        SecurityPolicy: 'TLS_1_2',
+        EndpointConfiguration: { Types: ['REGIONAL'], IpAddressType: 'ipv4' },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(surfaces, 'undeclared')).toContain('SecurityPolicy');
+  });
+});


### PR DESCRIPTION
Bundles four file-disjoint `fix(noise)` first-run false positives — all pure fold-table / derived-fold additions in `src/normalize/noise.ts` + `src/diff/classify.ts`, all live-proven on clean, un-mutated deploys (the zero-potential-drift invariant). Every fold is equality-gated, derived, or (only for an undeclared+immutable value) value-independent, so out-of-band change detection is preserved.

## Folds

**#642**
- `ApiGateway::GatewayResponse` `ResponseTemplates` default body template → `KNOWN_DEFAULTS`.
- `Cognito::UserPool` `AdminCreateUserConfig.UnusedAccountValidityDays` is the legacy alias that MIRRORS the declared `Policies.PasswordPolicy.TemporaryPasswordValidityDays` → **derive from the sibling** (was pinned to the constant 7, so a non-7 lifetime false-drifted).
- `Cognito::UserPool` `WebAuthnFactorConfiguration` `"SINGLE_FACTOR"` → `KNOWN_DEFAULTS`.
- `Batch::JobQueue` `JobQueueType` is createOnly + derived cross-resource from the attached compute environment → **value-independent** (undeclared + immutable, can never drift; closes the Fargate/EC2/EKS variants).

**#643**
- `ECR::RepositoryCreationTemplate` AES256 + MUTABLE constants → `KNOWN_DEFAULTS` (same family as `ECR::Repository`, type was missed).
- `SSM::ResourceDataSync` `SyncType` `"SyncToDestination"` → `KNOWN_DEFAULTS`; the declared `S3Destination.{BucketName,BucketRegion,SyncFormat}` echoed as **top-level twins** (schema's legacy flat shape) → fold against the declared sibling (equality-gated).

**#668** `CloudFront::Distribution` `GeoRestriction.Locations` is a country SET AWS may reorder while the distribution propagates → `UNORDERED_ARRAY_PROPS` (intermittent declared-tier reorder FP; a genuine membership change still surfaces).

**#678** a PRIVATE `RestApi` gets `TLS_1_2` + `dualstack` defaults (not the EDGE/REGIONAL `TLS_1_0` + `ipv4`) → **derive both from the declared `EndpointConfiguration.Types`**.

## Tests
- Corpus `expected` updated for the four committed cases (GatewayResponse, Batch JobQueue, two Cognito pools): the folded findings flip `undeclared` → `atDefault`. `corpus-replay` is the live proof for these.
- 16 new unit tests (`tests/noise-firstrun-folds.test.ts`) each assert BOTH the fold AND that a genuine divergence still surfaces.
- Full suite: 3094 tests pass; typecheck / lint+format / build green.

Closes #642
Closes #643
Closes #668
Closes #678
