### PR TITLE
fix(normalize): YAML-string Content structural compare — SSM Document DocumentFormat: YAML (#713)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1,6 +1,12 @@
 // Undeclared-property noise suppressors (slice fixes A1/A2/A4).
 // Keep conservative — over-suppression hides real undeclared drift.
 
+// The CFn-aware YAML codec (already a dependency). Used as a JSON-string compare
+// fallback: JSON is a subset of YAML, so `parse` handles a JSON string and a
+// genuine YAML string alike (SSM Document.Content declared `DocumentFormat: YAML`
+// reads back as canonical JSON — #713).
+import { parse as parseYaml } from 'yaml';
+
 // A4: defaults AWS applies that are NOT in the CFn schema's `default` field.
 // Every entry is equality-gated: it only suppresses a live value EQUAL to the
 // listed default, so an out-of-band change to anything else still surfaces (and
@@ -3221,21 +3227,51 @@ function deepCompareUnordered(a: unknown, b: unknown): boolean {
     ak.every((k) => Object.hasOwn(bo, k) && deepCompareUnordered(ao[k], bo[k]))
   );
 }
-export function isJsonStringStructEqual(a: unknown, b: unknown): boolean {
-  const parse = (s: string): unknown => {
+// Parse a string operand into a structured value for the JSON-string compare.
+// Try strict JSON first, then fall back to the CFn-aware YAML codec — JSON is a
+// SUBSET of YAML, so `parseYaml` handles both a JSON string and a genuine YAML
+// string (R75+: SSM Document.Content declared `DocumentFormat: YAML` reads back as
+// canonical JSON — #713). Only a parse that yields an OBJECT or ARRAY counts as a
+// structured operand; a bare scalar (`"hello"`, `42`) returns the SENTINEL so an
+// unrelated scalar string is never vacuously folded against an object.
+function parseStructured(s: string): unknown {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(s);
+  } catch {
     try {
-      return JSON.parse(s);
+      parsed = parseYaml(s);
     } catch {
       return SENTINEL_UNPARSEABLE;
     }
-  };
-  if (typeof a === 'string' && b !== null && typeof b === 'object') {
-    const pa = parse(a);
+  }
+  return parsed !== null && typeof parsed === 'object' ? parsed : SENTINEL_UNPARSEABLE;
+}
+export function isJsonStringStructEqual(a: unknown, b: unknown): boolean {
+  const aStr = typeof a === 'string';
+  const bStr = typeof b === 'string';
+  const aObj = !aStr && a !== null && typeof a === 'object';
+  const bObj = !bStr && b !== null && typeof b === 'object';
+  // string vs object (either order): declared object, live JSON/YAML string (or vice
+  // versa). Parse the string side and structurally compare, key-order-insensitive.
+  if (aStr && bObj) {
+    const pa = parseStructured(a);
     return pa !== SENTINEL_UNPARSEABLE && deepCompareUnordered(pa, b);
   }
-  if (typeof b === 'string' && a !== null && typeof a === 'object') {
-    const pb = parse(b);
+  if (bStr && aObj) {
+    const pb = parseStructured(b);
     return pb !== SENTINEL_UNPARSEABLE && deepCompareUnordered(a, pb);
+  }
+  // string vs string: a declared YAML string (`DocumentFormat: YAML`) whose live
+  // counterpart is the same document re-serialized to canonical JSON (#713). Parse
+  // BOTH — each side may be JSON or YAML — and structurally compare. The
+  // object/array guard in parseStructured keeps two unrelated scalar strings from
+  // folding, and a genuinely different document still differs after the parse.
+  if (aStr && bStr) {
+    const pa = parseStructured(a);
+    if (pa === SENTINEL_UNPARSEABLE) return false;
+    const pb = parseStructured(b);
+    return pb !== SENTINEL_UNPARSEABLE && deepCompareUnordered(pa, pb);
   }
   return false;
 }

--- a/tests/noise-ssm-yaml-713.test.ts
+++ b/tests/noise-ssm-yaml-713.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { isJsonStringStructEqual } from '../src/normalize/noise.js';
+
+// #713: an AWS::SSM::Document declared with `DocumentFormat: YAML` and a YAML-string
+// `Content` reads back re-serialized as canonical JSON. The declared YAML string can
+// never string-match the live JSON string even though they are semantically identical,
+// producing a first-run declared-tier false positive. isJsonStringStructEqual must parse
+// BOTH sides (JSON is a YAML subset) and structurally compare — without over-folding
+// unrelated scalar strings, and while still detecting a genuinely different document.
+
+// The exact repro strings from the issue.
+const DECLARED_YAML =
+  'schemaVersion: "2.2"\ndescription: hunt yaml doc\nmainSteps:\n  - action: aws:runShellScript\n    name: run\n    inputs:\n      runCommand:\n        - echo hi\n';
+const LIVE_JSON =
+  '{"description":"hunt yaml doc","mainSteps":[{"action":"aws:runShellScript","inputs":{"runCommand":["echo hi"]},"name":"run"}],"schemaVersion":"2.2"}';
+
+describe('isJsonStringStructEqual — SSM Document YAML Content (#713)', () => {
+  it('folds a declared YAML-string Content against the live JSON-string re-serialization', () => {
+    expect(isJsonStringStructEqual(DECLARED_YAML, LIVE_JSON)).toBe(true);
+    // symmetric (declared/live order must not matter)
+    expect(isJsonStringStructEqual(LIVE_JSON, DECLARED_YAML)).toBe(true);
+  });
+
+  it('still folds a declared parsed OBJECT against a live YAML string', () => {
+    const declaredObj = {
+      schemaVersion: '2.2',
+      description: 'hunt yaml doc',
+      mainSteps: [
+        { action: 'aws:runShellScript', name: 'run', inputs: { runCommand: ['echo hi'] } },
+      ],
+    };
+    expect(isJsonStringStructEqual(declaredObj, DECLARED_YAML)).toBe(true);
+    expect(isJsonStringStructEqual(DECLARED_YAML, declaredObj)).toBe(true);
+  });
+
+  it('DETECTS a genuinely different document (changed command)', () => {
+    const changedYaml = DECLARED_YAML.replace('echo hi', 'echo bye');
+    expect(isJsonStringStructEqual(changedYaml, LIVE_JSON)).toBe(false);
+  });
+
+  it('DETECTS a genuinely different document (changed field value)', () => {
+    const changedJson = LIVE_JSON.replace('"2.2"', '"2.3"');
+    expect(isJsonStringStructEqual(DECLARED_YAML, changedJson)).toBe(false);
+  });
+
+  it('does NOT vacuously fold an unrelated YAML-looking scalar string', () => {
+    // Two bare scalar strings that happen to parse as YAML scalars must not fold —
+    // the object/array guard rejects scalar operands.
+    expect(isJsonStringStructEqual('hello world', 'goodbye world')).toBe(false);
+    // A scalar string vs a structured document must not fold either.
+    expect(isJsonStringStructEqual('hello world', LIVE_JSON)).toBe(false);
+    expect(isJsonStringStructEqual(LIVE_JSON, 'hello world')).toBe(false);
+    // A scalar string vs an object: still no fold (guard on the parsed scalar).
+    expect(isJsonStringStructEqual('just a plain description', { a: 1 })).toBe(false);
+  });
+
+  it('returns false for two unparseable strings (no accidental equality)', () => {
+    expect(isJsonStringStructEqual('{unclosed', '{unclosed')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

An `AWS::SSM::Document` declared with `DocumentFormat: YAML` and a YAML-string `Content` produced a first-run declared-tier FP: the live read returns the document re-serialized as **canonical JSON**, so the declared YAML string never matched the live JSON string despite being semantically identical.

## Fix

cdkrd already tolerated JSON↔JSON (`canonicalizeJsonText`) and object↔JSON-string (`isJsonStringStructEqual`), but a YAML string was unparseable by `JSON.parse`. Extend `isJsonStringStructEqual`: parse each string operand JSON-first then fall back to the CFn-aware `yaml` codec (JSON is a subset of YAML), with an **object/array guard** so unrelated scalar strings never vacuously fold. Adds the missing string-vs-string branch (declared YAML vs live JSON) plus YAML tolerance to the existing string-vs-object branches. A genuinely different document still differs after parse.

## Verification

- New `tests/noise-ssm-yaml-713.test.ts` (6 tests): YAML↔JSON fold both orders, object↔YAML, detection preserved on a changed command/field, no scalar fold.
- Full suite 55 files / 3168 tests green; corpus-replay 685 green (existing `AWS__SSM__Document.Doc` JSON case unaffected). Live-proven in bug-hunt round 2026-07-08o (issue carries the repro).

Closes #713
