### PR TITLE
fix(baseline): block snapshot-completeness for readGap resources (#795)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -235,9 +235,14 @@ export async function writeBaselineFile(b: BaselineFile): Promise<string> {
 /**
  * Which resources the record snapshot covered COMPLETELY (R62): every undeclared
  * finding of the resource is in `recorded` (zero undeclared findings = trivially
- * complete), and the resource was actually observed — a `skipped` (unread) or
- * `deleted` resource cannot be snapshot. Ignored-tier values do not block
- * completeness: they were visible and deliberately ruled out.
+ * complete), and the resource was actually observed — a `skipped` (unread),
+ * `deleted`, or `readGap` (part of its live model UNREAD) resource cannot be
+ * snapshot. A `readGap` finding means some of the resource's live state could not
+ * be read this run (#795), so undeclared values hidden behind that gap were NOT
+ * captured — the resource must not claim completeness, else a later cdkrd that
+ * closes the read gap would surface those newly-visible values as false "appeared
+ * since record" drift. Ignored-tier values do not block completeness: they were
+ * visible and deliberately ruled out.
  * Monotonic via `previousComplete`: once complete, a resource stays complete
  * (declining to record an appeared-since-record value keeps it drift, instead of
  * demoting it back to unrecorded) — pruned to ids still in the template.
@@ -251,7 +256,8 @@ export function computeCompleteResources(
   const recordedKeys = new Set(recorded.map(recordedKey));
   const blocked = new Set<string>();
   for (const f of findings) {
-    if (f.tier === 'skipped' || f.tier === 'deleted') blocked.add(f.logicalId);
+    if (f.tier === 'skipped' || f.tier === 'deleted' || f.tier === 'readGap')
+      blocked.add(f.logicalId);
     if (f.tier === 'undeclared' && !recordedKeys.has(recordedKey(f))) blocked.add(f.logicalId);
   }
   const all = new Set(allLogicalIds);

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -665,6 +665,17 @@ describe('baseline', () => {
       ).toEqual(['Clean', 'Covered']); // sorted; Uncovered/Unread/Gone excluded
     });
 
+    it('a resource with a readGap finding is NOT complete (#795 — part of its model was unread)', () => {
+      // a readGap means some of the resource's live state could not be read this run,
+      // so undeclared values hidden behind the gap were never snapshotted — the
+      // resource must not be stamped complete (else a later cdkrd that closes the gap
+      // surfaces the newly-visible values as false "appeared since record" drift).
+      const findings: Finding[] = [
+        { tier: 'readGap', logicalId: 'Gap', resourceType: 'T', path: 'P' },
+      ];
+      expect(computeCompleteResources(['Gap'], findings, [])).toEqual([]);
+    });
+
     it('a resource with one of two values recorded is NOT complete', () => {
       const findings = [undeclared('A', 'P', 1), undeclared('A', 'Q', 2)];
       const recorded = [{ logicalId: 'A', resourceType: 'AWS::X::Y', path: 'P', value: 1 }];


### PR DESCRIPTION
Closes #795

## Problem
`computeCompleteResources` blocked snapshot-completeness only on `skipped`/`deleted` findings, so a resource carrying a `readGap` finding (part of its live model UNREAD) was wrongly stamped snapshot-complete. When a later cdkrd version closes the read gap (a new SDK override/supplement — the #716-class event), the newly-visible undeclared values surface as false "appeared since record" drift.

## Fix
Add `readGap` to the tiers that block completeness — an incompletely-read resource cannot honestly claim everything undeclared was snapshotted.

## Test
`tests/baseline.test.ts`: a resource with a `readGap` finding is NOT marked complete (fails without the fix, passes with it).

## Verification
- typecheck / lint+format / build / 3272 unit tests: green.
- Live-test N/A: `computeCompleteResources` is a pure function over findings (no AWS call); the unit test is authoritative.