### PR TITLE
fix(revert): paginate Lex structural-revert list calls (slot types / intents / slots) (#753)

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -180,6 +180,9 @@ import {
   ListIntentsCommand,
   ListSlotsCommand,
   ListSlotTypesCommand,
+  type IntentSummary,
+  type SlotSummary,
+  type SlotTypeSummary,
   type SlotValueElicitationSetting,
   UpdateBotLocaleCommand,
   type UpdateBotLocaleCommandInput,
@@ -1790,9 +1793,22 @@ const writeLexBotLocales: SdkWriter = async (ctx, ops) => {
     if (!localeId) throw new Error('Lex BotLocales revert: a declared locale has no LocaleId');
 
     // --- slot types: name<->id (custom only; AMAZON.* are built-in), create missing / update ---
-    const liveSlotTypes = await c.send(new ListSlotTypesCommand({ botId, botVersion, localeId }));
+    // PAGINATE (lowercase `nextToken`): a locale with more slot types than one page would omit
+    // page-2+ entities from the map — create-missing would then Create* an existing name (fails
+    // mid-revert) and the delete-extra pass would never see extras beyond page 1 (#753).
+    const slotTypeSummaries: SlotTypeSummary[] = [];
+    {
+      let nextToken: string | undefined;
+      do {
+        const r = await c.send(
+          new ListSlotTypesCommand({ botId, botVersion, localeId, ...(nextToken && { nextToken }) })
+        );
+        slotTypeSummaries.push(...(r.slotTypeSummaries ?? []));
+        nextToken = r.nextToken;
+      } while (nextToken);
+    }
     const slotTypeNameToId = new Map<string, string>();
-    for (const s of liveSlotTypes.slotTypeSummaries ?? []) {
+    for (const s of slotTypeSummaries) {
       const id = lexStr(s.slotTypeId);
       const name = lexStr(s.slotTypeName);
       if (id && name && !id.startsWith('AMAZON.')) slotTypeNameToId.set(name, id);
@@ -1866,9 +1882,21 @@ const writeLexBotLocales: SdkWriter = async (ctx, ops) => {
 
     // --- intents: name<->id, create missing / delete extra (skip AMAZON.FallbackIntent-style
     // built-ins), then update each ---
-    const liveIntents = await c.send(new ListIntentsCommand({ botId, botVersion, localeId }));
+    // PAGINATE (see slot-type note above, #753): an intent beyond page 1 must be in the map or
+    // create-missing recreates it (Create fails on the existing name) and delete-extra misses it.
+    const intentSummaries: IntentSummary[] = [];
+    {
+      let nextToken: string | undefined;
+      do {
+        const r = await c.send(
+          new ListIntentsCommand({ botId, botVersion, localeId, ...(nextToken && { nextToken }) })
+        );
+        intentSummaries.push(...(r.intentSummaries ?? []));
+        nextToken = r.nextToken;
+      } while (nextToken);
+    }
     const intentNameToId = new Map<string, string>();
-    for (const i of liveIntents.intentSummaries ?? []) {
+    for (const i of intentSummaries) {
       const id = lexStr(i.intentId);
       const name = lexStr(i.intentName);
       if (id && name) intentNameToId.set(name, id);
@@ -1915,12 +1943,28 @@ const writeLexBotLocales: SdkWriter = async (ctx, ops) => {
       const intentId = iName ? intentNameToId.get(iName) : undefined;
       if (!intentId || !iName || isBuiltinIntent(iName)) continue;
 
-      // slots for this intent: name<->id, create missing / delete extra, then update each
-      const liveSlots = await c.send(
-        new ListSlotsCommand({ botId, botVersion, localeId, intentId })
-      );
+      // slots for this intent: name<->id, create missing / delete extra, then update each.
+      // PAGINATE (see slot-type note above, #753): a slot beyond page 1 must be in the map or
+      // create-missing recreates it (Create fails on the existing name) and delete-extra misses it.
+      const slotSummaries: SlotSummary[] = [];
+      {
+        let nextToken: string | undefined;
+        do {
+          const r = await c.send(
+            new ListSlotsCommand({
+              botId,
+              botVersion,
+              localeId,
+              intentId,
+              ...(nextToken && { nextToken }),
+            })
+          );
+          slotSummaries.push(...(r.slotSummaries ?? []));
+          nextToken = r.nextToken;
+        } while (nextToken);
+      }
       const slotNameToId = new Map<string, string>();
-      for (const s of liveSlots.slotSummaries ?? []) {
+      for (const s of slotSummaries) {
         const id = lexStr(s.slotId);
         const name = lexStr(s.slotName);
         if (id && name) slotNameToId.set(name, id);

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -2948,6 +2948,130 @@ describe('Lex BotLocales writer (revert-by-rebuild via lexv2-models Update* APIs
       )
     ).rejects.toThrow(/Lex Bot id/);
   });
+
+  it('PAGINATES ListIntents: a declared intent on page 2 is found (not recreated) (#753)', async () => {
+    // live has two intents split across two pages (OrderFlowers on page 1, AddOns on page 2);
+    // both are declared. Without following nextToken, AddOns is invisible → the writer would
+    // CreateIntent an already-existing name (fails mid-revert). With pagination it is found and
+    // only updated.
+    lex.on(ListSlotTypesCommand).resolves({ slotTypeSummaries: [] });
+    lex
+      .on(ListIntentsCommand)
+      .resolvesOnce({
+        intentSummaries: [{ intentId: 'I1', intentName: 'OrderFlowers' }],
+        nextToken: 'page2',
+      })
+      .resolvesOnce({ intentSummaries: [{ intentId: 'I2', intentName: 'AddOns' }] });
+    lex.on(ListSlotsCommand).resolves({ slotSummaries: [] });
+    lex.on(DescribeIntentCommand).resolves({ intentId: 'I1' } as never);
+    lex.on(DescribeBotLocaleCommand).resolves({ botLocaleStatus: 'Built' } as never);
+    lex.on(CreateIntentCommand).resolves({ intentId: 'INEW' });
+    lex.on(UpdateIntentCommand).resolves({});
+    lex.on(UpdateBotLocaleCommand).resolves({});
+    lex.on(BuildBotLocaleCommand).resolves({});
+    const twoIntents = {
+      BotLocales: [
+        {
+          LocaleId: 'en_US',
+          Intents: [
+            { Name: 'OrderFlowers', SampleUtterances: [{ Utterance: 'order' }] },
+            { Name: 'AddOns', SampleUtterances: [{ Utterance: 'add ons' }] },
+          ],
+        },
+      ],
+    };
+    await SDK_NESTED_WRITERS['AWS::Lex::Bot']!.writer(lexCtx(twoIntents), [utteranceOp]);
+    // both pages were listed
+    expect(lex.commandCalls(ListIntentsCommand)).toHaveLength(2);
+    // page-2 AddOns was found → NOT recreated, both intents converged via UpdateIntent
+    expect(lex.commandCalls(CreateIntentCommand)).toHaveLength(0);
+    expect(lex.commandCalls(DeleteIntentCommand)).toHaveLength(0);
+    expect(lex.commandCalls(UpdateIntentCommand)).toHaveLength(2);
+  });
+
+  it('PAGINATES ListSlotTypes: a declared slot type on page 2 is found (not recreated) (#753)', async () => {
+    lex
+      .on(ListSlotTypesCommand)
+      .resolvesOnce({
+        slotTypeSummaries: [{ slotTypeId: 'ST1', slotTypeName: 'Flavor' }],
+        nextToken: 'page2',
+      })
+      .resolvesOnce({ slotTypeSummaries: [{ slotTypeId: 'ST2', slotTypeName: 'Size' }] });
+    lex.on(DescribeSlotTypeCommand).resolves({ slotTypeId: 'ST1' } as never);
+    lex.on(CreateSlotTypeCommand).resolves({ slotTypeId: 'STNEW' });
+    lex.on(UpdateSlotTypeCommand).resolves({});
+    lex.on(DeleteSlotTypeCommand).resolves({});
+    lex.on(ListIntentsCommand).resolves({
+      intentSummaries: [{ intentId: 'I1', intentName: 'OrderFlowers' }],
+    });
+    lex.on(ListSlotsCommand).resolves({ slotSummaries: [] });
+    lex.on(DescribeIntentCommand).resolves({ intentId: 'I1' } as never);
+    lex.on(DescribeBotLocaleCommand).resolves({ botLocaleStatus: 'Built' } as never);
+    lex.on(UpdateIntentCommand).resolves({});
+    lex.on(UpdateBotLocaleCommand).resolves({});
+    lex.on(BuildBotLocaleCommand).resolves({});
+    const withSlotTypes = {
+      BotLocales: [
+        {
+          LocaleId: 'en_US',
+          SlotTypes: [{ Name: 'Flavor' }, { Name: 'Size' }],
+          Intents: [{ Name: 'OrderFlowers', SampleUtterances: [{ Utterance: 'order' }] }],
+        },
+      ],
+    };
+    await SDK_NESTED_WRITERS['AWS::Lex::Bot']!.writer(lexCtx(withSlotTypes), [utteranceOp]);
+    expect(lex.commandCalls(ListSlotTypesCommand)).toHaveLength(2);
+    // page-2 Size was found → NOT recreated, both slot types converged via UpdateSlotType
+    expect(lex.commandCalls(CreateSlotTypeCommand)).toHaveLength(0);
+    expect(lex.commandCalls(DeleteSlotTypeCommand)).toHaveLength(0);
+    expect(lex.commandCalls(UpdateSlotTypeCommand)).toHaveLength(2);
+  });
+
+  it('PAGINATES ListSlots: a declared slot on page 2 is found (not recreated) (#753)', async () => {
+    lex.on(ListSlotTypesCommand).resolves({ slotTypeSummaries: [] });
+    lex.on(ListIntentsCommand).resolves({
+      intentSummaries: [{ intentId: 'I1', intentName: 'OrderFlowers' }],
+    });
+    lex
+      .on(ListSlotsCommand)
+      .resolvesOnce({
+        slotSummaries: [{ slotId: 'S1', slotName: 'FlavorSlot' }],
+        nextToken: 'page2',
+      })
+      .resolvesOnce({ slotSummaries: [{ slotId: 'S2', slotName: 'SizeSlot' }] });
+    lex.on(DescribeSlotCommand).resolves({ slotId: 'S1' } as never);
+    lex.on(CreateSlotCommand).resolves({ slotId: 'SNEW' });
+    lex.on(UpdateSlotCommand).resolves({});
+    lex.on(DeleteSlotCommand).resolves({});
+    lex.on(DescribeIntentCommand).resolves({ intentId: 'I1' } as never);
+    lex.on(DescribeBotLocaleCommand).resolves({ botLocaleStatus: 'Built' } as never);
+    lex.on(UpdateIntentCommand).resolves({});
+    lex.on(UpdateBotLocaleCommand).resolves({});
+    lex.on(BuildBotLocaleCommand).resolves({});
+    const withSlots = {
+      BotLocales: [
+        {
+          LocaleId: 'en_US',
+          Intents: [
+            {
+              Name: 'OrderFlowers',
+              SampleUtterances: [{ Utterance: 'order' }],
+              Slots: [
+                { Name: 'FlavorSlot', ValueElicitationSetting: { SlotConstraint: 'Optional' } },
+                { Name: 'SizeSlot', ValueElicitationSetting: { SlotConstraint: 'Optional' } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    await SDK_NESTED_WRITERS['AWS::Lex::Bot']!.writer(lexCtx(withSlots), [utteranceOp]);
+    expect(lex.commandCalls(ListSlotsCommand)).toHaveLength(2);
+    // page-2 SizeSlot was found → NOT recreated, both slots converged via UpdateSlot
+    expect(lex.commandCalls(CreateSlotCommand)).toHaveLength(0);
+    expect(lex.commandCalls(DeleteSlotCommand)).toHaveLength(0);
+    expect(lex.commandCalls(UpdateSlotCommand)).toHaveLength(2);
+  });
 });
 
 describe('ApiGatewayV2 Stage writer (autoDeploy — bypass CC UpdateStage, issue #667)', () => {


### PR DESCRIPTION
Closes #753

## Problem
The Lex BotLocales structural-revert writer built its name→id maps from a **single unpaginated page** — `ListSlotTypesCommand`, `ListIntentsCommand`, and the per-intent `ListSlotsCommand` all ignored `nextToken` (writers.ts ~L1793/L1869/L1919). On a locale with more entities than one page: an entity beyond page 1 was absent from the map → create-missing called `Create*` on an already-existing name (fails mid-revert, leaving a **partially mutated locale**), and the delete-extra pass never saw the overflow (revert reported success without converging). Write-path sibling of #729 (different call sites).

## Fix
Add `nextToken` accumulation loops on all three call sites (lowercase `nextToken`, matching the read-side idiom in `read/overrides.ts`) so the full cross-page list builds the name→id map. Single-page behavior is unchanged. Confined to `writers.ts`.

## Tests
`tests/writers.test.ts`: three tests (one per call site) mock page 1 (with `nextToken`) then page 2 (no token) and assert the page-2 entity lands in the map — it is updated, not recreated (`Create*` count 0, list called twice). Verified to fail when the loop is removed.

Found by an offline /hunt-bugs audit; loop absence confirmed from code.