### PR TITLE
fix(cli): reject verb-inapplicable flags (record --dry-run et al) (#780)

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -24,6 +24,48 @@ const BOOLEAN_FLAGS = new Set([
   '--all',
 ]);
 
+/** The four verbs, so parseCommonArgs can reject a flag the running verb never consumes. */
+export type Verb = 'check' | 'record' | 'ignore' | 'revert';
+
+// Canonical (long) form of a flag alias, for the per-verb applicability check below.
+const CANONICAL_FLAG: Record<string, string> = {
+  '-y': '--yes',
+  '-v': '--verbose',
+  '-a': '--app',
+  '-c': '--context',
+};
+const canonicalFlag = (flag: string): string => CANONICAL_FLAG[flag] ?? flag;
+
+// Flags every verb accepts (identity/targeting/output surface consumed by the shared
+// gather + report layers regardless of verb). `--json` suppresses the gather spinner and
+// selects JSON output where a verb emits it; `--yes` skips a confirm on every verb that
+// has one (check's inline actions included).
+const GLOBAL_FLAGS = ['--region', '--profile', '--app', '--context', '--all', '--json', '--yes'];
+
+// Per-verb allowed flag surface (canonical names), so a verb-INAPPLICABLE flag fails fast
+// with the same loud exit-2 as an unknown flag instead of being silently accepted — the
+// worst instances (`record --dry-run` WRITING the baseline it claims to preview,
+// `record --fail` never failing CI) invert the user's intent (#780). Derived from the flags
+// each command actually reads (`a.<flag>` in src/commands/<verb>.ts): only `check` consumes
+// the scope/coverage flags; `--dry-run` / `--wait` are revert-only; `--remove-unrecorded`
+// is read by `check` (its inline revert) and `revert`; `--verbose` by all but `ignore`.
+const ALLOWED_FLAGS_BY_VERB: Record<Verb, Set<string>> = {
+  check: new Set([
+    ...GLOBAL_FLAGS,
+    '--fail',
+    '--strict',
+    '--show-all',
+    '--pre-deploy',
+    '--undeclared-only',
+    '--declared-only',
+    '--verbose',
+    '--remove-unrecorded',
+  ]),
+  record: new Set([...GLOBAL_FLAGS, '--verbose']),
+  ignore: new Set(GLOBAL_FLAGS),
+  revert: new Set([...GLOBAL_FLAGS, '--verbose', '--remove-unrecorded', '--dry-run', '--wait']),
+};
+
 export interface CommonArgs {
   stackNames: string[]; // positional stack names (may be empty → all stacks the CDK app defines)
   all: boolean; // explicitly target EVERY stack the app defines (the default when no name is given); overrides any positional names
@@ -77,7 +119,7 @@ export function isInteractive(): boolean {
   return Boolean(process.stdin.isTTY);
 }
 
-export function parseCommonArgs(args: string[]): CommonArgs {
+export function parseCommonArgs(args: string[], verb?: Verb): CommonArgs {
   const values: Record<string, string> = {}; // canonical value-flag → its (last) value
   const found = new Set<string>(); // boolean flags seen
   const stackNames: string[] = [];
@@ -145,6 +187,25 @@ export function parseCommonArgs(args: string[]): CommonArgs {
       continue;
     }
     throw new Error(`unknown option "${a}" — see cdkrd --help`);
+  }
+
+  // Reject a flag the RUNNING verb never consumes with the same loud exit-2 as an unknown
+  // flag (#780). Without this, verb-inapplicable flags are silently accepted — and the
+  // dangerous pair INVERTS intent: `record --dry-run` / `ignore --dry-run` WRITE the file
+  // they claim to preview, `record --fail` never fails CI. Only when a verb is supplied
+  // (the CLI always does; the no-verb call in unit tests keeps today's permissive parse).
+  if (verb !== undefined) {
+    const allowed = ALLOWED_FLAGS_BY_VERB[verb];
+    for (const flag of found)
+      if (!allowed.has(canonicalFlag(flag)))
+        throw new Error(
+          `option "${flag}" is not valid for the \`${verb}\` command — see cdkrd --help`
+        );
+    // `--wait` is tracked as a value (waitMs), not in `found`, so check it separately.
+    if (waitMs !== undefined && !allowed.has('--wait'))
+      throw new Error(
+        `option "--wait" is not valid for the \`${verb}\` command — see cdkrd --help`
+      );
   }
 
   const has = (flag: string): boolean => found.has(flag);

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -171,7 +171,7 @@ export function finalCheckExit(code: number, fail: boolean): number {
 }
 
 export async function runCheck(args: string[]): Promise<number> {
-  const a = parseCommonArgs(args);
+  const a = parseCommonArgs(args, 'check');
   if (a.profile) process.env.AWS_PROFILE = a.profile; // honored by SDK clients + synth subprocess
 
   // .cdkrd/ignore.yaml ignore rules, loaded once (cwd-relative). A malformed config

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -20,7 +20,7 @@ import { gatherWithProgress, progressLabel } from './progress.js';
 import { ignoreStack } from './stack-actions.js';
 
 export async function runIgnore(args: string[]): Promise<number> {
-  const a = parseCommonArgs(args);
+  const a = parseCommonArgs(args, 'ignore');
   if (a.profile) process.env.AWS_PROFILE = a.profile;
 
   let config;

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -11,7 +11,7 @@ import { gatherWithProgress, progressLabel } from './progress.js';
 import { recordStack } from './stack-actions.js';
 
 export async function runRecord(args: string[]): Promise<number> {
-  const a = parseCommonArgs(args);
+  const a = parseCommonArgs(args, 'record');
   if (a.profile) process.env.AWS_PROFILE = a.profile;
 
   let config;

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -19,7 +19,7 @@ import { resolveStacks } from './resolve-stacks.js';
 import { revertStack } from './stack-actions.js';
 
 export async function runRevert(args: string[]): Promise<number> {
-  const a = parseCommonArgs(args);
+  const a = parseCommonArgs(args, 'revert');
   if (a.profile) process.env.AWS_PROFILE = a.profile;
   const dryRun = args.includes('--dry-run');
 

--- a/tests/cli-args.test.ts
+++ b/tests/cli-args.test.ts
@@ -207,3 +207,88 @@ describe('isInteractive (non-interactive simply means non-TTY, R58)', () => {
     withTTY(false, () => expect(isInteractive()).toBe(false));
   });
 });
+
+describe('parseCommonArgs per-verb flag applicability (#780)', () => {
+  // The dangerous pair: a preview/no-op flag on a FILE-WRITING verb used to be silently
+  // accepted, inverting intent (`record --dry-run --yes` WROTE the baseline).
+  it('rejects `--dry-run` on every verb except revert', () => {
+    for (const verb of ['check', 'record', 'ignore'] as const)
+      expect(() => parseCommonArgs(['--dry-run'], verb)).toThrow(
+        new RegExp(`"--dry-run" is not valid for the \`${verb}\` command`)
+      );
+    expect(() => parseCommonArgs(['--dry-run'], 'revert')).not.toThrow();
+  });
+
+  it('rejects `--fail` outside check', () => {
+    for (const verb of ['record', 'ignore', 'revert'] as const)
+      expect(() => parseCommonArgs(['--fail'], verb)).toThrow(/"--fail" is not valid/);
+    expect(() => parseCommonArgs(['--fail'], 'check')).not.toThrow();
+  });
+
+  it('rejects check-only scope/coverage flags on other verbs', () => {
+    for (const flag of [
+      '--strict',
+      '--show-all',
+      '--pre-deploy',
+      '--undeclared-only',
+      '--declared-only',
+    ])
+      expect(() => parseCommonArgs([flag], 'record')).toThrow(
+        /is not valid for the `record` command/
+      );
+  });
+
+  it('rejects `--wait` and `--remove-unrecorded` outside their verbs', () => {
+    expect(() => parseCommonArgs(['--wait'], 'record')).toThrow(/"--wait" is not valid/);
+    expect(() => parseCommonArgs(['--wait=5m'], 'check')).toThrow(/"--wait" is not valid/);
+    expect(() => parseCommonArgs(['--remove-unrecorded'], 'record')).toThrow(/is not valid/);
+    expect(() => parseCommonArgs(['--remove-unrecorded'], 'ignore')).toThrow(/is not valid/);
+  });
+
+  it('rejects `--verbose` (`-v`) on ignore but allows it on check/record/revert', () => {
+    expect(() => parseCommonArgs(['--verbose'], 'ignore')).toThrow(/"--verbose" is not valid/);
+    expect(() => parseCommonArgs(['-v'], 'ignore')).toThrow(/"-v" is not valid/);
+    for (const verb of ['check', 'record', 'revert'] as const)
+      expect(() => parseCommonArgs(['--verbose'], verb)).not.toThrow();
+  });
+
+  it('accepts each verb-appropriate flag set (no false rejection)', () => {
+    expect(() =>
+      parseCommonArgs(
+        ['--fail', '--strict', '--show-all', '--pre-deploy', '--json', '--verbose'],
+        'check'
+      )
+    ).not.toThrow();
+    expect(() => parseCommonArgs(['--yes', '--verbose', '--json'], 'record')).not.toThrow();
+    expect(() => parseCommonArgs(['--yes', '--json'], 'ignore')).not.toThrow();
+    expect(() =>
+      parseCommonArgs(['--dry-run', '--yes', '--wait=10m', '--remove-unrecorded'], 'revert')
+    ).not.toThrow();
+  });
+
+  it('global identity/targeting flags are accepted on every verb', () => {
+    for (const verb of ['check', 'record', 'ignore', 'revert'] as const)
+      expect(() =>
+        parseCommonArgs(
+          [
+            'MyStack',
+            '--region',
+            'us-east-1',
+            '--profile',
+            'p',
+            '--app',
+            'x',
+            '-c',
+            'k=v',
+            '--all',
+            '--json',
+          ],
+          verb
+        )
+      ).not.toThrow();
+  });
+
+  it('a no-verb call keeps the permissive parse (back-compat for internal callers)', () => {
+    expect(() => parseCommonArgs(['--dry-run', '--fail', '--wait=5m'])).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #780

All four verbs shared one flag surface, so a verb-inapplicable flag was silently accepted — and the worst cases INVERTED intent: `record --dry-run --yes` / `ignore --dry-run --yes` WROTE the file they claimed to preview; `record --fail` never failed CI.

## Fix
`parseCommonArgs(args, verb?)` now takes the running verb (threaded from the 4 command entry points) and rejects any flag that verb never consumes with the same loud exit-2 as an unknown flag. The per-verb allowed set is derived from the flags each command actually reads (`a.<flag>` in `src/commands/<verb>.ts`):

- **global** (all 4): `--region --profile --app -c/--context --all --json --yes`
- **check** +: `--fail --strict --show-all --pre-deploy --undeclared-only --declared-only --verbose --remove-unrecorded`
- **record** +: `--verbose`
- **ignore**: global only
- **revert** +: `--verbose --remove-unrecorded --dry-run --wait`

A no-verb call (internal/unit-test) keeps the permissive parse for back-compat.

## Verification
- Unit: new per-verb applicability block in `tests/cli-args.test.ts` (dangerous pair rejected, valid flags not falsely rejected, back-compat no-verb call). Full suite 3271 passed.
- Live (built binary): `record --dry-run --yes` → exit 2 **before any write**; `ignore --dry-run`, `record --fail` → exit 2; `revert --dry-run`, `check --fail` → pass validation; `record --bogus` → still unknown-option exit 2.
- Docs already scope `--dry-run` to revert and `--fail` to check — this enforces the documented surface; no README change needed.