### PR TITLE
fix(config): escape literal */? when the ignore verb writes a finding path

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,12 @@ ignore:
   `?` is **unbounded within that bracket** (the brackets delimit the key, so a `.`
   between them is data): `Alb.LoadBalancerAttributes[*]` and
   `Alb.LoadBalancerAttributes[routing.*]` both match the dotted key
-  `[routing.http2.enabled]`. On **stack / account / region**, `*` / `?` are unbounded
+  `[routing.http2.enabled]`. To match a **literal** `*` / `?` in a `path`
+  (e.g. an API Gateway `MethodSettings[*]` key from `HttpMethod: '*'`, or an S3
+  lifecycle `Id` like `clean*tmp`), backslash-escape it — `\*` / `\?` (and `\\`
+  for a literal backslash). The `ignore` verb writes such paths pre-escaped, so
+  a machine-written rule matches only the finding it came from; hand-copied rules
+  need the escape added. On **stack / account / region**, `*` / `?` are unbounded
   (those names carry no `.`). The three scope axes are exactly the
   baseline file's identity axes; each is **omitted to leave that axis unscoped**
   (match-all) — a present-but-empty `""` is rejected (it would match nothing),

--- a/src/commands/glob-match.ts
+++ b/src/commands/glob-match.ts
@@ -1,26 +1,76 @@
 // Tiny glob matcher for stack-name selection:
 //   *  matches any run of characters (including empty)
 //   ?  matches exactly one character
+//   \* \? \\  match a LITERAL `*` / `?` / `\` (backslash escape)
 // Anchored full-string match; every other character (incl. regex metachars like
 // `.` `+` `(`) is treated as a literal. No `[...]` classes, no `**` semantics.
+//
+// The `\`-escape exists so a rule can name a path segment that legitimately CONTAINS a
+// `*` / `?` — an API Gateway `MethodSettings[*]` bracket key (from `HttpMethod: '*'`),
+// an S3 lifecycle `Id: "clean*tmp"`, a free-form Glue/ECS map key — without the wildcard
+// silently widening the rule to every sibling (issue #776). `ignoreRuleFor` escapes such
+// literals when it writes a finding path into a rule, and the grammar honours them here.
 
-/** True when `s` contains a glob metachar (`*` or `?`). */
+/** True when `s` contains an UNESCAPED glob metachar (`*` or `?`). A `\*` / `\?` is a
+ *  literal, not a wildcard, so a pattern made only of escaped metachars is NOT a glob. */
 export function isGlob(s: string): boolean {
-  return s.includes('*') || s.includes('?');
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === '\\') {
+      i++; // skip the escaped char — it is a literal, not a metachar
+      continue;
+    }
+    if (s[i] === '*' || s[i] === '?') return true;
+  }
+  return false;
+}
+
+/**
+ * Collapse runs of consecutive UNESCAPED `*` to a single `*` (see `globToRegExp` for the
+ * ReDoS rationale), leaving `\`-escaped sequences untouched. An escaped `\*` must NOT be
+ * merged into (or collapsed with) an adjacent real `*` — `\**` is a literal `*` followed
+ * by a wildcard, which must survive as two distinct tokens.
+ */
+function collapseStars(pattern: string): string {
+  let out = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const ch = pattern[i];
+    if (ch === '\\') {
+      // copy the escape and its escaped char verbatim (the escaped char may be `*`)
+      out += pattern.slice(i, i + 2);
+      i += pattern[i + 1] === undefined ? 1 : 2;
+    } else if (ch === '*') {
+      out += '*';
+      while (pattern[i] === '*') i++; // swallow the whole run of UNESCAPED stars
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  return out;
 }
 
 /** Convert a glob pattern to an anchored RegExp (other metachars escaped to literals). */
 export function globToRegExp(pattern: string): RegExp {
   let out = '^';
-  // Collapse runs of consecutive `*` to a single `*` FIRST: `***` is semantically
+  // Collapse runs of consecutive UNESCAPED `*` to a single `*` FIRST: `***` is semantically
   // identical to `*` (any run of characters), but compiling each star to `.*` yields
   // `.*.*.*…` which backtracks CATASTROPHICALLY (O(len^N)) on a long non-matching
   // subject — a self-inflicted multi-second hang (ReDoS) on a user-authored glob like
-  // `*****` (a natural gitignore-style attempt). One `.*` per run can't backtrack.
-  for (const ch of pattern.replace(/\*+/g, '*')) {
-    if (ch === '*') out += '.*';
+  // `*****` (a natural gitignore-style attempt). One `.*` per run can't backtrack. The
+  // collapse is escape-aware so a literal `\*` is not merged into an adjacent wildcard.
+  const collapsed = collapseStars(pattern);
+  for (let i = 0; i < collapsed.length; i++) {
+    const ch = collapsed[i];
+    // A backslash escapes the NEXT char to a literal (`\*` `\?` `\\`): emit that char as a
+    // regex literal, never as a wildcard. A trailing lone `\` is treated as a literal `\`.
+    if (ch === '\\') {
+      const next = collapsed[i + 1] ?? '\\';
+      out += next.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      if (collapsed[i + 1] !== undefined) i++;
+    } else if (ch === '*') out += '.*';
     else if (ch === '?') out += '.';
-    else out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    else out += (ch as string).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
   out += '$';
   return new RegExp(out);
@@ -60,13 +110,22 @@ export function matchesGlob(pattern: string, name: string): boolean {
 export function matchesPathGlob(pattern: string, target: string): boolean {
   let out = '^';
   let inBracket = false;
-  for (const ch of pattern.replace(/\*+/g, '*')) {
-    if (ch === '*') out += inBracket ? '[^\\]]*' : '[^.[/]*';
+  const collapsed = collapseStars(pattern);
+  for (let i = 0; i < collapsed.length; i++) {
+    const ch = collapsed[i];
+    // A backslash escapes the NEXT char to a literal (`\*` `\?` `\\`, or `\[` / `\]`): it
+    // never wildcards and — for `\[` / `\]` — never toggles the bracket-segment state. A
+    // trailing lone `\` is a literal `\`.
+    if (ch === '\\') {
+      const next = collapsed[i + 1] ?? '\\';
+      out += next.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      if (collapsed[i + 1] !== undefined) i++;
+    } else if (ch === '*') out += inBracket ? '[^\\]]*' : '[^.[/]*';
     else if (ch === '?') out += inBracket ? '[^\\]]' : '[^.[/]';
     else {
       if (ch === '[') inBracket = true;
       else if (ch === ']') inBracket = false;
-      out += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      out += (ch as string).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     }
   }
   out += '$';

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -224,13 +224,34 @@ export function ignoreRuleFor(
     finding.constructPath && finding.tier !== 'added'
       ? withinStackPath(finding.constructPath, stackName)
       : finding.logicalId;
-  const rule: IgnoreRuleObject = { path: finding.path ? `${id}.${finding.path}` : id };
+  // A finding path can legitimately CONTAIN a literal `*` / `?`: an API Gateway
+  // `MethodSettings[*]` bracket key (from `HttpMethod: '*'`), an S3 lifecycle `Id`
+  // like `clean*tmp`, a free-form Glue/ECS map key. Written verbatim, the glob matcher
+  // would reinterpret each `*` / `?` as a wildcard and silently widen the rule to every
+  // sibling (issue #776). Escape them (and any pre-existing `\`) so the rule matches ONLY
+  // the finding it came from — `escapeGlobLiterals` is the inverse of the grammar's
+  // `\`-escape in glob-match.ts. Escape `\` FIRST so the `*` / `?` escapes we add are not
+  // themselves re-escaped.
+  const rawPath = finding.path ? `${id}.${finding.path}` : id;
+  const rule: IgnoreRuleObject = { path: escapeGlobLiterals(rawPath) };
   // Only stamp a scope field when the value is actually known — an empty string would
   // write `stack: ""`, a glob that matches nothing (silently disabling the rule).
   if (stackName) rule.stack = stackName;
   if (accountId) rule.account = accountId;
   if (region) rule.region = region;
   return rule;
+}
+
+/**
+ * Backslash-escape the glob metacharacters (`\`, `*`, `?`) in a literal path so the glob
+ * matcher treats them as literals, not wildcards. The inverse of the `\`-escape grammar in
+ * glob-match.ts. `\` is escaped FIRST so the `*` / `?` escapes we add are not re-escaped
+ * (otherwise `\*` would become `\\*` = a literal `\` + a wildcard). Structural separators
+ * (`.` `[` `]` `/`) are intentionally left alone — they are the rule's segment grammar, not
+ * data. Exported for tests.
+ */
+export function escapeGlobLiterals(literal: string): string {
+  return literal.replace(/\\/g, '\\\\').replace(/[*?]/g, '\\$&');
 }
 
 /** Canonical identity of a rule (path + the three optional scopes), for dedupe. */

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -7,6 +7,7 @@ import {
   addIgnoreRules,
   applyIgnores,
   type CdkrdConfig,
+  escapeGlobLiterals,
   type IgnoreRuleObject,
   type IgnoreScope,
   ignoreRuleFor,
@@ -629,6 +630,50 @@ describe('ignoreRuleFor', () => {
     const rule = ignoreRuleFor(addedFinding);
     expect(rule.path).toBe('Topic/arn:aws:sns:us-east-1:111111111111:T:sub-uuid');
     expect(rule.path).not.toContain('?');
+  });
+
+  it('escapes a LITERAL `*` in the finding path so the rule matches ONLY that finding (#776)', () => {
+    // An API Gateway MethodSettings key from `HttpMethod: "*"` — the `[*]` is a REAL bracket
+    // key, not a wildcard. Written verbatim the rule would glob every HTTP method's sibling;
+    // ignoreRuleFor must escape the `*` so the rule matches this finding and no other.
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'Stage0661E8F1',
+      resourceType: 'AWS::ApiGateway::Stage',
+      path: 'MethodSettings[*].CacheTtlInSeconds',
+      actual: 300,
+    };
+    const rule = ignoreRuleFor(f);
+    expect(rule.path).toBe('Stage0661E8F1.MethodSettings[\\*].CacheTtlInSeconds');
+    // it ignores the exact finding it came from (round-trip)...
+    expect(ign([f], 'S', cfg([rule]))[0]?.tier).toBe('ignored');
+    // ...but NOT a sibling method key that the un-escaped `*` would have swallowed
+    const sibling: Finding = { ...f, path: 'MethodSettings[GET].CacheTtlInSeconds' };
+    expect(ign([sibling], 'S', cfg([rule]))[0]?.tier).toBe('undeclared');
+  });
+
+  it('escapes a literal `*` in a free-form key (S3 lifecycle Id) so the rule is not over-broad (#776)', () => {
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'B',
+      resourceType: 'AWS::S3::Bucket',
+      path: 'Rules[clean*tmp].Status',
+      actual: 'Enabled',
+    };
+    const rule = ignoreRuleFor(f);
+    expect(rule.path).toBe('B.Rules[clean\\*tmp].Status');
+    expect(ign([f], 'S', cfg([rule]))[0]?.tier).toBe('ignored');
+    const sibling: Finding = { ...f, path: 'Rules[cleanXYZtmp].Status' };
+    expect(ign([sibling], 'S', cfg([rule]))[0]?.tier).toBe('undeclared');
+  });
+});
+
+describe('escapeGlobLiterals (#776)', () => {
+  it('escapes `*`, `?`, and `\\` (backslash first) and leaves separators alone', () => {
+    expect(escapeGlobLiterals('a*b?c')).toBe('a\\*b\\?c');
+    expect(escapeGlobLiterals('a\\b')).toBe('a\\\\b'); // `\` doubled — escaped first
+    expect(escapeGlobLiterals('a\\*b')).toBe('a\\\\\\*b'); // `\` then `*`, not `\\*`
+    expect(escapeGlobLiterals('X.Y[key]/Z')).toBe('X.Y[key]/Z'); // separators untouched
   });
 });
 

--- a/tests/glob-match.test.ts
+++ b/tests/glob-match.test.ts
@@ -124,3 +124,55 @@ describe('matchesPathGlob (segment-aware — does not cross . or [ boundaries)',
     expect(matchesPathGlob('Tags[a/*]', 'Tags[a/b]')).toBe(true);
   });
 });
+
+describe('backslash escape — `\\*` / `\\?` / `\\\\` are literals, not wildcards (#776)', () => {
+  it('an escaped `\\*` matches a LITERAL `*` and does NOT glob a sibling', () => {
+    // The API Gateway `MethodSettings[*]` bracket key (from `HttpMethod: "*"`): an escaped
+    // `\*` inside the bracket must match the literal `*`, not every sibling HTTP method.
+    expect(
+      matchesPathGlob('Stage.MethodSettings[\\*].CacheTtl', 'Stage.MethodSettings[*].CacheTtl')
+    ).toBe(true);
+    expect(
+      matchesPathGlob('Stage.MethodSettings[\\*].CacheTtl', 'Stage.MethodSettings[GET].CacheTtl')
+    ).toBe(false);
+    // an S3 lifecycle Id `clean*tmp` as a bracket key: only the literal-`*` key matches
+    expect(matchesPathGlob('B.Rules[clean\\*tmp].Status', 'B.Rules[clean*tmp].Status')).toBe(true);
+    expect(matchesPathGlob('B.Rules[clean\\*tmp].Status', 'B.Rules[cleanXYZtmp].Status')).toBe(
+      false
+    );
+  });
+
+  it('an UNESCAPED `*` still globs as before (no regression)', () => {
+    expect(
+      matchesPathGlob('Stage.MethodSettings[*].CacheTtl', 'Stage.MethodSettings[GET].CacheTtl')
+    ).toBe(true);
+    expect(matchesPathGlob('B.Rules[clean*tmp].Status', 'B.Rules[cleanXYZtmp].Status')).toBe(true);
+    expect(matchesGlob('Dev*', 'DevApi')).toBe(true);
+  });
+
+  it('an escaped `\\?` matches a LITERAL `?` and does NOT match an arbitrary char', () => {
+    expect(matchesPathGlob('Tags[a\\?]', 'Tags[a?]')).toBe(true);
+    expect(matchesPathGlob('Tags[a\\?]', 'Tags[ab]')).toBe(false);
+    // unescaped `?` still matches exactly one char
+    expect(matchesPathGlob('Tags[a?]', 'Tags[ab]')).toBe(true);
+  });
+
+  it('a literal `*` next to a real `*` survives the run-collapse (`\\**`)', () => {
+    // `\**` = a literal `*` then a wildcard: `X*Y` matches, `XY` (no literal star) does not.
+    expect(matchesGlob('X\\**Y', 'X*fooY')).toBe(true);
+    expect(matchesGlob('X\\**Y', 'X*Y')).toBe(true);
+    expect(matchesGlob('X\\**Y', 'XfooY')).toBe(false); // needs the literal `*`
+  });
+
+  it('`\\\\` matches a single literal backslash; `isGlob` sees escaped metachars as literals', () => {
+    expect(matchesGlob('a\\\\b', 'a\\b')).toBe(true);
+    expect(isGlob('Foo\\*')).toBe(false); // escaped `*` is a literal, not a glob
+    expect(isGlob('Foo\\?bar')).toBe(false);
+    expect(isGlob('Foo\\*bar*')).toBe(true); // a REAL trailing `*` is still a glob
+  });
+
+  it('globToRegExp compiles an escaped metachar to a regex literal', () => {
+    expect(globToRegExp('a\\*b').source).toBe('^a\\*b$');
+    expect(globToRegExp('a\\?b').source).toBe('^a\\?b$');
+  });
+});


### PR DESCRIPTION
Closes #776

## Problem
The `ignore` verb wrote a finding path **verbatim** into `.cdkrd/ignore.yaml`, but the glob matcher reinterprets every `*`/`?` in the rule as a wildcard — and the grammar had **no escape**. A finding path containing a literal `*`/`?` (API Gateway `MethodSettings[*]` from `HttpMethod: '*'`; an S3 lifecycle `Id` like `clean*tmp`; a free-form Glue/ECS map key) round-tripped into a silently over-broad rule that stopped watching every sibling the wildcard matched — a self-inflicted missed detection, invisible in the ignore.yaml git diff.

## Fix
- `src/commands/glob-match.ts`: add a `\`-escape to the grammar (`\*` `\?` `\\` = literal), escape-aware so `\**` (literal star + wildcard) survives the run-collapse and `\[`/`\]` don't toggle bracket state.
- `src/config/config-file.ts`: `ignoreRuleFor` runs the composed finding path through `escapeGlobLiterals` (escapes `\` first, then `*`/`?`), so both verb-written and hand-copied rules match ONLY the finding they came from.

`drift-calculator.ts` `PATH_UNSAFE_KEY` deliberately unchanged (adding `*`/`?` there would coarsen findings for every wildcard map key; the escape already fixes the round-trip).

## Tests
- `tests/glob-match.test.ts`: escaped `\*`/`\?` match a literal and do NOT glob a sibling; unescaped still globs (no regression); `\**`, `\\`, isGlob edge cases.
- `tests/config-file.test.ts`: a finding path with a literal `*` is written escaped and ignores ONLY that exact finding, not `MethodSettings[GET]`/`Rules[cleanXYZtmp]`.

## Live-test note
Pure offline matcher change — the unit tests exercise the real `globToRegExp`/`matchesPathGlob`/`ignoreRuleFor` code and are the authoritative evidence; no AWS involved.