### PR TITLE
fix(diff): detect out-of-band Lambda log re-pointing — LoggingConfig.LogGroup derived gate (#703)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1306,6 +1306,23 @@ export function classifyResource(
   if (resourceType === 'AWS::Lambda::Function' && 'DurableConfig' in declared) {
     knownDefPaths = { ...knownDefPaths, 'LoggingConfig.LogFormat': 'JSON' };
   }
+  // #703: a function's default log group is the DERIVED `/aws/lambda/<name>` (GENERATED_DEFAULTS
+  // resolves it, above, via resolveGeneratedDefault). It ALSO sits in GENERATED_NESTED_PATHS as a
+  // value-INDEPENDENT nested fold, which shadows the derivation when LoggingConfig is only
+  // PARTIALLY declared (e.g. `{ LogFormat: JSON }`) and LogGroup surfaces at sub-key level via
+  // emitNested — so an out-of-band log RE-POINT to a custom group was folded and INVISIBLE (a
+  // silent FN, and security-relevant: logs land elsewhere while the team watches /aws/lambda/<fn>).
+  // Promote it to a tier-2 derived equality gate: fold only the AWS-default value; a custom
+  // LogGroup surfaces. The value-independent branch in emitNested is suppressed for any nested
+  // path that already has a knownDefPaths gate (the equality gate handles the atDefault case).
+  if (resourceType === 'AWS::Lambda::Function') {
+    const genLogGroup = (genDef['LoggingConfig'] as Record<string, unknown> | undefined)?.[
+      'LogGroup'
+    ];
+    if (typeof genLogGroup === 'string') {
+      knownDefPaths = { ...knownDefPaths, 'LoggingConfig.LogGroup': genLogGroup };
+    }
+  }
   // #653: a Glue Schema declares its Registry by ARN (Registry.Arn); the live read echoes
   // the registry's NAME (Registry.Name) as an undeclared sub-key — the trailing segment of
   // the declared ARN. Derive the expected name from the declared Registry.Arn tail and
@@ -1395,8 +1412,12 @@ export function classifyResource(
         // physical-id segment (the AWS default) — a custom value the user set surfaces.
         (generatedPaths.includes(schemaPath) && isPhysicalIdSegment(value, physicalId)) ||
           // Value-INDEPENDENT nested generated path (KMS KeyPolicy.Id): AWS/CFn-injected,
-          // never derivable from the physical id — folded only in this live-only case.
-          generatedNestedPaths?.has(schemaPath)
+          // never derivable from the physical id — folded only in this live-only case. But NOT
+          // when the path also has a knownDefPaths equality gate this run (#703 Lambda
+          // LoggingConfig.LogGroup, derived above): the gate already folded the AWS-default
+          // value via `atDefault`, so a value reaching here is a real custom one that must
+          // surface, not be value-independent-folded.
+          (generatedNestedPaths?.has(schemaPath) && !(schemaPath in knownDefPaths))
         ? 'generated'
         : 'undeclared';
     // A free-form map key surfaces (not folded), but only when it is a real undeclared

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -9083,7 +9083,7 @@ describe('real-stack false-positive folds', () => {
     expect(t.undeclared).toEqual([]);
   });
 
-  it('Lambda default LoggingConfig sub-keys fold (LogGroup generated, LogFormat/SystemLogLevel atDefault)', () => {
+  it('Lambda default LoggingConfig sub-keys fold; a re-pointed LogGroup surfaces (#703)', () => {
     // The template declares a partial LoggingConfig (as a CDK provider-framework function
     // does); AWS fills in the default LogGroup + format/level, which descend as sub-keys.
     const res: DesiredResource = {
@@ -9102,9 +9102,28 @@ describe('real-stack false-positive folds', () => {
       },
     };
     const t = tiers(classifyResource(res, live, mkSchema()));
-    expect(t.generated).toEqual(['LoggingConfig.LogGroup']);
-    expect(t.atDefault.sort()).toEqual(['LoggingConfig.LogFormat', 'LoggingConfig.SystemLogLevel']);
+    // #703: the AWS-default LogGroup `/aws/lambda/<name>` now folds via a DERIVED equality gate
+    // (atDefault), not the value-independent `generated` fold, so a change away is detectable.
+    expect(t.generated).toEqual([]);
+    expect(t.atDefault.sort()).toEqual([
+      'LoggingConfig.LogFormat',
+      'LoggingConfig.LogGroup',
+      'LoggingConfig.SystemLogLevel',
+    ]);
     expect(t.undeclared).toEqual([]);
+    // #703 core: logs RE-POINTED out of band to a custom group must SURFACE (was invisible).
+    const repointed = {
+      FunctionName: 'my-fn',
+      LoggingConfig: {
+        ApplicationLogLevel: 'FATAL',
+        LogGroup: 'my-custom-log-group',
+        LogFormat: 'Text',
+        SystemLogLevel: 'INFO',
+      },
+    };
+    expect(tiers(classifyResource(res, repointed, mkSchema())).undeclared).toEqual([
+      'LoggingConfig.LogGroup',
+    ]);
     // a function that opts into JSON logging still surfaces the non-default LogFormat
     const jsonLive = {
       FunctionName: 'my-fn',


### PR DESCRIPTION
## What

`AWS::Lambda::Function` `LoggingConfig.LogGroup` was **value-independent** folded (GENERATED_NESTED_PATHS), so an out-of-band log **re-point** (`UpdateFunctionConfiguration` to a custom group) was **INVISIBLE** — logs land elsewhere while the team keeps watching `/aws/lambda/<fn>`. A silent FN, and security-relevant (log exfil / loss).

## Fix (classify.ts only)

The derived default already exists (`GENERATED_DEFAULTS` resolves `/aws/lambda/<name>` via `resolveGeneratedDefault`); the value-independent entry only shadowed it when `LoggingConfig` is **partially declared** and `LogGroup` descends at sub-key level via `emitNested`. Promote it to a **tier-2 derived equality gate**: inject the resolved default into `knownDefPaths` (folds the AWS-default value `atDefault`) and suppress the value-independent `emitNested` fold for any nested path that already has a `knownDefPaths` gate. The noise.ts `GENERATED_NESTED_PATHS` entry stays (now inert for Lambda via the guard).

## Live verification (us-east-1, partial-LoggingConfig fn)

| | result |
|---|---|
| clean deploy (fixed) | **CLEAN** — LogGroup folds via the derived gate (no first-run FP) |
| re-point to custom group — BEFORE (0.2.35) | **CLEAN / invisible** (the FN) |
| re-point to custom group — AFTER | **`[Potential Drift: 1] Fn.LoggingConfig.LogGroup`** surfaces |

## Tests

`classify.test.ts`: default `/aws/lambda/<name>` folds `atDefault`; a re-pointed custom group surfaces `undeclared`; JSON LogFormat still surfaces.

Closes #703.