### PR TITLE
fix(cleanup): back sweep protection with authoritative stack membership + sentinel (age guard backstop) (#900 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,8 +219,15 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
   use `delstack cdk -a cdk.out` (it was `cdk destroy`). Pinned in `.mise.toml`
   (`ubi:go-to-k/delstack`). `delstack` only sees stack members — after deleting,
   still SWEEP for stack-EXTERNAL orphans it can't reach: auto-created
-  `/aws/lambda/*` and access-log groups, RETAIN-policy stateful resources,
-  Secrets in their recovery window, KMS keys pending deletion.
+  `/aws/lambda/*` and access-log groups, **orphaned IAM roles / instance
+  profiles** (an API-GW CloudWatch or Lambda service role left when a stack is
+  force-deleted), RETAIN-policy stateful resources, Secrets in their recovery
+  window, KMS keys pending deletion. Use **`/sweep-resources`** — it drives
+  `tests/integration/sweep-orphans.sh` (token-scoped + a `cdkrd:ephemeral=1`
+  generic tag net), which protects active-stack members (case-insensitively,
+  across regions for global IAM) AND anything younger than
+  `CDKRD_SWEEP_MIN_AGE_HOURS` (default 2h — a name-match can miss a live resource
+  whose CFn physical name was truncated / hyphen-derived).
 - **markgate gates** (see `.markgate.yml`) — each has a companion skill that sets
   its marker:
   - `/check` → `check` marker (typecheck / lint+format / build / unit tests).
@@ -240,7 +247,11 @@ delete-stack` / `npx cdk destroy`.** Plain deletion leaves a stack
     peer's live hunt does not block an unrelated commit) — released by
     `bughunt-track.sh clear` only after every tracked stack is deleted (via
     `delstack`) and `sweep-orphans.sh` reports SWEEP CLEAN. A deployed stack can
-    never be forgotten.
+    never be forgotten. As a backstop (even for a live-test that never called
+    `add`), the `deploy-autoarm-gate` hook arms a generic token on ANY
+    deploy-shaped command, and the `stop-cleanup-warn` Stop hook warns at session
+    end if the sentinel is still armed. Run **`/sweep-resources`** to do the
+    cleanup + release the gate.
 - **ALWAYS develop in a git worktree — never edit or branch in the main
   checkout, even for a single "sequential" session.** Sessions that believed
   they were alone have collided twice: a README clobber, and a branch created in

--- a/tests/integration/sweep-orphans.sh
+++ b/tests/integration/sweep-orphans.sh
@@ -64,6 +64,38 @@ ACTIVE_STACKS_GLOBAL="$(
   done
 )"
 
+# Layer 2 — the bughunt SENTINEL lists peers' IN-FLIGHT stacks (they explicitly declared
+# "I'm deploying these"). Protect those too — covers a stack mid-CREATE and the strongest
+# cross-agent coordination signal. Best-effort: resolve the shared main-tree root via git;
+# degrade silently if unavailable. Skip the generic AUTODEPLOY token (not a stack name).
+SENTINEL_STACKS=""
+_gc="$(git -C "$(dirname "$0")" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+if [ -n "$_gc" ]; then
+  _root="$(dirname "$_gc")"
+  SENTINEL_STACKS="$(cat "$_root"/.markgate-bughunt-pending.d/* "$_root/.markgate-bughunt-pending" 2>/dev/null \
+    | grep -vE '^[[:space:]]*$' | grep -viF 'AUTODEPLOY' || true)"
+fi
+
+# Layer 1 — AUTHORITATIVE stack membership. Name-substring MISSES a live resource whose
+# CFn physical name was truncated to 64 chars or hyphen-derived by a service (an active
+# ImageBuilder role/pipeline was mis-flagged this way). Enumerate the actual members
+# (PhysicalResourceId) of every active + sentinel-tracked stack across the IAM regions and
+# protect anything whose id is a member — immune to name mangling AND to age. Best-effort
+# (list-stack-resources per stack); empty result → the name + age guards still apply.
+PROTECTED_STACKS="$(printf '%s\n%s\n' "$ACTIVE_STACKS_GLOBAL" "$SENTINEL_STACKS" | grep -vE '^[[:space:]]*$' | sort -u)"
+MEMBER_IDS="$(
+  printf '%s\n' "${_iam_regions[@]}" | sort -u | while IFS= read -r r; do
+    [ -n "$r" ] || continue
+    printf '%s\n' "$PROTECTED_STACKS" | while IFS= read -r s; do
+      [ -n "$s" ] || continue
+      aws cloudformation list-stack-resources --stack-name "$s" --region "$r" \
+        --query 'StackResourceSummaries[].PhysicalResourceId' --output text 2>/dev/null | tr '\t' '\n'
+    done
+  done | grep -vE '^[[:space:]]*$' | sort -u
+)"
+# is_member <name> — the resource IS a member of a protected stack (exact physical-id match).
+is_member() { [ -n "$MEMBER_IDS" ] && printf '%s\n' "$MEMBER_IDS" | grep -qFx "$1"; }
+
 # A cdkrd-token resource is an orphan unless its name embeds an active stack name.
 # `stacks` selects the guard set: the region-local set for regional resources, the
 # all-regions set for global (IAM) ones. Match is CASE-INSENSITIVE: AWS lowercases
@@ -80,8 +112,41 @@ _name_backed_by() {
   done
   return 1
 }
-is_backed()        { _name_backed_by "$1" "$ACTIVE_STACKS"; }
-is_backed_global() { _name_backed_by "$1" "$ACTIVE_STACKS_GLOBAL"; }
+# Backed = an actual stack MEMBER (authoritative, layer 1) OR its name embeds an active
+# stack name (cheap fallback). Membership is checked first — it is immune to name mangling.
+is_backed()        { is_member "$1" || _name_backed_by "$1" "$ACTIVE_STACKS"; }
+is_backed_global() { is_member "$1" || _name_backed_by "$1" "$ACTIVE_STACKS_GLOBAL"; }
+
+# --- age guard: protect a peer's IN-FLIGHT resources from a name-match miss ---------
+# is_backed's name-substring test MISSES a live resource when CloudFormation TRUNCATES
+# the physical name to 64 chars (dropping the stack-name suffix) or a service derives a
+# HYPHENATED name that no longer embeds the mixed-case stack name (ImageBuilder pipelines
+# / roles / instance profiles). A dogfood run flagged 3 ACTIVE peer hunt resources as
+# orphans exactly this way. An active peer's resources are RECENT, so ALSO refuse to
+# sweep anything younger than CDKRD_SWEEP_MIN_AGE_HOURS (default 2) — a belt to
+# is_backed's braces. Genuine orphans are hours/days/weeks old and still swept.
+MIN_AGE_HOURS="${CDKRD_SWEEP_MIN_AGE_HOURS:-2}"
+NOW_EPOCH="$(date -u +%s)"
+# Portable timestamp -> epoch seconds: ISO-8601 (IAM CreateDate) or epoch millis
+# (log-group creationTime). Unparseable/absent -> 0.
+to_epoch() {
+  local ts="$1" core e
+  case "$ts" in ''|None|null) echo 0; return ;; esac
+  printf '%s' "$ts" | grep -qE '^[0-9]{13}$' && { echo $(( ts / 1000 )); return; }
+  printf '%s' "$ts" | grep -qE '^[0-9]{10}$' && { echo "$ts"; return; }
+  e=$(date -u -d "$ts" +%s 2>/dev/null) && { echo "$e"; return; }   # GNU (Linux/CI)
+  core="${ts%%.*}"; core="${core%%+*}"; core="${core%Z}"
+  e=$(date -u -j -f "%Y-%m-%dT%H:%M:%S" "$core" +%s 2>/dev/null) && { echo "$e"; return; }  # BSD (macOS)
+  echo 0
+}
+# too_young <timestamp> -> true (protect) if younger than MIN_AGE_HOURS. FAIL-SAFE: an
+# unparseable/absent timestamp is treated as YOUNG (protect) so a bad clock never deletes
+# a live resource — a genuine orphan with no readable age is left for manual handling.
+too_young() {
+  local created; created="$(to_epoch "$1")"
+  [ "$created" -eq 0 ] && return 0
+  [ $(( NOW_EPOCH - created )) -lt $(( MIN_AGE_HOURS * 3600 )) ]
+}
 
 # delete <kind> <name> <delete-cmd...>
 sweep_one() {
@@ -138,9 +203,15 @@ for s in $(aws secretsmanager list-secrets --include-planned-deletion --region "
 done
 
 note "--- CloudWatch log groups ---"
-for g in $(aws logs describe-log-groups --region "$REGION" --query 'logGroups[].logGroupName' --output text 2>/dev/null | tr '\t' '\n' | grep -Ei "$TOKEN"); do
+while IFS=$'\t' read -r g created; do
+  [ -n "$g" ] || continue
+  printf '%s' "$g" | grep -Eqi "$TOKEN" || continue
+  if too_young "$created"; then
+    note "  SKIP (younger than ${MIN_AGE_HOURS}h — likely an in-flight deploy): LogGroup $g"
+    continue
+  fi
   sweep_one LogGroup "$g" aws logs delete-log-group --log-group-name "$g" --region "$REGION"
-done
+done < <(aws logs describe-log-groups --region "$REGION" --query 'logGroups[].[logGroupName,creationTime]' --output text 2>/dev/null)
 
 # --- IAM roles (GLOBAL) --------------------------------------------------------
 # CloudFormation-created roles (e.g. an API Gateway account CloudWatch role, a
@@ -164,9 +235,15 @@ iam_role_teardown() {
 }
 
 note "--- IAM roles (global) ---"
-for r in $(aws iam list-roles --query 'Roles[].RoleName' --output text 2>/dev/null | tr '\t' '\n' | grep -Ei "$TOKEN"); do
+while IFS=$'\t' read -r r created; do
+  [ -n "$r" ] || continue
+  printf '%s' "$r" | grep -Eqi "$TOKEN" || continue
   if is_backed_global "$r"; then
     note "  SKIP (active-stack member, any region): IAM-role $r"
+    continue
+  fi
+  if too_young "$created"; then
+    note "  SKIP (younger than ${MIN_AGE_HOURS}h — likely an in-flight deploy): IAM-role $r"
     continue
   fi
   hit
@@ -175,12 +252,18 @@ for r in $(aws iam list-roles --query 'Roles[].RoleName' --output text 2>/dev/nu
   else
     note "  ORPHAN (dry-run): IAM-role $r"
   fi
-done
+done < <(aws iam list-roles --query 'Roles[].[RoleName,CreateDate]' --output text 2>/dev/null)
 
 note "--- IAM instance profiles (global) ---"
-for ipf in $(aws iam list-instance-profiles --query 'InstanceProfiles[].InstanceProfileName' --output text 2>/dev/null | tr '\t' '\n' | grep -Ei "$TOKEN"); do
+while IFS=$'\t' read -r ipf created; do
+  [ -n "$ipf" ] || continue
+  printf '%s' "$ipf" | grep -Eqi "$TOKEN" || continue
   if is_backed_global "$ipf"; then
     note "  SKIP (active-stack member, any region): InstanceProfile $ipf"
+    continue
+  fi
+  if too_young "$created"; then
+    note "  SKIP (younger than ${MIN_AGE_HOURS}h — likely an in-flight deploy): InstanceProfile $ipf"
     continue
   fi
   hit
@@ -196,7 +279,7 @@ for ipf in $(aws iam list-instance-profiles --query 'InstanceProfiles[].Instance
   else
     note "  ORPHAN (dry-run): InstanceProfile $ipf"
   fi
-done
+done < <(aws iam list-instance-profiles --query 'InstanceProfiles[].[InstanceProfileName,CreateDate]' --output text 2>/dev/null)
 
 # --- Generic tag-based net (catches TYPES this script has no per-type rule for) --
 # The per-type sweeps above are an allowlist — an ephemeral resource of a type not

--- a/tests/integration/sweep-orphans.test.sh
+++ b/tests/integration/sweep-orphans.test.sh
@@ -30,7 +30,7 @@ case "$svc/$op" in
   cloudformation/list-stacks)   echo "Cdkrd717Verify" ;;            # the only ACTIVE stack (mixed case)
   rds/describe-db-instances)    echo "cdkrd717verify-writer-abc123" ;;  # lowercased -> backed by Cdkrd717Verify
   rds/describe-db-clusters)     : ;;
-  iam/list-roles)               echo "CdkRealDriftGone-ApiCloudWatchRole-xyz" ;; # stack gone -> ORPHAN
+  iam/list-roles)               printf '%s\t%s\n' "CdkRealDriftGone-ApiCloudWatchRole-xyz" "2020-01-01T00:00:00+00:00" ;; # stack gone + old -> ORPHAN
   iam/list-instance-profiles)   : ;;
   resourcegroupstaggingapi/get-resources) echo "arn:aws:sqs:us-east-1:123456789012:CdkrdGoneQueue" ;;
   kinesis/list-streams|dynamodb/list-tables|efs/describe-file-systems|secretsmanager/list-secrets|logs/describe-log-groups) : ;;
@@ -40,8 +40,10 @@ MOCK
 chmod +x "$tmp/aws"
 
 # The sweep exits 1 when it reports unresolved orphans (keeps verify RED) — expected
-# here (the tagged resource), so tolerate it; we assert on the OUTPUT.
-out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+# here (the tagged resource), so tolerate it; we assert on the OUTPUT. MIN_AGE_HOURS=0
+# turns the age guard off for these (they test the name/IAM/tag logic; the age guard
+# has its own test below).
+out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 CDKRD_SWEEP_MIN_AGE_HOURS=0 bash "$SWEEP" 2>&1 || true)"
 
 assert "case-insensitive active-stack protection (lowercased RDS backed by mixed-case stack -> SKIP)" "$out" "SKIP \(active-stack member\): RDS-instance cdkrd717verify-writer-abc123"
 assert "IAM role orphan is found (the leaked class)" "$out" "ORPHAN \(dry-run\): IAM-role CdkRealDriftGone-ApiCloudWatchRole-xyz"
@@ -56,6 +58,39 @@ MOCK
 chmod +x "$tmp/aws"
 clean_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1)"
 assert "SWEEP CLEAN when nothing token-matches" "$clean_out" "SWEEP CLEAN"
+
+# age guard: a RECENT, name-UNBACKED role (the ImageBuilder truncation/hyphen case that
+# name-substring misses) must be PROTECTED as too-young, never swept. Dynamic recent ts.
+RECENT="$(date -u -v-1M +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -d '1 minute ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null)"
+cat > "$tmp/aws" <<MOCK
+#!/usr/bin/env bash
+case "\$1/\${2:-}" in
+  cloudformation/list-stacks) echo "SomeUnrelatedStack" ;;
+  iam/list-roles) printf '%s\t%s\n' "CdkRealDriftIntegImageBuilderRi-BuilderRole-abc" "$RECENT" ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+age_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 bash "$SWEEP" 2>&1 || true)"
+assert "age guard PROTECTS a recent name-unbacked role (ImageBuilder truncation case)" "$age_out" "SKIP \(younger than.*IAM-role CdkRealDriftIntegImageBuilderRi-BuilderRole-abc"
+refute "the protected recent role is NOT reported as an orphan" "$age_out" "ORPHAN.*CdkRealDriftIntegImageBuilderRi-BuilderRole-abc"
+
+# layer 1 (authoritative membership): a name-UNBACKED, OLD role (age guard off) is still
+# PROTECTED because list-stack-resources reports it as a member of the active stack —
+# the truncation case the name-substring guard alone would delete.
+cat > "$tmp/aws" <<'MOCK'
+#!/usr/bin/env bash
+case "$1/${2:-}" in
+  cloudformation/list-stacks)          echo "CdkRealDriftIntegImageBuilderRich" ;;
+  cloudformation/list-stack-resources) echo "CdkRealDriftIntegImageBuilderRi-BuilderRole-abc" ;; # 64-char truncated member
+  iam/list-roles)                      printf '%s\t%s\n' "CdkRealDriftIntegImageBuilderRi-BuilderRole-abc" "2020-01-01T00:00:00+00:00" ;;
+  *) : ;;
+esac
+MOCK
+chmod +x "$tmp/aws"
+mem_out="$(PATH="$tmp:$PATH" AWS_REGION=us-east-1 CDKRD_SWEEP_MIN_AGE_HOURS=0 bash "$SWEEP" 2>&1 || true)"
+assert "layer 1 membership PROTECTS a truncated-name member even when OLD + name-unbacked" "$mem_out" "SKIP \(active-stack member.*IAM-role CdkRealDriftIntegImageBuilderRi-BuilderRole-abc"
+refute "the member role is NOT reported as an orphan" "$mem_out" "ORPHAN.*IAM-role CdkRealDriftIntegImageBuilderRi-BuilderRole-abc"
 
 rm -rf "$tmp"
 echo "----"


### PR DESCRIPTION
Follow-up to #900, found by **dogfooding** the sweep against the live account: it flagged **3 ACTIVE peer hunt-v resources** as orphans. A `--delete` would have deleted a peer's live resources. Root cause: the active-stack guard matched by **stack-name substring**, which breaks when CloudFormation **truncates** a physical name to 64 chars (role `CdkRealDriftIntegImageBuilderRi-...` vs stack `...ImageBuilderRich`) or a service derives a **hyphenated** name (`cdkrd-hunt-v-pipeline`).

## Robust fix, layered (name-match → authoritative)
- **Layer 1 (authoritative):** protect any resource that is an actual **member** of an active or sentinel-tracked stack — `list-stack-resources` → `PhysicalResourceId` set across the IAM regions. Immune to name truncation/hyphenation **and** to age.
- **Layer 2 (cross-agent):** also protect stacks listed in the bughunt **sentinel** — peers explicitly declared "I'm deploying these"; covers a stack still mid-CREATE.
- **Backstop:** the **age guard** (`CDKRD_SWEEP_MIN_AGE_HOURS`, default 2h) still covers stack-EXTERNAL byproducts that are NOT CFn members (service-auto-created log groups / instance profiles) in their recent window.
- Also: **case-insensitive** name fallback (AWS lowercases RDS/S3/ELB names — a latent bug that could delete a peer's live DB) and `DELETE_IN_PROGRESS` stacks protect mid-teardown members.

## Verified live
0 false orphans → `SWEEP CLEAN`. (Caught the 3 in dry-run; deleted only the one genuine weeks-old orphan.)

## Test
`sweep-orphans.test.sh` — 9 assertions incl. layer-1 membership (a truncated, OLD, name-unbacked member is protected) + the age-guard case. `vp` typecheck/check/test(3374)/pack green.

## Docs
CLAUDE.md lists orphaned IAM roles among stack-external orphans and points at `/sweep-resources` + the `deploy-autoarm-gate` / `stop-cleanup-warn` hooks.

Tooling/docs-only (no `src/**`).
