### PR TITLE
fix(read): do not cache transient kms:ListAliases failures (#789)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -550,6 +550,10 @@ _real change still detected_ ([tests/classify.test.ts](../tests/classify.test.ts
    positive) — but `gather` then prints a one-line per-region warning
    (`kmsListAliasesDeniedWarning`, deduped via a process-lifetime region set), so the
    degraded coverage (blind to a key swap) is surfaced rather than silent (R115).
+   Only a DEFINITIVE outcome is cached (success, or a definitive access-denial):
+   a TRANSIENT failure (throttle / network blip surviving adaptive retry) is NOT
+   cached, so the next stack in the region re-queries instead of one blip
+   poisoning key-swap detection for the whole run.
 
 > Classes 1 & 3 are a latent risk in any AWS-snapshot diff; they were also
 > back-ported to **cdkd** (PR #802, merged) since cdkd's `drift-calculator` shared

--- a/src/read/kms-aliases.ts
+++ b/src/read/kms-aliases.ts
@@ -3,26 +3,49 @@
 // stored by AWS as the key ARN) apart from a customer-managed key swapped in out of
 // band — the latter is a real, security-relevant drift the shape-only check missed.
 // Listing aliases is account-wide, so one paginated ListAliases per region is enough;
-// cached per region. On any error (e.g. missing kms:ListAliases) returns `denied: true`
-// with empty targets so the classifier falls back to the conservative shape-based match
-// (noise, not false drift) — but the caller WARNS, because that fallback is blind to a
-// customer-key swap (it suppresses every `alias/aws/*` vs key-ARN pair). The result
-// (success OR denial) is cached so a denied region is not re-queried per stack.
+// cached per region. On error returns `denied: true` with empty targets so the
+// classifier falls back to the conservative shape-based match (noise, not false drift)
+// — but the caller WARNS, because that fallback is blind to a customer-key swap (it
+// suppresses every `alias/aws/*` vs key-ARN pair).
+//
+// Only DEFINITIVE outcomes are cached (#789, mirroring gather.ts's post-#754
+// isManagedBySiblingStack): a success, or a definitive access-denial (missing
+// kms:ListAliases). A TRANSIENT error (throttle / network blip / 5xx / timeout that
+// survives adaptive retry) is NOT cached — it degrades THIS call gracefully
+// (`denied: true, transient: true`) but leaves the cache empty so the NEXT stack in the
+// region re-queries. Caching a transient failure would blind customer-KMS-key-swap
+// detection for every subsequent stack in the region for the whole run AND misreport
+// the blip as "kms:ListAliases denied", sending the user to fix IAM that isn't broken.
 import { KMSClient, ListAliasesCommand } from '@aws-sdk/client-kms';
 import { READ_RETRY } from './client-config.js';
 
 export interface ManagedAliasTargets {
   targets: Record<string, string>; // alias/aws/<svc> -> target key id
   denied: boolean; // true when ListAliases failed (e.g. missing kms:ListAliases)
+  transient?: boolean; // true when the failure was transient (not cached; retry next stack)
 }
 
 const cache = new Map<string, ManagedAliasTargets>();
+
+/** True when the error is a DEFINITIVE access-denial (cacheable), NOT a transient blip.
+ *  Matches an AccessDenied(Exception) / UnauthorizedOperation by name or code, or the AWS
+ *  HTTP 403 status. Anything else (throttle, network, 5xx, timeout) is treated as
+ *  transient and must NOT be cached. */
+export function isDefinitiveDenial(err: unknown): boolean {
+  const e = err as
+    | { name?: string; code?: string; $metadata?: { httpStatusCode?: number } }
+    | undefined;
+  if (!e) return false;
+  const definitive = /^(AccessDenied(Exception)?|UnauthorizedOperation)$/;
+  if (e.name && definitive.test(e.name)) return true;
+  if (e.code && definitive.test(e.code)) return true;
+  return e.$metadata?.httpStatusCode === 403;
+}
 
 export async function fetchManagedAliasTargets(region: string): Promise<ManagedAliasTargets> {
   const cached = cache.get(region);
   if (cached) return cached;
   const targets: Record<string, string> = {};
-  let result: ManagedAliasTargets;
   try {
     const c = new KMSClient({ region, ...READ_RETRY });
     let marker: string | undefined;
@@ -34,13 +57,21 @@ export async function fetchManagedAliasTargets(region: string): Promise<ManagedA
       }
       marker = r.Truncated ? r.NextMarker : undefined;
     } while (marker);
-    result = { targets, denied: false };
-  } catch {
-    // no kms:ListAliases (or any error) → fall back to shape-based suppression
-    result = { targets: {}, denied: true };
+    const result: ManagedAliasTargets = { targets, denied: false };
+    cache.set(region, result);
+    return result;
+  } catch (e) {
+    if (isDefinitiveDenial(e)) {
+      // definitive: no kms:ListAliases → cache the denial (a denied region is not
+      // re-queried per stack) and fall back to shape-based suppression.
+      const result: ManagedAliasTargets = { targets: {}, denied: true };
+      cache.set(region, result);
+      return result;
+    }
+    // transient (throttle / network / 5xx / timeout): degrade THIS call gracefully but
+    // do NOT cache, so the next stack in the region retries ListAliases.
+    return { targets: {}, denied: true, transient: true };
   }
-  cache.set(region, result);
-  return result;
 }
 
 /** The one-line warning emitted when ListAliases is denied but the stack declares an
@@ -52,6 +83,19 @@ export function kmsListAliasesDeniedWarning(region: string): string {
     `warning: ${region}: kms:ListAliases denied — managed-KMS-alias drift detection is degraded. ` +
     `A customer-managed key swapped in for an AWS-managed default (alias/aws/*) will NOT be detected ` +
     `(every alias/aws/* is treated as matching any live key). Grant kms:ListAliases for full coverage.`
+  );
+}
+
+/** The one-line warning emitted when ListAliases fails TRANSIENTLY (throttle / network
+ *  blip / 5xx) for a stack that declares an AWS-managed alias: the managed-vs-customer
+ *  key check is degraded for THIS stack only — the error is NOT an IAM denial, and the
+ *  region is not poisoned, so the next stack retries. Pure + exported so the wording is
+ *  unit-tested. */
+export function kmsListAliasesTransientWarning(region: string): string {
+  return (
+    `warning: ${region}: kms:ListAliases failed transiently (throttle/network) — ` +
+    `managed-KMS-alias drift detection is degraded for THIS stack and will be retried for ` +
+    `the next stack in the region. This is NOT an IAM permission problem; no action is needed.`
   );
 }
 

--- a/tests/kms-transient-789.test.ts
+++ b/tests/kms-transient-789.test.ts
@@ -1,0 +1,115 @@
+import { KMSClient, ListAliasesCommand } from '@aws-sdk/client-kms';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import {
+  fetchManagedAliasTargets,
+  isDefinitiveDenial,
+  kmsListAliasesTransientWarning,
+} from '../src/read/kms-aliases.js';
+
+// #789: fetchManagedAliasTargets must cache ONLY definitive outcomes (success or a
+// definitive access-denial). A TRANSIENT throttle / network blip must NOT be cached, so
+// the next stack in the region re-queries instead of being blinded to a customer-managed-
+// key swap for the whole run. The per-region cache is process-wide, so each scenario uses
+// a DISTINCT region to avoid cross-test bleed.
+
+const kms = mockClient(KMSClient);
+beforeEach(() => kms.reset());
+
+describe('fetchManagedAliasTargets — transient vs definitive caching (#789)', () => {
+  it('does NOT cache a transient throttle: the next call for the same region re-queries and succeeds', async () => {
+    const region = 'us-east-2';
+    const throttle = Object.assign(new Error('rate exceeded'), {
+      name: 'ThrottlingException',
+      $metadata: { httpStatusCode: 429 },
+    });
+    // First send throws a throttle (survives adaptive retry); every send after resolves.
+    kms
+      .on(ListAliasesCommand)
+      .rejectsOnce(throttle)
+      .resolves({ Aliases: [{ AliasName: 'alias/aws/rds', TargetKeyId: 'key-rds' }] });
+
+    // First stack: degrades gracefully, flagged transient, NOT cached.
+    const first = await fetchManagedAliasTargets(region);
+    expect(first).toEqual({ targets: {}, denied: true, transient: true });
+
+    // Second stack (same region): must RE-QUERY (cache was not poisoned) and resolve the
+    // real targets — proving the transient failure did not blind detection for the run.
+    const second = await fetchManagedAliasTargets(region);
+    expect(second).toEqual({ targets: { 'alias/aws/rds': 'key-rds' }, denied: false });
+
+    // Two ListAliases calls fired (the poisoned-cache bug would fire only one).
+    expect(kms.commandCalls(ListAliasesCommand).length).toBe(2);
+  });
+
+  it('DOES cache a definitive AccessDeniedException: the next call is served from cache (no re-query)', async () => {
+    const region = 'eu-west-3';
+    kms.on(ListAliasesCommand).rejects(
+      Object.assign(new Error('not authorized'), {
+        name: 'AccessDeniedException',
+        $metadata: { httpStatusCode: 403 },
+      })
+    );
+
+    const first = await fetchManagedAliasTargets(region);
+    expect(first).toEqual({ targets: {}, denied: true });
+    expect(first.transient).toBeUndefined();
+
+    const second = await fetchManagedAliasTargets(region);
+    expect(second).toEqual({ targets: {}, denied: true });
+
+    // Only ONE call: the definitive denial was cached and reused.
+    expect(kms.commandCalls(ListAliasesCommand).length).toBe(1);
+  });
+
+  it('treats a 5xx / network blip as transient (not cached)', async () => {
+    const region = 'ap-south-1';
+    kms
+      .on(ListAliasesCommand)
+      .rejectsOnce(
+        Object.assign(new Error('internal failure'), {
+          name: 'InternalFailure',
+          $metadata: { httpStatusCode: 500 },
+        })
+      )
+      .resolves({ Aliases: [{ AliasName: 'alias/aws/s3', TargetKeyId: 'key-s3' }] });
+
+    const first = await fetchManagedAliasTargets(region);
+    expect(first.transient).toBe(true);
+    const second = await fetchManagedAliasTargets(region);
+    expect(second).toEqual({ targets: { 'alias/aws/s3': 'key-s3' }, denied: false });
+    expect(kms.commandCalls(ListAliasesCommand).length).toBe(2);
+  });
+});
+
+describe('isDefinitiveDenial (#789)', () => {
+  it('is true for AccessDenied / AccessDeniedException / UnauthorizedOperation by name', () => {
+    expect(isDefinitiveDenial({ name: 'AccessDeniedException' })).toBe(true);
+    expect(isDefinitiveDenial({ name: 'AccessDenied' })).toBe(true);
+    expect(isDefinitiveDenial({ name: 'UnauthorizedOperation' })).toBe(true);
+  });
+  it('is true for a definitive denial by code or by 403 status', () => {
+    expect(isDefinitiveDenial({ code: 'AccessDeniedException' })).toBe(true);
+    expect(isDefinitiveDenial({ $metadata: { httpStatusCode: 403 } })).toBe(true);
+  });
+  it('is false for throttle / 5xx / network / undefined (transient)', () => {
+    expect(isDefinitiveDenial({ name: 'ThrottlingException' })).toBe(false);
+    expect(
+      isDefinitiveDenial({ name: 'InternalFailure', $metadata: { httpStatusCode: 500 } })
+    ).toBe(false);
+    expect(isDefinitiveDenial({ name: 'TimeoutError' })).toBe(false);
+    expect(isDefinitiveDenial(undefined)).toBe(false);
+  });
+});
+
+describe('kmsListAliasesTransientWarning (#789)', () => {
+  it('names the region, says transient/retry, and does NOT claim an IAM denial', () => {
+    const w = kmsListAliasesTransientWarning('ap-northeast-1');
+    expect(w).toContain('ap-northeast-1');
+    expect(w.toLowerCase()).toContain('transient');
+    expect(w.toLowerCase()).toContain('retried');
+    // Must NOT tell the user their permissions are denied.
+    expect(w).not.toContain('denied');
+    expect(w).not.toContain('Grant kms:ListAliases');
+  });
+});


### PR DESCRIPTION
Closes #789

## Problem
`fetchManagedAliasTargets` cached **any** failure as a permanent per-region `{ denied: true }`, conflating a definitive `AccessDeniedException` (cacheable) with a **transient** throttle/network blip. One transient error then blinded customer-managed-KMS-key-swap detection (a security-relevant FN) for **every subsequent stack in the region** for the rest of the run, and misreported the blip as "kms:ListAliases denied" (pointing the user at IAM that isn't broken). This violates the post-#754 standard applied 30 lines away in gather.ts.

## Fix
Cache only **definitive** outcomes (success, or `AccessDenied`/`UnauthorizedOperation`/HTTP 403 via new `isDefinitiveDenial`). A transient error degrades **this** call gracefully (`denied: true, transient: true`) but is **not** cached, so the next stack in the region re-queries. Added `kmsListAliasesTransientWarning` with accurate wording.

The caller (`gather.ts`, off-limits for this lane) can now branch on the returned `transient` flag to emit the right warning — a pure caller-side follow-up, no further edit here.

## Test
`tests/kms-transient-789.test.ts` (7 cases): transient throttle → second call re-queries (2 SDK calls); definitive denial → cached (1 call); 5xx treated transient; `isDefinitiveDenial` truth table; transient-warning wording (no "denied").

## Docs
`docs/ARCHITECTURE.md` KMS-alias section notes only definitive outcomes are cached.

Gates: typecheck / lint+format / build / 3212 tests all green.