### PR TITLE
fix(read): read AWS::IAM::AccessKey Status via SDK override — detect out-of-band deactivation (#716)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -1295,6 +1295,14 @@ export function classifyResource(
   // already emitted as a readGap above AND stripped from `declared` by writeOnlyPaths,
   // so it cannot reach this loop (the old guard was dead code for top-level keys).
   let knownDef = KNOWN_DEFAULTS[resourceType] ?? {};
+  // #716: an AWS::IAM::AccessKey (now readable via the SDK_OVERRIDES ListAccessKeys reader) whose
+  // template omits Status reads back the AWS default Status "Active". Equality-gate it here (a
+  // top-level KNOWN_DEFAULTS-equivalent kept in classify.ts so the fold ships with the reader in
+  // one lane) so a clean deploy stays CLEAN; an out-of-band flip to "Inactive" (a deactivated key)
+  // still surfaces as the drift #716 restores.
+  if (resourceType === 'AWS::IAM::AccessKey') {
+    knownDef = { ...knownDef, Status: 'Active' };
+  }
   // A Redshift RA3 cluster is ALWAYS encrypted (RA3 mandates encryption — it can never be false)
   // and AWS enables AvailabilityZoneRelocation for it by default, so an RA3 cluster that declares
   // neither reads back Encrypted=true / AvailabilityZoneRelocationStatus="enabled" — AWS-forced

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -67,6 +67,7 @@ import {
   GetRolePolicyCommand,
   GetUserPolicyCommand,
   IAMClient,
+  ListAccessKeysCommand,
   ListEntitiesForPolicyCommand,
 } from '@aws-sdk/client-iam';
 import { LambdaClient, GetPolicyCommand as LambdaGetPolicyCommand } from '@aws-sdk/client-lambda';
@@ -235,6 +236,24 @@ const readIamPolicy: OverrideReader = async ({ declared, region }) => {
         ? { Users: declared.Users }
         : { Groups: declared.Groups }),
   };
+};
+
+// AWS::IAM::AccessKey — Cloud Control GetResource throws UnsupportedActionException, so the
+// key was silently `skipped` and an out-of-band Status flip (Active <-> Inactive, a
+// security-relevant change) went undetected (#716). The CFn physical id IS the AccessKeyId; the
+// owning user comes from the declared `UserName` (resolved by classify). iam:ListAccessKeys
+// returns the user's key metadata (Status/CreateDate) — read back only `Status` (the one
+// mutable, meaningful property; the SecretAccessKey is writeOnly and stays unread). Serial is a
+// create/rotation trigger with no readable live value, so it is not projected.
+const readIamAccessKey: OverrideReader = async ({ declared, physicalId, region }) => {
+  const userName = str(declared.UserName);
+  if (!userName) return undefined;
+  const c = new IAMClient({ region, ...READ_RETRY });
+  // A user has at most 2 access keys, so a single ListAccessKeys page always suffices.
+  const r = await c.send(new ListAccessKeysCommand({ UserName: userName }));
+  const meta = (r.AccessKeyMetadata ?? []).find((m) => m.AccessKeyId === physicalId);
+  if (!meta) return undefined;
+  return { UserName: userName, Status: meta.Status };
 };
 
 const readIamManagedPolicy: OverrideReader = async ({ physicalId, region }) => {
@@ -2027,6 +2046,7 @@ export const SDK_OVERRIDES: Record<string, OverrideReader> = {
   'AWS::SQS::QueuePolicy': readSqsQueuePolicy,
   'AWS::IAM::Policy': readIamPolicy,
   'AWS::IAM::ManagedPolicy': readIamManagedPolicy,
+  'AWS::IAM::AccessKey': readIamAccessKey,
   'AWS::Lambda::Permission': readLambdaPermission,
   'AWS::Budgets::Budget': readBudget,
   'AWS::EC2::EIP': readEc2Eip,

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1206,6 +1206,23 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ).toEqual(['Policies']);
   });
 
+  it('#716: IAM AccessKey Status default Active folds; an out-of-band Inactive flip surfaces', () => {
+    const res: DesiredResource = {
+      logicalId: 'Ak',
+      resourceType: 'AWS::IAM::AccessKey',
+      physicalId: 'AKIA...',
+      declared: { UserName: 'svc' }, // Status omitted -> AWS default Active
+    };
+    // clean deploy: undeclared Status "Active" folds atDefault (no first-run FP from the new reader)
+    expect(
+      tiers(classifyResource(res, { UserName: 'svc', Status: 'Active' }, emptySchema)).atDefault
+    ).toEqual(['Status']);
+    // an out-of-band deactivation (Active -> Inactive) SURFACES — the drift #716 restores
+    expect(
+      tiers(classifyResource(res, { UserName: 'svc', Status: 'Inactive' }, emptySchema)).undeclared
+    ).toEqual(['Status']);
+  });
+
   it('noise-sweep batch: the default folds, a flipped (security-relevant) value surfaces', () => {
     const t = (rt: string, live: Record<string, unknown>) =>
       tiers(classifyResource(bare(rt), live, emptySchema));

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -77,6 +77,7 @@ import {
   GetPolicyVersionCommand,
   GetRolePolicyCommand,
   IAMClient,
+  ListAccessKeysCommand,
   ListEntitiesForPolicyCommand,
 } from '@aws-sdk/client-iam';
 import { ListResourceRecordSetsCommand, Route53Client } from '@aws-sdk/client-route-53';
@@ -252,6 +253,32 @@ describe('SDK overrides', () => {
       Groups: ['GroupA'],
     });
     expect(iam.commandCalls(ListEntitiesForPolicyCommand)).toHaveLength(2);
+  });
+
+  it('IAM AccessKey (#716): reads Status for the key matching the physical id', async () => {
+    iam.on(ListAccessKeysCommand).resolves({
+      AccessKeyMetadata: [
+        { UserName: 'svc', AccessKeyId: 'AKIAOTHER', Status: 'Active', CreateDate: new Date(0) },
+        { UserName: 'svc', AccessKeyId: 'AKIATARGET', Status: 'Inactive', CreateDate: new Date(0) },
+      ],
+    });
+    const out = await SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({ UserName: 'svc' }, 'AKIATARGET'));
+    // only Status (mutable) + UserName are projected — the secret is never read
+    expect(out).toEqual({ UserName: 'svc', Status: 'Inactive' });
+  });
+
+  it('IAM AccessKey (#716): undefined when no declared UserName or the key is not found', async () => {
+    iam.on(ListAccessKeysCommand).resolves({
+      AccessKeyMetadata: [
+        { UserName: 'svc', AccessKeyId: 'AKIAOTHER', Status: 'Active', CreateDate: new Date(0) },
+      ],
+    });
+    // no UserName -> cannot resolve the owning user
+    expect(await SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({}, 'AKIATARGET'))).toBeUndefined();
+    // the physical id is not among the user's keys -> undefined (falls back to skipped, no wrong read)
+    expect(
+      await SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({ UserName: 'svc' }, 'AKIATARGET'))
+    ).toBeUndefined();
   });
 
   it('Lambda Permission: matches statement by Action + Principal', async () => {


### PR DESCRIPTION
## What

`AWS::IAM::AccessKey` was silently `skipped` on every check (Cloud Control `GetResource` throws `UnsupportedActionException`), so an out-of-band `Status` flip (Active ↔ Inactive — a deactivated key is a real, security-relevant change) was **never detected**.

## Fix

Add an `SDK_OVERRIDES` reader (`readIamAccessKey`) using `iam:ListAccessKeys`: the CFn physical id IS the `AccessKeyId`, the owning user comes from the declared `UserName`, and the reader projects back only **`Status`** (the one mutable, meaningful property; the `SecretAccessKey` is writeOnly and stays unread; `Serial` is a create/rotation trigger with no readable value).

To keep a clean deploy CLEAN now that the type is readable, the AWS default `Status: Active` folds `atDefault` via a **classify.ts per-type `knownDef` override** (kept in classify.ts, not noise.ts, so the fold ships with the reader in one lane — noise.ts is held by other lanes); an out-of-band `Inactive` flip still surfaces.

## Live verification (us-east-1, IAM user + access key)

| | result |
|---|---|
| clean deploy | **CLEAN** — `Status=Active` folds; the key is no longer skipped |
| Active → Inactive out of band — BEFORE (0.2.41) | `CLEAN` + `skipped=1 (UnsupportedActionException)` — undetectable |
| Active → Inactive out of band — AFTER | **`[Potential Drift: 1] Ak.Status`** surfaces |

Fixture (user + key) torn down with `delstack`; user/key confirmed gone.

## Scope

Read/detection only (the issue's `SDK_OVERRIDES candidate`). A revert writer (`iam:UpdateAccessKey`) is a follow-up.

## Tests

`overrides.test.ts` (reads Status for the matching key; undefined without UserName or when the key is absent); `classify.test.ts` (default Active folds; Inactive surfaces).

Closes #716.