### PR TITLE
fix(desired): parse deployed YAML templates with the YAML 1.1 schema (#785)

### DIFF
--- a/src/desired/yaml-cfn.ts
+++ b/src/desired/yaml-cfn.ts
@@ -117,7 +117,16 @@ export function parseCfnTemplate(text: string): Record<string, unknown> {
   if (format === 'json') {
     parsed = JSON.parse(body);
   } else {
-    parsed = yamlParse(body, { customTags: CUSTOM_TAGS });
+    // CloudFormation's service-side YAML parser resolves the YAML 1.1 schema, not
+    // yaml@2's default 1.2 core schema. Under 1.2 `yes`/`no`/`on`/`off` stay strings
+    // and `0755` parses as decimal 755 — diverging from what CFn actually deployed
+    // (1.1 folds those to boolean / octal 493, and `1:30` to sexagesimal 90),
+    // producing first-run declared false positives and silent revert corruption
+    // (#785). Pinning `version: '1.1'` selects the `yaml-1.1` base schema so implicit
+    // scalar resolution matches CFn. CUSTOM_TAGS (the CFn short forms) still layer on
+    // top as additional tags; the YAML-1.1-only `!!binary`/`!!timestamp`/... tags only
+    // fire on explicit `!!` markers a CFn template never carries, so no regression.
+    parsed = yamlParse(body, { version: '1.1', customTags: CUSTOM_TAGS });
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Template root is not an object.');

--- a/tests/yaml-cfn.test.ts
+++ b/tests/yaml-cfn.test.ts
@@ -29,6 +29,44 @@ describe('yaml-cfn parse', () => {
     expect(p.Cond).toEqual({ 'Fn::If': ['C', 'a', 'b'] });
   });
 
+  it('resolves implicit scalars with the YAML 1.1 schema, matching CloudFormation (#785)', () => {
+    // CloudFormation's service-side parser resolves YAML 1.1, not yaml@2's default
+    // 1.2 core schema. Under 1.2 these would FAIL: `yes`/`off` stay strings, `0755`
+    // is decimal 755, `1:30` stays a string. cdkrd must match what CFn deployed.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::Fake::Type
+    Properties:
+      YesVal: yes
+      NoVal: no
+      OnVal: on
+      OffVal: off
+      Mode: 0755
+      Sexagesimal: 1:30`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.YesVal).toBe(true); // 1.2 -> "yes"
+    expect(p.NoVal).toBe(false); // 1.2 -> "no"
+    expect(p.OnVal).toBe(true); // 1.2 -> "on"
+    expect(p.OffVal).toBe(false); // 1.2 -> "off"
+    expect(p.Mode).toBe(493); // octal 0755; 1.2 -> 755
+    expect(p.Sexagesimal).toBe(90); // 60*1 + 30; 1.2 -> "1:30"
+  });
+
+  it('keeps a quoted leading-zero account id a string (no revert corruption, #785)', () => {
+    // The common shape for an account id in a template is a quoted string, which stays
+    // a string under both schemas. A BARE `012345678901` is octal-invalid (digits 8/9)
+    // so YAML 1.1 falls back to decimal — same as CFn — but the quoted form is what
+    // must never silently lose its leading zero on parse -> revert round-trip.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::Fake::Type
+    Properties:
+      Account: "012345678901"`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.Account).toBe('012345678901');
+    expect(typeof p.Account).toBe('string');
+  });
+
   it('rejects a non-object root', () => {
     expect(() => parseCfnTemplate('[1,2]')).toThrow();
   });


### PR DESCRIPTION
Closes #785

## Problem
`parseCfnTemplate` parsed deployed YAML with yaml@2's default 1.2 core schema, but CloudFormation's service parser resolves YAML **1.1**. Under 1.2, `yes`/`no`/`on`/`off` stay strings and `0755` parses as decimal 755 — diverging from what CFn actually deployed (1.1 → boolean / octal 493, `1:30` → sexagesimal 90). This caused first-run declared false positives (unrevertable) and silent revert corruption of leading-zero / boolean-like scalars.

## Fix
Pin `version: '1.1'` on the parse call so implicit scalar resolution matches CFn; CUSTOM_TAGS (the CFn short forms `!Ref`/`!GetAtt`/`!Sub`) still layer on top as additional tags. YAML-1.1-only `!!binary`/`!!timestamp` tags fire only on explicit `!!` markers a CFn template never carries.

## Test
`tests/yaml-cfn.test.ts`: `yes`→bool, `0755`→493, `1:30`→90, quoted leading-zero account id stays string; short-form intrinsics still parse. Fails on old 1.2 behavior.

## Verification
- typecheck / lint+format / build / 3273 unit tests: green.
- Live evidence: sub-cases live-confirmed in hunt round 2026-07-08s (issue #785 comment); 1.1-vs-1.2 resolution empirically re-probed offline.