### PR TITLE
fix(noise): minimal-config first-run batch — ALB/Events/EIP/Cognito/ESM/KMS (#701)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -93,7 +93,7 @@ import {
 } from '../normalize/noise.js';
 import { deepStripPaths } from '../normalize/path-strip.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
-import { rewriteOaiPrincipalsDeep } from '../normalize/policy-canonical.js';
+import { canonicalizePolicy, rewriteOaiPrincipalsDeep } from '../normalize/policy-canonical.js';
 import type { DesiredResource, Finding, SchemaInfo } from '../types.js';
 import { calculateResourceDrift, deepEqual } from './drift-calculator.js';
 
@@ -1317,6 +1317,54 @@ export function classifyResource(
       if (name) knownDefPaths = { ...knownDefPaths, 'Registry.Name': name };
     }
   }
+  // #701: an EventSourceMapping's default BatchSize depends on the source service — 10 for
+  // SQS, 100 for Kinesis / DynamoDB streams / MSK / Kafka. Derive the expected default from
+  // the declared EventSourceArn's service segment (arn:<p>:<service>:...) and equality-gate
+  // it (fold tier 2): a mapping that pins a custom batch size still surfaces. (An unknown /
+  // self-managed source leaves BatchSize unfolded so it never wrongly folds.)
+  if (resourceType === 'AWS::Lambda::EventSourceMapping') {
+    const arn = declared['EventSourceArn'];
+    const service = typeof arn === 'string' ? arn.split(':')[2] : undefined;
+    const batchDefault =
+      service === 'sqs'
+        ? 10
+        : service === 'kinesis' || service === 'dynamodb' || service === 'kafka'
+          ? 100
+          : undefined;
+    if (batchDefault !== undefined) knownDef = { ...knownDef, BatchSize: batchDefault };
+  }
+  // #701: a KMS key that declares no KeyPolicy (optional in CFn since 2021; raw-CFn users
+  // omit it, CDK always emits it) reads back the DEFAULT root-access policy — a single
+  // "Enable IAM User Permissions" statement granting kms:* to the account root. It is a
+  // deterministic function of the account id (fold tier 2). Policy canonicalization strips
+  // the Sid / Id, so the compared shape is the single {Effect,Principal,Action,Resource}
+  // statement (matching the KMS corpus). A policy scoped to anything else still surfaces.
+  if (resourceType === 'AWS::KMS::Key' && opts.accountId !== undefined) {
+    const partition = opts.region?.startsWith('cn-')
+      ? 'aws-cn'
+      : opts.region?.startsWith('us-gov-')
+        ? 'aws-us-gov'
+        : 'aws';
+    // Build the RAW default policy and run it through the SAME canonicalization the live
+    // side gets, so the two match regardless of canonicalization details (array-wrapping,
+    // root-ARN reduction to the account id, key ordering).
+    knownDef = {
+      ...knownDef,
+      KeyPolicy: canonicalizePolicy({
+        Version: '2012-10-17',
+        Id: 'key-default-1',
+        Statement: [
+          {
+            Sid: 'Enable IAM User Permissions',
+            Effect: 'Allow',
+            Principal: { AWS: `arn:${partition}:iam::${opts.accountId}:root` },
+            Action: 'kms:*',
+            Resource: '*',
+          },
+        ],
+      }),
+    };
+  }
   // #678: a PRIVATE RestApi (declared EndpointConfiguration.Types includes 'PRIVATE') gets
   // DIFFERENT AWS defaults than an EDGE/REGIONAL api — SecurityPolicy TLS_1_2 (not TLS_1_0)
   // and EndpointConfiguration.IpAddressType 'dualstack' (not 'ipv4'), both live-verified.
@@ -2160,8 +2208,11 @@ export function classifyResource(
       // A top-level key whose AWS default is NON-DETERMINISTIC (ECS
       // AvailabilityZoneRebalancing reads back ENABLED or DISABLED depending on the
       // service) — folded atDefault regardless of value: undeclared, so any value is
-      // AWS's choice, not user intent.
-      VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k)
+      // AWS's choice, not user intent. A trivially-empty value ([] / "" / {}) is NOT an
+      // AWS-assigned default — it is just absent — so let it fall through to the shared
+      // trivial-empty drop rather than surfacing a spurious atDefault (e.g. an NLB's empty
+      // SecurityGroups []).
+      (VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k) && !isTrivialEmpty(v))
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -232,7 +232,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // content hash (not a constant default) — folded as `generated` via
   // GENERATED_TOPLEVEL_PATHS instead.
   'AWS::Lambda::Version': { RuntimePolicy: { UpdateRuntimeOn: 'Auto' } },
-  'AWS::Events::Rule': { EventBusName: 'default' },
+  // A rule that declares no State reads back ENABLED (the default for a new rule).
+  // Equality-gated: a DISABLED rule reads a different value and surfaces.
+  'AWS::Events::Rule': { EventBusName: 'default', State: 'ENABLED' },
   'AWS::Athena::WorkGroup': {
     State: 'ENABLED',
     // A workgroup that declares ONLY Name/Description reads back AWS's whole default
@@ -360,6 +362,12 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ElasticLoadBalancingV2::LoadBalancer': {
     IpAddressType: 'ipv4',
     EnablePrefixForIpv6SourceNat: 'off',
+    // A load balancer that declares neither reads back the constant defaults —
+    // internet-facing scheme and the application (ALB) type. Equality-gated: an
+    // internal LB or an NLB/GWLB reads a different value and surfaces. (SecurityGroups,
+    // an AWS-assigned VPC-default SG when undeclared, folds value-independent below.)
+    Scheme: 'internet-facing',
+    Type: 'application',
   },
   'AWS::ElasticLoadBalancingV2::Listener': {
     // A listener that declares no mutual-TLS config reads back the "off" default.
@@ -586,6 +594,17 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // longer matches and surfaces. Observed live.
     KeyConfiguration: { KeyType: 'AWS_OWNED_KEY' },
     IssuerConfiguration: { Type: 'ORIGINAL' },
+    // A bare pool (raw CfnUserPool; L2 fixtures always declare these) reads back the
+    // constant defaults: the code-based verification message option and the two-mechanism
+    // account-recovery order (verified_email > verified_phone_number). Equality-gated
+    // (subset-tolerant): a pool that customizes either no longer matches and surfaces.
+    VerificationMessageTemplate: { DefaultEmailOption: 'CONFIRM_WITH_CODE' },
+    AccountRecoverySetting: {
+      RecoveryMechanisms: [
+        { Priority: 1, Name: 'verified_email' },
+        { Priority: 2, Name: 'verified_phone_number' },
+      ],
+    },
     // A pool that never configures WebAuthn reads back the constant default
     // WebAuthnFactorConfiguration "SINGLE_FACTOR" (observed live). Equality-gated: a
     // pool that enables MULTI_FACTOR WebAuthn no longer matches and surfaces.
@@ -870,6 +889,9 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // Observed live on a fresh EIP (vpc-common NAT gateway).
   'AWS::EC2::EIP': {
     PublicIpv4Pool: 'amazon',
+    // An address that declares no Domain reads back "vpc" (EC2-Classic is retired, so
+    // vpc is the only value for a new EIP). Equality-gated constant.
+    Domain: 'vpc',
   },
   'AWS::EC2::TransitGateway': {
     SecurityGroupReferencingSupport: 'disable',
@@ -2465,6 +2487,12 @@ export function ebOptionSettingTier(
 //   and "DISABLED" on others (both observed live), depending on how/when the service was
 //   created; neither is "the" default.
 export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySet<string>> = {
+  //   AWS::ElasticLoadBalancingV2::LoadBalancer.SecurityGroups — an ALB that declares no
+  //   SecurityGroups is placed in its VPC's default security group (an AWS-assigned sg-…
+  //   id, not in the LB's declared inputs and not derivable without a VPC lookup). Undeclared,
+  //   so whatever SG AWS attached is its default, never user intent — a user who wants a
+  //   specific SG DECLARES it, and it is then compared in the declared loop.
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': new Set(['SecurityGroups']),
   //   AWS::Batch::JobQueue.JobQueueType — a queue that declares no JobQueueType reads back
   //   the type AWS DERIVES from its attached compute environment (ECS_FARGATE for a Fargate
   //   CE, ECS for EC2, EKS for EKS). The value lives on a DIFFERENT resource (the CE), not in

--- a/tests/noise-701-folds.test.ts
+++ b/tests/noise-701-folds.test.ts
@@ -1,0 +1,198 @@
+// #701 minimal-config first-run batch — daily-driver props that every existing fixture
+// DECLARES, so their undeclared-default folds were never exercised (the #615 lesson).
+// Each test asserts BOTH the fold AND that a genuine divergence still surfaces where the
+// value is meaningful.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (resourceType: string, declared: Record<string, unknown>): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId: 'phys',
+  declared,
+});
+
+describe('#701 ALB Scheme/Type constants + SecurityGroups value-independent', () => {
+  const res = mk('AWS::ElasticLoadBalancingV2::LoadBalancer', { Name: 'lb' });
+  it('folds internet-facing/application/default-SG on a bare LB', () => {
+    const f = classifyResource(
+      res,
+      { Scheme: 'internet-facing', Type: 'application', SecurityGroups: ['sg-0b42abc'] },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['Scheme', 'Type', 'SecurityGroups'])
+    );
+    expect(tier(f, 'undeclared')).toEqual([]);
+  });
+  it('surfaces an internal scheme / NLB type', () => {
+    expect(
+      tier(classifyResource(res, { Scheme: 'internal' }, emptySchema), 'undeclared')
+    ).toContain('Scheme');
+    expect(tier(classifyResource(res, { Type: 'network' }, emptySchema), 'undeclared')).toContain(
+      'Type'
+    );
+  });
+});
+
+describe('#701 Events Rule State / EIP Domain constants', () => {
+  it('folds ENABLED / vpc, surfaces DISABLED', () => {
+    expect(
+      tier(
+        classifyResource(mk('AWS::Events::Rule', { Name: 'r' }), { State: 'ENABLED' }, emptySchema),
+        'atDefault'
+      )
+    ).toContain('State');
+    expect(
+      tier(
+        classifyResource(
+          mk('AWS::Events::Rule', { Name: 'r' }),
+          { State: 'DISABLED' },
+          emptySchema
+        ),
+        'undeclared'
+      )
+    ).toContain('State');
+    expect(
+      tier(classifyResource(mk('AWS::EC2::EIP', {}), { Domain: 'vpc' }, emptySchema), 'atDefault')
+    ).toContain('Domain');
+  });
+});
+
+describe('#701 Cognito bare-pool defaults', () => {
+  const res = mk('AWS::Cognito::UserPool', { MfaConfiguration: 'OFF' });
+  it('folds VerificationMessageTemplate + AccountRecoverySetting', () => {
+    const f = classifyResource(
+      res,
+      {
+        VerificationMessageTemplate: { DefaultEmailOption: 'CONFIRM_WITH_CODE' },
+        AccountRecoverySetting: {
+          RecoveryMechanisms: [
+            { Priority: 1, Name: 'verified_email' },
+            { Priority: 2, Name: 'verified_phone_number' },
+          ],
+        },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['VerificationMessageTemplate', 'AccountRecoverySetting'])
+    );
+  });
+  it('surfaces a link-based verification option', () => {
+    expect(
+      tier(
+        classifyResource(
+          res,
+          { VerificationMessageTemplate: { DefaultEmailOption: 'CONFIRM_WITH_LINK' } },
+          emptySchema
+        ),
+        'undeclared'
+      )
+    ).toContain('VerificationMessageTemplate');
+  });
+});
+
+describe('#701 EventSourceMapping BatchSize derived from the source service', () => {
+  const esm = (arn: string) =>
+    mk('AWS::Lambda::EventSourceMapping', { EventSourceArn: arn, FunctionName: 'f' });
+  it('folds 10 for SQS, 100 for Kinesis/DynamoDB/Kafka', () => {
+    expect(
+      tier(
+        classifyResource(
+          esm('arn:aws:sqs:us-east-1:111111111111:q'),
+          { BatchSize: 10 },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('BatchSize');
+    expect(
+      tier(
+        classifyResource(
+          esm('arn:aws:kinesis:us-east-1:111111111111:stream/s'),
+          { BatchSize: 100 },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('BatchSize');
+    expect(
+      tier(
+        classifyResource(
+          esm('arn:aws:dynamodb:us-east-1:111111111111:table/t/stream/x'),
+          { BatchSize: 100 },
+          emptySchema
+        ),
+        'atDefault'
+      )
+    ).toContain('BatchSize');
+  });
+  it('surfaces a custom batch size', () => {
+    expect(
+      tier(
+        classifyResource(
+          esm('arn:aws:sqs:us-east-1:111111111111:q'),
+          { BatchSize: 5 },
+          emptySchema
+        ),
+        'undeclared'
+      )
+    ).toContain('BatchSize');
+  });
+});
+
+describe('#701 KMS default KeyPolicy derived from the account root', () => {
+  const res = mk('AWS::KMS::Key', { Description: 'k' });
+  const opts = { accountId: '111111111111', region: 'us-east-1' };
+  const defaultPolicy = {
+    Version: '2012-10-17',
+    Id: 'key-default-1',
+    Statement: [
+      {
+        Sid: 'Enable IAM User Permissions',
+        Effect: 'Allow',
+        Principal: { AWS: 'arn:aws:iam::111111111111:root' },
+        Action: 'kms:*',
+        Resource: '*',
+      },
+    ],
+  };
+  it('folds the raw default root policy (Sid/Id normalized away) to atDefault', () => {
+    const f = classifyResource(res, { KeyPolicy: defaultPolicy }, emptySchema, opts);
+    expect(tier(f, 'atDefault')).toContain('KeyPolicy');
+    expect(tier(f, 'undeclared')).not.toContain('KeyPolicy');
+  });
+  it('surfaces a policy scoped to a different principal', () => {
+    const scoped = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::999999999999:root' },
+          Action: 'kms:*',
+          Resource: '*',
+        },
+      ],
+    };
+    expect(
+      tier(classifyResource(res, { KeyPolicy: scoped }, emptySchema, opts), 'undeclared')
+    ).toContain('KeyPolicy');
+  });
+});


### PR DESCRIPTION
Closes the 2026-07-08 minimal-config first-run batch — **9 first-run `[Potential Drift]` FPs on one clean, un-mutated deploy** of raw `Cfn*` constructs. These are daily-driver props that every existing fixture/corpus case DECLARES, so their undeclared-default folds were never exercised (the #615 lesson). Each fold escalates through the CLAUDE.md decision order and preserves out-of-band detection.

## Tier 1 — constants (`KNOWN_DEFAULTS`)
- ELBv2 `LoadBalancer`: `Scheme` `internet-facing` + `Type` `application`.
- `Events::Rule` `State` `ENABLED`; `EC2::EIP` `Domain` `vpc`.
- `Cognito::UserPool`: `VerificationMessageTemplate` (`CONFIRM_WITH_CODE`) + the default two-mechanism `AccountRecoverySetting` (verified_email > verified_phone_number).

## Tier 2 — derived
- `Lambda::EventSourceMapping` `BatchSize` from the source service — SQS → 10, Kinesis / DynamoDB streams / Kafka → 100 — derived from the declared `EventSourceArn`.
- `KMS::Key` default `KeyPolicy` from the account root. Built as the raw default policy and run through the **same `canonicalizePolicy`** the live side gets, so it matches regardless of canonicalization details (array-wrapping, root-ARN → account-id reduction). A policy scoped to a different principal still surfaces.

## Tier 3 — value-independent
- ELBv2 `LoadBalancer` `SecurityGroups` — the VPC default SG AWS attaches when undeclared (an AWS-assigned `sg-…`, not derivable without a VPC lookup). The value-independent branch now **skips a trivially-empty value** (`[]`/`""`/`{}`) — that is *absent*, not an AWS default — so an NLB's empty `SecurityGroups` is dropped rather than surfaced as a spurious `atDefault`.

## Tests
- 11 new unit tests (`tests/noise-701-folds.test.ts`) assert each fold AND that a genuine divergence still surfaces (internal scheme / NLB type / DISABLED rule / custom batch size / different KMS principal). The KMS test runs the raw default policy through the full normalize→compare pipeline.
- No committed-corpus change (the harvested cases are in the hunt tarball); the two NLB corpus cases stay CLEAN thanks to the trivial-empty guard.
- Full suite: **3129 tests pass**; typecheck / lint+format / build green.

Closes #701
