### PR TITLE
fix(desired): key ImportValue exports cache by account+region, degrade on ListExports failure (#784)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -363,8 +363,13 @@ at that attribute's current value.
 fetched mid-resolve. `loadDesired` prefetches them — but ONLY when the template body
 references `Fn::ImportValue` (a substring check), so a normal single-stack run pays
 nothing — via paginated CFn `ListExports`, account+region-scoped, cached in a
-module-level per-region Map. `Fn::ImportValue` then resolves a known export name to
-its value, else `UNRESOLVED`.
+module-level Map keyed by `${accountId}:${region}` (BOTH axes: exports are
+scoped to an account AND a region, so a region-only key would serve account A's
+exports to account B's same-region stack). `Fn::ImportValue` then resolves a
+known export name to its value, else `UNRESOLVED`. A `ListExports` failure (e.g.
+a principal without `cloudformation:ListExports`) DEGRADES to empty exports — the
+consuming properties resolve `UNRESOLVED`, with a one-line warning — rather than
+hard-failing the whole stack check.
 
 > Trade-off to review: cdkd has a fuller `IntrinsicFunctionResolver`. We
 > deliberately wrote a focused, fail-closed one. The remaining `unresolved`

--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -135,16 +135,21 @@ export function buildResolverContext(
   };
 }
 
-// Per-region cache of CFn exports (Name -> Value). Listing exports is account+region
-// scoped, so a single fetch serves every ImportValue in the stack; cache so repeated
-// gather runs in the same process don't re-page.
+// Per-account+region cache of CFn exports (Name -> Value). CFn exports are scoped to
+// an account AND a region, so the cache key MUST carry BOTH axes: keying on region
+// alone would serve account A's exports to account B's same-region stack (a multi-account
+// run) — a wrong-value resolution surfacing as a declared false positive / a wrong revert
+// value. A single fetch serves every ImportValue in the stack; cache so repeated gather
+// runs in the same process don't re-page.
 const exportsCache = new Map<string, Record<string, string>>();
 
-async function listExports(
+export async function listExports(
   client: CloudFormationClient,
+  accountId: string,
   region: string
 ): Promise<Record<string, string>> {
-  const cached = exportsCache.get(region);
+  const cacheKey = `${accountId}:${region}`;
+  const cached = exportsCache.get(cacheKey);
   if (cached) return cached;
   const exports: Record<string, string> = {};
   let next: string | undefined;
@@ -153,7 +158,7 @@ async function listExports(
     for (const e of res.Exports ?? []) if (e.Name) exports[e.Name] = e.Value ?? '';
     next = res.NextToken;
   } while (next);
-  exportsCache.set(region, exports);
+  exportsCache.set(cacheKey, exports);
   return exports;
 }
 
@@ -269,7 +274,21 @@ export async function loadDesired(
   // UNRESOLVED and its declared property is silently skipped (missed drift).
   // parseTemplateBody has already normalized short-form tags to long-form `Fn::ImportValue`.
   if (JSON.stringify(template).includes('Fn::ImportValue')) {
-    ctx.exports = await listExports(client, region);
+    // DEGRADE, don't die: a principal with cloudformation:GetTemplate + DescribeStacks but
+    // NO cloudformation:ListExports would otherwise hard-fail the ENTIRE stack check (exit 2)
+    // over a permission gap that affects only one resolution axis. A read-only check should
+    // leave ctx.exports empty on failure — the ImportValue-consuming properties then resolve
+    // to `unresolved` (visible, and blocks --strict) instead of taking down the whole stack.
+    try {
+      ctx.exports = await listExports(client, accountId, region);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `warning: ${stackName}: cloudformation:ListExports failed — Fn::ImportValue references ` +
+          `will resolve UNRESOLVED (their declared properties are skipped, not compared). ` +
+          `Grant cloudformation:ListExports for full coverage. (${msg})`
+      );
+    }
   }
 
   const resources: DesiredResource[] = [];

--- a/tests/importvalue-784.test.ts
+++ b/tests/importvalue-784.test.ts
@@ -1,0 +1,132 @@
+// Regression tests for issue #784 — two gaps in Fn::ImportValue support:
+//   Gap 1: exportsCache keyed by region only (account axis missing) → account A's
+//          exports served to account B's same-region stack (wrong-value resolution).
+//   Gap 2: a ListExports permission error hard-failed the WHOLE stack check (exit 2)
+//          instead of degrading the ImportValue-consuming properties to `unresolved`.
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+  GetTemplateCommand,
+  ListExportsCommand,
+  ListStackResourcesCommand,
+} from '@aws-sdk/client-cloudformation';
+import { mockClient } from 'aws-sdk-client-mock';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { listExports, loadDesired } from '../src/desired/template-adapter.js';
+
+// A minimal fake CloudFormationClient whose send() returns a caller-supplied result and
+// counts calls — enough to exercise listExports' cache key directly.
+function fakeClient(sendImpl: () => Promise<unknown>) {
+  const send = vi.fn(sendImpl);
+  return { client: { send } as unknown as CloudFormationClient, send };
+}
+
+describe('listExports account+region cache key (#784 Gap 1)', () => {
+  it('does NOT serve account A exports to account B in the same region', async () => {
+    // send returns DIFFERENT exports per invocation so a cache hit is detectable.
+    let call = 0;
+    const { client, send } = fakeClient(async () => {
+      call += 1;
+      return call === 1
+        ? { Exports: [{ Name: 'Shared', Value: 'account-A-value' }] }
+        : { Exports: [{ Name: 'Shared', Value: 'account-B-value' }] };
+    });
+
+    const region = 'ap-southeast-2'; // distinct combo to avoid module-cache bleed
+    const a = await listExports(client, '111111111111', region);
+    const b = await listExports(client, '222222222222', region);
+
+    expect(a).toEqual({ Shared: 'account-A-value' });
+    // If the cache keyed on region alone, account B would receive account A's cached value.
+    expect(b).toEqual({ Shared: 'account-B-value' });
+    expect(b).not.toEqual(a);
+    expect(send).toHaveBeenCalledTimes(2); // separate account → separate fetch
+  });
+
+  it('caches on the SECOND call for the same account+region (single fetch)', async () => {
+    const { client, send } = fakeClient(async () => ({
+      Exports: [{ Name: 'Shared', Value: 'v' }],
+    }));
+
+    const acct = '333333333333';
+    const region = 'ca-central-1'; // distinct combo to avoid module-cache bleed
+    const first = await listExports(client, acct, region);
+    const second = await listExports(client, acct, region);
+
+    expect(second).toBe(first); // same cached object
+    expect(send).toHaveBeenCalledTimes(1); // second call served from cache
+  });
+});
+
+describe('loadDesired degrades on ListExports failure (#784 Gap 2)', () => {
+  function stackMocks(cfn: ReturnType<typeof mockClient>, templateBody: string) {
+    cfn.on(GetTemplateCommand).resolves({ TemplateBody: templateBody });
+    cfn.on(ListStackResourcesCommand).resolves({
+      StackResourceSummaries: [
+        {
+          LogicalResourceId: 'Q',
+          PhysicalResourceId: 'q-phys',
+          ResourceType: 'AWS::SQS::Queue',
+          LastUpdatedTimestamp: new Date(0),
+          ResourceStatus: 'CREATE_COMPLETE',
+        },
+      ],
+    });
+    cfn.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackId: 'arn:aws:cloudformation:eu-north-1:999988887777:stack/IV784/x',
+          StackName: 'IV784',
+          CreationTime: new Date(0),
+          StackStatus: 'CREATE_COMPLETE',
+          Parameters: [],
+        },
+      ],
+    });
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT throw when ListExports is denied; leaves the import UNRESOLVED', async () => {
+    const cfn = mockClient(CloudFormationClient);
+    stackMocks(
+      cfn,
+      JSON.stringify({
+        Resources: {
+          Q: { Type: 'AWS::SQS::Queue', Properties: { Tag: { 'Fn::ImportValue': 'SharedArn' } } },
+        },
+      })
+    );
+    const denied = Object.assign(
+      new Error('User is not authorized to perform: cloudformation:ListExports'),
+      {
+        name: 'AccessDeniedException',
+      }
+    );
+    cfn.on(ListExportsCommand).rejects(denied);
+
+    // Silence the degradation warning the fix emits to stderr, and assert it fired.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // distinct region so the module-level exports cache can't cross-contaminate.
+    const desired = await loadDesired(
+      cfn as unknown as CloudFormationClient,
+      'IV784',
+      'eu-north-1'
+    );
+
+    // No hard failure; the whole stack still loaded.
+    expect(desired.resources).toHaveLength(1);
+    // The import could not be resolved → the property is NOT the (missing) export value.
+    // ctx.exports stayed its default empty object, so the import degrades to unresolved
+    // (the declared property carries no resolved value from the export).
+    expect(desired.ctx.exports).toEqual({});
+    expect(desired.resources[0]!.declared).not.toEqual({ Tag: 'arn:aws:x:::shared' });
+
+    // The degradation was surfaced (not silently swallowed).
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0]![0])).toContain('cloudformation:ListExports');
+  });
+});


### PR DESCRIPTION
Closes #784

Two robustness gaps in `Fn::ImportValue` support (`src/desired/template-adapter.ts`).

## Gap 1 — exportsCache keyed by region only (account axis missing)
CFn exports are **account+region** scoped, but the process-wide cache keyed on region alone. Latent today (a run is effectively single-account), but the moment multi-account runs land, account A's exports get served to account B's same-region stack — a **wrong-value** resolution (declared FP / wrong revert value), not a visible `unresolved`. Fix: key on `${accountId}:${region}`.

## Gap 2 — ListExports failure hard-fails the whole stack check
The prefetch had no catch: a principal with `GetTemplate`+`DescribeStacks` but no `cloudformation:ListExports` got a hard error (exit 2) for the **entire** stack, instead of the ImportValue-consuming properties degrading to visible `unresolved` findings. Now wrapped: on failure leave `ctx.exports` empty (imports resolve `unresolved`, with a one-line warning) rather than dying.

## Test
`tests/importvalue-784.test.ts`: (1a) same region, different accountIds → no cross-account cache bleed; (1b) same account+region → cached (1 fetch); (2) loadDesired with a client rejecting ListExports → does not throw, exports empty, import unresolved, warning surfaced.

## Docs
`docs/ARCHITECTURE.md` ImportValue section updated (account+region key + degrade-on-failure).

Gates: typecheck / lint+format / build / 3208 tests all green.