### PR TITLE
fix(diff): unmask declared-false/live-true drift for truthy-boolean KNOWN_DEFAULTS pins (#929)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -152,6 +152,11 @@ const MEANINGFUL_WHEN_OFF: Record<string, Record<string, (ctx: OffStateContext) 
   'AWS::Cognito::UserPoolClient': { EnableTokenRevocation: () => true },
   // A composite alarm is created with its actions ON; an undeclared `false` silences them.
   'AWS::CloudWatch::CompositeAlarm': { ActionsEnabled: () => true },
+  // A minimal ApplicationInsights application always reads back CWEMonitorEnabled=true (AWS
+  // enables CloudWatch Events monitoring at creation even though the CFn schema annotates the
+  // default as false — the KNOWN_DEFAULTS pin), so an OFF state (a live/declared `false`) is an
+  // out-of-band DISABLE of that monitoring toggle and is meaningful. Live-confirmed (#841/#925).
+  'AWS::ApplicationInsights::Application': { CWEMonitorEnabled: () => true },
 };
 
 // Identity-keyed object arrays where the template declares only a SUBSET of the elements
@@ -2288,10 +2293,20 @@ export function classifyResource(
       // gated on BOTH sides: the declared side must be empty (a real declared
       // value mismatch is never muted) and the live side must EQUAL the listed
       // default (any out-of-band change still surfaces).
+      //
+      // #929: EXCEPT when the path is meaningful-when-off. `isTrivialEmpty(false)` is
+      // true, so a user who DECLARES a boolean `false` against a truthy KNOWN_DEFAULTS
+      // pin (e.g. ApplicationInsights CWEMonitorEnabled, pinned `true`) would have that
+      // declared `false` silently folded here whenever AWS shows the pinned `true` — an
+      // out-of-band ENABLE of a monitoring/security toggle masked as "not drift". Reuse
+      // the SAME MEANINGFUL_WHEN_OFF predicate the undeclared loop consults (#632): when
+      // it flags this (type, path) as meaningful-when-off, skip the fold so the declared
+      // divergence surfaces. Paths NOT in the table keep folding (R74 precedent intact).
       if (
         isTrivialEmpty(d.stateValue) &&
         d.path in knownDef &&
-        deepEqual(d.awsValue, knownDef[d.path])
+        deepEqual(d.awsValue, knownDef[d.path]) &&
+        !(MEANINGFUL_WHEN_OFF[resourceType]?.[d.path]?.({ declared, live }) ?? false)
       )
         continue;
       // An UNORDERED_OBJECT_ARRAY element drift: the array was sorted on BOTH sides before

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -10765,6 +10765,87 @@ describe('#632 follow-up: unconditional boolean disables surface (undeclared)', 
   }
 });
 
+// #929: the DECLARED-side twin of #632. The declared trivially-empty husk fold
+// (classify.ts ~2291) mutes a declared value when it is trivially-empty AND its live
+// side equals a KNOWN_DEFAULTS pin. Because `isTrivialEmpty(false) === true`, a user who
+// DECLARES a boolean `false` against a TRUTHY pin (ApplicationInsights CWEMonitorEnabled,
+// pinned `true`) had that declared `false` silently folded whenever AWS showed the pinned
+// `true` — an out-of-band ENABLE of a monitoring toggle masked as "not drift". Gate the
+// husk fold with the SAME MEANINGFUL_WHEN_OFF predicate the undeclared loop uses so the
+// declared divergence surfaces, while a genuinely-empty default (R74 CloudTrail
+// EventSelectors, a path NOT in the table) keeps folding.
+describe('#929 declared boolean false vs truthy KNOWN_DEFAULTS pin is not masked', () => {
+  const bare: SchemaInfo = {
+    readOnly: new Set(),
+    writeOnly: new Set(),
+    createOnly: new Set(),
+    readOnlyPaths: [],
+    writeOnlyPaths: [],
+    createOnlyPaths: [],
+    defaults: {},
+    defaultPaths: {},
+  };
+  const classify = (
+    type: string,
+    declared: Record<string, unknown>,
+    live: Record<string, unknown>
+  ) =>
+    classifyResource({ logicalId: 'R', resourceType: type, physicalId: 'p', declared }, live, bare);
+
+  it('mask-lifted: declared CWEMonitorEnabled=false vs live pinned true surfaces as declared', () => {
+    const f = classify(
+      'AWS::ApplicationInsights::Application',
+      { CWEMonitorEnabled: false },
+      { CWEMonitorEnabled: true }
+    );
+    const hit = f.find((x) => x.path === 'CWEMonitorEnabled');
+    expect(hit?.tier).toBe('declared');
+    expect(hit?.desired).toBe(false);
+    expect(hit?.actual).toBe(true);
+  });
+
+  it('natural direction still works: declared true vs live false surfaces as declared', () => {
+    const f = classify(
+      'AWS::ApplicationInsights::Application',
+      { CWEMonitorEnabled: true },
+      { CWEMonitorEnabled: false }
+    );
+    const hit = f.find((x) => x.path === 'CWEMonitorEnabled');
+    expect(hit?.tier).toBe('declared');
+    expect(hit?.desired).toBe(true);
+    expect(hit?.actual).toBe(false);
+  });
+
+  it('agree: declared true == live pinned true is not drift', () => {
+    const f = classify(
+      'AWS::ApplicationInsights::Application',
+      { CWEMonitorEnabled: true },
+      { CWEMonitorEnabled: true }
+    );
+    expect(f.find((x) => x.path === 'CWEMonitorEnabled')).toBeUndefined();
+  });
+
+  it('still-folds (no over-lift): declared EventSelectors [] materialized to the CloudTrail default folds', () => {
+    // R74 precedent — EventSelectors is a KNOWN_DEFAULTS pin NOT listed in MEANINGFUL_WHEN_OFF,
+    // so a genuinely-empty declared [] that AWS materialized to the documented management
+    // selector must STILL fold (no declared finding).
+    const defaultSelector = [
+      {
+        IncludeManagementEvents: true,
+        ReadWriteType: 'All',
+        ExcludeManagementEventSources: [],
+        DataResources: [],
+      },
+    ];
+    const f = classify(
+      'AWS::CloudTrail::Trail',
+      { EventSelectors: [] },
+      { EventSelectors: defaultSelector }
+    );
+    expect(f.find((x) => x.path === 'EventSelectors')).toBeUndefined();
+  });
+});
+
 // #747: a live-only (out-of-band-added) map key containing a `.` / `[` / `]` must NOT be
 // appended verbatim as a `${path}.${key}` nested finding path — `toPointer` (and the
 // baseline `topSegment` / ignore-rule glob) re-split on `.`/`[`, corrupting the location

--- a/tests/noise-folds-910-914.test.ts
+++ b/tests/noise-folds-910-914.test.ts
@@ -71,17 +71,16 @@ describe('#841 ApplicationInsights undeclared CWEMonitorEnabled=true', () => {
     expect(pathsByTier(f, 'atDefault')).toContain('CWEMonitorEnabled');
     expect(pathsByTier(f, 'undeclared')).not.toContain('CWEMonitorEnabled');
   });
-  // A later-disabled CWEMonitorEnabled=false does NOT surface: the undeclared loop drops any
-  // `false`/`""` via isTrivialEmpty BEFORE the fold table ("false does not stay meaningful"),
-  // and detecting a true->false out-of-band disable would require a curated MEANINGFUL_WHEN_OFF
-  // entry (in diff/classify.ts) — which that table's own rule admits ONLY after a live confirm
-  // that OFF is meaningful in EVERY clean-deploy config. We have a single live observation
-  // (true on a minimal app), not that cross-config proof, so surfacing the disable is out of
-  // scope for this first-run-FP fold and is left for a live-verified follow-up. The fold here
-  // only mutes the AWS-assigned `true`, restoring the ZERO-potential-drift invariant.
-  it('drops an undeclared CWEMonitorEnabled=false as trivially-empty (not surfaced)', () => {
+  // #929/#925: a later-disabled CWEMonitorEnabled=false NOW surfaces. AWS always creates the
+  // application with CloudWatch Events monitoring ON (pinned `true`), so an OFF state is an
+  // out-of-band DISABLE of that monitoring toggle — meaningful in every clean-deploy config
+  // (live-confirmed). CWEMonitorEnabled is a curated MEANINGFUL_WHEN_OFF entry (in
+  // diff/classify.ts), so the undeclared loop's #632 guard keeps the diverging `false` from
+  // being swallowed by the trivial-empty drop and surfaces it as undeclared drift (the
+  // AWS-assigned `true` still folds atDefault above — see the previous case).
+  it('surfaces an undeclared CWEMonitorEnabled=false (out-of-band disable) as undeclared', () => {
     const f = classifyResource(res, { CWEMonitorEnabled: false }, emptySchema);
-    expect(pathsByTier(f, 'undeclared')).not.toContain('CWEMonitorEnabled');
+    expect(pathsByTier(f, 'undeclared')).toContain('CWEMonitorEnabled');
     expect(pathsByTier(f, 'atDefault')).not.toContain('CWEMonitorEnabled');
   });
 });


### PR DESCRIPTION
Closes #929

## Problem
`src/diff/classify.ts` (~line 2291) has a declared trivially-empty **husk fold**: a declared value is muted when it is trivially-empty AND its path has a `KNOWN_DEFAULTS` pin AND the live value equals that pin. Because `isTrivialEmpty(false) === true`, a **declared boolean `false`** qualifies. So a user who DECLARES `false` against a truthy-boolean `KNOWN_DEFAULTS` pin (e.g. `AWS::ApplicationInsights::Application` `CWEMonitorEnabled`, pinned `true`) had that declared `false` **silently folded** whenever AWS showed the pinned `true` — an out-of-band ENABLE of a monitoring/security toggle masked as "not drift" (a false NEGATIVE). The natural direction (declared `true`, live `false`) already surfaced correctly.

## Fix
Gate the husk-fold `continue` with the **shared** `MEANINGFUL_WHEN_OFF[resourceType]?.[path]` predicate — the SAME table the undeclared loop already consults (the #632 guard). No parallel table is introduced.

```js
if (
  isTrivialEmpty(d.stateValue) &&
  d.path in knownDef &&
  deepEqual(d.awsValue, knownDef[d.path]) &&
  !(MEANINGFUL_WHEN_OFF[resourceType]?.[d.path]?.({ declared, live }) ?? false)
)
  continue;
```

When a meaningful-when-off declared value's live side has flipped to the pinned default, the fold is SKIPPED and it surfaces as `declared` drift. Paths NOT listed keep folding — the R74 CloudTrail `EventSelectors` precedent (a genuinely-empty declared `[]` that materialized to its documented default) is preserved.

## MEANINGFUL_WHEN_OFF entry
Added the live-confirmed `'AWS::ApplicationInsights::Application': { CWEMonitorEnabled: () => true }`. AWS always creates the application with CloudWatch Events monitoring ON (the KNOWN_DEFAULTS pin already lives in `src/normalize/noise.ts`), so an OFF state is meaningful in every clean-deploy config.

## Why the shared undeclared #841 assertion flipped
Because `MEANINGFUL_WHEN_OFF` is shared with the undeclared loop's #632 guard, adding `CWEMonitorEnabled` also makes an **undeclared** `CWEMonitorEnabled=false` surface (an out-of-band disable). The prior #841 test deliberately dropped that case for lack of cross-config live proof; #929 confirms it is now live-confirmed meaningful-when-off (per #841/#925), so the assertion in `tests/noise-folds-910-914.test.ts` is updated to expect it surfaces `undeclared` (the AWS-assigned `true` still folds `atDefault`).

## Tests
New `#929` describe block in `tests/classify.test.ts` (4 cases):
- **mask-lifted**: declared `{CWEMonitorEnabled:false}` vs live `{CWEMonitorEnabled:true}` → `declared` finding (fails without the fix).
- natural direction: declared `true` vs live `false` → still `declared`.
- agree: `true`/`true` → no finding.
- **still-folds guard** (no over-lift): declared CloudTrail `EventSelectors: []` materialized to its default (a path NOT in `MEANINGFUL_WHEN_OFF`) → no finding.

Plus the updated #841 undeclared case in `tests/noise-folds-910-914.test.ts`.

## Gates
typecheck / lint+format / build all green; full suite **3418 passed (79 files)**. Only `src/diff/classify.ts` + the two test files touched.

> Note: this PR and #874 both add to `tests/classify.test.ts` in **different** describe blocks — a keep-both merge if a conflict arises.
