### PR TITLE
fix(config): reject all-wildcard ignore paths and bound path globs at '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,17 +474,22 @@ ignore:
   form still match. Widening a stamped scope to a `*` glob (to intentionally ignore a
   path across every stack/account/region) stays a hand-edit.
 - All four fields accept `*` / `?` globs, but the `path` axis is **segment-aware**
-  while the scope axes are not. In `path`, `*` / `?` match within a single `.`-delimited
-  segment (`*.DesiredCount` matches `<anyId>.DesiredCount`, not a deeper
-  `Tbl.Config.DesiredCount`) — a parent `path` still covers child paths via the subtree
-  walk, so the segment bound does not under-match. Inside a `[...]` bracket key a `*` /
+  while the scope axes are not. In `path`, `*` / `?` match within a single
+  segment, bounded by `.`, `/`, and `[` (`*.DesiredCount` matches
+  `<anyId>.DesiredCount`, not a deeper `Tbl.Config.DesiredCount`; `MyApi/*`
+  matches a direct construct-path child but not a grandchild
+  `MyApi/Resource/Method`) — a parent `path` still covers child paths via the
+  subtree walk, so the segment bound does not under-match. Inside a `[...]`
+  bracket key a `*` /
   `?` is **unbounded within that bracket** (the brackets delimit the key, so a `.`
   between them is data): `Alb.LoadBalancerAttributes[*]` and
   `Alb.LoadBalancerAttributes[routing.*]` both match the dotted key
   `[routing.http2.enabled]`. On **stack / account / region**, `*` / `?` are unbounded
   (those names carry no `.`). The three scope axes are exactly the
   baseline file's identity axes; each is **omitted to leave that axis unscoped**
-  (match-all) — a present-but-empty `""` is rejected (it would match nothing).
+  (match-all) — a present-but-empty `""` is rejected (it would match nothing),
+  as is an all-wildcard `path` (`*`, `**`, `*.*`) — it would silence _every_
+  finding, so a rule must name at least one literal segment.
   **Account** keeps a `stack: "Prod*"` rule from
   leaking into a same-named stack in another account (stack-name uniqueness only
   holds within one account / App); **region** is independent the same way — the same

--- a/src/commands/glob-match.ts
+++ b/src/commands/glob-match.ts
@@ -33,13 +33,22 @@ export function matchesGlob(pattern: string, name: string): boolean {
 
 /**
  * Path-axis glob (for ignore-rule `path` patterns against a `<id>.<sub.path>` target):
- * a SEGMENT-aware variant where `*` / `?` do NOT cross a `.` or `[` boundary. So
+ * a SEGMENT-aware variant where `*` / `?` do NOT cross a `.`, `[`, or `/` boundary. So
  * `*.DesiredCount` matches `<anyId>.DesiredCount` (the documented intent — `*` = one id
  * segment) but NOT a same-named leaf nested deeper (`Tbl.Config.DesiredCount`, or a
  * free-form-map key literally named `DesiredCount`). Subtree coverage of a PARENT rule
  * (`X.Policies` covering `X.Policies[Mp].Name`) is handled separately by the ancestor
  * walk in `pathMatches`, so bounding `*` here does not under-match. The stack/region
  * axes keep `matchesGlob` (their names contain no `.`/`[`, so it is equivalent there).
+ *
+ * `/` is ALSO a hard segment boundary: `applyIgnores` matches against `/`-joined
+ * construct paths (`MyApi/Resource/Method`), so `MyApi/*` means "a direct child of
+ * MyApi" — bounding `*` at `/` keeps it from leaking to arbitrarily deep descendants
+ * (`MyApi/Resource/Method`). Deep-subtree coverage of a `/`-parent rule is still
+ * handled by the ancestor walk in `pathMatches` (which trims at `.` / `[`; a rule that
+ * means the whole subtree ends at the parent segment). Inside a `[...]` bracket a `/`
+ * is DATA, not a boundary — the brackets already delimit the key — so it stays literal
+ * there, exactly like `.`.
  *
  * INSIDE a `[...]` bracket segment a `*` / `?` is UNBOUNDED within that bracket: the
  * brackets already delimit the key, so a `.` between them is DATA, not a segment
@@ -52,8 +61,8 @@ export function matchesPathGlob(pattern: string, target: string): boolean {
   let out = '^';
   let inBracket = false;
   for (const ch of pattern.replace(/\*+/g, '*')) {
-    if (ch === '*') out += inBracket ? '[^\\]]*' : '[^.[]*';
-    else if (ch === '?') out += inBracket ? '[^\\]]' : '[^.[]';
+    if (ch === '*') out += inBracket ? '[^\\]]*' : '[^.[/]*';
+    else if (ch === '?') out += inBracket ? '[^\\]]' : '[^.[/]';
     else {
       if (ch === '[') inBracket = true;
       else if (ch === ']') inBracket = false;

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -123,6 +123,24 @@ export async function loadConfig(): Promise<CdkrdConfig> {
 }
 
 /**
+ * True when `path` is an all-wildcard universal matcher — a pattern with NO literal
+ * segment content, made only of the glob metachars (`*` / `?`) and the segment
+ * separators (`.` `[` `]` `/`). Examples: `*`, `**`, `*.*`, `?`, a slash-joined
+ * `*` pair, `*.*[*]`.
+ * Such a rule ignores EVERY finding (issue #842), so the validator rejects it the same
+ * way it rejects an empty path. A pattern with even one literal character (`Foo*`,
+ * `*.DesiredCount`, `MyApi/*`) is NOT universal and is allowed. Exported for tests.
+ */
+export function isUniversalPath(path: string): boolean {
+  // Strip every wildcard and separator; if anything is left, the path names a literal
+  // segment and is a real scope. If NOTHING is left, it is pure wildcards/separators —
+  // a universal matcher. (A path that is only separators like `.` has no wildcard, so it
+  // matches nothing rather than everything, but it is an equally useless no-op and the
+  // same "name a literal segment" guidance applies, so we reject it here too.)
+  return path.replace(/[*?.[\]/]/g, '') === '';
+}
+
+/**
  * Validate one `ignore` array entry: a mapping with a required string `path` and
  * optional string `stack` / `account` / `region` (and no other keys — the same fail-fast
  * typo guard as the unknown-top-level-key check, so a mistyped `reigon` is rejected
@@ -145,6 +163,17 @@ function validateIgnoreEntry(entry: unknown, index: number): void {
     // and the ancestor walk never reaches empty) — a silent no-op rule the user believes
     // is suppressing a property. Reject it loudly so the no-op can't masquerade as active.
     throw new Error(`${at}: "path" must not be empty`);
+  if (isUniversalPath(obj.path))
+    // The mirror-image catastrophe of the empty path: a path made ONLY of wildcards and
+    // segment separators (`*`, `**`, `*.*`, `?`, `*/*`, `*.*[*]`, …) has no literal
+    // content, so — via `pathMatches`'s per-segment glob AND its ancestor walk — it
+    // silences EVERY declared / undeclared / added finding, not the one property the
+    // author meant to suppress (issue #842). That is a foot-gun the size of the whole
+    // report, so reject it as loudly as the empty path; a real rule must name at least
+    // one literal path segment to scope what it ignores.
+    throw new Error(
+      `${at}: "path" must not be an all-wildcard pattern ("${obj.path}") — it would ignore every finding; name at least one literal path segment`
+    );
   for (const k of ['stack', 'account', 'region'] as const) {
     if (obj[k] !== undefined && typeof obj[k] !== 'string')
       throw new Error(`${at}: "${k}" must be a string`);

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -10,6 +10,7 @@ import {
   type IgnoreRuleObject,
   type IgnoreScope,
   ignoreRuleFor,
+  isUniversalPath,
   loadConfig,
   mergeIgnoreRules,
   parseIgnoreRule,
@@ -142,6 +143,31 @@ describe('applyIgnores', () => {
       cfg([p('*.DesiredCount')])
     );
     expect(out.map((f) => f.tier)).toEqual(['ignored', 'declared', 'undeclared']);
+  });
+
+  it('a `Parent/*` rule matches a DIRECT construct-path child but NOT a deeper descendant (#842)', () => {
+    // A `/` is a real construct-path segment boundary; `Parent/*` means "a direct child",
+    // so it must not leak to arbitrarily deep descendants (`Parent/Child/Grandchild`).
+    const child: Finding = {
+      tier: 'undeclared',
+      logicalId: 'ChildAAAA',
+      constructPath: 'MyStack/Parent/Child',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      actual: [{}],
+    };
+    const grandchild: Finding = {
+      tier: 'undeclared',
+      logicalId: 'GrandBBBB',
+      constructPath: 'MyStack/Parent/Child/Grandchild',
+      resourceType: 'AWS::IAM::Role',
+      path: 'Policies',
+      actual: [{}],
+    };
+    // direct child (within-stack path `Parent/Child`) is ignored…
+    expect(ign([child], 'MyStack', cfg([p('Parent/*.Policies')]))[0]?.tier).toBe('ignored');
+    // …but the deeper `Parent/Child/Grandchild` must stay drift (no cross-slash leak)
+    expect(ign([grandchild], 'MyStack', cfg([p('Parent/*.Policies')]))[0]?.tier).toBe('undeclared');
   });
 
   it('a parent rule still covers a deep same-named leaf via the ancestor walk (no under-match)', () => {
@@ -374,6 +400,17 @@ describe('applyIgnores', () => {
   });
 });
 
+describe('isUniversalPath (#842 all-wildcard guard)', () => {
+  it('is true for a pure-wildcard/separator path (would ignore everything)', () => {
+    for (const path of ['*', '**', '***', '*.*', '?', '??', '*.?', '*[*]', '*.*[*]', '.'])
+      expect(isUniversalPath(path), path).toBe(true);
+  });
+  it('is false as soon as the path names any literal segment', () => {
+    for (const path of ['Foo', 'Foo*', '*.DesiredCount', 'MyApi/*', '*/ApiRole.Policies', 'a?'])
+      expect(isUniversalPath(path), path).toBe(false);
+  });
+});
+
 describe('loadConfig', () => {
   let dir: string;
   let prevCwd: string;
@@ -458,6 +495,20 @@ describe('loadConfig', () => {
   it('an empty "path" → throws (a silent no-op rule must not masquerade as active, WAVE23)', async () => {
     await write('ignore:\n  - path: ""\n');
     await expect(loadConfig()).rejects.toThrow(/"path" must not be empty/);
+  });
+
+  it('an all-wildcard "path" → throws (would ignore every finding, #842)', async () => {
+    for (const badPath of ['*', '**', '*.*', '?', '*/*', '*.*[*]']) {
+      await write(`ignore:\n  - path: "${badPath}"\n`);
+      await expect(loadConfig(), badPath).rejects.toThrow(/must not be an all-wildcard pattern/);
+    }
+  });
+
+  it('a "path" with at least one literal segment is accepted (not over-rejected)', async () => {
+    await write('ignore:\n  - path: "MyApi/*"\n  - path: "*.DesiredCount"\n  - path: "Foo*"\n');
+    expect(await loadConfig()).toEqual({
+      ignore: [{ path: 'MyApi/*' }, { path: '*.DesiredCount' }, { path: 'Foo*' }],
+    });
   });
 
   it('a mapping entry with a non-string scope → throws', async () => {

--- a/tests/glob-match.test.ts
+++ b/tests/glob-match.test.ts
@@ -106,4 +106,21 @@ describe('matchesPathGlob (segment-aware — does not cross . or [ boundaries)',
     expect(matchesPathGlob('****X', 'aaaaaX')).toBe(true);
     expect(matchesPathGlob('**********X', 'a'.repeat(60))).toBe(false);
   });
+
+  it('* / ? do NOT cross a `/` construct-path segment boundary (#842)', () => {
+    // `Parent/*` = a DIRECT child of Parent, not an arbitrarily deep descendant.
+    expect(matchesPathGlob('Parent/*', 'Parent/Child')).toBe(true); // direct child still matches
+    expect(matchesPathGlob('Parent/*', 'Parent/Child/Grandchild')).toBe(false); // no cross-slash leak
+    expect(matchesPathGlob('MyApi/*', 'MyApi/Resource/Method')).toBe(false);
+    expect(matchesPathGlob('MyApi/?', 'MyApi/A')).toBe(true);
+    expect(matchesPathGlob('MyApi/?', 'MyApi/A/B')).toBe(false);
+    // a `*` also can't cross `/` on the way to a trailing `.property`
+    expect(matchesPathGlob('MyApi/*.Prop', 'MyApi/Child.Prop')).toBe(true);
+    expect(matchesPathGlob('MyApi/*.Prop', 'MyApi/Child/Sub.Prop')).toBe(false);
+  });
+
+  it('inside a bracket key `/` stays literal (data, not a boundary)', () => {
+    expect(matchesPathGlob('Tags[*]', 'Tags[a/b]')).toBe(true); // `/` is data within the bracket
+    expect(matchesPathGlob('Tags[a/*]', 'Tags[a/b]')).toBe(true);
+  });
 });


### PR DESCRIPTION
Two apply-time over-match bugs let a hand-written `.cdkrd/ignore.yaml` rule silently over-ignore far more than intended (the STOPS-watching verb's most dangerous failure mode) (#842):

- **Bug 1** — a bare `*` / `**` / `*.*` path silences **every** finding (the ancestor walk trims to a single dot-free segment that `*` matches). `validateIgnoreEntry` now rejects an all-wildcard universal path the same way it already rejects an empty path; a rule must name at least one literal segment.
- **Bug 2** — `*` crossed the `/` construct-path separator, so `MyApi/*` leaked to `MyApi/Resource/Method`. `matchesPathGlob` now bounds `*`/`?` at `/` (outside brackets), so `MyApi/*` matches a direct child but not a deep descendant. Inside a `[...]` bracket key `/` stays literal.

Tests: `*`/`**`/`*.*` rejected + do not match everything; `Parent/*` matches `Parent/Child` but not `Parent/Child/Grandchild`. Full suite green (3357 tests).

Closes #842