### PR TITLE
fix(synth): pin QuietIoHost off CI-stdout so check --json stays pure JSON in CI (#867)

### DIFF
--- a/src/synth/io-host.ts
+++ b/src/synth/io-host.ts
@@ -64,6 +64,19 @@ export function planIoMessage(msg: Pick<IoMessage<unknown>, 'code' | 'level'>): 
 }
 
 export class QuietIoHost extends NonInteractiveIoHost {
+  constructor() {
+    // Pin isCI:false so synth passthrough (re-tagged to info/warn below) ALWAYS goes to
+    // STDERR, never stdout. The base NonInteractiveIoHost routes ALL non-error output to
+    // STDOUT when it detects CI mode (`process.env.CI`, which GitHub Actions sets to
+    // 'true') — that would prepend bundler chatter ("Bundling asset …"), the app's own
+    // console.logs, and re-tagged synth warnings to the single JSON.parse-able value
+    // `check --json` promises, in exactly the CI environment where `check --json --fail`
+    // is scripted (and would pollute the `^result:` grep in text mode the same way).
+    // cdkrd owns its own stdout (the drift report / the JSON document); a toolkit-lib
+    // message is never cdkrd's machine "result", so it must never reach stdout. (#867)
+    super({ isCI: false });
+  }
+
   override async notify(msg: IoMessage<unknown>): Promise<void> {
     const plan = planIoMessage(msg);
     if (plan.action === 'drop') return;

--- a/tests/io-host.test.ts
+++ b/tests/io-host.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vite-plus/test';
-import { planIoMessage } from '../src/synth/io-host.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vite-plus/test';
+import { planIoMessage, QuietIoHost } from '../src/synth/io-host.js';
 
 describe('planIoMessage (QuietIoHost routing)', () => {
   it('re-tags CDK app stderr passthrough (E1002, error) to info so it is not red', () => {
@@ -52,5 +52,37 @@ describe('planIoMessage (QuietIoHost routing)', () => {
       action: 'drop',
     });
     expect(planIoMessage({ code: undefined, level: 'trace' })).toEqual({ action: 'drop' });
+  });
+});
+
+describe('QuietIoHost pins non-error output to stderr even under CI (#867)', () => {
+  const saved = process.env.CI;
+  beforeEach(() => {
+    // GitHub Actions sets CI=true; the base NonInteractiveIoHost would then route all
+    // non-error messages to STDOUT, polluting `check --json`. Simulate that environment.
+    process.env.CI = 'true';
+  });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CI;
+    else process.env.CI = saved;
+  });
+
+  it('isCI is false regardless of process.env.CI', () => {
+    expect(new QuietIoHost().isCI).toBe(false);
+  });
+
+  it('info / warn (synth passthrough) select stderr, not stdout, under CI', () => {
+    const host = new QuietIoHost();
+    // selectStreamFromLevel is the base method the CI redirect lives in; cast to reach it.
+    const select = (level: string): unknown =>
+      (host as unknown as { selectStreamFromLevel: (l: string) => unknown }).selectStreamFromLevel(
+        level
+      );
+    expect(select('info')).toBe(process.stderr);
+    expect(select('warn')).toBe(process.stderr);
+    // a real error still goes to stderr (unchanged), and the toolkit's own `result`
+    // level still goes to stdout — but cdkrd never emits `result` through this host.
+    expect(select('error')).toBe(process.stderr);
+    expect(select('result')).toBe(process.stdout);
   });
 });


### PR DESCRIPTION
Closes #867.

## Problem
`QuietIoHost` extends toolkit-lib's `NonInteractiveIoHost`, whose `selectStreamFromLevel` routes **all non-error output to STDOUT when it detects CI mode** (`process.env.CI`, which GitHub Actions sets to `true`). So under CI the re-tagged synth passthrough — bundler chatter ("Bundling asset …"), the app's own `console.log`s, re-tagged validation warnings — prepends garbage to the single `JSON.parse`-able value `check --json` promises, **in exactly the environment where `check --json --fail` is scripted**. Text mode's `^result:` grep is polluted the same way.

## Fix
`QuietIoHost` constructor calls `super({ isCI: false })`. cdkrd owns its own stdout (the drift report / the JSON document); a toolkit-lib message is never cdkrd's machine `result`, so it must always go to **stderr**, CI or not.

## Verification
- **Unit** (`tests/io-host.test.ts`): with `process.env.CI='true'`, `new QuietIoHost().isCI === false`, and `info`/`warn` levels select `process.stderr` (`error`→stderr, `result`→stdout unchanged).
- **Live** (built binary, `CI=true`, chatty fake app): `check --json` stdout is exactly the JSON array — `HELLO-FROM-APP-STDOUT`/`STDERR` land on **stderr**, and `JSON.parse(stdout)` succeeds.

Offline output-contract fix; part of the `--json` robustness cluster with #871 (and #866/#868 remaining).