### PR TITLE
fix(noise): fold first-run FP defaults for ServerCertificate Path, ApiGwV2 Route AuthType, ApplicationInsights CWEMonitorEnabled, LakeFormation Tag CatalogId

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -15,6 +15,10 @@ import { parse as parseYaml } from 'yaml';
 // entries were all OBSERVED on real default-config stacks during dogfooding.
 export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::IAM::Role': { MaxSessionDuration: 3600, Path: '/', Description: '' },
+  // A server certificate declared without a Path reads back "/" (the IAM default),
+  // exactly like Role/kin above. Equality-gated, so an out-of-band UpdateServerCertificate
+  // path move still surfaces. Live-confirmed (#910).
+  'AWS::IAM::ServerCertificate': { Path: '/' },
   // An App Runner service that declares neither HealthCheckConfiguration nor
   // NetworkConfiguration reads both back fully materialized with AWS's constant
   // first-run defaults — a TCP health check and a public IPV4 DEFAULT-egress network.
@@ -1129,8 +1133,18 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::ApiGateway::Method': {
     ApiKeyRequired: false,
   },
+  // A minimal ApplicationInsights application (only ResourceGroupName declared) reads back
+  // CWEMonitorEnabled=true even though the CFn schema annotates its default as false — AWS
+  // assigns true at creation. Equality-gated, so disabling it (false) still surfaces.
+  // Live-confirmed (#841); sibling AutoConfigurationEnabled/OpsCenterEnabled=false already
+  // fold via schema defaults.
+  'AWS::ApplicationInsights::Application': { CWEMonitorEnabled: true },
   'AWS::ApiGatewayV2::Route': {
     ApiKeyRequired: false,
+    // A route declared without an authorizer reads back AuthorizationType="NONE" (the
+    // majority of WebSocket/HTTP-API routes). Equality-gated, so switching to
+    // AWS_IAM/CUSTOM/JWT still surfaces. Live-confirmed (#873).
+    AuthorizationType: 'NONE',
   },
   'AWS::ElasticLoadBalancingV2::ListenerRule': {
     IsDefault: false, // a declared rule is never the listener's default rule
@@ -2084,6 +2098,11 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string>> = {
     ServiceLinkedRoleARN:
       'arn:{partition}:iam::{accountId}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling',
   },
+  // A LakeFormation Tag that declares no CatalogId reads back the deploying account id — the
+  // default (own-account) Data Catalog. The bare `{accountId}` placeholder substitutes to the
+  // account id; equality-gated, so a Tag pointed at another account's catalog still surfaces.
+  // Live-confirmed (#914).
+  'AWS::LakeFormation::Tag': { CatalogId: '{accountId}' },
 };
 
 // Top-level UNDECLARED keys whose service default VALUE is derived from the resource's own

--- a/tests/noise-folds-910-914.test.ts
+++ b/tests/noise-folds-910-914.test.ts
@@ -1,0 +1,113 @@
+// First-run fold gaps mined from clean, un-mutated LIVE deploys (issues #910, #873, #841,
+// #914). Each fold is equality-gated (or account-derived), so a change away from the default
+// still surfaces — every test asserts BOTH the fold (atDefault on a clean deploy) AND that a
+// genuine divergence still surfaces as undeclared drift.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#910 IAM ServerCertificate undeclared Path="/"', () => {
+  const res: DesiredResource = {
+    logicalId: 'ServerCert',
+    resourceType: 'AWS::IAM::ServerCertificate',
+    physicalId: 'cert',
+    declared: { ServerCertificateName: 'cert' },
+  };
+  it('folds the default Path="/" to atDefault', () => {
+    const f = classifyResource(res, { Path: '/' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Path');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Path');
+  });
+  it('surfaces an out-of-band non-root path as undeclared', () => {
+    const f = classifyResource(res, { Path: '/team/' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('Path');
+  });
+});
+
+describe('#873 ApiGatewayV2 Route undeclared AuthorizationType="NONE"', () => {
+  const res: DesiredResource = {
+    logicalId: 'Route',
+    resourceType: 'AWS::ApiGatewayV2::Route',
+    physicalId: 'route',
+    declared: { RouteKey: '$default', ApiId: 'api' },
+  };
+  it('folds the default AuthorizationType="NONE" to atDefault', () => {
+    const f = classifyResource(res, { AuthorizationType: 'NONE' }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('AuthorizationType');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('AuthorizationType');
+  });
+  it('surfaces an out-of-band AWS_IAM authorizer as undeclared', () => {
+    const f = classifyResource(res, { AuthorizationType: 'AWS_IAM' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('AuthorizationType');
+  });
+});
+
+describe('#841 ApplicationInsights undeclared CWEMonitorEnabled=true', () => {
+  const res: DesiredResource = {
+    logicalId: 'Insights',
+    resourceType: 'AWS::ApplicationInsights::Application',
+    physicalId: 'app',
+    declared: { ResourceGroupName: 'grp' },
+  };
+  it('folds AWS-assigned CWEMonitorEnabled=true to atDefault', () => {
+    const f = classifyResource(res, { CWEMonitorEnabled: true }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('CWEMonitorEnabled');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('CWEMonitorEnabled');
+  });
+  // A later-disabled CWEMonitorEnabled=false does NOT surface: the undeclared loop drops any
+  // `false`/`""` via isTrivialEmpty BEFORE the fold table ("false does not stay meaningful"),
+  // and detecting a true->false out-of-band disable would require a curated MEANINGFUL_WHEN_OFF
+  // entry (in diff/classify.ts) — which that table's own rule admits ONLY after a live confirm
+  // that OFF is meaningful in EVERY clean-deploy config. We have a single live observation
+  // (true on a minimal app), not that cross-config proof, so surfacing the disable is out of
+  // scope for this first-run-FP fold and is left for a live-verified follow-up. The fold here
+  // only mutes the AWS-assigned `true`, restoring the ZERO-potential-drift invariant.
+  it('drops an undeclared CWEMonitorEnabled=false as trivially-empty (not surfaced)', () => {
+    const f = classifyResource(res, { CWEMonitorEnabled: false }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('CWEMonitorEnabled');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('CWEMonitorEnabled');
+  });
+});
+
+describe('#914 LakeFormation Tag undeclared CatalogId=<account>', () => {
+  const res: DesiredResource = {
+    logicalId: 'LfTag',
+    resourceType: 'AWS::LakeFormation::Tag',
+    physicalId: 'tag',
+    declared: { TagKey: 'tier', TagValues: ['gold', 'silver'] },
+  };
+  const opts = { accountId: '111122223333', region: 'us-east-1' };
+  it('folds CatalogId equal to the deploying account id to atDefault', () => {
+    const f = classifyResource(res, { CatalogId: '111122223333' }, emptySchema, opts);
+    expect(pathsByTier(f, 'atDefault')).toContain('CatalogId');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('CatalogId');
+  });
+  it('surfaces a CatalogId pointed at another account as undeclared', () => {
+    const f = classifyResource(res, { CatalogId: '999988887777' }, emptySchema, opts);
+    expect(pathsByTier(f, 'undeclared')).toContain('CatalogId');
+  });
+  it('leaves CatalogId undeclared (recordable) when the account is unresolved', () => {
+    const f = classifyResource(res, { CatalogId: '111122223333' }, emptySchema, {
+      region: 'us-east-1',
+    });
+    expect(pathsByTier(f, 'atDefault')).not.toContain('CatalogId');
+    expect(pathsByTier(f, 'undeclared')).toContain('CatalogId');
+  });
+});


### PR DESCRIPTION
Bundles four LIVE-confirmed first-run false-positive fold gaps, all landing in `src/normalize/noise.ts` (one central table, one PR per the file-disjoint rule).

| Issue | Type | Fold |
|---|---|---|
| #910 | `AWS::IAM::ServerCertificate` undeclared `Path="/"` | KNOWN_DEFAULTS (tier-1 constant, same as IAM::Role) |
| #873 | `AWS::ApiGatewayV2::Route` undeclared `AuthorizationType="NONE"` | KNOWN_DEFAULTS (tier-1 constant) |
| #841 | `AWS::ApplicationInsights::Application` undeclared `CWEMonitorEnabled=true` | KNOWN_DEFAULTS (tier-1 constant) |
| #914 | `AWS::LakeFormation::Tag` undeclared `CatalogId=<account>` | CONTEXT_ARN_DEFAULTS `{accountId}` (tier-2 derived) |

Each restores the ZERO-potential-drift invariant on a clean first `check`. All are equality-gated (or account-derived), so a real change away from the default still surfaces.

**Note on #841 detection nuance:** the `true` pin folds the undeclared FP. A later out-of-band DISABLE (`false`) is dropped by the pre-existing trivially-empty husk in the undeclared loop; surfacing that would need a curated `MEANINGFUL_WHEN_OFF` entry, which the fold-strategy rule admits only after a cross-config live confirm that OFF is meaningful — out of scope for this first-run-FP fold and left as a live-verified follow-up. Detection is preserved for the natural direction (declared `true`, live `false` → declared drift).

Regression tests: `tests/noise-folds-910-914.test.ts` (9 tests, both fold + divergence-surfaces per issue). Full suite: 3400 pass.

Closes #910
Closes #873
Closes #841
Closes #914