### PR TITLE
fix(read): ApiGatewayV2 Model/Deployment/IntegrationResponse composite CC ids (#872)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -71,6 +71,15 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   'AWS::ApiGatewayV2::Stage': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Route': compositeWith('ApiId'),
   'AWS::ApiGatewayV2::Integration': compositeWith('ApiId'),
+  // Model + Deployment are the same parent-first `[ApiId, <child>]` shape as
+  // Stage/Route/Integration — the CFn physical id (Ref) is the bare ModelId /
+  // DeploymentId, so a bare-id CC GetResource ValidationException-skips them (read-gap)
+  // on every WebSocket API with request-validation Models or explicit Deployments, so an
+  // out-of-band Model schema / Deployment description change is invisible. Verified live
+  // (#872, stack CdkrdHuntUWs, us-east-1): `<ApiId>|<ModelId>` / `<ApiId>|<DeploymentId>`
+  // read; the reverse orders return not-found.
+  'AWS::ApiGatewayV2::Model': compositeWith('ApiId'),
+  'AWS::ApiGatewayV2::Deployment': compositeWith('ApiId'),
   // ApiGatewayV2::Authorizer primaryIdentifier is [AuthorizerId, ApiId] — CHILD
   // first, the REVERSE of its v2 siblings (Stage/Route/Integration are [ApiId,
   // <child>] parent-first). The CFn physical id is the bare AuthorizerId; ApiId comes
@@ -302,6 +311,27 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
       typeof routeId === 'string' &&
       routeId.length > 0
       ? `${apiId}|${routeId}|${pid}`
+      : undefined;
+  },
+  // ApiGatewayV2 IntegrationResponse primaryIdentifier is the 3-SEGMENT composite
+  // [ApiId, IntegrationId, IntegrationResponseId] — parent-first, the same shape as its
+  // RouteResponse sibling above. The CFn physical id is only the LAST segment
+  // (IntegrationResponseId), so a bare-id CC GetResource ValidationException-skips it
+  // (read-gap) on every non-proxy WebSocket integration — the response templates / keys
+  // go entirely unwatched. BOTH parent segments are resolvable from the declared model:
+  // `ApiId` is a Ref to the Api, and `IntegrationId` is the declared Ref to the
+  // Integration. Verified live (#872, stack CdkrdHuntUWs, us-east-1):
+  // `ApiId|IntegrationId|IntegrationResponseId` reads; the reversed order returns
+  // not-found. An unresolved parent → fall back to the bare physical id (honest skip).
+  'AWS::ApiGatewayV2::IntegrationResponse': (pid, declared) => {
+    if (pid.includes('|')) return pid;
+    const apiId = declared.ApiId;
+    const integrationId = declared.IntegrationId;
+    return typeof apiId === 'string' &&
+      apiId.length > 0 &&
+      typeof integrationId === 'string' &&
+      integrationId.length > 0
+      ? `${apiId}|${integrationId}|${pid}`
       : undefined;
   },
   // GuardDuty Filter primaryIdentifier is [DetectorId, Name] — parent-first. The CFn

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -238,11 +238,14 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('phys');
   });
 
-  // R76: ApiGatewayV2 Stage/Route/Integration composite [ApiId, <child id>].
+  // R76 + #872: ApiGatewayV2 Stage/Route/Integration/Model/Deployment composite
+  // [ApiId, <child id>].
   for (const t of [
     'AWS::ApiGatewayV2::Stage',
     'AWS::ApiGatewayV2::Route',
     'AWS::ApiGatewayV2::Integration',
+    'AWS::ApiGatewayV2::Model',
+    'AWS::ApiGatewayV2::Deployment',
   ]) {
     it(`${t}: builds the ApiId|<child> composite identifier`, async () => {
       cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
@@ -255,6 +258,36 @@ describe('readLive (CC identifier adapters, R74)', () => {
       expect(sent()).toBe('api456|child123');
     });
   }
+
+  it('ApiGatewayV2 IntegrationResponse: builds the ApiId|IntegrationId|IntegrationResponseId 3-segment composite (#872)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::IntegrationResponse',
+        physicalId: 'intresp789',
+        declared: { ApiId: 'api456', IntegrationId: 'integ123' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('api456|integ123|intresp789');
+  });
+
+  it('ApiGatewayV2 IntegrationResponse: an unresolved parent (missing IntegrationId) falls back to the raw physical id', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApiGatewayV2::IntegrationResponse',
+        physicalId: 'intresp789',
+        declared: { ApiId: 'api456' },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe('intresp789');
+  });
 
   it('ApiGatewayV2 Authorizer: builds the AuthorizerId|ApiId composite — CHILD first (reverse of its siblings)', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });


### PR DESCRIPTION
## What

A WebSocket API stack's `AWS::ApiGatewayV2::Model`, `::Deployment`, and `::IntegrationResponse` are all silently `skipped` on every `check` — their Cloud Control `primaryIdentifier` is a composite, but the CFn physical id (Ref) is only the bare child id, so a bare-id CC `GetResource` `ValidationException`-skips them (read-gap).

## Impact

Out-of-band changes to a request-validation Model schema, a Deployment description, or IntegrationResponse templates/keys are invisible; the stack shows `skipped=3` forever. Hit by every WebSocket API with request validation / explicit deployments / non-proxy integrations.

## Fix

Three `CC_IDENTIFIER_ADAPTERS` entries in `src/read/router.ts`:

- **Model / Deployment** → `compositeWith('ApiId')` = `<ApiId>|<child>` (parent-first, identical shape to the existing Stage/Route/Integration siblings).
- **IntegrationResponse** → 3-segment `<ApiId>|<IntegrationId>|<IntegrationResponseId>` (parent-first, like `RouteResponse`); `IntegrationId` is the declared Ref, `ApiId` the Api Ref. An unresolved parent falls back to the bare physical id (honest skip).

## Verification

- Live-confirmed identifier orders (#872, stack `CdkrdHuntUWs`, us-east-1): the composites read; the reversed orders return not-found. Both orders were probed in the originating hunt.
- Unit tests added (`tests/router.test.ts`): the parameterized composite test now covers Model/Deployment, plus IntegrationResponse 3-segment build + unresolved-parent fallback. Full suite green (3397 tests), typecheck + lint + build clean.

Closes #872
