### PR TITLE
fix(check): --pre-deploy --strict no longer false-fails on a locally-added resource (#727)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -121,6 +121,17 @@ export function nestedStackWarning(resources: DesiredResource[], stackName: stri
   return `warning: ${stackName} has ${nested.length} nested CloudFormation stack(s) — cdkrd does not recurse into them, so the resources INSIDE them are NOT checked: ${names.join(', ')}`;
 }
 
+// #727: under --pre-deploy the declared source is the LOCAL synth template, so a
+// resource that exists there but has not been deployed yet legitimately has NO physical
+// id. gather.ts emits `skipped: no physical id` for it (correct on the deployed path,
+// where a missing physical id is a real anomaly — cf. #689), but under --pre-deploy this
+// is EXPECTED, not a coverage gap: the next deploy will create it. This predicate matches
+// ONLY that exact skip reason (note === 'no physical id'), so other skips — CC-unsupported,
+// read errors — remain genuine coverage gaps even under --pre-deploy. Pure + exported.
+export function isPendingCreationSkip(f: Finding): boolean {
+  return f.tier === 'skipped' && f.note === 'no physical id';
+}
+
 // Resources cdkrd could NOT read this run land in the `skipped` tier — a
 // CC-unsupported type with no SDK override, a read error (throttle / AccessDenied), a
 // missing physical id, a Custom resource. They are genuinely UNCHECKED, yet `skipped`
@@ -128,9 +139,17 @@ export function nestedStackWarning(resources: DesiredResource[], stackName: stri
 // footer — so a materially under-covered run can read `result: CLEAN`, exit 0. Surface
 // the gap LOUDLY (same not-silent principle as the nested-stack / KMS warnings); the
 // `--strict` flag additionally turns it into a non-zero exit. Returns null when nothing
-// was skipped. Pure + exported for unit tests.
-export function coverageWarning(findings: Finding[], stackName: string): string | null {
-  const skipped = findings.filter((f) => f.tier === 'skipped');
+// was skipped. Under --pre-deploy (#727) a "no physical id" skip is a not-yet-deployed
+// local resource, not a gap — excluded here so it is not warned as under-coverage. Pure
+// + exported for unit tests.
+export function coverageWarning(
+  findings: Finding[],
+  stackName: string,
+  preDeploy = false
+): string | null {
+  const skipped = findings.filter(
+    (f) => f.tier === 'skipped' && !(preDeploy && isPendingCreationSkip(f))
+  );
   if (skipped.length === 0) return null;
   const names = skipped
     .map((f) => (f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId))
@@ -140,11 +159,34 @@ export function coverageWarning(findings: Finding[], stackName: string): string 
   return `warning: ${stackName}: ${skipped.length} resource(s) were NOT checked (coverage incomplete) — ${shown.join(', ')}${more}; see the skipped breakdown (--verbose)`;
 }
 
+// #727: under --pre-deploy, the informational count of local resources that are not yet
+// deployed (a "no physical id" skip) — they will be created by the next deploy, so they
+// are surfaced as info, NOT a coverage gap. Returns the info line, or null when none.
+// Pure + exported for unit tests.
+export function pendingCreationInfo(findings: Finding[], stackName: string): string | null {
+  const pending = findings.filter(isPendingCreationSkip);
+  if (pending.length === 0) return null;
+  const names = pending
+    .map((f) => (f.constructPath ? withinStackPath(f.constructPath, stackName) : f.logicalId))
+    .sort();
+  const shown = names.slice(0, 10);
+  const more = names.length > shown.length ? `, …(+${names.length - shown.length} more)` : '';
+  return `info: ${stackName}: ${pending.length} resource(s) not yet deployed — will be created by the next deploy (pending creation, not a coverage gap): ${shown.join(', ')}${more}`;
+}
+
 // The coverage gap that `--strict` fails on: any resource skipped (unread) OR any
-// nested stack not recursed into. Pure + exported.
-export function hasCoverageGap(findings: Finding[], resources: DesiredResource[]): boolean {
+// nested stack not recursed into. Under --pre-deploy (#727) a "no physical id" skip is a
+// not-yet-deployed local resource (pending creation), which is EXPECTED and therefore not
+// a gap — excluded so `--strict --pre-deploy` no longer false-fails on a feature branch
+// that merely ADDS a resource with zero real drift. Non-pre-deploy behavior is unchanged.
+// Pure + exported.
+export function hasCoverageGap(
+  findings: Finding[],
+  resources: DesiredResource[],
+  preDeploy = false
+): boolean {
   return (
-    findings.some((f) => f.tier === 'skipped') ||
+    findings.some((f) => f.tier === 'skipped' && !(preDeploy && isPendingCreationSkip(f))) ||
     resources.some((r) => r.resourceType === 'AWS::CloudFormation::Stack')
   );
 }
@@ -155,13 +197,15 @@ export function hasCoverageGap(findings: Finding[], resources: DesiredResource[]
 // path fold the identical value into `worst` — the --pre-deploy branch returns
 // early (its own report + continue), so without sharing this it silently never
 // applied --strict (a skipped resource / un-recursed nested stack under
-// --strict --pre-deploy exited 0).
+// --strict --pre-deploy exited 0). Under --pre-deploy (#727) a "no physical id"
+// skip (a not-yet-deployed local resource) does not count as a gap.
 export function strictCoverageExit(
   strict: boolean,
   findings: Finding[],
-  resources: DesiredResource[]
+  resources: DesiredResource[],
+  preDeploy = false
 ): number {
-  return strict && hasCoverageGap(findings, resources) ? 1 : 0;
+  return strict && hasCoverageGap(findings, resources, preDeploy) ? 1 : 0;
 }
 
 /**
@@ -328,8 +372,16 @@ export async function runCheck(args: string[]): Promise<number> {
       // complaint that prompted R127) and (b) duplicate the footer. --json has no info:
       // footer, so keep the loud stderr warning there to preserve the invariant.
       if (a.json) {
-        const covWarn = coverageWarning(gathered.findings, stackName);
+        const covWarn = coverageWarning(gathered.findings, stackName, a.preDeploy);
         if (covWarn) console.error(covWarn);
+      }
+      // #727: under --pre-deploy, surface not-yet-deployed local resources (a "no physical
+      // id" skip) as INFORMATIONAL — they are excluded from the coverage gap / --strict
+      // exit above, so say WHY the count is not a gap (they will be created by the deploy).
+      // stderr keeps --json stdout clean.
+      if (a.preDeploy) {
+        const pendingInfo = pendingCreationInfo(gathered.findings, stackName);
+        if (pendingInfo) console.error(pendingInfo);
       }
       // a mid-operation / failed stack state still gets compared, but the result may be
       // transient/unreliable — say so loudly (REVIEW_IN_PROGRESS / deleting states never
@@ -394,8 +446,12 @@ export async function runCheck(args: string[]): Promise<number> {
         // --strict still applies under --pre-deploy: live reads (and so the skipped
         // tier / un-recursed nested stacks) happen here too, only the DECLARED side
         // comes from the synth template. Fold the coverage-gap exit BEFORE the early
-        // continue, or --strict --pre-deploy would silently never fail.
-        worst = Math.max(worst, strictCoverageExit(a.strict, gathered.findings, desired.resources));
+        // continue, or --strict --pre-deploy would silently never fail. Pass preDeploy so
+        // a not-yet-deployed local resource (#727) is pending-creation info, not a gap.
+        worst = Math.max(
+          worst,
+          strictCoverageExit(a.strict, gathered.findings, desired.resources, true)
+        );
         continue;
       }
 

--- a/tests/predeploy-strict-727.test.ts
+++ b/tests/predeploy-strict-727.test.ts
@@ -1,0 +1,137 @@
+// #727: under `--pre-deploy`, a resource that exists in the LOCAL synth template but is
+// not yet deployed has no physical id → gather.ts lands it in the `skipped` tier with
+// reason "no physical id". On the normal (deployed) path that IS a real coverage gap
+// (a deployed template resource should have a physical id — cf. #689). Under --pre-deploy
+// it is EXPECTED (pending creation), so it must NOT drive the `--strict` coverage exit,
+// while OTHER skip reasons (CC-unsupported / read errors) stay genuine gaps even there.
+import { describe, expect, it } from 'vite-plus/test';
+import {
+  coverageWarning,
+  hasCoverageGap,
+  isPendingCreationSkip,
+  pendingCreationInfo,
+  strictCoverageExit,
+} from '../src/commands/check.js';
+import type { DesiredResource, Finding } from '../src/types.js';
+
+// The exact "no physical id" skip gather.ts emits for a template resource with no
+// deployed physical id (src/commands/gather.ts classifyRead: tier 'skipped', note
+// 'no physical id').
+const noPhysId = (logicalId: string, over: Partial<Finding> = {}): Finding => ({
+  tier: 'skipped',
+  logicalId,
+  resourceType: 'AWS::SQS::Queue',
+  path: '',
+  note: 'no physical id',
+  ...over,
+});
+
+// A DIFFERENT skip reason (an unread / CC-unsupported resource) — a genuine coverage
+// gap regardless of --pre-deploy.
+const unread = (logicalId: string, over: Partial<Finding> = {}): Finding => ({
+  tier: 'skipped',
+  logicalId,
+  resourceType: 'AWS::X::Y',
+  path: '',
+  note: 'not readable',
+  ...over,
+});
+
+const dr = (resourceType: string): DesiredResource => ({
+  logicalId: 'L',
+  resourceType,
+  declared: {},
+});
+
+const topic = [dr('AWS::SNS::Topic')];
+
+describe('isPendingCreationSkip (#727 — matches ONLY the no-physical-id skip)', () => {
+  it('matches a skipped finding whose note is exactly "no physical id"', () => {
+    expect(isPendingCreationSkip(noPhysId('Q'))).toBe(true);
+  });
+
+  it('does NOT match other skip reasons (CC-unsupported / read error)', () => {
+    expect(isPendingCreationSkip(unread('Q'))).toBe(false);
+    expect(isPendingCreationSkip({ ...noPhysId('Q'), note: 'not readable' })).toBe(false);
+  });
+
+  it('does NOT match a non-skipped tier even with the same note', () => {
+    expect(isPendingCreationSkip({ ...noPhysId('Q'), tier: 'declared' })).toBe(false);
+  });
+});
+
+describe('hasCoverageGap under --pre-deploy (#727)', () => {
+  it('NON-pre-deploy: a no-physical-id skip is a real coverage gap (unchanged behavior)', () => {
+    expect(hasCoverageGap([noPhysId('Q')], topic)).toBe(true);
+    expect(hasCoverageGap([noPhysId('Q')], topic, false)).toBe(true);
+  });
+
+  it('--pre-deploy: a no-physical-id skip is NOT a coverage gap (pending creation)', () => {
+    expect(hasCoverageGap([noPhysId('Q')], topic, true)).toBe(false);
+  });
+
+  it('--pre-deploy: a DIFFERENT skip reason still IS a coverage gap', () => {
+    expect(hasCoverageGap([unread('Q')], topic, true)).toBe(true);
+  });
+
+  it('--pre-deploy: a nested stack still IS a coverage gap even with only pending-creation skips', () => {
+    expect(hasCoverageGap([noPhysId('Q')], [dr('AWS::CloudFormation::Stack')], true)).toBe(true);
+  });
+});
+
+describe('strictCoverageExit under --pre-deploy (#727 — the core false-fail fix)', () => {
+  it('WITHOUT --pre-deploy, --strict on a no-physical-id skip exits 1 (real gap)', () => {
+    // The regression this fixes: without the preDeploy flag threaded, this stays 1.
+    expect(strictCoverageExit(true, [noPhysId('Q')], topic /* preDeploy defaults false */)).toBe(1);
+  });
+
+  it('WITH --pre-deploy, --strict on a no-physical-id skip exits 0 (pending creation, not a gap)', () => {
+    // The exact --pre-deploy workflow: a feature branch ADDS a queue, zero real drift.
+    expect(strictCoverageExit(true, [noPhysId('Q')], topic, true)).toBe(0);
+  });
+
+  it('WITH --pre-deploy, a DIFFERENT skip reason still fails --strict (genuine gap)', () => {
+    expect(strictCoverageExit(true, [unread('Q')], topic, true)).toBe(1);
+  });
+
+  it('WITH --pre-deploy but no --strict, a genuine gap still exits 0 (strict axis only)', () => {
+    expect(strictCoverageExit(false, [unread('Q')], topic, true)).toBe(0);
+  });
+});
+
+describe('coverageWarning under --pre-deploy (#727 — no false under-coverage warning)', () => {
+  it('--pre-deploy: a pure no-physical-id skip produces NO coverage warning', () => {
+    expect(coverageWarning([noPhysId('Q')], 'S', true)).toBeNull();
+  });
+
+  it('NON-pre-deploy: a no-physical-id skip still warns (unchanged behavior)', () => {
+    expect(coverageWarning([noPhysId('Q')], 'S')).toContain('1 resource(s) were NOT checked');
+  });
+
+  it('--pre-deploy: a genuine unread skip still warns, and its count excludes pending-creation', () => {
+    const w = coverageWarning([noPhysId('Q'), unread('R')], 'S', true)!;
+    expect(w).toContain('1 resource(s) were NOT checked');
+  });
+});
+
+describe('pendingCreationInfo (#727 — informational surface)', () => {
+  it('is null when nothing is pending creation', () => {
+    expect(
+      pendingCreationInfo([unread('Q'), { ...noPhysId('Q'), tier: 'declared' }], 'S')
+    ).toBeNull();
+  });
+
+  it('counts + lists not-yet-deployed local resources (framed as pending, not a gap)', () => {
+    const info = pendingCreationInfo(
+      [noPhysId('B', { constructPath: 'S/Zeta' }), noPhysId('A', { constructPath: 'S/Alpha' })],
+      'MyStack'
+    )!;
+    expect(info).toContain('MyStack: 2 resource(s) not yet deployed');
+    expect(info).toContain('pending creation, not a coverage gap');
+    expect(info).toContain('S/Alpha, S/Zeta'); // construct path preferred, sorted
+  });
+
+  it('ignores other skip reasons entirely', () => {
+    expect(pendingCreationInfo([unread('Q')], 'S')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #727