### PR TITLE
fix(revert): toPointer splits dots only at bracket depth 0 — dotted identity in a bracket segment (#748)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -323,12 +323,34 @@ function nullHuskRemovalOps(model: Record<string, unknown>): PatchOp[] {
   return ops;
 }
 
-// dotted finding path ("A.B.0.C") -> RFC6902 JSON pointer ("/A/B/0/C")
-function toPointer(dotted: string): string {
+// dotted finding path ("A.B.0.C") -> RFC6902 JSON pointer ("/A/B/0/C"). Split on dots at
+// bracket depth 0 ONLY: an identity-keyed array segment `Prop[<id>]` may itself carry a `.`
+// in the id — IAM names allow `.` (`svc.deploy`, `john.doe`), a Backup rule name may too —
+// and splitting inside the bracket garbled the pointer (`Roles[my/role]` after escaping),
+// which then no-op'd the IAM detach (burning a policy version) or threw on a Backup nested
+// writer (#748). The bracket content stays in its owning segment so the writers' `\[(.+)\]$`
+// parse recovers the full id.
+function splitTopLevelDots(dotted: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let depth = 0;
+  for (const ch of dotted) {
+    if (ch === '[') depth++;
+    else if (ch === ']') depth = Math.max(0, depth - 1);
+    if (ch === '.' && depth === 0) {
+      out.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+export function toPointer(dotted: string): string {
   return (
     '/' +
-    dotted
-      .split('.')
+    splitTopLevelDots(dotted)
       .map((s) => s.replace(/~/g, '~0').replace(/\//g, '~1'))
       .join('/')
   );

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -12,6 +12,7 @@ import {
   rejectedEmptyStripOps,
   tagPreservingOps,
   toPatchDocument,
+  toPointer,
   writeOnlyReincludeOps,
 } from '../src/revert/plan.js';
 import { parseSchema } from '../src/schema/schema-strip.js';
@@ -2652,5 +2653,24 @@ describe('#641 symptom 2 — CC revert strips bare-null array husks from the mod
     expect(plan.items).toHaveLength(1);
     expect(plan.items[0]!.kind).toBe('sdk');
     expect(plan.items[0]!.ops.every((o) => o.path !== '/Foo')).toBe(true);
+  });
+});
+
+describe('#748: toPointer splits dots only at bracket depth 0', () => {
+  it('keeps a dotted identity inside a bracket segment intact', () => {
+    // IAM names allow `.` — an attachment member Roles[my.role] must NOT split inside the bracket
+    expect(toPointer('Roles[my.role]')).toBe('/Roles[my.role]');
+    expect(toPointer('Users[john.doe]')).toBe('/Users[john.doe]');
+    // a nested-writer path with a dotted id in the middle segment
+    expect(toPointer('BackupPlan.BackupPlanRule[daily.backups].ScheduleExpression')).toBe(
+      '/BackupPlan/BackupPlanRule[daily.backups]/ScheduleExpression'
+    );
+  });
+
+  it('still splits top-level dots and escapes ~ and / per segment (unchanged)', () => {
+    expect(toPointer('A.B.0.C')).toBe('/A/B/0/C');
+    expect(toPointer('VersioningConfiguration.Status')).toBe('/VersioningConfiguration/Status');
+    expect(toPointer('a~b')).toBe('/a~0b');
+    expect(toPointer('a/b')).toBe('/a~1b');
   });
 });


### PR DESCRIPTION
`toPointer` split a dotted finding path on **every** `.`, so an identity-keyed array segment whose id contains a `.` garbled the pointer. IAM names allow `.` (`svc.deploy`, `john.doe`): an out-of-band ManagedPolicy attachment `Roles[my.role]` became `/Roles[my/role]`, which `parseAttachmentOp` couldn't parse → the op was misclassified as a **document op** → the detach silently **no-op'd AND a policy version was burned** (CreatePolicyVersion, deleting the oldest at the 5-version cap). The same mis-parse garbled `SDK_NESTED_WRITERS` paths (Backup rule names with `.`).

Fix: split on `.` at **bracket depth 0 only** (`splitTopLevelDots`), so the bracket content stays in its owning segment and the writers' `\[(.+)\]$` parse recovers the full id. Top-level splitting + per-segment `~`/`/` escaping unchanged.

**Tests**: `tests/revert-plan.test.ts` — dotted id in a bracket segment kept intact (incl. a nested Backup path); plain paths + escaping unchanged. Live-test deferred (mis-parse confirmed from code + unit-covered; pure-function fix).

Closes #748.