### PR TITLE
fix(noise): fold first-run FP defaults — SG IpProtocol, S3 AccessPoint, ImageBuilder (#877, #919, #911)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -133,6 +133,43 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       ],
     },
   },
+  // An S3 Access Point that declares no PublicAccessBlockConfiguration reads back the
+  // same all-four-true block the AWS::S3::Bucket type already folds (the AccessPoint
+  // type just had no entry) — the secure AWS default, not user intent. Equality-gated
+  // (subset-tolerant): an out-of-band relaxation of any block (e.g. BlockPublicAcls=false)
+  // no longer matches, so it re-surfaces as real undeclared drift (security-relevant, so
+  // NOT value-independent). Observed live on a fresh s3objectlambda-rich AccessPoint (#919).
+  'AWS::S3::AccessPoint': {
+    PublicAccessBlockConfiguration: {
+      RestrictPublicBuckets: true,
+      BlockPublicPolicy: true,
+      BlockPublicAcls: true,
+      IgnorePublicAcls: true,
+    },
+  },
+  // An ImageBuilder InfrastructureConfiguration that declares no TerminateInstanceOnFailure
+  // reads back the constant documented default `true` (AWS terminates the build instance on
+  // failure). Equality-gated: the fold applies ONLY to the `true` default, so a different
+  // materialized value never folds. (A later `false` disable is an undeclared boolean that the
+  // classify undeclared loop drops as trivially-empty upstream — surfacing that disable would
+  // need a MEANINGFUL_WHEN_OFF entry in diff/classify.ts, out of scope for this first-run-FP
+  // fold; this entry only mutes the AWS-assigned `true`.) Live-confirmed on a fresh
+  // imagebuilder-rich deploy (#911).
+  'AWS::ImageBuilder::InfrastructureConfiguration': { TerminateInstanceOnFailure: true },
+  // An ImageBuilder ImagePipeline that declares neither EnhancedImageMetadataEnabled nor
+  // ImageTestsConfiguration reads both back with AWS's constant documented defaults: enhanced
+  // image metadata ON, and image tests ENABLED with a 720-minute timeout (the whole object is
+  // what AWS materializes on a fresh minimal pipeline, both keys together). Equality-gated
+  // (subset-tolerant): disabling image tests reads back ImageTestsConfiguration as a non-empty
+  // OBJECT ({ImageTestsEnabled:false, TimeoutMinutes:720}) that no longer matches the default,
+  // so it re-surfaces as real undeclared drift (detection preserved). (EnhancedImageMetadata
+  // ENABLED=false is a bare undeclared boolean the classify loop drops as trivially-empty
+  // upstream, same as TerminateInstanceOnFailure above.) Live-confirmed on a fresh
+  // imagebuilder-rich pipeline (#911).
+  'AWS::ImageBuilder::ImagePipeline': {
+    EnhancedImageMetadataEnabled: true,
+    ImageTestsConfiguration: { ImageTestsEnabled: true, TimeoutMinutes: 720 },
+  },
   // S3 Tables table buckets materialize three constant service defaults on read:
   // Standard storage class, table-level metrics off, and SSE-S3 encryption.
   // Observed live on a fresh s3express-s3tables-rich deploy; equality-gated like
@@ -2103,6 +2140,11 @@ export const CONTEXT_ARN_DEFAULTS: Record<string, Record<string, string>> = {
   // account id; equality-gated, so a Tag pointed at another account's catalog still surfaces.
   // Live-confirmed (#914).
   'AWS::LakeFormation::Tag': { CatalogId: '{accountId}' },
+  // An S3 Access Point that declares no BucketAccountId reads back the deploying account id —
+  // the default bucket-owner account. The bare `{accountId}` placeholder substitutes to the
+  // account id; equality-gated, so an AccessPoint pointed at a cross-account bucket owner still
+  // surfaces. Live-confirmed on a fresh s3objectlambda-rich AccessPoint (#919).
+  'AWS::S3::AccessPoint': { BucketAccountId: '{accountId}' },
 };
 
 // Top-level UNDECLARED keys whose service default VALUE is derived from the resource's own
@@ -3412,6 +3454,23 @@ export const CASE_INSENSITIVE_PATHS: Record<string, ReadonlySet<string>> = {
     'Listeners.*.Protocol',
     'Listeners.*.InstanceProtocol',
   ]),
+  // An EC2 SecurityGroup rule's IpProtocol — a raw-CFn / L1 template may declare it
+  // UPPERCASE (`TCP`/`UDP`), which CloudFormation accepts, but EC2 stores and echoes it
+  // LOWERCASE (`tcp`/`udp`) on the live read, so a case-sensitive compare false-flags
+  // DECLARED drift on every check of a freshly deployed group — and a revert re-writes
+  // `TCP` which EC2 lowercases again, so it never converges (CDK always emits lowercase,
+  // so only raw-template users hit it). The `*` matches the array index (the path arrives
+  // as `SecurityGroupIngress.0.IpProtocol`). The protocol values differ beyond case
+  // (tcp/udp/icmp/-1), so case-insensitive equality hides no real change — a genuine
+  // tcp->udp still surfaces. Live-confirmed (#877).
+  'AWS::EC2::SecurityGroup': new Set([
+    'SecurityGroupIngress.*.IpProtocol',
+    'SecurityGroupEgress.*.IpProtocol',
+  ]),
+  // The standalone ingress/egress rule types echo IpProtocol the same lowercased way
+  // (same EC2 canonicalization as the inline SecurityGroup rules above). Live-confirmed (#877).
+  'AWS::EC2::SecurityGroupIngress': new Set(['IpProtocol']),
+  'AWS::EC2::SecurityGroupEgress': new Set(['IpProtocol']),
 };
 export function isCaseInsensitiveScalarEqual(a: unknown, b: unknown): boolean {
   return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();

--- a/tests/corpus/AWS__S3__AccessPoint.Ap.json
+++ b/tests/corpus/AWS__S3__AccessPoint.Ap.json
@@ -88,7 +88,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Ap",
       "resourceType": "AWS::S3::AccessPoint",
       "path": "BucketAccountId",

--- a/tests/noise-folds-877-911-919.test.ts
+++ b/tests/noise-folds-877-911-919.test.ts
@@ -1,0 +1,204 @@
+// First-run fold gaps mined from clean, un-mutated LIVE deploys (issues #877, #919, #911).
+// Each fold is equality-gated (case-insensitive for #877, constant for the KNOWN_DEFAULTS
+// entries, account-derived for #919 BucketAccountId), so a change away from the default still
+// surfaces — every fix asserts BOTH the fold (no drift on a clean deploy) AND that a genuine
+// divergence still surfaces.
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#877 EC2 SecurityGroup rule IpProtocol case-normalized by EC2', () => {
+  const res: DesiredResource = {
+    logicalId: 'Sg',
+    resourceType: 'AWS::EC2::SecurityGroup',
+    physicalId: 'sg-1',
+    declared: {
+      GroupDescription: 'demo',
+      SecurityGroupIngress: [
+        { IpProtocol: 'TCP', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      ],
+      SecurityGroupEgress: [{ IpProtocol: 'UDP', FromPort: 53, ToPort: 53, CidrIp: '0.0.0.0/0' }],
+    },
+  };
+  it('does not flag declared drift when EC2 lowercases the declared IpProtocol', () => {
+    const live = {
+      GroupDescription: 'demo',
+      SecurityGroupIngress: [
+        { IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      ],
+      SecurityGroupEgress: [{ IpProtocol: 'udp', FromPort: 53, ToPort: 53, CidrIp: '0.0.0.0/0' }],
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(pathsByTier(f, 'declared')).not.toContain('SecurityGroupIngress.0.IpProtocol');
+    expect(pathsByTier(f, 'declared')).not.toContain('SecurityGroupEgress.0.IpProtocol');
+  });
+  it('surfaces a real protocol change (tcp -> udp) as declared drift', () => {
+    const live = {
+      GroupDescription: 'demo',
+      SecurityGroupIngress: [
+        { IpProtocol: 'udp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      ],
+      SecurityGroupEgress: [{ IpProtocol: 'udp', FromPort: 53, ToPort: 53, CidrIp: '0.0.0.0/0' }],
+    };
+    const f = classifyResource(res, live, emptySchema);
+    expect(pathsByTier(f, 'declared')).toContain('SecurityGroupIngress.0.IpProtocol');
+  });
+});
+
+describe('#877 standalone SecurityGroupIngress/Egress IpProtocol case-normalized', () => {
+  const mk = (type: string): DesiredResource => ({
+    logicalId: 'Rule',
+    resourceType: type,
+    physicalId: 'rule',
+    declared: {
+      GroupId: 'sg-1',
+      IpProtocol: 'TCP',
+      FromPort: 443,
+      ToPort: 443,
+      CidrIp: '0.0.0.0/0',
+    },
+  });
+  it('folds a lowercased IpProtocol on the ingress rule type', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::SecurityGroupIngress'),
+      { GroupId: 'sg-1', IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).not.toContain('IpProtocol');
+  });
+  it('folds a lowercased IpProtocol on the egress rule type', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::SecurityGroupEgress'),
+      { GroupId: 'sg-1', IpProtocol: 'tcp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).not.toContain('IpProtocol');
+  });
+  it('surfaces a real protocol change on the standalone rule type', () => {
+    const f = classifyResource(
+      mk('AWS::EC2::SecurityGroupIngress'),
+      { GroupId: 'sg-1', IpProtocol: 'udp', FromPort: 443, ToPort: 443, CidrIp: '0.0.0.0/0' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'declared')).toContain('IpProtocol');
+  });
+});
+
+describe('#919 S3 AccessPoint undeclared creation defaults', () => {
+  const res: DesiredResource = {
+    logicalId: 'Ap',
+    resourceType: 'AWS::S3::AccessPoint',
+    physicalId: 'ap',
+    declared: { Bucket: 'my-bucket', Name: 'my-ap' },
+  };
+  const opts = { accountId: '123456789012', region: 'us-east-1' };
+  const defaultPab = {
+    RestrictPublicBuckets: true,
+    BlockPublicPolicy: true,
+    BlockPublicAcls: true,
+    IgnorePublicAcls: true,
+  };
+  it('folds the all-true PublicAccessBlockConfiguration to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { PublicAccessBlockConfiguration: defaultPab, BucketAccountId: '123456789012' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('PublicAccessBlockConfiguration');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('PublicAccessBlockConfiguration');
+  });
+  it('folds BucketAccountId equal to the deploying account id to atDefault', () => {
+    const f = classifyResource(
+      res,
+      { PublicAccessBlockConfiguration: defaultPab, BucketAccountId: '123456789012' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('BucketAccountId');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('BucketAccountId');
+  });
+  it('surfaces an out-of-band relaxed PAB block as undeclared', () => {
+    const f = classifyResource(
+      res,
+      {
+        PublicAccessBlockConfiguration: { ...defaultPab, BlockPublicAcls: false },
+        BucketAccountId: '123456789012',
+      },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('PublicAccessBlockConfiguration');
+  });
+  it('surfaces a BucketAccountId pointed at another account as undeclared', () => {
+    const f = classifyResource(
+      res,
+      { PublicAccessBlockConfiguration: defaultPab, BucketAccountId: '999988887777' },
+      emptySchema,
+      opts
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('BucketAccountId');
+  });
+});
+
+describe('#911 ImageBuilder undeclared creation defaults', () => {
+  const infra: DesiredResource = {
+    logicalId: 'Infra',
+    resourceType: 'AWS::ImageBuilder::InfrastructureConfiguration',
+    physicalId: 'infra',
+    declared: { Name: 'infra', InstanceProfileName: 'prof' },
+  };
+  const pipeline: DesiredResource = {
+    logicalId: 'Pipeline',
+    resourceType: 'AWS::ImageBuilder::ImagePipeline',
+    physicalId: 'pipeline',
+    declared: { Name: 'pipeline', ImageRecipeArn: 'arn', InfrastructureConfigurationArn: 'arn' },
+  };
+  it('folds InfrastructureConfiguration TerminateInstanceOnFailure=true to atDefault', () => {
+    const f = classifyResource(infra, { TerminateInstanceOnFailure: true }, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('TerminateInstanceOnFailure');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('TerminateInstanceOnFailure');
+  });
+  it('folds ImagePipeline EnhancedImageMetadataEnabled + ImageTestsConfiguration to atDefault', () => {
+    const f = classifyResource(
+      pipeline,
+      {
+        EnhancedImageMetadataEnabled: true,
+        ImageTestsConfiguration: { ImageTestsEnabled: true, TimeoutMinutes: 720 },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'atDefault')).toContain('EnhancedImageMetadataEnabled');
+    expect(pathsByTier(f, 'atDefault')).toContain('ImageTestsConfiguration');
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+  it('surfaces disabled image tests (ImageTestsEnabled=false) as undeclared', () => {
+    const f = classifyResource(
+      pipeline,
+      {
+        EnhancedImageMetadataEnabled: true,
+        ImageTestsConfiguration: { ImageTestsEnabled: false, TimeoutMinutes: 720 },
+      },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('ImageTestsConfiguration');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('ImageTestsConfiguration');
+  });
+});


### PR DESCRIPTION
## What

Three **LIVE-confirmed** first-run false positives that violated the ZERO-drift invariant (a clean, un-mutated deploy surfaced `[Potential Drift]` / declared drift the user never caused). All folds are equality-gated / detection-preserving — none value-independent.

| Issue | Fix | Table |
| --- | --- | --- |
| **#877** EC2 SecurityGroup `IpProtocol` — CFn accepts uppercase `TCP`, EC2 echoes `tcp` (permanent declared FP + non-converging revert) | inline `SecurityGroupIngress/Egress.*.IpProtocol` + standalone `IpProtocol` | `CASE_INSENSITIVE_PATHS` |
| **#919a** S3 AccessPoint `PublicAccessBlockConfiguration` = all-four-true (the secure default the Bucket type already folds) | equality-gated whole-object (a relaxation re-surfaces) | `KNOWN_DEFAULTS` |
| **#919b** S3 AccessPoint `BucketAccountId` = deploying account id | `{accountId}` (LakeFormation `CatalogId` precedent; cross-account owner surfaces) | `CONTEXT_ARN_DEFAULTS` |
| **#911** ImageBuilder `TerminateInstanceOnFailure=true`, `EnhancedImageMetadataEnabled=true`, `ImageTestsConfiguration={ImageTestsEnabled:true,TimeoutMinutes:720}` | equality-gated constants (disabling image tests reads back a non-empty object that re-surfaces) | `KNOWN_DEFAULTS` |

## Detection preserved (not overclaimed)

`#877` tcp→udp still surfaces (values differ beyond case). `#919a` relaxing any PAB block re-surfaces. `#919b` a cross-account bucket owner surfaces. `#911` `ImageTestsConfiguration` disabled re-surfaces as a non-empty object.

**Known limitation, documented in the code comments (not this PR's scope):** the two *bare-boolean* ImageBuilder defaults (`TerminateInstanceOnFailure`, `EnhancedImageMetadataEnabled`) — a later `false` is dropped as trivially-empty by the classify undeclared loop **upstream** (the #841/#929 husk behavior). Surfacing those disables needs a `MEANINGFUL_WHEN_OFF` entry in `diff/classify.ts`, which is out of `noise.ts` scope (and classify.ts is owned by another lane, #929). The comments state this accurately rather than claim detection this fold does not provide.

## Verification

- New unit tests (`tests/noise-folds-877-911-919.test.ts`, 12 tests): fold + detection-preserved per fix. Verified they fail without the fix.
- The corpus golden `AWS__S3__AccessPoint.Ap.json` was harvested while #919 was live and recorded `BucketAccountId` as `undeclared` (the exact bug); the fold correctly reclassifies it `atDefault` (one-line `expected` tier update — `corpus-replay` is the authoritative live evidence for #919).
- All folds live-confirmed in their originating hunts (values quoted verbatim from the harvested models). Full suite green (3426), typecheck + lint + build clean.

Closes #877
Closes #919
Closes #911
