### PR TITLE
fix(check): emit '[]' for --json on a zero-stack app (#885)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -262,7 +262,13 @@ export async function runCheck(args: string[]): Promise<number> {
     return 2;
   }
   if (stacks.length === 0) {
-    console.error('note: the CDK app defines no stacks — nothing to check');
+    // Under --json the whole stdout stream is a single JSON.parse-able value (an
+    // array of per-stack reports, printed once at the end). The zero-stack early
+    // return happens BEFORE that print, so without this a consumer's
+    // JSON.parse(stdout) throws on '' while the exit code reads success (#885).
+    // Emit the empty array to keep the contract; the human note stays on stderr.
+    if (a.json) console.log('[]');
+    else console.error('note: the CDK app defines no stacks — nothing to check');
     return 0;
   }
 

--- a/tests/json-zerostacks-885.test.ts
+++ b/tests/json-zerostacks-885.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// runCheck resolves a CDK app (resolveApp) and discovers its stacks
+// (discoverStacks). Mock both so the app defines ZERO stacks: resolveApp is
+// truthy, discoverStacks yields [] → resolveStacks returns [] → runCheck hits
+// the zero-stack early return. loadConfig returns {ignore:[]} on a missing
+// .cdkrd/ignore.yaml, so no config fixture is needed.
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: () => Promise.resolve([]),
+}));
+
+import { runCheck } from '../src/commands/check.js';
+
+describe('check --json on a zero-stack app emits a parseable empty array, not empty stdout (#885)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('--json prints "[]" to stdout (so JSON.parse(stdout) succeeds) and exits 0', async () => {
+    const out: string[] = [];
+    const log = vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      out.push(String(m));
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const code = await runCheck(['--json']);
+
+    expect(code).toBe(0);
+    // exactly one stdout line, and it parses to an empty array — the contract
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0]!)).toEqual([]);
+    log.mockRestore();
+  });
+
+  it('text mode writes the human note to stderr and NOTHING to stdout', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      stdout.push(String(m));
+    });
+    vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      stderr.push(String(m));
+    });
+
+    const code = await runCheck([]);
+
+    expect(code).toBe(0);
+    expect(stdout).toEqual([]); // stdout stays clean in text mode
+    expect(stderr.join('\n')).toContain('defines no stacks');
+  });
+});


### PR DESCRIPTION
Closes #885.

## Problem
`check --json` on an app that defines zero matching stacks returned at the zero-stack early exit — **before** the single `console.log(JSON.stringify(jsonReports))` — emitting **empty stdout** (zero bytes) with exit 0. A consumer's `JSON.parse(stdout)` throws on `''` while the exit code reads success, breaking the README contract that the whole stdout stream is one `JSON.parse`-able value. Every other path (errored / skipped / not-deployed stacks) already emits an array element.

## Fix
The zero-stack early return now prints `[]` under `--json` (an empty array — consistent with the final print shape). The human 'defines no stacks' note stays on stderr; text mode is unchanged.

## Tests
New `tests/json-zerostacks-885.test.ts` (synth mocked to zero discovered stacks): `--json` prints exactly one stdout line that `JSON.parse`s to `[]` and exits 0; text mode writes nothing to stdout and the note to stderr.

Offline CLI-contract fix — no live-AWS component (the repro is a synthetic zero-stack app). Distinct from #866 (64KiB truncation) and #871 (under-signaled elements).