### PR TITLE
fix(baseline): surface out-of-band removal of NESTED recorded values (#749)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -497,7 +497,17 @@ export interface ApplyBaselineOptions {
   warn?: (s: string) => void; // stderr note channel for the promotion case
 }
 
-const topSegment = (p: string): string => p.split('.')[0] ?? p;
+// A recorded path is TOP-LEVEL when it is a bare template key — no nested descent
+// separator (`.` object step or `[` array/identity step). `declaredByLogical` carries
+// only top-level declared KEYS (Object.keys(declared)), so the "promoted into the
+// template" test can only be answered for a top-level path: a nested path's top segment
+// is ALWAYS a declared key by construction (collectNestedUndeclared descends only where
+// the parent key is declared), so testing that segment would fold EVERY nested recorded
+// value into `promotedStale` and never surface a legitimate removal (#749). A nested
+// value is "promoted" only if its DECLARED parent now declares that exact nested value —
+// which `declaredByLogical` cannot express — so a nested recorded path can never qualify
+// here and must fall through to the "removed since record" drift.
+const isTopLevelPath = (p: string): boolean => !p.includes('.') && !p.includes('[');
 
 /**
  * Reconcile undeclared findings against the recorded baseline (per ENTRY, R62):
@@ -728,8 +738,11 @@ export function applyBaseline(
       removedFromTemplate.push(`${a.logicalId}.${a.path}`);
       continue;
     }
-    // promoted into the template since record → not a removal, just stale baseline
-    if (opts.declaredByLogical?.get(a.logicalId)?.has(topSegment(a.path))) {
+    // promoted into the template since record → not a removal, just stale baseline.
+    // #749: gate on the FULL path (only meaningful for a top-level path), NOT its top
+    // segment — otherwise every nested recorded value, whose top segment is a declared
+    // key by construction, would be swallowed here and never surface as a removal.
+    if (isTopLevelPath(a.path) && opts.declaredByLogical?.get(a.logicalId)?.has(a.path)) {
       promotedStale.push(`${a.logicalId}.${a.path}`);
       continue;
     }

--- a/tests/baseline-nested-removal-749.test.ts
+++ b/tests/baseline-nested-removal-749.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { applyBaseline, type BaselineFile } from '../src/baseline/baseline-file.js';
+
+// #749: the "baseline value removed since record" drift never fired for NESTED recorded
+// values. Every nested undeclared path is built as `<TopLevelKey>.<...>` and is only ever
+// collected where its parent key is DECLARED (collectNestedUndeclared descends only into
+// `k in declaredVal`). The old promotion check tested `topSegment(path)` — the top-level
+// key — against `declaredByLogical`, so for EVERY nested recorded value that top segment
+// was a declared key and the vanished value was misclassified `promotedStale` (folded into
+// the "now declared in the template — re-run record" nudge) instead of surfacing as a real
+// removal. The fix gates the promotion check on the FULL path AND requires the path to be
+// top-level, since `declaredByLogical` only carries top-level declared keys.
+
+function baseline(recorded: BaselineFile['recorded']): BaselineFile {
+  return {
+    schemaVersion: 1,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded,
+  };
+}
+
+describe('#749 nested recorded value removed since record', () => {
+  it('surfaces a NESTED recorded value that vanished as "removed since record" (not promotedStale)', () => {
+    // `Environment.Variables.FOO` — nested under `Environment`, a DECLARED top-level key.
+    const b = baseline([
+      {
+        logicalId: 'Fn',
+        resourceType: 'AWS::Lambda::Function',
+        path: 'Environment.Variables.FOO',
+        value: 'bar',
+      },
+    ]);
+    const warnings: string[] = [];
+    // `Environment` is declared (top-level key present), but the nested value FOO is NOT in
+    // the template — the recorded value disappeared out of band → a genuine removal.
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Fn', new Set(['Environment'])]]),
+      warn: (m) => warnings.push(m),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      tier: 'undeclared',
+      logicalId: 'Fn',
+      path: 'Environment.Variables.FOO',
+      desired: 'bar',
+      actual: undefined,
+      note: 'baseline value removed since record',
+    });
+    // and it must NOT be swallowed into the "now declared in the template" nudge
+    expect(warnings.some((w) => w.includes('now declared in the template'))).toBe(false);
+  });
+
+  it('surfaces a vanished nested TAG in a declared map as "removed since record"', () => {
+    // an extra tag inside a declared `Tags` map that disappeared out of band.
+    const b = baseline([
+      {
+        logicalId: 'Bkt',
+        resourceType: 'AWS::S3::Bucket',
+        path: 'Tags.Owner',
+        value: 'team-a',
+      },
+    ]);
+    const warnings: string[] = [];
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Bkt', new Set(['Tags'])]]),
+      warn: (m) => warnings.push(m),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      path: 'Tags.Owner',
+      note: 'baseline value removed since record',
+    });
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('surfaces a vanished value under a declared ARRAY (bracket-notation path)', () => {
+    // an out-of-band Condition added inside a declared policy statement, then removed.
+    const b = baseline([
+      {
+        logicalId: 'Pol',
+        resourceType: 'AWS::IAM::Policy',
+        path: 'PolicyDocument.Statement[0].Condition',
+        value: { StringEquals: { 'aws:username': 'x' } },
+      },
+    ]);
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['Pol', new Set(['PolicyDocument'])]]),
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      path: 'PolicyDocument.Statement[0].Condition',
+      note: 'baseline value removed since record',
+    });
+  });
+
+  it('control: a TOP-LEVEL recorded key genuinely promoted into the template is still promotedStale', () => {
+    const b = baseline([
+      { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'ReservedConcurrentExecutions', value: 5 },
+    ]);
+    const warnings: string[] = [];
+    const out = applyBaseline([], b, {
+      declaredByLogical: new Map([['A', new Set(['ReservedConcurrentExecutions'])]]),
+      warn: (m) => warnings.push(m),
+    });
+    expect(out).toHaveLength(0); // no false "removed" finding for a real promotion
+    expect(warnings[0]).toContain('now declared in the template');
+  });
+});


### PR DESCRIPTION
Closes #749.

## Problem
The documented "baseline value removed since record" drift **never fired for nested recorded values** — the primary output of `record` (an extra env var, a tag in a map, an out-of-band `Condition` inside a policy statement). `applyBaseline`'s "promoted into the template" check tested only the **top path segment** (`p.split('.')[0]`) against `declaredByLogical`, which carries only top-level declared keys. Every nested undeclared path starts with a declared top-level key by construction (`collectNestedUndeclared` descends only where the parent key is declared), so the entire nested class was always misclassified `promotedStale` and folded into the wrong "now declared — re-run record" stderr nudge instead of surfacing as a removal.

## Fix
Gate the promotion branch on the **full path** via `isTopLevelPath` (a bare key: no `.` and no `[`), which `declaredByLogical` can only answer for a top-level path. A nested recorded path can never be spuriously promoted and now correctly falls through to the `'baseline value removed since record'` finding. Top-level promotion (the recommended declare-it-in-code path) is unchanged.

## Tests
`tests/baseline-nested-removal-749.test.ts` — nested env var / tag map / bracket-notation policy `Condition` removals now surface; a genuinely promoted top-level key still folds to `promotedStale` (control).

## Verification
Unit-only correctness fix in `src/baseline/baseline-file.ts`; no AWS mutation. Full suite green (typecheck / lint+fmt / build / 3195 tests).