### PR TITLE
fix(noise): detect Classic ELB SSL-policy downgrade — Policies per-element equality gate (#705)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -662,6 +662,33 @@ function dynamoGsiWarmThroughputAtDefault(
   return deepEqual(value, warmThroughputDefault(gsi.ProvisionedThroughput));
 }
 
+// #705: a Classic ELB (ElasticLoadBalancing::LoadBalancer) with an HTTPS/SSL listener but no
+// declared SSL policy reads back an AWS-assigned SSL negotiation policy. The whole `Policies`
+// array was folded value-independently, which made an out-of-band SSL-policy DOWNGRADE (an older
+// predefined policy, a custom SSLv3-enabled one) OR any added policy INVISIBLE — a security FN.
+// Fold atDefault ONLY when EVERY element is the AWS default SSL negotiation policy, identified by
+// its stable `PolicyName` (the ~100 cipher `Attributes` are a derived function of the name and
+// move over time, so they are ignored — the name is the pinnable identity, exactly like a
+// KNOWN_DEFAULTS constant; a future AWS default bump surfaces as a fold-gap to add here). Any
+// element with a different PolicyName, a non-SSL policy type, or any additional policy makes the
+// whole property surface (equality-gated — out-of-band detection restored).
+const CLB_DEFAULT_SSL_POLICY_NAME = 'ELBSecurityPolicy-2016-08';
+function clbDefaultSslPoliciesAtDefault(
+  resourceType: string,
+  key: string,
+  value: unknown
+): boolean {
+  if (resourceType !== 'AWS::ElasticLoadBalancing::LoadBalancer' || key !== 'Policies')
+    return false;
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every(
+    (el) =>
+      isNestedObject(el) &&
+      el['PolicyType'] === 'SSLNegotiationPolicyType' &&
+      el['PolicyName'] === CLB_DEFAULT_SSL_POLICY_NAME
+  );
+}
+
 // A CloudFormation AUTO-GENERATED physical name. When a resource declares no explicit name,
 // CFn mints `<stackName>-<logicalId>-<random>` (the stack name is the FIRST segment of the
 // CDK construct path). DELIBERATELY strict — it must start with this stack's name AND end
@@ -2279,7 +2306,10 @@ export function classifyResource(
       // AWS-assigned default — it is just absent — so let it fall through to the shared
       // trivial-empty drop rather than surfacing a spurious atDefault (e.g. an NLB's empty
       // SecurityGroups []).
-      (VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k) && !isTrivialEmpty(v))
+      (VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS[resourceType]?.has(k) && !isTrivialEmpty(v)) ||
+      // #705: a Classic ELB's undeclared Policies folds atDefault ONLY when it is exactly the
+      // AWS default SSL negotiation policy (by PolicyName); a downgrade / added policy surfaces.
+      clbDefaultSslPoliciesAtDefault(resourceType, k, v)
     ) {
       findings.push({ tier: 'atDefault', logicalId, resourceType, path: k, actual: v });
       continue;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2557,17 +2557,14 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   user intent; a user who wants specific AZs declares AvailabilityZones instead of
   //   Subnets, which is then compared in the declared loop. Observed live on a fresh
   //   internal CLB (elb-classic-rich, 2026-07-07).
-  //   AWS::ElasticLoadBalancing::LoadBalancer.Policies — a CLB with an HTTPS/SSL listener
-  //   that declares only a SSLCertificateId (no explicit SSL policy) reads back an
-  //   AWS-assigned SSL negotiation policy: `[{PolicyType:"SSLNegotiationPolicyType",
-  //   PolicyName:"ELBSecurityPolicy-2016-08", Attributes:[~100 cipher on/off flags]}]`. The
-  //   default predefined policy NAME AWS assigns moves over time as AWS publishes newer
-  //   security policies, and the huge cipher `Attributes` list is a derived function of the
-  //   name that cannot be practically pinned. Undeclared → whatever policy AWS assigned is
-  //   its default, not user intent; a user who wants a specific SSL policy declares
-  //   `Policies`, which is then compared in the declared loop. Observed live on a fresh
-  //   internet-facing CLB with an HTTPS listener (elb-classic-https, 2026-07-07).
-  'AWS::ElasticLoadBalancing::LoadBalancer': new Set(['AvailabilityZones', 'Policies']),
+  //   NOTE: AWS::ElasticLoadBalancing::LoadBalancer.Policies was value-independent here but is
+  //   now a per-element EQUALITY GATE (#705, clbDefaultSslPoliciesAtDefault in classify.ts): the
+  //   AWS-assigned default SSL negotiation policy is identified by its stable PolicyName
+  //   `ELBSecurityPolicy-2016-08` (the huge cipher `Attributes` list is a derived function of the
+  //   name and is ignored), so an out-of-band SSL-policy DOWNGRADE (an older/weaker predefined
+  //   policy, a custom SSLv3-enabled policy) OR any added policy now SURFACES instead of being
+  //   folded blind. Value-independent lost that detection and hid a security-load-bearing change.
+  'AWS::ElasticLoadBalancing::LoadBalancer': new Set(['AvailabilityZones']),
   //   AWS::AutoScaling::AutoScalingGroup.AvailabilityZones / .AvailabilityZoneIds — an ASG
   //   declares `VPCZoneIdentifier` (subnets); AWS reads back the AZs it PLACED the group in —
   //   the AZs of those subnets (["us-east-1a","us-east-1b"]) plus their per-account zone IDs

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1169,6 +1169,43 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     );
   });
 
+  it('#705: Classic ELB Policies folds ONLY the default SSL policy; a downgrade / added policy surfaces', () => {
+    const t = (policies: unknown[]) =>
+      tiers(
+        classifyResource(
+          bare('AWS::ElasticLoadBalancing::LoadBalancer'),
+          { Policies: policies },
+          emptySchema
+        )
+      );
+    // the AWS default SSL negotiation policy — identified by PolicyName; the huge cipher
+    // Attributes list is ignored (derived from the name).
+    const defaultPolicy = {
+      PolicyType: 'SSLNegotiationPolicyType',
+      PolicyName: 'ELBSecurityPolicy-2016-08',
+      Attributes: [{ Name: 'Protocol-SSLv3', Value: 'false' }],
+    };
+    // clean deploy: the default SSL policy folds atDefault
+    expect(t([defaultPolicy]).atDefault).toEqual(['Policies']);
+    // a DOWNGRADE to an older/weaker predefined policy (SSLv3 back on) SURFACES — the FN #705 fixes
+    expect(
+      t([
+        {
+          PolicyType: 'SSLNegotiationPolicyType',
+          PolicyName: 'ELBSecurityPolicy-2015-05',
+          Attributes: [{ Name: 'Protocol-SSLv3', Value: 'true' }],
+        },
+      ]).undeclared
+    ).toEqual(['Policies']);
+    // an out-of-band ADDED policy alongside the default SURFACES (array is no longer just the default)
+    expect(
+      t([
+        defaultPolicy,
+        { PolicyType: 'AppCookieStickinessPolicyType', PolicyName: 'my-stickiness' },
+      ]).undeclared
+    ).toEqual(['Policies']);
+  });
+
   it('noise-sweep batch: the default folds, a flipped (security-relevant) value surfaces', () => {
     const t = (rt: string, live: Record<string, unknown>) =>
       tiers(classifyResource(bare(rt), live, emptySchema));


### PR DESCRIPTION
## What

`AWS::ElasticLoadBalancing::LoadBalancer` `Policies` was folded **value-independently** on the claim that "the default SSL policy name moves over time". The corpus contradicts it: an undeclared HTTPS CLB reads back `PolicyName: "ELBSecurityPolicy-2016-08"` — **the stable default reference policy since 2016**. The whole-array value-independent fold made an out-of-band SSL negotiation policy **downgrade** (an older/weaker predefined policy, a custom SSLv3-enabled one) **and any out-of-band-added policy completely invisible** — a security-load-bearing FN.

## Fix

Replace the value-independent entry with a **per-element equality gate** (`clbDefaultSslPoliciesAtDefault` in classify.ts): fold `atDefault` **only** when every `Policies` element is the AWS default SSL negotiation policy, identified by its **stable `PolicyName`** (the ~100 cipher `Attributes` are a derived function of the name and are ignored — the name is the pinnable identity, exactly like a `KNOWN_DEFAULTS` constant; a future AWS default bump surfaces as a fold-gap to add here). A different `PolicyName`, a non-SSL policy type, or any additional policy makes the whole property surface.

## Verification (offline — corpus is the authoritative live data for a fold fix)

- `corpus-replay`: the live-harvested `ClbHttps` case still folds `Policies` → `atDefault` (default folds, **no new FP**).
- unit test (classify.test.ts): a downgrade (`ELBSecurityPolicy-2015-05`, SSLv3 back on) **surfaces**; an added policy alongside the default **surfaces**; the default folds.

Not re-deployed — the `ClbHttps` corpus (live-harvested in the elb-classic-https hunt) is the live evidence.

Closes #705.