### PR TITLE
fix(revert): derive EventBusPolicy ARN partition from region (GovCloud/China)

### DIFF
--- a/src/desired/template-adapter.ts
+++ b/src/desired/template-adapter.ts
@@ -41,7 +41,7 @@ export function parseTemplateBody(body: string): Record<string, unknown> {
 // Ordering note: `us-isob-` / `us-isof-` do not start with `us-iso-` (the char after `us-iso`
 // is a letter, not `-`), so the `us-iso-` test does not swallow them; still, keep the more
 // specific ISO prefixes listed for clarity.
-function partitionForRegion(region: string): { partition: string; urlSuffix: string } {
+export function partitionForRegion(region: string): { partition: string; urlSuffix: string } {
   if (region.startsWith('us-gov-')) return { partition: 'aws-us-gov', urlSuffix: 'amazonaws.com' };
   if (region.startsWith('cn-')) return { partition: 'aws-cn', urlSuffix: 'amazonaws.com.cn' };
   if (region.startsWith('us-iso-')) return { partition: 'aws-iso', urlSuffix: 'c2s.ic.gov' };

--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -200,6 +200,7 @@ import {
 } from '@aws-sdk/client-servicediscovery';
 import { SetTopicAttributesCommand, SNSClient } from '@aws-sdk/client-sns';
 import { SetQueueAttributesCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { partitionForRegion } from '../desired/template-adapter.js';
 import { NESTED_ARRAY_IDENTITY } from '../diff/classify.js';
 import { identityField } from '../normalize/noise.js';
 import { canonicalizeForCompare } from '../normalize/pipeline.js';
@@ -313,12 +314,15 @@ const writeEventBusPolicy: SdkWriter = async (ctx) => {
     const principal = str(ctx.declared['Principal']);
     if (action === undefined || principal === undefined)
       throw new Error('EventBusPolicy revert needs a Statement (or Action + Principal)');
+    // Partition is a function of the region — GovCloud (`aws-us-gov`) / China (`aws-cn`)
+    // need their own ARN prefix, else the reverted statement never matches / is rejected (#865).
+    const { partition } = partitionForRegion(ctx.region);
     desiredStatement = {
       Sid: statementId,
       Effect: 'Allow',
-      Principal: principal === '*' ? '*' : { AWS: `arn:aws:iam::${principal}:root` },
+      Principal: principal === '*' ? '*' : { AWS: `arn:${partition}:iam::${principal}:root` },
       Action: action,
-      Resource: `arn:aws:events:${ctx.region}:${ctx.accountId}:event-bus/${eventBusName}`,
+      Resource: `arn:${partition}:events:${ctx.region}:${ctx.accountId}:event-bus/${eventBusName}`,
       ...(ctx.declared['Condition'] !== undefined ? { Condition: ctx.declared['Condition'] } : {}),
     };
   }

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -759,6 +759,30 @@ describe('EventBusPolicy writer (CC RFC6902 patch fails on a singular-object Sta
       )
     ).rejects.toThrow(/StatementId/);
   });
+
+  it('uses the region partition for the legacy Action+Principal ARNs (GovCloud aws-us-gov, #865)', async () => {
+    eventbridge.on(DescribeEventBusCommand).resolves({
+      Policy: JSON.stringify({ Version: '2012-10-17', Statement: [] }),
+    });
+    await SDK_WRITERS['AWS::Events::EventBusPolicy'](
+      ebpCtx({
+        region: 'us-gov-west-1',
+        declared: {
+          EventBusName: 'mybus',
+          StatementId: 'AllowSelfPutEvents',
+          Action: 'events:PutEvents',
+          Principal: '123456789012',
+        },
+      }),
+      []
+    );
+    const policy = JSON.parse(
+      eventbridge.commandCalls(PutPermissionCommand)[0].args[0].input.Policy as string
+    );
+    const stmt = policy.Statement[0];
+    expect(stmt.Principal.AWS).toBe('arn:aws-us-gov:iam::123456789012:root');
+    expect(stmt.Resource).toBe('arn:aws-us-gov:events:us-gov-west-1:123456789012:event-bus/mybus');
+  });
 });
 
 describe('OpenSearch Domain writer (CC UpdateResource rejects on override_main_response_version)', () => {


### PR DESCRIPTION
Closes #865

## Problem
`writeEventBusPolicy`'s legacy `Action`+`Principal` branch (`src/revert/writers.ts`) hardcoded the commercial partition `arn:aws:`. On GovCloud (`us-gov-*`) / China (`cn-*`), the reverted statement's `Principal` (`arn:aws:iam::…`) and `Resource` (`arn:aws:events:…`) are wrong — `PutPermission` rejects it, or it writes a statement whose Resource never matches the bus (a silently non-converging revert).

## Fix
Export the existing `partitionForRegion` from `src/desired/template-adapter.ts` and derive the partition from `ctx.region` in `writeEventBusPolicy`, so the ARNs use `arn:aws-us-gov:` / `arn:aws-cn:` as appropriate.

## Test
`tests/writers.test.ts`: a `us-gov-west-1` ctx must produce `arn:aws-us-gov:iam::…:root` + `arn:aws-us-gov:events:…:event-bus/…` in the PutPermission policy. Fails on the old hardcode, passes with the fix.

## Live-test note
The failure is partition-specific and cannot be reproduced in a commercial region; the mocked-client unit test is the authoritative evidence (a GovCloud/China live deploy is not available).