### PR TITLE
fix(read): GuardDuty::Filter composite CC identifier [DetectorId, Name] (#878)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -304,6 +304,14 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
       ? `${apiId}|${routeId}|${pid}`
       : undefined;
   },
+  // GuardDuty Filter primaryIdentifier is [DetectorId, Name] — parent-first. The CFn
+  // physical id (Ref) is the bare filter Name, so a bare-id CC GetResource
+  // ValidationException-skips it (read-gap) on every check — a security-tooling stack
+  // (detector + finding filters) never sees an out-of-band filter change (e.g. a
+  // weakened severity criterion hiding findings). DetectorId is a required declared
+  // prop (a Ref to the detector, resolvable). Verified live (#878, stack CdkrdHuntUGd,
+  // us-east-1): `<DetectorId>|<FilterName>` reads; the reverse order returns NotFound.
+  'AWS::GuardDuty::Filter': compositeWith('DetectorId'),
 };
 
 // `${PolicyARN}|${ScalableDimension}` for a ScalingPolicy, extracting the

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -375,6 +375,36 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('cdkrd-readgap-dg');
   });
 
+  it('GuardDuty Filter: builds the DetectorId|Name composite — PARENT first (#878)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::GuardDuty::Filter',
+        physicalId: 'my-filter',
+        declared: { DetectorId: 'abc123detector' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('abc123detector|my-filter');
+  });
+
+  it('GuardDuty Filter: an unresolved DetectorId falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::GuardDuty::Filter',
+        physicalId: 'my-filter',
+        declared: {},
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('my-filter');
+  });
+
   it('AutoScaling ScheduledAction: builds the ScheduledActionName|AutoScalingGroupName composite — CHILD first (reverse of LifecycleHook)', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(


### PR DESCRIPTION
## What

`AWS::GuardDuty::Filter`'s Cloud Control `primaryIdentifier` is `[DetectorId, Name]` (parent-first), but its CFn physical id (Ref) is the **bare filter Name**. A bare-id CC `GetResource` therefore `ValidationException`-skips the resource on every `check` — a silent read-gap.

## Impact

Security-tooling stacks (a GuardDuty detector + finding filters) never see an out-of-band filter change. Someone raising a filter's severity threshold to hide findings — or deleting the criterion — is invisible; the stack just shows `skipped=1` forever.

## Fix

Add a `CC_IDENTIFIER_ADAPTERS` entry in `src/read/router.ts`:

```ts
'AWS::GuardDuty::Filter': compositeWith('DetectorId'),
```

which builds the identifier as `<DetectorId>|<FilterName>`. `DetectorId` is a required declared prop (a resolvable Ref to the detector); an unresolved parent falls back to the bare physical id (honest skip), matching every existing parent-first composite adapter.

## Verification

- Live-confirmed identifier order (issue #878, stack `CdkrdHuntUGd`, us-east-1): `<DetectorId>|<FilterName>` reads; the reverse order returns NotFound.
- Unit tests added (`tests/router.test.ts`): composite build + unresolved-parent fallback. Full suite green (3393 tests), typecheck + lint + build clean.

Closes #878
