### PR TITLE
fix(baseline): complete identity guards (stackName/region/record-account/schemaVersion) (#870)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -92,6 +92,29 @@ export async function loadBaseline(
   }
   if (parsed === null || typeof parsed !== 'object')
     throw new Error(`baseline file ${path} is malformed: root is not an object`);
+  // Identity guard (load side): the baseline is keyed on three axes —
+  // stackName.accountId.region — encoded in BOTH the filename and the stored fields.
+  // The account axis is checked by the secondary `checkBaselineAccount` guard the
+  // callers invoke; this checks the OTHER two, so a file whose stored `stackName`/
+  // `region` disagrees with the path it was loaded from (hand-copied / renamed to the
+  // wrong path, or a case-insensitive-FS collision like `MyStack` vs `mystack` sharing
+  // one on-disk file) fails LOUDLY here (caller surfaces exit 2) instead of silently
+  // applying another env's recorded state. Only checked when the field is PRESENT — an
+  // older/partial file with no `stackName`/`region` is tolerated (the next `record`
+  // stamps it), mirroring `checkBaselineAccount`'s leniency for a missing accountId.
+  if (parsed.stackName && parsed.stackName !== stackName)
+    throw new Error(
+      `baseline file ${path} was captured for stack ${parsed.stackName}, but it was loaded as stack ${stackName} ` +
+        '(the file was likely copied or renamed to the wrong path, or a case-insensitive filesystem collided two ' +
+        "stacks onto one file). Baselines are per-stack — run `cdkrd record` to write this stack's own baseline " +
+        'file, or restore the correct file from git.'
+    );
+  if (parsed.region && parsed.region !== region)
+    throw new Error(
+      `baseline file ${path} was captured in region ${parsed.region}, but the current region is ${region} ` +
+        '(the file was likely copied or renamed to the wrong region path). Baselines are per-region — ' +
+        "run `cdkrd record` to write this region's own baseline file, or restore the correct file from git."
+    );
   // Back-compat: baselines written before `accept` was renamed to `record` stored the
   // entries under `accepted`; the field is now `recorded`. Read the old key so a
   // committed baseline keeps loading — the next `record` rewrites it under `recorded`.
@@ -102,6 +125,14 @@ export async function loadBaseline(
   // artifact): a newer schemaVersion must error CLEARLY rather than be silently
   // mis-applied as v2, and a missing/non-array `recorded` must error here rather than
   // crash later with an opaque TypeError inside applyBaseline (`recorded.find`).
+  // A PRESENT schemaVersion must be a number: reject a non-number (e.g. a string "3"
+  // from a bad merge or hand-edit) rather than let it slip past the `> 2` future-guard
+  // below (which only fires for numbers) and be silently mis-applied as ≤v2. An ABSENT
+  // schemaVersion is tolerated (a very old file with no field reads as v1).
+  if (parsed.schemaVersion !== undefined && typeof parsed.schemaVersion !== 'number')
+    throw new Error(
+      `baseline file ${path} has a non-numeric schemaVersion (${JSON.stringify(parsed.schemaVersion)}); it is malformed (corrupt or hand-edited)`
+    );
   if (typeof parsed.schemaVersion === 'number' && parsed.schemaVersion > 2)
     throw new Error(
       `baseline file ${path} was written by a newer cdkrd (schemaVersion ${parsed.schemaVersion}); upgrade cdkrd`

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -10,6 +10,7 @@ import {
   type BaselineFile,
   buildRecorded,
   carryForwardUnreadable,
+  checkBaselineAccount,
   constructPathsByLogical,
   declaredKeysByLogical,
   loadBaseline,
@@ -280,6 +281,13 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
   const { stackName, region, desired, findings, yes, interactive, preselectedKeys, expandNested } =
     p;
   const existing = await loadBaseline(stackName, desired.accountId, region);
+  // Identity guard BEFORE consuming `existing`: record reads the prior baseline
+  // (carryForwardUnreadable, completeResources monotonicity, prior physical-id fallback)
+  // and then `writeBaseline` re-stamps the CURRENT accountId — so without this a baseline
+  // captured in another account would be silently consumed and re-stamped, laundering the
+  // mismatch. `loadBaseline` already guards the stack/region axes; this covers the account
+  // axis, matching the check/ignore/revert callers (throws → caller surfaces exit 2).
+  if (existing) checkBaselineAccount(existing, desired.accountId, stackName);
   if (!yes && existing)
     console.error(
       `note: ${stackName}: will overwrite the existing baseline file on confirm (nothing written yet; it is git-tracked — review the diff afterwards). Pass --yes to silence.`

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -1290,6 +1290,49 @@ describe('baseline', () => {
       });
     });
 
+    it('#870: throws on a NON-NUMBER schemaVersion (a string "3" bypasses the > 2 future-guard)', async () => {
+      // A merge-damaged / hand-edited string version must not slip past `typeof === number`
+      // and be silently treated as ≤ v2.
+      await withBaselineFile(
+        JSON.stringify({ schemaVersion: '3', recorded: [], stackName: 's' }),
+        async () => {
+          await expect(loadBaseline('s', '111122223333', 'r')).rejects.toThrow(
+            /non-numeric schemaVersion/
+          );
+        }
+      );
+    });
+
+    it('#870: throws when the stored stackName disagrees with the loaded path (wrong-stack / case-collision)', async () => {
+      // The file lives at the path for stack `s`, but its stored stackName is another
+      // stack — a hand-copy / rename, or a case-insensitive-FS collision (MyStack vs mystack).
+      await withBaselineFile(
+        JSON.stringify({ schemaVersion: 2, recorded: [], stackName: 'OtherStack', region: 'r' }),
+        async () => {
+          await expect(loadBaseline('s', '111122223333', 'r')).rejects.toThrow(
+            /captured for stack OtherStack.*loaded as stack s/s
+          );
+        }
+      );
+    });
+
+    it('#870: throws when the stored region disagrees with the loaded path', async () => {
+      await withBaselineFile(
+        JSON.stringify({ schemaVersion: 2, recorded: [], stackName: 's', region: 'other-region' }),
+        async () => {
+          await expect(loadBaseline('s', '111122223333', 'r')).rejects.toThrow(
+            /captured in region other-region.*current region is r/s
+          );
+        }
+      );
+    });
+
+    it('#870: tolerates an older/partial file with no stackName/region (next record stamps it)', async () => {
+      await withBaselineFile(JSON.stringify({ schemaVersion: 2, recorded: [] }), async () => {
+        expect((await loadBaseline('s', '111122223333', 'r'))?.recorded).toEqual([]);
+      });
+    });
+
     it('still loads a valid v1/v2 baseline (no false rejection)', async () => {
       await withBaselineFile(
         JSON.stringify({ schemaVersion: 2, recorded: [], stackName: 's' }),

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import {
   CloudControlClient,
   GetResourceCommand,
@@ -900,6 +900,53 @@ describe('recordStack non-interactive refusal (R38)', () => {
           value: { AccelerationStatus: 'Enabled' },
         },
       ]);
+    } finally {
+      if (existsSync(path)) rmSync(path);
+    }
+  });
+});
+
+describe('recordStack identity guard (#870 — account mismatch throws before consuming existing)', () => {
+  it('throws (does not launder) when the existing baseline was captured in another account', async () => {
+    // An existing baseline whose stored accountId differs from the current run's account.
+    // Without the guard, recordStack would consume it and re-stamp the CURRENT accountId,
+    // silently laundering the mismatch. The stack/region match (guarded on load), so only
+    // the account axis diverges here.
+    const desired = {
+      stackName: 'AcctGuardStack',
+      region: 'acct-guard-region',
+      accountId: '999988887777',
+      resources: [],
+      rawTemplate: '{}',
+      ctx: {},
+    } as unknown as Desired;
+    const path = baselinePath(desired.stackName, desired.accountId, desired.region);
+    mkdirSync(dirname(path), { recursive: true });
+    // File at the CURRENT account's path, but its stored accountId is a DIFFERENT account.
+    writeFileSync(
+      path,
+      JSON.stringify({
+        schemaVersion: 2,
+        stackName: desired.stackName,
+        region: desired.region,
+        accountId: '111122223333',
+        capturedAt: '',
+        templateHash: '',
+        recorded: [],
+      }),
+      'utf8'
+    );
+    try {
+      await expect(
+        recordStack({
+          stackName: desired.stackName,
+          region: desired.region,
+          desired,
+          findings: [undeclared()],
+          yes: true,
+          interactive: false,
+        })
+      ).rejects.toThrow(/account 111122223333.*current account is 999988887777/s);
     } finally {
       if (existsSync(path)) rmSync(path);
     }


### PR DESCRIPTION
Closes #870.

Baseline files are keyed on three identity axes — `<stack>.<accountId>.<region>` — but the load/record guards were incomplete. This PR closes all three gaps.

## Gap 1 — `loadBaseline` never cross-checked stackName/region
Only the account axis had a guard (`checkBaselineAccount`, called by check/ignore/revert). `loadBaseline` already receives the requested stack/region (they build the path), so it now cross-checks the stored `stackName`/`region` against them and throws (exit-2 style) on mismatch. This turns a hand-copied/renamed file — and a case-insensitive-FS collision (`MyStack` vs `mystack` sharing one on-disk file) — from silent corruption into a loud error. Enforced only when the field is present (older/partial files tolerated, mirroring the account guard's leniency). All load paths (check/ignore/revert/record) inherit it with no caller-signature change.

## Gap 2 — `record` never ran the account guard
`recordStack` loaded `existing` unguarded, consumed it (carryForwardUnreadable, completeResources monotonicity, prior-physical-id fallback), then `writeBaseline` re-stamped the CURRENT accountId — laundering the mismatch. It now calls `checkBaselineAccount(existing, …)` BEFORE consuming `existing`. The stack/region axes are already covered by `loadBaseline`.

## Gap 3 — `schemaVersion` future-guard was type-gated
`if (typeof parsed.schemaVersion === 'number' && parsed.schemaVersion > 2)` let a string `"3"` bypass the future-guard and be mis-applied as ≤v2. A present-but-non-number `schemaVersion` now throws.

## Files
- `src/baseline/baseline-file.ts` — load-time stackName/region guard + strict schemaVersion type check.
- `src/commands/stack-actions.ts` — `checkBaselineAccount` call in `recordStack` before consuming `existing`.
- `tests/baseline.test.ts` / `tests/stack-actions.test.ts` — new unit tests.

`checkBaselineAccount`'s signature/behavior is unchanged, so no edits to check.ts/ignore.ts/revert.ts.

## Tests added
- stackName mismatch throws; region mismatch throws; older/partial file (no stackName/region) still loads.
- string schemaVersion `"3"` throws (non-numeric schemaVersion).
- record path throws on an account mismatch before writing (laundering prevented).
- Existing account-mismatch + newer-numeric-schemaVersion tests remain green (regression).

## Gates
typecheck pass / lint+format pass / build pass / tests pass (3419 passed)
