### PR TITLE
fix(read): paginate isManagedBySiblingStack via ListStackResources (DescribeStackResources 100-cap, #726)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -4,6 +4,7 @@ import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcon
 import {
   CloudFormationClient,
   DescribeStackResourcesCommand,
+  ListStackResourcesCommand,
 } from '@aws-sdk/client-cloudformation';
 import { buildCorpusCase, CORPUS_DIR_ENV, recordCorpusCase } from '../corpus/record.js';
 import { type Desired, loadDesired } from '../desired/template-adapter.js';
@@ -172,11 +173,35 @@ export async function isManagedBySiblingStack(
     const res = await cfn.send(
       new DescribeStackResourcesCommand({ PhysicalResourceId: physicalId })
     );
-    // DescribeStackResources(PhysicalResourceId) returns every resource of the OWNING
-    // stack; confirm the one matching this child's id + type is present (a stack owns it).
-    managed = (res.StackResources ?? []).some(
-      (r) => r.PhysicalResourceId === physicalId && r.ResourceType === c.resourceType
-    );
+    const owns = (
+      rs: { PhysicalResourceId?: string | undefined; ResourceType?: string | undefined }[]
+    ): boolean =>
+      rs.some((r) => r.PhysicalResourceId === physicalId && r.ResourceType === c.resourceType);
+    const first = res.StackResources ?? [];
+    if (owns(first)) {
+      managed = true;
+    } else {
+      // DescribeStackResources(PhysicalResourceId) returns ONLY the first 100 resources of the
+      // owning stack and CANNOT paginate (#726). When the child is beyond that window in a big
+      // sibling stack the match above misses and a fully CFn-managed child would be false-flagged
+      // `added` (with a DeleteResource revert offer). Fall back to the PAGINATED
+      // ListStackResources on the owning stack — its name comes from any resource Describe DID
+      // return (they all belong to the one owning stack).
+      const stackName = first[0]?.StackName;
+      if (stackName) {
+        let next: string | undefined;
+        do {
+          const page = await cfn.send(
+            new ListStackResourcesCommand({ StackName: stackName, NextToken: next })
+          );
+          if (owns(page.StackResourceSummaries ?? [])) {
+            managed = true;
+            break;
+          }
+          next = page.NextToken;
+        } while (next);
+      }
+    }
   } catch {
     // No stack owns this physical id (ValidationError "does not exist") -> genuinely out of
     // band; or a permission/throttle error -> fail open to the current "report as added".

--- a/tests/gather.test.ts
+++ b/tests/gather.test.ts
@@ -838,4 +838,94 @@ describe('isManagedBySiblingStack (#666 cross-stack added FP)', () => {
     expect(cfn.commandCalls(DescribeStackResourcesCommand)).toHaveLength(1);
     expect(cache.get(subArn)).toBe(true);
   });
+
+  it('#726: child BEYOND the DescribeStackResources 100-window resolves via paginated ListStackResources', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    // DescribeStackResources returns only the first 100 (no pagination), and the child is NOT
+    // among them — but every returned resource still names the owning stack.
+    cfn.on(DescribeStackResourcesCommand).resolves({
+      StackResources: [
+        {
+          StackName: 'BigProducer',
+          LogicalResourceId: 'SomeOther',
+          PhysicalResourceId: 'other-phys',
+          ResourceType: 'AWS::SQS::Queue',
+          Timestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    // ListStackResources paginates: page 1 lacks the child, page 2 (via NextToken) has it.
+    cfn
+      .on(ListStackResourcesCommand)
+      .resolvesOnce({
+        StackResourceSummaries: [
+          {
+            LogicalResourceId: 'Filler',
+            PhysicalResourceId: 'filler-phys',
+            ResourceType: 'AWS::SQS::Queue',
+            LastUpdatedTimestamp: new Date(0),
+            ResourceStatus: 'CREATE_COMPLETE',
+          },
+        ],
+        NextToken: 'page2',
+      })
+      .resolves({
+        StackResourceSummaries: [
+          {
+            LogicalResourceId: 'NotifTopicSub',
+            PhysicalResourceId: subArn,
+            ResourceType: 'AWS::SNS::Subscription',
+            LastUpdatedTimestamp: new Date(0),
+            ResourceStatus: 'CREATE_COMPLETE',
+          },
+        ],
+      });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      new Map()
+    );
+    expect(managed).toBe(true);
+    // it queried the OWNING stack by name and paginated to page 2
+    expect(cfn.commandCalls(ListStackResourcesCommand)).toHaveLength(2);
+    expect(cfn.commandCalls(ListStackResourcesCommand)[0]!.args[0].input).toMatchObject({
+      StackName: 'BigProducer',
+    });
+  });
+
+  it('#726: a genuinely out-of-band child stays added even after paginating the whole owning-window', async () => {
+    // Describe returns 100 without the child; ListStackResources paginates fully and never finds
+    // it (it truly belongs to no stack that owns this physical id) -> report as added (fail safe).
+    const cfn = mockClient(CloudFormationClient);
+    cfn.on(DescribeStackResourcesCommand).resolves({
+      StackResources: [
+        {
+          StackName: 'BigProducer',
+          LogicalResourceId: 'X',
+          PhysicalResourceId: 'x-phys',
+          ResourceType: 'AWS::SQS::Queue',
+          Timestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Y',
+          PhysicalResourceId: 'y-phys',
+          ResourceType: 'AWS::SQS::Queue',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    const managed = await isManagedBySiblingStack(
+      cfn as unknown as CloudFormationClient,
+      child(subArn),
+      new Map()
+    );
+    expect(managed).toBe(false);
+  });
 });


### PR DESCRIPTION
## What

The #666 cross-stack sibling fold queried `DescribeStackResources(PhysicalResourceId)` — documented to return only the **first 100 resources** of the owning stack and **cannot paginate**. When a sibling stack has >100 resources and the queried child is outside that arbitrary 100-window, the membership match missed → `managed=false` → a fully CloudFormation-managed cross-stack child (the canonical `topic.addSubscription()` Subscription, ELBv2 Listener/Rule, Lambda ESM/Alias, EventBus Rule, …) was false-flagged `added`, **and `revert` then offered Cloud Control `DeleteResource` on a CFn-managed resource**. The result is cached, so one truncation poisons the whole run.

## Fix

When the child is not in the `DescribeStackResources` first-100 result, fall back to the **paginated `ListStackResources`** on the owning stack (its name comes from any resource Describe *did* return — they all belong to the one owning stack) and check membership across all pages. Fast path unchanged (≤100-resource stacks resolve in the single Describe call); fails open on any error as before.

## Tests

`gather.test.ts`: a child beyond the 100-window resolves via paginated `ListStackResources` page 2 (asserts it queried the owning stack by name + paginated); a genuinely out-of-band child stays `added` after full pagination.

**Live-test deferred**: exercising the >100-resource path needs a >100-resource sibling stack; the pagination is deterministic and unit-covered.

Closes #726 (follow-up to #666).