### PR TITLE
fix(synth): honor GovCloud/ISO region pins — widen CONCRETE_REGION for multi-part infixes (#742)

### DIFF
--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -19,7 +19,11 @@ export interface SynthStack {
   template: Record<string, unknown>;
 }
 
-const CONCRETE_REGION = /^[a-z]{2}-[a-z]+-\d+$/;
+// A concrete AWS region pin. Allows the multi-part infixes of GovCloud / ISO partitions
+// (`us-gov-west-1`, `us-iso-east-1`, `us-isob-east-1`, `eu-isoe-west-1`), not just the
+// three-segment commercial form — otherwise those pins test false and env.region is silently
+// discarded, so the stack is read against the wrong region (#742).
+export const CONCRETE_REGION = /^[a-z]{2}(-[a-z]+)+-\d+$/;
 
 export async function synthApp(app: string, opts: SynthOptions = {}): Promise<SynthStack[]> {
   const { region, profile, context = {} } = opts;

--- a/tests/synth-region.test.ts
+++ b/tests/synth-region.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { CONCRETE_REGION } from '../src/synth/synth.js';
+
+describe('CONCRETE_REGION (env.region pin recognition, #742)', () => {
+  it('accepts commercial regions', () => {
+    for (const r of ['us-east-1', 'eu-west-3', 'ap-southeast-2', 'ca-central-1']) {
+      expect(CONCRETE_REGION.test(r)).toBe(true);
+    }
+  });
+
+  it('accepts GovCloud / ISO multi-infix regions (#742)', () => {
+    for (const r of [
+      'us-gov-west-1',
+      'us-gov-east-1',
+      'us-iso-east-1',
+      'us-isob-east-1',
+      'eu-isoe-west-1',
+    ]) {
+      expect(CONCRETE_REGION.test(r)).toBe(true);
+    }
+  });
+
+  it('rejects non-concrete / malformed values (tokens, empty, unresolved)', () => {
+    for (const r of [
+      '',
+      'aws-region',
+      '${Token[AWS.Region.123]}',
+      'us-east',
+      'useast1',
+      'US-EAST-1',
+    ]) {
+      expect(CONCRETE_REGION.test(r)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
`CONCRETE_REGION` was `/^[a-z]{2}-[a-z]+-\d+$/` (exactly three segments), so a stack pinned to a GovCloud / ISO region (`us-gov-west-1`, `us-iso-east-1`, `us-isob-east-1`, `eu-isoe-west-1`) tested false and its `env.region` was silently discarded → the stack fell back to `--region` / the profile default and was read against the **wrong region**.

Widen to `/^[a-z]{2}(-[a-z]+)+-\d+$/` so multi-part infixes match while tokens / malformed values still reject.

**Tests**: `tests/synth-region.test.ts` — commercial + GovCloud/ISO accept; tokens/malformed (empty, unresolved `${Token[...]}`, `us-east`, `US-EAST-1`) reject. Live-test deferred (needs an account in that partition; the regex is deterministic + unit-covered).

Closes #742.