### PR TITLE
fix(read): paginate unpaginated SDK override list readers (#729)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -6,7 +6,7 @@
 // differ from the underlying target. Returns CFn-shaped properties for the
 // classifier; undefined when the target can't be resolved/read (→ skipped).
 
-import { AppSyncClient, ListApiKeysCommand } from '@aws-sdk/client-appsync';
+import { type ApiKey, AppSyncClient, ListApiKeysCommand } from '@aws-sdk/client-appsync';
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
 import {
@@ -31,6 +31,7 @@ import {
   type MetricFilter,
 } from '@aws-sdk/client-cloudwatch-logs';
 import {
+  type AuthorizationRule,
   DescribeAddressesCommand,
   DescribeClientVpnAuthorizationRulesCommand,
   DescribeClientVpnEndpointsCommand,
@@ -113,15 +114,19 @@ import {
 } from '@aws-sdk/client-kafka';
 import { GetWorkgroupCommand, RedshiftServerlessClient } from '@aws-sdk/client-redshift-serverless';
 import {
+  type BotLocaleSummary,
   DescribeBotLocaleCommand,
   DescribeIntentCommand,
   DescribeSlotCommand,
   DescribeSlotTypeCommand,
+  type IntentSummary,
   LexModelsV2Client,
   ListBotLocalesCommand,
   ListIntentsCommand,
   ListSlotsCommand,
   ListSlotTypesCommand,
+  type SlotSummary,
+  type SlotTypeSummary,
 } from '@aws-sdk/client-lex-models-v2';
 import { GetScheduleCommand, SchedulerClient } from '@aws-sdk/client-scheduler';
 import {
@@ -506,8 +511,10 @@ const dimSetEqual = (a: unknown, b: unknown): boolean => {
   const norm = (v: unknown): string =>
     JSON.stringify(
       (Array.isArray(v) ? (v as { Name?: unknown; Value?: unknown }[]) : [])
-        .map((d) => [str(d.Name) ?? '', str(d.Value) ?? ''])
-        .sort()
+        .map((d): [string, string] => [str(d.Name) ?? '', str(d.Value) ?? ''])
+        // Explicit comparator (require-array-sort-compare): order the [Name, Value]
+        // pairs deterministically so the JSON.stringify equality is order-insensitive.
+        .sort((x, y) => (x[0] === y[0] ? x[1].localeCompare(y[1]) : x[0].localeCompare(y[0])))
     );
   return norm(a) === norm(b);
 };
@@ -984,14 +991,24 @@ const readEc2ClientVpnAuthorizationRule: OverrideReader = async ({ declared, reg
   const cidr = str(declared.TargetNetworkCidr);
   const groupId = str(declared.AccessGroupId);
   const c = new EC2Client({ region, ...READ_RETRY });
-  const r = await c.send(
-    new DescribeClientVpnAuthorizationRulesCommand({ ClientVpnEndpointId: endpointId })
-  );
-  const rule = (r.AuthorizationRules ?? []).find(
-    (a) =>
-      (cidr === undefined || a.DestinationCidr === cidr) &&
-      (groupId === undefined || a.GroupId === groupId)
-  );
+  // PAGINATE: an endpoint can hold many authorization rules; reading only page 1 could
+  // misread a PRESENT rule (on a later page) as absent → a FALSE `deleted`. Follow
+  // NextToken (EC2 capitalizes it) until the matching rule is found or all pages are read.
+  const isOurRule = (a: AuthorizationRule): boolean =>
+    (cidr === undefined || a.DestinationCidr === cidr) &&
+    (groupId === undefined || a.GroupId === groupId);
+  let rule: AuthorizationRule | undefined;
+  let nextToken: string | undefined;
+  do {
+    const r = await c.send(
+      new DescribeClientVpnAuthorizationRulesCommand({
+        ClientVpnEndpointId: endpointId,
+        NextToken: nextToken,
+      })
+    );
+    rule = (r.AuthorizationRules ?? []).find(isOurRule);
+    nextToken = r.NextToken;
+  } while (!rule && nextToken);
   if (!rule)
     throw new ResourceGoneError(
       `ClientVpnAuthorizationRule cidr=${cidr} group=${groupId} absent from endpoint ${endpointId}`
@@ -1904,8 +1921,20 @@ const readAppSyncApiKey: OverrideReader = async ({ physicalId, declared, region 
   const keyId = m?.[2];
   if (!apiId) return undefined;
   const c = new AppSyncClient({ region, ...READ_RETRY });
-  const keys = (await c.send(new ListApiKeysCommand({ apiId }))).apiKeys ?? [];
-  const k = keyId ? keys.find((x) => x.id === keyId) : keys[0];
+  // PAGINATE: an API can hold many keys; reading only page 1 could miss the declared key
+  // (on a later page) → a FALSE `skipped` for a still-present key. Follow nextToken
+  // (AppSync lowercases it) to gather ALL keys before matching. Stop early once the
+  // keyId-matched key is found; otherwise accumulate every page.
+  const keys: ApiKey[] = [];
+  let nextToken: string | undefined;
+  let k: ApiKey | undefined;
+  do {
+    const r = await c.send(new ListApiKeysCommand({ apiId, ...(nextToken && { nextToken }) }));
+    keys.push(...(r.apiKeys ?? []));
+    if (keyId) k = keys.find((x) => x.id === keyId);
+    nextToken = r.nextToken;
+  } while (!k && nextToken);
+  if (!keyId) k = keys[0];
   if (!k) return undefined; // key deleted out of band -> router maps undefined to skipped
   const model: Record<string, unknown> = { ApiId: apiId };
   if (k.description !== undefined && k.description !== '') model.Description = k.description;
@@ -2510,8 +2539,21 @@ const supplementLexBot: SupplementReader = async ({ physicalId, region }) => {
   const botVersion = 'DRAFT';
   const c = new LexModelsV2Client({ region, ...READ_RETRY });
   try {
-    const locales = await c.send(new ListBotLocalesCommand({ botId, botVersion }));
-    const localeSummaries = locales.botLocaleSummaries ?? [];
+    // PAGINATE every LexModelsV2 list call (all use lowercase `nextToken`): reading only
+    // page 1 of locales / slot types / intents / slots would silently DROP later-page
+    // elements → a PARTIAL BotLocales model (a false-confidence FN — an out-of-band intent
+    // / slot on page 2 stays invisible). Accumulate all pages before use.
+    const localeSummaries: BotLocaleSummary[] = [];
+    {
+      let nextToken: string | undefined;
+      do {
+        const r = await c.send(
+          new ListBotLocalesCommand({ botId, botVersion, ...(nextToken && { nextToken }) })
+        );
+        localeSummaries.push(...(r.botLocaleSummaries ?? []));
+        nextToken = r.nextToken;
+      } while (nextToken);
+    }
     const botLocales: Rec[] = [];
     for (const ls of localeSummaries) {
       const localeId = str(ls.localeId);
@@ -2534,9 +2576,24 @@ const supplementLexBot: SupplementReader = async ({ physicalId, region }) => {
 
       // SlotTypes — custom slot types only; build id→name for slot resolution.
       const slotTypeNames = new Map<string, string>();
-      const slotTypes = await c.send(new ListSlotTypesCommand({ botId, botVersion, localeId }));
+      const slotTypeSummaries: SlotTypeSummary[] = [];
+      {
+        let nextToken: string | undefined;
+        do {
+          const r = await c.send(
+            new ListSlotTypesCommand({
+              botId,
+              botVersion,
+              localeId,
+              ...(nextToken && { nextToken }),
+            })
+          );
+          slotTypeSummaries.push(...(r.slotTypeSummaries ?? []));
+          nextToken = r.nextToken;
+        } while (nextToken);
+      }
       const cfnSlotTypes: Rec[] = [];
-      for (const sts of slotTypes.slotTypeSummaries ?? []) {
+      for (const sts of slotTypeSummaries) {
         const slotTypeId = str(sts.slotTypeId);
         if (!slotTypeId) continue;
         // Built-in slot types (AMAZON.*) carry no describe-able user model; skip them.
@@ -2582,9 +2639,19 @@ const supplementLexBot: SupplementReader = async ({ physicalId, region }) => {
       }
 
       // Intents — with their slots + slot-priority name resolution.
-      const intents = await c.send(new ListIntentsCommand({ botId, botVersion, localeId }));
+      const intentSummaries: IntentSummary[] = [];
+      {
+        let nextToken: string | undefined;
+        do {
+          const r = await c.send(
+            new ListIntentsCommand({ botId, botVersion, localeId, ...(nextToken && { nextToken }) })
+          );
+          intentSummaries.push(...(r.intentSummaries ?? []));
+          nextToken = r.nextToken;
+        } while (nextToken);
+      }
       const cfnIntents: Rec[] = [];
-      for (const is of intents.intentSummaries ?? []) {
+      for (const is of intentSummaries) {
         const intentId = str(is.intentId);
         if (!intentId) continue;
         const intent = await c.send(
@@ -2608,8 +2675,24 @@ const supplementLexBot: SupplementReader = async ({ physicalId, region }) => {
         // Slots — build id→name for the SlotPriorities resolution.
         const slotNames = new Map<string, string>();
         const cfnSlots: Rec[] = [];
-        const slots = await c.send(new ListSlotsCommand({ botId, botVersion, localeId, intentId }));
-        for (const ss of slots.slotSummaries ?? []) {
+        const slotSummaries: SlotSummary[] = [];
+        {
+          let nextToken: string | undefined;
+          do {
+            const r = await c.send(
+              new ListSlotsCommand({
+                botId,
+                botVersion,
+                localeId,
+                intentId,
+                ...(nextToken && { nextToken }),
+              })
+            );
+            slotSummaries.push(...(r.slotSummaries ?? []));
+            nextToken = r.nextToken;
+          } while (nextToken);
+        }
+        for (const ss of slotSummaries) {
           const slotId = str(ss.slotId);
           if (!slotId) continue;
           const slot = await c.send(

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -2276,6 +2276,24 @@ describe('SDK overrides', () => {
     it('undefined when no apiId can be resolved', async () => {
       expect(await SDK_OVERRIDES['AWS::AppSync::ApiKey'](ctx({}))).toBeUndefined();
     });
+
+    it('PAGINATES ListApiKeys: finds the declared key on page 2 (nextToken loop)', async () => {
+      // Page 1 carries a nextToken and NOT our key; page 2 holds da2-xyz. Reading only
+      // page 1 (the pre-fix behavior) would miss it → a FALSE `skipped` for a present key.
+      appsync
+        .on(ListApiKeysCommand)
+        .resolvesOnce({ apiKeys: [{ id: 'da2-other', expires: 111 }], nextToken: 'p2' })
+        .resolvesOnce({
+          apiKeys: [{ id: 'da2-xyz', description: 'the key', expires: 1784631600 }],
+        });
+      const out = await SDK_OVERRIDES['AWS::AppSync::ApiKey'](ctx({}, ARN));
+      expect(out).toEqual({ ApiId: 'abc123', Description: 'the key', Expires: 1784631600 });
+      // Page 2 was requested with the page-1 nextToken.
+      expect(appsync.commandCalls(ListApiKeysCommand)[1]?.args[0].input).toEqual({
+        apiId: 'abc123',
+        nextToken: 'p2',
+      });
+    });
   });
 });
 
@@ -2683,6 +2701,45 @@ describe('EC2 ClientVpn family (NON_PROVISIONABLE, issue #534)', () => {
           ctx({ TargetNetworkCidr: '192.168.0.0/16' })
         )
       ).toBeUndefined();
+    });
+
+    it('PAGINATES DescribeClientVpnAuthorizationRules: matches a rule on page 2 (NextToken loop)', async () => {
+      // Page 1 carries a NextToken and NOT the declared rule; page 2 holds it. Reading only
+      // page 1 (the pre-fix behavior) would throw ResourceGoneError → a FALSE `deleted`.
+      ec2
+        .on(DescribeClientVpnAuthorizationRulesCommand)
+        .resolvesOnce({
+          AuthorizationRules: [{ DestinationCidr: '10.0.0.0/16', GroupId: 'other' }],
+          NextToken: 'p2',
+        } as never)
+        .resolvesOnce({
+          AuthorizationRules: [
+            {
+              DestinationCidr: '192.168.0.0/16',
+              GroupId: 'grp-1',
+              Description: 'admins',
+              AccessAll: false,
+            },
+          ],
+        } as never);
+      const out = await SDK_OVERRIDES['AWS::EC2::ClientVpnAuthorizationRule'](
+        ctx({
+          ClientVpnEndpointId: 'cvpn-endpoint-abc',
+          TargetNetworkCidr: '192.168.0.0/16',
+          AccessGroupId: 'grp-1',
+        })
+      );
+      expect(out).toEqual({
+        ClientVpnEndpointId: 'cvpn-endpoint-abc',
+        TargetNetworkCidr: '192.168.0.0/16',
+        AccessGroupId: 'grp-1',
+        Description: 'admins',
+        AuthorizeAllGroups: false,
+      });
+      // Page 2 was requested with the page-1 NextToken.
+      expect(
+        ec2.commandCalls(DescribeClientVpnAuthorizationRulesCommand)[1]?.args[0].input
+      ).toEqual({ ClientVpnEndpointId: 'cvpn-endpoint-abc', NextToken: 'p2' });
     });
   });
 
@@ -3151,6 +3208,67 @@ describe('SDK supplements', () => {
     });
     // The built-in slot type was never described.
     expect(lex.commandCalls(DescribeSlotTypeCommand)).toHaveLength(0);
+  });
+
+  it('Lex::Bot: PAGINATES every list call — page-2 intent AND page-2 slot both appear (nextToken loops)', async () => {
+    // Two locales across two ListBotLocales pages; each list (locales/intents/slots) carries
+    // a page-1 nextToken. Reading only page 1 (the pre-fix behavior) would DROP the page-2
+    // locale (fr_FR), the page-2 intent (CdkrdCancel), and the page-2 slot (Qty) → a PARTIAL
+    // BotLocales model (a false-confidence FN). Assert every page-2 element survives.
+    lex
+      .on(ListBotLocalesCommand)
+      .resolvesOnce({ botLocaleSummaries: [{ localeId: 'en_US' }], nextToken: 'bl2' })
+      .resolvesOnce({ botLocaleSummaries: [{ localeId: 'fr_FR' }] });
+    lex.on(DescribeBotLocaleCommand).resolves({ localeId: 'x' });
+    // No custom slot types (keep the fixture focused on intent/slot pagination).
+    lex.on(ListSlotTypesCommand).resolves({ slotTypeSummaries: [] });
+
+    // Intents paginate: I_ORDER on page 1, I_CANCEL on page 2 (both under en_US and fr_FR).
+    lex
+      .on(ListIntentsCommand)
+      .resolvesOnce({ intentSummaries: [{ intentId: 'I_ORDER' }], nextToken: 'in2' })
+      .resolvesOnce({ intentSummaries: [{ intentId: 'I_CANCEL' }] })
+      .resolvesOnce({ intentSummaries: [{ intentId: 'I_ORDER' }], nextToken: 'in2' })
+      .resolvesOnce({ intentSummaries: [{ intentId: 'I_CANCEL' }] });
+    lex.on(DescribeIntentCommand, { intentId: 'I_ORDER' }).resolves({
+      intentId: 'I_ORDER',
+      intentName: 'CdkrdOrder',
+    });
+    lex.on(DescribeIntentCommand, { intentId: 'I_CANCEL' }).resolves({
+      intentId: 'I_CANCEL',
+      intentName: 'CdkrdCancel',
+    });
+
+    // Slots for I_ORDER paginate: Size on page 1, Qty on page 2. I_CANCEL has no slots.
+    lex
+      .on(ListSlotsCommand, { intentId: 'I_ORDER' })
+      .resolvesOnce({ slotSummaries: [{ slotId: 'SL_SIZE' }], nextToken: 'sl2' })
+      .resolvesOnce({ slotSummaries: [{ slotId: 'SL_QTY' }] })
+      .resolvesOnce({ slotSummaries: [{ slotId: 'SL_SIZE' }], nextToken: 'sl2' })
+      .resolvesOnce({ slotSummaries: [{ slotId: 'SL_QTY' }] });
+    lex.on(ListSlotsCommand, { intentId: 'I_CANCEL' }).resolves({ slotSummaries: [] });
+    lex
+      .on(DescribeSlotCommand, { slotId: 'SL_SIZE' })
+      .resolves({ slotId: 'SL_SIZE', slotName: 'Size' });
+    lex
+      .on(DescribeSlotCommand, { slotId: 'SL_QTY' })
+      .resolves({ slotId: 'SL_QTY', slotName: 'Qty' });
+
+    const out = (await SDK_SUPPLEMENTS['AWS::Lex::Bot'](ctx({}, 'I3PRF2VKMG'))) as {
+      BotLocales: {
+        LocaleId: string;
+        Intents: { Name: string; Slots?: { Name: string }[] }[];
+      }[];
+    };
+    // Page-2 locale (fr_FR) survived pagination.
+    expect(out.BotLocales.map((l) => l.LocaleId)).toEqual(['en_US', 'fr_FR']);
+    for (const loc of out.BotLocales) {
+      // Page-2 intent (CdkrdCancel) survived.
+      expect(loc.Intents.map((i) => i.Name)).toEqual(['CdkrdOrder', 'CdkrdCancel']);
+      // Page-2 slot (Qty) survived under the paginated intent.
+      const order = loc.Intents.find((i) => i.Name === 'CdkrdOrder');
+      expect(order?.Slots?.map((s) => s.Name)).toEqual(['Size', 'Qty']);
+    }
   });
 
   it('Lex::Bot: an empty botLocaleSummaries yields undefined (nothing to add)', async () => {


### PR DESCRIPTION
## What

Three SDK-override list readers in `src/read/overrides.ts` fetched only PAGE 1 of a paginated AWS call and treated it as complete — a silent partial live model (FN-with-false-confidence). Each is now wrapped in the standard next-token loop:

- **`supplementLexBot`** — `ListBotLocales` / `ListSlotTypes` / `ListIntents` / `ListSlots` (all paginate via `nextToken`). A bot with >1 page of intents/slots yielded a partial `BotLocales` model → declared intents appear absent (declared-tier FP), and the #564 structural revert would re-create existing intents.
- **`readAppSyncApiKey`** — `ListApiKeys` (`nextToken`); a key beyond page 1 was missed (skipped, semi-silent FN).
- **`readEc2ClientVpnAuthorizationRule`** — `DescribeClientVpnAuthorizationRules` (`NextToken`); a miss threw `ResourceGoneError` → false `deleted`, revert re-creates the rule.

## Verification

- 3 new `overrides.test.ts` cases via `aws-sdk-client-mock`: each mocks a page-1 (+token) then page-2 response and asserts the page-2 element (intent/slot/apikey/rule) survives in the assembled model — fails today, passes after the loop. Per the issue, the mocked-page unit test covers this better than a >50-item live repro.
- Full suite green; typecheck + lint clean.

Also adds an explicit comparator to the DAX `dimSetEqual` `[Name,Value]` sort (`require-array-sort-compare` — a latent lint error on main from #738 that flaked CI red under full type inference).

Closes #729
