### PR TITLE
fix(synth): widen CONCRETE_REGION to accept GovCloud/ISO region pins (#742)

### DIFF
--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -19,7 +19,12 @@ export interface SynthStack {
   template: Record<string, unknown>;
 }
 
-const CONCRETE_REGION = /^[a-z]{2}-[a-z]+-\d+$/;
+// A resolved AWS region code. The multi-part infix (`(-[a-z]+)+`) admits partition
+// regions with extra segments — `us-gov-west-1`, `us-iso-east-1`, `us-isob-east-1`,
+// `eu-isoe-west-1` — alongside ordinary two-infix regions like `us-east-1`. It still
+// rejects an env-agnostic stack's unresolved region (a `${Token[...]}` placeholder /
+// `unknown-region` string), so that stays folded to `undefined` (env-agnostic).
+export const CONCRETE_REGION = /^[a-z]{2}(-[a-z]+)+-\d+$/;
 
 export async function synthApp(app: string, opts: SynthOptions = {}): Promise<SynthStack[]> {
   const { region, profile, context = {} } = opts;

--- a/tests/synth-region.test.ts
+++ b/tests/synth-region.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { CONCRETE_REGION } from '../src/synth/synth.js';
+
+describe('CONCRETE_REGION', () => {
+  it('accepts ordinary commercial regions', () => {
+    for (const r of ['us-east-1', 'eu-west-3', 'ap-northeast-1', 'ca-central-1']) {
+      expect(CONCRETE_REGION.test(r)).toBe(true);
+    }
+  });
+
+  it('accepts GovCloud / ISO partition regions with multi-part infixes (#742)', () => {
+    for (const r of [
+      'us-gov-west-1',
+      'us-gov-east-1',
+      'us-iso-east-1',
+      'us-isob-east-1',
+      'us-isof-south-1',
+      'eu-isoe-west-1',
+    ]) {
+      expect(CONCRETE_REGION.test(r)).toBe(true);
+    }
+  });
+
+  it('rejects non-region / unresolved-token strings (env-agnostic stays undefined)', () => {
+    for (const s of [
+      'unknown-region',
+      '${Token[AWS.Region.4]}',
+      'us-east',
+      'useast1',
+      'US-EAST-1',
+      '',
+      'foobar',
+    ]) {
+      expect(CONCRETE_REGION.test(s)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
fix(synth): widen CONCRETE_REGION to accept GovCloud/ISO region pins (#742)

CONCRETE_REGION was /^[a-z]{2}-[a-z]+-\d+$/ (exactly three segments), so a stack
pinned to us-gov-west-1 / us-iso-east-1 / us-isob-east-1 / eu-isoe-west-1 tested
false → synthApp returned region: undefined → resolve-stacks fell back as if the
env pin did not exist (wrong-region "not deployed yet" skip, or a "no region"
error). Widen the infix to a repeatable group /^[a-z]{2}(-[a-z]+)+-\d+$/ so
multi-part partition regions match while an env-agnostic stack's unresolved
${Token[...]} / non-region string still folds to undefined.

Unit-tested offline (all partition regions accepted, ordinary regions still
accepted, tokens/junk still rejected). No GovCloud/ISO account available to
deploy against; the regex is deterministic and the test pins every partition.

Closes #742
