### PR TITLE
fix(revert): selective-update writers converge remove ops or bar honestly, not silently drop (#913)

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -832,16 +832,25 @@ const writeGlueWorkflow: SdkWriter = async (ctx, ops) => {
   const m = await desiredModel('AWS::Glue::Workflow', ctx, ops);
   const name = str(m.Name) ?? str(ctx.physicalId) ?? str(ctx.declared['Name']);
   if (!name) throw new Error('cannot resolve Glue workflow target for revert');
-  await new GlueClient({ region: ctx.region }).send(
-    new UpdateWorkflowCommand({
-      Name: name,
-      ...(m.Description !== undefined && { Description: str(m.Description) }),
-      ...(m.DefaultRunProperties !== undefined && {
-        DefaultRunProperties: m.DefaultRunProperties as Record<string, string>,
-      }),
-      ...(m.MaxConcurrentRuns !== undefined && { MaxConcurrentRuns: Number(m.MaxConcurrentRuns) }),
-    })
-  );
+  // A `remove` op (revert of an OOB-added value back to unset) must send an EXPLICIT clearing
+  // value — UpdateWorkflow is a selective update, so an omitted field keeps the live value and
+  // the revert silently non-converges (#913). Description clears with '' and DefaultRunProperties
+  // with {} (both expressible clears); MaxConcurrentRuns has NO selective clear (its unset state,
+  // "no limit", cannot be sent as a number), so bar it honestly.
+  const removed = (field: string): boolean =>
+    ops.some((o) => o.op === 'remove' && o.path.replace(/^\//, '').split('/')[0] === field);
+  if (removed('MaxConcurrentRuns'))
+    throw new Error(
+      'Glue Workflow MaxConcurrentRuns cannot be cleared via UpdateWorkflow (its unset state, "no limit", is not expressible in a selective update); update it manually'
+    );
+  const input: { Name: string; [k: string]: unknown } = { Name: name };
+  if (m.Description !== undefined) input.Description = str(m.Description);
+  else if (removed('Description')) input.Description = '';
+  if (m.DefaultRunProperties !== undefined)
+    input.DefaultRunProperties = m.DefaultRunProperties as Record<string, string>;
+  else if (removed('DefaultRunProperties')) input.DefaultRunProperties = {};
+  if (m.MaxConcurrentRuns !== undefined) input.MaxConcurrentRuns = Number(m.MaxConcurrentRuns);
+  await new GlueClient({ region: ctx.region }).send(new UpdateWorkflowCommand(input));
 };
 
 // AWS::Glue::Connection — read via the GetConnection override (the whole Glue family is a
@@ -976,6 +985,23 @@ const writeCloudWatchAnomalyDetector: SdkWriter = async (ctx, ops) => {
 const writeDlmLifecyclePolicy: SdkWriter = async (ctx, ops) => {
   const id = str(ctx.physicalId);
   if (!id) throw new Error('cannot resolve DLM lifecycle policy id for revert');
+  // A top-level `remove` op (State / Description / ExecutionRoleArn back to unset) has NO safe
+  // selective-update clearing value: UpdateLifecyclePolicy always requires a State, and whether an
+  // undeclared State / Description / ExecutionRoleArn even folds (so an OOB change surfaces as a
+  // `remove`) is UNCONFIRMED live. Rather than silently omit the field — which keeps the live value
+  // and non-converges (#913) — fail honestly; the declared-value case still converges via the
+  // `add` path below. (Needs-live: confirm the fold + the exact clearing payload before turning any
+  // of these into a real clear.)
+  for (const o of ops) {
+    const top = o.path.replace(/^\//, '').split('/')[0] ?? '';
+    if (
+      o.op === 'remove' &&
+      (top === 'State' || top === 'Description' || top === 'ExecutionRoleArn')
+    )
+      throw new Error(
+        `DLM LifecyclePolicy ${top} cannot be cleared via UpdateLifecyclePolicy (no safe clearing value; needs live confirmation); update it manually`
+      );
+  }
   const c = new DLMClient({ region: ctx.region });
   const m = await desiredModel('AWS::DLM::LifecyclePolicy', ctx, ops);
   let details = m.PolicyDetails as Record<string, unknown> | undefined;
@@ -1110,7 +1136,15 @@ const writeConfigRuleInputParameters: SdkWriter = async (ctx, ops) => {
   const name = str(ctx.physicalId) ?? str(ctx.declared['ConfigRuleName']);
   if (!name) throw new Error('cannot resolve Config rule name for revert');
   const op = ops.find((o) => o.path === '/InputParameters');
-  if (op?.op !== 'add') throw new Error('Config rule InputParameters revert: unexpected op');
+  if (!op) throw new Error('Config rule InputParameters revert: op not found');
+  // An OOB-ADDED InputParameters blob on a rule that declared none reverts as a `remove`. Config
+  // stores InputParameters as a whole-rule field, and clearing it needs a re-PUT — but whether the
+  // clear is "omit InputParameters" or "'{}'" is UNCONFIRMED live. Rather than silently drop the op
+  // (a non-converge, #913), fail honestly; an `add` (declared value) converges below.
+  if (op.op !== 'add')
+    throw new Error(
+      'Config rule InputParameters cannot be cleared via revert: PutConfigRule re-PUTs the whole rule and the exact clearing payload (omit vs empty {}) needs live confirmation; clear it manually'
+    );
   const client = new ConfigServiceClient({ region: ctx.region });
   const got = await client.send(new DescribeConfigRulesCommand({ ConfigRuleNames: [name] }));
   const rule = got.ConfigRules?.[0];
@@ -1520,13 +1554,22 @@ const writeDaxCluster: SdkWriter = async (ctx, ops) => {
     const top = op.path.replace(/^\//, '').split('/')[0] ?? '';
     const apiKey = DAX_CLUSTER_MODIFY_PARAMS[top];
     if (!apiKey) continue;
-    // A revert that CLEARS a value (op removed it, e.g. NotificationTopicARN back to none) sends
-    // the empty string DAX accepts to detach the topic; otherwise send the desired value.
-    const val = desired[top] ?? (apiKey === 'NotificationTopicArn' ? '' : undefined);
-    if (val !== undefined) {
-      input[apiKey] = val;
-      any = true;
+    let val = desired[top];
+    if (val === undefined) {
+      // A `remove` op (the desired value is now ABSENT) needs an EXPLICIT clearing value, or
+      // UpdateCluster — a selective modify — keeps the live value and the revert silently
+      // non-converges (#913). NotificationTopicARN / Description clear with '' (detach / unset);
+      // PreferredMaintenanceWindow / ParameterGroupName / SecurityGroupIds have NO selective clear
+      // (their unset state is an AWS-assigned window / the default param group / the default VPC
+      // security group — not expressible here), so bar them honestly.
+      if (top === 'NotificationTopicARN' || top === 'Description') val = '';
+      else
+        throw new Error(
+          `DAX Cluster ${top} cannot be cleared via UpdateCluster (its unset state is AWS-assigned, not expressible in a selective modify); update it manually`
+        );
     }
+    input[apiKey] = val;
+    any = true;
   }
   if (!any) return;
   await new DAXClient({ region: ctx.region }).send(new UpdateClusterCommand(input));

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -518,6 +518,17 @@ describe('DLM LifecyclePolicy writer (UpdateLifecyclePolicy, issue #468)', () =>
       SDK_WRITERS['AWS::DLM::LifecyclePolicy'](ctx({ physicalId: '', declared: {} }), [])
     ).rejects.toThrow(/DLM lifecycle policy/);
   });
+
+  it('bars a top-level State remove honestly instead of silently dropping it (#913)', async () => {
+    // no clearing value is safe for a top-level `remove` (Update always requires a State) — fail
+    // honestly rather than omit the field and non-converge; the throw precedes any live read.
+    await expect(
+      SDK_WRITERS['AWS::DLM::LifecyclePolicy'](dlmCtx({}), [
+        { op: 'remove', path: '/State', human: 'State -> (none)' },
+      ])
+    ).rejects.toThrow(/State cannot be cleared/);
+    expect(dlm.commandCalls(UpdateLifecyclePolicyCommand)).toHaveLength(0);
+  });
 });
 
 describe('ECS ServiceConnect writer (re-supplies the whole writeOnly config via UpdateService)', () => {
@@ -1026,6 +1037,43 @@ describe('Glue Workflow writer (CC UnsupportedActionException)', () => {
     // the other live fields are re-sent so UpdateWorkflow's whole-object overwrite never wipes them
     expect(input.Description).toBe('etl');
     expect(input.DefaultRunProperties).toEqual({ env: 'test' });
+  });
+
+  it('clears an OOB-added Description / DefaultRunProperties on a remove, not a silent drop (#913)', async () => {
+    glue.on(GetWorkflowCommand).resolves({
+      Workflow: {
+        Name: 'w',
+        Description: 'oob',
+        DefaultRunProperties: { env: 'oob' },
+        MaxConcurrentRuns: 7,
+      },
+    } as never);
+    glue.on(UpdateWorkflowCommand).resolves({});
+    await SDK_WRITERS['AWS::Glue::Workflow'](ctx({ physicalId: 'w', declared: { Name: 'w' } }), [
+      { op: 'remove', path: '/Description', human: 'Description -> (none)' },
+      { op: 'remove', path: '/DefaultRunProperties', human: 'DefaultRunProperties -> (none)' },
+    ]);
+    const input = glue.commandCalls(UpdateWorkflowCommand)[0]!.args[0].input as unknown as Record<
+      string,
+      unknown
+    >;
+    // explicit clearing values — a selective UpdateWorkflow would keep the live value if omitted
+    expect(input.Description).toBe('');
+    expect(input.DefaultRunProperties).toEqual({});
+    // the untouched live value is still re-sent so the whole-object overwrite never wipes it
+    expect(input.MaxConcurrentRuns).toBe(7);
+  });
+
+  it('bars a MaxConcurrentRuns remove honestly ("no limit" is not expressible, #913)', async () => {
+    glue
+      .on(GetWorkflowCommand)
+      .resolves({ Workflow: { Name: 'w', MaxConcurrentRuns: 7 } } as never);
+    await expect(
+      SDK_WRITERS['AWS::Glue::Workflow'](ctx({ physicalId: 'w', declared: { Name: 'w' } }), [
+        { op: 'remove', path: '/MaxConcurrentRuns', human: 'MaxConcurrentRuns -> (none)' },
+      ])
+    ).rejects.toThrow(/MaxConcurrentRuns cannot be cleared/);
+    expect(glue.commandCalls(UpdateWorkflowCommand)).toHaveLength(0);
   });
 
   it('throws when the workflow name is unresolvable', async () => {
@@ -1699,6 +1747,28 @@ describe('DAX Cluster writer (NON_PROVISIONABLE; UpdateCluster partial modify, i
     await SDK_WRITERS['AWS::DAX::Cluster'](ctx({ physicalId: CN }), [
       { op: 'add', path: '/NodeType', value: 'dax.r5.xlarge', human: 'x' },
     ]);
+    expect(dax.commandCalls(UpdateClusterCommand)).toHaveLength(0);
+  });
+
+  it('clears a Description remove with "" instead of silently dropping it (#913)', async () => {
+    stubRead();
+    dax.on(UpdateClusterCommand).resolves({});
+    await SDK_WRITERS['AWS::DAX::Cluster'](ctx({ physicalId: CN }), [
+      { op: 'remove', path: '/Description', human: 'Description -> (none)' },
+    ]);
+    expect(dax.commandCalls(UpdateClusterCommand)[0]!.args[0].input).toEqual({
+      ClusterName: CN,
+      Description: '',
+    });
+  });
+
+  it('bars a ParameterGroupName remove honestly (AWS-assigned unset, not expressible, #913)', async () => {
+    stubRead();
+    await expect(
+      SDK_WRITERS['AWS::DAX::Cluster'](ctx({ physicalId: CN }), [
+        { op: 'remove', path: '/ParameterGroupName', human: 'ParameterGroupName -> (none)' },
+      ])
+    ).rejects.toThrow(/ParameterGroupName cannot be cleared/);
     expect(dax.commandCalls(UpdateClusterCommand)).toHaveLength(0);
   });
 });
@@ -2515,6 +2585,20 @@ describe('writeConfigRuleInputParameters (AWS::Config::ConfigRule, JSON-string p
     expect(
       configService.commandCalls(PutConfigRuleCommand)[0].args[0].input.ConfigRule!.InputParameters
     ).toBe('{"a":"1"}');
+  });
+
+  it('bars a remove (clear) honestly — the clearing payload needs a live probe (#913)', async () => {
+    const removeOp: PatchOp = {
+      op: 'remove',
+      path: '/InputParameters',
+      human: 'InputParameters -> (none)',
+    };
+    const writer = resolveSdkWriter('AWS::Config::ConfigRule', [removeOp])!;
+    // the bar precedes DescribeConfigRules, so no silent PutConfigRule drop
+    await expect(writer(ctx({ physicalId: 'r' }), [removeOp])).rejects.toThrow(
+      /InputParameters cannot be cleared/
+    );
+    expect(configService.commandCalls(PutConfigRuleCommand)).toHaveLength(0);
   });
 
   it('throws when the rule cannot be found (no silent no-op)', async () => {


### PR DESCRIPTION
## What

Four selective-update SDK writers spread-guarded every field, so a `remove` op (reverting an out-of-band-added value back to unset) was silently omitted from the API call. Because these APIs are selective (an unsupplied field = unchanged), the live value was kept and the **revert silently NON-CONVERGED** — a later `check` re-flags the same drift forever.

## Fix

Each writer now sends an **explicit clearing value** where the API can express it, or **fails honestly** where it cannot (an honest FAILED beats a silent non-converge — the barred cases throw *before any AWS write*):

| Writer | Real clears | Honest bars (uncertain clearing payload) |
| --- | --- | --- |
| **Glue Workflow** | `Description`→`''`, `DefaultRunProperties`→`{}` | `MaxConcurrentRuns` ("no limit" not expressible) |
| **DAX Cluster** | `Description`→`''` (joins existing `NotificationTopicARN`→`''`) | `PreferredMaintenanceWindow` / `ParameterGroupName` / `SecurityGroupIds` (unset = AWS-assigned) |
| **DLM LifecyclePolicy** | — | top-level `State` / `Description` / `ExecutionRoleArn` (Update always requires a State; fold unconfirmed live) |
| **Config ConfigRule** | — | `InputParameters` remove-clear (omit vs `'{}'` needs a live probe) |

The declared-value (`add`) revert path is untouched for all four and still converges. The needs-live halves are flagged in comments for a future live confirmation.

## Tests

6 unit tests in `tests/writers.test.ts` — each asserts either the explicit clear value in the constructed API input, or **zero API calls** for an honest bar. Full suite green (3410), typecheck + lint + build clean.

Closes #913
