### PR TITLE
fix(noise): fold RDS DBCluster BackupRetentionPeriod=1 + DBProxy IdleClientTimeout=1800 (#717)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -803,6 +803,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     TargetConnectionNetworkType: 'IPV4',
     DefaultAuthScheme: 'NONE',
     EndpointNetworkType: 'IPV4',
+    // RDS Proxy's documented default idle client connection timeout — 1800 seconds
+    // (30 minutes), surfaced as undeclared first-run noise whenever a template omits it.
+    // Equality-gated: a shorter/longer timeout the user sets (or later changes out of
+    // band) is not 1800, so it still surfaces.
+    IdleClientTimeout: 1800,
   },
   // R-noise-sweep (offline audit of the golden corpus via scripts/measure-noise.sh):
   // constant, documented service defaults common stateful/streaming types report as
@@ -854,6 +859,11 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
     // era behind the restore-date ClusterCreateTime, so it is not a constant KNOWN_DEFAULTS value.
     NetworkType: 'IPV4',
     EngineMode: 'provisioned', // default; serverless/parallelquery are explicit opt-ins
+    // Aurora's documented default backup retention (1 day) — surfaced as undeclared
+    // first-run noise whenever a template omits it. The twin AWS::DocDB::DBCluster folds
+    // the same BackupRetentionPeriod: 1. Equality-gated: a longer retention the user sets
+    // (or later changes out of band) is not 1, so it still surfaces.
+    BackupRetentionPeriod: 1,
   },
   'AWS::Neptune::DBInstance': {
     AutoMinorVersionUpgrade: true,

--- a/tests/noise-717-rds-twin.test.ts
+++ b/tests/noise-717-rds-twin.test.ts
@@ -1,0 +1,74 @@
+// #717 — two RDS-family undeclared-default fold gaps of the twin-type class (found by a
+// never-undeclared corpus scan). Both are first-run false positives: an undeclared value
+// AWS assigns at creation that must fold to atDefault, not surface as [Potential Drift].
+// Both fold as tier-1 equality-gated constants (KNOWN_DEFAULTS). Each test asserts the fold
+// to atDefault AND that a genuine divergence still surfaces (detection preserved).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+// A — Aurora's default backup retention (1 day), the twin of the already-folded
+// AWS::DocDB::DBCluster.BackupRetentionPeriod: 1.
+describe('#717 RDS::DBCluster BackupRetentionPeriod (equality-gated constant)', () => {
+  const res = mk('AWS::RDS::DBCluster', { Engine: 'aurora-mysql' });
+  it('folds the 1-day Aurora default on a clean deploy', () => {
+    const f = classifyResource(res, { BackupRetentionPeriod: 1 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('BackupRetentionPeriod');
+    expect(tier(f, 'undeclared')).not.toContain('BackupRetentionPeriod');
+  });
+  it('surfaces a longer retention out of band — detection preserved', () => {
+    const f = classifyResource(res, { BackupRetentionPeriod: 7 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('BackupRetentionPeriod');
+  });
+});
+
+// B — RDS Proxy's default idle client connection timeout (1800 s / 30 min).
+describe('#717 RDS::DBProxy IdleClientTimeout (equality-gated constant)', () => {
+  const res = mk('AWS::RDS::DBProxy', {
+    DBProxyName: 'p',
+    EngineFamily: 'MYSQL',
+    RoleArn: 'arn:aws:iam::123456789012:role/r',
+    Auth: [
+      {
+        AuthScheme: 'SECRETS',
+        SecretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:s',
+      },
+    ],
+    VpcSubnetIds: ['subnet-1'],
+  });
+  it('folds the 1800s (30 min) service default on a clean deploy', () => {
+    const f = classifyResource(res, { IdleClientTimeout: 1800 }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('IdleClientTimeout');
+    expect(tier(f, 'undeclared')).not.toContain('IdleClientTimeout');
+  });
+  it('surfaces a changed timeout out of band — detection preserved', () => {
+    const f = classifyResource(res, { IdleClientTimeout: 900 }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('IdleClientTimeout');
+  });
+});

--- a/tests/noise-and-strip.test.ts
+++ b/tests/noise-and-strip.test.ts
@@ -552,6 +552,7 @@ describe('noise suppressors', () => {
       TargetConnectionNetworkType: 'IPV4',
       DefaultAuthScheme: 'NONE',
       EndpointNetworkType: 'IPV4',
+      IdleClientTimeout: 1800,
     });
     expect(KNOWN_DEFAULTS['AWS::AmazonMQ::Broker']).toEqual({
       AuthenticationStrategy: 'SIMPLE',


### PR DESCRIPTION
Closes #717

## Problem
Two RDS-family undeclared-default fold gaps of the twin-type class — a clean, un-mutated deploy must produce zero `[Potential Drift]`, but these undeclared defaults surfaced on every first `check`:
- **`AWS::RDS::DBCluster.BackupRetentionPeriod`** — Aurora's documented default is `1` (day). The twin `AWS::DocDB::DBCluster` already folds `BackupRetentionPeriod: 1`; `AWS::RDS::DBCluster` did not.
- **`AWS::RDS::DBProxy.IdleClientTimeout`** — AWS default is `1800` seconds (30 min).

## Fix
Add both as **tier-1 equality-gated** `KNOWN_DEFAULTS` (noise.ts): the exact default folds to `atDefault`, and any value the user sets or that changes out of band is not the default, so it still surfaces (detection preserved).

## Tests
New `tests/noise-717-rds-twin.test.ts`: each default folds to `atDefault` on a clean deploy, and a changed value (BackupRetentionPeriod: 7 / IdleClientTimeout: 900) still surfaces as `undeclared`. The existing `AWS::RDS::DBProxy` KNOWN_DEFAULTS pin in `noise-and-strip.test.ts` was updated to include the new key.

Offline-predicted from the golden corpus (bug-hunt round 2026-07-08o); defaults confirmed against the CloudFormation/RDS docs. Equality-gated, so a wrong constant would only fail to fold, never hide drift.