### PR TITLE
fix(commands): exact-name stack selection targets every same-named region instance (#884)

### DIFF
--- a/src/commands/resolve-stacks.ts
+++ b/src/commands/resolve-stacks.ts
@@ -118,10 +118,16 @@ export async function resolveStacks(a: CommonArgs): Promise<ResolvedStack[]> {
           `glob "${name}" matched no stacks defined by the CDK app (found: ${known()})`
         );
     } else {
-      const hit = discovered.find((s) => s.stackName === name);
-      if (!hit)
+      // Collect ALL discovered stacks with this exact name, NOT just the first
+      // (#884). A multi-REGION app can define the same stackName in two envs
+      // (e.g. `Dup` in us-east-1 AND us-west-2); `add` dedups on name+region so
+      // the two distinct-region instances are both kept while a same-name
+      // same-region duplicate still collapses. `find` silently dropped every
+      // instance but the first, so `check Dup --fail` greenlit the other region.
+      const hits = discovered.filter((s) => s.stackName === name);
+      if (hits.length === 0)
         throw new Error(`stack "${name}" is not defined by the CDK app (found: ${known()})`);
-      add(hit.stackName, hit.region ?? fallbackRegion, hit.template);
+      for (const hit of hits) add(hit.stackName, hit.region ?? fallbackRegion, hit.template);
     }
   }
   if (out.length === 0) {

--- a/tests/multiregion-dup-884.test.ts
+++ b/tests/multiregion-dup-884.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+// resolveStacks synthesizes a CDK app (resolveApp) and discovers its stacks
+// (discoverStacks) — both heavy. Mock them: resolveApp returns a truthy app,
+// discoverStacks returns a fixed set so the exact-name / glob matching can be
+// exercised in isolation. Here the app defines the SAME stackName in two
+// regions (a supported multi-region shape — check.ts keys --pre-deploy synth
+// templates by name+region for exactly this).
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+const discovered = [
+  { stackName: 'Dup', region: 'us-east-1', template: { east: true } },
+  { stackName: 'Dup', region: 'us-west-2', template: { west: true } },
+  { stackName: 'Solo', region: 'us-east-1', template: {} },
+];
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: () => Promise.resolve(discovered),
+}));
+
+import type { CommonArgs } from '../src/cli-args.js';
+import { resolveStacks } from '../src/commands/resolve-stacks.js';
+
+function args(overrides: Partial<CommonArgs>): CommonArgs {
+  return {
+    stackNames: [],
+    all: false,
+    region: 'us-east-1',
+    profile: undefined,
+    app: undefined,
+    context: {},
+    json: false,
+    showAll: false,
+    yes: false,
+    preDeploy: false,
+    undeclaredOnly: false,
+    declaredOnly: false,
+    fail: false,
+    strict: false,
+    removeUnrecorded: false,
+    verbose: false,
+    waitMs: undefined,
+    ...overrides,
+  };
+}
+
+describe('resolveStacks — exact name selects EVERY same-named region instance (#884)', () => {
+  it('returns BOTH regions for an exact same-name selection (not just the first)', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Dup'] }));
+    expect(out.map((s) => s.region).sort()).toEqual(['us-east-1', 'us-west-2']);
+    // each instance carries its OWN synth template — the drop bug would have lost west
+    expect(out.map((s) => s.template)).toEqual(
+      expect.arrayContaining([{ east: true }, { west: true }])
+    );
+  });
+
+  it('parity with the glob branch — `Dup*` and exact `Dup` resolve the same set', async () => {
+    const exact = await resolveStacks(args({ stackNames: ['Dup'] }));
+    const glob = await resolveStacks(args({ stackNames: ['Dup*'] }));
+    expect(exact.map((s) => s.region).sort()).toEqual(glob.map((s) => s.region).sort());
+  });
+
+  it('still dedups a same-name same-region instance to one entry', async () => {
+    // `Dup Dup` (exact name twice) must not double it; add() dedups on name+region.
+    const out = await resolveStacks(args({ stackNames: ['Dup', 'Dup'] }));
+    expect(out.filter((s) => s.stackName === 'Dup')).toHaveLength(2); // two REGIONS, once each
+  });
+
+  it('leaves a single-instance exact name unaffected', async () => {
+    const out = await resolveStacks(args({ stackNames: ['Solo'] }));
+    expect(out.map((s) => s.stackName)).toEqual(['Solo']);
+  });
+
+  it('still throws for an unknown exact name', async () => {
+    await expect(resolveStacks(args({ stackNames: ['Missing'] }))).rejects.toThrow(
+      /stack "Missing" is not defined by the CDK app/
+    );
+  });
+});


### PR DESCRIPTION
Closes #884.

## Problem
`resolveStacks`' exact-name positional branch used `discovered.find(s => s.stackName === name)` — returning only the **first** discovered stack with that name. All other same-named instances (a multi-**region** app defining the same `stackName` in two envs) were silently dropped. The glob branch already loops over all matches. Result: `check Dup --fail` in CI reports clean while the us-west-2 `Dup` drifts (same 'CI believes it was covered' class as #778), and there was no way to target the second instance by exact name. Applies to all four verbs via `resolveStacks`; `revert Dup --yes` mutating one region while claiming the name is the sharpest edge.

## Fix
The exact branch now collects `discovered.filter(s => s.stackName === name)` and adds each. The existing `add()` dedup (keyed on `name + region`) keeps the two distinct-region instances while still collapsing a same-name **same-region** duplicate. The unknown-exact-name throw is preserved.

## Tests
New `tests/multiregion-dup-884.test.ts` (synth mocked to a two-region same-name assembly): exact `Dup` returns both regions (each with its own synth template), parity with the `Dup*` glob, same-name same-region still dedups to one, single-instance names unaffected, unknown name still throws.

Offline stack-discovery fix — no live-AWS component (the repro is a synthetic assembly, as the issue notes).