### PR TITLE
fix(ignore): key added-tier ignore rules on the unique logicalId, not the label (#802)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -173,6 +173,17 @@ function validateIgnoreEntry(entry: unknown, index: number): void {
  * key) so a rule is writable even on a non-CDK / metadata-stripped stack. Pure + exported;
  * `applyIgnores` matches the within-stack path, the full construct path (older rules), AND
  * the logicalId, so every form works.
+ *
+ * EXCEPTION — an `added`-tier finding always keys on `logicalId`, NEVER constructPath
+ * (issue #802). For an added child the constructPath is a display LABEL
+ * (`<parent> ▸ <label>`, gather.ts) built from a NON-unique, human name — a Cognito
+ * UserPoolClient's ClientName, an SNS subscription's `protocol endpoint` — so a rule
+ * written against it silently ignores EVERY same-labelled added child under the parent,
+ * present and future. The label can also carry glob metacharacters (an https endpoint's
+ * `?query` turns the `?` into a wildcard). The logicalId form `<parent>/<CC-identifier>`
+ * is the UNIQUE identity (and `applyIgnores` matches logicalId targets), so it is the only
+ * safe thing to write. This is scoped to `added` only; declared/undeclared keep the
+ * human-friendly constructPath, whose path IS unique.
  */
 export function ignoreRuleFor(
   finding: Finding,
@@ -180,9 +191,10 @@ export function ignoreRuleFor(
   accountId = '',
   region = ''
 ): IgnoreRuleObject {
-  const id = finding.constructPath
-    ? withinStackPath(finding.constructPath, stackName)
-    : finding.logicalId;
+  const id =
+    finding.constructPath && finding.tier !== 'added'
+      ? withinStackPath(finding.constructPath, stackName)
+      : finding.logicalId;
   const rule: IgnoreRuleObject = { path: finding.path ? `${id}.${finding.path}` : id };
   // Only stamp a scope field when the value is actually known — an empty string would
   // write `stack: ""`, a glob that matches nothing (silently disabling the rule).

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -538,6 +538,47 @@ describe('ignoreRuleFor', () => {
     };
     expect(ignoreRuleFor(f)).toEqual({ path: 'Svc' });
   });
+
+  it('keys an `added` finding on the unique logicalId, NOT the non-unique display label (#802)', () => {
+    // A Cognito UserPoolClient added child: its constructPath label is the ClientName,
+    // which is NOT unique — writing a rule against it would silence EVERY same-named
+    // client under the pool (present and future). The logicalId form
+    // `<parent>/<CC-identifier>` is the unique identity — that is what must be written.
+    const addedFinding: Finding = {
+      tier: 'added',
+      logicalId: 'UserPool/us-east-1_abc123|7clientid7',
+      constructPath: 'MyStack/UserPool ▸ my-app-client',
+      resourceType: 'AWS::Cognito::UserPoolClient',
+      path: '',
+    };
+    // NOT the label form 'MyStack/UserPool ▸ my-app-client'
+    expect(ignoreRuleFor(addedFinding)).toEqual({ path: 'UserPool/us-east-1_abc123|7clientid7' });
+    // stamping a stack scope must not re-introduce the label either
+    expect(ignoreRuleFor(addedFinding, 'MyStack')).toEqual({
+      path: 'UserPool/us-east-1_abc123|7clientid7',
+      stack: 'MyStack',
+    });
+    // and the rule the verb writes round-trips: it ignores exactly this finding
+    expect(
+      ign([addedFinding], 'MyStack', cfg([ignoreRuleFor(addedFinding, 'MyStack')]))[0]?.tier
+    ).toBe('ignored');
+  });
+
+  it('an `added` finding whose label carries a glob metachar keys on logicalId (no accidental wildcard) (#802)', () => {
+    // An SNS https subscription's label `https https://host/path?q=1` has a `?` — as a
+    // path glob the `?` is a single-char wildcard, so a label-based rule would over-match.
+    // The logicalId form is a literal composite id with no glob semantics leaking in.
+    const addedFinding: Finding = {
+      tier: 'added',
+      logicalId: 'Topic/arn:aws:sns:us-east-1:111111111111:T:sub-uuid',
+      constructPath: 'MyStack/Topic ▸ https https://host/path?q=1',
+      resourceType: 'AWS::SNS::Subscription',
+      path: '',
+    };
+    const rule = ignoreRuleFor(addedFinding);
+    expect(rule.path).toBe('Topic/arn:aws:sns:us-east-1:111111111111:T:sub-uuid');
+    expect(rule.path).not.toContain('?');
+  });
 });
 
 describe('mergeIgnoreRules', () => {


### PR DESCRIPTION
Closes #802

## Problem
`ignoreRuleFor` built an `added`-tier ignore rule from `constructPath`, which for an added child is the display **label** `<parent> ▸ <label>` (gather.ts). That label is **non-unique** — a Cognito UserPoolClient uses `ClientName` (multiple clients can share one), an SNS subscription uses `protocol endpoint` — so one written rule silently ignores **every same-labelled** added child under the parent, including future ones the user never saw. The label can also carry **glob metacharacters** (an https endpoint's `?query` makes `?` a wildcard — same class as #776, via the added-label channel).

## Fix
For `added`-tier findings, write the rule against the unique `<parent>/<CC-identifier>` **logicalId** form (`applyIgnores` already matches logicalId targets). Declared/undeclared tiers are unchanged — their constructPath path IS unique and stays human-friendly.

## Tests
`tests/config-file.test.ts`: non-unique Cognito ClientName label → rule path is the logicalId composite (+ round-trip re-tags exactly that finding to `ignored`); glob-metachar SNS https label → rule path is the literal logicalId, `not.toContain('?')`. Both fail without the fix.

Found by an offline /hunt-bugs added-tier audit (round 2026-07-08r).