### PR TITLE
fix(noise): EC2 Instance/Volume/ENI first-run undeclared folds (#640)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -455,6 +455,30 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     Tenancy: 'default',
     SourceDestCheck: true,
     InstanceInitiatedShutdownBehavior: 'stop',
+    // An instance that declares no MetadataOptions reads back the IMDS defaults AWS
+    // materializes at launch: IMDSv2 required (HttpTokens), a hop limit of 2, IPv6 and
+    // metadata-tags disabled, endpoint enabled — the AL2023-era secure defaults. Whole-object
+    // KNOWN_DEFAULTS (equality-gated, subset-tolerant): weaken any of them out of band
+    // (HttpTokens:"optional" to drop IMDSv2 enforcement, or raise the hop limit) and the
+    // object no longer matches, so it re-surfaces as real undeclared drift — detection is
+    // preserved. An older AMI whose defaults differ (e.g. hop limit 1) simply doesn't match
+    // and surfaces once, recordable. Observed live on fresh ec2-instance-rich / -sets deploys (#640).
+    MetadataOptions: {
+      HttpTokens: 'required',
+      HttpPutResponseHopLimit: 2,
+      HttpProtocolIpv6: 'disabled',
+      InstanceMetadataTags: 'disabled',
+      HttpEndpoint: 'enabled',
+    },
+    // An instance in an IPv4 subnet that declares no PrivateDnsNameOptions reads back the
+    // constant default: an ip-name hostname with resource-name DNS A/AAAA records off.
+    // Equality-gated, so switching HostnameType (resource-name) or enabling a DNS record out
+    // of band no longer matches and re-surfaces. Observed live (ec2-instance-rich / -sets, #640).
+    PrivateDnsNameOptions: {
+      HostnameType: 'ip-name',
+      EnableResourceNameDnsARecord: false,
+      EnableResourceNameDnsAAAARecord: false,
+    },
   },
   // R105 (second dogfood-audit wave): more top-level constant service defaults
   // (same exclusions as R104 — no names/ids/ARNs, no region-/account-specific
@@ -2710,7 +2734,24 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //     * EC2 NatGateway `VpcId` — AWS DERIVES the VPC id from the declared SubnetId and reads
   //       it back (create-only, embeds the per-resource `vpc-…` id, never declared by CDK).
   'AWS::EC2::Instance': new Set(['PrivateIpAddress']),
-  'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress']),
+  //   AWS::EC2::NetworkInterface.PrivateIpAddresses — an ENI that declares no
+  //   PrivateIpAddresses reads back the single auto-assigned primary
+  //   ([{PrivateIpAddress:"10.0.0.x", Primary:true}]) — the plural-array twin of the singular
+  //   PrivateIpAddress fold above. GroupSet — an ENI that declares no security groups is
+  //   placed in its VPC's default group (an AWS-assigned sg-… id, not derivable without a VPC
+  //   lookup); the exact twin of the ElasticLoadBalancingV2::LoadBalancer.SecurityGroups fold.
+  //   Both are undeclared → whatever AWS assigned is its default, never user intent; a user who
+  //   manages the ENI's IPs or SGs DECLARES them (the eni-rich fixture does), and they are then
+  //   compared in the declared loop. Live-confirmed on fresh eni-rich ENIs (2026-07-08, #640).
+  'AWS::EC2::NetworkInterface': new Set(['PrivateIpAddress', 'PrivateIpAddresses', 'GroupSet']),
+  //   AWS::EC2::Volume.KmsKeyId — an encrypted volume (Encrypted:true) that declares no key
+  //   reads back the account aws/ebs managed-key ARN (per-account, AWS-assigned) — the exact
+  //   twin of the RDS/OpenSearch/EFS AWS-assigned KmsKeyId folds (#533). An EBS volume's key is
+  //   set at creation and immutable (re-encryption requires snapshot+recreate), so this can
+  //   never hide a real out-of-band change. AvailabilityZoneId — the zone-id (use1-az1) AWS
+  //   derives from the declared AvailabilityZone; per-account mapping, create-only. Both
+  //   undeclared → not user intent. Live-confirmed on fresh volumes (2026-07-08, #640).
+  'AWS::EC2::Volume': new Set(['KmsKeyId', 'AvailabilityZoneId']),
   'AWS::EC2::NatGateway': new Set(['PrivateIpAddress', 'VpcId']),
   'AWS::EFS::MountTarget': new Set(['IpAddress']),
   //   AWS::EC2::EIP.NetworkInterfaceId — an EIP associated with an ENI (directly or via an

--- a/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
+++ b/tests/corpus/AWS__EC2__Instance.HostB4E45AD7.json
@@ -299,19 +299,75 @@
   },
   "expected": [
     {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.216",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "HostB4E45AD7",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Tenancy",
+      "actual": "default",
+      "physicalId": "i-0b7c750351d0a5aa6",
+      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
+    },
+    {
       "tier": "readGap",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
       "path": "LaunchTemplate",
       "note": "write-only — cannot be read back",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "unresolved",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "AvailabilityZone",
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
@@ -337,55 +393,14 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "unresolved",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "UserData",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "Tenancy",
-      "actual": "default",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
       "tier": "undeclared",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SecurityGroups",
-      "actual": ["CdkRealDriftIntegEc2Rich-SgD4954771-nA4Jj877L60k"],
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.0.216",
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "Volumes",
-      "actual": [
-        {
-          "VolumeId": "vol-094cd4ee2e33c8e54",
-          "Device": "/dev/xvda"
-        },
-        {
-          "VolumeId": "vol-010c7274153ce356a",
-          "Device": "/dev/sdf"
-        }
-      ],
+      "path": "CpuOptions",
+      "actual": {
+        "ThreadsPerCore": 2,
+        "CoreCount": 1
+      },
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
@@ -422,23 +437,8 @@
       "tier": "undeclared",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "MetadataOptions",
-      "actual": {
-        "HttpPutResponseHopLimit": 2,
-        "HttpProtocolIpv6": "disabled",
-        "HttpTokens": "required",
-        "InstanceMetadataTags": "disabled",
-        "HttpEndpoint": "enabled"
-      },
-      "physicalId": "i-0b7c750351d0a5aa6",
-      "constructPath": "CdkRealDriftIntegEc2Rich/Host"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "HostB4E45AD7",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "InstanceInitiatedShutdownBehavior",
-      "actual": "stop",
+      "path": "SecurityGroups",
+      "actual": ["CdkRealDriftIntegEc2Rich-SgD4954771-nA4Jj877L60k"],
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
@@ -446,33 +446,33 @@
       "tier": "undeclared",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "CpuOptions",
-      "actual": {
-        "ThreadsPerCore": 2,
-        "CoreCount": 1
-      },
+      "path": "Volumes",
+      "actual": [
+        {
+          "VolumeId": "vol-094cd4ee2e33c8e54",
+          "Device": "/dev/xvda"
+        },
+        {
+          "VolumeId": "vol-010c7274153ce356a",
+          "Device": "/dev/sdf"
+        }
+      ],
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "undeclared",
+      "tier": "unresolved",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateDnsNameOptions",
-      "actual": {
-        "EnableResourceNameDnsARecord": false,
-        "HostnameType": "ip-name",
-        "EnableResourceNameDnsAAAARecord": false
-      },
+      "path": "AvailabilityZone",
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     },
     {
-      "tier": "atDefault",
+      "tier": "unresolved",
       "logicalId": "HostB4E45AD7",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SourceDestCheck",
-      "actual": true,
+      "path": "UserData",
       "physicalId": "i-0b7c750351d0a5aa6",
       "constructPath": "CdkRealDriftIntegEc2Rich/Host"
     }

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -300,23 +300,11 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "AvailabilityZone",
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "Volumes[/dev/xvda]",
-      "actual": {
-        "VolumeId": "vol-0aac921ab46964337",
-        "Device": "/dev/xvda"
-      },
-      "nested": true,
+      "path": "InstanceInitiatedShutdownBehavior",
+      "actual": "stop",
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
@@ -324,17 +312,27 @@
       "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "Tenancy",
-      "actual": "default",
+      "path": "MetadataOptions",
+      "actual": {
+        "HttpPutResponseHopLimit": 2,
+        "HttpProtocolIpv6": "disabled",
+        "HttpTokens": "required",
+        "InstanceMetadataTags": "disabled",
+        "HttpEndpoint": "enabled"
+      },
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SecurityGroups",
-      "actual": ["default"],
+      "path": "PrivateDnsNameOptions",
+      "actual": {
+        "EnableResourceNameDnsARecord": false,
+        "HostnameType": "ip-name",
+        "EnableResourceNameDnsAAAARecord": false
+      },
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
@@ -344,6 +342,24 @@
       "resourceType": "AWS::EC2::Instance",
       "path": "PrivateIpAddress",
       "actual": "10.0.0.226",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "SourceDestCheck",
+      "actual": true,
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Tenancy",
+      "actual": "default",
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
@@ -394,39 +410,6 @@
       "tier": "undeclared",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SubnetId",
-      "actual": "subnet-0f3c7a3910f1a4f50",
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "MetadataOptions",
-      "actual": {
-        "HttpPutResponseHopLimit": 2,
-        "HttpProtocolIpv6": "disabled",
-        "HttpTokens": "required",
-        "InstanceMetadataTags": "disabled",
-        "HttpEndpoint": "enabled"
-      },
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "InstanceInitiatedShutdownBehavior",
-      "actual": "stop",
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
       "path": "CpuOptions",
       "actual": {
         "ThreadsPerCore": 2,
@@ -439,11 +422,9 @@
       "tier": "undeclared",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "PrivateDnsNameOptions",
+      "path": "CreditSpecification",
       "actual": {
-        "EnableResourceNameDnsARecord": false,
-        "HostnameType": "ip-name",
-        "EnableResourceNameDnsAAAARecord": false
+        "CPUCredits": "unlimited"
       },
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
@@ -458,11 +439,11 @@
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
     {
-      "tier": "atDefault",
+      "tier": "undeclared",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "SourceDestCheck",
-      "actual": true,
+      "path": "SecurityGroups",
+      "actual": ["default"],
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     },
@@ -470,10 +451,29 @@
       "tier": "undeclared",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
-      "path": "CreditSpecification",
+      "path": "SubnetId",
+      "actual": "subnet-0f3c7a3910f1a4f50",
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "undeclared",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "Volumes[/dev/xvda]",
       "actual": {
-        "CPUCredits": "unlimited"
+        "VolumeId": "vol-0aac921ab46964337",
+        "Device": "/dev/xvda"
       },
+      "nested": true,
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "unresolved",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
+      "path": "AvailabilityZone",
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
     }

--- a/tests/corpus/AWS__EC2__NetworkInterface.Eni.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.Eni.json
@@ -115,13 +115,40 @@
       "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0876958cf7bca8260",
+      "constructPath": "CdkRealDriftIntegEniRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",
       "actual": "10.0.0.221",
       "physicalId": "eni-0876958cf7bca8260",
       "constructPath": "CdkRealDriftIntegEniRich/Eni"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddresses",
@@ -140,33 +167,6 @@
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "SecondaryPrivateIpAddressCount",
       "actual": 0,
-      "physicalId": "eni-0876958cf7bca8260",
-      "constructPath": "CdkRealDriftIntegEniRich/Eni"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Eni",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv6PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-0876958cf7bca8260",
-      "constructPath": "CdkRealDriftIntegEniRich/Eni"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Eni",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv4PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-0876958cf7bca8260",
-      "constructPath": "CdkRealDriftIntegEniRich/Eni"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "Eni",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "InterfaceType",
-      "actual": "interface",
       "physicalId": "eni-0876958cf7bca8260",
       "constructPath": "CdkRealDriftIntegEniRich/Eni"
     }

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniA.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniA.json
@@ -96,13 +96,49 @@
       "tier": "atDefault",
       "logicalId": "EniA",
       "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "GroupSet",
+      "actual": ["sg-068968f8cf5536d62"],
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-0020122cb730d7d89",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniA",
+      "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",
       "actual": "10.0.0.150",
       "physicalId": "eni-0020122cb730d7d89",
       "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EniA",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddresses",
@@ -128,44 +164,8 @@
       "tier": "atDefault",
       "logicalId": "EniA",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv6PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-0020122cb730d7d89",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "EniA",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv4PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-0020122cb730d7d89",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "EniA",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "GroupSet",
-      "actual": ["sg-068968f8cf5536d62"],
-      "physicalId": "eni-0020122cb730d7d89",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "EniA",
-      "resourceType": "AWS::EC2::NetworkInterface",
       "path": "SourceDestCheck",
       "actual": true,
-      "physicalId": "eni-0020122cb730d7d89",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "EniA",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "InterfaceType",
-      "actual": "interface",
       "physicalId": "eni-0020122cb730d7d89",
       "constructPath": "CdkRealDriftIntegAuthNetRich/EniA"
     }

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniB.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniB.json
@@ -96,13 +96,49 @@
       "tier": "atDefault",
       "logicalId": "EniB",
       "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "GroupSet",
+      "actual": ["sg-068968f8cf5536d62"],
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv6PrefixCount",
+      "actual": 0,
+      "physicalId": "eni-09f7c461bd5f47f4c",
+      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "EniB",
+      "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddress",
       "actual": "10.0.0.134",
       "physicalId": "eni-09f7c461bd5f47f4c",
       "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "EniB",
       "resourceType": "AWS::EC2::NetworkInterface",
       "path": "PrivateIpAddresses",
@@ -128,44 +164,8 @@
       "tier": "atDefault",
       "logicalId": "EniB",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv6PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-09f7c461bd5f47f4c",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "EniB",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv4PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-09f7c461bd5f47f4c",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "EniB",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "GroupSet",
-      "actual": ["sg-068968f8cf5536d62"],
-      "physicalId": "eni-09f7c461bd5f47f4c",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "EniB",
-      "resourceType": "AWS::EC2::NetworkInterface",
       "path": "SourceDestCheck",
       "actual": true,
-      "physicalId": "eni-09f7c461bd5f47f4c",
-      "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
-    },
-    {
-      "tier": "atDefault",
-      "logicalId": "EniB",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "InterfaceType",
-      "actual": "interface",
       "physicalId": "eni-09f7c461bd5f47f4c",
       "constructPath": "CdkRealDriftIntegAuthNetRich/EniB"
     }

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
@@ -133,17 +133,26 @@
       "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "PrivateIpAddress",
-      "actual": "10.0.0.10",
+      "path": "GroupSet",
+      "actual": ["sg-0dd629030dbd15c82"],
       "physicalId": "eni-01ce38782d866c24f",
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "SecondaryPrivateIpAddressCount",
-      "actual": 3,
+      "path": "InterfaceType",
+      "actual": "interface",
+      "physicalId": "eni-01ce38782d866c24f",
+      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Eni",
+      "resourceType": "AWS::EC2::NetworkInterface",
+      "path": "Ipv4PrefixCount",
+      "actual": 0,
       "physicalId": "eni-01ce38782d866c24f",
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     },
@@ -160,17 +169,8 @@
       "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "Ipv4PrefixCount",
-      "actual": 0,
-      "physicalId": "eni-01ce38782d866c24f",
-      "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Eni",
-      "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "GroupSet",
-      "actual": ["sg-0dd629030dbd15c82"],
+      "path": "PrivateIpAddress",
+      "actual": "10.0.0.10",
       "physicalId": "eni-01ce38782d866c24f",
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     },
@@ -184,11 +184,11 @@
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     },
     {
-      "tier": "atDefault",
+      "tier": "undeclared",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "InterfaceType",
-      "actual": "interface",
+      "path": "SecondaryPrivateIpAddressCount",
+      "actual": 3,
       "physicalId": "eni-01ce38782d866c24f",
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     }

--- a/tests/corpus/AWS__EC2__Volume.Data666C94C7.json
+++ b/tests/corpus/AWS__EC2__Volume.Data666C94C7.json
@@ -70,15 +70,16 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::EC2::Volume",
-      "path": "AvailabilityZone",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
       "physicalId": "vol-010c7274153ce356a",
       "constructPath": "CdkRealDriftIntegEc2Rich/Data"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::EC2::Volume",
       "path": "KmsKeyId",
@@ -87,11 +88,10 @@
       "constructPath": "CdkRealDriftIntegEc2Rich/Data"
     },
     {
-      "tier": "undeclared",
+      "tier": "unresolved",
       "logicalId": "Data666C94C7",
       "resourceType": "AWS::EC2::Volume",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
+      "path": "AvailabilityZone",
       "physicalId": "vol-010c7274153ce356a",
       "constructPath": "CdkRealDriftIntegEc2Rich/Data"
     }

--- a/tests/corpus/AWS__EC2__Volume.Gp2Vol0A540FFC.json
+++ b/tests/corpus/AWS__EC2__Volume.Gp2Vol0A540FFC.json
@@ -69,15 +69,16 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "Gp2Vol0A540FFC",
       "resourceType": "AWS::EC2::Volume",
-      "path": "AvailabilityZone",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
       "physicalId": "vol-035b5abfc83c3e495",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Gp2Vol0A540FFC",
       "resourceType": "AWS::EC2::Volume",
       "path": "KmsKeyId",
@@ -89,17 +90,16 @@
       "tier": "undeclared",
       "logicalId": "Gp2Vol0A540FFC",
       "resourceType": "AWS::EC2::Volume",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
+      "path": "Iops",
+      "actual": 100,
       "physicalId": "vol-035b5abfc83c3e495",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
     },
     {
-      "tier": "undeclared",
+      "tier": "unresolved",
       "logicalId": "Gp2Vol0A540FFC",
       "resourceType": "AWS::EC2::Volume",
-      "path": "Iops",
-      "actual": 100,
+      "path": "AvailabilityZone",
       "physicalId": "vol-035b5abfc83c3e495",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
     }

--- a/tests/corpus/AWS__EC2__Volume.Io2VolB902C7A4.json
+++ b/tests/corpus/AWS__EC2__Volume.Io2VolB902C7A4.json
@@ -70,15 +70,16 @@
   },
   "expected": [
     {
-      "tier": "unresolved",
+      "tier": "atDefault",
       "logicalId": "Io2VolB902C7A4",
       "resourceType": "AWS::EC2::Volume",
-      "path": "AvailabilityZone",
+      "path": "AvailabilityZoneId",
+      "actual": "use1-az1",
       "physicalId": "vol-0f12afde5901a01f1",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Io2VolB902C7A4",
       "resourceType": "AWS::EC2::Volume",
       "path": "KmsKeyId",
@@ -87,11 +88,10 @@
       "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol"
     },
     {
-      "tier": "undeclared",
+      "tier": "unresolved",
       "logicalId": "Io2VolB902C7A4",
       "resourceType": "AWS::EC2::Volume",
-      "path": "AvailabilityZoneId",
-      "actual": "use1-az1",
+      "path": "AvailabilityZone",
       "physicalId": "vol-0f12afde5901a01f1",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Io2Vol"
     }

--- a/tests/noise-640-ec2-firstrun.test.ts
+++ b/tests/noise-640-ec2-firstrun.test.ts
@@ -1,0 +1,135 @@
+// #640 — EC2 Instance / Volume / NetworkInterface first-run undeclared batch (the
+// pure-noise.ts subset: equality-gated constants + value-independent AWS-assigned
+// identifiers). Every test asserts the fold AND, where the fold is equality-gated,
+// that a genuine divergence still surfaces. The derived/sibling members of #640
+// (Instance CpuOptions/sibling echoes, Volume gp2 Iops, ENI SecondaryPrivateIpAddressCount)
+// need classify.ts logic and are tracked separately on the issue.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+const IMDS_DEFAULT = {
+  HttpTokens: 'required',
+  HttpPutResponseHopLimit: 2,
+  HttpProtocolIpv6: 'disabled',
+  InstanceMetadataTags: 'disabled',
+  HttpEndpoint: 'enabled',
+};
+const DNS_DEFAULT = {
+  HostnameType: 'ip-name',
+  EnableResourceNameDnsARecord: false,
+  EnableResourceNameDnsAAAARecord: false,
+};
+
+describe('#640 EC2 Instance MetadataOptions / PrivateDnsNameOptions (equality-gated constants)', () => {
+  const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 't3.micro' });
+  it('folds the AL2023 IMDSv2 + ip-name DNS defaults on a clean deploy', () => {
+    const f = classifyResource(
+      res,
+      { MetadataOptions: IMDS_DEFAULT, PrivateDnsNameOptions: DNS_DEFAULT },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['MetadataOptions', 'PrivateDnsNameOptions'])
+    );
+    expect(tier(f, 'undeclared')).not.toContain('MetadataOptions');
+    expect(tier(f, 'undeclared')).not.toContain('PrivateDnsNameOptions');
+  });
+  it('surfaces an out-of-band IMDSv2 weakening (HttpTokens optional) — detection preserved', () => {
+    const f = classifyResource(
+      res,
+      { MetadataOptions: { ...IMDS_DEFAULT, HttpTokens: 'optional' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('MetadataOptions');
+  });
+  it('surfaces an out-of-band resource-name hostname switch — detection preserved', () => {
+    const f = classifyResource(
+      res,
+      { PrivateDnsNameOptions: { ...DNS_DEFAULT, HostnameType: 'resource-name' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('PrivateDnsNameOptions');
+  });
+});
+
+describe('#640 EC2 Volume KmsKeyId / AvailabilityZoneId (value-independent, undeclared)', () => {
+  const res = mk('AWS::EC2::Volume', {
+    AvailabilityZone: 'us-east-1a',
+    Encrypted: true,
+    Size: 8,
+    VolumeType: 'gp3',
+  });
+  it('folds the AWS-assigned aws/ebs managed key ARN and the derived zone id', () => {
+    const f = classifyResource(
+      res,
+      {
+        KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc-123',
+        AvailabilityZoneId: 'use1-az1',
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['KmsKeyId', 'AvailabilityZoneId'])
+    );
+    // value-independent: any key ARN folds (the volume key is create-only, cannot drift).
+    const f2 = classifyResource(
+      res,
+      { KmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/some-cmk' },
+      emptySchema
+    );
+    expect(tier(f2, 'atDefault')).toContain('KmsKeyId');
+  });
+});
+
+describe('#640 EC2 NetworkInterface PrivateIpAddresses / GroupSet (value-independent, undeclared)', () => {
+  const res = mk('AWS::EC2::NetworkInterface', { SubnetId: 'subnet-1', Description: 'd' });
+  it('folds the auto-assigned primary IP array and the VPC default security group', () => {
+    const f = classifyResource(
+      res,
+      {
+        PrivateIpAddresses: [{ PrivateIpAddress: '10.0.0.7', Primary: true }],
+        GroupSet: ['sg-0abc'],
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining(['PrivateIpAddresses', 'GroupSet'])
+    );
+  });
+  it('does NOT fold when the user declares them (compared in the declared loop instead)', () => {
+    const declaredRes = mk('AWS::EC2::NetworkInterface', {
+      SubnetId: 'subnet-1',
+      GroupSet: ['sg-declared'],
+    });
+    const f = classifyResource(declaredRes, { GroupSet: ['sg-different'] }, emptySchema);
+    // a declared GroupSet that differs from live surfaces as declared drift, not atDefault.
+    expect(tier(f, 'atDefault')).not.toContain('GroupSet');
+  });
+});

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -466,15 +466,27 @@ describe('noise suppressors', () => {
     expect(KNOWN_DEFAULTS['AWS::IAM::Role'].MaxSessionDuration).toBe(3600);
   });
 
-  it('EC2 Instance known defaults present — the 3 constant defaults a fresh instance reports (PR #310 follow-up)', () => {
-    // Tenancy/SourceDestCheck/InstanceInitiatedShutdownBehavior are account-/
-    // instance-independent constant defaults; the ec2-instance-rich corpus case
-    // exercises the fold. Resource-specific live values (PrivateIpAddress,
-    // SecurityGroups, CpuOptions, …) are deliberately NOT folded.
+  it('EC2 Instance known defaults present — constant defaults a fresh instance reports (PR #310 / #640)', () => {
+    // Tenancy/SourceDestCheck/InstanceInitiatedShutdownBehavior plus the IMDS +
+    // PrivateDnsName option blocks (#640) are account-/instance-independent constant
+    // defaults; the ec2-instance-rich corpus case exercises the fold. Resource-specific
+    // live values (PrivateIpAddress, SecurityGroups, CpuOptions, …) are deliberately NOT folded.
     expect(KNOWN_DEFAULTS['AWS::EC2::Instance']).toEqual({
       Tenancy: 'default',
       SourceDestCheck: true,
       InstanceInitiatedShutdownBehavior: 'stop',
+      MetadataOptions: {
+        HttpTokens: 'required',
+        HttpPutResponseHopLimit: 2,
+        HttpProtocolIpv6: 'disabled',
+        InstanceMetadataTags: 'disabled',
+        HttpEndpoint: 'enabled',
+      },
+      PrivateDnsNameOptions: {
+        HostnameType: 'ip-name',
+        EnableResourceNameDnsARecord: false,
+        EnableResourceNameDnsAAAARecord: false,
+      },
     });
   });
 


### PR DESCRIPTION
## What

Folds the pure-`noise.ts` subset of the #640 first-run false-positive batch — the values a **fresh, un-mutated** EC2 deploy reports as `[Potential Drift]` on the most-deployed resource types (Instance / Volume / NetworkInterface). Core invariant: a clean deploy must produce ZERO potential drift.

| Type | Path(s) | Tier | Detection |
|---|---|---|---|
| `EC2::Instance` | `MetadataOptions`, `PrivateDnsNameOptions` | equality-gated `KNOWN_DEFAULTS` constant | **preserved** — weaken `HttpTokens`/switch `HostnameType` and it re-surfaces |
| `EC2::Volume` | `KmsKeyId`, `AvailabilityZoneId` | value-independent | key is create-only (aws/ebs managed, RDS/EFS #533 twin); undeclared = delegated |
| `EC2::NetworkInterface` | `PrivateIpAddresses`, `GroupSet` | value-independent | plural twin of folded singular / VPC-default-SG (ELBv2 `SecurityGroups` precedent) |

## Why these tiers

`MetadataOptions`/`PrivateDnsNameOptions` are stable constants → tier-1 equality-gated (detection preserved — the security-load-bearing IMDSv2 `HttpTokens` still surfaces if weakened out of band). The Volume/ENI paths are AWS-assigned identifiers with no offline-derivable constant → value-independent, acceptable only because they are UNDECLARED (a user who cares declares them, then compared in the declared loop).

## Verification

- 9 golden-corpus cases flip cleanly `undeclared` → `atDefault` (exact live payloads pinned in `tests/corpus/`), no unexpected ripples elsewhere.
- New `tests/noise-640-ec2-firstrun.test.ts` (6 tests) asserts each fold and, for the equality-gated constants, that a genuine divergence still surfaces.
- Full suite: 52 files / 3135 tests green; typecheck + lint/format clean.

## Scope / follow-up

`#640` stays **open**. The derived/sibling members need `classify.ts` logic (currently locked by PR #709) and are deferred:
- Instance `CpuOptions` (InstanceType-derived) / `CreditSpecification` (family-derived) / sibling echoes (`SecurityGroups`/`SubnetId`/`Volumes`/`BlockDeviceMappings`)
- Volume gp2 `Iops` (Size-derived)
- ENI `SecondaryPrivateIpAddressCount` (count-derived)

Refs #640
