### PR TITLE
fix(desired): restrict YAML 1.1 schema — no implicit Date, no single-letter Y/N booleans

### DIFF
--- a/src/desired/yaml-cfn.ts
+++ b/src/desired/yaml-cfn.ts
@@ -3,7 +3,15 @@
 // resolving each to its long-form object ({Ref:...} / {Fn::Foo:...}) so the rest
 // of cdk-real-drift reads one canonical (JSON-equivalent) representation.
 
-import type { CollectionTag, ScalarTag, YAMLMap, YAMLSeq } from 'yaml';
+import type {
+  CollectionTag,
+  ParseOptions,
+  ScalarTag,
+  SchemaOptions,
+  Tags,
+  YAMLMap,
+  YAMLSeq,
+} from 'yaml';
 import { parse as yamlParse } from 'yaml';
 
 export type TemplateFormat = 'json' | 'yaml';
@@ -102,6 +110,62 @@ function buildCustomTags(): Array<ScalarTag | CollectionTag> {
 
 const CUSTOM_TAGS = buildCustomTags();
 
+// The stock `yaml@2` YAML-1.1 schema over-resolves two plain-scalar shapes that
+// CloudFormation itself does NOT resolve (CFn deploys both as strings), producing
+// declared-tier false positives that survive `record` and corrupt `revert` (#850):
+//   1. Implicit timestamps — an unquoted `2026-01-01` / `2010-09-09` /
+//      `2001-12-14 21:59:43.10 -5` resolves to a JS `Date` OBJECT via the
+//      `tag:yaml.org,2002:timestamp` tag.
+//   2. Single-letter booleans — the 1.1 `bool` test regexes include `Y|y` and
+//      `N|n`, so `N` -> `false` and `Y` -> `true` (an AttributeType, a flag, ...).
+// These regexes exclude the single-letter `Y/y/N/n` forms while KEEPING the
+// `yes/no/on/off/true/false` forms — matching CFn and preserving the #785 fix.
+const TRUE_BOOL_TEST = /^(?:[Yy]es|YES|[Tt]rue|TRUE|[Oo]n|ON)$/;
+const FALSE_BOOL_TEST = /^(?:[Nn]o|NO|[Ff]alse|FALSE|[Oo]ff|OFF)$/;
+const BOOL_TAG = 'tag:yaml.org,2002:bool';
+// The `Date`-producing tag. The sexagesimal `intTime`/`floatTime` tags share the
+// int/float tag URIs (they yield NUMBERS like `1:30` -> 90, which #785 needs), so
+// only THIS tag URI is dropped — the sexagesimal number resolution is preserved.
+const TIMESTAMP_TAG = 'tag:yaml.org,2002:timestamp';
+
+// Take the resolved YAML-1.1 core tags and (a) drop the implicit `timestamp`
+// resolver so a date-like plain scalar stays a string, and (b) swap the two `bool`
+// tags for copies whose `test` excludes single-letter `Y/y/N/n`. The CFn short-form
+// tags (`!Ref`/`!GetAtt`/...) are appended so they still layer on top.
+function restrictYaml11Tags(baseTags: Tags): Tags {
+  const restricted: Tags = [];
+  for (const tag of baseTags) {
+    // A resolved schema's tags are objects, but the `Tags` element type also admits
+    // `TagId` string aliases — leave any such entry untouched (it is not a bool/timestamp).
+    if (typeof tag === 'string') {
+      restricted.push(tag);
+      continue;
+    }
+    if (tag.tag === TIMESTAMP_TAG) continue; // no implicit Date resolution
+    if (tag.tag === BOOL_TAG) {
+      // The 1.1 schema carries a separate tag for `true` and for `false`; each
+      // `identify`s only its own boolean. Use that to pick the matching narrowed
+      // `test`, so the swap is robust regardless of the tag array's order. Rebuild it
+      // as an explicit ScalarTag (a spread of the tag union widens `test` and loses
+      // the ScalarTag discriminant).
+      const scalar = tag as ScalarTag;
+      const isTrueTag = scalar.identify?.(true) === true;
+      restricted.push({
+        ...scalar,
+        test: isTrueTag ? TRUE_BOOL_TEST : FALSE_BOOL_TEST,
+      } as ScalarTag);
+      continue;
+    }
+    restricted.push(tag);
+  }
+  return restricted.concat(CUSTOM_TAGS as Tags);
+}
+
+const CFN_YAML_PARSE_OPTIONS: ParseOptions & SchemaOptions = {
+  schema: 'yaml-1.1',
+  customTags: restrictYaml11Tags,
+};
+
 export function detectTemplateFormat(text: string): TemplateFormat {
   const stripped = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
   const trimmed = stripped.trimStart();
@@ -122,11 +186,13 @@ export function parseCfnTemplate(text: string): Record<string, unknown> {
     // and `0755` parses as decimal 755 — diverging from what CFn actually deployed
     // (1.1 folds those to boolean / octal 493, and `1:30` to sexagesimal 90),
     // producing first-run declared false positives and silent revert corruption
-    // (#785). Pinning `version: '1.1'` selects the `yaml-1.1` base schema so implicit
-    // scalar resolution matches CFn. CUSTOM_TAGS (the CFn short forms) still layer on
-    // top as additional tags; the YAML-1.1-only `!!binary`/`!!timestamp`/... tags only
-    // fire on explicit `!!` markers a CFn template never carries, so no regression.
-    parsed = yamlParse(body, { version: '1.1', customTags: CUSTOM_TAGS });
+    // (#785). But the STOCK 1.1 schema also over-resolves plain date-like scalars to
+    // `Date` and single-letter `Y/N` to boolean, which CFn does NOT do (#850) — so we
+    // use a RESTRICTED yaml-1.1 schema (`restrictYaml11Tags`): 1.1 semantics minus
+    // implicit timestamps minus single-letter bools, composed with the CFn short
+    // forms. The YAML-1.1 `!!binary`/... tags only fire on explicit `!!` markers a
+    // CFn template never carries, so no regression.
+    parsed = yamlParse(body, CFN_YAML_PARSE_OPTIONS);
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('Template root is not an object.');

--- a/tests/yaml-cfn.test.ts
+++ b/tests/yaml-cfn.test.ts
@@ -67,6 +67,74 @@ describe('yaml-cfn parse', () => {
     expect(typeof p.Account).toBe('string');
   });
 
+  it('keeps an unquoted date-like plain scalar a string, not a Date (#850)', () => {
+    // The stock yaml@2 YAML-1.1 schema resolves an unquoted date-like scalar to a JS
+    // `Date` object via the implicit `!!timestamp` tag — but CloudFormation deploys it
+    // verbatim as a string. A `Date` compared against the live string is a declared
+    // false positive that survives `record` and corrupts `revert`. It must stay a string.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::Fake::Type
+    Properties:
+      ExpirationDate: 2026-01-01
+      Ver: 2010-09-09
+      Ts: 2001-12-14 21:59:43.10 -5`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.ExpirationDate).toBe('2026-01-01');
+    expect(p.ExpirationDate instanceof Date).toBe(false);
+    expect(p.Ver).toBe('2010-09-09');
+    expect(p.Ver instanceof Date).toBe(false);
+    expect(p.Ts).toBe('2001-12-14 21:59:43.10 -5');
+    expect(p.Ts instanceof Date).toBe(false);
+  });
+
+  it('keeps a single-letter Y/N plain scalar a string, not a boolean (#850)', () => {
+    // The YAML 1.1 `bool` regex includes single letters `Y|y|N|n`, so a bare
+    // `AttributeType: N` resolves to boolean `false` and `Y` to `true`. CloudFormation
+    // does NOT do this (a DynamoDB AttributeType `N`/`S`/`B` deploys as the string).
+    // A boolean compared against the live string is a declared false positive.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttrN: N
+      AttrY: Y
+      AttrLowerN: n
+      AttrLowerY: y`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.AttrN).toBe('N');
+    expect(p.AttrY).toBe('Y');
+    expect(p.AttrLowerN).toBe('n');
+    expect(p.AttrLowerY).toBe('y');
+  });
+
+  it('still resolves yes/no/on/off and octal/sexagesimal under the restricted 1.1 schema (#785 preserved)', () => {
+    // The #850 restriction (drop implicit timestamps, exclude single-letter bools) must
+    // NOT regress the #785 fix: multi-letter YAML 1.1 booleans and octal/sexagesimal
+    // integers must still resolve exactly as CloudFormation's 1.1 parser produces them.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::Fake::Type
+    Properties:
+      YesVal: yes
+      NoVal: no
+      OnVal: on
+      OffVal: off
+      TrueVal: true
+      FalseVal: false
+      Mode: 0755
+      Sexagesimal: 1:30`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.YesVal).toBe(true);
+    expect(p.NoVal).toBe(false);
+    expect(p.OnVal).toBe(true);
+    expect(p.OffVal).toBe(false);
+    expect(p.TrueVal).toBe(true);
+    expect(p.FalseVal).toBe(false);
+    expect(p.Mode).toBe(493); // octal 0755
+    expect(p.Sexagesimal).toBe(90); // 60*1 + 30
+  });
+
   it('rejects a non-object root', () => {
     expect(() => parseCfnTemplate('[1,2]')).toThrow();
   });


### PR DESCRIPTION
The #785 fix (PR #831) parsed deployed templates with the stock `yaml@2` `version:'1.1'` schema, which over-resolves two plain-scalar shapes CloudFormation keeps as **strings** (#850):

1. an unquoted date-like scalar (`ExpirationDate: 2026-01-01`) → a JS `Date` **object**;
2. a single-letter `Y`/`N` (`AttributeType: N`) → a **boolean**.

Both cause declared-tier false positives that survive `record` and corrupt `revert`.

Fix: replace `version:'1.1'` with a **restricted** `yaml-1.1` schema (`restrictYaml11Tags`) — drop the implicit `timestamp` tag and swap the two `bool` tags for copies whose `test` regex excludes single-letter `Y/y/N/n`, while keeping `yes/no/on/off` booleans and octal/sexagesimal integers (so the **#785** behavior is preserved). CFn short-form tags (`!Ref`/`!GetAtt`/…) are composed on top.

Tests: unquoted date stays a string; `AttributeType: N` stays `"N"`; `Flag: yes` still → `true` (#785 preserved). Full suite green.

Closes #850