### PR TITLE
fix(read): fold RDS Multi-AZ DB cluster implicit member instances, not 'added' (#896)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -108,6 +108,7 @@ import {
 } from '@aws-sdk/client-lambda';
 import {
   type DBInstance as RdsDBInstance,
+  DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
   RDSClient,
 } from '@aws-sdk/client-rds';
@@ -2628,13 +2629,22 @@ async function enumerateEfsFileSystemChildren(ctx: EnumeratorContext): Promise<A
 export interface RdsClusterChildInput {
   declaredInstanceIds: string[]; // physical ids (DBInstanceIdentifiers) of AWS::RDS::DBInstance
   liveInstances: { id: string; label?: string | undefined }[];
+  // DBInstanceIdentifiers the PARENT cluster reports as its own members (DBClusterMembers).
+  // These are AWS-managed cluster membership, NOT out-of-band additions: a Multi-AZ DB cluster
+  // (non-Aurora, DBClusterInstanceClass set) implicitly materializes its writer + reader
+  // instances (`<cluster>-instance-1/2/3`) that the template never declares, so they must fold
+  // (else 3 false `[Added]` on every clean deploy — the #801-class ZERO-drift violation, #896).
+  // The cluster itself is the authoritative source of truth for membership, so this needs no
+  // name-marker guess and still surfaces a genuinely out-of-band instance (one NOT a member).
+  clusterMemberIds: string[];
 }
 
 export function diffRdsClusterChildren(input: RdsClusterChildInput): AddedChild[] {
   const declared = new Set(input.declaredInstanceIds);
+  const clusterMembers = new Set(input.clusterMemberIds);
   const added: AddedChild[] = [];
   for (const i of input.liveInstances) {
-    if (declared.has(i.id)) continue;
+    if (declared.has(i.id) || clusterMembers.has(i.id)) continue;
     added.push({
       resourceType: 'AWS::RDS::DBInstance',
       identifier: i.id, // DBInstanceIdentifier IS the CC primaryIdentifier
@@ -2661,7 +2671,18 @@ async function pageDbInstances(client: RDSClient, clusterId: string): Promise<Rd
   return out;
 }
 
-async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+// The cluster's OWN live description authoritatively lists its members (each DBClusterMembers
+// entry carries a DBInstanceIdentifier). Instances it claims are AWS-managed membership, not
+// out-of-band additions — folded by diffRdsClusterChildren (see #896).
+async function describeClusterMemberIds(client: RDSClient, clusterId: string): Promise<string[]> {
+  const res = await client.send(new DescribeDBClustersCommand({ DBClusterIdentifier: clusterId }));
+  const cluster = res.DBClusters?.[0];
+  return (cluster?.DBClusterMembers ?? [])
+    .map((m) => m.DBInstanceIdentifier)
+    .filter((id): id is string => typeof id === 'string');
+}
+
+export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const clusterId = parent.physicalId; // a DBCluster's physical id IS its DBClusterIdentifier
   if (!clusterId) return [];
@@ -2680,7 +2701,10 @@ async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promise<Adde
   }
 
   const client = new RDSClient({ region, ...READ_RETRY });
-  const instances = await pageDbInstances(client, clusterId);
+  const [instances, clusterMemberIds] = await Promise.all([
+    pageDbInstances(client, clusterId),
+    describeClusterMemberIds(client, clusterId),
+  ]);
   const liveInstances = instances
     .filter(
       (i): i is RdsDBInstance & { DBInstanceIdentifier: string } =>
@@ -2688,5 +2712,5 @@ async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promise<Adde
     )
     .map((i) => ({ id: i.DBInstanceIdentifier, label: i.DBInstanceIdentifier }));
 
-  return diffRdsClusterChildren({ declaredInstanceIds, liveInstances });
+  return diffRdsClusterChildren({ declaredInstanceIds, liveInstances, clusterMemberIds });
 }

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vite-plus/test';
 import {
+  DescribeDBClustersCommand,
+  DescribeDBInstancesCommand,
+  RDSClient,
+} from '@aws-sdk/client-rds';
+import { mockClient } from 'aws-sdk-client-mock';
+import { describe, expect, it } from 'vite-plus/test';
+import type { EnumeratorContext } from '../src/read/child-enumerators.js';
+import {
+  enumerateRdsClusterChildren,
   diffApiGatewayAuthorizers,
   diffApiGatewayChildren,
   diffApiGatewayGatewayResponses,
@@ -1327,6 +1335,7 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
         { id: 'cluster-writer', label: 'cluster-writer' },
         { id: 'cdkrd-integ-oob', label: 'cdkrd-integ-oob' },
       ],
+      clusterMemberIds: [],
     });
     expect(added).toEqual([
       {
@@ -1342,6 +1351,7 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
     const added = diffRdsClusterChildren({
       declaredInstanceIds: [],
       liveInstances: [{ id: 'reader-1', label: 'reader-1' }],
+      clusterMemberIds: [],
     });
     expect(added[0]!.identifier).toBe('reader-1');
   });
@@ -1354,8 +1364,69 @@ describe('diffRdsClusterChildren (RDS DB cluster instances)', () => {
           { id: 'writer', label: 'writer' },
           { id: 'reader', label: 'reader' },
         ],
+        clusterMemberIds: [],
       })
     ).toEqual([]);
+  });
+
+  // #896: a Multi-AZ DB cluster implicitly materializes its writer + 2 reader instances
+  // (undeclared) — folded because the parent cluster reports them in DBClusterMembers; a
+  // genuinely out-of-band instance (NOT a member) still surfaces.
+  it('folds implicit cluster members (in DBClusterMembers) but still flags a non-member instance', () => {
+    const added = diffRdsClusterChildren({
+      declaredInstanceIds: [],
+      liveInstances: [
+        { id: 'c1-instance-1', label: 'c1-instance-1' },
+        { id: 'c1-instance-2', label: 'c1-instance-2' },
+        { id: 'c1-instance-3', label: 'c1-instance-3' },
+        { id: 'rogue-oob', label: 'rogue-oob' },
+      ],
+      clusterMemberIds: ['c1-instance-1', 'c1-instance-2', 'c1-instance-3'],
+    });
+    expect(added).toEqual([
+      {
+        resourceType: 'AWS::RDS::DBInstance',
+        identifier: 'rogue-oob',
+        label: 'rogue-oob',
+        live: { DBInstanceIdentifier: 'rogue-oob' },
+      },
+    ]);
+  });
+});
+
+describe('enumerateRdsClusterChildren (DBClusterMembers fold, #896)', () => {
+  it('folds the Multi-AZ cluster member instances the parent reports, flags a non-member', async () => {
+    const rds = mockClient(RDSClient);
+    rds
+      .on(DescribeDBInstancesCommand)
+      .resolves({
+        DBInstances: [
+          { DBInstanceIdentifier: 'c1-instance-1' },
+          { DBInstanceIdentifier: 'c1-instance-2' },
+          { DBInstanceIdentifier: 'c1-instance-3' },
+          { DBInstanceIdentifier: 'rogue-oob' },
+        ],
+      })
+      .on(DescribeDBClustersCommand)
+      .resolves({
+        DBClusters: [
+          {
+            DBClusterMembers: [
+              { DBInstanceIdentifier: 'c1-instance-1' },
+              { DBInstanceIdentifier: 'c1-instance-2' },
+              { DBInstanceIdentifier: 'c1-instance-3' },
+            ],
+          },
+        ],
+      });
+    const ctx = {
+      parent: { physicalId: 'c1' },
+      desired: { resources: [] },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateRdsClusterChildren(ctx);
+    expect(added.map((a) => a.identifier)).toEqual(['rogue-oob']);
+    rds.restore();
   });
 });
 


### PR DESCRIPTION
## What

A **Multi-AZ DB CLUSTER** (non-Aurora `AWS::RDS::DBCluster` with `DBClusterInstanceClass`, engine mysql/postgres) implicitly materializes its writer + two reader instances (`<cluster>-instance-1/2/3`) — the template declares **zero** `AWS::RDS::DBInstance` children. `enumerateRdsClusterChildren`'s `DescribeDBInstances(cluster)` returned all three and `diffRdsClusterChildren` flagged them **`added`** on the very first `check` of a clean, un-mutated stack: 3 false `[Added]` per Multi-AZ-cluster deploy, each with a `DeleteResource` revert offer against a live cluster member. This violates the core ZERO-drift invariant (#801 class).

## Fix

Fold instances the **parent cluster authoritatively reports** as its own members. The `DBCluster`'s live description lists `DBClusterMembers` (each carrying a `DBInstanceIdentifier`); instances it claims are AWS-managed cluster membership, not out-of-band additions. `enumerateRdsClusterChildren` now `DescribeDBClusters` (in parallel with the existing `DescribeDBInstances`) and passes the member ids to `diffRdsClusterChildren`, which skips them.

This is **authoritative** (the cluster itself is the source of truth for its membership) — no name-marker guess — and still surfaces a genuinely out-of-band instance (one **not** in the member list).

## Verification

- Unit tests (`tests/child-enumerators.test.ts`): a diff-level test folds the 3 members but flags a non-member `rogue-oob`; an enumerator-level test with a mocked `RDSClient` (`DescribeDBInstances` returns the 3 members + a rogue; `DescribeDBClusters` reports the 3 as `DBClusterMembers`) asserts only `rogue-oob` is returned. Existing tests updated for the new field. Full suite green (3416), typecheck + lint + build clean.
- No live deploy needed: the fold keys off the parent's own authoritative `DBClusterMembers` list (documented RDS behavior), not a guessed marker — so it is correct by construction. (A live Multi-AZ cluster deploy — ~$1-2/hr — would only re-confirm the documented membership list.)

Closes #896
