### PR TITLE
fix(noise): six-type first-run undeclared-default constant folds (#711)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -138,6 +138,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   // reads back "CWL") — observed-only like the ApiGateway Authorizer AuthType fold; an
   // S3/FH/XRay destination's value simply doesn't match and surfaces once, recordable.
   'AWS::Logs::DeliveryDestination': { DeliveryDestinationType: 'CWL' },
+  // An account policy that declares no Scope reads back the AWS service default "ALL"
+  // (the policy applies to all log groups). Equality-gated: a scoped policy DECLARES its
+  // own Scope, which no longer matches this constant and surfaces. #711.
+  'AWS::Logs::AccountPolicy': { Scope: 'ALL' },
   // A Delivery that declares no RecordFields materializes the source's FULL default
   // field list on read. This is the CloudFront ACCESS_LOGS default (the most common
   // vended source) — equality-gated, so a field added/removed/reordered out of band no
@@ -556,6 +560,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::Kinesis::Stream': {
     MaxRecordSizeInKiB: 1024,
+    // A stream that declares no RetentionPeriodHours reads back the AWS service default
+    // (24 hours). Equality-gated: a stream that sets a longer retention no longer matches
+    // and surfaces (undeclared), and an out-of-band retention change still surfaces. #711.
+    RetentionPeriodHours: 24,
   },
   'AWS::SSM::Parameter': {
     DataType: 'text',
@@ -735,6 +743,10 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     GroupName: 'default',
     ActionAfterCompletion: 'NONE',
     ScheduleExpressionTimezone: 'UTC',
+    // A schedule that declares no State reads back the AWS service default (ENABLED).
+    // Equality-gated: a DISABLED schedule no longer matches and surfaces, and an
+    // out-of-band disable still surfaces. #711.
+    State: 'ENABLED',
   },
   // R-noise-sweep (found by the eni-rich / dbproxy-rich / elasticache-cachecluster-rich
   // hunt): constant, documented service defaults a fresh resource reports as undeclared
@@ -893,6 +905,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   },
   'AWS::EC2::VPCEndpoint': {
     IpAddressType: 'ipv4',
+    // A Gateway endpoint that omits VpcEndpointType reads back the AWS service default
+    // "Gateway". Equality-gated: an Interface (or GatewayLoadBalancer) endpoint DECLARES
+    // its own type, which no longer matches this constant and surfaces; only the exact
+    // "Gateway" default folds. #711.
+    VpcEndpointType: 'Gateway',
     // An endpoint that declares no `PolicyDocument` reads back the AWS-attached DEFAULT policy:
     // full access ("allow every principal every action on every resource"). It is the standard
     // default, not user intent — a user who tightens access DECLARES a policy, which no longer
@@ -1692,6 +1709,10 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
     // constant default to atDefault; a container that actually reserves CPU (Cpu != 0)
     // no longer matches and surfaces. Observed live on the ecs-taskdef-caps deploy.
     'ContainerDefinitions.*.Cpu': 0,
+    // A container that does not declare Essential reads back the AWS service default
+    // (true) for EVERY container. Equality-gated: a container that sets Essential: false
+    // no longer matches and surfaces, and an out-of-band change still surfaces. #711.
+    'ContainerDefinitions.*.Essential': true,
   },
   'AWS::Glue::Database': {
     'DatabaseInput.CreateTableDefaultPermissions': [
@@ -1707,6 +1728,12 @@ export const KNOWN_DEFAULT_PATHS: Record<string, Record<string, unknown>> = {
   },
   'AWS::Route53::HealthCheck': {
     'HealthCheckConfig.EnableSNI': true,
+    // A health check that declares neither RequestInterval nor FailureThreshold reads back
+    // the AWS service defaults (30-second interval, 3 consecutive failures). Equality-gated:
+    // a check that sets a different interval/threshold no longer matches and surfaces, and an
+    // out-of-band change still surfaces. #711.
+    'HealthCheckConfig.RequestInterval': 30,
+    'HealthCheckConfig.FailureThreshold': 3,
   },
   'AWS::Route53::RecordSet': {
     // A geoproximity record may declare only AWSRegion (or Coordinates); AWS then sets

--- a/tests/noise-711-firstrun.test.ts
+++ b/tests/noise-711-firstrun.test.ts
@@ -1,0 +1,163 @@
+// #711 — first-run undeclared AWS-default constants surfacing as [Potential Drift] on a
+// clean deploy of six raw-L1 types. All are stable service-default constants, folded as
+// tier-1 equality-gated constants (KNOWN_DEFAULTS / KNOWN_DEFAULT_PATHS). Each test asserts
+// the fold to atDefault AND, where meaningful, that a genuine divergence still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+describe('#711 Kinesis::Stream RetentionPeriodHours (equality-gated constant)', () => {
+  const res = mk('AWS::Kinesis::Stream', { Name: 's', ShardCount: 1 });
+  it('folds the 24h service default on a clean deploy', () => {
+    const f = classifyResource(res, { RetentionPeriodHours: 24 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('RetentionPeriodHours');
+    expect(tier(f, 'undeclared')).not.toContain('RetentionPeriodHours');
+  });
+  it('surfaces a longer retention out of band — detection preserved', () => {
+    const f = classifyResource(res, { RetentionPeriodHours: 168 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('RetentionPeriodHours');
+  });
+});
+
+describe('#711 Scheduler::Schedule State (equality-gated constant)', () => {
+  const res = mk('AWS::Scheduler::Schedule', {
+    ScheduleExpression: 'rate(1 hour)',
+    FlexibleTimeWindow: { Mode: 'OFF' },
+  });
+  it('folds the ENABLED service default on a clean deploy', () => {
+    const f = classifyResource(res, { State: 'ENABLED' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('State');
+    expect(tier(f, 'undeclared')).not.toContain('State');
+  });
+  it('surfaces an out-of-band DISABLED — detection preserved', () => {
+    const f = classifyResource(res, { State: 'DISABLED' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('State');
+  });
+});
+
+describe('#711 Route53::HealthCheck RequestInterval / FailureThreshold (nested constants)', () => {
+  const res = mk('AWS::Route53::HealthCheck', {
+    HealthCheckConfig: { Type: 'HTTP', FullyQualifiedDomainName: 'example.com' },
+  });
+  it('folds the 30s interval + 3-failure threshold defaults on a clean deploy', () => {
+    const f = classifyResource(
+      res,
+      { HealthCheckConfig: { RequestInterval: 30, FailureThreshold: 3 } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toEqual(
+      expect.arrayContaining([
+        'HealthCheckConfig.RequestInterval',
+        'HealthCheckConfig.FailureThreshold',
+      ])
+    );
+    expect(tier(f, 'undeclared')).not.toContain('HealthCheckConfig.RequestInterval');
+    expect(tier(f, 'undeclared')).not.toContain('HealthCheckConfig.FailureThreshold');
+  });
+  it('surfaces an out-of-band interval/threshold change — detection preserved', () => {
+    const f = classifyResource(
+      res,
+      { HealthCheckConfig: { RequestInterval: 10, FailureThreshold: 5 } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toEqual(
+      expect.arrayContaining([
+        'HealthCheckConfig.RequestInterval',
+        'HealthCheckConfig.FailureThreshold',
+      ])
+    );
+  });
+});
+
+describe('#711 ECS::TaskDefinition ContainerDefinitions[*].Essential (nested constant)', () => {
+  const res = mk('AWS::ECS::TaskDefinition', {
+    ContainerDefinitions: [{ Name: 'c', Image: 'nginx' }],
+  });
+  // The nested finding path is keyed by the container's identity field (Name = "c"),
+  // i.e. `ContainerDefinitions[c].Essential`, not a numeric index.
+  it('folds the Essential: true service default on a clean deploy', () => {
+    const f = classifyResource(
+      res,
+      { ContainerDefinitions: [{ Name: 'c', Image: 'nginx', Essential: true }] },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('ContainerDefinitions[c].Essential');
+    expect(tier(f, 'undeclared')).not.toContain('ContainerDefinitions[c].Essential');
+  });
+  // Detection note: the only non-default value is Essential: false, which is
+  // structurally trivial-empty (isTrivialEmpty(false) === true), so an UNDECLARED
+  // Essential: false never surfaces regardless of this fold — a pre-existing
+  // trivial-false concern that is out of scope for #711 and not expressible in
+  // noise.ts. When the user DECLARES Essential, it is compared in the declared
+  // dimension and this fold does not touch it (verified below).
+  it('does NOT fold a DECLARED Essential that differs from live (declared-dimension compare)', () => {
+    const declaredRes = mk('AWS::ECS::TaskDefinition', {
+      ContainerDefinitions: [{ Name: 'c', Image: 'nginx', Essential: true }],
+    });
+    const f = classifyResource(
+      declaredRes,
+      { ContainerDefinitions: [{ Name: 'c', Image: 'nginx', Essential: false }] },
+      emptySchema
+    );
+    // a declared Essential:true whose live value is false is real declared drift,
+    // not silently folded to atDefault by the KNOWN_DEFAULT_PATHS entry. (The declared
+    // dimension reports the numeric-index path form.)
+    expect(tier(f, 'atDefault')).not.toContain('ContainerDefinitions.0.Essential');
+    expect(tier(f, 'declared')).toContain('ContainerDefinitions.0.Essential');
+  });
+});
+
+describe('#711 EC2::VPCEndpoint VpcEndpointType (equality-gated constant)', () => {
+  const res = mk('AWS::EC2::VPCEndpoint', {
+    ServiceName: 'com.amazonaws.us-east-1.s3',
+    VpcId: 'vpc-1',
+  });
+  it('folds the Gateway service default on a clean deploy', () => {
+    const f = classifyResource(res, { VpcEndpointType: 'Gateway' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('VpcEndpointType');
+    expect(tier(f, 'undeclared')).not.toContain('VpcEndpointType');
+  });
+});
+
+describe('#711 Logs::AccountPolicy Scope (equality-gated constant)', () => {
+  const res = mk('AWS::Logs::AccountPolicy', {
+    PolicyName: 'p',
+    PolicyType: 'DATA_PROTECTION_POLICY',
+    PolicyDocument: '{}',
+  });
+  it('folds the ALL service default on a clean deploy', () => {
+    const f = classifyResource(res, { Scope: 'ALL' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('Scope');
+    expect(tier(f, 'undeclared')).not.toContain('Scope');
+  });
+  it('surfaces an out-of-band scope change — detection preserved', () => {
+    const f = classifyResource(res, { Scope: 'SOME_SELECTION' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('Scope');
+  });
+});


### PR DESCRIPTION
## What

Folds six first-run false positives — undeclared AWS service-default constants that a clean, un-mutated deploy of common raw-L1 types reports as `[Potential Drift]` (core invariant: a clean deploy shows ZERO potential drift). All tier-1 equality-gated `KNOWN_DEFAULTS` / `KNOWN_DEFAULT_PATHS` additions in `src/normalize/noise.ts`; detection of a later change away is preserved.

| Type | Path | Default |
|---|---|---|
| `Kinesis::Stream` | `RetentionPeriodHours` | `24` |
| `Scheduler::Schedule` | `State` | `ENABLED` |
| `Route53::HealthCheck` | `HealthCheckConfig.RequestInterval` / `.FailureThreshold` | `30` / `3` |
| `ECS::TaskDefinition` | `ContainerDefinitions.*.Essential` | `true` |
| `EC2::VPCEndpoint` | `VpcEndpointType` | `Gateway` |
| `Logs::AccountPolicy` | `Scope` | `ALL` (new type entry) |

## Why latent under coverage

Every existing fixture/corpus case for these types **declares** the property (CDK L2 constructs always emit them), so the undeclared-default fold was never exercised (the #615 class). Raw-CFn / L1 users who omit them hit the FP.

## Verification

- New `tests/noise-711-firstrun.test.ts` (11 tests): each fold → `atDefault`; changed value still surfaces (Kinesis/Scheduler/Route53/Logs). Live-observed on bug-hunt round 2026-07-08o (issue carries the repro).
- corpus-replay unaffected (existing cases declare the props); full suite 53 files / 3148 tests green; typecheck + lint clean.

Note: `EC2::VPCEndpoint VpcEndpointType` is an equality-gated constant `Gateway` — Interface endpoints declare their type and compare in the declared loop, so only the exact `Gateway` default folds. `ECS Essential: false` detection is separately blocked by the pre-existing `isTrivialEmpty(false)` FN class (out of scope for #711); the `Essential: true` default fold is the fix here.

Closes #711
