### PR TITLE
fix(schema): warn + do not cache an empty schema on DescribeType failure (#751)

### DIFF
--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -25,6 +25,28 @@ const EMPTY: SchemaInfo = {
   freeFormMapPaths: [],
 };
 
+// Types whose DescribeType has already emitted a failure warning THIS process, keyed
+// on `${region}\0${resourceType}` (the same axis as the cache — a rollout / permission
+// can differ per region). The warning is one-per-type-per-region so N resources of the
+// same type do not each print it (mirrors the KMS ListAliases one-per-region warning at
+// commands/gather.ts). A repeated failure stays silent, but is STILL not cached (below),
+// so the schema is re-fetched on the next occurrence rather than poisoned with EMPTY.
+const failureWarned = new Set<string>();
+
+// The one-line warning emitted when cloudformation:DescribeType fails (denied / throttled
+// / network) for a resourceType. Without the schema, readOnly live attributes are not
+// stripped (first-run [Potential Drift] noise) and declared writeOnly props are not routed
+// to readGap (false declared drift → `--fail` exits 1 on an untouched stack). Pure +
+// exported so the wording is unit-tested. Mirrors kmsListAliasesDeniedWarning.
+export function describeTypeFailedWarning(resourceType: string, region: string): string {
+  return (
+    `warning: ${region}: cloudformation:DescribeType failed for ${resourceType} — schema-based ` +
+    `drift suppression is degraded for this type. Undeclared read-only attributes may surface as ` +
+    `[Potential Drift] and declared write-only properties may report false drift. Grant ` +
+    `cloudformation:DescribeType (and retry if throttled) for full coverage.`
+  );
+}
+
 export async function getSchemaInfo(
   client: CloudFormationClient,
   resourceType: string
@@ -33,9 +55,23 @@ export async function getSchemaInfo(
   const cacheKey = `${region}\0${resourceType}`;
   const cached = cache.get(cacheKey);
   if (cached) return cached;
-  const info = await fetch(client, resourceType);
-  cache.set(cacheKey, info);
-  return info;
+  const result = await fetch(client, resourceType);
+  if (result.ok) {
+    // Only cache a REAL schema. A DescribeType failure must NOT be persisted as if it
+    // were a successful empty schema (#751) — caching EMPTY would poison every later read
+    // of this type in this region with an unrecoverable "no schema" state (readOnly not
+    // stripped, writeOnly not readGap'd) even after the permission is granted / the
+    // throttle clears. Leaving it uncached lets the next occurrence re-fetch.
+    cache.set(cacheKey, result.info);
+    return result.info;
+  }
+  // Failure: warn once per type+region, then return EMPTY for THIS call (best-effort — a
+  // missing schema means no strip, never a crash) WITHOUT caching it.
+  if (!failureWarned.has(cacheKey)) {
+    failureWarned.add(cacheKey);
+    console.error(describeTypeFailedWarning(resourceType, region));
+  }
+  return result.info;
 }
 
 // Top-level writeOnly properties that an SDK_OVERRIDES reader (read/overrides.ts) CAN
@@ -185,20 +221,28 @@ export function exemptOverrideReadable(info: SchemaInfo, resourceType: string): 
   };
 }
 
-async function fetch(client: CloudFormationClient, resourceType: string): Promise<SchemaInfo> {
+// A DescribeType outcome: `ok` distinguishes a real schema (safe to cache) from a
+// DescribeType failure (must NOT be cached as a successful empty schema — #751). On
+// failure `info` is EMPTY so callers degrade gracefully (no strip) without a crash.
+type FetchResult = { ok: true; info: SchemaInfo } | { ok: false; info: SchemaInfo };
+
+async function fetch(client: CloudFormationClient, resourceType: string): Promise<FetchResult> {
   try {
     const r = await client.send(
       new DescribeTypeCommand({ Type: 'RESOURCE', TypeName: resourceType })
     );
-    return injectReaderGaps(
-      exemptOverrideReadable(
-        supplementReadOnly(parseSchema(r.Schema ?? '{}'), resourceType),
+    return {
+      ok: true,
+      info: injectReaderGaps(
+        exemptOverrideReadable(
+          supplementReadOnly(parseSchema(r.Schema ?? '{}'), resourceType),
+          resourceType
+        ),
         resourceType
       ),
-      resourceType
-    );
+    };
   } catch {
-    return EMPTY;
+    return { ok: false, info: EMPTY };
   }
 }
 

--- a/tests/schema-strip.test.ts
+++ b/tests/schema-strip.test.ts
@@ -1,0 +1,98 @@
+import type { CloudFormationClient } from '@aws-sdk/client-cloudformation';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { describeTypeFailedWarning, getSchemaInfo } from '../src/schema/schema-strip.js';
+
+// #751: when cloudformation:DescribeType fails (permission denied / throttled), the fetch
+// caught the error and returned an EMPTY schema, and getSchemaInfo cached that EMPTY result
+// process-wide. Consequences: readOnly live attributes are no longer stripped (first-run
+// [Potential Drift] noise) and declared writeOnly props are no longer routed to readGap
+// (false declared drift → `--fail` exits 1 on an untouched stack) — and it never recovered
+// because the poisoned EMPTY was returned forever. The fix: warn once per type+region, and
+// do NOT cache a failure so the next occurrence re-fetches.
+
+// A CloudFormationClient-like fake whose `.config.region()` resolves to `region` and whose
+// `.send()` is a vitest mock (so per-call behavior — throw then succeed — is scriptable).
+function fakeClient(region: string, send: () => Promise<unknown>): CloudFormationClient {
+  return {
+    config: { region: () => Promise.resolve(region) },
+    send,
+  } as unknown as CloudFormationClient;
+}
+
+describe('getSchemaInfo DescribeType failure handling (#751)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT cache a DescribeType failure — a later call re-fetches the real schema', async () => {
+    const resourceType = 'AWS::Foo::Failure751Bar';
+    const region = 'eu-west-1';
+    const schema = {
+      properties: { Secret: { type: 'string' }, Name: { type: 'string' } },
+      writeOnlyProperties: ['/properties/Secret'],
+    };
+    // First send() throws (denied / throttled); the second succeeds with a real schema.
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('AccessDeniedException'))
+      .mockResolvedValue({ Schema: JSON.stringify(schema) });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const client = fakeClient(region, send as unknown as () => Promise<unknown>);
+
+    // First call: DescribeType failed -> EMPTY (degrade, no strip), NOT cached.
+    const first = await getSchemaInfo(client, resourceType);
+    expect(first.writeOnly.has('Secret')).toBe(false);
+
+    // Second call: because the failure was NOT cached, it re-fetches and now gets the real
+    // schema (Secret writeOnly). Before the fix this returned the cached EMPTY forever.
+    const second = await getSchemaInfo(client, resourceType);
+    expect(second.writeOnly.has('Secret')).toBe(true);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('warns ONCE per type+region across repeated failures (no spam)', async () => {
+    const resourceType = 'AWS::Foo::Failure751Warn';
+    const region = 'us-west-2';
+    const send = vi.fn().mockRejectedValue(new Error('ThrottlingException'));
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const client = fakeClient(region, send as unknown as () => Promise<unknown>);
+
+    await getSchemaInfo(client, resourceType);
+    await getSchemaInfo(client, resourceType);
+    await getSchemaInfo(client, resourceType);
+
+    // The warning is emitted exactly once for this type+region despite three failures
+    // (mirrors the KMS ListAliases one-per-region warning). Re-fetch still happens each
+    // time (failure not cached), but the stderr line is deduped.
+    const warnCalls = errSpy.mock.calls.filter((c) =>
+      String(c[0]).includes('cloudformation:DescribeType failed')
+    );
+    expect(warnCalls.length).toBe(1);
+    expect(send).toHaveBeenCalledTimes(3);
+  });
+
+  it('caches a successful schema (no re-fetch on the second call)', async () => {
+    const resourceType = 'AWS::Foo::Success751';
+    const region = 'ap-southeast-2';
+    const schema = { properties: { A: { type: 'string' } }, readOnlyProperties: ['/properties/A'] };
+    const send = vi.fn().mockResolvedValue({ Schema: JSON.stringify(schema) });
+
+    const client = fakeClient(region, send as unknown as () => Promise<unknown>);
+
+    const first = await getSchemaInfo(client, resourceType);
+    const second = await getSchemaInfo(client, resourceType);
+    expect(first.readOnly.has('A')).toBe(true);
+    expect(second.readOnly.has('A')).toBe(true);
+    // A real schema IS cached, so send() runs only once.
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('describeTypeFailedWarning names the type and region', () => {
+    const msg = describeTypeFailedWarning('AWS::S3::Bucket', 'us-east-1');
+    expect(msg).toContain('us-east-1');
+    expect(msg).toContain('AWS::S3::Bucket');
+    expect(msg).toContain('cloudformation:DescribeType');
+  });
+});


### PR DESCRIPTION
Closes #751

## Problem
When `cloudformation:DescribeType` fails (permission denied — the README lists the permission but nothing enforces it — or throttled past retries on an `--all` run), `fetch()` caught the error and returned the shared `EMPTY` schema, which `getSchemaInfo()` then **cached process-wide**. Consequences on every later read of that type: readOnly live attributes are no longer stripped (first-run `[Potential Drift]` noise, invariant violated), and declared **writeOnly** props are no longer routed to `readGap` → red false `[CFn-Declared Drift]` → **`--fail` exits 1 on an untouched stack**. No warning anywhere (contrast the KMS `ListAliases`-denied warning).

## Fix
- `fetch()` returns a discriminated `FetchResult` (`{ok:true}` real schema / `{ok:false}` failure).
- `getSchemaInfo()` caches **only** a real schema; a failure returns `EMPTY` for that single call (graceful degrade, no crash) **without caching it**, so the next occurrence re-fetches and recovers once the permission is granted / throttle clears.
- Emits a loud stderr warning **once per type+region** (deduped), mirroring the KMS one-per-region warning. Wording extracted to an exported pure `describeTypeFailedWarning()` for unit-testing.

## Tests
New `tests/schema-strip.test.ts`: failure-not-cached (fail once then succeed → re-fetch, `send` called twice), warn-once (3 failures → 1 warning, still re-fetches), success-cached, warning wording. Fails without the fix.

## Deferred
Degrading affected resources to `skipped`/`readGap` when the schema is unavailable would require touching a diff/classify file — out of scope for this schema-strip.ts fix; this PR delivers the warning + no-poison-cache half.

Found by an offline /hunt-bugs audit; confirmed from code.