### PR TITLE
fix(desired): drop condition-false resources from the desired set (#689)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -10,7 +10,7 @@ import {
   ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { classifyStackStatus, StackNotCheckableError } from '../aws-errors.js';
-import { resolveProperties } from '../normalize/intrinsic-resolver.js';
+import { evalCondition, resolveProperties } from '../normalize/intrinsic-resolver.js';
 import type { DesiredResource, ResolverContext } from '../types.js';
 import { recoverNonAsciiMasks } from './recover-nonascii.js';
 import { parseCfnTemplate } from './yaml-cfn.js';
@@ -244,6 +244,19 @@ export async function loadDesired(
     (template.Resources ?? {}) as Record<string, any>
   )) {
     if (res.Type === 'AWS::CDK::Metadata') continue;
+    // A resource guarded by a template `Condition:` that evaluates definitively FALSE is
+    // never created by CloudFormation (the raw-CFn multi-env staple — one template serving
+    // dev/prod). It has no physical id and no live counterpart to compare, so pushing it
+    // would make classifyRead tag it a permanent `skipped: no physical id` — false
+    // "coverage incomplete" noise that also keeps `check --strict` red forever, with
+    // nothing the user can do in-tool. Drop it (matching CloudFormation's own semantics:
+    // the resource is not part of the stack). Gate on "condition FALSE **and** no physical
+    // id" so the fold is strictly noise-only: an UNRESOLVED or TRUE condition keeps today's
+    // conservative behavior, and a false condition that somehow has a physical id (a CFn
+    // anomaly) still surfaces.
+    if (typeof res.Condition === 'string' && !physIds[logicalId]) {
+      if (evalCondition(res.Condition, ctx) === false) continue;
+    }
     const cdkPath = res.Metadata?.['aws:cdk:path'];
     const declaredRaw = (res.Properties ?? {}) as Record<string, unknown>;
     resources.push({

--- a/tests/integration/cfn-conditions/app.ts
+++ b/tests/integration/cfn-conditions/app.ts
@@ -1,0 +1,44 @@
+// CDK app for the cdk-real-drift resource-level Condition hunt (the raw-CFn
+// multi-env staple: `Condition:` on a resource so one template serves dev/prod).
+// A condition-FALSE resource is never created, so it has no physical id — the
+// template-adapter pushed it anyway and classifyRead tagged it `skipped: no
+// physical id` on EVERY check, permanent footer noise a user cannot act on
+// (indistinguishable from a real read gap) that also kept `check --strict` red.
+// A condition-TRUE resource and an `Fn::If` property selection must classify clean.
+import { App, CfnCondition, CfnParameter, Fn, Stack } from "aws-cdk-lib";
+import { CfnTopic } from "aws-cdk-lib/aws-sns";
+
+const app = new App();
+const stack = new Stack(app, "CdkRealDriftIntegCfnConditions");
+
+const isProd = new CfnParameter(stack, "IsProd", {
+  type: "String",
+  allowedValues: ["true", "false"],
+  default: "false",
+});
+const prodCond = new CfnCondition(stack, "ProdCond", {
+  expression: Fn.conditionEquals(isProd.valueAsString, "true"),
+});
+const devCond = new CfnCondition(stack, "DevCond", {
+  expression: Fn.conditionEquals(isProd.valueAsString, "false"),
+});
+
+// Created only in prod — with the default parameter this resource does NOT exist.
+const prodOnly = new CfnTopic(stack, "ProdOnlyTopic", {
+  displayName: "prod-only",
+});
+prodOnly.cfnOptions.condition = prodCond;
+
+// Created in dev (condition TRUE) — must read + classify clean.
+const devOnly = new CfnTopic(stack, "DevOnlyTopic", {
+  displayName: "dev-only",
+});
+devOnly.cfnOptions.condition = devCond;
+
+// Always created, with an Fn::If-selected property — resolver must pick the
+// FALSE branch ("dev-name") and classify clean.
+new CfnTopic(stack, "AlwaysTopic", {
+  displayName: Fn.conditionIf(prodCond.logicalId, "prod-name", "dev-name").toString(),
+});
+
+app.synth();

--- a/tests/integration/cfn-conditions/cdk.json
+++ b/tests/integration/cfn-conditions/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node --experimental-strip-types app.ts"
+}

--- a/tests/integration/cfn-conditions/package.json
+++ b/tests/integration/cfn-conditions/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "cdk-real-drift-integ-cfn-conditions",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Fixture CDK app for the cdk-real-drift resource-level Condition (#689) integration test — a condition-false resource must not surface as a permanent skipped read gap.",
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "aws-cdk-lib": "^2.0.0",
+    "constructs": "^10.0.0"
+  },
+  "type": "module"
+}

--- a/tests/integration/cfn-conditions/verify.sh
+++ b/tests/integration/cfn-conditions/verify.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Resource-level Condition integration test (real AWS): a resource guarded by a
+# template Condition that evaluates FALSE is never created, so it must NOT surface
+# as a permanent `skipped: no physical id` and must NOT keep `check --strict` red.
+# The condition-TRUE resource and the Fn::If property selection must classify clean.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+cd "$HERE"
+STACK=CdkRealDriftIntegCfnConditions
+REGION="${AWS_REGION:-us-east-1}"
+CLI="node $ROOT/dist/cli.js"
+
+cleanup() {
+  echo "--- cleanup ($STACK) ---"
+  delstack cdk -a cdk.out -r "$REGION" -f -y >/dev/null 2>&1 || npx cdk destroy -f "$STACK" >/dev/null 2>&1 || true
+  rm -rf .cdkrd cdk.out
+}
+trap cleanup EXIT
+
+fail() { echo "INTEG FAIL ($STACK): $*"; exit 1; }
+
+echo "=== [$STACK] deploy fixture ==="
+npx cdk deploy -f "$STACK" --require-approval never || fail "deploy"
+
+echo "=== [$STACK] check MUST NOT list the condition-false ProdOnlyTopic as skipped ==="
+$CLI check "$STACK" --region "$REGION" --verbose 2>&1 | tee "/tmp/cdkrd-$STACK.out"
+grep -q "ProdOnlyTopic" "/tmp/cdkrd-$STACK.out" \
+  && fail "condition-false ProdOnlyTopic still surfaced (skipped footer / drift)"
+
+echo "=== [$STACK] record (write baseline) ==="
+$CLI record "$STACK" --region "$REGION" --yes || fail "record"
+
+echo "=== [$STACK] check --strict MUST pass (exit 0) on a clean recorded stack ==="
+$CLI check "$STACK" --region "$REGION" --strict
+rc=$?
+[ "$rc" -eq 0 ] || fail "--strict expected exit 0 (coverage complete), got $rc"
+
+echo "INTEG PASS ($STACK)"

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -505,3 +505,69 @@ describe('loadDesired stack parameter resolution', () => {
     expect(desired.resources[0]!.declared).toEqual({ Tag: 'plain' });
   });
 });
+
+describe('loadDesired resource-level Condition (#689)', () => {
+  // A resource guarded by a Condition that evaluates FALSE is never created, so it has
+  // no physical id and no live counterpart. It must be DROPPED from the desired set —
+  // not pushed through to classifyRead where it becomes a permanent
+  // `skipped: no physical id` (false "coverage incomplete" noise; keeps --strict red).
+  function condStack(
+    cfn: ReturnType<typeof mockClient>,
+    envValue: string,
+    resourceSummaries: Array<{ LogicalResourceId: string; PhysicalResourceId: string }>
+  ) {
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Parameters: { Env: { Type: 'String', Default: 'dev' } },
+        Conditions: {
+          ProdCond: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] }, // false when Env=dev
+          DevCond: { 'Fn::Equals': [{ Ref: 'Env' }, 'dev'] }, // true when Env=dev
+          UnkCond: { 'Fn::Equals': [{ Ref: 'Nonexistent' }, 'x'] }, // UNRESOLVED
+        },
+        Resources: {
+          ProdOnly: { Type: 'AWS::SNS::Topic', Condition: 'ProdCond' }, // false → drop
+          DevOnly: { Type: 'AWS::SNS::Topic', Condition: 'DevCond' }, // true → keep
+          Unk: { Type: 'AWS::SNS::Topic', Condition: 'UnkCond' }, // unresolved → keep
+          Always: { Type: 'AWS::SNS::Topic' }, // no condition → keep
+          // A condition-FALSE resource that somehow HAS a physical id (a CFn anomaly)
+          // must still surface — the fold is gated on "false AND no physical id".
+          AnomalyFalse: { Type: 'AWS::SNS::Topic', Condition: 'ProdCond' },
+        },
+      }),
+    });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: resourceSummaries.map((s) => ({
+        LogicalResourceId: s.LogicalResourceId,
+        PhysicalResourceId: s.PhysicalResourceId,
+        ResourceType: 'AWS::SNS::Topic',
+        LastUpdatedTimestamp: new Date(0),
+        ResourceStatus: 'CREATE_COMPLETE',
+      })),
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/C/x',
+          StackName: 'C',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [{ ParameterKey: 'Env', ParameterValue: envValue }],
+        },
+      ],
+    });
+  }
+
+  it('drops a condition-FALSE resource with no physical id; keeps true/unresolved/unconditioned', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    condStack(cfn, 'dev', [
+      { LogicalResourceId: 'DevOnly', PhysicalResourceId: 'arn:dev' },
+      { LogicalResourceId: 'Always', PhysicalResourceId: 'arn:always' },
+      // Anomaly: a condition-false resource that nonetheless has a physical id.
+      { LogicalResourceId: 'AnomalyFalse', PhysicalResourceId: 'arn:anomaly' },
+    ]);
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'C', 'us-east-1');
+    const ids = desired.resources.map((r) => r.logicalId).sort();
+    // ProdOnly (condition false, no physical id) is dropped; everything else survives.
+    expect(ids).toEqual(['Always', 'AnomalyFalse', 'DevOnly', 'Unk']);
+  });
+});


### PR DESCRIPTION
fix(desired): drop condition-false resources from the desired set (#689)

A resource guarded by a template Condition that evaluates definitively FALSE is
never created by CloudFormation (the raw-CFn multi-env staple: one template
serving dev/prod). It has no physical id and no live counterpart, but the
template-adapter pushed it through anyway, so classifyRead tagged it a permanent
"skipped: no physical id" on every check — false "coverage incomplete" noise a
user cannot act on that also kept "check --strict" red forever.

Evaluate res.Condition via the resolver context already built for Fn::If and,
when it is definitively false AND the resource has no physical id, drop it from
the desired set (matching CloudFormation's own semantics — the resource is not
part of the stack). Gate on "false AND no physical id" so the fold is strictly
noise-only: an UNRESOLVED or TRUE condition keeps the conservative behavior, and
a false condition that somehow has a physical id (a CFn anomaly) still surfaces.

Adds a template-adapter unit test and the cfn-conditions integration fixture.

Closes #689
