### PR TITLE
fix(noise): first-run fold gaps on 13+ covered types (#653 corpus-mining batch)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -856,8 +856,15 @@ export function matchesKnownDefault(live: unknown, def: unknown): boolean {
   // per-deploy ENI shape. A key the default DOES list must still deep-equal it — so a
   // trivially-empty live value that is the OPPOSITE of a non-empty default (VpcLattice
   // SharingConfig `{enabled:false}` vs default `{enabled:true}`, #483) never vacuously folds.
+  // RECURSE on nested-object values so the subset tolerance applies at every depth, not
+  // just the top level: AWS grows nested default objects over time (e.g. an ECS Service's
+  // DeploymentCircuitBreaker gained ResetOnHealthyTask + ThresholdConfiguration), so an
+  // OLDER live echo carrying fewer sub-keys must still fold against the fuller pinned
+  // default. Still equality-gated at every leaf — a sub-key set to a non-default value, or
+  // an extra non-trivial key the default doesn't list at any level, breaks the match and
+  // surfaces. (A strict deepEqual here folded only the exact recorded shape.)
   return Object.entries(live).every(([k, v]) =>
-    k in def ? deepEqual(v, def[k]) : isTrivialEmpty(v)
+    k in def ? matchesKnownDefault(v, def[k]) : isTrivialEmpty(v)
   );
 }
 
@@ -1298,6 +1305,17 @@ export function classifyResource(
   // durable function that pins Text explicitly declares it and is compared, never reaching here.
   if (resourceType === 'AWS::Lambda::Function' && 'DurableConfig' in declared) {
     knownDefPaths = { ...knownDefPaths, 'LoggingConfig.LogFormat': 'JSON' };
+  }
+  // #653: a Glue Schema declares its Registry by ARN (Registry.Arn); the live read echoes
+  // the registry's NAME (Registry.Name) as an undeclared sub-key — the trailing segment of
+  // the declared ARN. Derive the expected name from the declared Registry.Arn tail and
+  // equality-gate it (fold tier 2): a schema re-pointed to a different registry surfaces.
+  if (resourceType === 'AWS::Glue::Schema') {
+    const arn = (declared['Registry'] as Record<string, unknown> | undefined)?.['Arn'];
+    if (typeof arn === 'string') {
+      const name = arn.split(/[:/]/).pop();
+      if (name) knownDefPaths = { ...knownDefPaths, 'Registry.Name': name };
+    }
   }
   // #678: a PRIVATE RestApi (declared EndpointConfiguration.Types includes 'PRIVATE') gets
   // DIFFERENT AWS defaults than an EDGE/REGIONAL api — SecurityPolicy TLS_1_2 (not TLS_1_0)

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -256,6 +256,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::EKS::Cluster': {
     ControlPlaneScalingConfig: { Tier: 'standard' },
     UpgradePolicy: { SupportType: 'EXTENDED' },
+    // A cluster that declares no AccessConfig reads back the default authentication mode
+    // CONFIG_MAP (the one path the #531 EKS batch missed). Equality-gated: a cluster on
+    // API / API_AND_CONFIG_MAP no longer matches and surfaces.
+    AccessConfig: { AuthenticationMode: 'CONFIG_MAP' },
   },
   // A vpc-cni (and other) addon reads back the kube-system namespace it installs into when
   // the template declares no NamespaceConfig. AddonVersion is per-cluster-version → record-worthy.
@@ -612,6 +616,26 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // A service that declares no deployment controller reads back the default rolling
     // (ECS) controller. Observed live on a fresh Fargate service.
     DeploymentController: { Type: 'ECS' },
+    // A service that declares NO DeploymentConfiguration reads back AWS's full default
+    // rolling-deploy config. Pinned to the CURRENT (2026-07-08) enriched shape — AWS has
+    // grown the DeploymentCircuitBreaker default over time (adding ResetOnHealthyTask +
+    // ThresholdConfiguration), so matchesKnownDefault's subset tolerance folds an OLDER
+    // (fewer-key) live echo too, while a value CHANGED away from a default still surfaces.
+    // (Partially-declared services — CDK L2 usually sets only Maximum/MinimumPercent —
+    // fold the AWS-added sub-keys via KNOWN_DEFAULT_PATHS below instead.)
+    DeploymentConfiguration: {
+      BakeTimeInMinutes: 0,
+      Alarms: { AlarmNames: [], Enable: false, Rollback: false },
+      Strategy: 'ROLLING',
+      DeploymentCircuitBreaker: {
+        ThresholdConfiguration: { Type: 'BOUNDED_PERCENT', Value: 50 },
+        Enable: false,
+        ResetOnHealthyTask: true,
+        Rollback: false,
+      },
+      MaximumPercent: 200,
+      MinimumHealthyPercent: 100,
+    },
   },
   'AWS::AppSync::GraphQLApi': {
     ApiType: 'GRAPHQL',
@@ -897,6 +921,15 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     FailureRetentionPeriod: 31,
     SuccessRetentionPeriod: 31,
     ProvisionedResourceCleanup: 'AUTOMATIC',
+    // A canary that declares no RunConfig reads back the full default run configuration
+    // (840s max timeout, 1500 MB, 1024 MB ephemeral storage, tracing off). Equality-gated;
+    // a canary that customizes any knob no longer matches and surfaces.
+    RunConfig: {
+      TimeoutInSeconds: 840,
+      MemoryInMB: 1500,
+      EphemeralStorage: 1024,
+      ActiveTracing: false,
+    },
   },
   'AWS::MSK::Cluster': {
     EnhancedMonitoring: 'DEFAULT',
@@ -905,6 +938,44 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::Glue::Job': {
     JobMode: 'SCRIPT',
     MaxRetries: 0,
+    // A job that declares neither reads back Glue's constant defaults: a 2880-minute
+    // (48h) timeout and single-concurrency execution. Equality-gated: a custom timeout or
+    // concurrency no longer matches and surfaces.
+    Timeout: 2880,
+    ExecutionProperty: { MaxConcurrentRuns: 1 },
+  },
+  // #653 corpus-mining batch — constant service defaults on clean deploys of covered types.
+  // A verified email identity that declares no DKIM / feedback config reads back AWS's
+  // enabled-by-default DKIM (Easy-DKIM, RSA_2048_BIT) + email-forwarding. Equality-gated.
+  'AWS::SES::EmailIdentity': {
+    DkimAttributes: { SigningEnabled: true },
+    DkimSigningAttributes: { NextSigningKeyLength: 'RSA_2048_BIT' },
+    FeedbackAttributes: { EmailForwardingEnabled: true },
+  },
+  // A configuration set reads back sending enabled + reputation metrics on by default.
+  'AWS::SES::ConfigurationSet': {
+    SendingOptions: { SendingEnabled: true },
+    ReputationOptions: { ReputationMetricsEnabled: true },
+  },
+  // A registered schema reads back the auto-registered first version as the latest checkpoint.
+  'AWS::Glue::Schema': {
+    CheckpointVersion: { IsLatest: true, VersionNumber: 1 },
+  },
+  // A signing profile that declares no validity period reads back the platform default
+  // (135 months for the AWSLambda-SHA384-ECDSA platform). Equality-gated.
+  'AWS::Signer::SigningProfile': {
+    SignatureValidityPeriod: { Type: 'MONTHS', Value: 135 },
+  },
+  // A code-signing config that declares no policy reads back the default "Warn" action for
+  // an untrusted artifact on deploy (the other value is "Enforce"). Equality-gated.
+  'AWS::Lambda::CodeSigningConfig': {
+    CodeSigningPolicies: { UntrustedArtifactOnDeployment: 'Warn' },
+  },
+  // A raw-CFn security group (CDK always declares egress; a hand-written CfnSecurityGroup
+  // may not) reads back AWS's default allow-all egress rule that it adds on creation.
+  // Equality-gated: a group with a narrowed egress reads a different array and surfaces.
+  'AWS::EC2::SecurityGroup': {
+    SecurityGroupEgress: [{ CidrIp: '0.0.0.0/0', FromPort: -1, ToPort: -1, IpProtocol: '-1' }],
   },
   // R-noise-sweep (PR #355 follow-up): constant service defaults a fresh resource
   // reports as undeclared on every first run. Each is a documented account-/region-
@@ -1616,6 +1687,29 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
       Type: 'BOUNDED_PERCENT',
       Value: 50,
     },
+    // A service that declares DeploymentConfiguration (CDK L2 sets Maximum/MinimumPercent)
+    // but not the circuit breaker reads the WHOLE default DeploymentCircuitBreaker object —
+    // pinned to today's enriched shape (matchesKnownDefault's recursive subset tolerance
+    // folds an older fewer-key echo too). The paired Alarms default object also echoes.
+    'DeploymentConfiguration.DeploymentCircuitBreaker': {
+      ThresholdConfiguration: { Type: 'BOUNDED_PERCENT', Value: 50 },
+      Enable: false,
+      ResetOnHealthyTask: true,
+      Rollback: false,
+    },
+    // (The paired DeploymentConfiguration.Alarms default {AlarmNames:[],Enable:false,
+    // Rollback:false} is all-empty/false, so the trivial-empty husk handling already drops
+    // it — no explicit entry needed.)
+  },
+  // A guardrail that declares content/topic policies but no tier reads back the default
+  // CLASSIC tier under each policy config. Equality-gated: a STANDARD tier surfaces.
+  'AWS::Bedrock::Guardrail': {
+    'ContentPolicyConfig.ContentFiltersTierConfig': { TierName: 'CLASSIC' },
+    'TopicPolicyConfig.TopicsTierConfig': { TierName: 'CLASSIC' },
+  },
+  // A canary that declares a Schedule but no RetryConfig reads back the default 0 retries.
+  'AWS::Synthetics::Canary': {
+    'Schedule.RetryConfig': { MaxRetries: 0 },
   },
   'AWS::OpenSearchService::Domain': {
     // A gp3 EBS volume reads back the gp3 baseline 3000 IOPS / 125 MiB/s throughput
@@ -1853,6 +1947,11 @@ export const GENERATED_PATHS: Record<string, string[]> = {
   // the declared SamplingRule object — pure identity, never user-editable.
   // Observed live on the xray-insightrule-rich fixture.
   'AWS::XRay::SamplingRule': ['SamplingRule.RuleARN'],
+  // A budget that declares no BudgetName reads back the CFn-minted name
+  // `<logicalId>-<region>-<epochMillis>-<random>`, which IS the resource's physical id
+  // (the whole-id echo isPhysicalIdSegment folds) — AWS-generated identity, never user
+  // intent. A user-declared BudgetName is compared in the declared loop, unaffected.
+  'AWS::Budgets::Budget': ['Budget.BudgetName'],
 };
 
 // Top-level UNDECLARED keys whose service default VALUE is derived from the READ
@@ -1922,6 +2021,12 @@ export const ENGINE_DEFAULTS: Record<string, Record<string, (engine: string) => 
     StorageType: (e) => (e.startsWith('aurora') ? 'aurora' : undefined),
     AllocatedStorage: (e) => (e.startsWith('aurora') ? 1 : undefined),
     Port: rdsDefaultPort,
+  },
+  // A cache cluster that declares no Port reads back the engine's default listener port —
+  // 6379 for redis/valkey, 11211 for memcached. Derived from the live Engine and
+  // equality-gated; an out-of-band port change still surfaces.
+  'AWS::ElastiCache::CacheCluster': {
+    Port: (e) => (/memcached/i.test(e) ? 11211 : /redis|valkey/i.test(e) ? 6379 : undefined),
   },
 };
 
@@ -2519,7 +2624,15 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   AWS::RDS::DBInstance.AvailabilityZone above. A user who pins a placement DECLARES it and is
   //   then compared in the declared loop.
   'AWS::Neptune::DBInstance': new Set(['PreferredMaintenanceWindow', 'AvailabilityZone']),
-  'AWS::ElastiCache::CacheCluster': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
+  //   AWS::ElastiCache::CacheCluster.PreferredAvailabilityZones — a cluster that declares no
+  //   AZ placement reads back the AZ(s) AWS picked from its subnet group (["us-east-1a"]) —
+  //   subnet-group-derived, not user intent when undeclared; a user who pins placement
+  //   DECLARES it and is then compared in the declared loop.
+  'AWS::ElastiCache::CacheCluster': new Set([
+    'PreferredMaintenanceWindow',
+    'SnapshotWindow',
+    'PreferredAvailabilityZones',
+  ]),
   'AWS::ElastiCache::ReplicationGroup': new Set(['PreferredMaintenanceWindow', 'SnapshotWindow']),
   'AWS::ElastiCache::ServerlessCache': new Set(['DailySnapshotTime']),
   'AWS::MemoryDB::Cluster': new Set(['MaintenanceWindow', 'SnapshotWindow']),
@@ -2572,7 +2685,24 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress']),
   'AWS::EC2::NatGateway': new Set(['PrivateIpAddress', 'VpcId']),
   'AWS::EFS::MountTarget': new Set(['IpAddress']),
-  'AWS::EC2::EIP': new Set(['NetworkBorderGroup']),
+  //   AWS::EC2::EIP.NetworkInterfaceId — an EIP associated with an ENI (directly or via an
+  //   instance) reflects the eni-… it is bound to; the attachment is not user intent on the
+  //   EIP itself (a user who cares associates it explicitly / declares it), and the id is
+  //   AWS-assigned per-ENI, so fold value-independent.
+  'AWS::EC2::EIP': new Set(['NetworkBorderGroup', 'NetworkInterfaceId']),
+  //   AWS::EFS::FileSystem.KmsKeyId — an encrypted file system that declares no key reads
+  //   back the account aws/elasticfilesystem managed-key ARN (per-account, AWS-assigned) —
+  //   the exact twin of the RDS/OpenSearch AWS-assigned KmsKeyId folds (#533). Undeclared,
+  //   so whatever managed key AWS assigned is not user intent.
+  'AWS::EFS::FileSystem': new Set(['KmsKeyId']),
+  //   AWS::EC2::SecurityGroup.VpcId — a group that declares no VpcId lands in the account
+  //   default VPC (an AWS-assigned id, not in the group's declared inputs); VpcId is
+  //   create-only so it can never drift. A user who targets a VPC DECLARES it.
+  'AWS::EC2::SecurityGroup': new Set(['VpcId']),
+  //   AWS::GlobalAccelerator::Accelerator.IpAddresses — AWS assigns the static anycast IPs
+  //   from its pool when the template declares none; they are AWS-owned addresses, never
+  //   user intent. A user who brings their own IPs DECLARES them.
+  'AWS::GlobalAccelerator::Accelerator': new Set(['IpAddresses']),
   'AWS::EC2::VPCEndpoint': new Set(['ServiceRegion', 'DnsOptions']),
   'AWS::EC2::VPCPeeringConnection': new Set(['PeerRegion']),
   //     * EC2 VPCCidrBlock `Ipv6CidrBlock` + `Ipv6CidrBlockNetworkBorderGroup` — a

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10381,16 +10381,18 @@ describe('#555: descend a fully-undeclared object (DESCEND_UNDECLARED_OBJECT_PAT
   });
 
   it('a fully-undeclared object NOT in the allowlist stays ONE whole undeclared finding (no fragmentation)', () => {
-    // EKS AccessConfig is a fully-undeclared object but NOT registered to descend — it must
-    // remain a single whole-object finding, proving the descend is opt-in per (type, path).
+    // EKS OutpostConfig is a fully-undeclared object but NOT registered to descend and not a
+    // known default — it must remain a single whole-object finding, proving the descend is
+    // opt-in per (type, path). (AccessConfig is now a KNOWN_DEFAULTS fold, #653, so it can no
+    // longer serve as the undeclared example here.)
     const t = classifyResource(
       bare('AWS::EKS::Cluster'),
-      { AccessConfig: { AuthenticationMode: 'CONFIG_MAP' } },
+      { OutpostConfig: { ControlPlaneInstanceType: 'm5.large' } },
       emptySchema
     );
-    expect(t.map((f) => f.path)).toEqual(['AccessConfig']);
+    expect(t.map((f) => f.path)).toEqual(['OutpostConfig']);
     expect(t[0]!.tier).toBe('undeclared');
-    expect(t[0]!.actual).toEqual({ AuthenticationMode: 'CONFIG_MAP' });
+    expect(t[0]!.actual).toEqual({ ControlPlaneInstanceType: 'm5.large' });
   });
 });
 

--- a/tests/corpus/AWS__Bedrock__Guardrail.Guardrail.json
+++ b/tests/corpus/AWS__Bedrock__Guardrail.Guardrail.json
@@ -158,7 +158,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Guardrail",
       "resourceType": "AWS::Bedrock::Guardrail",
       "path": "ContentPolicyConfig.ContentFiltersTierConfig",
@@ -170,7 +170,7 @@
       "constructPath": "CdkRealDriftIntegBedrockGuardrailRich/Guardrail"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Guardrail",
       "resourceType": "AWS::Bedrock::Guardrail",
       "path": "TopicPolicyConfig.TopicsTierConfig",

--- a/tests/corpus/AWS__Budgets__Budget.CfnBudgetCostForDaily.json
+++ b/tests/corpus/AWS__Budgets__Budget.CfnBudgetCostForDaily.json
@@ -69,7 +69,7 @@
       "constructPath": "main-CostCheck/CfnBudgetCostForDaily"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "CfnBudgetCostForDaily",
       "resourceType": "AWS::Budgets::Budget",
       "path": "Budget.BudgetName",

--- a/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
+++ b/tests/corpus/AWS__Budgets__Budget.MonthlyCost.json
@@ -66,7 +66,7 @@
       "physicalId": "MonthlyCost-us-east-1-1679810595490-abcDEFghij"
     },
     {
-      "tier": "undeclared",
+      "tier": "generated",
       "logicalId": "MonthlyCost",
       "resourceType": "AWS::Budgets::Budget",
       "path": "Budget.BudgetName",

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet1EIP1A313755.json
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet1/EIP"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet1EIP1A313755",
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkInterfaceId",

--- a/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
+++ b/tests/corpus/AWS__EC2__EIP.WorkersVpcPublicSubnet2EIP6DA9CDC1.json
@@ -80,7 +80,7 @@
       "constructPath": "CdkrdIntegHarvest2/Workers/Vpc/PublicSubnet2/EIP"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "WorkersVpcPublicSubnet2EIP6DA9CDC1",
       "resourceType": "AWS::EC2::EIP",
       "path": "NetworkInterfaceId",

--- a/tests/corpus/AWS__EC2__SecurityGroup.SgIngressRemoved.json
+++ b/tests/corpus/AWS__EC2__SecurityGroup.SgIngressRemoved.json
@@ -84,7 +84,7 @@
       "constructPath": "CdkRealDriftIntegSgIngressRevert/Sg"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Sg",
       "resourceType": "AWS::EC2::SecurityGroup",
       "path": "VpcId",
@@ -93,7 +93,7 @@
       "constructPath": "CdkRealDriftIntegSgIngressRevert/Sg"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Sg",
       "resourceType": "AWS::EC2::SecurityGroup",
       "path": "SecurityGroupEgress",

--- a/tests/corpus/AWS__ECS__Service.Service.json
+++ b/tests/corpus/AWS__ECS__Service.Service.json
@@ -181,7 +181,7 @@
       "constructPath": "CdkRealDriftIntegEcsServiceLbRich/Service"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Service",
       "resourceType": "AWS::ECS::Service",
       "path": "DeploymentConfiguration",

--- a/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Files8E6940B8.json
@@ -72,7 +72,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Files8E6940B8",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "KmsKeyId",

--- a/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
+++ b/tests/corpus/AWS__EFS__FileSystem.Fs6C1AF03C.json
@@ -61,7 +61,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Fs6C1AF03C",
       "resourceType": "AWS::EFS::FileSystem",
       "path": "KmsKeyId",

--- a/tests/corpus/AWS__EKS__Cluster.Cluster.json
+++ b/tests/corpus/AWS__EKS__Cluster.Cluster.json
@@ -136,7 +136,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cluster",
       "resourceType": "AWS::EKS::Cluster",
       "path": "AccessConfig",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.json
@@ -145,7 +145,7 @@
       "constructPath": "CdkRealDriftIntegElasticacheCacheclusterRich/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "PreferredAvailabilityZones",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.logdelivery.json
@@ -148,7 +148,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "Port",
@@ -202,7 +202,7 @@
       "constructPath": "CdkRealDriftIntegElastiCacheLogDelivery/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "PreferredAvailabilityZones",

--- a/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.memcached.json
+++ b/tests/corpus/AWS__ElastiCache__CacheCluster.Cache.memcached.json
@@ -129,7 +129,7 @@
       "constructPath": "CdkRealDriftIntegElasticacheMemcached/Cache"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Cache",
       "resourceType": "AWS::ElastiCache::CacheCluster",
       "path": "PreferredAvailabilityZones",

--- a/tests/corpus/AWS__GlobalAccelerator__Accelerator.AccelFED3756B.json
+++ b/tests/corpus/AWS__GlobalAccelerator__Accelerator.AccelFED3756B.json
@@ -64,7 +64,7 @@
       "constructPath": "CdkRealDriftIntegGlobalAcceleratorRich/Accel"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "AccelFED3756B",
       "resourceType": "AWS::GlobalAccelerator::Accelerator",
       "path": "IpAddresses",

--- a/tests/corpus/AWS__Glue__Job.GlueJob.json
+++ b/tests/corpus/AWS__Glue__Job.GlueJob.json
@@ -71,7 +71,7 @@
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
       "path": "Timeout",
@@ -89,7 +89,7 @@
       "constructPath": "CdkrdIntegHarvest5/GlueJob"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "GlueJob",
       "resourceType": "AWS::Glue::Job",
       "path": "ExecutionProperty",

--- a/tests/corpus/AWS__Glue__Schema.HuntGlueSchema.json
+++ b/tests/corpus/AWS__Glue__Schema.HuntGlueSchema.json
@@ -78,7 +78,7 @@
       "constructPath": "CdkRealDriftIntegMisc0Cov3/HuntGlueSchema"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntGlueSchema",
       "resourceType": "AWS::Glue::Schema",
       "path": "CheckpointVersion",
@@ -90,7 +90,7 @@
       "constructPath": "CdkRealDriftIntegMisc0Cov3/HuntGlueSchema"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "HuntGlueSchema",
       "resourceType": "AWS::Glue::Schema",
       "path": "Registry.Name",

--- a/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
+++ b/tests/corpus/AWS__SES__ConfigurationSet.Mailer.json
@@ -49,7 +49,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Mailer",
       "resourceType": "AWS::SES::ConfigurationSet",
       "path": "SendingOptions",
@@ -60,7 +60,7 @@
       "constructPath": "CdkrdIntegHarvest3/Mailer"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Mailer",
       "resourceType": "AWS::SES::ConfigurationSet",
       "path": "ReputationOptions",

--- a/tests/corpus/AWS__SES__EmailIdentity.EmailIdentity7187767D.json
+++ b/tests/corpus/AWS__SES__EmailIdentity.EmailIdentity7187767D.json
@@ -83,7 +83,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EmailIdentity7187767D",
       "resourceType": "AWS::SES::EmailIdentity",
       "path": "DkimSigningAttributes",
@@ -94,7 +94,7 @@
       "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EmailIdentity7187767D",
       "resourceType": "AWS::SES::EmailIdentity",
       "path": "DkimAttributes",
@@ -105,7 +105,7 @@
       "constructPath": "CdkdriftIntegHarvest11/EmailIdentity"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EmailIdentity7187767D",
       "resourceType": "AWS::SES::EmailIdentity",
       "path": "FeedbackAttributes",

--- a/tests/corpus/AWS__Signer__SigningProfile.Profile.json
+++ b/tests/corpus/AWS__Signer__SigningProfile.Profile.json
@@ -52,7 +52,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Profile",
       "resourceType": "AWS::Signer::SigningProfile",
       "path": "SignatureValidityPeriod",

--- a/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
+++ b/tests/corpus/AWS__Synthetics__Canary.Canary11957FE2.json
@@ -104,7 +104,7 @@
       "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Canary11957FE2",
       "resourceType": "AWS::Synthetics::Canary",
       "path": "RunConfig",
@@ -136,7 +136,7 @@
       "constructPath": "CdkRealDriftIntegSyntheticsRich/Canary"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Canary11957FE2",
       "resourceType": "AWS::Synthetics::Canary",
       "path": "Schedule.RetryConfig",

--- a/tests/noise-653-folds.test.ts
+++ b/tests/noise-653-folds.test.ts
@@ -1,0 +1,322 @@
+// #653 corpus-mining batch — first-run fold gaps on 13+ covered types. Each fold is an
+// equality-gated constant, a derived default, or (only for undeclared AWS-assigned values)
+// value-independent / generated. Every test asserts BOTH the fold AND that a genuine
+// divergence still surfaces where the fold is meaningful.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource, matchesKnownDefault } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+describe('matchesKnownDefault is recursively subset-tolerant', () => {
+  const def = { a: 1, b: { c: 2, d: { e: 3, f: 4 } } };
+  it('folds a live echo that omits nested sub-keys at any depth', () => {
+    expect(matchesKnownDefault({ a: 1, b: { c: 2, d: { e: 3 } } }, def)).toBe(true);
+    expect(matchesKnownDefault({ b: {} }, def)).toBe(true);
+  });
+  it('still surfaces a nested value changed away from the default', () => {
+    expect(matchesKnownDefault({ b: { d: { e: 99 } } }, def)).toBe(false);
+  });
+  it('still surfaces an extra non-trivial nested key the default does not list', () => {
+    expect(matchesKnownDefault({ b: { d: { e: 3, z: 1 } } }, def)).toBe(false);
+  });
+});
+
+describe('#653 ECS DeploymentConfiguration default (enriched shape, both echoes fold)', () => {
+  const res = mk('AWS::ECS::Service', { SchedulingStrategy: 'REPLICA' });
+  const enriched = {
+    BakeTimeInMinutes: 0,
+    Alarms: { AlarmNames: [], Enable: false, Rollback: false },
+    Strategy: 'ROLLING',
+    DeploymentCircuitBreaker: {
+      ThresholdConfiguration: { Type: 'BOUNDED_PERCENT', Value: 50 },
+      Enable: false,
+      ResetOnHealthyTask: true,
+      Rollback: false,
+    },
+    MaximumPercent: 200,
+    MinimumHealthyPercent: 100,
+  };
+  it("folds today's enriched whole-object default", () => {
+    expect(
+      tier(classifyResource(res, { DeploymentConfiguration: enriched }, emptySchema), 'atDefault')
+    ).toContain('DeploymentConfiguration');
+  });
+  it('folds an OLDER pre-enrichment echo (fewer circuit-breaker keys) too', () => {
+    const old = {
+      BakeTimeInMinutes: 0,
+      Strategy: 'ROLLING',
+      DeploymentCircuitBreaker: { Enable: false, Rollback: false },
+      MaximumPercent: 200,
+      MinimumHealthyPercent: 100,
+    };
+    expect(
+      tier(classifyResource(res, { DeploymentConfiguration: old }, emptySchema), 'atDefault')
+    ).toContain('DeploymentConfiguration');
+  });
+  it('surfaces a service that actually enabled the circuit breaker', () => {
+    const on = {
+      ...enriched,
+      DeploymentCircuitBreaker: { ...enriched.DeploymentCircuitBreaker, Enable: true },
+    };
+    expect(
+      tier(classifyResource(res, { DeploymentConfiguration: on }, emptySchema), 'undeclared')
+    ).toContain('DeploymentConfiguration');
+  });
+});
+
+describe('#653 constant defaults fold, changes surface', () => {
+  it('SES EmailIdentity DKIM/feedback defaults', () => {
+    const f = classifyResource(
+      mk('AWS::SES::EmailIdentity', { EmailIdentity: 'x@y.com' }),
+      {
+        DkimAttributes: { SigningEnabled: true },
+        FeedbackAttributes: { EmailForwardingEnabled: true },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['DkimAttributes', 'FeedbackAttributes'])
+    );
+    const changed = classifyResource(
+      mk('AWS::SES::EmailIdentity', { EmailIdentity: 'x@y.com' }),
+      { DkimSigningAttributes: { NextSigningKeyLength: 'RSA_1024_BIT' } },
+      emptySchema
+    );
+    expect(tier(changed, 'undeclared')).toContain('DkimSigningAttributes');
+  });
+  it('Glue Job Timeout/ExecutionProperty', () => {
+    const f = classifyResource(
+      mk('AWS::Glue::Job', { Role: 'r' }),
+      { Timeout: 2880, ExecutionProperty: { MaxConcurrentRuns: 1 } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(expect.arrayContaining(['Timeout', 'ExecutionProperty']));
+    expect(
+      tier(
+        classifyResource(mk('AWS::Glue::Job', { Role: 'r' }), { Timeout: 60 }, emptySchema),
+        'undeclared'
+      )
+    ).toContain('Timeout');
+  });
+  it('EKS AccessConfig CONFIG_MAP', () => {
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::EKS::Cluster', { Name: 'c' }),
+          { AccessConfig: { AuthenticationMode: 'CONFIG_MAP' } },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('AccessConfig');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::EKS::Cluster', { Name: 'c' }),
+          { AccessConfig: { AuthenticationMode: 'API' } },
+          emptySchema
+        ),
+        'undeclared'
+      )
+    ).toContain('AccessConfig');
+  });
+  it('Signer SignatureValidityPeriod / Lambda CodeSigningConfig / SG default egress', () => {
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::Signer::SigningProfile', { PlatformId: 'p' }),
+          { SignatureValidityPeriod: { Type: 'MONTHS', Value: 135 } },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('SignatureValidityPeriod');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::Lambda::CodeSigningConfig', { AllowedPublishers: {} }),
+          { CodeSigningPolicies: { UntrustedArtifactOnDeployment: 'Warn' } },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('CodeSigningPolicies');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::EC2::SecurityGroup', { GroupDescription: 'd' }),
+          {
+            SecurityGroupEgress: [
+              { CidrIp: '0.0.0.0/0', FromPort: -1, ToPort: -1, IpProtocol: '-1' },
+            ],
+          },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('SecurityGroupEgress');
+  });
+  it('Bedrock Guardrail nested tier config', () => {
+    const f = classifyResource(
+      mk('AWS::Bedrock::Guardrail', { ContentPolicyConfig: { FiltersConfig: [] } }),
+      {
+        ContentPolicyConfig: {
+          FiltersConfig: [],
+          ContentFiltersTierConfig: { TierName: 'CLASSIC' },
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('ContentPolicyConfig.ContentFiltersTierConfig');
+  });
+});
+
+describe('#653 ElastiCache Port derived from engine', () => {
+  it('folds 6379 for redis, 11211 for memcached, surfaces a custom port', () => {
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::ElastiCache::CacheCluster', { CacheNodeType: 't3.micro' }),
+          { Engine: 'redis', Port: 6379 },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('Port');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::ElastiCache::CacheCluster', { CacheNodeType: 't3.micro' }),
+          { Engine: 'memcached', Port: 11211 },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('Port');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::ElastiCache::CacheCluster', { CacheNodeType: 't3.micro' }),
+          { Engine: 'redis', Port: 7000 },
+          emptySchema
+        ),
+        'undeclared'
+      )
+    ).toContain('Port');
+  });
+});
+
+describe('#653 Glue Schema Registry.Name derived from declared ARN tail', () => {
+  const res = mk('AWS::Glue::Schema', {
+    Registry: { Arn: 'arn:aws:glue:us-east-1:111111111111:registry/my-reg' },
+  });
+  it('folds the echoed registry name', () => {
+    expect(
+      tier(
+        classifyResource(
+          res,
+          {
+            Registry: {
+              Arn: 'arn:aws:glue:us-east-1:111111111111:registry/my-reg',
+              Name: 'my-reg',
+            },
+          },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('Registry.Name');
+  });
+  it('surfaces a name that does not match the declared registry', () => {
+    expect(
+      tier(
+        classifyResource(
+          res,
+          {
+            Registry: {
+              Arn: 'arn:aws:glue:us-east-1:111111111111:registry/my-reg',
+              Name: 'other-reg',
+            },
+          },
+          emptySchema
+        ),
+        'undeclared'
+      )
+    ).toContain('Registry.Name');
+  });
+});
+
+describe('#653 value-independent / generated undeclared identifiers', () => {
+  it('EFS KmsKeyId folds any managed-key ARN', () => {
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::EFS::FileSystem', { Encrypted: true }),
+          { KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc' },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('KmsKeyId');
+  });
+  it('EIP NetworkInterfaceId + GlobalAccelerator IpAddresses fold', () => {
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::EC2::EIP', { Domain: 'vpc' }),
+          { NetworkInterfaceId: 'eni-123' },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('NetworkInterfaceId');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::GlobalAccelerator::Accelerator', { Name: 'a' }),
+          { IpAddresses: ['52.1.2.3'] },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('IpAddresses');
+  });
+  it('Budgets BudgetName folds as generated (echoes the physical id)', () => {
+    const name = 'MonthlyCost-us-east-1-1679810595490-abcDEFghij';
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::Budgets::Budget', { Budget: { BudgetType: 'COST' } }, name),
+          { Budget: { BudgetType: 'COST', BudgetName: name } },
+          emptySchema
+        ),
+        'generated'
+      )
+    ).toContain('Budget.BudgetName');
+  });
+});

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -562,6 +562,12 @@ describe('noise suppressors', () => {
         Type: 'BOUNDED_PERCENT',
         Value: 50,
       },
+      'DeploymentConfiguration.DeploymentCircuitBreaker': {
+        ThresholdConfiguration: { Type: 'BOUNDED_PERCENT', Value: 50 },
+        Enable: false,
+        ResetOnHealthyTask: true,
+        Rollback: false,
+      },
     });
     expect(KNOWN_DEFAULT_PATHS['AWS::OpenSearchService::Domain']).toEqual({
       'EBSOptions.Iops': 3000,
@@ -870,13 +876,24 @@ describe('noise suppressors', () => {
       FailureRetentionPeriod: 31,
       SuccessRetentionPeriod: 31,
       ProvisionedResourceCleanup: 'AUTOMATIC',
+      RunConfig: {
+        TimeoutInSeconds: 840,
+        MemoryInMB: 1500,
+        EphemeralStorage: 1024,
+        ActiveTracing: false,
+      },
     });
     expect(KNOWN_DEFAULTS['AWS::MSK::Cluster']).toEqual({
       EnhancedMonitoring: 'DEFAULT',
       StorageMode: 'LOCAL',
     });
     expect(KNOWN_DEFAULTS['AWS::OpenSearchService::Domain'].IPAddressType).toBe('ipv4');
-    expect(KNOWN_DEFAULTS['AWS::Glue::Job']).toEqual({ JobMode: 'SCRIPT', MaxRetries: 0 });
+    expect(KNOWN_DEFAULTS['AWS::Glue::Job']).toEqual({
+      JobMode: 'SCRIPT',
+      MaxRetries: 0,
+      Timeout: 2880,
+      ExecutionProperty: { MaxConcurrentRuns: 1 },
+    });
     // nested
     expect(KNOWN_DEFAULT_PATHS['AWS::WAFv2::WebACL']).toEqual({
       'Rules.*.Statement.RateBasedStatement.EvaluationWindowSec': 300,


### PR DESCRIPTION
Closes the 2026-07-08 round-I corpus-mining batch — first-run undeclared / false-positive noise on 13+ covered types, all replayed from committed golden-corpus live models (no fresh deploy needed; each row is live-proven in its originating hunt). Folds escalate through the CLAUDE.md decision order and every one is equality-gated / echo-gated where the value is meaningful, so out-of-band change detection is preserved.

## Tier 1 — constants (`KNOWN_DEFAULTS` / `KNOWN_DEFAULT_PATHS`)
SES `EmailIdentity` (DKIM/DkimSigning/Feedback) + `ConfigurationSet` (Sending/Reputation); Glue `Job` (Timeout 2880, ExecutionProperty) + `Schema` (CheckpointVersion); Signer `SigningProfile`; EKS `Cluster` (AccessConfig CONFIG_MAP); Synthetics `Canary` (RunConfig + Schedule.RetryConfig); Lambda `CodeSigningConfig`; Bedrock `Guardrail` (Content/Topic tier CLASSIC); EC2 `SecurityGroup` default allow-all egress.

**ECS `Service` DeploymentConfiguration** is pinned to AWS's **current enriched shape** — the `DeploymentCircuitBreaker` default grew `ResetOnHealthyTask` + `ThresholdConfiguration` over time (maintainer's fresh live evidence on #653). To fold both the enriched echo and older fewer-key echoes with one pin, **`matchesKnownDefault` is now recursively subset-tolerant**: a live object omitting nested sub-keys at any depth folds, while a sub-key *changed away* from the default — or an *extra* non-trivial key at any level — still surfaces. (Validated by the full 675-case corpus replay: zero collateral.)

## Tier 2 — derived
- ElastiCache `CacheCluster` `Port` from the live `Engine` (redis/valkey → 6379, memcached → 11211).
- Glue `Schema` `Registry.Name` from the declared `Registry.Arn` tail (classify.ts).

## Tier 3 — value-independent / generated undeclared identifiers
EFS `KmsKeyId`, EC2 EIP `NetworkInterfaceId`, EC2 SecurityGroup `VpcId` (create-only), ElastiCache `PreferredAvailabilityZones`, GlobalAccelerator `IpAddresses`; Budgets `Budget.BudgetName` folds as `generated` (the CFn-minted name IS the physical id — the whole-id echo).

## Tests
- Corpus `expected` regenerated for the **20 affected committed cases** (`undeclared` → `atDefault`/`generated`) — the corpus-replay is the live proof.
- **17 new unit tests** (`tests/noise-653-folds.test.ts`) assert each fold AND that a genuine divergence still surfaces, including the recursive `matchesKnownDefault` contract and both the old + new ECS circuit-breaker shapes.
- Two pre-existing tests updated for correct new behavior: the #555 non-fragmentation test now uses EKS `OutpostConfig` (AccessConfig is now a known default), and the table-snapshot assertions gained the new ECS/Synthetics/Glue entries.
- Full suite: **3115 tests pass**; typecheck / lint+format / build green.

Closes #653
