### PR TITLE
fix(baseline): recordedPhysicalIds cover zero-entry complete resources (#674 void) (#792)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -872,11 +872,13 @@ replace it — lives in [why-a-baseline-file.md](why-a-baseline-file.md).
 ```
 
 `recordedPhysicalIds` (additive, optional — #674) records the PHYSICAL id each
-resource's entries were snapshot against, so a later deploy that **replaces** a
-resource (new physical id) can void the now-stale entries (see the lifecycle
-paragraph below). Old committed baselines have no such field; a resource whose
-physical id was unknown at record time is simply absent — both fall back to the
-pre-#674 behavior (never void).
+recorded-OR-snapshot-`complete` resource was captured against, so a later deploy
+that **replaces** a resource (new physical id) can void the now-stale entries (see
+the lifecycle paragraph below). It covers a `complete` resource even with ZERO
+undeclared entries (#792), so a replacement of such a resource does not surface its
+fresh AWS defaults as false "appeared since record" drift. Old committed baselines
+have no such field; a resource whose physical id was unknown at record time is
+simply absent — both fall back to the pre-#674 behavior (never void).
 
 **Per-entry classification (R62).** The unit of "recorded" is the ENTRY, not the
 file: an undeclared finding with a matching entry is suppressed; with an entry

--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -186,16 +186,21 @@ function sortRecorded(recorded: RecordedEntry[]): RecordedEntry[] {
   );
 }
 
-/** #674: keep only physical ids for logicalIds that still carry a recorded entry, with
- *  sorted keys, so the baseline JSON is byte-stable and free of dead entries. */
+/** #674/#792: keep physical ids for logicalIds that either carry a recorded entry OR
+ *  are snapshot-`complete` (a complete resource with ZERO undeclared entries has nothing
+ *  in `recorded`, but its physical id must still be persisted so #674's replacement void
+ *  fires for it — else an out-of-band REPLACEMENT of a zero-entry complete resource, whose
+ *  fresh AWS defaults now "appear since record", surfaces as false drift). Sorted keys keep
+ *  the JSON byte-stable; a logicalId neither recorded nor complete is dropped as dead. */
 function sortedPhysicalIds(
   ids: Record<string, string>,
-  recorded: RecordedEntry[]
+  recorded: RecordedEntry[],
+  complete: string[]
 ): Record<string, string> {
-  const live = new Set(recorded.map((e) => e.logicalId));
+  const persist = new Set([...recorded.map((e) => e.logicalId), ...complete]);
   const out: Record<string, string> = {};
   for (const key of Object.keys(ids).sort())
-    if (live.has(key) && ids[key] !== undefined) out[key] = ids[key];
+    if (persist.has(key) && ids[key] !== undefined) out[key] = ids[key];
   return out;
 }
 
@@ -208,12 +213,19 @@ export async function writeBaselineFile(b: BaselineFile): Promise<string> {
     ...b,
     recorded: sortRecorded(b.recorded),
     ...(b.completeResources ? { completeResources: [...b.completeResources].sort() } : {}),
-    // #674: write the physical-id map with sorted keys so the JSON stays byte-stable
-    // across machines (same clean-PR-diff goal as sortRecorded). Only for logicalIds
-    // that still have at least one recorded entry — a stray id for a resource with no
-    // entries would be dead weight.
+    // #674/#792: write the physical-id map with sorted keys so the JSON stays byte-stable
+    // across machines (same clean-PR-diff goal as sortRecorded). Kept for logicalIds that
+    // have a recorded entry OR are snapshot-`complete` — a complete resource with zero
+    // undeclared entries must still carry its id so #674's replacement void can fire for
+    // it (else an out-of-band REPLACEMENT surfaces as false "appeared since record").
     ...(b.recordedPhysicalIds
-      ? { recordedPhysicalIds: sortedPhysicalIds(b.recordedPhysicalIds, b.recorded) }
+      ? {
+          recordedPhysicalIds: sortedPhysicalIds(
+            b.recordedPhysicalIds,
+            b.recorded,
+            b.completeResources ?? []
+          ),
+        }
       : {}),
   };
   await writeFile(p, JSON.stringify(stable, null, 2) + '\n', 'utf8'); // pretty + stable for clean PR diffs
@@ -275,6 +287,12 @@ export async function writeBaseline(
   const allIds = opts.allLogicalIds ?? [
     ...new Set([...findings.map((f) => f.logicalId), ...recorded.map((a) => a.logicalId)]),
   ];
+  const completeResources = computeCompleteResources(
+    allIds,
+    findings,
+    recorded,
+    opts.previous?.completeResources ?? []
+  );
   const path = await writeBaselineFile({
     schemaVersion: 2,
     stackName,
@@ -283,39 +301,47 @@ export async function writeBaseline(
     capturedAt: new Date().toISOString(),
     templateHash: hashTemplate(rawTemplate),
     recorded,
-    completeResources: computeCompleteResources(
-      allIds,
-      findings,
+    completeResources,
+    // #674/#792: capture the physical id per recorded logicalId AND per zero-entry
+    // `complete` resource. writeBaselineFile prunes this to recorded-or-complete ids.
+    // Carry forward the previous baseline's map for ids this run did not resolve a
+    // physical id for, so a re-record does not drop a previously-captured id (symmetric
+    // with carryForwardUnreadable on `recorded`).
+    ...buildRecordedPhysicalIds(
       recorded,
-      opts.previous?.completeResources ?? []
+      completeResources,
+      opts.physicalIdByLogical,
+      opts.previous
     ),
-    // #674: capture the physical id per recorded logicalId. writeBaselineFile prunes
-    // this to ids that still have an entry. Carry forward the previous baseline's map
-    // for ids this run did not resolve a physical id for, so a re-record does not drop
-    // a previously-captured id (symmetric with carryForwardUnreadable on `recorded`).
-    ...buildRecordedPhysicalIds(recorded, opts.physicalIdByLogical, opts.previous),
   });
   return { path, count: recorded.length };
 }
 
 /**
- * #674: build the `recordedPhysicalIds` map (logicalId -> physical id) for the entries
- * being written. Prefers the physical id resolved THIS run; falls back to the previous
- * baseline's stored id when this run did not resolve one (a resource skipped / with no
- * physical id must not lose its previously-captured id on re-record — else a later
- * replacement could not be detected). Returns `{}` (spread to nothing) when no id is
- * known, so the field stays absent on baselines with no physical ids at all.
+ * #674/#792: build the `recordedPhysicalIds` map (logicalId -> physical id) for the
+ * resources being written. Covers every RECORDED logicalId PLUS every snapshot-`complete`
+ * resource — the latter so a resource recorded as complete but with ZERO undeclared
+ * entries (nothing in `recorded`) still carries its physical id, letting #674's replacement
+ * void fire for it too (an out-of-band REPLACEMENT of such a resource must not surface as
+ * false "appeared since record" drift; see #792). Prefers the physical id resolved THIS
+ * run; falls back to the previous baseline's stored id when this run did not resolve one
+ * (a resource skipped / with no physical id must not lose its previously-captured id on
+ * re-record — else a later replacement could not be detected). A resource with no known
+ * physical id (this run or prior) is simply absent — today's behavior, never invented.
+ * Returns `{}` (spread to nothing) when no id is known, so the field stays absent on
+ * baselines with no physical ids at all.
  */
 function buildRecordedPhysicalIds(
   recorded: RecordedEntry[],
+  complete: string[],
   live: Map<string, string> | undefined,
   previous: BaselineFile | undefined
 ): { recordedPhysicalIds?: Record<string, string> } {
   const prior = previous?.recordedPhysicalIds ?? {};
   const out: Record<string, string> = {};
-  for (const e of recorded) {
-    const id = live?.get(e.logicalId) ?? prior[e.logicalId];
-    if (id !== undefined) out[e.logicalId] = id;
+  for (const logicalId of new Set([...recorded.map((e) => e.logicalId), ...complete])) {
+    const id = live?.get(logicalId) ?? prior[logicalId];
+    if (id !== undefined) out[logicalId] = id;
   }
   return Object.keys(out).length > 0 ? { recordedPhysicalIds: out } : {};
 }

--- a/tests/physid-void-792.test.ts
+++ b/tests/physid-void-792.test.ts
@@ -1,0 +1,140 @@
+// #792: `recordedPhysicalIds` must cover a `complete` resource EVEN when it has ZERO
+// undeclared entries (nothing in `recorded`). Before the fix, `writeBaseline` /
+// `writeBaselineFile` pruned physical ids to entry-bearing logicalIds only, so a resource
+// recorded as complete but with no recorded entry lost its physical id — and #674's
+// replacement void could not fire for it. Then an out-of-band REPLACEMENT (new physical id,
+// fresh AWS defaults on a complete resource) surfaced as false "appeared since record" drift.
+//
+// The fix persists the physical id for every recorded-OR-complete resource with a known
+// physical id (a resource with no known physical id stays absent — today's behavior).
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  applyBaseline,
+  type BaselineFile,
+  loadBaseline,
+  writeBaseline,
+} from '../src/baseline/baseline-file.js';
+import type { Finding } from '../src/types.js';
+
+// A resource read CLEAN this run: no undeclared/atDefault finding for it at all, so it is
+// snapshot-`complete` (zero entries) yet carries a physical id in `physicalIdByLogical`.
+// `atDefault` finding — an initial/default AWS assigned undeclared (folds, not recorded).
+const atDef = (logicalId: string, path: string, value: unknown): Finding => ({
+  tier: 'atDefault',
+  logicalId,
+  resourceType: 'AWS::SQS::Queue',
+  path,
+  actual: value,
+});
+
+async function inTmp<T>(fn: () => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'cdkrd-792-'));
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(cwd);
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('#792 — zero-entry complete resource keeps its physical id so #674 void fires', () => {
+  // Record: resource "Q" is complete (in allLogicalIds) with ZERO undeclared entries, and
+  // its live physical id is known. Nothing is `recorded`, so the pre-fix prune dropped Q's id.
+  const recordZeroEntryComplete = async (): Promise<BaselineFile> =>
+    inTmp(async () => {
+      await writeBaseline(
+        's',
+        'r',
+        '111122223333',
+        [], // no undeclared/atDefault findings this run -> Q recorded clean = complete, zero entries
+        '{"Resources":{}}',
+        undefined, // default recorded = buildRecorded([]) = []
+        {
+          allLogicalIds: ['Q'], // Q is a template resource, read clean -> snapshot-complete
+          physicalIdByLogical: new Map([['Q', 'phys-old']]),
+        }
+      );
+      const b = await loadBaseline('s', '111122223333', 'r');
+      if (!b) throw new Error('baseline should have been written');
+      return b;
+    });
+
+  it('persists the physical id for a zero-entry complete resource', async () => {
+    const b = await recordZeroEntryComplete();
+    // Pre-fix: recordedPhysicalIds pruned to entry-bearing ids -> {} (field absent). Fixed:
+    // Q is complete with a known id -> persisted.
+    expect(b.recordedPhysicalIds?.Q).toBe('phys-old');
+    expect(b.completeResources).toContain('Q');
+    expect(b.recorded).toEqual([]);
+  });
+
+  it('voids the fresh AWS default of a REPLACED zero-entry complete resource (no false "appeared since record")', async () => {
+    const b = await recordZeroEntryComplete();
+    // Deploy REPLACES Q (new physical id). The new queue reads a fresh undeclared default
+    // that is a genuine non-default value (so it does NOT fold to atDefault) -> arrives as
+    // `undeclared`. Because Q is `complete`, without the void it would be flagged
+    // "appeared since record" drift. With the physical id persisted (#792), #674 detects the
+    // replacement and the value folds to unrecorded (never surfaced), plus a folded nudge.
+    const warnings: string[] = [];
+    const out = applyBaseline(
+      [
+        {
+          tier: 'undeclared',
+          logicalId: 'Q',
+          resourceType: 'AWS::SQS::Queue',
+          path: 'VisibilityTimeout',
+          actual: 999,
+        },
+      ],
+      b,
+      {
+        physicalIdByLogical: new Map([['Q', 'phys-new']]), // DIFFERS -> replaced
+        warn: (m) => warnings.push(m),
+      }
+    );
+    // Not surfaced as drift, and not tagged "appeared since record".
+    const q = out.find((f) => f.logicalId === 'Q' && f.path === 'VisibilityTimeout');
+    expect(q?.note).not.toBe('appeared since record');
+    expect(q?.unrecorded).toBe(true); // folded to inventory, never drift
+    expect(warnings.some((w) => w.includes('since REPLACED by a deploy'))).toBe(false);
+    // (no recorded entry existed for Q, so there is nothing to list in the replaced-stale note;
+    // the point is the undeclared value did NOT surface as drift.)
+  });
+
+  it('a MATCHING physical id keeps normal behavior: a new undeclared value on a complete resource DOES surface', async () => {
+    const b = await recordZeroEntryComplete();
+    // Same physical id -> NOT replaced. A genuine non-default undeclared value on a
+    // snapshot-complete resource appeared since record -> real drift (must still be caught).
+    const out = applyBaseline(
+      [
+        {
+          tier: 'undeclared',
+          logicalId: 'Q',
+          resourceType: 'AWS::SQS::Queue',
+          path: 'VisibilityTimeout',
+          actual: 999,
+        },
+      ],
+      b,
+      { physicalIdByLogical: new Map([['Q', 'phys-old']]) } // same id -> not replaced
+    );
+    const q = out.find((f) => f.logicalId === 'Q' && f.path === 'VisibilityTimeout');
+    expect(q?.note).toBe('appeared since record');
+    expect(q?.unrecorded).toBeUndefined();
+  });
+
+  it('an atDefault value on a same-id complete resource still folds (control: replacement not needed to fold a real default)', async () => {
+    const b = await recordZeroEntryComplete();
+    const out = applyBaseline([atDef('Q', 'VisibilityTimeout', 30)], b, {
+      physicalIdByLogical: new Map([['Q', 'phys-old']]),
+    });
+    // atDefault folds through untouched (not drift, not unrecorded) whether or not replaced.
+    expect(out.some((f) => f.tier === 'undeclared')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #792