### PR TITLE
fix(baseline): validate baseline elements + guard reused-logicalId type mismatch (#794, #793)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -108,7 +108,67 @@ export async function loadBaseline(
     );
   if (!Array.isArray(parsed.recorded))
     throw new Error(`baseline file ${path} is malformed: \`recorded\` is missing or not an array`);
+  // Element-level validation (#794): the container shape passing is not enough — a
+  // baseline is git-committed, hand-editable, and merge-conflictable, so a malformed
+  // ELEMENT (a `null` entry from a bad merge, a scalar where an array/map is expected)
+  // must fail LOUDLY here (naming the file + the offending index/key) rather than crash
+  // opaquely deep in applyBaseline (`recorded.find` on a null → "Cannot read properties
+  // of null") or silently misbehave (`new Set("MyRes")` iterating string CHARACTERS,
+  // turning completeness quietly off). Same loud-vs-silent principle the ignore.yaml
+  // validation applies (config-file.ts validateIgnoreEntry).
+  parsed.recorded.forEach((entry, i) => validateRecordedEntry(entry, i, path));
+  validateCompleteResources(parsed.completeResources, path);
+  validateRecordedPhysicalIds(parsed.recordedPhysicalIds, path);
   return parsed;
+}
+
+/**
+ * #794: validate one `recorded` array element. Each must be a non-null object with a
+ * string `logicalId` and a string `path` (the two fields the match logic reads —
+ * `recorded.find(a => a.logicalId === … && a.path === …)`), plus a string `resourceType`
+ * (used for the #793 type-mismatch guard and stamped onto the synthetic removed-since-record
+ * finding). `value` is intentionally unconstrained (any JSON is a valid recorded value,
+ * including `null`). Errors name the file + the offending index/key, mirroring the
+ * ignore.yaml validation style.
+ */
+function validateRecordedEntry(entry: unknown, index: number, path: string): void {
+  const at = `baseline file ${path}: \`recorded\`[${index}]`;
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry))
+    throw new Error(`${at} must be an object { logicalId, resourceType, path, value }`);
+  const obj = entry as Record<string, unknown>;
+  for (const k of ['logicalId', 'resourceType', 'path'] as const)
+    if (typeof obj[k] !== 'string')
+      throw new Error(`${at}: "${k}" is required and must be a string`);
+}
+
+/**
+ * #794: validate `completeResources` (optional; absent on v1 files). When present it must
+ * be an array of strings — a bare string would have `new Set(...)` iterate its CHARACTERS
+ * (silently mis-scoping completeness), and a number would crash with an opaque
+ * "not iterable" later. Reject both loudly, naming the file + index.
+ */
+function validateCompleteResources(value: unknown, path: string): void {
+  if (value === undefined) return;
+  const at = `baseline file ${path}: \`completeResources\``;
+  if (!Array.isArray(value)) throw new Error(`${at} must be an array of strings`);
+  value.forEach((v, i) => {
+    if (typeof v !== 'string') throw new Error(`${at}[${i}] must be a string`);
+  });
+}
+
+/**
+ * #794: validate `recordedPhysicalIds` (optional; #674). When present it must be a plain
+ * object mapping string logicalId -> string physical id — `Object.entries` on a non-object
+ * or a non-string value would otherwise mis-drive the #674 replacement check silently.
+ * Reject non-object shapes and non-string values loudly, naming the file + key.
+ */
+function validateRecordedPhysicalIds(value: unknown, path: string): void {
+  if (value === undefined) return;
+  const at = `baseline file ${path}: \`recordedPhysicalIds\``;
+  if (typeof value !== 'object' || value === null || Array.isArray(value))
+    throw new Error(`${at} must be an object mapping logicalId to physical id`);
+  for (const [key, v] of Object.entries(value as Record<string, unknown>))
+    if (typeof v !== 'string') throw new Error(`${at}: "${key}" must map to a string`);
 }
 
 /** Deterministic order for `recorded` entries: lexicographic by (logicalId, path).
@@ -455,8 +515,13 @@ export function splitRecordedByBaseline(
   const unchanged: RecordedEntry[] = [];
   const changed: RecordedEntry[] = [];
   for (const entry of recorded) {
+    // #793: match on resourceType too — a logicalId reused for a different type must not
+    // match the old-type baseline entry (which would falsely read as "unchanged").
     const baselineEntry = baseline.recorded.find(
-      (a) => a.logicalId === entry.logicalId && a.path === entry.path
+      (a) =>
+        a.logicalId === entry.logicalId &&
+        a.path === entry.path &&
+        a.resourceType === entry.resourceType
     );
     if (baselineEntry && baselineValueMatches(baselineEntry.value, entry.value))
       unchanged.push(entry);
@@ -563,6 +628,28 @@ export function applyBaseline(
     const liveId = opts.physicalIdByLogical?.get(logicalId);
     if (liveId !== undefined && liveId !== recordedId) replacedLogical.add(logicalId);
   }
+  // #793: a logicalId's CURRENT resource type (from the live findings). A recorded entry
+  // whose `resourceType` differs from the live type belongs to an OLD resource that was
+  // deleted and re-added under the SAME logicalId as a DIFFERENT type (a template refactor
+  // that recycled the id). Its recorded values are meaningless against the new type — worse,
+  // the synthetic "removed since record" finding would pair the entry's OLD resourceType
+  // with the new resource's LIVE physical id, so a revert would issue an op with the wrong
+  // TypeName against the new resource. Treat such an entry as VOID, exactly like the #674
+  // physical-id-mismatch path. Only voids when a live type is KNOWN and DIFFERS (an unread
+  // logicalId has no finding here → no known live type → today's behavior, no void).
+  const liveTypeByLogical = new Map<string, string>();
+  for (const f of findings) if (f.resourceType) liveTypeByLogical.set(f.logicalId, f.resourceType);
+  // #793: an entry is type-VOID when a live type is known for its logicalId and disagrees
+  // with the entry's recorded type. Used both at the match sites (so it never suppresses /
+  // surfaces against the wrong type) and in the removed-since-record loop below.
+  const isTypeVoid = (e: { logicalId: string; resourceType: string }): boolean => {
+    const liveType = liveTypeByLogical.get(e.logicalId);
+    return liveType !== undefined && liveType !== e.resourceType;
+  };
+  // #793: match a recorded entry to a finding on logicalId + path AND resource type, so a
+  // logicalId reused for a different type never matches old-type entries.
+  const entryMatches = (a: RecordedEntry, f: Finding): boolean =>
+    a.logicalId === f.logicalId && a.path === f.path && a.resourceType === f.resourceType;
   for (const f of findings) {
     // PR4: reconcile `added` against the baseline as a full mirror of undeclared — but on
     // the WHOLE resource (path ''), not a property. A matching entry whose value is equal
@@ -573,7 +660,7 @@ export function applyBaseline(
     // resource, and an added child has a synthesized id that never enters allLogicalIds),
     // so a newly-appeared added resource is simply unrecorded until the user records it.
     if (f.tier === 'added') {
-      const entry = recorded.find((a) => a.logicalId === f.logicalId && a.path === f.path);
+      const entry = recorded.find((a) => entryMatches(a, f));
       // PR4: the full model could not be read this run — `actual` is only the identity
       // snippet, so we CANNOT decide changed-vs-unchanged. Never false-flag "changed": a
       // recorded resource is suppressed (it was verified before; re-checked next clean
@@ -612,7 +699,7 @@ export function applyBaseline(
     // value on the new resource is unrecorded, not drift — the user never recorded IT).
     const entry = replacedLogical.has(f.logicalId)
       ? undefined
-      : recorded.find((a) => a.logicalId === f.logicalId && a.path === f.path);
+      : recorded.find((a) => entryMatches(a, f));
     // re-canonicalize the baseline value through the CURRENT pipeline before comparing
     // (f.actual is already canonical from classify): a baseline recorded under older
     // normalization rules still matches today's live, so a cdkrd version bump alone
@@ -713,12 +800,21 @@ export function applyBaseline(
   const promotedStale: string[] = [];
   const removedFromTemplate: string[] = []; // #675
   const replacedStale: string[] = []; // #674
+  const typeMismatchStale: string[] = []; // #793
   for (const a of recorded) {
     // PR4: an `added`-resource entry has an empty path (the whole resource is the value)
     // and is reconciled in the loop above, never here. If its live resource is gone the
     // out-of-band addition was simply removed — nothing to "restore", so skip it (a
     // property-removal note against a synthesized child id would be meaningless).
     if (a.path === '') continue;
+    // #793: the logicalId now hosts a DIFFERENT resource type (id reused across a refactor),
+    // so this entry belongs to the old type. Void it: without this the synthetic "removed
+    // since record" finding below would pair the entry's OLD resourceType with the new
+    // resource's LIVE physical id, so a revert would issue an op with the wrong TypeName.
+    if (isTypeVoid(a)) {
+      typeMismatchStale.push(`${a.logicalId}.${a.path}`);
+      continue;
+    }
     // #674: the resource was REPLACED by a deploy — this entry belongs to the old,
     // deleted physical resource, so it is void, not "removed since record". Fold it.
     if (replacedLogical.has(a.logicalId)) {
@@ -773,6 +869,7 @@ export function applyBaseline(
   if (removedFromTemplate.length > 0)
     opts.warn?.(formatRemovedFromTemplateNote(removedFromTemplate));
   if (replacedStale.length > 0) opts.warn?.(formatReplacedStaleNote(replacedStale));
+  if (typeMismatchStale.length > 0) opts.warn?.(formatTypeMismatchStaleNote(typeMismatchStale));
   return kept;
 }
 
@@ -808,6 +905,18 @@ export function formatReplacedStaleNote(paths: string[]): string {
   const n = paths.length;
   const subject = n === 1 ? `baseline entry (${paths[0]}) was` : `${n} baseline entries were`;
   return `note: ${subject} recorded against a resource since REPLACED by a deploy — re-run \`cdkrd record\`.`;
+}
+
+/**
+ * #793: the folded one-line note for baseline entries whose logicalId now hosts a resource
+ * of a DIFFERENT type (the id was recycled across a template refactor). The old-type entries
+ * are void against the new resource. Mirror of formatReplacedStaleNote. Pure + exported for
+ * unit tests.
+ */
+export function formatTypeMismatchStaleNote(paths: string[]): string {
+  const n = paths.length;
+  const subject = n === 1 ? `baseline entry (${paths[0]}) was` : `${n} baseline entries were`;
+  return `note: ${subject} recorded against a resource whose logicalId now has a DIFFERENT type — re-run \`cdkrd record\`.`;
 }
 
 /** logicalId -> set of declared top-level keys, for applyBaseline's promotion check. */

--- a/tests/baseline-resourcetype-793.test.ts
+++ b/tests/baseline-resourcetype-793.test.ts
@@ -1,0 +1,103 @@
+// #793: baseline entries store `resourceType` but the match ignored it. A logicalId reused
+// for a DIFFERENT type (delete + re-add / refactor recycling the id) must not match the
+// old-type entries. Worst case: the synthetic "baseline value removed since record" finding
+// would pair the entry's OLD resourceType with the new resource's LIVE physical id → a
+// revert would issue an op with the wrong TypeName. Guard: an entry whose resourceType
+// disagrees with the live finding's type is VOID.
+
+import { describe, expect, it } from 'vite-plus/test';
+import { applyBaseline, type BaselineFile } from '../src/baseline/baseline-file.js';
+import type { Finding } from '../src/types.js';
+
+const OLD_TYPE = 'AWS::SQS::Queue';
+const NEW_TYPE = 'AWS::SNS::Topic';
+
+function baseline(recorded: BaselineFile['recorded']): BaselineFile {
+  return {
+    schemaVersion: 2,
+    stackName: 's',
+    region: 'r',
+    accountId: '111122223333',
+    capturedAt: '',
+    templateHash: '',
+    recorded,
+    completeResources: recorded.map((e) => e.logicalId),
+  };
+}
+
+const undeclared = (
+  logicalId: string,
+  resourceType: string,
+  path: string,
+  actual: unknown
+): Finding => ({
+  tier: 'undeclared',
+  logicalId,
+  resourceType,
+  path,
+  actual,
+});
+
+describe('#793 resourceType-mismatch void guard', () => {
+  it('a same-logicalId same-value entry of a DIFFERENT type does not suppress the live value', () => {
+    // Old baseline: logicalId "R" was an SQS::Queue with VisibilityTimeout=30.
+    // The template now hosts an SNS::Topic under "R", live value also 30 (coincidence).
+    // Without the type guard the entry would MATCH+suppress; with it, the SNS value is
+    // reconciled as unrecorded (no entry for the NEW type), not silently suppressed.
+    const b = baseline([{ logicalId: 'R', resourceType: OLD_TYPE, path: 'X', value: 30 }]);
+    const live = [undeclared('R', NEW_TYPE, 'X', 30)];
+    const out = applyBaseline(live, b, {});
+    // completeResources says R is complete → an entry-less value "appeared since record",
+    // NOT suppressed as a matching baseline value. Either way it must NOT be dropped.
+    expect(out).toHaveLength(1);
+    expect(out[0]?.resourceType).toBe(NEW_TYPE);
+    // it did not silently vanish as a suppressed match
+    expect(out[0]?.note).toMatch(/appeared since record/);
+  });
+
+  it('no synthetic "removed since record" finding pairs the OLD type with the new resource', () => {
+    // Old entry for a path the NEW type does not have. Without the guard this becomes a
+    // synthetic "baseline value removed since record" finding carrying resourceType=OLD_TYPE
+    // and (via physicalIdByLogical) the NEW resource's physical id — a revert landmine.
+    const b = baseline([
+      { logicalId: 'R', resourceType: OLD_TYPE, path: 'OldOnlyProp', value: 'v' },
+    ]);
+    const live = [undeclared('R', NEW_TYPE, 'DifferentProp', 'w')];
+    const out = applyBaseline(live, b, {
+      physicalIdByLogical: new Map([['R', 'arn:new-topic']]),
+    });
+    // No finding should carry the OLD type paired with the NEW physical id.
+    const stale = out.find(
+      (f) => f.resourceType === OLD_TYPE && f.note === 'baseline value removed since record'
+    );
+    expect(stale).toBeUndefined();
+    // Nothing at all should reference OldOnlyProp for the mismatched-type resource.
+    expect(out.some((f) => f.path === 'OldOnlyProp')).toBe(false);
+  });
+
+  it('a SAME-type entry still matches and suppresses (guard does not over-void)', () => {
+    const b = baseline([{ logicalId: 'R', resourceType: OLD_TYPE, path: 'X', value: 30 }]);
+    const live = [undeclared('R', OLD_TYPE, 'X', 30)];
+    const out = applyBaseline(live, b, {});
+    // matching same-type entry with equal value is suppressed
+    expect(out).toHaveLength(0);
+  });
+
+  it('a SAME-type entry whose value changed still surfaces as drift', () => {
+    const b = baseline([{ logicalId: 'R', resourceType: OLD_TYPE, path: 'X', value: 30 }]);
+    const live = [undeclared('R', OLD_TYPE, 'X', 999)];
+    const out = applyBaseline(live, b, {});
+    expect(out).toHaveLength(1);
+    expect(out[0]?.tier).toBe('undeclared');
+    expect(out[0]?.actual).toBe(999); // the changed live value surfaces as drift
+  });
+
+  it("an entry for a logicalId with NO live finding (unread) keeps today's behavior", () => {
+    // No live finding for R at all → live type unknown → not type-void → the removed-since-
+    // record path applies as before (surfaces as a removal finding of the recorded type).
+    const b = baseline([{ logicalId: 'R', resourceType: OLD_TYPE, path: 'X', value: 30 }]);
+    const out = applyBaseline([], b, {});
+    const removal = out.find((f) => f.note === 'baseline value removed since record');
+    expect(removal?.resourceType).toBe(OLD_TYPE);
+  });
+});

--- a/tests/baseline-validate-794.test.ts
+++ b/tests/baseline-validate-794.test.ts
@@ -1,0 +1,127 @@
+// #794: loadBaseline element-level validation — a hand-edited / merge-conflicted baseline
+// (git-committed, so it CAN be malformed) must fail LOUDLY naming the file + the offending
+// index/key, not crash opaquely deep in applyBaseline or silently disable completeness.
+//
+// #793: a logicalId reused for a DIFFERENT resource type must void the old-type baseline
+// entries — never suppress/surface against the new type, never emit a "removed since record"
+// finding pairing the OLD resourceType with the new resource's live physical id.
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { type BaselineFile, baselinePath, loadBaseline } from '../src/baseline/baseline-file.js';
+
+const ACCOUNT = '111122223333';
+const REGION = 'r';
+const STACK = 's';
+
+// Write a raw JSON string to the baseline path loadBaseline() reads, then load it.
+async function loadRaw(rawJson: string): Promise<BaselineFile | undefined> {
+  const p = baselinePath(STACK, ACCOUNT, REGION);
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, rawJson, 'utf8');
+  return loadBaseline(STACK, ACCOUNT, REGION);
+}
+
+describe('#794 loadBaseline element-level validation', () => {
+  let cwd: string;
+  let dir: string;
+  beforeEach(async () => {
+    cwd = process.cwd();
+    dir = await mkdtemp(join(tmpdir(), 'cdkrd-baseline-794-'));
+    process.chdir(dir);
+  });
+  afterEach(async () => {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const base = (extra: Record<string, unknown>): string =>
+    JSON.stringify({
+      schemaVersion: 2,
+      stackName: STACK,
+      region: REGION,
+      accountId: ACCOUNT,
+      capturedAt: '',
+      templateHash: '',
+      recorded: [],
+      ...extra,
+    });
+
+  it('a null element in `recorded` throws, naming the file + index', async () => {
+    await expect(loadRaw(base({ recorded: [null] }))).rejects.toThrow(
+      /baseline file .*`recorded`\[0\] must be an object/
+    );
+  });
+
+  it('a `recorded` element missing a string logicalId throws, naming the file + key', async () => {
+    await expect(
+      loadRaw(base({ recorded: [{ resourceType: 'AWS::X::Y', path: 'P', value: 1 }] }))
+    ).rejects.toThrow(
+      /baseline file .*`recorded`\[0\]: "logicalId" is required and must be a string/
+    );
+  });
+
+  it('a `recorded` element with a non-string resourceType throws', async () => {
+    await expect(
+      loadRaw(base({ recorded: [{ logicalId: 'L', resourceType: 42, path: 'P', value: 1 }] }))
+    ).rejects.toThrow(/`recorded`\[0\]: "resourceType" is required and must be a string/);
+  });
+
+  it('a scalar (non-object) `recorded` element throws', async () => {
+    await expect(loadRaw(base({ recorded: ['MyRes'] }))).rejects.toThrow(
+      /`recorded`\[0\] must be an object/
+    );
+  });
+
+  it('completeResources as a bare string throws (would silently iterate CHARACTERS)', async () => {
+    await expect(loadRaw(base({ completeResources: 'MyRes' }))).rejects.toThrow(
+      /baseline file .*`completeResources` must be an array of strings/
+    );
+  });
+
+  it('completeResources as a number throws (opaque "not iterable" otherwise)', async () => {
+    await expect(loadRaw(base({ completeResources: 42 }))).rejects.toThrow(
+      /`completeResources` must be an array of strings/
+    );
+  });
+
+  it('completeResources with a non-string element throws, naming the index', async () => {
+    await expect(loadRaw(base({ completeResources: ['ok', 5] }))).rejects.toThrow(
+      /`completeResources`\[1\] must be a string/
+    );
+  });
+
+  it('recordedPhysicalIds as an array throws', async () => {
+    await expect(loadRaw(base({ recordedPhysicalIds: ['x'] }))).rejects.toThrow(
+      /`recordedPhysicalIds` must be an object mapping logicalId to physical id/
+    );
+  });
+
+  it('recordedPhysicalIds with a non-string value throws, naming the key', async () => {
+    await expect(loadRaw(base({ recordedPhysicalIds: { L: 123 } }))).rejects.toThrow(
+      /`recordedPhysicalIds`: "L" must map to a string/
+    );
+  });
+
+  it('a well-formed baseline still loads', async () => {
+    const loaded = await loadRaw(
+      base({
+        recorded: [{ logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P', value: 1 }],
+        completeResources: ['L'],
+        recordedPhysicalIds: { L: 'phys-1' },
+      })
+    );
+    expect(loaded?.recorded).toHaveLength(1);
+    expect(loaded?.completeResources).toEqual(['L']);
+    expect(loaded?.recordedPhysicalIds).toEqual({ L: 'phys-1' });
+  });
+
+  it('a v1 baseline (no completeResources / recordedPhysicalIds) still loads', async () => {
+    const loaded = await loadRaw(
+      base({ recorded: [{ logicalId: 'L', resourceType: 'AWS::X::Y', path: 'P', value: 1 }] })
+    );
+    expect(loaded?.recorded).toHaveLength(1);
+  });
+});

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -181,10 +181,15 @@ describe('baseline', () => {
   });
 
   describe('atDefault reconciliation (R86 — folded inventory, never drift, never a false removal)', () => {
-    const atDefault = (logicalId: string, path: string, value: unknown): Finding => ({
+    const atDefault = (
+      logicalId: string,
+      path: string,
+      value: unknown,
+      resourceType = 'AWS::Lambda::Function'
+    ): Finding => ({
       tier: 'atDefault',
       logicalId,
-      resourceType: 'AWS::Lambda::Function',
+      resourceType,
       path,
       actual: value,
     });
@@ -217,7 +222,10 @@ describe('baseline', () => {
           value: { alg: 'AES256' },
         },
       ]);
-      const out = applyBaseline([atDefault('Bkt', 'Encryption', { alg: 'AES256' })], b);
+      const out = applyBaseline(
+        [atDefault('Bkt', 'Encryption', { alg: 'AES256' }, 'AWS::S3::Bucket')],
+        b
+      );
       expect(out).toEqual([]);
     });
 
@@ -229,7 +237,7 @@ describe('baseline', () => {
       const b = baseline([
         { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'MaxSessionDuration', value: 7200 },
       ]);
-      const out = applyBaseline([atDefault('A', 'MaxSessionDuration', 3600)], b);
+      const out = applyBaseline([atDefault('A', 'MaxSessionDuration', 3600, 'AWS::IAM::Role')], b);
       expect(out).toHaveLength(1);
       expect(out[0]).toMatchObject({
         tier: 'undeclared',
@@ -358,7 +366,7 @@ describe('baseline', () => {
 
     it('applyBaseline attaches arrayDelta to a changed recorded array (display-only, path stays whole)', () => {
       const b = baseline([
-        { logicalId: 'A', resourceType: 'AWS::IAM::Role', path: 'Policies', value: [p('a', 1)] },
+        { logicalId: 'A', resourceType: 'AWS::X::Y', path: 'Policies', value: [p('a', 1)] },
       ]);
       const out = applyBaseline([undeclared('A', 'Policies', [p('a', 1), p('aaa', 2)])], b);
       expect(out).toHaveLength(1);


### PR DESCRIPTION
Closes #794
Closes #793