### PR TITLE
fix(revert): RFC6902 test preconditions guard CC index patches against stale-index writes (#762)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -1114,9 +1114,40 @@ export function rejectedEmptyStripOps(
   return out;
 }
 
-/** Serialize a RevertItem's ops to an RFC6902 PatchDocument string for Cloud Control. */
+// A JSON pointer carries a NUMERIC array-index segment when any `/`-separated segment is
+// all digits (e.g. `/CacheBehaviors/0/ViewerProtocolPolicy` -> the `0`). Such a pointer
+// is POSITIONAL: it addresses "whatever element sits at index N right now", not a stable
+// identity. If the live array shifted between when classify computed the index and when
+// the user confirms the revert (a prepend/reorder in a same-length object array during the
+// confirm-prompt window), an op at `/Prop/0/Sub` silently lands on a DIFFERENT element and
+// corrupts a sibling (#762).
+function hasArrayIndexSegment(pointer: string): boolean {
+  return pointer.split('/').some((seg) => /^\d+$/.test(seg));
+}
+
+/**
+ * Serialize a RevertItem's ops to an RFC6902 PatchDocument string for Cloud Control.
+ *
+ * #762: the Cloud Control path had no analogue of the SDK-writer guard (writers.ts
+ * `desiredModel` re-reads + re-canonicalizes the live model so an indexed op lands on the
+ * SAME element classify diffed). For an INDEX-BEARING pointer we emit a preceding RFC6902
+ * `test` precondition asserting the addressed location still equals the value classify saw
+ * (`op.prior` = the finding's live `actual`). Cloud Control accepts standard RFC6902 and
+ * evaluates `test` atomically before the mutation, so a shifted index makes it REJECT the
+ * whole patch instead of writing the wrong element — fail-closed, the same intent as the
+ * writer-path re-read. Scalar non-indexed pointers carry no aliasing risk (a named property
+ * is stable regardless of array order), so they get NO `test` op — the patch stays minimal.
+ */
 export function toPatchDocument(item: RevertItem): string {
-  return JSON.stringify(
-    item.ops.map(({ op, path, value }) => (op === 'remove' ? { op, path } : { op, path, value }))
-  );
+  const doc: { op: string; path: string; value?: unknown }[] = [];
+  for (const { op, path, value, prior } of item.ops) {
+    // Guard only index-bearing pointers, and only when we know the value classify diffed
+    // against (`prior` = f.actual). A `test` with an `undefined` value is meaningless
+    // (RFC6902 has no "undefined"): skip it rather than assert an absent value.
+    if (hasArrayIndexSegment(path) && prior !== undefined) {
+      doc.push({ op: 'test', path, value: prior });
+    }
+    doc.push(op === 'remove' ? { op, path } : { op, path, value });
+  }
+  return JSON.stringify(doc);
 }

--- a/tests/cc-patch-test-762.test.ts
+++ b/tests/cc-patch-test-762.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { type RevertItem, toPatchDocument } from '../src/revert/plan.js';
+
+// #762: a Cloud Control revert patch for an INDEX-BEARING pointer (`/Prop/0/Sub`) is
+// positional — it addresses "whatever element is at index 0 right now". If the live array
+// shifts (prepend/reorder in a same-length object array) between check/gather time and the
+// user confirming the revert, a bare mutating op corrupts a SIBLING element. The fix emits a
+// preceding RFC6902 `test` precondition asserting the addressed location still equals the
+// value classify diffed against (`op.prior` = the finding's live `actual`), so Cloud Control
+// REJECTS the whole patch on a shift instead of writing the wrong element.
+
+const item = (ops: RevertItem['ops']): RevertItem => ({
+  logicalId: 'Dist',
+  displayId: 'Dist',
+  resourceType: 'AWS::CloudFront::Distribution',
+  physicalId: 'ABCDEF',
+  kind: 'cc',
+  ops,
+});
+
+describe('#762 CC index patch test-preconditions', () => {
+  it('an index-bearing `add` op gets a preceding `test` asserting the live (prior) value', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          {
+            op: 'add',
+            path: '/CacheBehaviors/0/ViewerProtocolPolicy',
+            value: 'https-only',
+            prior: 'allow-all', // what classify saw live at that index
+            human: 'CacheBehaviors[0].ViewerProtocolPolicy -> deployed-template value',
+          },
+        ])
+      )
+    );
+    // the `test` precedes the mutating op and asserts the LIVE (prior) value at the pointer
+    expect(doc).toEqual([
+      { op: 'test', path: '/CacheBehaviors/0/ViewerProtocolPolicy', value: 'allow-all' },
+      { op: 'add', path: '/CacheBehaviors/0/ViewerProtocolPolicy', value: 'https-only' },
+    ]);
+  });
+
+  it('an index-bearing `remove` op gets a preceding `test` (leaf value), then a bare remove', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          {
+            op: 'remove',
+            path: '/Origins/1/CustomHeaders',
+            prior: [{ HeaderName: 'X', HeaderValue: 'secret' }],
+            human: 'Origins[1].CustomHeaders -> remove (undeclared)',
+          },
+        ])
+      )
+    );
+    expect(doc).toEqual([
+      {
+        op: 'test',
+        path: '/Origins/1/CustomHeaders',
+        value: [{ HeaderName: 'X', HeaderValue: 'secret' }],
+      },
+      { op: 'remove', path: '/Origins/1/CustomHeaders' },
+    ]);
+  });
+
+  it('a NON-indexed scalar op gets NO spurious `test` (no aliasing risk, keep patch minimal)', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          {
+            op: 'add',
+            path: '/Comment',
+            value: 'intended',
+            prior: 'drifted',
+            human: 'Comment -> deployed-template value',
+          },
+        ])
+      )
+    );
+    expect(doc).toEqual([{ op: 'add', path: '/Comment', value: 'intended' }]);
+  });
+
+  it('an index-bearing op with NO prior (undefined) emits NO test (cannot assert an absent value)', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          {
+            op: 'add',
+            path: '/Aliases/0',
+            value: 'a.example.com',
+            // no `prior` — e.g. a removed-undeclared re-add where actual was undefined
+            human: 'Aliases[0] -> restore baseline value',
+          },
+        ])
+      )
+    );
+    expect(doc).toEqual([{ op: 'add', path: '/Aliases/0', value: 'a.example.com' }]);
+  });
+
+  it('mixed ops: only the index-bearing one is guarded, order preserved', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          { op: 'add', path: '/Comment', value: 'x', prior: 'y', human: 'Comment' },
+          {
+            op: 'add',
+            path: '/CacheBehaviors/2/Compress',
+            value: true,
+            prior: false,
+            human: 'CacheBehaviors[2].Compress',
+          },
+        ])
+      )
+    );
+    expect(doc).toEqual([
+      { op: 'add', path: '/Comment', value: 'x' },
+      { op: 'test', path: '/CacheBehaviors/2/Compress', value: false },
+      { op: 'add', path: '/CacheBehaviors/2/Compress', value: true },
+    ]);
+  });
+
+  it('a top-level array-INDEX scalar (`/Prop/0`) is also guarded (positional element)', () => {
+    const doc = JSON.parse(
+      toPatchDocument(
+        item([
+          {
+            op: 'remove',
+            path: '/CustomErrorResponses/0',
+            prior: { ErrorCode: 404 },
+            human: 'CustomErrorResponses[0] -> remove',
+          },
+        ])
+      )
+    );
+    expect(doc).toEqual([
+      { op: 'test', path: '/CustomErrorResponses/0', value: { ErrorCode: 404 } },
+      { op: 'remove', path: '/CustomErrorResponses/0' },
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #762