### PR TITLE
fix(synth): surface missing-context dummy lookup values (--pre-deploy) (#907)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -311,11 +311,23 @@ export async function runCheck(args: string[]): Promise<number> {
       emitEmptyJsonOnError();
       return 2;
     }
-    const synthed = await synthApp(app, {
-      region: a.region,
-      profile: a.profile,
-      context: a.context,
-    });
+    let synthed;
+    try {
+      synthed = await synthApp(app, {
+        region: a.region,
+        profile: a.profile,
+        context: a.context,
+        // Refuse (not just warn) an assembly with unresolved context lookups here: under
+        // --pre-deploy the synth template is the DECLARED source, so CDK's dummy-value
+        // placeholders (vpc-12345, ...) would surface as guaranteed false declared drift
+        // and a revert would write them back to AWS (#907).
+        preDeploy: true,
+      });
+    } catch (e) {
+      console.error(`error: ${(e as Error).message}`);
+      emitEmptyJsonOnError();
+      return 2;
+    }
     // Key by stackName + region, NOT stackName alone: a stack name is region-scoped in
     // CloudFormation, so an app can define two same-named stacks in different regions.
     // Keyed by name alone, the second would overwrite the first and BOTH would then be

--- a/src/synth/missing-context.ts
+++ b/src/synth/missing-context.ts
@@ -1,0 +1,50 @@
+// When a CDK app's context lookups (VPC / AZ / AMI / hosted-zone / ...) are unresolved,
+// CDK still synthesizes: it fills every gap with a well-known DUMMY value (`vpc-12345`,
+// `availability-zone-1a`, ...) and records the gap in the assembly manifest's `missing`
+// array. A template carrying those placeholders does not reflect real infrastructure, so
+// any drift computed against it is fabricated. That is invisible on a normal check (the
+// deployed template is the declared source), but under `--pre-deploy` the SYNTH template
+// IS the declared source: live `VpcId=vpc-0abc...` compared against desired `vpc-12345`
+// becomes guaranteed false declared drift, `--fail` turns it into a CI failure, and an
+// interactive revert would offer to write `vpc-12345` back to AWS. This module surfaces
+// that gap loudly (#907) — a plain warning on discovery, a hard refusal under --pre-deploy.
+
+/** Minimal shape of a cx-api `MissingContext` entry — only its `key` matters here. */
+export interface MissingContextEntry {
+  readonly key: string;
+}
+
+/** Unique, sorted missing-context keys (dedup by key). Empty array when nothing is missing. */
+export function missingContextKeys(missing: readonly MissingContextEntry[] | undefined): string[] {
+  if (!missing || missing.length === 0) return [];
+  return [...new Set(missing.map((m) => m.key))].sort();
+}
+
+/**
+ * Build the stderr message body (no `warning:`/`error:` prefix — the caller adds it) for an
+ * assembly synthesized with unresolved context lookups. Returns `null` when `keys` is empty
+ * (a clean assembly — behavior unchanged). Under `preDeploy` the wording escalates to an
+ * explicit REFUSAL: the placeholders are the declared source there, so proceeding on
+ * fabricated values (false drift, a bad `--fail`, a revert that writes dummies back) is worse
+ * than stopping — the user must supply the context or deploy so the lookups resolve.
+ */
+export function missingContextWarning(
+  keys: string[],
+  opts: { preDeploy?: boolean | undefined } = {}
+): string | null {
+  if (keys.length === 0) return null;
+  const lead = `the CDK app synthesized with ${keys.length} unresolved context lookup(s): ${keys.join(', ')}`;
+  const why =
+    'CDK filled these with placeholder dummy values (e.g. vpc-12345), so the synthesized ' +
+    'template does not reflect real infrastructure.';
+  if (opts.preDeploy) {
+    return (
+      `${lead}\n${why}\n` +
+      '(--pre-deploy) refusing: those placeholders are the DECLARED source, so every check ' +
+      'would report fabricated declared drift and a revert would write the dummy values back ' +
+      'to AWS. Provide the context (commit cdk.context.json, pass -c key=value, or deploy so ' +
+      'the lookups resolve) and re-run.'
+    );
+  }
+  return `${lead}\n${why}`;
+}

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -6,11 +6,17 @@ import { existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { BaseCredentials, CdkAppMultiContext, Toolkit } from '@aws-cdk/toolkit-lib';
 import { QuietIoHost } from './io-host.js';
+import { missingContextKeys, missingContextWarning } from './missing-context.js';
 
 export interface SynthOptions {
   region?: string | undefined;
   profile?: string | undefined;
   context?: Record<string, string>;
+  // When the caller uses the synth template as the DECLARED source (`--pre-deploy`), an
+  // assembly synthesized with unresolved context lookups is fabricated (CDK's dummy
+  // `vpc-12345` placeholders). Escalate the missing-context surface from a warning to a
+  // hard refusal (throw) in that mode (#907). Discovery (default) only warns.
+  preDeploy?: boolean;
 }
 
 export interface SynthStack {
@@ -63,6 +69,19 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
 
   const cached = await toolkit.synth(source);
   try {
+    // A CDK app whose context lookups are unresolved still synthesizes — CDK fills every
+    // gap with a well-known DUMMY value (`vpc-12345`, ...) and records the gap in the
+    // manifest's `missing` array. Surface that loudly (#907): a template carrying those
+    // placeholders does not reflect real infrastructure. Always warn on discovery; under
+    // `--pre-deploy` (synth template = declared source) REFUSE, because the fabricated
+    // values would drive false declared drift and a revert would write them back to AWS.
+    const missingKeys = missingContextKeys(cached.cloudAssembly.manifest.missing);
+    if (missingKeys.length > 0) {
+      const msg = missingContextWarning(missingKeys, { preDeploy: opts.preDeploy });
+      if (opts.preDeploy) throw new Error(msg ?? 'unresolved CDK context lookups');
+      console.error(`warning: ${msg}`);
+    }
+
     // `stacksRecursively` (NOT `stacks`): `stacks` returns only the TOP-LEVEL
     // assembly's stacks, so every stack nested inside a CDK `Stage` (the CDK
     // Pipelines / multi-env pattern) is silently invisible — never discovered, never

--- a/tests/missing-context-907.test.ts
+++ b/tests/missing-context-907.test.ts
@@ -1,0 +1,58 @@
+// #907: CDK synthesizes an app with unresolved context lookups by filling every gap with a
+// well-known DUMMY value (vpc-12345, ...) and recording the gap in the manifest's `missing`
+// array. cdkrd used to ignore `missing` entirely, so under --pre-deploy the fabricated
+// template became the DECLARED source → guaranteed false declared drift (and a revert that
+// would write vpc-12345 back). These tests pin the pure helpers that drive the new surface:
+// a warning on discovery, an escalated REFUSAL under --pre-deploy.
+import { describe, expect, it } from 'vite-plus/test';
+import { missingContextKeys, missingContextWarning } from '../src/synth/missing-context.js';
+
+const entry = (key: string) => ({ key, provider: 'vpc-provider', props: {} });
+
+describe('missingContextKeys (#907)', () => {
+  it('is empty for undefined / empty missing (a clean assembly)', () => {
+    expect(missingContextKeys(undefined)).toEqual([]);
+    expect(missingContextKeys([])).toEqual([]);
+  });
+
+  it('extracts, dedups by key, and sorts', () => {
+    const keys = missingContextKeys([
+      entry('vpc-provider:account=1:filter.vpc-name=main'),
+      entry('availability-zones:account=1:region=us-east-1'),
+      entry('vpc-provider:account=1:filter.vpc-name=main'), // duplicate key
+    ]);
+    expect(keys).toEqual([
+      'availability-zones:account=1:region=us-east-1',
+      'vpc-provider:account=1:filter.vpc-name=main',
+    ]);
+  });
+});
+
+describe('missingContextWarning (#907)', () => {
+  it('returns null when nothing is missing (behavior unchanged for a clean assembly)', () => {
+    expect(missingContextWarning([])).toBeNull();
+  });
+
+  it('names the missing keys and count (discovery warning)', () => {
+    const msg = missingContextWarning(['vpc-provider:xyz', 'availability-zones:abc'])!;
+    expect(msg).toContain('2 unresolved context lookup(s)');
+    expect(msg).toContain('vpc-provider:xyz');
+    expect(msg).toContain('availability-zones:abc');
+    expect(msg).toContain('vpc-12345'); // explains the dummy placeholders
+    // discovery mode does NOT escalate
+    expect(msg).not.toContain('refusing');
+    expect(msg).not.toContain('--pre-deploy');
+  });
+
+  it('escalates to a refusal under --pre-deploy and still names the keys', () => {
+    const msg = missingContextWarning(['vpc-provider:xyz'], { preDeploy: true })!;
+    expect(msg).toContain('vpc-provider:xyz');
+    expect(msg).toContain('(--pre-deploy) refusing');
+    expect(msg).toContain('revert would write the dummy values back');
+    expect(msg).toContain('cdk.context.json');
+  });
+
+  it('returns null under --pre-deploy too when nothing is missing (no false refusal)', () => {
+    expect(missingContextWarning([], { preDeploy: true })).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #907.

## Problem
CDK synthesizes an app with **unresolved context lookups** by filling every gap with a well-known DUMMY value (`vpc-12345`, `availability-zone-1a`, ...) and recording the gap in the assembly manifest's `missing` array. cdkrd loaded assemblies with `fromAssemblyDirectory(p, { failOnMissingContext: false })` and never inspected `manifest.missing`.

Under `--pre-deploy` the synth template is the DECLARED source, so the fabricated placeholders poison the comparison: live `VpcId=vpc-0abc...` vs desired `vpc-12345` = guaranteed **false declared drift**; `--fail` turns it into a CI failure; an interactive revert would offer to **write `vpc-12345` back to AWS**.

## Fix
- New pure helper `src/synth/missing-context.ts`: `missingContextKeys()` (dedup + sort the manifest `missing` keys) and `missingContextWarning(keys, { preDeploy })` (builds the stderr message body; escalated wording under pre-deploy).
- `synthApp` reads `cloudAssembly.manifest.missing`:
  - **discovery** (default, incl. every non-pre-deploy `check`): prints `warning: ...` naming the missing keys.
  - **`--pre-deploy`**: **REFUSES** (throws) — the placeholders are the declared source, so proceeding on fabricated values is worse than stopping.
- `check`'s `--pre-deploy` path threads `preDeploy: true` and wraps the synth in try/catch → prints `error: ...`, honors the `--json` empty-array contract, exits 2.
- A clean assembly (empty `missing`) is unchanged.

## Escalation choice: refuse (not just hard-warn) under --pre-deploy
Chose to **refuse** because under `--pre-deploy` the fabricated template is the declared baseline for the whole run — a hard-warn would still emit false declared drift, still fail `--fail`, and still let a revert write dummy values to AWS. Refusing (exit 2, actionable message: commit `cdk.context.json` / pass `-c` / deploy so lookups resolve) is the safe, explicit surface. Discovery stays a warning so normal `check` is not blocked.

## Tests
`tests/missing-context-907.test.ts` — pins `missingContextKeys` (dedup/sort, empty for clean) and `missingContextWarning` (null for clean incl. under pre-deploy, names keys, discovery does not escalate, pre-deploy escalates to a refusal). Fails without the helper, passes with it.

Gates: typecheck + lint/format + build + `vp test run` (80 files, 3420 tests) all green.