### PR TITLE
fix(noise): fold Lambda Function URL Cors AllowHeaders/ExposeHeaders case-insensitively (#874)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -3660,11 +3660,17 @@ export function isPropertiesFileEqual(a: unknown, b: unknown): boolean {
 // reports false declared drift on every check. Compared case- AND order-
 // insensitively (a CORS header list is an unordered set); a genuine header
 // add/remove still differs. Observed live on a fresh apigwv2-http-rich deploy.
+// AWS::Lambda::Url exhibits the identical platform behavior (#874): its
+// `Cors.AllowHeaders` / `Cors.ExposeHeaders` are stored/echoed lowercased, so a
+// declared `["Content-Type","Authorization"]` reads back
+// `["content-type","authorization"]`. `Cors.AllowMethods` is deliberately NOT
+// listed — methods echo back verbatim, with no observed divergence.
 export const CASE_INSENSITIVE_ARRAY_PATHS: Record<string, ReadonlySet<string>> = {
   'AWS::ApiGatewayV2::Api': new Set([
     'CorsConfiguration.AllowHeaders',
     'CorsConfiguration.ExposeHeaders',
   ]),
+  'AWS::Lambda::Url': new Set(['Cors.AllowHeaders', 'Cors.ExposeHeaders']),
 };
 // True when both values are string arrays holding the same multiset of values
 // modulo ASCII case (order- and case-insensitive). Non-string-array inputs never

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -3477,6 +3477,60 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
     });
   });
 
+  // #874: AWS::Lambda::Url exhibits the same platform behavior as apigwv2 (#257) —
+  // the Function URL CORS header lists (`Cors.AllowHeaders` / `Cors.ExposeHeaders`)
+  // are stored/echoed LOWERCASED, so a declared `["Content-Type","Authorization"]`
+  // reads back `["content-type","authorization"]` and false-flagged declared drift.
+  describe('case-insensitive header-name array path (Lambda Url CORS AllowHeaders/ExposeHeaders)', () => {
+    const T = 'AWS::Lambda::Url';
+    const cors = (headers: string[]) => ({
+      Cors: { AllowHeaders: headers, AllowMethods: ['GET', 'POST'] },
+    });
+
+    it('mixed-case declared vs lowercase live CORS AllowHeaders is NOT drift', () => {
+      expect(
+        classifyResource(
+          res(T, cors(['Content-Type', 'X-Custom-Header', 'Authorization'])),
+          cors(['content-type', 'x-custom-header', 'authorization']),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a header set in a different order is NOT drift (unordered)', () => {
+      expect(
+        classifyResource(
+          res(T, cors(['Content-Type', 'Authorization'])),
+          cors(['authorization', 'content-type']),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+
+    it('a genuinely changed header (same length) is still drift', () => {
+      expect(
+        tiers(
+          classifyResource(
+            res(T, cors(['Content-Type', 'Authorization'])),
+            cors(['content-type', 'x-api-key']),
+            emptySchema
+          )
+        ).declared
+      ).toEqual(['Cors.AllowHeaders']);
+    });
+
+    it('ExposeHeaders is folded case-insensitively too', () => {
+      const expose = (h: string[]) => ({ Cors: { ExposeHeaders: h } });
+      expect(
+        classifyResource(
+          res(T, expose(['X-Request-Id', 'Content-Length'])),
+          expose(['x-request-id', 'content-length']),
+          emptySchema
+        )
+      ).toEqual([]);
+    });
+  });
+
   // Found live by the apigwv2-http-rich bug-hunt fixture: the CDK HttpApi $default
   // stage runs AutoDeploy=true, so AWS mints (and re-mints on every auto-deploy) the
   // stage's DeploymentId. It is live-only (the user can't declare it under AutoDeploy),


### PR DESCRIPTION
Closes #874

## Problem
Lambda Function URL CORS header lists (`AWS::Lambda::Url` `Cors.AllowHeaders` / `Cors.ExposeHeaders`) are stored and echoed back **lowercased** by the service, so a declared `["Content-Type","X-Custom-Header","Authorization"]` reads back as `["content-type","x-custom-header","authorization"]`. A positional/case-sensitive diff false-flags CFn-Declared drift on every `check`. HTTP header names are case-insensitive per RFC 9110, so this is noise, not a real divergence.

This is the exact same platform behavior already folded for `AWS::ApiGatewayV2::Api` `CorsConfiguration.AllowHeaders/ExposeHeaders` in #257.

## Fix
Added `AWS::Lambda::Url` to `CASE_INSENSITIVE_ARRAY_PATHS` in `src/normalize/noise.ts`, reusing the exact same mechanism as the ApiGatewayV2 #257 entry (compared case- and order-insensitively via `isCaseInsensitiveEqualScalarSet`):

```ts
'AWS::Lambda::Url': new Set(['Cors.AllowHeaders', 'Cors.ExposeHeaders']),
```

`Cors.AllowMethods` is deliberately **not** listed — methods echo back verbatim with no observed divergence.

## Tests
Added a `describe` block in `tests/classify.test.ts` mirroring the ApiGatewayV2 CORS test:
- mixed-case declared vs lowercase live `Cors.AllowHeaders` → no drift
- different-order header set → no drift (unordered)
- genuinely changed header (same length) → still declared drift on `Cors.AllowHeaders`
- `Cors.ExposeHeaders` folded case-insensitively → no drift

These fail without the fix (Lambda::Url falls through to strict compare) and pass with it.

## Gates
All green: typecheck, lint + format (0 errors), build, unit tests (79 files, 3418 tests).
