### PR TITLE
fix(check): --json signals deleted-stack drift, keeps warnings on stderr, never empties stdout on error (#871)

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,8 +574,19 @@ element so a consumer sees which stacks ran: it carries `"error": "<reason>"` al
 `"drifted": 0` and an empty `"findings": []`. (`error` is absent on a
 successfully-checked stack.)
 
+A **stack deleted out of band** — its committed baseline proves it was once deployed but
+it is now gone from CloudFormation — is the strongest drift, so it carries
+`"drifted": 1` and `"stackDeleted": true` (never `"error"`, which is reserved for a
+pre-check failure). A consumer summing `drifted` across stacks therefore sees the
+deletion instead of a misleading zero.
+
+If the whole invocation fails before any stack is reached (bad config, an
+un-synthesizable app, or a zero-stack app), stdout is still a valid empty array
+`[]` (exit code non-zero, the reason on stderr) — never empty bytes.
+
 Each stack element is `{ "stack": "<name> (<region>)", "drifted": <n>, "findings": [...] }`
-(`error` added only on failure). Each **finding** has a stable shape:
+(`error` added only on a pre-check failure; `stackDeleted: true` only on a deleted
+stack). Each **finding** has a stable shape:
 
 - Always present: `tier`, `logicalId`, `resourceType`, `path`.
 - Usually present: `desired`, `actual`, `note`, `physicalId`, `constructPath` (any of

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -25,7 +25,14 @@ import {
 import { isInteractive, parseCommonArgs } from '../cli-args.js';
 import { applyIgnores, loadConfig } from '../config/config-file.js';
 import { withinStackPath } from '../construct-path.js';
-import { buildStackJson, report, type StackJsonReport, stackSeparator } from '../report/report.js';
+import {
+  buildStackJson,
+  deletedStackReport,
+  report,
+  type StackJsonReport,
+  stackSeparator,
+} from '../report/report.js';
+import { style } from '../report/style.js';
 import { resolveApp } from '../synth/resolve-app.js';
 import { synthApp } from '../synth/synth.js';
 import type { DesiredResource, Finding } from '../types.js';
@@ -246,11 +253,21 @@ export async function runCheck(args: string[]): Promise<number> {
 
   // .cdkrd/ignore.yaml ignore rules, loaded once (cwd-relative). A malformed config
   // fails the whole run fast — a silently-ineffective ignore rule is the dangerous case.
+  // A whole-run failure BEFORE any stack is known (bad config, un-synthesizable app, a
+  // zero-stack app) still exits non-zero — but under --json it must leave stdout a single
+  // JSON.parse-able value, not empty. Emit `[]` (no stacks reached) so a consumer's
+  // JSON.parse(stdout) succeeds and it reads the failure from the exit code + stderr,
+  // instead of throwing on '' (#871 — the top-level twin of the #885 zero-stack fix).
+  const emitEmptyJsonOnError = (): void => {
+    if (a.json) console.log('[]');
+  };
+
   let config;
   try {
     config = await loadConfig();
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    emitEmptyJsonOnError();
     return 2;
   }
 
@@ -259,6 +276,7 @@ export async function runCheck(args: string[]): Promise<number> {
     stacks = await resolveStacks(a);
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    emitEmptyJsonOnError();
     return 2;
   }
   if (stacks.length === 0) {
@@ -290,6 +308,7 @@ export async function runCheck(args: string[]): Promise<number> {
     const app = resolveApp(a.app);
     if (!app) {
       console.error('error: --pre-deploy needs a CDK app (--app or a cdk.json in the cwd)');
+      emitEmptyJsonOnError();
       return 2;
     }
     const synthed = await synthApp(app, {
@@ -502,9 +521,11 @@ export async function runCheck(args: string[]): Promise<number> {
             // #675: current template's logical-id set so recorded entries for a resource
             // removed from the template fold into a nudge (not phantom "removed" drift).
             allLogicalIds: desired.resources.map((r) => r.logicalId),
-            warn: (s: string) => {
-              if (!a.json) console.error(s);
-            },
+            // Baseline nudges (removed-entry / stale-baseline) go to STDERR unconditionally
+            // — under --json stdout stays pure JSON, but these warnings must NOT vanish
+            // entirely (they did under the old `if (!a.json)`). README: all note/warning
+            // lines go to stderr; ignore.ts passes console.error unconditionally too. (#871)
+            warn: (s: string) => console.error(s),
           },
         }),
         { stackName, accountId: desired.accountId, region },
@@ -586,8 +607,22 @@ export async function runCheck(args: string[]): Promise<number> {
         // (and `--strict`) exit 0 on a deleted stack, indistinguishable from never-deployed.
         if (hasBaselineForStack(stackName)) {
           const msg = 'deployed baseline exists but the stack is gone — deleted out of band';
-          console.error(`[Drift] ${stackName} (${region}): ${msg}`);
-          jsonError(stackName, region, msg);
+          const label = `${stackName} (${region})`;
+          console.error(`[Drift] ${label}: ${msg}`);
+          if (a.json) {
+            // A deleted stack is the STRONGEST drift, not a pre-check error: emit
+            // drifted:1 + stackDeleted:true (NOT the jsonError shape, which is
+            // drifted:0 + `error` reserved for stacks that failed BEFORE being checked).
+            // Without this a consumer summing `drifted` sees ZERO on an exit-1 run. (#871)
+            jsonReports.push(deletedStackReport(label));
+          } else {
+            // Text mode: a stdout `result:` line so the documented `^result:` grep catches
+            // the deleted stack too (the [Drift] detail above is on stderr like other
+            // notes). Without it, `check | grep '^result:'` misses the deleted stack. (#871)
+            console.log(
+              `${style.resultLabel('result:')} ${style.drift('1 drift(s)')} — ${label}: stack deleted out of band`
+            );
+          }
           // Drift, not an error: gate on --fail exactly like a per-stack drift code (R53), and
           // make --strict fail regardless (a missing whole stack is the ultimate coverage gap).
           worst = Math.max(worst, finalCheckExit(1, a.fail), a.strict ? 1 : 0);

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -290,6 +290,20 @@ export interface StackJsonReport {
   // pre-#755 behavior printed nothing for an errored stack). Never set on a
   // successfully-checked stack.
   error?: string;
+  // Set ONLY on a stack whose committed baseline proves it was once deployed but which is
+  // now GONE from CloudFormation (deleted out of band). This is the STRONGEST drift, not a
+  // pre-check error, so it carries `drifted: 1` (never `error`): a consumer summing
+  // `drifted` across stacks must see it. Absent on every other stack. (#871)
+  stackDeleted?: boolean;
+}
+
+// The --json element for a stack DELETED out of band (#871): the STRONGEST drift, so
+// `drifted: 1` + `stackDeleted: true` — never the `drifted: 0` + `error` shape (`error`
+// is reserved for a stack that failed BEFORE it could be checked). A consumer summing
+// `drifted` across stacks must see the deleted stack. Used by check.ts's not-deployed
+// catch when a committed baseline proves the stack was once deployed.
+export function deletedStackReport(label: string): StackJsonReport {
+  return { stack: label, drifted: 1, findings: [], stackDeleted: true };
 }
 
 export function buildStackJson(

--- a/tests/json-signal-871.test.ts
+++ b/tests/json-signal-871.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { deletedStackReport } from '../src/report/report.js';
+
+// #871 part 1 — a DELETED stack is the strongest drift, so its --json element must be
+// drifted:1 + stackDeleted:true, NOT the drifted:0 + `error` shape (`error` is reserved
+// for a stack that failed BEFORE it could be checked). A consumer summing `drifted`
+// across stacks would otherwise see ZERO on an exit-1 run where a whole stack is gone.
+describe('deletedStackReport (#871)', () => {
+  it('signals drifted:1 + stackDeleted:true, no error field', () => {
+    const r = deletedStackReport('MyStack (us-east-1)');
+    expect(r).toEqual({
+      stack: 'MyStack (us-east-1)',
+      drifted: 1,
+      findings: [],
+      stackDeleted: true,
+    });
+    expect(r.error).toBeUndefined(); // never the pre-check-error shape
+    expect(r.drifted).toBe(1); // a consumer summing `drifted` sees the deletion
+  });
+});
+
+// #871 part 2 — a whole-run failure BEFORE any stack is known still leaves --json stdout
+// a single JSON.parse-able value ([]), not empty. Mock synth so resolveStacks throws.
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: () => Promise.reject(new Error('boom: app could not be synthesized')),
+}));
+
+import { runCheck } from '../src/commands/check.js';
+
+describe('check --json emits [] (not empty stdout) on a top-level error (#871)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('--json prints "[]" to stdout and exits 2 when resolveStacks throws', async () => {
+    const out: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      out.push(String(m));
+    });
+    const err: string[] = [];
+    vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      err.push(String(m));
+    });
+
+    const code = await runCheck(['--json']);
+
+    expect(code).toBe(2);
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0]!)).toEqual([]); // parseable, never ''
+    expect(err.join('\n')).toContain('boom'); // the error still surfaces on stderr
+  });
+
+  it('text mode writes the error only to stderr, nothing to stdout', async () => {
+    const out: string[] = [];
+    const err: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      out.push(String(m));
+    });
+    vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+      err.push(String(m));
+    });
+
+    const code = await runCheck([]);
+
+    expect(code).toBe(2);
+    expect(out).toEqual([]); // no stray stdout in text mode
+    expect(err.join('\n')).toContain('boom');
+  });
+});


### PR DESCRIPTION
Closes #871. (Also closes the top-level `--json`-on-error empty-stdout gap flagged on #898/#885.)

Three `check --json` output-contract gaps, one lane (`src/commands/check.ts` + a `report.ts` helper/type):

## 1. Deleted stack under-signaled `drifted: 0`
A stack whose committed baseline proves it was deployed but which is **gone** from CloudFormation set exit 1 yet emitted `{ drifted: 0, findings: [], error: "…" }` — but `error` is reserved for a **pre-check** failure, so a consumer summing `drifted` saw ZERO on the strongest possible drift. Now emits `{ drifted: 1, findings: [], stackDeleted: true }` (new `deletedStackReport` helper in report.ts) plus a stdout `result:` line in text mode so the documented `^result:` grep catches it.

## 2. applyBaseline warnings dropped entirely under `--json`
`warn: (s) => { if (!a.json) console.error(s) }` **swallowed** removed-entry / stale-baseline nudges under `--json`. They now go to stderr **unconditionally** (stdout stays pure JSON; matches `ignore.ts`).

## 3. Empty stdout on a top-level error under `--json`
A whole-run failure before any stack is known (bad config / un-synthesizable app / `--pre-deploy` without an app) emitted **empty stdout**, so `JSON.parse('')` threw while the exit code read the failure. Now emits `[]` — the top-level twin of the #885 zero-stack fix.

## Docs + tests
- README JSON-contract section documents `stackDeleted` and the empty-array-on-error rule.
- Unit (`tests/json-signal-871.test.ts`): `deletedStackReport` shape; `runCheck(['--json'])` prints `[]` + exit 2 when synth throws; text mode writes nothing to stdout.
- Live-verified: a top-level error prints `[]` under `--json`, exit 2, reason on stderr.

The full deploy→delete→check cycle for the deleted-stack path is covered by the unit helper + the existing #781 exit-math test (a real AWS deploy/delete is deferred — the machine contract is pure-testable).