### PR TITLE
fix(revert): bar Cloud Control update revert for types with no update handler (#908)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -708,6 +708,29 @@ export function buildRevertPlan(
       });
       continue;
     }
+    // A resource type whose CFn schema declares a `handlers` block but NO `update` handler
+    // (create/read/delete only — e.g. AWS::CloudFront::MonitoringSubscription) can never be
+    // patched via Cloud Control UpdateResource: the apply fails with a raw
+    // UnsupportedActionException (#908). Bar the doomed cc-kind revert here with a clear
+    // reason instead of emitting a patch that always fails. EXEMPT: a type with a
+    // type-specific SDK writer (SDK_WRITERS / prop- / nested-scoped) reverts via its own API,
+    // and a `delete`-kind out-of-band-added item already `continue`d far above. `updatable`
+    // is `false` ONLY when handlers ARE present and `update` is absent — an `undefined`
+    // (schema unavailable / no handlers block) is NOT barred (that degradation is #858).
+    if (
+      schema?.updatable === false &&
+      !SDK_WRITERS[f.resourceType] &&
+      !propScoped &&
+      !nestedScoped
+    ) {
+      notRevertable.push({
+        displayId,
+        resourceType: f.resourceType,
+        path: f.path,
+        reason: 'type has no update handler — detect/record only',
+      });
+      continue;
+    }
     const kind: RevertItem['kind'] =
       SDK_WRITERS[f.resourceType] || propScoped || nestedScoped ? 'sdk' : 'cc';
 

--- a/src/schema/schema-strip.ts
+++ b/src/schema/schema-strip.ts
@@ -446,6 +446,7 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     conditionalCreateOnlyProperties?: string[];
     properties?: Record<string, SchemaNode>;
     definitions?: Record<string, SchemaNode>;
+    handlers?: Record<string, unknown>;
   };
   const dotted = (arr: string[] | undefined): string[] => (arr ?? []).map(pointerToDotted);
   const topLevel = (paths: string[]): Set<string> => new Set(paths.filter((p) => !p.includes('.')));
@@ -475,6 +476,11 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     schema.definitions ?? {},
     schema.properties ?? {}
   );
+  // A type is `updatable` when its schema's `handlers` block declares an `update` handler.
+  // ONLY decide when handlers are PRESENT: an absent handlers block is unknown updatability
+  // (leave `updatable` undefined), so revert never bars on a schema-unavailable degradation.
+  const updatable =
+    schema.handlers === undefined ? undefined : Object.hasOwn(schema.handlers, 'update');
   return {
     readOnly: topLevel(readOnlyPaths),
     writeOnly: topLevel(writeOnlyPaths),
@@ -487,5 +493,6 @@ export function parseSchema(schemaJson: string): SchemaInfo {
     unorderedScalarPaths: unorderedArrayPaths.scalar,
     unorderedObjectArrayPaths: unorderedArrayPaths.object,
     freeFormMapPaths,
+    updatable,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -134,6 +134,15 @@ export interface SchemaInfo {
   // is surfaced in the report rather than folded into the `undeclared-subkey` count (R96).
   // Optional like the above; classify reads it with `?.`.
   freeFormMapPaths?: string[];
+  // True when the CFn resource schema's `handlers` block declares an `update` handler;
+  // false when handlers ARE present but `update` is absent — the type is create/read/delete
+  // only (e.g. AWS::CloudFront::MonitoringSubscription), so a Cloud Control UpdateResource
+  // always fails at apply with a raw UnsupportedActionException, and revert must bar the
+  // cc-kind item instead of emitting a patch that can never succeed (#908). UNDEFINED when
+  // the schema had NO handlers block at all (unknown updatability — e.g. a DescribeType
+  // failure returning EMPTY): revert must NOT bar on unknown, to avoid regressing on
+  // schema-unavailable degradation (#858 handles that separately). Optional like the above.
+  updatable?: boolean | undefined;
 }
 
 export interface ResolverContext {

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -1417,6 +1417,88 @@ describe('buildRevertPlan', () => {
     expect(plan.items).toHaveLength(1);
   });
 
+  // #908 — a type whose CFn schema has a `handlers` block but NO `update` handler
+  // (create/read/delete only, shaped like AWS::CloudFront::MonitoringSubscription) can never
+  // be patched via Cloud Control UpdateResource — the apply fails with a raw
+  // UnsupportedActionException. buildRevertPlan must bar the doomed cc-kind item at plan
+  // time, driven by parseSchema reading handlers.update presence into SchemaInfo.updatable.
+  describe('handlers.update guard (#908)', () => {
+    // A mutable non-createOnly / non-readOnly prop (Foo) + a real handlers block.
+    const withHandlers = (type: string, ...names: string[]): Map<string, SchemaInfo> =>
+      new Map([
+        [
+          type,
+          parseSchema(
+            JSON.stringify({
+              properties: { Foo: { type: 'string' } },
+              handlers: Object.fromEntries(names.map((n) => [n, {}])),
+            })
+          ),
+        ],
+      ]);
+    const NO_UPDATE = ['create', 'read', 'delete'];
+    const WITH_UPDATE = ['create', 'read', 'update', 'delete'];
+    const CF_MONSUB = 'AWS::CloudFront::MonitoringSubscription';
+    const drift = (type: string): Finding =>
+      F({ tier: 'declared', resourceType: type, path: 'Foo', desired: 'a', actual: 'b' });
+
+    it('parseSchema.updatable: false with no update handler, true with one, undefined when no handlers block', () => {
+      expect(parseSchema(JSON.stringify({ handlers: { create: {}, read: {} } })).updatable).toBe(
+        false
+      );
+      expect(parseSchema(JSON.stringify({ handlers: { create: {}, update: {} } })).updatable).toBe(
+        true
+      );
+      // NO handlers block at all -> unknown updatability -> undefined (must not bar)
+      expect(parseSchema(JSON.stringify({ properties: { Foo: {} } })).updatable).toBeUndefined();
+    });
+
+    it('BARS a cc revert on a no-update-handler type; notRevertable reason names the missing handler', () => {
+      const plan = buildRevertPlan([drift(CF_MONSUB)], undefined, {
+        schemas: withHandlers(CF_MONSUB, ...NO_UPDATE),
+      });
+      expect(plan.items).toHaveLength(0);
+      expect(plan.notRevertable).toHaveLength(1);
+      expect(plan.notRevertable[0]!.reason).toContain('no update handler');
+    });
+
+    it('a type WITH an update handler still produces the cc item (no regression)', () => {
+      const plan = buildRevertPlan([drift(CF_MONSUB)], undefined, {
+        schemas: withHandlers(CF_MONSUB, ...WITH_UPDATE),
+      });
+      expect(plan.notRevertable).toHaveLength(0);
+      expect(plan.items).toHaveLength(1);
+      expect(plan.items[0]!.kind).toBe('cc');
+    });
+
+    it('an unknown-updatability schema (no handlers block) is NOT barred — schema-unavailable degradation stays revertable (#858)', () => {
+      const type = 'AWS::Some::Type';
+      const schemas = new Map([[type, parseSchema(JSON.stringify({ properties: { Foo: {} } }))]]);
+      const plan = buildRevertPlan([drift(type)], undefined, { schemas });
+      expect(plan.notRevertable).toHaveLength(0);
+      expect(plan.items[0]!.kind).toBe('cc');
+    });
+
+    it('an SDK_WRITERS type stays revertable (kind sdk) even with no update handler — exempt', () => {
+      const type = 'AWS::DAX::Cluster'; // has an SDK_WRITERS entry
+      const plan = buildRevertPlan([drift(type)], undefined, {
+        schemas: withHandlers(type, ...NO_UPDATE),
+      });
+      expect(plan.notRevertable).toHaveLength(0);
+      expect(plan.items[0]!.kind).toBe('sdk');
+    });
+
+    it('a delete-kind (out-of-band added) item stays offered even for a no-update-handler type', () => {
+      const plan = buildRevertPlan(
+        [F({ tier: 'added', resourceType: CF_MONSUB, path: '', physicalId: 'phys-1' })],
+        undefined,
+        { schemas: withHandlers(CF_MONSUB, ...NO_UPDATE) }
+      );
+      expect(plan.notRevertable).toHaveLength(0);
+      expect(plan.items[0]!.kind).toBe('delete');
+    });
+  });
+
   it('a NESTED create-only path (parent mutable) is notRevertable, not a doomed in-place patch', () => {
     // ECR EncryptionConfiguration is mutable but EncryptionConfiguration.KmsKey is
     // create-only; the top-level-only check missed it and built a patch AWS rejects at


### PR DESCRIPTION
Closes #908

## Problem

`buildRevertPlan` offered a Cloud Control `UpdateResource` (`cc`-kind plan item) even for resource types whose CloudFormation schema has NO `update` handler. Those types (create/read/delete only, e.g. `AWS::CloudFront::MonitoringSubscription`) always fail at apply with a raw `UnsupportedActionException`. `parseSchema` never read the schema's `handlers` block, so such a type still got a doomed `cc` item instead of a clean not-revertable report.

## Fix

- **`src/schema/schema-strip.ts`** — `parseSchema` now reads the schema's `handlers` block (already present in the same `DescribeType` response, zero extra API cost) and records `handlers.update` presence into the new `SchemaInfo.updatable` field.
- **`src/types.ts`** — added `updatable?: boolean | undefined` to `SchemaInfo`.
- **`src/revert/plan.ts`** — a new guard (mirroring the existing createOnly / JSON-string / writeOnly-nested guards) bars `cc`-kind findings when `schema.updatable === false`, with reason `type has no update handler — detect/record only`.

## `updatable` tri-state

- `true` — `handlers` present AND `handlers.update` exists → revert proceeds.
- `false` — `handlers` present AND `update` absent → the ONLY case that bars the `cc` revert.
- `undefined` — no `handlers` block at all (unknown updatability, e.g. a `DescribeType` failure returning the EMPTY schema). NOT barred: barring on unknown would regress on schema-unavailable degradation, which #858 handles separately. The plan guard bars strictly on `=== false`.

Exemptions preserved: types with an `SDK_WRITERS` entry (they revert via their own API), `delete`-kind out-of-band `added`-resource items, and unknown-updatability schemas.

## Tests

Added a `describe('handlers.update guard (#908)')` block in `tests/revert-plan.test.ts` (6 tests, driving the real `parseSchema` + `buildRevertPlan`):

1. `parseSchema.updatable` is `false` with no update handler, `true` with one, `undefined` when no `handlers` block.
2. A `MonitoringSubscription`-shaped no-update type → 0 items, 1 notRevertable naming "no update handler".
3. A type WITH an update handler → still a `cc` item (no regression).
4. Unknown-updatability schema (no `handlers` block) → NOT barred, stays `cc` (#858 guard).
5. An `SDK_WRITERS` type with no update handler → stays revertable (`sdk`), exempt.
6. A `delete`-kind (out-of-band added) item → stays offered.

## Gates

typecheck, `vp check --fix` (0 errors), `vp pack`, and `vp test run` (79 files, 3420 tests) all green.
