### PR TITLE
fix(normalize): harden Fn::Cidr — UNRESOLVED-arg crash + non-aligned ipBlock mis-resolution

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -162,6 +162,12 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
         // unresolved / mistyped / out-of-range arg (IPv6 is not resolved).
         if (!Array.isArray(v) || v.length < 3) return UNRESOLVED;
         const [ipBlock, count, cidrBits] = v.slice(0, 3).map((x) => resolve(x, ctx));
+        // Any arg still UNRESOLVED (a first-pass Fn::GetAtt, a missing Fn::ImportValue,
+        // an unresolvable Fn::If) is the UNRESOLVED Symbol — Number() on it throws, so
+        // guard first, exactly as the Fn::Select case above does for its index.
+        if (ipBlock === UNRESOLVED || count === UNRESOLVED || cidrBits === UNRESOLVED) {
+          return UNRESOLVED;
+        }
         return resolveCidr(ipBlock, count, cidrBits);
       }
       case 'Fn::ImportValue': {
@@ -375,13 +381,17 @@ function resolveCidr(ipBlock: unknown, count: unknown, cidrBits: unknown): unkno
   if (maskLen < prefix) return UNRESOLVED;
   const step = 2 ** bits; // addresses per subnet
   const blockSize = 2 ** (32 - prefix); // addresses in the whole block
-  // The base is aligned to its own prefix; the first subnet starts there.
-  const alignedBase = Math.floor(base / step) * step;
+  // Fail closed on a non-canonical block: if the ipBlock carries host bits (its base is not
+  // the network address for its own prefix) we cannot know which address AWS canonicalizes
+  // to, and generating from the host address both starts at the wrong place and can run past
+  // the block. AWS always stores the network address, so a real Fn::Cidr input is aligned.
+  if (base % blockSize !== 0) return UNRESOLVED;
+  // The base is the block's network address; subnets tile from there.
   // `count` subnets of `step` addresses each must fit inside the block.
   if (cnt * step > blockSize) return UNRESOLVED;
   const out: string[] = [];
   for (let i = 0; i < cnt; i++) {
-    const addr = alignedBase + i * step;
+    const addr = base + i * step;
     if (addr > 0xffffffff) return UNRESOLVED;
     out.push(`${intToIpv4(addr)}/${maskLen}`);
   }

--- a/tests/intrinsic-resolver.test.ts
+++ b/tests/intrinsic-resolver.test.ts
@@ -489,6 +489,41 @@ describe('intrinsic resolver', () => {
     expect(resolve({ 'Fn::Cidr': ['10.0.0.0/16', 6] }, ctx())).toBe(UNRESOLVED);
   });
 
+  // #902: hardening — an UNRESOLVED count/cidrBits must not reach Number() (it throws on the
+  // Symbol and killed the whole check with exit 2), and a non-network-aligned ipBlock must
+  // fail closed rather than fabricate wrong CIDRs.
+  it('#902: an UNRESOLVED count/cidrBits/ipBlock fails closed, never throws', () => {
+    // count as a first-pass Fn::GetAtt (Fn.cidr(vpc.attrCidrBlock, ...) count from a GetAtt):
+    // resolve() returns the UNRESOLVED Symbol; Number(Symbol) would throw TypeError.
+    expect(() =>
+      resolve({ 'Fn::Cidr': ['10.0.0.0/16', { 'Fn::GetAtt': ['X', 'Y'] }, 8] }, ctx())
+    ).not.toThrow();
+    expect(resolve({ 'Fn::Cidr': ['10.0.0.0/16', { 'Fn::GetAtt': ['X', 'Y'] }, 8] }, ctx())).toBe(
+      UNRESOLVED
+    );
+    // cidrBits UNRESOLVED
+    expect(resolve({ 'Fn::Cidr': ['10.0.0.0/16', 6, { 'Fn::GetAtt': ['X', 'Y'] }] }, ctx())).toBe(
+      UNRESOLVED
+    );
+    // ipBlock UNRESOLVED (a GetAtt that yields a Symbol rather than a non-string scalar)
+    expect(resolve({ 'Fn::Cidr': [{ 'Fn::GetAtt': ['X', 'Y'] }, 6, 8] }, ctx())).toBe(UNRESOLVED);
+  });
+
+  it('#902: a non-network-aligned ipBlock (host bits set) fails closed', () => {
+    // base starts at a host address, not the /24 network address → fail closed, do not
+    // fabricate ["10.0.0.128/28", ...].
+    expect(resolve({ 'Fn::Cidr': ['10.0.0.128/24', 2, 4] }, ctx())).toBe(UNRESOLVED);
+    // 16 /28 subnets from a host base would run past the /24 → fail closed.
+    expect(resolve({ 'Fn::Cidr': ['10.0.0.128/24', 16, 4] }, ctx())).toBe(UNRESOLVED);
+    // any host bits set are rejected (not silently aligned down to 10.0.0.0/28).
+    expect(resolve({ 'Fn::Cidr': ['10.0.0.3/24', 2, 4] }, ctx())).toBe(UNRESOLVED);
+    // a correctly network-aligned block still resolves.
+    expect(resolve({ 'Fn::Cidr': ['10.0.0.0/24', 2, 4] }, ctx())).toEqual([
+      '10.0.0.0/28',
+      '10.0.0.16/28',
+    ]);
+  });
+
   it('R130: isDynamicReference matches only real dynamic-reference tokens', () => {
     expect(isDynamicReference('{{resolve:secretsmanager:my-secret:SecretString:user::}}')).toBe(
       true


### PR DESCRIPTION
Two defects in the `Fn::Cidr` support added by #859, found by hunt-v re-audit (#902).

**1. HIGH — an UNRESOLVED `count`/`cidrBits`/`ipBlock` crashed the whole check (exit 2).**
`resolve()` returns the `UNRESOLVED` Symbol for a first-pass `Fn::GetAtt` (a real CDK pattern: `Fn.cidr(vpc.attrCidrBlock, …)`), a missing `Fn::ImportValue`, or an unresolvable `Fn::If`. `resolveCidr` then did `Number(count)` on the Symbol → `TypeError: Cannot convert a Symbol value to a number`, and `resolveProperties` is called uncaught → the entire `check` died with exit 2. Now guarded `=== UNRESOLVED` before `resolveCidr`, mirroring the existing `Fn::Select` index guard.

**2. MEDIUM — a non-network-aligned `ipBlock` silently fabricated wrong CIDRs.**
The base was aligned to the subnet *step* rather than the block's own network address, and the fit check assumed the base was the network address — so `["10.0.0.128/24", 16, 4]` generated 16 subnets running past the `/24`, and `["10.0.0.3/24", …]` was silently aligned down. AWS canonicalizes to the network address, so these fabricated values would produce false declared drift (and a revert would write them back). Now fails closed to `UNRESOLVED` when the ipBlock carries host bits (`base % blockSize !== 0`); subnets tile from the block network address. The dominant real input (`GetAtt Vpc.CidrBlock`) is always aligned, so valid inputs still resolve.

Regression tests: `tests/intrinsic-resolver.test.ts` (#902 — all three arg positions UNRESOLVED without throwing, host-bit blocks fail closed, aligned blocks still resolve). Full suite: 3393 pass.

Closes #902