### PR TITLE
fix(report): emit multi-stack --json as one valid JSON array; document the full contract (#755)

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,13 +533,67 @@ reserved for picker rows you aren't on. Piped / CI / `--json` output is plain te
 
 ### JSON output contract
 
-`--json` emits
-`{ "stack": "<name> (<region>)", "drifted": <n>, "findings": [...] }`.
-Each finding has a stable shape: `tier` (`deleted` | `declared` | `undeclared` |
-`readGap` | `unresolved` | `skipped` | `ignored`), `logicalId`, `resourceType`,
-`path`, `desired`, `actual`, `note`, `physicalId`, `constructPath`. An unrecorded
-value keeps `tier: "undeclared"` and carries `"unrecorded": true`; `drifted`
-excludes it. The output always carries every finding regardless of `--verbose`.
+`--json` emits **one top-level JSON array for the whole invocation — one element per
+stack**:
+
+```json
+[
+  { "stack": "stackA (us-east-1)", "drifted": 1, "findings": [ ... ] },
+  { "stack": "stackB (us-east-1)", "drifted": 0, "findings": [] }
+]
+```
+
+The whole stdout stream is a single `JSON.parse`-able value. This holds even for a
+single-stack run — it is an **array of one** (never a bare object), so a consumer's
+`JSON.parse` always yields an array and never has to special-case the count. (Earlier
+builds printed one pretty-printed `{...}` per stack back-to-back, which was neither one
+valid JSON value nor JSONL; multi-stack `--json` was unparseable — issue #755.) All
+`note` / `warning` / progress lines go to **stderr**, so stdout stays pure JSON.
+
+A **stack that errored or was skipped** before it could be checked still appears as an
+element so a consumer sees which stacks ran: it carries `"error": "<reason>"` alongside
+`"drifted": 0` and an empty `"findings": []`. (`error` is absent on a
+successfully-checked stack.)
+
+Each stack element is `{ "stack": "<name> (<region>)", "drifted": <n>, "findings": [...] }`
+(`error` added only on failure). Each **finding** has a stable shape:
+
+- Always present: `tier`, `logicalId`, `resourceType`, `path`.
+- Usually present: `desired`, `actual`, `note`, `physicalId`, `constructPath` (any of
+  these may be omitted when it doesn't apply — e.g. an undeclared finding has no
+  `desired`).
+- `tier` is one of `deleted` | `added` | `declared` | `undeclared` | `atDefault` |
+  `generated` | `ignored` | `readGap` | `unresolved` | `skipped`. The output carries
+  **every** finding of every tier (including the informational `atDefault` / `generated`
+  / `ignored` / `readGap` / `unresolved` / `skipped` ones the text report folds into its
+  `info:` footer), regardless of `--verbose`.
+- `drifted` counts only confirmed-drift tiers (`deleted` / `declared` / `undeclared` /
+  `added`) that are not `unrecorded`; the informational tiers and unrecorded values are
+  excluded.
+
+Optional per-finding fields, present only when they apply:
+
+- `hint` — a non-classifying, human-facing note on where a live value likely came from
+  (e.g. an account/region-level auto-instrumentation footprint). Display-only; it never
+  changes the tier.
+- `unrecorded` (`true`) — a live-only value (`undeclared` or `added`) with no baseline
+  entry yet: **potential drift**, not confirmed drift. Excluded from `drifted`.
+- `attributeKey` — for a `declared` drift inside an identity-keyed attribute bag (ELB
+  `LoadBalancerAttributes` / `TargetGroupAttributes`), the `Key` of the changed
+  attribute (`path` stays at the bag property; `desired`/`actual` are the scalar value).
+- `arrayDelta` — for an `undeclared` recorded identity-keyed array that changed vs the
+  baseline, the element-level delta (`{ identityField, added, changed, removed }`) so a
+  consumer sees which element(s) differ, not the whole-array dump.
+- `nested` (`true`) — an `undeclared` value is a live sub-key inside a property you
+  _did_ declare (dotted `path`). `freeFormKey` (`true`) additionally marks it as living
+  inside a free-form map (e.g. a Lambda env var).
+- `modelReadFailed` (`true`) — an `added` resource whose full live model could not be
+  read this run (`actual` is only the enumerator's identity snippet); it exists but is
+  not change-watchable until the next check.
+- On an `added` finding, `desired` carries the **recorded baseline model** and `actual`
+  the live one (so a recorded `added` resource that changed shows the delta), and
+  `unrecorded` marks a never-recorded one as potential drift.
+
 After publication this shape is a backward-compatible API.
 
 ## IAM permissions

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -22,7 +22,7 @@ import {
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { withinStackPath } from '../construct-path.js';
-import { report, stackSeparator } from '../report/report.js';
+import { buildStackJson, report, type StackJsonReport, stackSeparator } from '../report/report.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
@@ -234,6 +234,24 @@ export async function runCheck(args: string[]): Promise<number> {
 
   let worst = 0;
   let anyDrift = false; // for the report-only hint (R53)
+  // #755: in --json mode each stack's report object is COLLECTED here and a single
+  // top-level JSON ARRAY (one element per stack) is printed once, after the loop —
+  // instead of each stack's report() printing its own pretty-printed object inline,
+  // which concatenated into `{...}\n{...}` (not one parseable JSON value, not JSONL).
+  // A stack that ERRORED / was skipped still gets an element (with an `error` field) so
+  // a consumer sees which stacks ran. In text mode this stays empty and unused.
+  const jsonReports: StackJsonReport[] = [];
+  // Record an errored/skipped stack in the --json output so it is not silently omitted
+  // (no-op in text mode, where the reason already goes to stderr).
+  const jsonError = (stackName: string, region: string | undefined, message: string): void => {
+    if (a.json)
+      jsonReports.push({
+        stack: region ? `${stackName} (${region})` : stackName,
+        drifted: 0,
+        findings: [],
+        error: message,
+      });
+  };
   // R37: one blank line between consecutive stack reports (text mode only) — done
   // here at the call site so a single-stack run never gets a stray leading blank.
   const separate = stackSeparator();
@@ -241,9 +259,10 @@ export async function runCheck(args: string[]): Promise<number> {
   const showProgress = !a.json && isInteractive();
   for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
-      console.error(
-        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
-      );
+      const msg =
+        'no region — set env on the stack, pass --region, or set a region for the AWS profile';
+      console.error(`error: ${stackName}: ${msg}`);
+      jsonError(stackName, region, msg);
       worst = Math.max(worst, 2);
       continue;
     }
@@ -256,6 +275,7 @@ export async function runCheck(args: string[]): Promise<number> {
       const sKey = synthKey(stackName, region);
       if (synthTemplates && !synthTemplates.has(sKey)) {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
+        jsonError(stackName, region, 'not in the synth output — skipped (--pre-deploy)');
         continue;
       }
       // The stack's synth template (always carried by resolveStacks) is the non-ASCII
@@ -325,14 +345,24 @@ export async function runCheck(args: string[]): Promise<number> {
             `note: ${stackName}: --pre-deploy reports declared drift only (undeclared tiers are evaluated against the deployed template — run check without --pre-deploy)`
           );
         if (!a.json) separate();
-        const preDeployCode = report(
-          applyIgnores(declaredOnly, { stackName, accountId: desired.accountId, region }, config),
-          `${posPrefix}${stackName} (${region})`,
-          {
-            json: a.json,
-            verbose: a.verbose,
-          }
+        const preDeployReconciled = applyIgnores(
+          declaredOnly,
+          { stackName, accountId: desired.accountId, region },
+          config
         );
+        const preDeployHeader = `${posPrefix}${stackName} (${region})`;
+        // #755: in --json collect the stack's object (printed as one array at the end);
+        // in text mode render inline as before.
+        let preDeployCode: number;
+        if (a.json) {
+          const { json, code } = buildStackJson(preDeployReconciled, preDeployHeader);
+          jsonReports.push(json);
+          preDeployCode = code;
+        } else {
+          preDeployCode = report(preDeployReconciled, preDeployHeader, {
+            verbose: a.verbose,
+          });
+        }
         if (preDeployCode === 1) anyDrift = true;
         worst = Math.max(worst, finalCheckExit(preDeployCode, a.fail));
         // --strict still applies under --pre-deploy: live reads (and so the skipped
@@ -393,13 +423,23 @@ export async function runCheck(args: string[]): Promise<number> {
         config
       );
       if (!a.json) separate();
-      let code = report(reconciled, `${posPrefix}${stackName} (${region})`, {
-        json: a.json,
-        verbose: a.verbose,
-        // --show-all is inventory mode: list every undeclared value, including the
-        // ones at an AWS default (otherwise folded to a count) (R86).
-        expandAtDefault: a.showAll,
-      });
+      const reportHeader = `${posPrefix}${stackName} (${region})`;
+      // #755: in --json collect the stack's object (one top-level array printed after the
+      // loop); in text mode render inline as before. The interactive flow below is
+      // suppressed under --json, so this branch is the whole json output path.
+      let code: number;
+      if (a.json) {
+        const { json, code: jsonCode } = buildStackJson(reconciled, reportHeader);
+        jsonReports.push(json);
+        code = jsonCode;
+      } else {
+        code = report(reconciled, reportHeader, {
+          verbose: a.verbose,
+          // --show-all is inventory mode: list every undeclared value, including the
+          // ones at an AWS default (otherwise folded to a count) (R86).
+          expandAtDefault: a.showAll,
+        });
+      }
       const hasUnrecorded = reconciled.some((f) => f.unrecorded === true);
 
       // R28 (extended R121): drift found in a TTY → offer to resolve it inline
@@ -452,18 +492,27 @@ export async function runCheck(args: string[]): Promise<number> {
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — skipped`);
+        jsonError(stackName, region, 'not deployed yet — skipped');
         continue;
       }
       // a stack that exists but has no meaningful deployed state (REVIEW_IN_PROGRESS /
       // deleting): skip with a clear reason, not a meaningless CLEAN and not an error.
       if (e instanceof StackNotCheckableError) {
         console.error(`note: ${stackName}: ${e.message} — skipped`);
+        jsonError(stackName, region, `${e.message} — skipped`);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);
+      jsonError(stackName, region, (e as Error).message);
       worst = Math.max(worst, 2);
     }
   }
+  // #755: emit the whole invocation's --json output as ONE top-level array (one element
+  // per stack — checked, errored, or skipped) so the stream is a single JSON.parse-able
+  // value. Printed once here, after the loop, on stdout (the machine channel; all notes /
+  // warnings above go to stderr). Even a single-stack run is an array of one, kept uniform
+  // so a consumer's JSON.parse always yields an array.
+  if (a.json) console.log(JSON.stringify(jsonReports, null, 2));
   // Report-only mode found drift: say so, and say how to make it fail — a script
   // author piping this must discover --fail from the output, not from a surprise
   // green pipeline (R53). Suppressed under --json (machine consumers read stdout).

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -270,6 +270,41 @@ function groupReasons(items: Finding[]): string {
     .join(', ');
 }
 
+// The `--json` payload for a SINGLE stack: `{ stack, drifted, findings }` plus the
+// exit code the same findings map to. Pure + exported so the multi-stack check loop
+// can COLLECT one object per stack and serialize a single top-level JSON ARRAY at the
+// end (issue #755) — instead of each stack's report() printing its own pretty-printed
+// object inline, which concatenated into `{...}\n{...}`: not a single parseable JSON
+// value and not JSONL. The array is the machine contract for a whole invocation; a lone
+// stack is simply an array of one (kept uniform so `JSON.parse` always yields an array —
+// see README "JSON output contract"). `report()`'s own json path still logs the bare
+// object so report-level unit tests / any single-report caller are unchanged; the ARRAY
+// framing is owned by the check loop.
+export interface StackJsonReport {
+  stack: string;
+  drifted: number;
+  findings: Finding[];
+  // Present ONLY on a stack that ERRORED before it could be checked — so a --json
+  // consumer sees WHICH stacks ran and which failed, rather than a silent omission (the
+  // pre-#755 behavior printed nothing for an errored stack). Never set on a
+  // successfully-checked stack.
+  error?: string;
+}
+
+export function buildStackJson(
+  rawFindings: Finding[],
+  header: string
+): { json: StackJsonReport; code: number } {
+  // Annotate origin hints (diff/hints.ts) so the --json payload carries them exactly as
+  // the text path does — the single render chokepoint. A hint is display-only.
+  const findings = annotateHints(rawFindings);
+  // unrecorded findings (R60/R62): inventory awaiting a baseline decision, not drift —
+  // never counted toward the verdict/exit.
+  const isDriftHere = (f: Finding): boolean => DRIFT_TIERS.includes(f.tier) && !f.unrecorded;
+  const drifted = findings.filter(isDriftHere).length;
+  return { json: { stack: header, drifted, findings }, code: drifted === 0 ? 0 : 1 };
+}
+
 export function report(rawFindings: Finding[], header: string, opts: ReportOptions = {}): number {
   const log = opts.log ?? console.log;
   const stackName = stackNameFromHeader(header);
@@ -283,7 +318,10 @@ export function report(rawFindings: Finding[], header: string, opts: ReportOptio
   const drifted = findings.filter(isDriftHere).length;
 
   if (opts.json) {
-    log(JSON.stringify({ stack: header, drifted, findings }, null, 2));
+    // Single-report json (direct callers / unit tests): the bare object. The multi-stack
+    // check loop does NOT route through here for --json — it collects buildStackJson()
+    // objects and prints one top-level array (issue #755).
+    log(JSON.stringify(buildStackJson(rawFindings, header).json, null, 2));
     return drifted === 0 ? 0 : 1;
   }
 

--- a/tests/json-contract-755.test.ts
+++ b/tests/json-contract-755.test.ts
@@ -1,0 +1,99 @@
+// #755: the multi-stack `--json` output must be ONE valid JSON value for the whole
+// invocation — a single top-level ARRAY with one element per stack — not the
+// concatenated `{...}\n{...}` pretty-printed documents the old per-stack inline
+// `report({ json: true })` produced (neither a single parseable value nor JSONL). An
+// errored / skipped stack must still appear as an element (with an `error` field) so a
+// consumer sees which stacks ran. These tests exercise the pure `buildStackJson` helper
+// and the array-assembly contract the check loop uses.
+import { describe, expect, it } from 'vite-plus/test';
+import { buildStackJson, type StackJsonReport } from '../src/report/report.js';
+import type { Finding } from '../src/types.js';
+
+const F = (tier: Finding['tier'], path = 'P'): Finding => ({
+  tier,
+  logicalId: 'L',
+  resourceType: 'AWS::X::Y',
+  path,
+  actual: 1,
+});
+
+// Mirror the check loop's --json assembly: collect one buildStackJson() object per
+// checked stack, plus an { error } element for each errored/skipped stack, then
+// serialize the whole array once.
+function assembleJson(
+  checked: { findings: Finding[]; header: string }[],
+  errored: { stack: string; error: string }[] = []
+): string {
+  const reports: StackJsonReport[] = [
+    ...checked.map((c) => buildStackJson(c.findings, c.header).json),
+    ...errored.map((e) => ({ stack: e.stack, drifted: 0, findings: [], error: e.error })),
+  ];
+  return JSON.stringify(reports, null, 2);
+}
+
+describe('#755 multi-stack --json contract', () => {
+  it('buildStackJson returns { stack, drifted, findings } + the matching exit code', () => {
+    const { json, code } = buildStackJson([F('declared'), F('skipped')], 'stackA (us-east-1)');
+    expect(json.stack).toBe('stackA (us-east-1)');
+    expect(json.drifted).toBe(1); // declared is drift; skipped is not
+    expect(json.findings).toHaveLength(2);
+    expect(code).toBe(1);
+    expect(json.error).toBeUndefined(); // a successfully-checked stack has no error field
+  });
+
+  it('an unrecorded value is not counted as drift (drifted excludes it)', () => {
+    const u: Finding = { ...F('undeclared'), unrecorded: true };
+    const { json, code } = buildStackJson([u], 'stackA (us-east-1)');
+    expect(json.drifted).toBe(0);
+    expect(code).toBe(0);
+    expect(json.findings[0]?.unrecorded).toBe(true);
+  });
+
+  it('the multi-stack output is a SINGLE JSON.parse-able value — an array, one element per stack', () => {
+    const combined = assembleJson([
+      { findings: [F('declared')], header: 'stackA (us-east-1)' },
+      { findings: [], header: 'stackB (us-east-1)' },
+      { findings: [F('undeclared'), F('added')], header: 'stackC (us-west-2)' },
+    ]);
+    // The WHOLE stream parses as one value (the old concatenated {...}\n{...} did not).
+    const parsed = JSON.parse(combined);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(3); // one element per stack
+    expect(parsed.map((r: StackJsonReport) => r.stack)).toEqual([
+      'stackA (us-east-1)',
+      'stackB (us-east-1)',
+      'stackC (us-west-2)',
+    ]);
+    expect(parsed[0].drifted).toBe(1);
+    expect(parsed[1].drifted).toBe(0);
+    expect(parsed[2].drifted).toBe(2);
+  });
+
+  it('a single-stack run is still an array — of one — so JSON.parse always yields an array', () => {
+    const parsed = JSON.parse(
+      assembleJson([{ findings: [F('declared')], header: 'solo (us-east-1)' }])
+    );
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].stack).toBe('solo (us-east-1)');
+  });
+
+  it('an errored / skipped stack still appears as an element, with an error marker', () => {
+    const combined = assembleJson(
+      [{ findings: [F('declared')], header: 'ok (us-east-1)' }],
+      [{ stack: 'boom (us-east-1)', error: 'Access denied' }]
+    );
+    const parsed = JSON.parse(combined);
+    expect(parsed).toHaveLength(2); // both the checked and the errored stack are present
+    const boom = parsed.find((r: StackJsonReport) => r.stack === 'boom (us-east-1)');
+    expect(boom).toBeDefined();
+    expect(boom.error).toBe('Access denied'); // consumer sees WHICH stack failed
+    expect(boom.drifted).toBe(0);
+    expect(boom.findings).toEqual([]);
+  });
+
+  it('an empty run (no stacks reached) is an empty array — still valid JSON', () => {
+    const parsed = JSON.parse(assembleJson([]));
+    expect(parsed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #755.

## Problem
Multi-stack `--json` printed **concatenated** pretty-printed JSON documents (each stack's `report()` did its own `console.log(JSON.stringify(...))`), so `cdkrd check --all --json` produced `{...}\n{...}` — not one `JSON.parse`-able value and not JSONL. A stack that **errored** mid-run emitted nothing to stdout, so a consumer could not tell which stacks were missing. README's documented tier enum was also missing `added` / `atDefault` / `generated`, and several shipped fields were undocumented.

## Fix
`--json` now emits **one top-level JSON array** for the whole invocation, one element per stack (even a single stack is an array of one, so a consumer's `JSON.parse` always yields an array). An errored/skipped stack appears as an element with an `error` field. `report()`'s own single-object json path is unchanged (direct callers / unit tests) — the array framing lives only in the check loop via a new pure exported `buildStackJson()` chokepoint.

README "JSON output contract" rewritten: the array shape + error element, the complete tier enum, and the previously-undocumented fields (`hint`, `unrecorded`, `attributeKey`, `arrayDelta`, `modelReadFailed`, added-tier `desired`), verified against `report.ts`.

## Tests
`tests/json-contract-755.test.ts` — multi-stack output is a single `JSON.parse`-able array, one element per stack; an errored stack appears with its `error` marker; single stack is an array of one.

## Verification
Machine-contract change in `src/report/report.ts` + `src/commands/check.ts`; no AWS interaction. Full suite green (3197 tests). Note: this is a **pre-publication** JSON shape change (the issue flags now as the time to fix it before the contract is public).