### PR TITLE
chore(cleanup): enforce zero-orphan test resources (IAM+tag sweep, deploy auto-arm, Stop warn, /sweep-resources)

### DIFF
--- a/.claude/hooks/deploy-autoarm-gate.sh
+++ b/.claude/hooks/deploy-autoarm-gate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# deploy-autoarm-gate.sh
+#
+# PreToolUse hook (Bash). Closes the "forgot to arm the cleanup sentinel" hole
+# (hole A): when a command that DEPLOYS real AWS resources is about to run, arm the
+# bughunt-clean sentinel automatically so a commit / PR cannot land until the account
+# is verified clean — even if the operator/skill never called `bughunt-track.sh add`.
+#
+# WHY generic, not per-stack: parsing the exact stack name from an arbitrary deploy
+# command is fragile (a misparse tracks the WRONG name, which `verify` finds "gone"
+# and passes — leaking the real stack). Instead we arm a single GENERIC token
+# ("a deploy happened — prove the account clean before committing"). `bughunt-track
+# verify` ALWAYS runs sweep-orphans.sh (now a tag-based, any-type net), so the real
+# check is an account-wide clean-proof, not a name match. The token just holds the
+# gate until that proof passes.
+#
+# NON-BLOCKING: this hook only ARMS (a side effect) and always exits 0 — it never
+# blocks the deploy itself. The bughunt-clean-gate blocks the later commit/PR.
+#
+# Owner is the fixed key "autoarm" (not per-worktree): a deploy can run from a throwaway
+# /tmp app with no worktree, and the clean-proof is account-global anyway, so any agent
+# whose `verify` shows the account clean may clear it (the account being clean means
+# every agent's ephemeral resources are already gone). Per-STACK tracking stays per-owner
+# in bughunt-track; this generic flag is deliberately shared.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+# Strip quoted substrings first so a deploy phrase merely PRINTED inside a string
+# (echo "aws cloudformation deploy …") does not false-positive — a real deploy verb
+# is an unquoted command word. Then match deploy-shaped commands. Deliberately NOT
+# matched: `cdk synth`, `cdk destroy`, `delstack` (synth/delete, not deploy).
+unquoted=$(printf '%s' "$cmd" | sed "s/\"[^\"]*\"//g; s/'[^']*'//g")
+deploy_re='(aws[[:space:]]+cloudformation[[:space:]]+(deploy|create-stack|update-stack)|(^|[[:space:]])cdk([[:space:]]+[^&|;]*)?[[:space:]]+deploy([[:space:]]|$)|(^|[[:space:]])sam[[:space:]]+deploy([[:space:]]|$))'
+printf '%s' "$unquoted" | grep -qE "$deploy_re" || exit 0
+
+# Resolve this checkout's bughunt-track.sh (sibling skills dir) and arm the generic
+# token under the fixed "autoarm" owner. Never let an arming failure block the deploy.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null || true)"
+# CDKRD_AUTOARM_TRACK lets the self-test point at a stub instead of arming the real
+# sentinel; defaults to the sibling bughunt-track.sh.
+TRACK="${CDKRD_AUTOARM_TRACK:-${HOOK_DIR}/../skills/hunt-bugs/bughunt-track.sh}"
+if [ -x "$TRACK" ]; then
+  CDKRD_BUGHUNT_OWNER=autoarm "$TRACK" add "AUTODEPLOY-pending-verify" >/dev/null 2>&1 || true
+  {
+    echo "[deploy-autoarm] A deploy-shaped command was detected — the bughunt-clean"
+    echo "gate is now ARMED (owner: autoarm). Before you can commit / open a PR, prove"
+    echo "the account is clean and release it:"
+    echo "  /sweep-resources          # or, manually:"
+    echo "  CDKRD_BUGHUNT_OWNER=autoarm ${TRACK} verify --region <region>"
+    echo "  CDKRD_BUGHUNT_OWNER=autoarm ${TRACK} clear"
+  } >&2
+fi
+
+exit 0

--- a/.claude/hooks/deploy-autoarm-gate.test.sh
+++ b/.claude/hooks/deploy-autoarm-gate.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Smoke tests for deploy-autoarm-gate.sh
+#
+# Feeds simulated tool input and asserts the hook (a) always exits 0 (never blocks a
+# deploy) and (b) ARMS exactly on deploy-shaped commands. A stub bughunt-track (via
+# CDKRD_AUTOARM_TRACK) records the arm to a temp file instead of touching the real
+# sentinel. Run: bash .claude/hooks/deploy-autoarm-gate.test.sh
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/deploy-autoarm-gate.sh"
+PASS=0
+FAIL=0
+
+# run <name> <cmd> <expect_armed:0|1>
+run() {
+  local name="$1" cmd="$2" expect_armed="$3"
+
+  local tmp stub armlog
+  tmp=$(mktemp -d)
+  armlog="$tmp/armed"
+  stub="$tmp/track-stub.sh"
+  cat > "$stub" <<EOF
+#!/usr/bin/env bash
+echo "\$@" >> "$armlog"
+EOF
+  chmod +x "$stub"
+
+  local payload exit_code
+  payload="{\"tool_input\":{\"command\":$(printf '%s' "$cmd" | jq -Rs .)},\"cwd\":\"$tmp\"}"
+  set +e
+  printf '%s' "$payload" | CDKRD_AUTOARM_TRACK="$stub" bash "$HOOK" >/dev/null 2>&1
+  exit_code=$?
+  set -e
+
+  local armed=0
+  [ -s "$armlog" ] && armed=1
+
+  local ok=1
+  [ "$exit_code" -eq 0 ] || ok=0            # must NEVER block a deploy
+  [ "$armed" -eq "$expect_armed" ] || ok=0
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1)); echo "ok   - $name (exit=$exit_code armed=$armed)"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL - $name (exit=$exit_code armed=$armed, want armed=$expect_armed)"
+  fi
+  rm -rf "$tmp"
+}
+
+# deploy-shaped → ARM
+run "aws cfn deploy"          "aws cloudformation deploy --template-file t.yaml --stack-name Foo" 1
+run "aws create-stack"        "aws cloudformation create-stack --stack-name Foo --template-body file://t" 1
+run "cd && npx cdk deploy"    "cd /tmp/x && npx cdk deploy Foo --require-approval never" 1
+run "mise cdk deploy --all"   "mise exec -- cdk deploy --all" 1
+run "sam deploy"              "sam deploy --guided" 1
+
+# not a deploy → do NOT arm
+run "cdk synth"               "cdk synth --app 'node app.cjs'" 0
+run "cdk destroy"             "cdk destroy Foo" 0
+run "delstack"               "delstack -s Foo -r us-east-1 -y -f" 0
+run "cdkrd check"             "cdkrd check Foo --region us-east-1" 0
+run "echo mentions deploy"    'echo "run aws cloudformation deploy later"' 0
+run "git commit mentions"     "git commit -m 'add cloudformation deploy notes'" 0
+
+echo "----"
+echo "deploy-autoarm-gate: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/stop-cleanup-warn.sh
+++ b/.claude/hooks/stop-cleanup-warn.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# stop-cleanup-warn.sh
+#
+# Stop hook. Closes hole B — "deployed real AWS resources, then ended the session
+# WITHOUT committing" — which the commit/PR gate (bughunt-clean-gate) never sees
+# because no commit/PR is attempted. At session end, if the bughunt-clean sentinel
+# is armed (a tracked stack, or the generic autoarm token from deploy-autoarm-gate),
+# print a prominent reminder to clean up.
+#
+# WARN ONLY (exit 0): a /hunt-bugs session legitimately keeps resources live between
+# turns, so this must NOT hard-block stopping (that is the commit/PR gate's job).
+# It only surfaces outstanding resources so they are never SILENTLY forgotten.
+
+set -u
+
+input=$(cat 2>/dev/null || true)
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+target_dir="${hook_cwd:-$PWD}"
+
+# Resolve the shared main-tree root (parent of the common .git dir) so the sentinel
+# path matches what bughunt-track.sh / bughunt-clean-gate.sh use.
+git -C "$target_dir" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+git_common="$(git -C "$target_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$git_common" ]; then
+  main_root="$(dirname "$git_common")"
+else
+  main_root="$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || echo "$target_dir")"
+fi
+
+pending_dir="${main_root}/.markgate-bughunt-pending.d"
+legacy="${main_root}/.markgate-bughunt-pending"
+
+count=0
+if [ -d "$pending_dir" ]; then
+  while IFS= read -r f; do
+    [ -s "$f" ] && count=$((count + $(grep -cvE '^[[:space:]]*$' "$f" 2>/dev/null || echo 0)))
+  done < <(find "$pending_dir" -type f 2>/dev/null)
+fi
+[ -s "$legacy" ] && count=$((count + $(grep -cvE '^[[:space:]]*$' "$legacy" 2>/dev/null || echo 0)))
+
+[ "$count" -gt 0 ] || exit 0
+
+{
+  echo "⚠️  cdkrd cleanup reminder: ${count} deploy/stack token(s) are still ARMED in the"
+  echo "    bughunt-clean sentinel — you deployed real AWS resources this session and have"
+  echo "    NOT yet verified them gone. Do not leave them billing:"
+  echo "      /sweep-resources        # discover + delete cdkrd test resources, then release the gate"
+  echo "    (or: delstack the stacks, run bughunt-track.sh verify, then clear)."
+} >&2
+exit 0

--- a/.claude/hooks/stop-cleanup-warn.test.sh
+++ b/.claude/hooks/stop-cleanup-warn.test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Smoke tests for stop-cleanup-warn.sh
+#
+# Sets up a throwaway git repo, optionally arms the sentinel, runs the Stop hook, and
+# asserts it exits 0 always (warn-only) and prints a reminder ONLY when armed.
+# Run: bash .claude/hooks/stop-cleanup-warn.test.sh
+
+set -euo pipefail
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/stop-cleanup-warn.sh"
+PASS=0
+FAIL=0
+
+# run <name> <armed:0|1> <expect_warn:0|1>
+run() {
+  local name="$1" armed="$2" expect_warn="$3"
+
+  local tmp
+  tmp=$(mktemp -d)
+  ( cd "$tmp" && git init -q -b main && git config user.email t@t && git config user.name t && : > seed && git add -A && git commit -q -m init )
+
+  if [ "$armed" = "1" ]; then
+    mkdir -p "$tmp/.markgate-bughunt-pending.d"
+    printf 'AUTODEPLOY-pending-verify\n' > "$tmp/.markgate-bughunt-pending.d/autoarm"
+  fi
+
+  local out exit_code
+  set +e
+  out=$(printf '{"cwd":"%s"}' "$tmp" | bash "$HOOK" 2>&1)
+  exit_code=$?
+  set -e
+
+  local warned=0
+  printf '%s' "$out" | grep -q "cleanup reminder" && warned=1
+
+  local ok=1
+  [ "$exit_code" -eq 0 ] || ok=0        # warn-only, never blocks
+  [ "$warned" -eq "$expect_warn" ] || ok=0
+
+  if [ "$ok" -eq 1 ]; then
+    PASS=$((PASS + 1)); echo "ok   - $name (exit=$exit_code warned=$warned)"
+  else
+    FAIL=$((FAIL + 1)); echo "FAIL - $name (exit=$exit_code warned=$warned, want warn=$expect_warn)"
+  fi
+  rm -rf "$tmp"
+}
+
+run "armed sentinel warns"      1 1
+run "empty sentinel is silent"  0 0
+
+echo "----"
+echo "stop-cleanup-warn: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; bughunt-clean-gate blocks `git commit`/`gh pr create`/`gh pr merge` while the .markgate-bughunt-pending sentinel is non-empty (armed by /hunt-bugs via bughunt-track.sh add before any integ deploy; released by bughunt-track.sh clear only after every tracked stack is deleted + SWEEP CLEAN); stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule); worktree-guard (matcher Edit|Write|NotebookEdit) blocks an Edit/Write to the MAIN checkout's `src/**`/`tests/**` while a `.worktrees/` worktree exists (CLAUDE.md: main is integration-only; direct main edits have caused cross-session collisions — the #408 contamination). NOT wired: pr-review and the read-only integ gate — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
+  "//": "PreToolUse hooks for cdk-real-drift. The repo now has a GitHub remote and a PR-based flow, so the cdkd-derived branch-protection and verify-pr-merge gates are active (R83). Wired (per .markgate.yml, ONLY to gates with companion skills): check-gate blocks `git commit` unless check+docs markers are fresh; branch-gate blocks commit/push directly on main; bughunt-clean-gate blocks `git commit`/`gh pr create`/`gh pr merge` while the .markgate-bughunt-pending sentinel is non-empty (armed by /hunt-bugs via bughunt-track.sh add before any integ deploy; released by bughunt-track.sh clear only after every tracked stack is deleted + SWEEP CLEAN); stale-base-gate blocks `git push` of a branch that sits on origin/main yet reverts recent main work (the stale-base soft-reset clobber); verify-pr-gate blocks `gh pr create`/`gh pr merge` unless the verify-pr marker is fresh (EXEMPT for docs/tooling-only diffs touching no src/**); non-english-text-gate blocks `gh pr create`/`edit`/`merge` when the PR diff contains non-English text (the OSS English-only rule); deploy-autoarm-gate ARMS the bughunt-clean sentinel (generic `autoarm` token) the moment a deploy-shaped command (`aws cloudformation deploy`/`create-stack`/`update-stack`, `cdk deploy`, `sam deploy`) runs, so the commit/PR gate then blocks until the account is verified clean via /sweep-resources — this closes the 'deployed a throwaway live-test but never called bughunt-track.sh add' hole; worktree-guard (matcher Edit|Write|NotebookEdit) blocks an Edit/Write to the MAIN checkout's `src/**`/`tests/**` while a `.worktrees/` worktree exists (CLAUDE.md: main is integration-only; direct main edits have caused cross-session collisions — the #408 contamination). Stop hook: stop-cleanup-warn warns at session end if the sentinel is still armed (deployed but not cleaned up — closes the 'deploy then end without committing' hole; warn-only so /hunt-bugs can keep resources live between turns). NOT wired: pr-review and the read-only integ gate — they have no companion skill in cdkrd (pr-review is multi-agent; cdkrd has no providers/state/destroy integ), so wiring them would brick the flow.",
   "hooks": {
     "PreToolUse": [
       {
@@ -53,6 +53,13 @@
             "if": "Bash(gh pr create*) or Bash(gh pr edit*) or Bash(gh pr merge*) or Bash(gh -C * pr create*) or Bash(gh -C * pr edit*) or Bash(gh -C * pr merge*)",
             "timeout": 20,
             "statusMessage": "Scanning PR diff for non-English text..."
+          },
+          {
+            "type": "command",
+            "command": ".claude/hooks/deploy-autoarm-gate.sh",
+            "if": "Bash(*deploy*) or Bash(*create-stack*) or Bash(*update-stack*)",
+            "timeout": 10,
+            "statusMessage": "Auto-arming the cleanup gate on deploy..."
           }
         ]
       },
@@ -64,6 +71,17 @@
             "command": ".claude/hooks/worktree-guard.sh",
             "timeout": 10,
             "statusMessage": "Checking edit targets a worktree, not the main checkout..."
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/stop-cleanup-warn.sh",
+            "timeout": 10
           }
         ]
       }

--- a/.claude/skills/hunt-bugs/SKILL.md
+++ b/.claude/skills/hunt-bugs/SKILL.md
@@ -225,6 +225,12 @@ this arms the cleanup gate:**
 .claude/skills/hunt-bugs/bughunt-track.sh add CdkRealDriftIntegS3Rich CdkRealDriftIntegVpcCommon ...
 ```
 
+(The `deploy-autoarm-gate` hook also arms a generic `autoarm` token on any deploy as
+a backstop, but `add` with the real stack names gives the clearer gate message.) **Tag
+every fixture `cdkrd:ephemeral=1`** (`Tags.of(app).add('cdkrd:ephemeral','1')` in
+`app.ts`) so the generic tag net in `sweep-orphans.sh` catches any resource type it has
+no per-type rule for.
+
 ### 3. Deploy (parallel, capped) + check
 
 Run the `verify.sh` set in parallel (≤3–4). Each `verify.sh` MUST have a cleanup
@@ -370,8 +376,11 @@ Then fix it:
 
 ### 7. Cleanup — non-negotiable (see below), then ship
 
-Delete every tracked stack, run `bughunt-track.sh verify`, then `clear`. Then
-`/check` + `/check-docs` markers → commit → push → `/verify-pr` → `gh pr create`.
+Run **`/sweep-resources`** — the shared cleanup phase: it deletes every tracked stack
+with `delstack`, sweeps the stack-external orphans (IAM roles, log groups, RETAIN
+resources, tagged-any-type), verifies `SWEEP CLEAN`, and releases the gate
+(`bughunt-track.sh verify` → `clear`, incl. the `autoarm` owner). Then `/check` +
+`/check-docs` markers → commit → push → `/verify-pr` → `gh pr create`.
 
 ### 8. Merge + remove the worktree
 

--- a/.claude/skills/sweep-resources/SKILL.md
+++ b/.claude/skills/sweep-resources/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: sweep-resources
+description: Discover and delete leftover cdkrd TEST AWS resources (ephemeral stacks + stack-external orphans like IAM roles, log groups, RETAIN resources), then release the bughunt-clean gate. Use as the cleanup phase of /work-issues live-tests and /hunt-bugs, or standalone to sweep test debris. NEVER touches non-cdkrd or production resources.
+---
+
+# Sweep cdkrd test resources
+
+The single, safe cleanup entry point for the real-AWS debris that live-tests and
+bug-hunts leave behind. It is the cleanup PHASE that `/work-issues` (live-test) and
+`/hunt-bugs` call, and it is invocable standalone ("clean up my test resources").
+
+**Why this exists:** `delstack` deletes only stack MEMBERS; teardown leaves
+stack-EXTERNAL orphans (auto-created `/aws/lambda/*` and API-GW CloudWatch **IAM
+roles**, RETAIN-policy stateful resources, Secrets in recovery, KMS pending deletion).
+`sweep-orphans.sh` is the safety net for those, scoped STRICTLY to cdkrd name tokens
+(`cdkrd|cdkdrift|cdkrealdrift`) + a generic `cdkrd:ephemeral=1` tag net, and it NEVER
+touches a resource still backed by an active CloudFormation stack.
+
+## Safety invariants (read first)
+
+- **Token-scoped only.** Everything below matches `Cdkrd*` / `CdkRealDrift*` /
+  `Cdkdrift*` names or the `cdkrd:ephemeral=1` tag. A resource without a cdkrd token
+  is out of scope — never delete it.
+- **Never a production stack.** The deploy account may hold the maintainer's prod
+  stacks. Only ever delete UNIQUE test names (`Cdkrd<issue>Verify`, hunt fixtures).
+  If a candidate name is not obviously an ephemeral test resource, STOP and ask.
+- **Protect peers.** `sweep-orphans.sh` skips any resource backed by an active stack
+  (incl. `CREATE/UPDATE/DELETE_IN_PROGRESS`), case-insensitively, across all project
+  regions for global IAM. Still eyeball the dry-run: anything created TODAY by a peer
+  live-test/hunt (a `wt-*` worktree exists, or the name matches another agent's issue)
+  is theirs — leave it.
+- **`delstack`, never `cdk destroy` / `aws cloudformation delete-stack`** (plain
+  deletion orphans blocking members).
+
+## Procedure
+
+Set `REGION` (default `us-east-1`) and, for global-IAM protection, the region set the
+project actually deploys to. The scripts live at the repo root; run from a checkout.
+
+### 1. Discover (read-only — deletes nothing)
+
+```bash
+REGION=us-east-1
+# a) leftover ephemeral stacks
+aws cloudformation list-stacks --region "$REGION" \
+  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE ROLLBACK_COMPLETE DELETE_FAILED \
+  --query "StackSummaries[?starts_with(StackName,'Cdkrd') || starts_with(StackName,'CdkRealDrift')].StackName" \
+  --output text
+# b) stack-external orphans (IAM roles, log groups, RETAIN resources, tagged-any-type)
+AWS_REGION="$REGION" bash tests/integration/sweep-orphans.sh   # DRY RUN
+```
+
+Review the output. Confirm every listed item is a cdkrd EPHEMERAL test resource and
+not a peer's in-flight one (§ Safety). If anything is ambiguous, STOP and ask the
+maintainer before deleting.
+
+### 2. Delete the leftover stacks (if any)
+
+For each confirmed-ephemeral stack (from a fixture dir with its `cdk.out`, or by name):
+
+```bash
+delstack -s <Stack> -r "$REGION" -y -f            # CFn-by-name
+# or, from a fixture dir: delstack cdk -a cdk.out -r "$REGION" -f -y
+```
+
+### 3. Sweep the stack-external orphans
+
+```bash
+AWS_REGION="$REGION" bash tests/integration/sweep-orphans.sh --delete
+AWS_REGION="$REGION" bash tests/integration/sweep-orphans.sh          # must print SWEEP CLEAN
+```
+
+The generic tag net reports any `cdkrd:ephemeral=1` resource of a type the script has
+no per-type rule for as `ORPHAN (needs manual delete …)` and keeps the sweep RED —
+delete those with `delstack`/console, then re-run until `SWEEP CLEAN`. A type never
+hides under a false CLEAN.
+
+### 4. Release the bughunt-clean gate
+
+The `deploy-autoarm-gate` hook arms a generic `autoarm` token on any deploy, and
+`/hunt-bugs` arms per-stack owners. Release only after §1–3 show clean:
+
+```bash
+# the generic auto-armed token (set by the deploy hook):
+CDKRD_BUGHUNT_OWNER=autoarm .claude/skills/hunt-bugs/bughunt-track.sh verify --region "$REGION"
+CDKRD_BUGHUNT_OWNER=autoarm .claude/skills/hunt-bugs/bughunt-track.sh clear
+# any per-owner hunt tracking (run verify + clear from the SAME worktree that armed):
+.claude/skills/hunt-bugs/bughunt-track.sh verify --region "$REGION"
+.claude/skills/hunt-bugs/bughunt-track.sh clear
+```
+
+`verify` re-runs `sweep-orphans.sh`; `clear` REFUSES without a passing verify stamp, so
+the gate can never release while orphans remain. Run `verify` and `clear` as separate,
+un-piped commands (a `verify | tail && clear` pipeline once cleared on a FAILED verify).
+
+### 5. Confirm
+
+```bash
+git worktree list   # remove any throwaway worktrees you made
+```
+
+Report what was deleted and that `SWEEP CLEAN` + the gate is released. If you deployed
+to more than one region, repeat §1–4 per region.
+
+## Ephemeral tagging (makes the generic net work)
+
+For the tag-based net (§3) to catch types the per-type list misses, EVERY ephemeral
+test deploy should carry `cdkrd:ephemeral=1`:
+
+- **CDK app:** `Tags.of(app).add('cdkrd:ephemeral', '1')` (or per-stack).
+- **Raw-CFn / SAM:** `aws cloudformation deploy --tags cdkrd:ephemeral=1 …`.
+
+`/work-issues` and `/hunt-bugs` add this to their deploy steps; do the same for any
+ad-hoc live-test.

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -219,10 +219,19 @@ node_modules` to borrow `aws-cdk-lib` (rm any existing dir first — `ln -sfn` i
 
 **Fresh deploys: UNIQUE hunt-style stack names only** (`Cdkrd<issue>Verify`), never
 a shared fixed name and never a real prod stack — the account may hold the
-maintainer's production stacks. **Tear down with `delstack`, never `cdk destroy`**
-(`delstack cdk -a cdk.out -r <region> -f -y` reads the existing synth), then SWEEP
-orphans it can't reach (auto-created `/aws/lambda/*` log groups, RETAIN resources,
-KMS pending-deletion). Confirm the stacks are gone.
+maintainer's production stacks. **Tag every ephemeral deploy `cdkrd:ephemeral=1`**
+(`Tags.of(app).add('cdkrd:ephemeral','1')`, or `aws cloudformation deploy --tags
+cdkrd:ephemeral=1`) so the generic sweep net can find it whatever its type.
+
+**Cleanup is enforced, not optional.** The `deploy-autoarm-gate` hook ARMS the
+bughunt-clean sentinel the moment you run any deploy command, so a commit / PR is
+BLOCKED until you release it — even if you deployed from a throwaway `/tmp` app.
+After the live-test, run **`/sweep-resources`** (the cleanup phase): it tears down
+with `delstack` (never `cdk destroy`), sweeps the stack-EXTERNAL orphans `delstack`
+can't reach (auto-created `/aws/lambda/*` + API-GW CloudWatch **IAM roles**, RETAIN
+resources, KMS pending-deletion, any `cdkrd:ephemeral`-tagged type), verifies
+`SWEEP CLEAN`, and releases the gate (`bughunt-track verify` + `clear`, incl. the
+`autoarm` owner). Confirm the stacks are gone.
 
 `/verify-pr` sets the `check` + `docs` + `verify-pr` markers, which unblock
 `gh pr merge`. Docs/tooling-only PRs (no `src/**`) are EXEMPT from the live-test —

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -37,20 +37,51 @@ note() { printf '%s\n' "$*"; }
 hit()  { found=$((found + 1)); }
 
 # is the given physical name a member of an ACTIVE stack? (protect live resources)
-ACTIVE_STACKS="$(aws cloudformation list-stacks --region "$REGION" \
-  --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
-    ROLLBACK_COMPLETE CREATE_IN_PROGRESS UPDATE_IN_PROGRESS REVIEW_IN_PROGRESS \
-    UPDATE_ROLLBACK_IN_PROGRESS DELETE_FAILED \
-  --query 'StackSummaries[].StackName' --output text 2>/dev/null)"
+# List every not-yet-deleted stack name in a region (any status a live/pending
+# resource could belong to). Prints one name per line.
+list_active_stacks() {
+  # Include DELETE_IN_PROGRESS: a stack mid-teardown is still deleting its own
+  # members, so those are NOT orphans yet — let CloudFormation finish rather than
+  # racing it (and false-flagging a peer's in-flight teardown).
+  aws cloudformation list-stacks --region "$1" \
+    --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE \
+      ROLLBACK_COMPLETE CREATE_IN_PROGRESS UPDATE_IN_PROGRESS REVIEW_IN_PROGRESS \
+      UPDATE_ROLLBACK_IN_PROGRESS DELETE_FAILED DELETE_IN_PROGRESS \
+    --query 'StackSummaries[].StackName' --output text 2>/dev/null | tr '\t' '\n'
+}
+
+ACTIVE_STACKS="$(list_active_stacks "$REGION")"
+
+# GLOBAL resources (IAM roles/instance profiles) are not region-scoped, so a role
+# left by a stack in ANOTHER region must NOT be swept while sweeping this one. Guard
+# them against active stacks across ALL the project's regions, not just $REGION.
+# Override the set with CDKRD_SWEEP_IAM_REGIONS="us-east-1 us-west-2 ...".
+IAM_REGIONS="${CDKRD_SWEEP_IAM_REGIONS:-$REGION us-east-1 us-west-2 ap-northeast-1}"
+read -ra _iam_regions <<<"$IAM_REGIONS"
+ACTIVE_STACKS_GLOBAL="$(
+  printf '%s\n' "${_iam_regions[@]}" | sort -u | while IFS= read -r r; do
+    [ -n "$r" ] && list_active_stacks "$r"
+  done
+)"
 
 # A cdkrd-token resource is an orphan unless its name embeds an active stack name.
-is_backed() {
-  local name="$1" s
-  for s in $ACTIVE_STACKS; do
+# `stacks` selects the guard set: the region-local set for regional resources, the
+# all-regions set for global (IAM) ones. Match is CASE-INSENSITIVE: AWS lowercases
+# many physical names (RDS/DocDB identifiers, S3 buckets, ELB names) while stack
+# names are mixed-case, so a case-sensitive compare would fail to see the backing
+# stack and FALSE-flag a live resource as an orphan (→ delete a peer's active DB).
+_name_backed_by() {
+  local name stacks="$2" s
+  name="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  for s in $stacks; do
+    [ -n "$s" ] || continue
+    s="$(printf '%s' "$s" | tr '[:upper:]' '[:lower:]')"
     case "$name" in *"$s"*) return 0 ;; esac
   done
   return 1
 }
+is_backed()        { _name_backed_by "$1" "$ACTIVE_STACKS"; }
+is_backed_global() { _name_backed_by "$1" "$ACTIVE_STACKS_GLOBAL"; }
 
 # delete <kind> <name> <delete-cmd...>
 sweep_one() {
@@ -109,6 +140,89 @@ done
 note "--- CloudWatch log groups ---"
 for g in $(aws logs describe-log-groups --region "$REGION" --query 'logGroups[].logGroupName' --output text 2>/dev/null | tr '\t' '\n' | grep -Ei "$TOKEN"); do
   sweep_one LogGroup "$g" aws logs delete-log-group --log-group-name "$g" --region "$REGION"
+done
+
+# --- IAM roles (GLOBAL) --------------------------------------------------------
+# CloudFormation-created roles (e.g. an API Gateway account CloudWatch role, a
+# Lambda service role) can outlive their stack when the stack is force-deleted or
+# the role was RETAINed — the class that leaked undetected before this sweep knew
+# about IAM. IAM is global, so guard against active stacks across ALL project
+# regions (is_backed_global), never just $REGION. Tear down fully (detach managed +
+# delete inline + detach from instance profiles) before delete.
+iam_role_teardown() {
+  local r="$1" p ip
+  for p in $(aws iam list-attached-role-policies --role-name "$r" --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null); do
+    aws iam detach-role-policy --role-name "$r" --policy-arn "$p" >/dev/null 2>&1 || return 1
+  done
+  for p in $(aws iam list-role-policies --role-name "$r" --query 'PolicyNames[]' --output text 2>/dev/null); do
+    aws iam delete-role-policy --role-name "$r" --policy-name "$p" >/dev/null 2>&1 || return 1
+  done
+  for ip in $(aws iam list-instance-profiles-for-role --role-name "$r" --query 'InstanceProfiles[].InstanceProfileName' --output text 2>/dev/null); do
+    aws iam remove-role-from-instance-profile --instance-profile-name "$ip" --role-name "$r" >/dev/null 2>&1 || true
+  done
+  aws iam delete-role --role-name "$r" >/dev/null 2>&1
+}
+
+note "--- IAM roles (global) ---"
+for r in $(aws iam list-roles --query 'Roles[].RoleName' --output text 2>/dev/null | tr '\t' '\n' | grep -Ei "$TOKEN"); do
+  if is_backed_global "$r"; then
+    note "  SKIP (active-stack member, any region): IAM-role $r"
+    continue
+  fi
+  hit
+  if [ "$DELETE" -eq 1 ]; then
+    if iam_role_teardown "$r"; then note "  DELETED: IAM-role $r"; else note "  FAILED:  IAM-role $r"; failed=$((failed + 1)); fi
+  else
+    note "  ORPHAN (dry-run): IAM-role $r"
+  fi
+done
+
+note "--- IAM instance profiles (global) ---"
+for ipf in $(aws iam list-instance-profiles --query 'InstanceProfiles[].InstanceProfileName' --output text 2>/dev/null | tr '\t' '\n' | grep -Ei "$TOKEN"); do
+  if is_backed_global "$ipf"; then
+    note "  SKIP (active-stack member, any region): InstanceProfile $ipf"
+    continue
+  fi
+  hit
+  if [ "$DELETE" -eq 1 ]; then
+    for rr in $(aws iam get-instance-profile --instance-profile-name "$ipf" --query 'InstanceProfile.Roles[].RoleName' --output text 2>/dev/null); do
+      aws iam remove-role-from-instance-profile --instance-profile-name "$ipf" --role-name "$rr" >/dev/null 2>&1 || true
+    done
+    if aws iam delete-instance-profile --instance-profile-name "$ipf" >/dev/null 2>&1; then
+      note "  DELETED: InstanceProfile $ipf"
+    else
+      note "  FAILED:  InstanceProfile $ipf"; failed=$((failed + 1))
+    fi
+  else
+    note "  ORPHAN (dry-run): InstanceProfile $ipf"
+  fi
+done
+
+# --- Generic tag-based net (catches TYPES this script has no per-type rule for) --
+# The per-type sweeps above are an allowlist — an ephemeral resource of a type not
+# listed silently escaped (and `verify` falsely reported CLEAN). To close that, every
+# ephemeral test deploy is tagged `cdkrd:ephemeral=1` (see the /sweep-resources and
+# /work-issues + /hunt-bugs skills). Here we ask the Resource Groups Tagging API for
+# ANY resource carrying that tag, regardless of type, and surface any not backed by an
+# active stack. We do NOT auto-delete arbitrary types (risky + each needs its own
+# API); we REPORT them so `found`>0 makes `verify` fail — an unknown-type orphan can
+# never hide under a false SWEEP CLEAN again. Delete them with delstack / the console.
+# (RGT API is regional and does not cover IAM — handled above — but does cover most
+# taggable service resources.)
+note "--- Tagged ephemeral resources (generic, any type) ---"
+for arn in $(aws resourcegroupstaggingapi get-resources --region "$REGION" \
+  --tag-filters Key=cdkrd:ephemeral,Values=1 \
+  --query 'ResourceTagMappingList[].ResourceARN' --output text 2>/dev/null | tr '\t' '\n'); do
+  [ -n "$arn" ] || continue
+  # ARN already deleted by a per-type sweep above may still be listed briefly; the
+  # active-stack guard + a existence-agnostic report is fine (verify re-runs later).
+  if is_backed "$arn" || is_backed_global "$arn"; then
+    note "  SKIP (active-stack member): $arn"
+    continue
+  fi
+  hit
+  failed=$((failed + 1)) # unresolved by this script → keep verify RED until handled
+  note "  ORPHAN (needs manual delete — delstack/console): $arn"
 done
 
 note "=== summary: $found orphan(s) found, $failed delete failure(s) ==="

--- a/tests/integration/sweep-orphans.test.sh
+++ b/tests/integration/sweep-orphans.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Smoke test for sweep-orphans.sh — runs the DRY-RUN sweep against a MOCK `aws` CLI
+# (canned list/describe output on PATH) and asserts the safety-critical behaviors:
+#   1. case-INSENSITIVE active-stack protection (a lowercased RDS name is recognized
+#      as backed by its mixed-case stack → SKIP, never a false orphan → never deleted)
+#   2. IAM roles are swept (the class that leaked before) — an orphan role is found
+#   3. the generic tag net reports an any-type tagged resource (no false SWEEP CLEAN)
+# Run: bash tests/integration/sweep-orphans.test.sh
+
+set -euo pipefail
+
+SWEEP="$(cd "$(dirname "$0")" && pwd)/sweep-orphans.sh"
+PASS=0
+FAIL=0
+# assert <name> <haystack> <regex> — grep inside `if` is a condition context, so a
+# no-match does not trip `set -e`.
+assert() {
+  if printf '%s' "$2" | grep -qE "$3"; then PASS=$((PASS + 1)); echo "ok   - $1"; else FAIL=$((FAIL + 1)); echo "FAIL - $1"; fi
+}
+refute() {
+  if printf '%s' "$2" | grep -qE "$3"; then FAIL=$((FAIL + 1)); echo "FAIL - $1"; else PASS=$((PASS + 1)); echo "ok   - $1"; fi
+}
+
+tmp=$(mktemp -d)
+# --- mock aws: dispatch on "<service> <op>", emit canned --output text ---
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+svc="$1"; op="${2:-}"
+case "$svc/$op" in
+  cloudformation/list-stacks)   echo "Cdkrd717Verify" ;;            # the only ACTIVE stack (mixed case)
+  rds/describe-db-instances)    echo "cdkrd717verify-writer-abc123" ;;  # lowercased -> backed by Cdkrd717Verify
+  rds/describe-db-clusters)     : ;;
+  iam/list-roles)               echo "CdkRealDriftGone-ApiCloudWatchRole-xyz" ;; # stack gone -> ORPHAN
+  iam/list-instance-profiles)   : ;;
+  resourcegroupstaggingapi/get-resources) echo "arn:aws:sqs:us-east-1:123456789012:CdkrdGoneQueue" ;;
+  kinesis/list-streams|dynamodb/list-tables|efs/describe-file-systems|secretsmanager/list-secrets|logs/describe-log-groups) : ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+
+# The sweep exits 1 when it reports unresolved orphans (keeps verify RED) — expected
+# here (the tagged resource), so tolerate it; we assert on the OUTPUT.
+out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+
+assert "case-insensitive active-stack protection (lowercased RDS backed by mixed-case stack -> SKIP)" "$out" "SKIP \(active-stack member\): RDS-instance cdkrd717verify-writer-abc123"
+assert "IAM role orphan is found (the leaked class)" "$out" "ORPHAN \(dry-run\): IAM-role CdkRealDriftGone-ApiCloudWatchRole-xyz"
+assert "generic tag net reports an any-type tagged orphan (no false SWEEP CLEAN)" "$out" "ORPHAN \(needs manual delete.*arn:aws:sqs:.*CdkrdGoneQueue"
+assert "summary counts the 2 orphans (IAM + tagged), RDS protected" "$out" "2 orphan\(s\) found"
+
+# negative: with NO token-matching resources, sweep is CLEAN
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+case "$1/${2:-}" in cloudformation/list-stacks) echo "SomeUnrelatedStack" ;; *) : ;; esac
+MOCK
+chmod +x "$tmp/aws"
+clean_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1)"
+assert "SWEEP CLEAN when nothing token-matches" "$clean_out" "SWEEP CLEAN"
+
+rm -rf "$tmp"
+echo "----"
+echo "sweep-orphans: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Makes "never leave garbage AWS resources from a live-test / bug-hunt" a structural guarantee. Motivated by a real leak this session: an API-Gateway CloudWatch IAM role survived weeks because sweep-orphans.sh had no IAM rule, and /work-issues live-tests never armed the cleanup sentinel.

## Holes closed
- generic Resource Groups Tagging API net: any cdkrd:ephemeral=1-tagged resource of an unlisted type is REPORTED, keeping verify RED (no false SWEEP CLEAN).
- IAM role + instance-profile sweep (the leaked class), guarded against active stacks across all project regions.
- deploy-autoarm-gate (PreToolUse): any deploy-shaped command arms a generic autoarm token so the commit/PR gate blocks until verified clean.
- stop-cleanup-warn (Stop): warns if the sentinel is still armed at session end (warn-only).
- /sweep-resources skill: single cleanup entrypoint; called by /work-issues + /hunt-bugs, invocable standalone.

## Latent safety bug fixed
Active-stack protection was case-SENSITIVE; AWS lowercases RDS/S3/ELB names while stack names are mixed-case, so it could false-flag a peer's live DB as an orphan and delete it. Now case-insensitive; DELETE_IN_PROGRESS stacks protect mid-teardown members.

## Tests
Mock-aws self-tests green: sweep-orphans.test.sh (5), deploy-autoarm-gate.test.sh (11), stop-cleanup-warn.test.sh (2). vp typecheck/check/test(3367)/pack green.

Tooling/docs-only (no src).
