### PR TITLE
fix(desired): collect IAM standalone inline-policy siblings (RolePolicy/UserPolicy/GroupPolicy) (#697)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -307,14 +307,10 @@ export function collectPrincipalsWithSiblingPolicies(
   ctx?: ResolverContext
 ): Map<string, string[] | 'unresolved'> {
   const principals = new Map<string, string[] | 'unresolved'>();
-  for (const res of Object.values(resources)) {
-    if (res?.Type !== 'AWS::IAM::Policy') continue;
-    const name = resolvePolicyName(res.Properties?.PolicyName, ctx);
-    const refs = [
-      ...((res.Properties?.Roles ?? []) as unknown[]),
-      ...((res.Properties?.Users ?? []) as unknown[]),
-      ...((res.Properties?.Groups ?? []) as unknown[]),
-    ];
+  // Register one inline-policy sibling: attach `name` (resolved PolicyName) to each
+  // principal logicalId in `refs`. An unresolvable PolicyName marks the principal
+  // 'unresolved' (classify then suppresses the whole live Policies property).
+  const attach = (name: string | undefined, refs: unknown[]) => {
     for (const r of refs) {
       const ref = r && typeof r === 'object' ? (r as Record<string, unknown>).Ref : undefined;
       if (typeof ref !== 'string') continue;
@@ -323,9 +319,36 @@ export function collectPrincipalsWithSiblingPolicies(
       if (name === undefined) principals.set(ref, 'unresolved');
       else principals.set(ref, [...(prev ?? []), name]);
     }
+  };
+  for (const res of Object.values(resources)) {
+    const name = resolvePolicyName(res?.Properties?.PolicyName, ctx);
+    if (res?.Type === 'AWS::IAM::Policy') {
+      // Array reference props: attach the same inline policy to every referenced principal.
+      attach(name, [
+        ...((res.Properties?.Roles ?? []) as unknown[]),
+        ...((res.Properties?.Users ?? []) as unknown[]),
+        ...((res.Properties?.Groups ?? []) as unknown[]),
+      ]);
+    } else {
+      // Standalone inline-policy types attach to a SINGLE principal via a singular
+      // RoleName / UserName / GroupName (a Ref/GetAtt to the principal, or a literal
+      // name). Only a Ref maps to a principal logicalId — resolve exactly like the
+      // Policy array entries (a literal name has no logicalId, so it is ignored).
+      const singular = IAM_STANDALONE_INLINE_POLICY_TYPES.get(res?.Type);
+      if (singular !== undefined) attach(name, [res?.Properties?.[singular]]);
+    }
   }
   return principals;
 }
+
+// The standalone inline-policy resource types, mapped to the singular property that
+// references their one attached principal. Each is the CDK `CfnRolePolicy` /
+// `CfnUserPolicy` / `CfnGroupPolicy` equivalent of an inline policy on the principal.
+const IAM_STANDALONE_INLINE_POLICY_TYPES: ReadonlyMap<string, string> = new Map([
+  ['AWS::IAM::RolePolicy', 'RoleName'],
+  ['AWS::IAM::UserPolicy', 'UserName'],
+  ['AWS::IAM::GroupPolicy', 'GroupName'],
+]);
 
 /**
  * The set of ECS Cluster logicalIds that a sibling AWS::ECS::ClusterCapacityProviderAssociations

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -95,6 +95,70 @@ describe('collectPrincipalsWithSiblingPolicies', () => {
     expect(m.get('MyUser')).toEqual(['UserDefaultPolicyA55']);
     expect(m.get('MyGroup')).toEqual(['GroupDefaultPolicyB33']);
   });
+
+  it('also maps standalone RolePolicy/UserPolicy/GroupPolicy inline-policy types (#697)', () => {
+    const resources = {
+      MyRole: { Type: 'AWS::IAM::Role' },
+      MyUser: { Type: 'AWS::IAM::User' },
+      MyGroup: { Type: 'AWS::IAM::Group' },
+      RolePol: {
+        Type: 'AWS::IAM::RolePolicy',
+        Properties: { PolicyName: 'RoleInlineA', RoleName: { Ref: 'MyRole' } },
+      },
+      UserPol: {
+        Type: 'AWS::IAM::UserPolicy',
+        Properties: { PolicyName: 'UserInlineB', UserName: { Ref: 'MyUser' } },
+      },
+      GroupPol: {
+        Type: 'AWS::IAM::GroupPolicy',
+        Properties: { PolicyName: 'GroupInlineC', GroupName: { Ref: 'MyGroup' } },
+      },
+    };
+    const m = collectPrincipalsWithSiblingPolicies(resources);
+    expect(m.get('MyRole')).toEqual(['RoleInlineA']);
+    expect(m.get('MyUser')).toEqual(['UserInlineB']);
+    expect(m.get('MyGroup')).toEqual(['GroupInlineC']);
+  });
+
+  it('merges standalone RolePolicy names with an AWS::IAM::Policy on the same role (#697)', () => {
+    const resources = {
+      MyRole: { Type: 'AWS::IAM::Role' },
+      DefaultPol: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { PolicyName: 'RoleDefaultPolicyABC', Roles: [{ Ref: 'MyRole' }] },
+      },
+      StandalonePol: {
+        Type: 'AWS::IAM::RolePolicy',
+        Properties: { PolicyName: 'RoleInlineStandalone', RoleName: { Ref: 'MyRole' } },
+      },
+    };
+    // does not regress the existing AWS::IAM::Policy handling: BOTH names present
+    expect(collectPrincipalsWithSiblingPolicies(resources).get('MyRole')).toEqual([
+      'RoleDefaultPolicyABC',
+      'RoleInlineStandalone',
+    ]);
+  });
+
+  it("marks the principal 'unresolved' for a standalone type with an unresolvable PolicyName (#697)", () => {
+    const resources = {
+      MyRole: { Type: 'AWS::IAM::Role' },
+      RolePol: {
+        Type: 'AWS::IAM::RolePolicy',
+        Properties: { PolicyName: { 'Fn::GetAtt': ['X', 'Y'] }, RoleName: { Ref: 'MyRole' } },
+      },
+    };
+    expect(collectPrincipalsWithSiblingPolicies(resources).get('MyRole')).toBe('unresolved');
+  });
+
+  it('ignores a standalone type whose principal is a literal name, not a Ref (#697)', () => {
+    const resources = {
+      RolePol: {
+        Type: 'AWS::IAM::RolePolicy',
+        Properties: { PolicyName: 'p', RoleName: 'literal-role-name' },
+      },
+    };
+    expect(collectPrincipalsWithSiblingPolicies(resources).size).toBe(0); // literal has no logicalId
+  });
 });
 
 describe('collectClustersWithSiblingCapacityProviders', () => {


### PR DESCRIPTION
## What

A clean, un-mutated deploy showed a first-run `[Potential Drift]` FP on `Role.Policies` / `User.Policies` / `Group.Policies` whenever the inline policy was declared via the **standalone** types `AWS::IAM::RolePolicy` / `UserPolicy` / `GroupPolicy` (CDK's `CfnRolePolicy`/etc). The sibling guard `collectPrincipalsWithSiblingPolicies` (`src/desired/template-adapter.ts`) matched only `AWS::IAM::Policy`, so those principals' live-read inline policies surfaced as live-only.

## Fix

Factor the per-sibling attach into a helper and also collect the three standalone types, resolving their singular `RoleName`/`UserName`/`GroupName` Ref to the principal logicalId exactly like the `AWS::IAM::Policy` array props. The downstream sibling-name filter (classify) is unchanged.

## Verification

- 4 new `collectPrincipalsWithSiblingPolicies` unit tests: standalone types folded, merge with an `AWS::IAM::Policy` on the same principal (no regression), unresolved `PolicyName`, literal name ignored.
- Full suite 54 files / 3166 tests green; the existing `AWS::IAM::Policy` sibling corpus + template-adapter tests stayed green.
- Note: verified by unit test, not corpus replay — the golden corpus captures pipeline input produced *after* template-adapter, so a replay of pre-fix cases cannot reflect this change. Live-proven in bug-hunt round 2026-07-08n (issue carries the repro).

Cross-stack (sibling-stack) standalone policies remain the #666 class, same as `AWS::IAM::Policy`.

Closes #697
