### PR TITLE
chore(integ): drop reservedConcurrentExecutions from lambda-rich fixture (#685)

### DIFF
--- a/tests/integration/lambda-rich/app.ts
+++ b/tests/integration/lambda-rich/app.ts
@@ -33,7 +33,12 @@ const fn = new LambdaFunction(stack, "Handler", {
   timeout: Duration.seconds(15),
   ephemeralStorageSize: Size.mebibytes(1024),
   tracing: Tracing.ACTIVE,
-  reservedConcurrentExecutions: 2,
+  // NOTE: reservedConcurrentExecutions intentionally omitted — setting it is rejected in
+  // regions/accounts at the small default Lambda concurrency limit (the deploy fails with
+  // "decreases account's UnreservedConcurrentExecution below its minimum value of [10]",
+  // wasting a paid deploy + delstack cycle). It exercises no cdkrd-specific fold — a plain
+  // declared mutable prop — and verify-detect.sh mutates MemorySize/Timeout, so detection
+  // coverage is unaffected. See #685.
   description: "cdkrd lambda-rich test handler",
   environment: {
     STAGE: "test",


### PR DESCRIPTION
Setting reservedConcurrentExecutions=2 is rejected in a region/account at the
small default Lambda concurrency limit ("decreases account's
UnreservedConcurrentExecution below its minimum value of [10]"), rolling the
stack back and wasting a paid deploy + delstack cycle before the fixture can be
retried (hit live during the 2026-07-08 region-shift hunt round).

The property exercises no cdkrd-specific fold — a plain declared mutable prop —
and verify-detect.sh mutates MemorySize/Timeout, not concurrency, so detection
coverage is unaffected. Remove it so the fixture deploys in constrained
regions/accounts.

Closes #685

Fixture-only change (no `src/**`) — verify-pr-gate exempt; `check`+`docs` cover it.