### PR TITLE
fix(desired): resolve Fn::GetAtt Nested.Outputs.X against the CC Outputs array (#782)

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -284,7 +284,38 @@ export function resolveGetAtt(v: unknown, ctx: ResolverContext): unknown {
   }
   const model = ctx.liveAttrs[logicalId];
   if (!model) return UNRESOLVED;
-  const got = getPath(model, attr.split('.'));
+  const segs = attr.split('.');
+  // A parent stack consuming a NESTED stack's output uses
+  // `Fn::GetAtt [Nested, "Outputs.<OutputKey>"]` (and the `Fn::Sub`
+  // `${Nested.Outputs.<OutputKey>}` form). The live Cloud Control model for
+  // `AWS::CloudFormation::Stack` stores `Outputs` as an ARRAY of
+  // `{ OutputKey, OutputValue }` objects (readOnly), so descending
+  // `["Outputs", "<OutputKey>"]` through getPath indexes the array by the string
+  // key -> undefined -> permanently UNRESOLVED. Build an OutputKey -> OutputValue
+  // map and resolve the key against it (detection-preserving: a changed output
+  // still differs). Confined to AWS::CloudFormation::Stack so getPath's general
+  // array behavior is unchanged for every other type.
+  if (
+    ctx.typeOf?.[logicalId] === 'AWS::CloudFormation::Stack' &&
+    segs.length >= 2 &&
+    segs[0] === 'Outputs'
+  ) {
+    const outputs = model['Outputs'];
+    if (Array.isArray(outputs)) {
+      const key = segs[1];
+      const entry = outputs.find(
+        (o): o is Record<string, unknown> =>
+          o !== null && typeof o === 'object' && (o as Record<string, unknown>)['OutputKey'] === key
+      );
+      if (entry === undefined) return UNRESOLVED;
+      // Descend any remaining path segments (rare, but keep parity with getPath).
+      const rest = segs.slice(2);
+      const got =
+        rest.length === 0 ? entry['OutputValue'] : getPath(entry, ['OutputValue', ...rest]);
+      return got === undefined ? UNRESOLVED : got;
+    }
+  }
+  const got = getPath(model, segs);
   return got === undefined ? UNRESOLVED : got;
 }
 

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -195,6 +195,50 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::GetAtt': ['IdPool', 'Name'] }, c)).toBe('auto-generated');
   });
 
+  // A parent stack consuming a NESTED stack's output uses
+  // `Fn::GetAtt [Nested, "Outputs.<key>"]` / `Fn::Sub ${Nested.Outputs.<key>}`.
+  // The live Cloud Control model for AWS::CloudFormation::Stack stores `Outputs` as
+  // an ARRAY of { OutputKey, OutputValue }, so a naive path descent indexes the array
+  // by the string key -> permanently UNRESOLVED (issue #782). Resolve via an
+  // OutputKey -> OutputValue lookup, scoped to AWS::CloudFormation::Stack.
+  it('Fn::GetAtt Outputs.<key> resolves against a nested Stacks OutputKey/OutputValue array', () => {
+    const c = ctx({
+      typeOf: { Nested: 'AWS::CloudFormation::Stack' },
+      liveAttrs: {
+        Nested: {
+          Outputs: [
+            { OutputKey: 'BucketArn', OutputValue: 'arn:aws:s3:::my-nested-bucket' },
+            { OutputKey: 'QueueUrl', OutputValue: 'https://sqs/q' },
+          ],
+        },
+      },
+    });
+    expect(resolve({ 'Fn::GetAtt': ['Nested', 'Outputs.BucketArn'] }, c)).toBe(
+      'arn:aws:s3:::my-nested-bucket'
+    );
+    expect(resolve({ 'Fn::GetAtt': ['Nested', 'Outputs.QueueUrl'] }, c)).toBe('https://sqs/q');
+    // the Fn::Sub ${Nested.Outputs.<key>} form goes through the same resolveGetAtt path
+    expect(resolve({ 'Fn::Sub': 'b=${Nested.Outputs.BucketArn}' }, c)).toBe(
+      'b=arn:aws:s3:::my-nested-bucket'
+    );
+    // an unknown output key fails closed (never fabricates a value)
+    expect(resolve({ 'Fn::GetAtt': ['Nested', 'Outputs.Nope'] }, c)).toBe(UNRESOLVED);
+  });
+
+  // The Outputs-array special case is scoped to AWS::CloudFormation::Stack — for every
+  // other type getPath's general behavior is unchanged (a non-Stack type with an
+  // Outputs array indexed by key still fails closed, i.e. no accidental widening).
+  it('Outputs-array lookup is confined to AWS::CloudFormation::Stack', () => {
+    const c = ctx({
+      typeOf: { Other: 'AWS::Some::Other' },
+      liveAttrs: {
+        Other: { Outputs: [{ OutputKey: 'BucketArn', OutputValue: 'arn:aws:s3:::x' }] },
+      },
+    });
+    // not a Stack -> array indexed by key -> undefined -> UNRESOLVED (unchanged)
+    expect(resolve({ 'Fn::GetAtt': ['Other', 'Outputs.BucketArn'] }, c)).toBe(UNRESOLVED);
+  });
+
   it('resolveProperties prunes NoValue keys', () => {
     const out = resolveProperties({ A: 'x', B: { Ref: 'AWS::NoValue' } }, ctx());
     expect(out).toEqual({ A: 'x' });


### PR DESCRIPTION
Closes #782

## Problem
The live Cloud Control model for `AWS::CloudFormation::Stack` stores `Outputs` as an **array** of `{OutputKey, OutputValue}` objects. `resolveGetAtt` descended `["Outputs", "<key>"]` via `getPath`, which indexed the array by the string key → `undefined` → permanently **UNRESOLVED**. Every parent-side nested-stack output consumer (`Fn::GetAtt [Nested, "Outputs.X"]` and the `Fn::Sub ${Nested.Outputs.X}` form) was therefore an unresolved finding whose compare is skipped — out-of-band drift on those consumer properties invisible.

## Fix
In `resolveGetAtt`, special-case `AWS::CloudFormation::Stack` models whose attribute path starts with `Outputs.`: build the `OutputKey → OutputValue` lookup from the array and resolve against it (descending any trailing segments for parity). Scoped strictly to `AWS::CloudFormation::Stack` via `ctx.typeOf` — `getPath`'s general array behavior is unchanged for every other type. Detection-preserving (a changed output still differs).

## Tests
`tests/intrinsic-resolver.test.ts`: array-shaped `Outputs` → `Outputs.BucketArn`/`QueueUrl` resolve to the matching `OutputValue`; the `Fn::Sub` form resolves too; unknown key → UNRESOLVED; a non-Stack type with an `Outputs` array still fails closed (confinement guard). Fails without the fix.

Found by an offline /hunt-bugs resolver audit (round 2026-07-08r); CC Outputs shape live-confirmed.