### PR TITLE
fix(diff): emit whole map for undeclared path-unsafe keys, mirroring the declared side (#747)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -990,6 +990,22 @@ function collectNestedUndeclared(
     return;
   }
   if (!isNestedObject(declaredVal) || !isNestedObject(liveVal)) return;
+  // A free-form map (Glue Table `Parameters`, API Gateway Method `RequestParameters`,
+  // map Tags, ECS `DockerLabels`, parameter-group entries) can hold live-only keys that
+  // contain the path grammar's separators — an Athena `projection.enabled`, a
+  // `method.request.querystring.x`, a `app.kubernetes.io/name` tag, a key with `[`/`]`.
+  // Descending would build a child path like `Parameters.projection.enabled` that every
+  // downstream consumer (`toPointer` for the revert JSON-pointer, the baseline
+  // `topSegment`, the ignore-rule glob) RE-SPLITS on `.`/`[`, landing on the WRONG
+  // location — a misdirected revert write and a silently ineffective ignore/baseline
+  // rule. Mirror the declared-side guard (drift-calculator `hasPathUnsafeKey`): when any
+  // key would corrupt the path, don't descend — emit the whole map at the current (safe)
+  // path so the revert rewrites the map as a unit and the finding path carries no
+  // ambiguous segment.
+  if (Object.keys(liveVal).some((k) => PATH_UNSAFE_KEY.test(k))) {
+    emit(path, liveVal);
+    return;
+  }
   for (const [k, val] of Object.entries(liveVal)) {
     const childPath = `${path}.${k}`;
     if (k in declaredVal)
@@ -997,6 +1013,12 @@ function collectNestedUndeclared(
     else emit(childPath, val);
   }
 }
+
+// A key that contains the path grammar's separators (`.`, `[`, `]`). Descending into
+// such a key would produce a finding path that downstream consumers re-split into the
+// wrong location — so a map holding one is emitted whole at its parent path. Mirrors
+// drift-calculator's declared-side `PATH_UNSAFE_KEY` guard for the undeclared side.
+const PATH_UNSAFE_KEY = /[.[\]]/;
 
 // Bring a raw Cloud Control live model into the SAME canonical, noise-subtracted form
 // classify's live side uses: strip AWS-managed fields + `aws:*` tags, reconcile OAI

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10764,3 +10764,84 @@ describe('#632 follow-up: unconditional boolean disables surface (undeclared)', 
     });
   }
 });
+
+// #747: a live-only (out-of-band-added) map key containing a `.` / `[` / `]` must NOT be
+// appended verbatim as a `${path}.${key}` nested finding path — `toPointer` (and the
+// baseline `topSegment` / ignore-rule glob) re-split on `.`/`[`, corrupting the location
+// so a revert patches the WRONG place. The declared side already emits the whole map at
+// the parent path (drift-calculator `hasPathUnsafeKey`); the UNDECLARED side must mirror
+// it. Assert the finding path is the PARENT (`Parameters`), value = the whole live map,
+// NOT a split `Parameters.projection.enabled`.
+describe('#747 dotted live-only map key -> whole map at parent path (undeclared)', () => {
+  const bareSchema: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+
+  it('Glue Table Parameters with Athena projection.enabled emits parent path only', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Tbl',
+      resourceType: 'AWS::Glue::Table',
+      physicalId: 'my-table',
+      // The property is DECLARED (so the nested-undeclared descent runs) but the dotted key
+      // is live-only (out-of-band added / AWS-materialized).
+      declared: { Parameters: { classification: 'csv' } },
+    };
+    const live: Record<string, unknown> = {
+      Parameters: { classification: 'csv', 'projection.enabled': 'true' },
+    };
+    const findings = classifyResource(resource, live, bareSchema);
+    const undeclared = findings.filter((f) => f.tier === 'undeclared');
+    // Exactly one undeclared finding, at the PARENT path — no split segments.
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0].path).toBe('Parameters');
+    // NEVER the corrupt per-key path.
+    expect(findings.map((f) => f.path)).not.toContain('Parameters.projection.enabled');
+    expect(findings.map((f) => f.path)).not.toContain('Parameters.projection');
+    // The whole live map is carried so revert rewrites it as a unit.
+    expect(undeclared[0].actual).toEqual({
+      classification: 'csv',
+      'projection.enabled': 'true',
+    });
+  });
+
+  it('safe live-only keys still descend per-key (guard is scoped to path-unsafe keys)', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Tbl',
+      resourceType: 'AWS::Glue::Table',
+      physicalId: 'my-table',
+      declared: { Parameters: { classification: 'csv' } },
+    };
+    const live: Record<string, unknown> = {
+      Parameters: { classification: 'csv', safeKey: 'v' },
+    };
+    const undeclared = classifyResource(resource, live, bareSchema).filter(
+      (f) => f.tier === 'undeclared'
+    );
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0].path).toBe('Parameters.safeKey');
+  });
+
+  it('bracket key ([]) also emits parent path only', () => {
+    const resource: DesiredResource = {
+      logicalId: 'Tbl',
+      resourceType: 'AWS::Glue::Table',
+      physicalId: 'my-table',
+      declared: { Parameters: { a: '1' } },
+    };
+    const live: Record<string, unknown> = {
+      Parameters: { a: '1', 'weird[0]': 'x' },
+    };
+    const undeclared = classifyResource(resource, live, bareSchema).filter(
+      (f) => f.tier === 'undeclared'
+    );
+    expect(undeclared).toHaveLength(1);
+    expect(undeclared[0].path).toBe('Parameters');
+  });
+});


### PR DESCRIPTION
Closes #747

## Problem
`collectNestedUndeclared` appended live-only (out-of-band-added) map keys verbatim as `${path}.${k}`, so a key containing the path grammar's separators built a corrupt finding path. Dotted map keys are common: Glue Table `Parameters` (Athena `projection.enabled`), API Gateway Method `RequestParameters` (`method.request.querystring.x`), map Tags (`app.kubernetes.io/name`), ECS `DockerLabels`, parameter-group entries. Downstream `toPointer` (revert JSON-pointer), the baseline `topSegment`, and the ignore glob all **re-split** on `.`/`[` — landing on the WRONG location (a misdirected revert write, a silently ineffective ignore/baseline rule). The declared side already guards this via `hasPathUnsafeKey`; the undeclared side did not.

## Fix
Port the guard into `collectNestedUndeclared`: when any live-only key at a map level matches `PATH_UNSAFE_KEY = /[.[\]]/`, emit the **whole map** at the parent (safe) path instead of descending key-by-key — exactly mirroring the declared side, so revert rewrites the map as a unit and the finding path carries no ambiguous segment. (`PATH_UNSAFE_KEY` is not exported from drift-calculator.ts, so a local equivalent const is defined in classify.ts.)

## Tests
`tests/classify.test.ts`: a Glue Table whose declared `Parameters` gains a live-only `projection.enabled` → finding path is the parent `Parameters` with the whole map as value, and the corrupt split path never appears; plus a bracket-key case and a safe-key control (still descends). Fails without the fix.

Found by an offline /hunt-bugs audit; pointer mis-segmentation confirmed from code.