### PR TITLE
fix(desired): derive AWS::Partition / AWS::URLSuffix from the region (#730)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -33,6 +33,24 @@ export function parseTemplateBody(body: string): Record<string, unknown> {
   return parseCfnTemplate(body);
 }
 
+// The AWS::Partition / AWS::URLSuffix pseudo-parameters are a deterministic function of the
+// region, NOT a commercial-partition constant. CDK env-agnostic stacks emit ${AWS::Partition}
+// inside nearly every Sub/Join-built ARN, so hard-coding `aws` / `amazonaws.com` mis-resolves
+// EVERY such declared ARN in GovCloud (`arn:aws-us-gov:...`) or China (`arn:aws-cn:...`) → a
+// declared-tier FP on essentially every resource. Derive both from the region prefix (#730).
+// Ordering note: `us-isob-` / `us-isof-` do not start with `us-iso-` (the char after `us-iso`
+// is a letter, not `-`), so the `us-iso-` test does not swallow them; still, keep the more
+// specific ISO prefixes listed for clarity.
+function partitionForRegion(region: string): { partition: string; urlSuffix: string } {
+  if (region.startsWith('us-gov-')) return { partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' };
+  if (region.startsWith('cn-')) return { partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' };
+  if (region.startsWith('us-iso-')) return { partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' };
+  if (region.startsWith('us-isob-')) return { partition: 'aws-iso-b', urlSuffix: 'sc2s.sgov.gov' };
+  if (region.startsWith('us-isof-')) return { partition: 'aws-iso-f', urlSuffix: 'csp.hci.ic.gov' };
+  if (region.startsWith('eu-isoe-')) return { partition: 'aws-iso-e', urlSuffix: 'cloud.adc-e.uk' };
+  return { partition: 'aws', urlSuffix: 'amazonaws.com' };
+}
+
 export function buildResolverContext(
   template: Record<string, any>,
   stackParams: Record<string, string>,
@@ -75,13 +93,14 @@ export function buildResolverContext(
     if (res?.Type) typeOf[lid] = res.Type;
     if (res?.Properties) declaredRawProps[lid] = res.Properties;
   }
+  const { partition, urlSuffix } = partitionForRegion(region);
   return {
     params,
     pseudo: {
       'AWS::Region': region,
       'AWS::AccountId': accountId,
-      'AWS::Partition': 'aws',
-      'AWS::URLSuffix': 'amazonaws.com',
+      'AWS::Partition': partition,
+      'AWS::URLSuffix': urlSuffix,
       'AWS::StackName': stackName,
       'AWS::StackId': stackId,
     },

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -246,6 +246,25 @@ describe('buildResolverContext', () => {
     const ctx = buildResolverContext(template, { L: '' }, {}, 'us-east-1', '999', 'S', 'arn');
     expect(ctx.params.L).toEqual([]);
   });
+
+  it('derives AWS::Partition / AWS::URLSuffix from the region (#730)', () => {
+    // CDK env-agnostic stacks emit ${AWS::Partition} inside nearly every ARN; hard-coding
+    // `aws`/`amazonaws.com` FPs every declared ARN in GovCloud/China/ISO partitions.
+    const partOf = (region: string) => {
+      const ctx = buildResolverContext({}, {}, {}, region, '999', 'S', 'arn');
+      return { p: ctx.pseudo['AWS::Partition'], u: ctx.pseudo['AWS::URLSuffix'] };
+    };
+    expect(partOf('us-east-1')).toEqual({ p: 'aws', u: 'amazonaws.com' });
+    expect(partOf('eu-west-3')).toEqual({ p: 'aws', u: 'amazonaws.com' });
+    expect(partOf('us-gov-west-1')).toEqual({ p: 'aws-us-gov', u: 'amazonaws.com' });
+    expect(partOf('cn-north-1')).toEqual({ p: 'aws-cn', u: 'amazonaws.com.cn' });
+    expect(partOf('cn-northwest-1')).toEqual({ p: 'aws-cn', u: 'amazonaws.com.cn' });
+    expect(partOf('us-iso-east-1')).toEqual({ p: 'aws-iso', u: 'c2s.ic.gov' });
+    // us-isob-/us-isof- must NOT be swallowed by the us-iso- prefix test.
+    expect(partOf('us-isob-east-1')).toEqual({ p: 'aws-iso-b', u: 'sc2s.sgov.gov' });
+    expect(partOf('us-isof-south-1')).toEqual({ p: 'aws-iso-f', u: 'csp.hci.ic.gov' });
+    expect(partOf('eu-isoe-west-1')).toEqual({ p: 'aws-iso-e', u: 'cloud.adc-e.uk' });
+  });
 });
 
 describe('parseTemplateBody', () => {


### PR DESCRIPTION
fix(desired): derive AWS::Partition / AWS::URLSuffix from the region (#730)

buildResolverContext hard-coded the partition pseudo-parameters to commercial values
('AWS::Partition': 'aws', 'AWS::URLSuffix': 'amazonaws.com'). CDK env-agnostic stacks emit
${AWS::Partition} inside nearly every Sub/Join-built ARN, so in GovCloud (aws-us-gov) or
China (aws-cn) every declared ARN mis-resolved (arn:aws:... vs live arn:aws-us-gov:...) →
a declared-tier FP on essentially every resource of every stack, making cdkrd unusable in
those partitions.

Both values are a deterministic function of the region already in the resolver context, so
derive them from the region prefix (us-gov-* → aws-us-gov, cn-* → aws-cn/amazonaws.com.cn,
the ISO partitions likewise). Commercial regions are byte-identical to the previous hard-coded
values (no behavior change), so no commercial regression is possible.

Adds a unit test pinning all partitions offline (no GovCloud/China account needed).
Live-verified in commercial: an IAM Role with an arn:${AWS::Partition}:iam::aws:policy/...
managed-policy ARN checks CLEAN.

Closes #730
