### PR TITLE
fix(diff): numeric-string tolerance for matchesKnownDefault + unordered scalar sets (#731)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -38,6 +38,7 @@ import {
   ACCESS_STRING_PATHS,
   PROPERTIES_FILE_PATHS,
   SSH_PUBLIC_KEY_PATHS,
+  isNumericStringEqualScalar,
   isStringlyEqualScalar,
   isStringlyEqualScalarArray,
   isStringlyEqualDeep,
@@ -874,6 +875,15 @@ function isPolicySubsetOf(sub: Record<string, unknown>, sup: Record<string, unkn
 // unit tests.
 export function matchesKnownDefault(live: unknown, def: unknown): boolean {
   if (deepEqual(live, def)) return true;
+  // SCALAR leaves fold through NUMERIC-string representation tolerance: a pinned default `1`
+  // must match a live `"1"` when a provider echoes the value stringified (real: SQS returns
+  // `"5"` for `5`, Budgets `"5.0"` for `5`). This only relaxes REPRESENTATION of
+  // semantically-equal NUMBERS (`1` vs `"1"`); `1` vs `"2"` still differs, so no real drift
+  // is hidden. Deliberately numeric-ONLY (not isStringlyEqualScalar's boolean<->string arm):
+  // an S3 schema default `EventBridgeEnabled` stored as the STRING "true" must NOT fold a
+  // live BOOLEAN true, which would hide a real user-enabled EventBridge config (#731).
+  // Restricted to scalar leaves — the object/array subset tolerance below is untouched.
+  if (!isNestedObject(live) && !isNestedObject(def)) return isNumericStringEqualScalar(live, def);
   if (!isNestedObject(live) || !isNestedObject(def)) return false;
   // Trivially-empty live sub-keys the default does NOT list carry no inventory value (a
   // schema-strip residue husk — RedshiftServerless Workgroup's echo attribute reads back an

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -4143,9 +4143,22 @@ export function isEqualUnorderedScalarSet(a: unknown, b: unknown): boolean {
   const scalar = (v: unknown): boolean =>
     typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean';
   if (!a.every(scalar) || !b.every(scalar)) return false;
-  const sort = (arr: unknown[]): string[] => arr.map((v) => `${typeof v}:${String(v)}`).sort();
-  const sa = sort(a);
-  const sb = sort(b);
+  // CANONICAL scalar key: normalize numeric strings the SAME way `isStringlyEqualScalar`
+  // does, so a numeric value and its decimal-string representation produce IDENTICAL keys.
+  // Without this the `${typeof v}:…` prefix made `number:80` and `string:80` distinct, so a
+  // path that both REORDERS and STRINGIFIES (declared `[80, 443]` vs live `["443", "80"]`)
+  // folded in neither the positional stringly guard (order differs) nor here (type differs).
+  // A string that round-trips as a number (per DECIMAL_RE, the exact rule
+  // `isStringlyEqualScalar` uses) collapses to `num:<Number(v)>`; a non-numeric string stays
+  // `str:<v>`, and a genuine value change (`"80"` vs `"81"`) still yields distinct keys, so
+  // real drift is preserved.
+  const key = (v: unknown): string => {
+    if (typeof v === 'number') return `num:${v}`;
+    if (typeof v === 'string' && DECIMAL_RE.test(v.trim())) return `num:${Number(v)}`;
+    return `${typeof v}:${String(v)}`;
+  };
+  const sa = a.map(key).sort();
+  const sb = b.map(key).sort();
   return sa.every((v, i) => v === sb[i]);
 }
 
@@ -4674,6 +4687,26 @@ export function isStringlyEqualScalar(a: unknown, b: unknown): boolean {
   if (prim(a) && typeof b === 'string') return eq(a, b);
   if (prim(b) && typeof a === 'string') return eq(b, a);
   return false;
+}
+
+// NUMERIC-string representation equality ONLY — the numeric arm of isStringlyEqualScalar
+// WITHOUT its `String(p) === s` boolean<->string arm. Two operands are equal iff both are
+// numeric (a number, or a plain-decimal string per DECIMAL_RE) and denote the same number:
+// `1` == `"1"`, `5` == `"5.0"`, but `"80"` != `"81"`. Used by matchesKnownDefault's leaf
+// gate (#731): a KNOWN_DEFAULTS default stored as the STRING "true" must NOT fold a live
+// BOOLEAN true — that would hide a real S3 EventBridge-enabled config (the S3 schema
+// default `EventBridgeEnabled` is the string "true"). So the fold tolerates numeric
+// representation but never boolean<->string. Non-numeric operands never fold here.
+export function isNumericStringEqualScalar(a: unknown, b: unknown): boolean {
+  const num = (v: unknown): number | undefined =>
+    typeof v === 'number'
+      ? v
+      : typeof v === 'string' && DECIMAL_RE.test(v.trim())
+        ? Number(v)
+        : undefined;
+  const na = num(a);
+  const nb = num(b);
+  return na !== undefined && nb !== undefined && na === nb;
 }
 
 // R23: a scalar ARRAY whose elements are pairwise stringly-equal is not drift.

--- a/tests/stringly-tolerance-731.test.ts
+++ b/tests/stringly-tolerance-731.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { matchesKnownDefault } from '../src/diff/classify.js';
+import { isEqualUnorderedScalarSet } from '../src/normalize/noise.js';
+
+// Issue #731: two equality gates adjacent to the globally numeric-string-tolerant
+// declared comparator were NOT tolerant of scalar REPRESENTATION, leaving latent
+// first-run-FP windows when a provider stringifies a scalar (Budgets `"5.0"` for 5,
+// CodePipeline `"false"` for false, SQS `"5"` for 5). Both now fold semantically-equal
+// numeric-string forms while keeping genuinely-different values distinct.
+describe('isEqualUnorderedScalarSet stringly tolerance (#731)', () => {
+  it('folds a set that both REORDERS and STRINGIFIES', () => {
+    // declared [80, 443] vs live ["443", "80"] — order differs AND types differ.
+    expect(isEqualUnorderedScalarSet([80, 443], ['443', '80'])).toBe(true);
+  });
+
+  it('preserves detection when a value genuinely differs', () => {
+    expect(isEqualUnorderedScalarSet([80, 443], ['443', '81'])).toBe(false);
+  });
+
+  it('still folds non-numeric reordered sets', () => {
+    expect(isEqualUnorderedScalarSet(['a', 'b'], ['b', 'a'])).toBe(true);
+  });
+
+  it('folds a mixed numeric/non-numeric set that stringifies the number', () => {
+    expect(isEqualUnorderedScalarSet(['a', 80], ['80', 'a'])).toBe(true);
+  });
+
+  it('keeps distinct numeric strings distinct', () => {
+    expect(isEqualUnorderedScalarSet(['80'], ['81'])).toBe(false);
+  });
+
+  it('folds decimal-string representation variants (5 vs "5.0")', () => {
+    expect(isEqualUnorderedScalarSet([5], ['5.0'])).toBe(true);
+  });
+
+  it('does not fold non-numeric string vs number', () => {
+    expect(isEqualUnorderedScalarSet(['abc'], [80])).toBe(false);
+  });
+});
+
+describe('matchesKnownDefault stringly tolerance (#731)', () => {
+  it('folds a pinned scalar default 1 against a live "1"', () => {
+    expect(matchesKnownDefault('1', 1)).toBe(true);
+  });
+
+  it('preserves detection: default 1 vs live "2"', () => {
+    expect(matchesKnownDefault('2', 1)).toBe(false);
+  });
+
+  it('does NOT fold boolean<->string (a schema default "true" must not hide a live boolean true)', () => {
+    // #731: numeric-only tolerance. The S3 schema default `EventBridgeEnabled` is the STRING
+    // "true"; folding it against a live BOOLEAN true would hide a real user-enabled config.
+    expect(matchesKnownDefault('false', false)).toBe(false);
+    expect(matchesKnownDefault(true, 'true')).toBe(false);
+  });
+
+  it('folds a decimal-string live "5.0" against a numeric default 5', () => {
+    expect(matchesKnownDefault('5.0', 5)).toBe(true);
+  });
+
+  it('folds a nested object default with a numeric leaf against a stringified live leaf', () => {
+    expect(
+      matchesKnownDefault(
+        { RetentionDays: '1', Enabled: true },
+        { RetentionDays: 1, Enabled: true }
+      )
+    ).toBe(true);
+  });
+
+  it('still surfaces a genuinely different nested value', () => {
+    expect(
+      matchesKnownDefault(
+        { RetentionDays: '2', Enabled: true },
+        { RetentionDays: 1, Enabled: true }
+      )
+    ).toBe(false);
+  });
+
+  it('keeps the object subset tolerance intact (live omits a default key)', () => {
+    // live carries only a subset of the default's keys — must still fold.
+    expect(
+      matchesKnownDefault({ Types: ['EDGE'] }, { IpAddressType: 'ipv4', Types: ['EDGE'] })
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Closes a latent representation-drift FP class. cdkrd's declared-tier comparator is numeric-string-coercion-tolerant globally, but two adjacent equality gates were type-strict, leaving latent first-run-FP windows when a provider changes scalar REPRESENTATION (real: Budgets `"5.0"` for `5`, SQS `"5"` for `5`):

1. **`isEqualUnorderedScalarSet`** (`noise.ts`) sorted by `` `${typeof v}:…` ``, so `number:80` ≠ `string:80` — a path that both REORDERS and STRINGIFIES (`[80,443]` vs `["443","80"]`) folded in neither the positional stringly guard nor here. Now uses a canonical numeric key (same `DECIMAL_RE` rule as `isStringlyEqualScalar`).
2. **`matchesKnownDefault`** (`classify.ts`) compared leaves with `deepEqual`, so a pinned default `1` never folded a live `"1"`. Scalar leaves now route through a new **numeric-only** helper `isNumericStringEqualScalar`.

## Why numeric-ONLY (not full `isStringlyEqualScalar`)

Adversarial corpus-replay during review caught that the full helper's `String(p) === s` boolean↔string arm made the S3 schema default `EventBridgeEnabled` (stored as the STRING `"true"`) fold a live BOOLEAN `true` — **hiding a real user-enabled EventBridge config** (an FN, violates the zero-FP invariant). So the leaf tolerance is deliberately numeric-only; boolean↔string never folds.

## Verification

- `tests/stringly-tolerance-731.test.ts` (14 assertions) incl. the boolean↔string NON-fold guard, decimal variants, and detection-preservation.
- corpus-replay unchanged (the 677-case scan found zero current instances — purely latent); full suite green; typecheck + lint clean.

Only relaxes numeric REPRESENTATION of semantically-equal values, so no real drift is hidden. Offline-predicted (hunt round P coercion audit); no live deploy needed — pure comparator tolerance.

Closes #731
