### PR TITLE
fix(commands): error on a glob stack arg that matches no stacks (#778)

### DIFF
--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -100,10 +100,23 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
   const known = (): string => discovered.map((s) => s.stackName).join(', ') || 'none';
   for (const name of a.stackNames) {
     if (isGlob(name)) {
+      // Count MATCHES (matchesGlob true), NOT net add() calls: `add` dedups via
+      // `seen`, so a glob hitting an already-added stack is still a match and must
+      // NOT error. A glob that matches ZERO discovered stacks is a hard error,
+      // mirroring the exact-name-typo throw — otherwise `check 'Pord-*' Dev --fail`
+      // (a typo'd prod glob) silently checks nothing for the glob and exits 0, so
+      // CI believes prod was covered.
+      let matched = 0;
       for (const s of discovered) {
-        if (matchesGlob(name, s.stackName))
+        if (matchesGlob(name, s.stackName)) {
+          matched++;
           add(s.stackName, s.region ?? fallbackRegion, s.template);
+        }
       }
+      if (matched === 0)
+        throw new Error(
+          `glob "${name}" matched no stacks defined by the CDK app (found: ${known()})`
+        );
     } else {
       const hit = discovered.find((s) => s.stackName === name);
       if (!hit)

--- a/tests/glob-nomatch-778.test.ts
+++ b/tests/glob-nomatch-778.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// resolveStacks synthesizes a CDK app (resolveApp) and discovers its stacks
+// (discoverStacks) — both heavy. Mock them: resolveApp returns a truthy app,
+// discoverStacks returns a fixed set of discovered stacks so we can exercise the
+// name/glob matching in isolation.
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+const discovered = [{ stackName: 'Dev', region: 'us-east-1', template: {} }];
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: () => Promise.resolve(discovered),
+}));
+
+import type { CommonArgs } from '../src/cli-args.js';
+import { resolveStacks } from '../src/commands/resolve-stacks.js';
+
+// Minimal CommonArgs with only the fields resolveStacks reads; the rest are
+// defaulted to keep the fixture focused on stack resolution.
+function args(overrides: Partial<CommonArgs>): CommonArgs {
+  return {
+    stackNames: [],
+    all: false,
+    region: 'us-east-1',
+    profile: undefined,
+    app: undefined,
+    context: {},
+    json: false,
+    showAll: false,
+    yes: false,
+    preDeploy: false,
+    undeclaredOnly: false,
+    declaredOnly: false,
+    fail: false,
+    strict: false,
+    removeUnrecorded: false,
+    verbose: false,
+    waitMs: undefined,
+    ...overrides,
+  };
+}
+
+describe('resolveStacks — a glob positional that matches zero stacks is a hard error (#778)', () => {
+  beforeEach(() => {
+    // Some other stacks resolved fine — the aggregate result is NON-empty, which is
+    // exactly the case the old backstop `if (out.length === 0)` misses.
+  });
+
+  it('throws naming the unmatched glob even when a sibling exact name resolves', async () => {
+    // `check 'Pord-*' Dev` — the exact `Dev` resolves, so out.length > 0 and the
+    // aggregate check passes; without the per-glob count the typo'd `Pord-*` glob is
+    // silently ignored (exit 0). It must throw, naming the pattern.
+    await expect(resolveStacks(args({ stackNames: ['Pord-*', 'Dev'] }))).rejects.toThrow(
+      /glob "Pord-\*" matched no stacks/
+    );
+  });
+
+  it('throws for a lone no-match glob', async () => {
+    await expect(resolveStacks(args({ stackNames: ['Nope-*'] }))).rejects.toThrow(
+      /glob "Nope-\*" matched no stacks/
+    );
+  });
+
+  it('resolves a glob that DOES match plus an exact name (no false throw)', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dev*'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev']);
+  });
+
+  it('does not throw when a glob matches an ALREADY-added exact-name stack (dedup)', async () => {
+    // `Dev` is added by the exact name; `Dev*` then matches it again. `add` dedups so
+    // no net addition happens, but the glob DID match — counting matchesGlob hits (not
+    // add() calls) means it must NOT error.
+    const out = await resolveStacks(args({ stackNames: ['Dev', 'Dev*'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Dev']);
+  });
+
+  it('still throws the exact-name message for an unknown exact name', async () => {
+    await expect(resolveStacks(args({ stackNames: ['Missing'] }))).rejects.toThrow(
+      /stack "Missing" is not defined by the CDK app/
+    );
+  });
+});


### PR DESCRIPTION
Closes #778

## Problem
In `resolveStacks`, an exact stack name that doesn't exist throws per-name, but a **glob** positional matching zero stacks only errored when the *aggregate* result set was empty. So `cdkrd check 'Pord-*' Dev --fail` (a typo'd prod glob) checked `Dev`, silently checked **nothing** for the glob, and exited 0 — a CI pipeline believes prod was covered. A lone no-match glob does throw (the aggregate check), which is why the multi-arg case is easy to miss.

## Fix
Count `matchesGlob` **hits** per glob (not `add()` calls, which dedup via `seen` — a glob re-matching an already-added stack still counts) and throw the moment a glob matches zero discovered stacks, mirroring the exact-name-typo error.

## Test
`tests/glob-nomatch-778.test.ts` (5 cases): `['Pord-*','Dev']` rejects naming the glob (the core bug); lone no-match glob rejects; matching glob resolves; dedup case (glob re-matches an exact) does **not** error; exact-name typo unchanged.

Gates: typecheck / lint+format / build / 3210 tests all green.