### PR TITLE
fix(config): bracket-aware path glob + reject empty scope; doc glob semantics (#777)

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,9 +473,19 @@ ignore:
   non-CDK stack). Rules written with the older full `<stack>/<constructPath>.<path>`
   form still match. Widening a stamped scope to a `*` glob (to intentionally ignore a
   path across every stack/account/region) stays a hand-edit.
-- All four fields accept the same `*` / `?` glob, and a parent `path` covers child
-  paths. The three scope axes — **stack, account, region** — are exactly the
-  baseline file's identity axes. **Account** keeps a `stack: "Prod*"` rule from
+- All four fields accept `*` / `?` globs, but the `path` axis is **segment-aware**
+  while the scope axes are not. In `path`, `*` / `?` match within a single `.`-delimited
+  segment (`*.DesiredCount` matches `<anyId>.DesiredCount`, not a deeper
+  `Tbl.Config.DesiredCount`) — a parent `path` still covers child paths via the subtree
+  walk, so the segment bound does not under-match. Inside a `[...]` bracket key a `*` /
+  `?` is **unbounded within that bracket** (the brackets delimit the key, so a `.`
+  between them is data): `Alb.LoadBalancerAttributes[*]` and
+  `Alb.LoadBalancerAttributes[routing.*]` both match the dotted key
+  `[routing.http2.enabled]`. On **stack / account / region**, `*` / `?` are unbounded
+  (those names carry no `.`). The three scope axes are exactly the
+  baseline file's identity axes; each is **omitted to leave that axis unscoped**
+  (match-all) — a present-but-empty `""` is rejected (it would match nothing).
+  **Account** keeps a `stack: "Prod*"` rule from
   leaking into a same-named stack in another account (stack-name uniqueness only
   holds within one account / App); **region** is independent the same way — the same
   stack in several accounts or regions may drift in only one.

--- a/src/commands/glob-match.ts
+++ b/src/commands/glob-match.ts
@@ -40,13 +40,25 @@ export function matchesGlob(pattern: string, name: string): boolean {
  * (`X.Policies` covering `X.Policies[Mp].Name`) is handled separately by the ancestor
  * walk in `pathMatches`, so bounding `*` here does not under-match. The stack/region
  * axes keep `matchesGlob` (their names contain no `.`/`[`, so it is equivalent there).
+ *
+ * INSIDE a `[...]` bracket segment a `*` / `?` is UNBOUNDED within that bracket: the
+ * brackets already delimit the key, so a `.` between them is DATA, not a segment
+ * boundary — cdkrd's own canonical paths carry dotted bracket keys such as
+ * `Alb.LoadBalancerAttributes[routing.http2.enabled]`. So `...[*]` and `...[routing.*]`
+ * match those keys, while `.` OUTSIDE brackets stays a hard segment boundary. A `*`/`?`
+ * inside a bracket may not cross the closing `]` (still one bracket segment).
  */
 export function matchesPathGlob(pattern: string, target: string): boolean {
   let out = '^';
+  let inBracket = false;
   for (const ch of pattern.replace(/\*+/g, '*')) {
-    if (ch === '*') out += '[^.[]*';
-    else if (ch === '?') out += '[^.[]';
-    else out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (ch === '*') out += inBracket ? '[^\\]]*' : '[^.[]*';
+    else if (ch === '?') out += inBracket ? '[^\\]]' : '[^.[]';
+    else {
+      if (ch === '[') inBracket = true;
+      else if (ch === ']') inBracket = false;
+      out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
   }
   out += '$';
   return new RegExp(out).test(target);

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -145,9 +145,16 @@ function validateIgnoreEntry(entry: unknown, index: number): void {
     // and the ancestor walk never reaches empty) — a silent no-op rule the user believes
     // is suppressing a property. Reject it loudly so the no-op can't masquerade as active.
     throw new Error(`${at}: "path" must not be empty`);
-  for (const k of ['stack', 'account', 'region'] as const)
+  for (const k of ['stack', 'account', 'region'] as const) {
     if (obj[k] !== undefined && typeof obj[k] !== 'string')
       throw new Error(`${at}: "${k}" must be a string`);
+    if (obj[k] === '')
+      // a present-but-empty scope axis matches NOTHING (the glob `^$` never matches a
+      // real stack/account/region), so the whole rule silently suppresses nothing — the
+      // same silent no-op trap as an empty `path`. Reject it loudly; omit the key to
+      // leave the axis unscoped (match-all).
+      throw new Error(`${at}: "${k}" must not be empty (omit it to leave the axis unscoped)`);
+  }
 }
 
 /**

--- a/tests/glob-gaps-777.test.ts
+++ b/tests/glob-gaps-777.test.ts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { matchesPathGlob } from '../src/commands/glob-match.js';
+import { loadConfig } from '../src/config/config-file.js';
+
+// Issue #777 — two "rule silently never matches" traps.
+
+describe('matchesPathGlob — bracket-aware `*` / `?` (#777 part 1)', () => {
+  // cdkrd's own canonical ELB attribute paths carry DOTTED bracket keys; a `*` inside a
+  // `[...]` bracket is unbounded within that bracket (the `.` between brackets is data,
+  // not a segment boundary), so these must match.
+  const albKey = 'Alb.LoadBalancerAttributes[routing.http2.enabled]';
+
+  it('`[*]` matches a dotted bracket key', () => {
+    expect(matchesPathGlob('Alb.LoadBalancerAttributes[*]', albKey)).toBe(true);
+    expect(
+      matchesPathGlob(
+        'Alb.LoadBalancerAttributes[*]',
+        'Alb.LoadBalancerAttributes[idle_timeout.timeout_seconds]'
+      )
+    ).toBe(true);
+    expect(
+      matchesPathGlob(
+        'Alb.LoadBalancerAttributes[*]',
+        'Alb.LoadBalancerAttributes[access_logs.s3.enabled]'
+      )
+    ).toBe(true);
+    // simple (no-dot) key still matches, as before
+    expect(matchesPathGlob('Tags[*]', 'Tags[env]')).toBe(true);
+  });
+
+  it('`[prefix.*]` matches the rest of a dotted bracket key', () => {
+    expect(matchesPathGlob('Alb.LoadBalancerAttributes[routing.*]', albKey)).toBe(true);
+    expect(matchesPathGlob('Alb.LoadBalancerAttributes[routing.http2.*]', albKey)).toBe(true);
+  });
+
+  it('a bracket `*` does NOT cross the closing `]` (still one bracket segment)', () => {
+    expect(matchesPathGlob('Alb.LoadBalancerAttributes[*]', `${albKey}.Sub`)).toBe(false);
+    expect(matchesPathGlob('Tags[*]', 'Tags[env].Sub')).toBe(false);
+  });
+
+  it('a `*` OUTSIDE brackets still does NOT cross a `.` segment boundary', () => {
+    expect(matchesPathGlob('*.DesiredCount', 'Svc123.DesiredCount')).toBe(true);
+    expect(matchesPathGlob('*.DesiredCount', 'Tbl.Config.DesiredCount')).toBe(false);
+    expect(matchesPathGlob('Alb.*', 'Alb.LoadBalancerAttributes')).toBe(true);
+    // the segment star must not swallow the dotted tail outside brackets
+    expect(matchesPathGlob('Alb.*', albKey)).toBe(false);
+  });
+
+  it('`?` inside a bracket matches one char but does not cross `]`', () => {
+    expect(matchesPathGlob('Tags[en?]', 'Tags[env]')).toBe(true);
+    expect(matchesPathGlob('Tags[?]', 'Tags[e]')).toBe(true);
+    expect(matchesPathGlob('Tags[?]', 'Tags[env]')).toBe(false); // exactly one char
+  });
+});
+
+describe('loadConfig — reject present-but-empty scope axes (#777 part 2)', () => {
+  let dir: string;
+  let prevCwd: string;
+  beforeEach(async () => {
+    prevCwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-777-'));
+    process.chdir(dir);
+  });
+  afterEach(async () => {
+    process.chdir(prevCwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const write = async (content: string) => {
+    await mkdir('.cdkrd', { recursive: true });
+    await writeFile('.cdkrd/ignore.yaml', content, 'utf8');
+  };
+
+  it('empty `stack` → throws (would match nothing, a silent no-op rule)', async () => {
+    await write('ignore:\n  - path: x\n    stack: ""\n');
+    await expect(loadConfig()).rejects.toThrow(/"stack" must not be empty/);
+  });
+
+  it('empty `account` → throws', async () => {
+    await write('ignore:\n  - path: x\n    account: ""\n');
+    await expect(loadConfig()).rejects.toThrow(/"account" must not be empty/);
+  });
+
+  it('empty `region` → throws', async () => {
+    await write('ignore:\n  - path: x\n    region: ""\n');
+    await expect(loadConfig()).rejects.toThrow(/"region" must not be empty/);
+  });
+
+  it('a scope axis simply OMITTED is fine (unscoped = match-all)', async () => {
+    await write('ignore:\n  - path: x\n');
+    expect(await loadConfig()).toEqual({ ignore: [{ path: 'x' }] });
+  });
+});


### PR DESCRIPTION
Closes #777