### PR TITLE
fix(diff): EC2 derived first-run folds — CreditSpecification/gp2 Iops/ENI SecondaryIpCount (#640)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1474,6 +1474,48 @@ export function classifyResource(
       knownDef = { ...knownDef, ...twins };
     }
   }
+  // #640: an EC2 Instance on a BURSTABLE (T-family) InstanceType reads back an undeclared
+  // CreditSpecification.CPUCredits whose default depends on the family — the T2 family
+  // defaults to "standard", every later burstable family (t3 / t3a / t4g) defaults to
+  // "unlimited". Derive the expected default from the declared InstanceType family and
+  // equality-gate the whole {CPUCredits} object (fold tier 2): a user who pins the other
+  // credit mode still surfaces. Non-burstable families carry no CreditSpecification, so
+  // leave the default unset there (nothing to fold).
+  if (resourceType === 'AWS::EC2::Instance') {
+    const instanceType = declared['InstanceType'];
+    const family = typeof instanceType === 'string' ? instanceType.split('.')[0] : undefined;
+    const creditDefault =
+      family === 't2'
+        ? 'standard'
+        : family === 't3' || family === 't3a' || family === 't4g'
+          ? 'unlimited'
+          : undefined;
+    if (creditDefault !== undefined) {
+      knownDef = { ...knownDef, CreditSpecification: { CPUCredits: creditDefault } };
+    }
+  }
+  // #640: a gp2 EBS Volume (declared VolumeType "gp2", or omitted — gp2 is the AWS default)
+  // reads back an undeclared baseline Iops that AWS computes from the declared Size:
+  // 3 IOPS/GiB, clamped to [100, 16000]. Derive that baseline and equality-gate it (fold
+  // tier 2): a user who bumps Iops still surfaces. gp3 / io1 / io2 declare Iops explicitly
+  // and are compared in the declared loop, so only gate the gp2 case.
+  if (resourceType === 'AWS::EC2::Volume') {
+    const volumeType = declared['VolumeType'] ?? 'gp2';
+    const size = declared['Size'];
+    if (volumeType === 'gp2' && typeof size === 'number') {
+      knownDef = { ...knownDef, Iops: Math.min(16000, Math.max(100, 3 * size)) };
+    }
+  }
+  // #640: an EC2 NetworkInterface that declares a PrivateIpAddresses list reads back an
+  // undeclared SecondaryPrivateIpAddressCount = all-but-the-primary of that list, i.e.
+  // max(0, len - 1). Derive it from the declared list and equality-gate it (fold tier 2):
+  // an out-of-band change to the secondary-IP count still surfaces.
+  if (resourceType === 'AWS::EC2::NetworkInterface') {
+    const ips = declared['PrivateIpAddresses'];
+    if (Array.isArray(ips)) {
+      knownDef = { ...knownDef, SecondaryPrivateIpAddressCount: Math.max(0, ips.length - 1) };
+    }
+  }
   // R140: nested paths that are always an AWS-assigned generated id (value-independent),
   // folded as `generated` like the top-level isGeneratedName/GENERATED_DEFAULTS cases.
   const generatedPaths = GENERATED_PATHS[resourceType] ?? [];

--- a/tests/classify-640-derived.test.ts
+++ b/tests/classify-640-derived.test.ts
@@ -1,0 +1,137 @@
+// #640 — the DERIVED remainder (classify.ts tier-2 folds computed from declared inputs):
+//   - Instance CreditSpecification.CPUCredits from the InstanceType burstable FAMILY,
+//   - Volume gp2 Iops = clamp(3 * Size, 100, 16000),
+//   - NetworkInterface SecondaryPrivateIpAddressCount = max(0, len(PrivateIpAddresses) - 1).
+// Each test asserts the clean-deploy fold to atDefault AND that a value away from the
+// computed default still surfaces as undeclared (detection preserved).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+describe('#640 EC2 Instance CreditSpecification derived from InstanceType family', () => {
+  it('folds "unlimited" on a t3 burstable instance (t3/t3a/t4g default)', () => {
+    const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 't3.micro' });
+    const f = classifyResource(
+      res,
+      { CreditSpecification: { CPUCredits: 'unlimited' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('CreditSpecification');
+    expect(tier(f, 'undeclared')).not.toContain('CreditSpecification');
+  });
+  it('folds "standard" on a t2 burstable instance (t2 default)', () => {
+    const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 't2.small' });
+    const f = classifyResource(
+      res,
+      { CreditSpecification: { CPUCredits: 'standard' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('CreditSpecification');
+    expect(tier(f, 'undeclared')).not.toContain('CreditSpecification');
+  });
+  it('surfaces a t3 instance pinned to "standard" (away from the t3 default) — detection preserved', () => {
+    const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 't3.micro' });
+    const f = classifyResource(
+      res,
+      { CreditSpecification: { CPUCredits: 'standard' } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('CreditSpecification');
+  });
+  it('does NOT fold a non-burstable (m5) instance — no default is set', () => {
+    const res = mk('AWS::EC2::Instance', { ImageId: 'ami-1', InstanceType: 'm5.large' });
+    const f = classifyResource(
+      res,
+      { CreditSpecification: { CPUCredits: 'unlimited' } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).not.toContain('CreditSpecification');
+  });
+});
+
+describe('#640 EC2 Volume gp2 Iops derived from Size', () => {
+  it('folds the clamped-floor 100 IOPS for a small gp2 volume (Size 20 -> max(100, 60))', () => {
+    const res = mk('AWS::EC2::Volume', { VolumeType: 'gp2', Size: 20, Encrypted: true });
+    const f = classifyResource(res, { Iops: 100 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('Iops');
+    expect(tier(f, 'undeclared')).not.toContain('Iops');
+  });
+  it('folds the 3-IOPS/GiB baseline for a larger gp2 volume (Size 1000 -> 3000)', () => {
+    const res = mk('AWS::EC2::Volume', { VolumeType: 'gp2', Size: 1000 });
+    const f = classifyResource(res, { Iops: 3000 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('Iops');
+  });
+  it('folds gp2 as the default VolumeType when omitted', () => {
+    const res = mk('AWS::EC2::Volume', { Size: 20 });
+    const f = classifyResource(res, { Iops: 100 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('Iops');
+  });
+  it('surfaces a gp2 volume with a bumped Iops (away from the baseline) — detection preserved', () => {
+    const res = mk('AWS::EC2::Volume', { VolumeType: 'gp2', Size: 20 });
+    const f = classifyResource(res, { Iops: 500 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('Iops');
+  });
+});
+
+describe('#640 EC2 NetworkInterface SecondaryPrivateIpAddressCount derived from PrivateIpAddresses', () => {
+  it('folds the all-but-primary count for a declared IP list (4 IPs -> 3)', () => {
+    const res = mk('AWS::EC2::NetworkInterface', {
+      SubnetId: 'subnet-1',
+      PrivateIpAddresses: [
+        { Primary: true, PrivateIpAddress: '10.0.0.10' },
+        { Primary: false, PrivateIpAddress: '10.0.0.200' },
+        { Primary: false, PrivateIpAddress: '10.0.0.50' },
+        { Primary: false, PrivateIpAddress: '10.0.0.150' },
+      ],
+    });
+    const f = classifyResource(res, { SecondaryPrivateIpAddressCount: 3 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('SecondaryPrivateIpAddressCount');
+    expect(tier(f, 'undeclared')).not.toContain('SecondaryPrivateIpAddressCount');
+  });
+  it('folds 0 for a single-primary-only declared list', () => {
+    const res = mk('AWS::EC2::NetworkInterface', {
+      SubnetId: 'subnet-1',
+      PrivateIpAddresses: [{ Primary: true, PrivateIpAddress: '10.0.0.10' }],
+    });
+    const f = classifyResource(res, { SecondaryPrivateIpAddressCount: 0 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('SecondaryPrivateIpAddressCount');
+  });
+  it('surfaces a count that does not match the declared IP list — detection preserved', () => {
+    const res = mk('AWS::EC2::NetworkInterface', {
+      SubnetId: 'subnet-1',
+      PrivateIpAddresses: [
+        { Primary: true, PrivateIpAddress: '10.0.0.10' },
+        { Primary: false, PrivateIpAddress: '10.0.0.200' },
+      ],
+    });
+    // declared list implies 1 secondary; live shows 5 (an out-of-band add) -> surfaces.
+    const f = classifyResource(res, { SecondaryPrivateIpAddressCount: 5 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('SecondaryPrivateIpAddressCount');
+  });
+});

--- a/tests/corpus/AWS__EC2__Instance.Inst.sets.json
+++ b/tests/corpus/AWS__EC2__Instance.Inst.sets.json
@@ -303,6 +303,17 @@
       "tier": "atDefault",
       "logicalId": "Inst",
       "resourceType": "AWS::EC2::Instance",
+      "path": "CreditSpecification",
+      "actual": {
+        "CPUCredits": "unlimited"
+      },
+      "physicalId": "i-06fd4581f0d168d8a",
+      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
+    },
+    {
+      "tier": "atDefault",
+      "logicalId": "Inst",
+      "resourceType": "AWS::EC2::Instance",
       "path": "InstanceInitiatedShutdownBehavior",
       "actual": "stop",
       "physicalId": "i-06fd4581f0d168d8a",
@@ -414,17 +425,6 @@
       "actual": {
         "ThreadsPerCore": 2,
         "CoreCount": 1
-      },
-      "physicalId": "i-06fd4581f0d168d8a",
-      "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"
-    },
-    {
-      "tier": "undeclared",
-      "logicalId": "Inst",
-      "resourceType": "AWS::EC2::Instance",
-      "path": "CreditSpecification",
-      "actual": {
-        "CPUCredits": "unlimited"
       },
       "physicalId": "i-06fd4581f0d168d8a",
       "constructPath": "CdkRealDriftIntegEc2InstanceSets/Inst"

--- a/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
+++ b/tests/corpus/AWS__EC2__NetworkInterface.EniMultiip.json
@@ -178,17 +178,17 @@
       "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "SourceDestCheck",
-      "actual": true,
+      "path": "SecondaryPrivateIpAddressCount",
+      "actual": 3,
       "physicalId": "eni-01ce38782d866c24f",
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Eni",
       "resourceType": "AWS::EC2::NetworkInterface",
-      "path": "SecondaryPrivateIpAddressCount",
-      "actual": 3,
+      "path": "SourceDestCheck",
+      "actual": true,
       "physicalId": "eni-01ce38782d866c24f",
       "constructPath": "CdkRealDriftIntegEniMultiipRich/Eni"
     }

--- a/tests/corpus/AWS__EC2__Volume.Gp2Vol0A540FFC.json
+++ b/tests/corpus/AWS__EC2__Volume.Gp2Vol0A540FFC.json
@@ -81,17 +81,17 @@
       "tier": "atDefault",
       "logicalId": "Gp2Vol0A540FFC",
       "resourceType": "AWS::EC2::Volume",
-      "path": "KmsKeyId",
-      "actual": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
+      "path": "Iops",
+      "actual": 100,
       "physicalId": "vol-035b5abfc83c3e495",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Gp2Vol0A540FFC",
       "resourceType": "AWS::EC2::Volume",
-      "path": "Iops",
-      "actual": 100,
+      "path": "KmsKeyId",
+      "actual": "arn:aws:kms:us-east-1:111111111111:key/76039e55-2469-4c94-95ab-e12d8615bb98",
       "physicalId": "vol-035b5abfc83c3e495",
       "constructPath": "CdkRealDriftIntegVpcEpRich/Gp2Vol"
     },


### PR DESCRIPTION
## What

The `classify.ts`-derived remainder of the #640 first-run false-positive batch (the pure-`noise.ts` constants shipped in #719 / v0.2.38). Each default is a deterministic function of the declared inputs, so it is computed and equality-gated (tier-2 derived — detection of a change away preserved):

- **EC2::Instance** `CreditSpecification.CPUCredits` — derived from the InstanceType burstable family (`t2` → `standard`, `t3`/`t3a`/`t4g` → `unlimited`; non-burstable → no fold).
- **EC2::Volume** gp2 `Iops` — `min(16000, max(100, 3 × Size))` from declared `Size` (gp3/io1/io2 declare Iops → declared loop).
- **EC2::NetworkInterface** `SecondaryPrivateIpAddressCount` — `max(0, len(declared PrivateIpAddresses) − 1)`.

## Verification

- 3 golden-corpus cases flip `undeclared` → `atDefault` (exact target flips, no other findings altered).
- New `tests/classify-640-derived.test.ts` (11 tests): each fold + a value-away-from-default surfaces (t3-pinned-standard, gp2 bumped Iops, mismatched IP count).
- Full suite 53 files / 3148 tests green; typecheck + lint clean.

## Scope

`#640` stays **open** for the remaining items that need heavier machinery: Instance `CpuOptions` (full instance-type→vCPU table), `CreditSpecification` for non-T families, and the sibling echoes (`SecurityGroups`/`SubnetId`/`Volumes`/`BlockDeviceMappings`).

Refs #640
