### PR TITLE
fix(noise): fold AutoScaling ScheduledAction StartTime/EndTime first-run FPs

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2863,6 +2863,19 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   the ARN carries the machine's generated name segment). Not user intent when undeclared —
   //   fold value-independent. Live, hunt 2026-07-08 (#628).
   'AWS::StepFunctions::StateMachineAlias': new Set(['StateMachineArn']),
+  //   AWS::AutoScaling::ScheduledAction.StartTime / .EndTime — a scheduled action that declares
+  //   a `Recurrence` (a cron expression) but no explicit `StartTime` reads back the concrete
+  //   timestamp of the NEXT occurrence AWS computed from that recurrence (e.g. declared
+  //   "0 9 * * MON-FRI" → live StartTime "2026-06-22T09:00:00Z"). It is UNDECLARED and
+  //   TIME-VARYING: each later read yields a fresh next-occurrence, so it does NOT converge under
+  //   `record` — a constant cannot pin it and it is not a stable function of the declared inputs
+  //   (it depends on the wall-clock time of the read). Fold value-independent: whatever AWS
+  //   computes is not user intent; a user who wants a specific StartTime DECLARES it, and it is
+  //   then compared in the declared loop. `EndTime` reads back the literal string "null" when no
+  //   end time is set (a serialized-null artifact from the SDK/CC read) — folding it here strips
+  //   that cosmetic stringified null. A DECLARED EndTime goes through the declared loop, compared.
+  //   Live, hunt 2026-07-09 (#847).
+  'AWS::AutoScaling::ScheduledAction': new Set(['StartTime', 'EndTime']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/corpus/AWS__AutoScaling__ScheduledAction.Schedule.json
+++ b/tests/corpus/AWS__AutoScaling__ScheduledAction.Schedule.json
@@ -43,7 +43,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Schedule",
       "resourceType": "AWS::AutoScaling::ScheduledAction",
       "path": "EndTime",
@@ -52,7 +52,7 @@
       "constructPath": "CdkRealDriftIntegAutoScalingScheduledActionRich/Schedule"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Schedule",
       "resourceType": "AWS::AutoScaling::ScheduledAction",
       "path": "StartTime",

--- a/tests/noise-firstrun-folds.test.ts
+++ b/tests/noise-firstrun-folds.test.ts
@@ -273,3 +273,32 @@ describe('#678 PRIVATE RestApi derives TLS_1_2 + dualstack from the declared end
     expect(pathsByTier(surfaces, 'undeclared')).toContain('SecurityPolicy');
   });
 });
+
+describe('#847 AutoScaling ScheduledAction StartTime / EndTime (undeclared, time-varying)', () => {
+  const res: DesiredResource = {
+    logicalId: 'Schedule',
+    resourceType: 'AWS::AutoScaling::ScheduledAction',
+    physicalId: 'CdkRea-Sched-Y8TVCVCJA9P3',
+    declared: {
+      AutoScalingGroupName: 'Asg',
+      DesiredCapacity: 1,
+      MaxSize: 2,
+      MinSize: 1,
+      Recurrence: '0 9 * * MON-FRI',
+      TimeZone: 'UTC',
+    },
+  };
+  it('folds the AWS-computed next-occurrence StartTime value-independent', () => {
+    // Time-varying: each read yields a fresh next-occurrence, so any value must fold.
+    for (const t of ['2026-06-22T09:00:00Z', '2026-07-13T09:00:00Z']) {
+      const f = classifyResource(res, { StartTime: t }, emptySchema);
+      expect(pathsByTier(f, 'atDefault')).toContain('StartTime');
+      expect(pathsByTier(f, 'undeclared')).not.toContain('StartTime');
+    }
+  });
+  it('folds the serialized-null EndTime="null" artifact', () => {
+    const f = classifyResource(res, { EndTime: 'null' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('EndTime');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('EndTime');
+  });
+});


### PR DESCRIPTION
Closes #847

## Problem
`AWS::AutoScaling::ScheduledAction` produces two first-run false positives on a clean deploy (violating the core invariant — a clean un-mutated deploy must produce zero `[Potential Drift]`):
1. **`StartTime`** — a scheduled action declaring `Recurrence` but no explicit `StartTime` reads back the concrete timestamp of the **next occurrence** AWS computed (e.g. `0 9 * * MON-FRI` → `2026-06-22T09:00:00Z`). It is undeclared, **time-varying**, and does NOT converge under `record` (each later read yields a fresh next-occurrence → permanent noise).
2. **`EndTime`** = the literal string `"null"` — a serialized-null artifact when no end time is set.

## Fix
Fold both value-independent (`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS`). `StartTime` is AWS-computed and time-varying — it cannot be pinned to a constant (tier 1) nor derived as a deterministic function of declared inputs (tier 2, it depends on wall-clock read time), so tier 3 is correct; a user who declares an explicit `StartTime` is still caught in the declared dimension. `EndTime`'s stringified null is cosmetic. Corpus `expected` updated (both flip `undeclared`→`atDefault`, nothing else).

## Tests
- `tests/corpus/AWS__AutoScaling__ScheduledAction.Schedule.json`: both paths now `atDefault`.
- `tests/noise-firstrun-folds.test.ts`: StartTime (two distinct next-occurrence timestamps, proving value-independence) + EndTime=`"null"` fold away, do not surface as `undeclared`.

## Live-test note
The corpus case was harvested + live-proven in its originating hunt (2026-07-09); it is pinned by `corpus-replay` and is the authoritative live data — no fresh deploy needed.