### PR TITLE
fix(desired): explicit !!timestamp no longer resolves to a JS Date (#909)

### DIFF
--- a/src/desired/yaml-cfn.ts
+++ b/src/desired/yaml-cfn.ts
@@ -125,13 +125,13 @@ const FALSE_BOOL_TEST = /^(?:[Nn]o|NO|[Ff]alse|FALSE|[Oo]ff|OFF)$/;
 const BOOL_TAG = 'tag:yaml.org,2002:bool';
 // The `Date`-producing tag. The sexagesimal `intTime`/`floatTime` tags share the
 // int/float tag URIs (they yield NUMBERS like `1:30` -> 90, which #785 needs), so
-// only THIS tag URI is dropped — the sexagesimal number resolution is preserved.
+// only THIS tag URI is neutralized — the sexagesimal number resolution is preserved.
 const TIMESTAMP_TAG = 'tag:yaml.org,2002:timestamp';
 
-// Take the resolved YAML-1.1 core tags and (a) drop the implicit `timestamp`
-// resolver so a date-like plain scalar stays a string, and (b) swap the two `bool`
-// tags for copies whose `test` excludes single-letter `Y/y/N/n`. The CFn short-form
-// tags (`!Ref`/`!GetAtt`/...) are appended so they still layer on top.
+// Take the resolved YAML-1.1 core tags and (a) neutralize the `timestamp` tag so a
+// date-like scalar stays a string, and (b) swap the two `bool` tags for copies whose
+// `test` excludes single-letter `Y/y/N/n`. The CFn short-form tags (`!Ref`/`!GetAtt`/...)
+// are appended so they still layer on top.
 function restrictYaml11Tags(baseTags: Tags): Tags {
   const restricted: Tags = [];
   for (const tag of baseTags) {
@@ -141,7 +141,23 @@ function restrictYaml11Tags(baseTags: Tags): Tags {
       restricted.push(tag);
       continue;
     }
-    if (tag.tag === TIMESTAMP_TAG) continue; // no implicit Date resolution
+    if (tag.tag === TIMESTAMP_TAG) {
+      // #860 merely DROPPED this tag so a date-like PLAIN scalar stays a string. But
+      // omitting the tag leaves yaml@2's `knownTags` fallback intact, so the EXPLICIT
+      // form `!!timestamp 2026-01-01` still resolved through the base schema's tag to a
+      // JS `Date` — a declared-tier false positive that survives `record` and corrupts
+      // `revert` (#909). Instead of dropping the tag, KEEP it but override `resolve` to
+      // return the raw source string. That kills the `Date` for BOTH the implicit and
+      // the explicit form, so a date-like scalar (however tagged) stays the string
+      // CloudFormation deployed. Rebuild it as an explicit ScalarTag (a spread of the
+      // tag union widens the shape and loses the ScalarTag discriminant).
+      const scalar = tag as ScalarTag;
+      restricted.push({
+        ...scalar,
+        resolve: (value: string) => value,
+      } as ScalarTag);
+      continue;
+    }
     if (tag.tag === BOOL_TAG) {
       // The 1.1 schema carries a separate tag for `true` and for `false`; each
       // `identify`s only its own boolean. Use that to pick the matching narrowed
@@ -189,7 +205,7 @@ export function parseCfnTemplate(text: string): Record<string, unknown> {
     // (#785). But the STOCK 1.1 schema also over-resolves plain date-like scalars to
     // `Date` and single-letter `Y/N` to boolean, which CFn does NOT do (#850) — so we
     // use a RESTRICTED yaml-1.1 schema (`restrictYaml11Tags`): 1.1 semantics minus
-    // implicit timestamps minus single-letter bools, composed with the CFn short
+    // timestamps (implicit AND explicit) minus single-letter bools, composed with the CFn short
     // forms. The YAML-1.1 `!!binary`/... tags only fire on explicit `!!` markers a
     // CFn template never carries, so no regression.
     parsed = yamlParse(body, CFN_YAML_PARSE_OPTIONS);

--- a/tests/yaml-cfn.test.ts
+++ b/tests/yaml-cfn.test.ts
@@ -88,6 +88,28 @@ describe('yaml-cfn parse', () => {
     expect(p.Ts instanceof Date).toBe(false);
   });
 
+  it('keeps an EXPLICIT !!timestamp scalar a string, not a Date (#909)', () => {
+    // #860 dropped the implicit timestamp resolver, but yaml@2 still resolved the
+    // EXPLICIT `!!timestamp` form through its `knownTags` fallback — `P: !!timestamp
+    // 2026-01-01` produced a JS `Date`, not a string. CloudFormation deploys the scalar
+    // verbatim as a string; a `Date` compared against the live string is a declared
+    // false positive that survives `record` and corrupts `revert`. It must stay a string.
+    const t = parseCfnTemplate(`Resources:
+  R:
+    Type: AWS::Fake::Type
+    Properties:
+      ExpirationDate: !!timestamp 2026-01-01
+      Ver: !!timestamp 2010-09-09
+      Ts: !!timestamp 2001-12-14T21:59:43.10-05:00`);
+    const p = (t as any).Resources.R.Properties;
+    expect(p.ExpirationDate).toBe('2026-01-01');
+    expect(p.ExpirationDate instanceof Date).toBe(false);
+    expect(p.Ver).toBe('2010-09-09');
+    expect(p.Ver instanceof Date).toBe(false);
+    expect(p.Ts).toBe('2001-12-14T21:59:43.10-05:00');
+    expect(p.Ts instanceof Date).toBe(false);
+  });
+
   it('keeps a single-letter Y/N plain scalar a string, not a boolean (#850)', () => {
     // The YAML 1.1 `bool` regex includes single letters `Y|y|N|n`, so a bare
     // `AttributeType: N` resolves to boolean `false` and `Y` to `true`. CloudFormation


### PR DESCRIPTION
Closes #909.

## Root cause
#860 removed the implicit `timestamp` tag from the restricted YAML 1.1 schema so a bare date-like scalar (`2026-01-01`) stays a string. But it only DROPPED the tag, and yaml@2 still resolves the EXPLICIT form `P: !!timestamp 2026-01-01` through its `knownTags` fallback — producing a JS `Date` instance, not a string. A `Date` compared against the live string is a declared-tier false positive that survives `record` and corrupts `revert`.

## Fix
In `restrictYaml11Tags` (`src/desired/yaml-cfn.ts`), instead of `continue`-ing past the timestamp tag, KEEP it but push a copy whose `resolve` returns the raw source string. This neutralizes the `Date` for BOTH the implicit and explicit forms, while preserving #860's string-not-Date behavior for bare scalars (implicit form still yields a string).

## Test
Added `tests/yaml-cfn.test.ts` case 'keeps an EXPLICIT !!timestamp scalar a string, not a Date (#909)' asserting `!!timestamp 2026-01-01` / `2010-09-09` / an ISO datetime parse to strings (not `Date`). Verified it FAILS without the fix (the old drop-the-tag behavior produces a `Date`) and PASSES with it. The existing #850 implicit-form test guards against regression.

Gates: typecheck / lint+format / build / unit tests all green (79 files, 3415 tests passed).