### PR TITLE
fix(revert): strip bare-null array husks from a CC revert patch (#641 symptom 2)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -778,6 +778,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     schemas: gathered.schemas,
     siblingSgRules: buildSiblingSgRules(gathered.desired),
     stackName,
+    // raw live models so a CC revert patch can strip a bare-null array husk out of CC's
+    // server-side model (#641 symptom 2), else the unrelated-property revert fails validation.
+    liveByLogical: gathered.liveByLogical,
   });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {

--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -281,6 +281,38 @@ export interface RevertPlan {
   notRevertable: NotRevertable[];
 }
 
+// A bare `null` array ELEMENT is a service read artifact (S3 echoes `TagFilters: [null]`
+// inside every prefix-scoped IntelligentTiering / Metrics config element that declares no
+// tag filter — #641). It is stripped from the DIFF view (cc-api-strip, symptom 1), but a
+// Cloud Control revert of ANY property on the same resource sends an RFC6902 patch that CC
+// applies to its OWN server-side model — which still contains the husk — and the provider's
+// update validation then REJECTS the null element ("expected type JSONObject, found Null"),
+// FAILING the revert of the unrelated property (#641 symptom 2). Emit `remove` ops that drop
+// the husk from CC's model too. Restricted to a PURE-null array (every element null): remove
+// the WHOLE property (absent = valid, and it dodges any minItems constraint an empty `[]`
+// would trip). Removing a KEY never shifts an array index, so the ops are order-independent
+// and safe to prepend to the real revert op. A REAL out-of-band edit produces non-null
+// objects (a mixed array is left untouched — not the observed husk shape), so detection and
+// legitimate reverts are unaffected.
+function nullHuskRemovalOps(model: Record<string, unknown>): PatchOp[] {
+  const ops: PatchOp[] = [];
+  const walk = (value: unknown, pointer: string): void => {
+    if (Array.isArray(value)) {
+      if (value.length > 0 && value.every((v) => v === null || v === undefined)) {
+        if (pointer !== '')
+          ops.push({ op: 'remove', path: pointer, human: `strip null array husk at ${pointer}` });
+        return; // a pure-null array has no non-null children to recurse into
+      }
+      value.forEach((v, i) => walk(v, `${pointer}/${i}`));
+    } else if (value && typeof value === 'object') {
+      for (const [k, v] of Object.entries(value as Record<string, unknown>))
+        walk(v, `${pointer}/${k.replace(/~/g, '~0').replace(/\//g, '~1')}`);
+    }
+  };
+  walk(model, '');
+  return ops;
+}
+
 // dotted finding path ("A.B.0.C") -> RFC6902 JSON pointer ("/A/B/0/C")
 function toPointer(dotted: string): string {
   return (
@@ -320,6 +352,12 @@ export interface RevertOptions {
   // — a self-ref / peer / prefix-list rule wiped). Merge them back into the revert value so
   // CC preserves them. Same shape classify uses to subtract them (buildSiblingSgRules).
   siblingSgRules?: Record<string, { ingress: unknown[]; egress: unknown[] }>;
+  // logicalId -> the RAW live model (read.live, pre-normalize). Used to sanitize a bare
+  // `null` array-element husk out of a Cloud Control revert patch (#641 symptom 2): the husk
+  // is stripped from the DIFF view (cc-api-strip) but persists in Cloud Control's OWN
+  // server-side model, so a CC UpdateResource of ANY property on the same resource fails
+  // model validation ("expected type JSONObject, found Null") unless the patch also drops it.
+  liveByLogical?: Map<string, Record<string, unknown>>;
 }
 
 // True when a finding path is AT or UNDER any create-only schema path. The schema's
@@ -667,6 +705,23 @@ export function buildRevertPlan(
       } as RevertItem);
     item.ops.push(op);
     itemsByLogical.set(key, item);
+  }
+
+  // #641 symptom 2: a Cloud Control UpdateResource patch is applied by CC to its OWN
+  // server-side model, which still carries any bare-null array husk the service echoes on
+  // read (e.g. S3 `TagFilters: [null]`). Prepend `remove` ops that strip the husk so the
+  // resulting model validates — otherwise the revert of an UNRELATED property on that
+  // resource hard-fails with a model-validation error. Only `cc` items (SDK writers build
+  // their own native payloads, never a CC patch); computed once per resource from its raw
+  // live model.
+  if (opts.liveByLogical) {
+    for (const item of itemsByLogical.values()) {
+      if (item.kind !== 'cc') continue;
+      const live = opts.liveByLogical.get(item.logicalId);
+      if (!live) continue;
+      const huskOps = nullHuskRemovalOps(live);
+      if (huskOps.length > 0) item.ops.unshift(...huskOps);
+    }
   }
 
   // Order DELETE items LAST. A `delete` (out-of-band `added` resource) can be REFERENCED

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -2531,3 +2531,95 @@ describe('#553: Lex BotLocales routes to the nested SDK writer (kind=sdk), not C
     expect(plan.items[0]).toMatchObject({ kind: 'sdk', resourceType: 'AWS::Lex::Bot' });
   });
 });
+
+describe('#641 symptom 2 — CC revert strips bare-null array husks from the model', () => {
+  // S3 echoes `TagFilters: [null]` inside every prefix-scoped IntelligentTiering / Metrics
+  // config element; the husk lives in Cloud Control's own server-side model, so a CC revert
+  // of an unrelated property (here VersioningConfiguration) fails model validation unless the
+  // patch also drops the husk.
+  const bucketLive = (): Record<string, unknown> => ({
+    VersioningConfiguration: { Status: 'Enabled' },
+    IntelligentTieringConfigurations: [{ Id: 'dataTier', Prefix: 'data/', TagFilters: [null] }],
+    MetricsConfigurations: [
+      { Id: 'EntireBucket' },
+      { Id: 'LogsOnly', Prefix: 'logs/', TagFilters: [null] },
+    ],
+  });
+  const versioningRemoval = (): Finding =>
+    F({
+      tier: 'undeclared',
+      path: 'VersioningConfiguration',
+      actual: { Status: 'Enabled' },
+      unrecorded: true,
+    });
+
+  it('prepends remove ops for each pure-null array husk before the real revert op', () => {
+    const plan = buildRevertPlan([versioningRemoval()], undefined, {
+      removeUnrecorded: true,
+      liveByLogical: new Map([['R', bucketLive()]]),
+    });
+    expect(plan.items).toHaveLength(1);
+    const ops = plan.items[0]!.ops;
+    // the husk removals lead, then the unrelated-property revert
+    expect(ops.map((o) => ({ op: o.op, path: o.path }))).toEqual([
+      { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
+      { op: 'remove', path: '/MetricsConfigurations/1/TagFilters' },
+      { op: 'remove', path: '/VersioningConfiguration' },
+    ]);
+    // and they serialize to Cloud Control as pure remove ops (no value)
+    expect(JSON.parse(toPatchDocument(plan.items[0]!))).toEqual([
+      { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
+      { op: 'remove', path: '/MetricsConfigurations/1/TagFilters' },
+      { op: 'remove', path: '/VersioningConfiguration' },
+    ]);
+  });
+
+  it('no husk in the live model -> no extra ops (unchanged plan)', () => {
+    const clean = {
+      VersioningConfiguration: { Status: 'Enabled' },
+      MetricsConfigurations: [{ Id: 'EntireBucket' }],
+    };
+    const plan = buildRevertPlan([versioningRemoval()], undefined, {
+      removeUnrecorded: true,
+      liveByLogical: new Map([['R', clean]]),
+    });
+    expect(plan.items[0]!.ops.map((o) => o.path)).toEqual(['/VersioningConfiguration']);
+  });
+
+  it('leaves a MIXED array (real object + null) untouched — only pure-null husks are dropped', () => {
+    const mixed = {
+      VersioningConfiguration: { Status: 'Enabled' },
+      MetricsConfigurations: [{ Id: 'LogsOnly', TagFilters: [{ Key: 'team', Value: 'a' }, null] }],
+    };
+    const plan = buildRevertPlan([versioningRemoval()], undefined, {
+      removeUnrecorded: true,
+      liveByLogical: new Map([['R', mixed]]),
+    });
+    // no husk op emitted for the mixed array; only the real revert remains
+    expect(plan.items[0]!.ops.map((o) => o.path)).toEqual(['/VersioningConfiguration']);
+  });
+
+  it('no liveByLogical provided -> no husk sanitization (back-compat)', () => {
+    const plan = buildRevertPlan([versioningRemoval()], undefined, { removeUnrecorded: true });
+    expect(plan.items[0]!.ops.map((o) => o.path)).toEqual(['/VersioningConfiguration']);
+  });
+
+  it('does NOT add husk ops to an SDK-writer (non-cc) item', () => {
+    // AWS::Config::ConfigRule InputParameters routes to an SDK writer, not a CC patch, so
+    // even with a (hypothetical) husk in its live model no husk op is injected.
+    const f = F({
+      tier: 'declared',
+      resourceType: 'AWS::Config::ConfigRule',
+      physicalId: 'cdkrd-rule',
+      path: 'InputParameters',
+      desired: { maxAccessKeyAge: 90 },
+      actual: { maxAccessKeyAge: '365' },
+    });
+    const plan = buildRevertPlan([f], undefined, {
+      liveByLogical: new Map([['R', { Foo: [null] }]]),
+    });
+    expect(plan.items).toHaveLength(1);
+    expect(plan.items[0]!.kind).toBe('sdk');
+    expect(plan.items[0]!.ops.every((o) => o.path !== '/Foo')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Closes **#641 symptom 2** (the revert-poison half; symptom 1 shipped in #687).

A Cloud Control `UpdateResource` patch is applied by CC to its **own server-side model**, which still carries any bare-`null` array husk the service echoes on read — S3 returns `TagFilters: [null]` inside every prefix-scoped IntelligentTiering / Metrics config element that declares no tag filter. Symptom 1 strips that husk from the **diff view** (`cc-api-strip`, #687), but the revert path never touched it, so a CC revert of **any unrelated property** on that bucket hard-failed model validation:

```
FAILED: Bkt — ValidationException: Model validation failed
  (#/MetricsConfigurations/0/TagFilters/0: expected type: JSONObject, found: Null
   #/IntelligentTieringConfigurations/0/TagFilters/0: expected type: JSONObject, found: Null)
```

## Fix

`buildRevertPlan` now prepends `remove` ops that drop each **pure-null** array husk from the target's raw live model (`liveByLogical`), once per `cc`-kind item (SDK writers build native payloads and never send a CC patch, so they are exempt). Restricted to pure-null arrays → **whole-property removal** (absent is valid and dodges any `minItems` constraint an empty `[]` would trip); removing a KEY never shifts an array index, so the ops are order-independent and safe to prepend to the real revert op. A **mixed** array (real object + null) is left untouched — not the observed husk shape, and touching it could drop real data.

## Live verification (us-east-1)

Prefix-scoped intelligent-tiering + metrics bucket, versioning enabled out of band, `revert --remove-unrecorded`:

| | released 0.2.33 | this PR |
|---|---|---|
| revert of unrelated `VersioningConfiguration` | **FAILED** `ValidationException` | dry-run prepends 2 husk-removal ops; **converged** ("CLEAN after revert") |
| real `dataTier` / `LogsOnly` configs afterward | — | **intact** |

Fixture torn down with `delstack`; stack + bucket swept, orphan-clean.

## Tests

`tests/revert-plan.test.ts`: prepend order + `toPatchDocument` serialization, no-husk no-op, mixed-array left alone, no-`liveByLogical` back-compat, SDK-item exempt.

Closes #641.
