### PR TITLE
fix(ignore): stamp stack/account/region scope onto written ignore rules (#757)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,13 +462,17 @@ ignore:
 ```
 
 - Every rule is a mapping `{ path, stack?, account?, region? }`. `cdkrd ignore`
-  writes the unscoped form (and is **comment-preserving and append-only**: it keeps
-  your existing comments and layout, and appends new rules at the end — you own the
-  order). `path` is an exact `<constructPath>.<path>` — the construct path WITHIN the
-  stack (the stack/Stage prefix stripped), byte-identical to what `cdkrd check` prints, so
-  you can copy what you see (or `<logicalId>.<path>` on a non-CDK stack). Rules written with
-  the older full `<stack>/<constructPath>.<path>` form still match. The optional `stack` /
-  `account` / `region` scopes are a hand-edit.
+  stamps the current **stack / account / region** onto each rule it writes (the same
+  three identity axes a baseline file is keyed on), so ignoring a within-stack path on
+  one stack never leaks to a same-named twin stack in another account/region — an
+  unscoped `{ path }` was match-all (#757). The verb is **comment-preserving and
+  append-only**: it keeps your existing comments and layout, and appends new rules at
+  the end — you own the order. `path` is an exact `<constructPath>.<path>` — the
+  construct path WITHIN the stack (the stack/Stage prefix stripped), byte-identical to
+  what `cdkrd check` prints, so you can copy what you see (or `<logicalId>.<path>` on a
+  non-CDK stack). Rules written with the older full `<stack>/<constructPath>.<path>`
+  form still match. Widening a stamped scope to a `*` glob (to intentionally ignore a
+  path across every stack/account/region) stays a hand-edit.
 - All four fields accept the same `*` / `?` glob, and a parent `path` covers child
   paths. The three scope axes — **stack, account, region** — are exactly the
   baseline file's identity axes. **Account** keeps a `stack: "Prod*"` rule from

--- a/docs/why-a-baseline-file.md
+++ b/docs/why-a-baseline-file.md
@@ -139,8 +139,10 @@ keeps a personal-account run from colliding with a committed shared-account
 baseline. Value-pinned rules would leak per-account facts into the single shared
 file. (An ignore rule _can_ narrow itself with the same `stack` / `account` /
 `region` scopes — those exist exactly so a `stack: "Prod*"` rule does not leak
-into a same-named stack in another account — but those are optional hand-edits,
-not the per-account, per-value facts a baseline must isolate.)
+into a same-named stack in another account, and the `ignore` verb now stamps the
+current stack/account/region onto each rule it writes (#757; widening to a `*`
+glob is the hand-edit) — but they are policy narrowing, not the per-account,
+per-value facts a baseline must isolate.)
 
 **Store only paths there → the third mode is gone.** An ignore rule has no
 value, so it can only express "never look at X again" (mode two of §1). Ignoring

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -81,6 +81,8 @@ export async function runIgnore(args: string[]): Promise<number> {
         findings: reconciled,
         yes: a.yes,
         interactive: isInteractive(),
+        accountId: desired.accountId,
+        region,
       });
       if (result.wrote) wroteAny = true;
       // a non-interactive ignore that needed a decision but had no --yes refuses (R38)

--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -434,6 +434,8 @@ async function ignoreAll(p: ResolveParams): Promise<SubResult | null> {
     findings,
     yes: p.yes,
     interactive: true,
+    accountId: p.desired.accountId,
+    region: p.region,
   });
   // reconciled findings are all not-yet-ignored, so a completed run always writes a new
   // rule; !wrote means the multiselect was cancelled → back to the menu.
@@ -513,6 +515,8 @@ async function perFinding(p: ResolveParams, decidable: Finding[]): Promise<SubRe
       findings: groups.ignore,
       yes: true,
       interactive: true,
+      accountId: p.desired.accountId,
+      region: p.region,
     });
   }
   // revert (AWS, last): pass ONLY the chosen findings; autoSelectAll skips the op

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -412,6 +412,11 @@ export interface IgnoreStackParams {
   findings: Finding[];
   yes: boolean;
   interactive: boolean; // whether the multiselect decision prompt may be shown (TTY only)
+  // Current identity scope, stamped onto each written rule (issue #757) so an ignore
+  // does not leak to a same-named stack in another account/region. Optional only for
+  // callers that cannot resolve them; a missing field is omitted from the rule (match-any).
+  accountId?: string | undefined;
+  region?: string | undefined;
 }
 
 /**
@@ -471,7 +476,7 @@ export function ignoreSelectOptions(
  * ignore` and (PR-B2) check's interactive flow, so both write rules identically.
  */
 export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
-  const { stackName, findings, yes, interactive } = p;
+  const { stackName, findings, yes, interactive, accountId = '', region = '' } = p;
   // ignore is symmetric with revert (declared + undeclared + added), unlike record
   // (undeclared only) — it fills the gap of accepting a DECLARED or out-of-band ADDED
   // drift in-tool.
@@ -506,7 +511,7 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
     }
   }
   const { path, added, alreadyPresent } = await addIgnoreRules(
-    chosen.map((f) => ignoreRuleFor(f, stackName))
+    chosen.map((f) => ignoreRuleFor(f, stackName, accountId, region))
   );
   if (added.length > 0) {
     const dup = alreadyPresent.length > 0 ? `, ${alreadyPresent.length} already present` : '';

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -151,23 +151,38 @@ function validateIgnoreEntry(entry: unknown, index: number): void {
 }
 
 /**
- * The exact ignore rule the `ignore` verb writes for a finding — always the unscoped
- * rule (just `path`); the optional `stack` / `region` scopes stay hand-authored (the
- * verb writes the simplest rule; narrowing is a manual edit). Prefer the human-friendly
- * `<constructPath>.<path>` when present (CDK stacks): it is what `cdk-local` targets on
- * and readable in the git-committed config diff. The construct path is written WITHIN the
- * stack (the stack/Stage prefix stripped, given `stackName`) so it is byte-identical to
- * what the report prints for the finding — copy what you see. Naturally stack-scoped even
- * without the prefix (a `stack:` scope narrows further). Falls back to `<logicalId>.<path>`,
- * ALWAYS present (the CloudFormation key) so a rule is writable even on a non-CDK /
- * metadata-stripped stack. Pure + exported; `applyIgnores` matches the within-stack path,
- * the full construct path (older rules), AND the logicalId, so every form works.
+ * The exact ignore rule the `ignore` verb (and check's inline ignore) writes for a
+ * finding. The rule is STAMPED with the current stack / account / region scope (the same
+ * three identity axes a baseline file is keyed on), so ignoring a within-stack path on one
+ * stack does NOT leak to a same-named twin stack in another account/region — an unscoped
+ * `{ path }` was match-all, silently silencing the identical path everywhere (issue #757).
+ * The literal identity values are valid exact globs; hand-widening to a `*` glob stays a
+ * manual edit. A scope field is omitted only when genuinely unavailable (empty string).
+ * Prefer the human-friendly `<constructPath>.<path>` for `path` when present (CDK stacks):
+ * it is what `cdk-local` targets on and readable in the git-committed config diff. The
+ * construct path is written WITHIN the stack (the stack/Stage prefix stripped, given
+ * `stackName`) so it is byte-identical to what the report prints for the finding — copy
+ * what you see. Falls back to `<logicalId>.<path>`, ALWAYS present (the CloudFormation
+ * key) so a rule is writable even on a non-CDK / metadata-stripped stack. Pure + exported;
+ * `applyIgnores` matches the within-stack path, the full construct path (older rules), AND
+ * the logicalId, so every form works.
  */
-export function ignoreRuleFor(finding: Finding, stackName = ''): IgnoreRuleObject {
+export function ignoreRuleFor(
+  finding: Finding,
+  stackName = '',
+  accountId = '',
+  region = ''
+): IgnoreRuleObject {
   const id = finding.constructPath
     ? withinStackPath(finding.constructPath, stackName)
     : finding.logicalId;
-  return { path: finding.path ? `${id}.${finding.path}` : id };
+  const rule: IgnoreRuleObject = { path: finding.path ? `${id}.${finding.path}` : id };
+  // Only stamp a scope field when the value is actually known — an empty string would
+  // write `stack: ""`, a glob that matches nothing (silently disabling the rule).
+  if (stackName) rule.stack = stackName;
+  if (accountId) rule.account = accountId;
+  if (region) rule.region = region;
+  return rule;
 }
 
 /** Canonical identity of a rule (path + the three optional scopes), for dedupe. */

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -508,10 +508,12 @@ describe('ignoreRuleFor', () => {
       path: 'Policies',
       actual: [{}],
     };
-    // plain stack + a CDK Stage both collapse to the same within-stack rule
-    expect(ignoreRuleFor(f, 'MyStack')).toEqual({ path: 'ApiRole.Policies' });
+    // plain stack + a CDK Stage both collapse to the same within-stack path (the stack
+    // scope is stamped on, but no account/region were passed here so those stay omitted)
+    expect(ignoreRuleFor(f, 'MyStack')).toEqual({ path: 'ApiRole.Policies', stack: 'MyStack' });
     expect(ignoreRuleFor({ ...f, constructPath: 'my-app/Rds/ApiRole' }, 'my-app-Rds')).toEqual({
       path: 'ApiRole.Policies',
+      stack: 'my-app-Rds',
     });
     // round-trip: the within-stack rule the verb now writes matches the finding it came from
     expect(ign([f], 'MyStack', cfg([ignoreRuleFor(f, 'MyStack')]))[0]?.tier).toBe('ignored');

--- a/tests/ignore-scope-757.test.ts
+++ b/tests/ignore-scope-757.test.ts
@@ -1,0 +1,83 @@
+// Issue #757: the `ignore` verb / check's inline ignore used to write an UNSCOPED rule
+// (just `{ path }`), whose absent scopes are match-all — so ignoring a within-stack path
+// on one stack silently stopped watching the identical path on a same-named twin stack in
+// every account/region, a durable false negative. The fix stamps the current stack /
+// account / region identity onto each written rule so it only silences the SAME
+// stack+account+region.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyIgnores,
+  type CdkrdConfig,
+  type IgnoreScope,
+  ignoreRuleFor,
+} from '../src/config/config-file.js';
+import type { Finding } from '../src/types.js';
+
+const cfg = (ignore: CdkrdConfig['ignore']): CdkrdConfig => ({ ignore });
+const sc = (stackName: string, accountId: string, region: string): IgnoreScope => ({
+  stackName,
+  accountId,
+  region,
+});
+
+// A within-stack declared finding — the exact shape a user would ignore on one stack.
+const finding = (): Finding => ({
+  tier: 'declared',
+  logicalId: 'ApiRole1234ABCD',
+  constructPath: 'DevStack/ApiRole',
+  resourceType: 'AWS::IAM::Role',
+  path: 'Policies',
+  desired: [{}],
+  actual: [{ extra: true }],
+});
+
+describe('ignoreRuleFor stamps the current identity scope (issue #757)', () => {
+  it('returns a rule carrying stack, account, and region — not just path', () => {
+    const rule = ignoreRuleFor(finding(), 'DevStack', '111111111111', 'us-east-1');
+    expect(rule).toEqual({
+      path: 'ApiRole.Policies',
+      stack: 'DevStack',
+      account: '111111111111',
+      region: 'us-east-1',
+    });
+  });
+
+  it('omits a scope field that is genuinely unavailable (empty string), never writes stack: ""', () => {
+    // no account/region known → those axes stay absent (match-any); a `stack: ""` glob
+    // would match nothing and silently disable the rule, so it must not be written.
+    expect(ignoreRuleFor(finding(), 'DevStack')).toEqual({
+      path: 'ApiRole.Policies',
+      stack: 'DevStack',
+    });
+    // with no stackName the stack prefix is not stripped and no scope is stamped
+    expect(ignoreRuleFor(finding())).toEqual({ path: 'DevStack/ApiRole.Policies' });
+  });
+});
+
+describe('the scoped rule no longer leaks across stacks/accounts/regions (issue #757)', () => {
+  it('re-tags the SAME-identity finding but NOT a twin on a different stack/account/region', () => {
+    // What the `ignore` verb now writes when the user ignores this finding on DevStack.
+    const rule = ignoreRuleFor(finding(), 'DevStack', '111111111111', 'us-east-1');
+    const config = cfg([rule]);
+
+    // Same stack + account + region → silenced (re-tagged `ignored`).
+    expect(
+      applyIgnores([finding()], sc('DevStack', '111111111111', 'us-east-1'), config)[0]?.tier
+    ).toBe('ignored');
+
+    // The identical within-stack path on a DIFFERENT stack → still reported (the leak fixed).
+    expect(
+      applyIgnores([finding()], sc('ProdStack', '111111111111', 'us-east-1'), config)[0]?.tier
+    ).toBe('declared');
+
+    // Same stack name, DIFFERENT account → still reported (stack names are unique per account).
+    expect(
+      applyIgnores([finding()], sc('DevStack', '222222222222', 'us-east-1'), config)[0]?.tier
+    ).toBe('declared');
+
+    // Same stack + account, DIFFERENT region → still reported.
+    expect(
+      applyIgnores([finding()], sc('DevStack', '111111111111', 'eu-west-1'), config)[0]?.tier
+    ).toBe('declared');
+  });
+});

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -1318,10 +1318,12 @@ describe('ignoreStack (PR-B — write ignore.yaml ignore rules; declared + undec
     });
     expect(r.wrote).toBe(true);
     expect(r.added).toBe(2);
-    // append-only writes in finding order (declared first, then undeclared) — not sorted
+    // append-only writes in finding order (declared first, then undeclared) — not sorted.
+    // Each rule is stamped with the stack scope (issue #757); no accountId/region were
+    // passed here, so those axes stay omitted (match-any).
     expect((await loadConfig()).ignore).toEqual([
-      { path: 'B.VersioningConfiguration' },
-      { path: 'B.AccelerateConfiguration' },
+      { path: 'B.VersioningConfiguration', stack: 'S' },
+      { path: 'B.AccelerateConfiguration', stack: 'S' },
     ]);
   });
 


### PR DESCRIPTION
Closes #757.

## Problem
The `ignore` verb and check's inline ignore wrote an **unscoped** rule (`{ path }` only). Absent scopes are match-all, so ignoring a within-stack path on DevStack silently stopped watching the identical path on **ProdStack in every account/region** — a durable false negative (`ignore` is the permanent stop-watching action). The path is written WITHIN the stack (prefix stripped), erasing the disambiguator, and Dev/Prod twin stacks instantiate the same construct, so collisions are the norm not the exception.

## Fix
`ignoreRuleFor` now stamps the current **stack / account / region** identity (the same three axes a baseline file is keyed on) onto each written rule; a scope field is omitted only when genuinely unavailable (an empty string would write a match-nothing glob). `accountId`/`region` are threaded through `IgnoreStackParams` from the `ignore` verb (`ignore.ts`) and the interactive resolve flow (`interactive-resolve.ts`, both `ignoreAll` and `perFinding`). Widening a stamped scope to a `*` glob stays a manual hand-edit.

## Tests / docs
- `tests/ignore-scope-757.test.ts` — the written rule carries `stack`/`account`/`region`; `applyIgnores` re-tags only the same-identity finding, not a twin on a different stack/account/region.
- Updated `tests/config-file.test.ts` + `tests/stack-actions.test.ts` (previously asserted the `{ path }`-only rule).
- README + `docs/why-a-baseline-file.md`: the verb no longer writes the unscoped form.

## Verification
No AWS mutation (writes only `.cdkrd/ignore.yaml`). Full suite green (3194 tests).