### PR TITLE
docs(check): rule out a stale worktree cache before calling a vp check failure a main regression

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -49,6 +49,15 @@ Report as a table:
 If all pass, confirm "All checks passed."
 If any fail, show the error output and STOP — do not write the commit-gate marker.
 
+**Before treating a failure in a file you did NOT touch as a real (or peer-introduced)
+`main` regression, rule out a stale worktree cache.** A long-lived worktree's
+tsgo/oxc cache can REPLAY phantom errors from an earlier dependency/lockfile state
+(the inverse of the cache MASKING real ones). If CI on `main` is green and the
+failure is in code outside your diff, REPRODUCE it in a throwaway fresh worktree
+(`git worktree add … main` → `pnpm install` → `vp check`) before reporting "main is
+red" or opening a fix lane — a clean fresh worktree means the error was a local cache
+artifact, not a regression.
+
 ## Commit-gate marker (on success only)
 
 After all four checks pass, record the `check` marker so the markgate `check`


### PR DESCRIPTION
docs(check): rule out a stale worktree cache before calling a vp check failure a main regression

A long-lived worktree's tsgo/oxc cache can REPLAY phantom errors from an earlier
dependency/lockfile state (the inverse of the cache masking real errors) — this
session it printed 9 non-existent TS2353 in a file the diff never touched, which a
fresh worktree off the same main showed clean. Add a note to /check's Output
section: when a failure lands in code outside your diff and CI on main is green,
reproduce in a throwaway fresh worktree before reporting "main is red" or opening a
fix lane.

Docs/tooling-only (no src/**). CI-equivalent (vp run check) green.
