### PR TITLE
fix(read): degrade a failed SDK supplement read to a loud readGap, not false declared drift (#752)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -3,6 +3,7 @@
 //   GetResource → skip + log. Declared/undeclared labeling happens later.
 import { type CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
 import { isResourceNotFoundError } from '../aws-errors.js';
+import { OVERRIDE_READABLE_WRITEONLY } from '../schema/schema-strip.js';
 import type { DesiredResource } from '../types.js';
 import { SDK_OVERRIDES, SDK_SUPPLEMENTS } from './overrides.js';
 
@@ -332,6 +333,38 @@ function compositeWith(
   };
 }
 
+// A supplement read failed, so its props (exempted from the writeOnly/readGap strip by
+// OVERRIDE_READABLE_WRITEONLY on the assumption the supplement provides the live value)
+// would false-flag as declared drift against an absent live value (#752). Restore the
+// readGap for the props the user DECLARED — mirror the declared value into the live model
+// so declared == live folds to no drift (the readGap outcome) — and warn on stderr naming
+// the failed supplement call, so a permission gap degrades LOUDLY to coverage-incomplete
+// instead of silently to false declared drift. Only exempted TOP-LEVEL props that are (a)
+// declared and (b) NOT already present in the live model are mirrored (an undeclared prop
+// has nothing to compare, and a prop the CC read already echoed is genuinely readable).
+function restoreSupplementReadGaps(
+  resourceType: string,
+  declared: Record<string, unknown>,
+  live: Record<string, unknown>,
+  error: unknown
+): void {
+  const exempt = OVERRIDE_READABLE_WRITEONLY[resourceType];
+  const restored: string[] = [];
+  for (const path of exempt ?? []) {
+    if (path in declared && !(path in live)) {
+      live[path] = declared[path];
+      restored.push(path);
+    }
+  }
+  const call = (error as Error)?.name || 'unknown error';
+  const gap = restored.length
+    ? ` — treating ${restored.join(', ')} as an unverifiable read-gap (declared value assumed unchanged; grant the missing read permission to detect out-of-band drift on it)`
+    : '';
+  process.stderr.write(
+    `[cdkrd] warning: supplement read for ${resourceType} failed (${call})${gap}\n`
+  );
+}
+
 export async function readLive(
   cc: CloudControlClient,
   resource: DesiredResource,
@@ -376,8 +409,18 @@ export async function readLive(
           accountId,
         });
         if (extra) Object.assign(live, extra);
-      } catch {
-        /* keep the CC model; the supplement prop stays an (unavoidable) readGap */
+      } catch (e) {
+        // The supplement read FAILED (a missing narrow IAM permission like
+        // ssm:DescribeParameters / ecs:DescribeServices / elasticache:DescribeUsers /
+        // lex:DescribeBotLocale, or a transient throttle). Those props are exempted from
+        // the writeOnly/readGap strip by OVERRIDE_READABLE_WRITEONLY on the ASSUMPTION the
+        // supplement WILL provide the live value — so leaving them absent makes a DECLARED
+        // value compare against nothing and FALSE-flag as declared-tier drift (#752). Degrade
+        // LOUDLY to coverage-incomplete instead: re-fold each exempted prop the user DECLARED
+        // back to a readGap by mirroring the declared value into the live model (declared ==
+        // live -> no drift surfaced, exactly the readGap semantic), and warn on stderr naming
+        // the failed call so the permission gap is visible rather than silent false drift.
+        restoreSupplementReadGaps(resourceType, declared, live, e);
       }
     }
     return { live };

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1230,6 +1230,85 @@ describe('readLive (SDK supplement path — ECS Service ServiceConnectConfigurat
   });
 });
 
+describe('readLive (supplement failure re-folds exempted props to a readGap, #752)', () => {
+  // When a supplement read fails (missing narrow IAM permission / throttle), a DECLARED
+  // exempted prop (OVERRIDE_READABLE_WRITEONLY) must NOT false-flag as declared drift
+  // against an absent live value — it must degrade to a readGap (declared value mirrored
+  // into live so it folds to no drift) plus a LOUD stderr warning naming the failed call.
+  let warnings: string[] = [];
+  beforeEach(() => {
+    warnings = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      warnings.push(String(chunk));
+      return true;
+    });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  const ecUser = (declared: Record<string, unknown>): DesiredResource =>
+    res({ resourceType: 'AWS::ElastiCache::User', physicalId: 'reader', declared });
+
+  it('mirrors the DECLARED exempted prop into live (declared==live -> no drift, a readGap)', async () => {
+    // CC never echoes AccessString (writeOnly); the user DECLARED it. When
+    // elasticache:DescribeUsers is denied, without the fix AccessString stays absent from
+    // live and false-flags declared drift; with the fix it is mirrored from declared.
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: {
+        Properties: '{"UserId":"reader","UserName":"reader","Engine":"redis","Status":"active"}',
+      },
+    });
+    elasticache.on(DescribeCacheUsersCommand).rejects(named('AccessDeniedException'));
+    const r = await readLive(
+      cc as unknown as CloudControlClient,
+      ecUser({
+        UserId: 'reader',
+        UserName: 'reader',
+        Engine: 'redis',
+        AccessString: 'on ~app:* -@all +@read',
+      }),
+      'us-east-1',
+      '1'
+    );
+    // The declared AccessString is mirrored onto live so declared == live -> readGap, NOT
+    // a `desired="…" actual=undefined` declared-tier drift.
+    expect(r.live?.AccessString).toBe('on ~app:* -@all +@read');
+    expect(r.skippedReason).toBeUndefined();
+  });
+
+  it('emits a LOUD stderr warning naming the failed supplement call and the read-gap prop', async () => {
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: { Properties: '{"UserId":"reader","Status":"active"}' },
+    });
+    elasticache.on(DescribeCacheUsersCommand).rejects(named('ThrottlingException'));
+    await readLive(
+      cc as unknown as CloudControlClient,
+      ecUser({ UserId: 'reader', AccessString: 'on ~* +@all' }),
+      'us-east-1',
+      '1'
+    );
+    const joined = warnings.join('');
+    expect(joined).toContain('AWS::ElastiCache::User');
+    expect(joined).toContain('ThrottlingException');
+    expect(joined).toContain('AccessString');
+  });
+
+  it('does NOT mirror an UNDECLARED exempted prop (nothing to compare -> stays absent)', async () => {
+    cc.on(GetResourceCommand).resolves({
+      ResourceDescription: { Properties: '{"UserId":"reader","Status":"active"}' },
+    });
+    elasticache.on(DescribeCacheUsersCommand).rejects(named('AccessDeniedException'));
+    const r = await readLive(
+      cc as unknown as CloudControlClient,
+      ecUser({ UserId: 'reader' }), // AccessString NOT declared
+      'us-east-1',
+      '1'
+    );
+    expect('AccessString' in (r.live ?? {})).toBe(false);
+    // still warns (loud), but reports no restored read-gap prop
+    expect(warnings.join('')).toContain('AWS::ElastiCache::User');
+  });
+});
+
 describe('readLive (SDK supplement path — cache user AccessString, #482)', () => {
   const ecUser = (): DesiredResource =>
     res({


### PR DESCRIPTION
Closes #752

## Problem
When an `SDK_SUPPLEMENTS` read failed (a missing narrow IAM permission like `ssm:DescribeParameters` / `ecs:DescribeServices` / `elasticache:DescribeUsers` / `lex:DescribeBotLocale`, or a transient throttle), the exempted props (removed from the writeOnly/readGap strip by `OVERRIDE_READABLE_WRITEONLY` on the assumption the supplement would provide the live value) were compared against an absent live value and false-flagged as **red declared drift** — silently. For `AWS::Lex::Bot` the whole `BotLocales` model rendered red, and an unattended `revert --yes` could try to rebuild a healthy bot.

## Fix (router.ts only)
On supplement failure, re-fold each exempted prop the user DECLARED back to a readGap (mirror the declared value into the live model so `declared == live` surfaces no drift) and warn on stderr naming the failed call. A permission gap now degrades **loudly** to coverage-incomplete instead of silently to false drift. Undeclared exempted props stay absent; already-echoed (genuinely readable) props are untouched. `OVERRIDE_READABLE_WRITEONLY` is imported READ-only — `schema-strip.ts` is not modified.

## Test
`tests/router.test.ts` (#752 block, 3 cases): declared exempted prop mirrored (no drift); loud stderr warning names the failed call + prop; undeclared exempted prop stays absent. All fail without the fix.

## Verification
- typecheck / lint+format / build / 3274 unit tests: green.
- Live-test **deferred**: the fix is a failure branch (supplement read throws); a real repro needs deliberate IAM denial on a deployed resource. The branch is deterministic given the throw and is simulated in the unit tests. Recommend an IAM-denied live pass before release if desired.