### PR TITLE
fix(schema): key DescribeType schema cache by region (#788)

### DIFF
--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -4,6 +4,12 @@
 import { type CloudFormationClient, DescribeTypeCommand } from '@aws-sdk/client-cloudformation';
 import type { SchemaInfo } from '../types.js';
 
+// DescribeType is a REGIONAL call (the CloudFormationClient is per-region), and
+// registry schema rollouts are region-staggered (readOnly/writeOnly/default
+// annotations can differ across regions). So the cache is keyed on BOTH the
+// client's region AND the resourceType (`${region}\0${resourceType}`) — keying on
+// resourceType alone would leak region 1's schema to every other region in a
+// multi-region `--all` run, skewing the writeOnly/defaults sets (#788).
 const cache = new Map<string, SchemaInfo>();
 const EMPTY: SchemaInfo = {
   readOnly: new Set(),
@@ -23,10 +29,12 @@ export async function getSchemaInfo(
   client: CloudFormationClient,
   resourceType: string
 ): Promise<SchemaInfo> {
-  const cached = cache.get(resourceType);
+  const region = await client.config.region();
+  const cacheKey = `${region}\0${resourceType}`;
+  const cached = cache.get(cacheKey);
   if (cached) return cached;
   const info = await fetch(client, resourceType);
-  cache.set(resourceType, info);
+  cache.set(cacheKey, info);
   return info;
 }
 

--- a/tests/schema-region-788.test.ts
+++ b/tests/schema-region-788.test.ts
@@ -1,0 +1,50 @@
+import type { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { describe, expect, it } from 'vite-plus/test';
+import { getSchemaInfo } from '../src/schema/schema-strip.js';
+
+// #788: the DescribeType schema cache is a REGIONAL call keyed per-region. Registry
+// schema rollouts are region-staggered, so region 1's schema must NOT leak to another
+// region's stack of the same resourceType in a multi-region `--all` run. The cache is
+// keyed on `${region}\0${resourceType}` — a fake client whose region + DescribeType
+// response differ per region must yield the region-correct schema, not a cached copy.
+
+// Build a minimal CloudFormationClient-like fake: `.config.region()` resolves to the
+// given region, and `.send()` returns a DescribeType response with the given Schema.
+function fakeClient(region: string, schema: unknown): CloudFormationClient {
+  return {
+    config: { region: () => Promise.resolve(region) },
+    send: () => Promise.resolve({ Schema: JSON.stringify(schema) }),
+  } as unknown as CloudFormationClient;
+}
+
+describe('getSchemaInfo region-aware cache (#788)', () => {
+  it('does not leak region A schema to region B for the same resourceType', async () => {
+    // Same resourceType, but the property `Foo` is writeOnly ONLY in us-east-1.
+    const resourceType = 'AWS::Foo::Region788Bar';
+    const schemaEast = {
+      properties: { Foo: { type: 'string' }, Baz: { type: 'string' } },
+      writeOnlyProperties: ['/properties/Foo'],
+    };
+    const schemaTokyo = {
+      properties: { Foo: { type: 'string' }, Baz: { type: 'string' } },
+      writeOnlyProperties: [],
+    };
+
+    const clientEast = fakeClient('us-east-1', schemaEast);
+    const clientTokyo = fakeClient('ap-northeast-1', schemaTokyo);
+
+    // Populate the cache under us-east-1 first.
+    const east = await getSchemaInfo(clientEast, resourceType);
+    expect(east.writeOnly.has('Foo')).toBe(true);
+
+    // The Tokyo client must get Tokyo's schema (Foo NOT writeOnly), NOT the cached
+    // us-east-1 copy. Before the fix (cache keyed on resourceType only) this returned
+    // the us-east-1 schema and `writeOnly.has('Foo')` would wrongly be true.
+    const tokyo = await getSchemaInfo(clientTokyo, resourceType);
+    expect(tokyo.writeOnly.has('Foo')).toBe(false);
+
+    // And the us-east-1 entry is still correct (both regions coexist in the cache).
+    const eastAgain = await getSchemaInfo(clientEast, resourceType);
+    expect(eastAgain.writeOnly.has('Foo')).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #788

## Problem
The DescribeType schema cache (`src/schema/schema-strip.ts`) was keyed by `resourceType` **only**. DescribeType is a **regional** call (the CloudFormationClient is per-region), and registry schema rollouts are region-staggered. In a multi-region `--all` run, the first region populated the cache and every other region's stack of the same type got the first region's schema — skewing the writeOnly/defaults sets (declared-drift FP/FN, wrong folding/revert planning).

## Fix
Key the cache on `${region}\0${resourceType}`, resolving the region from the passed-in client via `client.config.region()` — no new parameter, gather.ts callers untouched.

## Test
`tests/schema-region-788.test.ts`: two fake clients whose `.config.region()` differ and whose `.send()` returns different schemas for the same resourceType; asserts the second region gets its own schema, not the first region's cached copy. Fails against the resourceType-only key.

Gates: typecheck / lint+format / build / 3206 tests all green.