### PR TITLE
fix(revert): dependency-aware bounded retry for delete-kind revert items (#765)

### DIFF
--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -28,7 +28,7 @@ import { withinStackPath } from '../construct-path.js';
 import { style } from '../report/style.js';
 import { bulkMultiselect } from './bulk-multiselect.js';
 import { CC_IDENTIFIER_ADAPTERS } from '../read/router.js';
-import { applyRevertDelete, applyRevertItem } from '../revert/apply.js';
+import { applyRevertDelete, applyRevertDeletes, applyRevertItem } from '../revert/apply.js';
 import {
   buildRevertPlan,
   rejectedEmptyStripOps,
@@ -894,13 +894,14 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       );
     },
   });
+  // Partition `delete`-kind items out of the main loop: they are applied as a batch AFTER
+  // all non-delete items, with dependency-aware retry (issue #765). Non-deletes (plan.ts
+  // already orders them first) keep their inline path and MUST run before the deletes.
+  const deleteItems = plan.items.filter((i) => i.kind === 'delete');
   for (const item of plan.items) {
+    if (item.kind === 'delete') continue;
     let r: { ok: boolean; error?: string; hint?: string };
-    if (item.kind === 'delete') {
-      // physicalId IS the CC identifier (the composite the finding carried); delete it.
-      r = await applyRevertDelete(cc, item, item.physicalId, buildRetryOpts(item.displayId));
-      if (!r.ok) failedDeleteIds.add(item.logicalId);
-    } else if (item.kind === 'sdk') {
+    if (item.kind === 'sdk') {
       const res = byLogical.get(item.logicalId);
       // Same transient-retry wrapper as the Cloud Control path (issue #467): an SDK
       // writer can also throw a "resource is currently updating" error that settles on
@@ -968,9 +969,28 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       ...(r.hint !== undefined && { hint: r.hint }),
     });
     if (!r.ok) worst = Math.max(worst, 2);
-    // A failed NON-delete op (delete failures already tracked above) — feed the convergence
+    // A failed NON-delete op (this loop no longer runs deletes) — feed the convergence
     // verdict so a FAILED update never rides under a CLEAN summary.
-    if (!r.ok && item.kind !== 'delete') failedUpdateIds.add(item.logicalId);
+    if (!r.ok) failedUpdateIds.add(item.logicalId);
+  }
+  // Apply the `delete`-kind items as a dependency-aware batch AFTER the non-deletes
+  // (issue #765): a delete that first fails on a DependencyViolation is retried once the
+  // pass that frees its dependency has run. Fold each outcome back into applied / worst /
+  // failedDeleteIds exactly as the old inline single-item delete path did.
+  const deleteOutcomes = await applyRevertDeletes(deleteItems, (item) =>
+    // physicalId IS the CC identifier (the composite the finding carried); delete it.
+    applyRevertDelete(cc, item, item.physicalId, buildRetryOpts(item.displayId))
+  );
+  for (const { item, result: r } of deleteOutcomes) {
+    if (!r.ok) failedDeleteIds.add(item.logicalId);
+    applied.push({
+      logicalId: item.logicalId,
+      displayId: item.displayId,
+      ok: r.ok,
+      ...(r.error !== undefined && { error: r.error }),
+      ...(r.hint !== undefined && { hint: r.hint }),
+    });
+    if (!r.ok) worst = Math.max(worst, 2);
   }
   // Print ONE outcome per resource (a resource that split into a `cc` + `sdk` item
   // produced two results) so a fully reverted resource never prints `reverted:` twice.

--- a/src/revert/apply.ts
+++ b/src/revert/apply.ts
@@ -100,6 +100,64 @@ export async function applyRevertItem(
   }, retry);
 }
 
+// Per-item outcome of a batch delete pass (issue #765). Carries the source item so the
+// caller can fold the result back into its own state (failedDeleteIds / applied / worst)
+// exactly as the inline single-item path does.
+export interface BatchDeleteOutcome<T> {
+  item: T;
+  result: ApplyResult;
+}
+
+// Apply a batch of `delete`-kind revert items with DEPENDENCY-AWARE retry (issue #765).
+//
+// Deleting out-of-band `added` resources in an arbitrary order can fail on a
+// DependencyViolation: a resource can only be deleted AFTER the resource that depends on
+// it is gone (e.g. a security group still referenced by an ENI, an API Gateway parent
+// Resource whose child Methods are also queued for deletion). A single pass in the wrong
+// order leaves such an item stuck as FAILED even though it WOULD succeed once its
+// dependent siblings are deleted.
+//
+// Strategy: run a FIRST pass over all delete items, collecting the still-failed ones.
+// Then, while the LAST pass deleted >=1 item AND some remain failed, run another pass
+// over only the still-failed items — a freed dependency can now succeed. Bounded by
+// `deleteItems.length` total passes (each pass must clear >=1 item to continue, so at
+// most N passes) with an explicit no-progress break, guaranteeing termination.
+//
+// Behavior is IDENTICAL to a single inline pass when there are 0 failures (one pass, all
+// succeed) or 0 progress (one pass, the still-failed set never shrinks so no retry runs).
+// `applyOne` performs ONE delete (reusing applyRevertDelete semantics, incl. isAlreadyGone
+// already-gone tolerance) and returns its ApplyResult. Results are returned in the SAME
+// order as `deleteItems` so the caller's output/state folding is deterministic.
+export async function applyRevertDeletes<T>(
+  deleteItems: readonly T[],
+  applyOne: (item: T) => Promise<ApplyResult>
+): Promise<BatchDeleteOutcome<T>[]> {
+  // Latest result per item, keyed by array index (stable + preserves input order).
+  const results = new Map<number, ApplyResult>();
+  let pending = deleteItems.map((item, index) => ({ item, index }));
+
+  // First pass + bounded retry passes. Total passes capped at deleteItems.length: each
+  // continuing pass must have cleared >=1 item, so N items settle in at most N passes.
+  const maxPasses = Math.max(1, deleteItems.length);
+  for (let pass = 0; pass < maxPasses && pending.length > 0; pass++) {
+    const stillFailed: typeof pending = [];
+    for (const p of pending) {
+      const r = await applyOne(p.item);
+      results.set(p.index, r);
+      if (!r.ok) stillFailed.push(p);
+    }
+    // No progress this pass (nothing cleared) → retrying cannot help; stop.
+    if (stillFailed.length === pending.length) break;
+    pending = stillFailed;
+  }
+
+  return deleteItems.map((item, index) => ({
+    item,
+    // Every index is populated: the loop runs at least one pass over every item.
+    result: results.get(index) ?? { ok: false, error: 'delete not attempted' },
+  }));
+}
+
 // DELETE an `added` (out-of-band) resource via Cloud Control DeleteResource. The
 // identifier is the resource's CC primaryIdentifier (for API Gateway children, the
 // `RestApiId|ResourceId[|HttpMethod]` composite already carried on the finding).

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -5,7 +5,13 @@ import {
 } from '@aws-sdk/client-cloudcontrol';
 import { mockClient } from 'aws-sdk-client-mock';
 import { beforeEach, describe, expect, it } from 'vite-plus/test';
-import { applyRevertDelete, applyRevertItem, isAlreadyGone } from '../src/revert/apply.js';
+import {
+  type ApplyResult,
+  applyRevertDelete,
+  applyRevertDeletes,
+  applyRevertItem,
+  isAlreadyGone,
+} from '../src/revert/apply.js';
 import type { RevertItem } from '../src/revert/plan.js';
 
 const cc = mockClient(CloudControlClient);
@@ -148,6 +154,78 @@ describe('applyRevertItem — transient retry then hint (issue #467)', () => {
     expect(r.ok).toBe(false);
     expect(r.error).toContain('Throttling');
     expect(r.transient).toBe(true);
+  });
+});
+
+describe('applyRevertDeletes — dependency-aware batch retry (issue #765)', () => {
+  const DEP_VIOLATION = 'DependencyViolation: resource is still referenced by another resource';
+
+  // A: fails on the FIRST attempt (its dependency B not yet gone), succeeds on retry.
+  // B: succeeds immediately. After B is deleted, retrying A converges.
+  it('retries a DependencyViolation-failed delete once its dependency is deleted', async () => {
+    let aAttempts = 0;
+    const applyOne = (id: string): Promise<ApplyResult> => {
+      if (id === 'A') {
+        aAttempts++;
+        // Fail A once (B not yet deleted), then succeed on the retry pass.
+        return Promise.resolve(
+          aAttempts === 1 ? { ok: false, error: DEP_VIOLATION } : { ok: true }
+        );
+      }
+      return Promise.resolve({ ok: true }); // B deletes cleanly
+    };
+
+    const outcomes = await applyRevertDeletes(['A', 'B'], applyOne);
+
+    // The batch converges — no still-failed deletes.
+    expect(outcomes.every((o) => o.result.ok)).toBe(true);
+    expect(outcomes.map((o) => o.item)).toEqual(['A', 'B']); // input order preserved
+    expect(aAttempts).toBe(2); // A retried exactly once after B freed it
+  });
+
+  it('a SINGLE pass (no retry) would leave A failed — proving the retry is load-bearing', async () => {
+    // Same fail-A-once thunk, but drive ONE pass by hand (what the pre-fix inline loop did).
+    let aAttempts = 0;
+    const applyOne = (id: string): Promise<ApplyResult> => {
+      if (id === 'A') {
+        aAttempts++;
+        return Promise.resolve(
+          aAttempts === 1 ? { ok: false, error: DEP_VIOLATION } : { ok: true }
+        );
+      }
+      return Promise.resolve({ ok: true });
+    };
+    const firstPass = [
+      { item: 'A', result: await applyOne('A') },
+      { item: 'B', result: await applyOne('B') },
+    ];
+    // Without a retry pass A stays failed even though B is now gone.
+    expect(firstPass.find((o) => o.item === 'A')?.result.ok).toBe(false);
+  });
+
+  it('a genuinely-stuck delete (never succeeds) stops after a no-progress pass', async () => {
+    let calls = 0;
+    const applyOne = (id: string): Promise<ApplyResult> => {
+      calls++;
+      // A always fails; B succeeds. First pass clears B (progress), so ONE retry pass runs
+      // over A only; that pass clears nothing → no-progress break. A remains failed.
+      return Promise.resolve(id === 'B' ? { ok: true } : { ok: false, error: DEP_VIOLATION });
+    };
+    const outcomes = await applyRevertDeletes(['A', 'B'], applyOne);
+    expect(outcomes.find((o) => o.item === 'A')?.result.ok).toBe(false);
+    expect(outcomes.find((o) => o.item === 'B')?.result.ok).toBe(true);
+    // pass 1: A + B (2 calls); pass 2: A only (1 call); then no-progress break.
+    expect(calls).toBe(3);
+  });
+
+  it('single pass when everything succeeds (identical to inline behavior)', async () => {
+    let calls = 0;
+    const outcomes = await applyRevertDeletes(['A', 'B', 'C'], () => {
+      calls++;
+      return Promise.resolve({ ok: true });
+    });
+    expect(outcomes.every((o) => o.result.ok)).toBe(true);
+    expect(calls).toBe(3); // exactly one attempt per item — no extra passes
   });
 });
 


### PR DESCRIPTION
Closes #765

## Problem
Delete-kind revert items (out-of-band `added` resources) were applied in a single pass with no retry (`src/commands/stack-actions.ts` delete branch). Two added siblings with a reference between them — e.g. an added ApiGatewayV2 Route pointing at an added Integration — could fail on a DependencyViolation when the referenced one is attempted first, exiting 2 even though a bounded second pass would converge. `isAlreadyGone` only covered the opposite (cascade-already-removed) direction.

## Fix
Add `applyRevertDeletes()` to `src/revert/apply.ts`: a first pass plus bounded retry passes over the still-failed deletes while progress is made (capped at N passes with a no-progress break — termination guaranteed; results returned in input order). `stack-actions.ts` routes delete-kind items through it AFTER the non-delete items (plan.ts already partitions non-deletes first), folding each outcome back into `applied`/`worst`/`failedDeleteIds` identically to the old inline path. Behavior is unchanged when there are 0 failures or 0 progress; ordering of the `applied` output is preserved.

## Test
`tests/apply.test.ts` (#765 block, 5 cases): the load-bearing pair — A fails first pass, B succeeds, retry converges A (all ok, A retried once) vs a single pass leaving A failed (the without-fix behavior) — plus a genuinely-stuck no-progress-break case and an all-succeed single-pass case.

## Verification
- typecheck / lint+format / build / 3275 unit tests: green.
- Live-test deferred: low-severity self-healing-on-rerun path; the retry logic is a pure bounded loop fully covered by the fail-then-succeed unit test. Issue notes the live repro is speculative.