### PR TITLE
fix(read): ApplicationAutoScaling ScalingPolicy flat-form declaration read-gap (#836)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -346,15 +346,28 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
 
 // `${PolicyARN}|${ScalableDimension}` for a ScalingPolicy, extracting the
 // dimension from the resolved ScalingTargetId (`resourceId|dimension|namespace`).
-// undefined when the target ref did not resolve (→ honest skip).
+// The CFn schema ALSO allows the "flat" form — `ResourceId` + `ScalableDimension` +
+// `ServiceNamespace` declared directly, NO `ScalingTargetId` (all createOnly,
+// ScalingTargetId optional) — which raw-CFn / SAM / CDK L1 (`CfnScalingPolicy`)
+// authors commonly use. In that form the dimension comes straight off
+// `declared.ScalableDimension`; without this fallback the adapter returned undefined,
+// cdkrd sent the bare policy ARN, and CC GetResource ValidationException-skipped it
+// (permanent declared read-gap — a mutation to the policy invisible). The composite
+// ORDER (`${Arn}|${dimension}`) is unchanged from the ScalingTargetId path, only the
+// SOURCE of the dimension differs. undefined when neither is resolvable (→ honest skip).
+// Live-surfaced by the flat-form ScalableTarget+ScalingPolicy fixture (#836).
 function scalingPolicyComposite(
   pid: string,
   declared: Record<string, unknown>
 ): string | undefined {
   if (pid.includes('|')) return pid; // already composite — never double-suffix
   const targetId = declared.ScalingTargetId;
-  if (typeof targetId !== 'string') return undefined;
-  const dimension = targetId.split('|')[1];
+  const dimension =
+    typeof targetId === 'string'
+      ? targetId.split('|')[1]
+      : typeof declared.ScalableDimension === 'string'
+        ? declared.ScalableDimension
+        : undefined;
   return dimension ? `${pid}|${dimension}` : undefined;
 }
 

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -906,7 +906,31 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe(`${policyArn}|dynamodb:table:ReadCapacityUnits`);
   });
 
-  it('ScalingPolicy: an unresolved ScalingTargetId falls back to the raw physical id', async () => {
+  // #836: the "flat" form declares ScalableDimension directly (with ResourceId /
+  // ServiceNamespace), NO ScalingTargetId — the dimension comes off the declared
+  // ScalableDimension so the policy still reads instead of read-gapping.
+  it('ScalingPolicy: composes PolicyARN|ScalableDimension from the flat ScalableDimension (no ScalingTargetId, #836)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    const policyArn =
+      'arn:aws:autoscaling:us-east-1:1:scalingPolicy:abc:resource/dynamodb/table/T:policyName/p';
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::ApplicationAutoScaling::ScalingPolicy',
+        physicalId: policyArn,
+        declared: {
+          ResourceId: 'table/T',
+          ScalableDimension: 'dynamodb:table:ReadCapacityUnits',
+          ServiceNamespace: 'dynamodb',
+        },
+      }),
+      'us-east-1',
+      '1'
+    );
+    expect(sent()).toBe(`${policyArn}|dynamodb:table:ReadCapacityUnits`);
+  });
+
+  it('ScalingPolicy: neither ScalingTargetId nor a flat ScalableDimension falls back to the raw physical id', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(
       cc as unknown as CloudControlClient,


### PR DESCRIPTION
## What

`scalingPolicyComposite` (the CC identifier adapter for `AWS::ApplicationAutoScaling::ScalingPolicy`) derived `ScalableDimension` **only** from a resolved `declared.ScalingTargetId`. But the CFn schema equally allows the **flat** form — `ResourceId` + `ScalableDimension` + `ServiceNamespace` declared directly, with **no** `ScalingTargetId` (all createOnly; `ScalingTargetId` is optional) — the style raw-CFn / SAM / CDK L1 (`CfnScalingPolicy`) authors commonly use.

In that form the adapter returned `undefined`, cdkrd sent the bare policy ARN, and Cloud Control `GetResource` `ValidationException`-skipped it → a **permanent declared read-gap**: the policy is never checked, so a mutation to it is invisible. (CDK L2 `scaleToTrackMetric(...)` emits `ScalingTargetId`, which is why no existing corpus case exposed it.)

## Fix

In `scalingPolicyComposite`, fall back to `declared.ScalableDimension` when `ScalingTargetId` is absent. The composite **order** (`${Arn}|${dimension}`) is unchanged from the `ScalingTargetId` path — only the *source* of the dimension differs — so there is no new identifier order to live-probe. Neither present → honest skip (unchanged).

## Verification

- Unit tests (`tests/router.test.ts`): the flat form now composes `PolicyARN|ScalableDimension`; the both-absent case still falls back to the raw id. Full suite green (3415), typecheck + lint + build clean.
- No fresh live deploy needed: the `[Arn, ScalableDimension]` composite order was already live-proven by the existing `ScalingTargetId` path (this change only reads the dimension from a different declared prop). The sibling `ScalableTarget` adapter already reads these same flat props.

Closes #836
