### PR TITLE
fix(read): recognize service-specific not-found codes so deleted resources aren't downgraded to skipped (#743)

### DIFF
--- a/src/aws-errors.ts
+++ b/src/aws-errors.ts
@@ -64,7 +64,14 @@ export function classifyStackStatus(status: string | undefined): {
 //   SNS / Budgets       : NotFoundException
 //   IAM                 : NoSuchEntity / NoSuchEntityException
 //   EC2 EIP             : InvalidAllocationID.NotFound / InvalidAddress.NotFound
+//   EC2 LaunchTemplate  : InvalidLaunchTemplateId.NotFound (deleted launch template)
+//   EC2 NetworkAcl      : InvalidNetworkAclID.NotFound (NACL of a NetworkAclEntry deleted)
 //   Glue                : EntityNotFoundException (GetTable on a deleted table/db)
+//   DMS                 : ResourceNotFoundFault (Describe{Endpoints,ReplicationSubnetGroups})
+//   DAX                 : ClusterNotFoundFault / ParameterGroupNotFoundFault /
+//                         SubnetGroupNotFoundFault (Describe{Clusters,ParameterGroups,SubnetGroups})
+//   ElastiCache         : CacheParameterGroupNotFoundFault (DescribeCacheParameterGroups)
+//   Route53             : NoSuchHostedZone (ListResourceRecordSets on a deleted hosted zone)
 //   cdkrd ResourceGoneError : a list/describe-based override whose PARENT container
 //                             exists but whose specific keyed resource is absent (a
 //                             Route53 record / MetricFilter deleted while its zone /
@@ -83,10 +90,24 @@ const NOT_FOUND_ERROR_NAMES = new Set([
   'NoSuchEntityException',
   'InvalidAllocationID.NotFound',
   'InvalidAddress.NotFound',
+  // EC2 DescribeLaunchTemplateVersions on a deleted launch template (readEc2LaunchTemplate).
+  'InvalidLaunchTemplateId.NotFound',
+  // EC2 DescribeNetworkAcls on a deleted NACL (readEc2NetworkAclEntry's parent NACL).
+  'InvalidNetworkAclID.NotFound',
   'EntityNotFoundException',
   // DocumentDB describe-db-clusters / describe-db-instances on a deleted target.
   'DBClusterNotFoundFault',
   'DBInstanceNotFoundFault',
+  // DMS DescribeEndpoints / DescribeReplicationSubnetGroups on a deleted target.
+  'ResourceNotFoundFault',
+  // DAX DescribeClusters / DescribeParameterGroups / DescribeSubnetGroups on a deleted target.
+  'ClusterNotFoundFault',
+  'ParameterGroupNotFoundFault',
+  'SubnetGroupNotFoundFault',
+  // ElastiCache DescribeCacheParameterGroups on a deleted parameter group.
+  'CacheParameterGroupNotFoundFault',
+  // Route53 ListResourceRecordSets when the record's hosted ZONE was deleted out of band.
+  'NoSuchHostedZone',
   // Cloud Map (ServiceDiscovery) GetNamespace / GetService on a deleted target.
   'NamespaceNotFound',
   'ServiceNotFound',

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -666,13 +666,13 @@ const readDlmLifecyclePolicy: OverrideReader = async ({ physicalId, declared, re
 // drift) and AWS default-fills them, so a passthrough would false-flag; scalar coverage is
 // the deliverable. Read-ONLY: a ModifyEndpoint writer is deferred to a follow-up (revert of
 // connection settings needs per-engine care). A deleted endpoint surfaces as
-// ResourceNotFoundException → the router maps it to `deleted`.
+// ResourceNotFoundFault → the router maps it to `deleted`.
 const readDmsEndpoint: OverrideReader = async ({ physicalId, region }) => {
   const id = str(physicalId);
   if (!id) return undefined;
   const c = new DatabaseMigrationServiceClient({ region, ...READ_RETRY });
   const filterName = id.startsWith('arn:') ? 'endpoint-arn' : 'endpoint-id';
-  // ResourceNotFoundException propagates so a deleted endpoint maps to `deleted`.
+  // ResourceNotFoundFault propagates so a deleted endpoint maps to `deleted`.
   const r = await c.send(
     new DescribeEndpointsCommand({ Filters: [{ Name: filterName, Values: [id] }] })
   );

--- a/tests/aws-errors.test.ts
+++ b/tests/aws-errors.test.ts
@@ -21,7 +21,19 @@ describe('isResourceNotFoundError', () => {
       'NoSuchEntityException', // IAM
       'InvalidAllocationID.NotFound',
       'InvalidAddress.NotFound', // EC2 EIP
+      'InvalidLaunchTemplateId.NotFound', // EC2 DescribeLaunchTemplateVersions (deleted template)
+      'InvalidNetworkAclID.NotFound', // EC2 DescribeNetworkAcls (deleted NACL of a NetworkAclEntry)
       'EntityNotFoundException', // Glue GetTable on a deleted table/db
+      'DBClusterNotFoundFault', // DocumentDB describe-db-clusters
+      'DBInstanceNotFoundFault', // DocumentDB describe-db-instances
+      'NamespaceNotFound', // Cloud Map GetNamespace
+      'ServiceNotFound', // Cloud Map GetService
+      'ResourceNotFoundFault', // DMS Describe{Endpoints,ReplicationSubnetGroups}
+      'ClusterNotFoundFault', // DAX DescribeClusters
+      'ParameterGroupNotFoundFault', // DAX DescribeParameterGroups
+      'SubnetGroupNotFoundFault', // DAX DescribeSubnetGroups
+      'CacheParameterGroupNotFoundFault', // ElastiCache DescribeCacheParameterGroups
+      'NoSuchHostedZone', // Route53 ListResourceRecordSets (deleted hosted zone)
       'RuleSetDoesNotExistException', // SES DescribeReceiptRuleSet
       'RuleDoesNotExistException', // SES DescribeReceiptRule
     ]) {


### PR DESCRIPTION
fix(read): recognize service-specific not-found codes so deleted resources are not downgraded to skipped (#743)

isResourceNotFoundError's NOT_FOUND_ERROR_NAMES is an exact-match set, but several
SDK override readers throw service-specific not-found codes that were absent from
it. An out-of-band DELETED resource of those types therefore fell to
skippedReason → tier skipped (excluded from the drift verdict; check --fail
wrongly exits 0) instead of the deleted tier (always drift, red).

Adds the documented not-found codes: EC2 InvalidLaunchTemplateId.NotFound /
InvalidNetworkAclID.NotFound, DMS ResourceNotFoundFault, DAX ClusterNotFoundFault
/ ParameterGroupNotFoundFault / SubnetGroupNotFoundFault, ElastiCache
CacheParameterGroupNotFoundFault, Route53 NoSuchHostedZone. Also corrects the DMS
readEc2/endpoint comment that named the wrong wire code (ResourceNotFoundException
→ ResourceNotFoundFault). The ClientVPN code is deliberately left out — it needs
live confirmation and the ClientVPN readers already raise ResourceGoneError.

Unit-tested offline (each added code classified as not-found; non-not-found errors
still false). Live-deleting 8 resource types out of band is impractical; the
classification is deterministic on the error name.

Closes #743
