### PR TITLE
fix(desired): parameter-resolution batch — NoEcho default / SSM list param / NotificationARNs (#744, #745, #746)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -65,11 +65,22 @@ export function buildResolverContext(
   // Fn::Join and mis-evaluate conditions like HasTrustedAccounts).
   const paramDefs = (template.Parameters ?? {}) as Record<
     string,
-    { Default?: unknown; Type?: string }
+    { Default?: unknown; Type?: string; NoEcho?: unknown }
   >;
   const isList = (k: string): boolean => {
     const t = paramDefs[k]?.Type ?? '';
-    return t === 'CommaDelimitedList' || t.startsWith('List<');
+    // Plain list params AND SSM list-typed params. An SSM list param
+    // (AWS::SSM::Parameter::Value<List<...>> / <CommaDelimitedList>) is returned by
+    // DescribeStacks' ResolvedValue as a COMMA-JOINED string (AWS-documented), so it must
+    // split to an array too — else declared "sg-a,sg-b" (string) vs live ["sg-a","sg-b"]
+    // is a declared FP on every list-typed property fed by it, and an Fn::Select/Join over
+    // it fails closed to UNRESOLVED (#745).
+    return (
+      t === 'CommaDelimitedList' ||
+      t.startsWith('List<') ||
+      t.includes('::Parameter::Value<List<') ||
+      t.includes('::Parameter::Value<CommaDelimitedList')
+    );
   };
   // CommaDelimitedList values are whitespace-trimmed by CloudFormation
   // ("a, b , c" -> ["a","b","c"]); mirror that so a Fn::Select / membership test
@@ -78,6 +89,15 @@ export function buildResolverContext(
     isList(k) ? (raw === '' ? [] : raw.split(',').map((s) => s.trim())) : raw;
   const params: Record<string, string | string[]> = {};
   for (const [k, def] of Object.entries(paramDefs)) {
+    // A NoEcho parameter's template Default is a PLACEHOLDER (the raw-CFn/SAM
+    // `Default: "changeme"` staple), NOT the real deployed secret. Seeding it makes every
+    // property fed by the param a declared FP ("placeholder" vs the live secret) that
+    // survives record and whose revert would OVERWRITE the live secret with the placeholder;
+    // a Condition/Fn::If over it would also bake the wrong branch. The real deployed value
+    // comes back masked '****' from DescribeStacks and is dropped in loadDesired, so skip the
+    // Default too and let the param resolve UNRESOLVED (property skipped, conditions
+    // fail-closed) — the same safe treatment as the masked deployed value (#744).
+    if (def?.NoEcho === true || def?.NoEcho === 'true') continue;
     if (def && 'Default' in def) params[k] = toParam(k, String(def.Default));
   }
   for (const [k, v] of Object.entries(stackParams)) params[k] = toParam(k, v); // deployed values win
@@ -231,6 +251,15 @@ export async function loadDesired(
     stackName,
     stackId
   );
+
+  // AWS::NotificationARNs is a LIST-valued pseudo-parameter that DescribeStacks already
+  // returned above — plumb it so a `{ Ref: "AWS::NotificationARNs" }` (nested-stack /
+  // alarm-action pattern) resolves instead of surfacing as a permanent `unresolved` footer
+  // that also blocks `--strict`. It goes in `params` (which carries arrays) rather than the
+  // scalar-typed `pseudo` map; resolveRef checks pseudo then params, and CFn reserves the
+  // `AWS::` prefix so no user parameter can collide. Absent/empty → leave it unresolved (#746).
+  const notificationArns = stack?.NotificationARNs ?? [];
+  if (notificationArns.length > 0) ctx.params['AWS::NotificationARNs'] = notificationArns;
 
   // Fn::ImportValue is synchronous in the resolver, so prefetch exports here — but
   // ONLY when the template actually references it, so normal stacks pay nothing for the

--- a/tests/template-adapter.test.ts
+++ b/tests/template-adapter.test.ts
@@ -265,6 +265,48 @@ describe('buildResolverContext', () => {
     expect(partOf('us-isof-south-1')).toEqual({ p: 'aws-iso-f', u: 'csp.hci.ic.gov' });
     expect(partOf('eu-isoe-west-1')).toEqual({ p: 'aws-iso-e', u: 'cloud.adc-e.uk' });
   });
+
+  it('splits an SSM list-typed param (Parameter::Value<List<...>>) to a trimmed array (#745)', () => {
+    // An SSM list param's deployed ResolvedValue is a COMMA-JOINED string; it must split to
+    // an array or a list-typed property (SecurityGroupIds/Subnets) Ref'ing it is a declared
+    // FP (declared "sg-a,sg-b" vs live ["sg-a","sg-b"]).
+    const template = {
+      Parameters: {
+        Sgs: { Type: 'AWS::SSM::Parameter::Value<List<AWS::EC2::SecurityGroup::Id>>' },
+        Csv: { Type: 'AWS::SSM::Parameter::Value<CommaDelimitedList>' },
+        Plain: { Type: 'AWS::SSM::Parameter::Value<String>' },
+      },
+    };
+    const ctx = buildResolverContext(
+      template,
+      { Sgs: 'sg-a, sg-b ,sg-c', Csv: 'x,y', Plain: 'single' },
+      {},
+      'us-east-1',
+      '999',
+      'S',
+      'arn'
+    );
+    expect(ctx.params.Sgs).toEqual(['sg-a', 'sg-b', 'sg-c']);
+    expect(ctx.params.Csv).toEqual(['x', 'y']);
+    expect(ctx.params.Plain).toBe('single'); // a scalar SSM param is NOT split
+  });
+
+  it('does NOT seed a NoEcho parameter from its template Default (#744)', () => {
+    // A NoEcho Default is a placeholder, not the deployed secret. Seeding it FPs every
+    // property fed by the param and revert would overwrite the live secret; it must stay
+    // out of ctx so a Ref resolves UNRESOLVED (deployed value is masked '****' and dropped).
+    const template = {
+      Parameters: {
+        Secret: { Type: 'String', NoEcho: true, Default: 'changeme' },
+        SecretStr: { Type: 'String', NoEcho: 'true', Default: 'changeme2' }, // NoEcho as string
+        Plain: { Type: 'String', Default: 'kept' },
+      },
+    };
+    const ctx = buildResolverContext(template, {}, {}, 'us-east-1', '999', 'S', 'arn');
+    expect('Secret' in ctx.params).toBe(false); // NoEcho Default NOT seeded
+    expect('SecretStr' in ctx.params).toBe(false);
+    expect(ctx.params.Plain).toBe('kept'); // an ordinary Default is still seeded
+  });
 });
 
 describe('parseTemplateBody', () => {
@@ -586,6 +628,56 @@ describe('loadDesired stack parameter resolution', () => {
     paramMocks(cfn, [{ ParameterKey: 'P', ParameterValue: 'plain' }]);
     const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'P', 'us-east-1');
     expect(desired.resources[0]!.declared).toEqual({ Tag: 'plain' });
+  });
+});
+
+describe('loadDesired Ref AWS::NotificationARNs (#746)', () => {
+  function notifMocks(cfn: ReturnType<typeof mockClient>, notificationArns?: string[]) {
+    cfn.on(GetTemplateCommand).resolves({
+      TemplateBody: JSON.stringify({
+        Resources: {
+          Q: { Type: 'AWS::SQS::Queue', Properties: { Arns: { Ref: 'AWS::NotificationARNs' } } },
+        },
+      }),
+    });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Q',
+          PhysicalResourceId: 'q-phys',
+          ResourceType: 'AWS::SQS::Queue',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:us-east-1:111122223333:stack/N/x',
+          StackName: 'N',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+          ...(notificationArns ? { NotificationARNs: notificationArns } : {}),
+        },
+      ],
+    });
+  }
+
+  it('resolves Ref AWS::NotificationARNs to the DescribeStacks NotificationARNs list', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    const arns = ['arn:aws:sns:us-east-1:111122223333:Topic1'];
+    notifMocks(cfn, arns);
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'N', 'us-east-1');
+    expect(desired.resources[0]!.declared).toEqual({ Arns: arns });
+  });
+
+  it('leaves Ref AWS::NotificationARNs UNRESOLVED when the stack has none', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    notifMocks(cfn, undefined);
+    const desired = await loadDesired(cfn as unknown as CloudFormationClient, 'N', 'us-east-1');
+    expect(desired.resources[0]!.declared).toEqual({ Arns: UNRESOLVED });
   });
 });
 


### PR DESCRIPTION
fix(desired): parameter-resolution batch — NoEcho default / SSM list param / NotificationARNs (#744, #745, #746)

Three template-adapter parameter-resolution gaps, all offline-confirmed from code
and unit-tested through loadDesired against the real DescribeStacks wire shapes:

- #744 NoEcho parameter with a template Default: the Default is a placeholder, not
  the deployed secret. Seeding it made every property fed by the param a declared
  FP ("placeholder" vs the live secret) that survives record and whose revert would
  OVERWRITE the live secret, plus conditions over it baked the wrong branch. Skip
  seeding a NoEcho param's Default so it resolves UNRESOLVED (the same safe
  treatment as the masked '****' deployed value already gets).

- #745 SSM list-typed params (AWS::SSM::Parameter::Value<List<...>> /
  <CommaDelimitedList>): DescribeStacks returns their ResolvedValue as a
  comma-joined string, so isList must split them to an array too — else declared
  "sg-a,sg-b" (string) vs live ["sg-a","sg-b"] is a declared FP on every list-typed
  property, and Fn::Select/Join over them fails closed to UNRESOLVED.

- #746 Ref AWS::NotificationARNs was permanently unresolved (a "nothing the user
  can do" footer that also blocks --strict), even though DescribeStacks already
  returns stack.NotificationARNs. Plumb it into ctx.params (which carries arrays;
  resolveRef checks pseudo then params, and CFn reserves the AWS:: prefix). Absent
  → left unresolved.

Closes #744
Closes #745
Closes #746
