### PR TITLE
fix(revert): converge Cognito UserPool Policies revert — write the KNOWN_DEFAULTS default (#702)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -129,6 +129,16 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::Cognito::UserPool\0DeletionProtection',
   'AWS::Cognito::UserPool\0MfaConfiguration',
   'AWS::Cognito::UserPool\0UserPoolTier',
+  // Policies is the same UpdateUserPool omit-ignored behavior (#702, live-proven: mutating
+  // PasswordPolicy.MinimumLength out of band, then `revert --remove-unrecorded` planned a
+  // `remove`, reported reverted, yet the live pool stayed MinimumLength=10). Its whole-object
+  // KNOWN_DEFAULTS default (min length 8, all four char classes, 7-day temp lifetime, PASSWORD
+  // first factor) is written back explicitly so revert converges.
+  // BLAST RADIUS: UpdateUserPool ignores EVERY omitted field, so ANY future UserPool
+  // KNOWN_DEFAULTS addition needs a matching entry here. VerificationMessageTemplate /
+  // AccountRecoverySetting are the next two (their folds land with #701 — add them once the
+  // KNOWN_DEFAULTS defaults exist so the set-default write resolves a value).
+  'AWS::Cognito::UserPool\0Policies',
   // SNS SetSubscriptionAttributes HARD-FAILS a `remove` of FilterPolicyScope (#630,
   // live-proven: setting it to MessageBody out of band, then reverting via `remove` fails with
   // InvalidRequest "FilterPolicyScope: Invalid value [null]. Please use either MessageBody or

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -361,6 +361,37 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#702: appeared-since-record undeclared Cognito UserPool Policies -> add op writing the KNOWN_DEFAULTS default', () => {
+    // AWS::Cognito::UserPool Policies is in REVERT_SET_DEFAULT_PATHS: UpdateUserPool is a
+    // full-PUT that IGNORES an omitted property, so a bare `remove` of an out-of-band
+    // PasswordPolicy change is a silent no-op (live-proven #702: MinimumLength stayed 10).
+    // Revert must write the whole-object KNOWN_DEFAULTS default back explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::Cognito::UserPool',
+      physicalId: 'us-east-1_pool',
+      path: 'Policies',
+      actual: { PasswordPolicy: { MinimumLength: 10 } },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Policies',
+      value: {
+        PasswordPolicy: {
+          MinimumLength: 8,
+          RequireLowercase: true,
+          RequireNumbers: true,
+          RequireSymbols: true,
+          RequireUppercase: true,
+          TemporaryPasswordValidityDays: 7,
+        },
+        SignInPolicy: { AllowedFirstAuthFactors: ['PASSWORD'] },
+      },
+      prior: { PasswordPolicy: { MinimumLength: 10 } },
+    });
+  });
+
   it('#651: appeared-since-record undeclared EC2 Subnet EnableDns64 -> add op writing the false default', () => {
     // AWS::EC2::Subnet EnableDns64 is in REVERT_SET_DEFAULT_PATHS: EC2 ModifySubnetAttribute
     // leaves an OMITTED EnableDns64 UNCHANGED, so a bare `remove` of an out-of-band `true` is


### PR DESCRIPTION
## What

Cognito `UpdateUserPool` is a full-PUT provider that **ignores an omitted property**, so a bare `remove` revert of an out-of-band `Policies` change is a silent no-op (the #597 class, already fixed for DeletionProtection / MfaConfiguration / UserPoolTier in #630). Live-proven #702: `PasswordPolicy.MinimumLength` mutated 8→10 out of band, `revert --remove-unrecorded` planned a `remove`, reported reverted, yet the live pool stayed 10.

## Fix (revert/plan.ts only)

Add `AWS::Cognito::UserPool\0Policies` to `REVERT_SET_DEFAULT_PATHS` so revert writes the whole-object `KNOWN_DEFAULTS` default (min length 8, all four char classes, 7-day temp lifetime, PASSWORD first factor) back explicitly. Its whole-object default already exists in `KNOWN_DEFAULTS`, so the set-default write resolves.

**Blast-radius note added**: `UpdateUserPool` ignores EVERY omitted field, so any future UserPool `KNOWN_DEFAULTS` addition needs a matching entry here.

## Scope

`Policies` **only** (live-verifiable now). `VerificationMessageTemplate` / `AccountRecoverySetting` (also in #702) depend on their **folds landing with #701** — their `KNOWN_DEFAULTS` defaults do not exist yet, so a set-default write can't resolve a value. They follow once #701 lands; #702 stays open for them.

## Live verification (us-east-1, minimal CfnUserPool)

| | result |
|---|---|
| BEFORE (0.2.35) | `NOT reverted: Pool.Policies — removal was a no-op`, live MinimumLength = 10 |
| AFTER | `Policies -> AWS default`, live MinimumLength restored to **8** (converged) |

## Tests

`revert-plan.test.ts`: the add op writes the whole-object `KNOWN_DEFAULTS` Policies default.

Refs #702.