### PR TITLE
fix(diff): fold API Gateway execute-api:/* resource-policy shorthand against the echoed ARN (#676)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1054,6 +1054,37 @@ function remapSortedIndexToDeclared(
   return rawIdx < 0 ? path : `${arrayKey}.${rawIdx}${m[2]}`;
 }
 
+// #676: an API Gateway resource policy authored with the documented abbreviated resource form
+// `execute-api:/...` (the shape CDK's grantInvokeFromVpcEndpointsOnly + the AWS console/docs use,
+// since the api id does not exist at authoring time) is echo-EXPANDED by the service to the full
+// ARN `arn:<partition>:execute-api:<region>:<account>:<apiId>/...` on read. The two are
+// semantically identical, so expand the DECLARED shorthand to the same ARN before the compare —
+// `execute-api:` is a literal prefix AWS replaces textually, so a suffix like `/*` or
+// `/prod/GET/*` is preserved. Equality-gated (context-derived, fold tier 2): a resource pointing
+// at a DIFFERENT api id / region / path expands to a non-matching ARN and still surfaces. Applied
+// to Resource + NotResource on every statement; other (already-ARN or non-execute-api) resources
+// are untouched.
+function expandExecuteApiResources(policy: unknown, arnPrefix: string): unknown {
+  if (!policy || typeof policy !== 'object' || Array.isArray(policy)) return policy;
+  const p = policy as Record<string, unknown>;
+  const stmts = p['Statement'];
+  if (!Array.isArray(stmts)) return policy;
+  const PREFIX = 'execute-api:';
+  const expand = (r: unknown): unknown =>
+    typeof r === 'string' && r.startsWith(PREFIX) ? arnPrefix + r.slice(PREFIX.length) : r;
+  const newStmts = stmts.map((s) => {
+    if (!s || typeof s !== 'object' || Array.isArray(s)) return s;
+    const stmt = { ...(s as Record<string, unknown>) };
+    for (const key of ['Resource', 'NotResource']) {
+      const v = stmt[key];
+      if (typeof v === 'string') stmt[key] = expand(v);
+      else if (Array.isArray(v)) stmt[key] = v.map(expand);
+    }
+    return stmt;
+  });
+  return { ...p, Statement: newStmts };
+}
+
 export function classifyResource(
   resource: DesiredResource,
   liveRaw: Record<string, unknown>,
@@ -1395,6 +1426,21 @@ export function classifyResource(
     if (Array.isArray(types) && types.includes('PRIVATE')) {
       knownDef = { ...knownDef, SecurityPolicy: 'TLS_1_2' };
       knownDefPaths = { ...knownDefPaths, 'EndpointConfiguration.IpAddressType': 'dualstack' };
+    }
+    // #676: expand the declared resource policy's `execute-api:/...` shorthand to the ARN the
+    // service echoes back, so a clean private (or any) api with the documented shorthand policy
+    // does not false-drift on every statement. Re-canonicalize so the expanded Resource arrays
+    // sort identically to the live side. Needs the api id (physicalId) + account + region.
+    if (physicalId && opts.accountId !== undefined && declared['Policy']) {
+      const partition = opts.region?.startsWith('cn-')
+        ? 'aws-cn'
+        : opts.region?.startsWith('us-gov-')
+          ? 'aws-us-gov'
+          : 'aws';
+      const arnPrefix = `arn:${partition}:execute-api:${opts.region ?? ''}:${opts.accountId}:${physicalId}`;
+      declared['Policy'] = canonicalizePolicy(
+        expandExecuteApiResources(declared['Policy'], arnPrefix) as Record<string, unknown>
+      );
     }
   }
   // #642: a UserPool's undeclared AdminCreateUserConfig.UnusedAccountValidityDays is

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1102,6 +1102,73 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(t({ Scope: 'arn:aws:iam::111111111111:root' }).undeclared).toEqual(['Scope']);
   });
 
+  it('#676: RestApi resource-policy execute-api:/* shorthand folds against the echoed full ARN', () => {
+    const apiId = 'wmvd2s08ng';
+    const opts = { accountId: '111111111111', region: 'us-east-1' };
+    const arn = `arn:aws:execute-api:us-east-1:111111111111:${apiId}/*`;
+    const res: DesiredResource = {
+      logicalId: 'PrivApi',
+      resourceType: 'AWS::ApiGateway::RestApi',
+      physicalId: apiId,
+      declared: {
+        // the documented abbreviated form (CDK grantInvokeFromVpcEndpointsOnly / AWS docs)
+        Policy: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: '*',
+              Action: 'execute-api:Invoke',
+              Resource: ['execute-api:/*'],
+            },
+            {
+              Effect: 'Deny',
+              Principal: '*',
+              Action: 'execute-api:Invoke',
+              Resource: ['execute-api:/*'],
+              Condition: { StringNotEquals: { 'aws:SourceVpce': 'vpce-abc123' } },
+            },
+          ],
+        },
+      },
+    };
+    // clean deploy: the service echoes the shorthand back as the full ARN. Expansion makes the
+    // two match -> ZERO declared drift.
+    const mkLive = (resource: string) => ({
+      Policy: JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [
+          { Effect: 'Allow', Principal: '*', Action: 'execute-api:Invoke', Resource: [resource] },
+          {
+            Effect: 'Deny',
+            Principal: '*',
+            Action: 'execute-api:Invoke',
+            Resource: [resource],
+            Condition: { StringNotEquals: { 'aws:SourceVpce': 'vpce-abc123' } },
+          },
+        ],
+      }),
+    });
+    expect(tiers(classifyResource(res, mkLive(arn), emptySchema, opts)).declared).toEqual([]);
+    // a policy live-repointed at a DIFFERENT api id is NOT the echo of this api's shorthand and
+    // still surfaces (equality-gated — out-of-band detection preserved).
+    expect(
+      tiers(
+        classifyResource(
+          res,
+          mkLive('arn:aws:execute-api:us-east-1:111111111111:OTHERAPIID/*'),
+          emptySchema,
+          opts
+        )
+      ).declared.length
+    ).toBeGreaterThan(0);
+    // with no resolved account the expansion is skipped -> the shorthand vs ARN still surfaces
+    // (never a wrong silent fold when context is missing)
+    expect(tiers(classifyResource(res, mkLive(arn), emptySchema)).declared.length).toBeGreaterThan(
+      0
+    );
+  });
+
   it('noise-sweep batch: the default folds, a flipped (security-relevant) value surfaces', () => {
     const t = (rt: string, live: Record<string, unknown>) =>
       tiers(classifyResource(bare(rt), live, emptySchema));


### PR DESCRIPTION
## What

A PRIVATE (or any) `AWS::ApiGateway::RestApi` whose resource policy uses the **documented abbreviated resource form** `execute-api:/*` (the shape CDK's `grantInvokeFromVpcEndpointsOnly` + AWS's own docs/console use, since the api id doesn't exist at authoring time) reads back with the resource **echo-expanded to the full ARN** `arn:<partition>:execute-api:<region>:<account>:<apiId>/*`. Every statement produced a **declared-tier FP** on a clean, un-mutated deploy — and it **survives record** (declared dimension).

## Fix (classify.ts)

At classify time the RestApi's own api id (`physicalId`), region, account, and partition are all known, so **expand the declared `execute-api:` shorthand to the same ARN before the compare** (context-derived, fold tier 2), then re-canonicalize so the Resource arrays sort identically to the live side. `execute-api:` is a literal prefix AWS replaces textually, so a `/*` or `/stage/verb/path` suffix is preserved.

**Equality-gated**: a resource pointing at a DIFFERENT api id / region / path expands to a non-matching ARN and still surfaces; with no resolved account the expansion is skipped (never a wrong silent fold). Applies to `Resource` + `NotResource` on every statement.

## Live verification (us-east-1, private REST API + shorthand policy)

| | result |
|---|---|
| BEFORE (0.2.37) | `[CFn-Declared Drift: 2] PrivApi.Policy.Statement.{0,1}.Resource` (desired `execute-api:/*` vs actual full ARN) |
| AFTER | `result: CLEAN` |

Fixture torn down with `delstack`.

## Scope

The FP fold only. The separate `Policy` **revert** hard-fail (CC holds Policy as a JSON string; sub-path patch rejected) is noted in the issue as a distinct problem and is out of scope here.

## Tests

`classify.test.ts`: folds against the echoed ARN; a different api id surfaces; no-context surfaces.

Closes #676.