### PR TITLE
docs: correct README/HELP region-precedence and --yes contract (#886)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ CI (with `--yes`).
 
 | option                     | meaning                                                                                                                                                                                    |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--region <r>`             | AWS region (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`); else `env.region` per stack, else the `--profile`'s region                                                                          |
+| `--region <r>`             | a stack's own `env.region` ALWAYS wins; for an env-AGNOSTIC stack (no `env`) it falls back to `--region` (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`), else the `--profile`'s region         |
 | `--profile <p>`            | AWS profile (or `$AWS_PROFILE`)                                                                                                                                                            |
 | `-a, --app <cmd\|cdk.out>` | CDK app command or pre-synthesized assembly dir (or `$CDKRD_APP` / cdk.json `"app"`); stack auto-discovery + construct paths                                                               |
 | `-c, --context key=value`  | context for synth (repeatable; cdk.json is the base layer)                                                                                                                                 |
@@ -353,14 +353,14 @@ CI (with `--yes`).
 | `--json`                   | machine-readable output (see [JSON contract](#json-output-contract))                                                                                                                       |
 | `--fail`                   | (check) exit 1 on drift and never prompt; for scripts/CI. Without it, check reports drift but exits 0                                                                                      |
 | `--strict`                 | (check) exit 1 when coverage is incomplete. A coverage gap is always surfaced loudly; `--strict` makes it CI-failing. Orthogonal to `--fail`                                               |
-| `--show-all`               | inventory mode: show all current undeclared state, ignoring the baseline                                                                                                                   |
-| `--verbose` / `-v`         | (check) expand the `info:` footer tiers / (revert) expand the per-reason not-revertable summary to full lists                                                                              |
+| `--show-all`               | (check) inventory mode: show all current undeclared state, ignoring the baseline                                                                                                           |
+| `--verbose` / `-v`         | (check) expand the `info:` footer tiers / (revert) expand the not-revertable summary to full lists; (record) itemizes nested sub-keys in the multiselect                                   |
 | `--pre-deploy`             | (check) compare live vs the LOCAL synth template: the declared drift your next `cdk deploy` would silently overwrite                                                                       |
 | `--undeclared-only`        | (check) undeclared drift only: pair cdkrd with `cdk drift` for the declared side                                                                                                           |
 | `--declared-only`          | (check) declared drift vs the deployed template only (undeclared tier skipped; baseline untouched). Not `--pre-deploy`                                                                     |
 | `--dry-run`                | (revert) print the plan; make no changes                                                                                                                                                   |
 | `--wait[=DURATION]`        | (revert) on a transient "resource is mid-update" error (e.g. Route53Resolver `RSLVR-00705`) keep retrying until it settles, up to DURATION (default `10m`; e.g. `--wait=5m`, `--wait=90s`) |
-| `--remove-unrecorded`      | (revert) REMOVE unrecorded values + DELETE unrecorded added resources in a no-prompt run (`--yes`/CI); an interactive revert already lists them                                            |
+| `--remove-unrecorded`      | (revert, and check for its inline revert) REMOVE unrecorded values + DELETE unrecorded added resources in a no-prompt run (`--yes`/CI); an interactive revert already lists them           |
 | `--yes` / `-y`             | skip confirmations (revert apply; record records all without the multiselect)                                                                                                              |
 
 Unknown options (`--apq`) and options missing their value (`--app` at the end of
@@ -371,8 +371,10 @@ the line) are errors (exit `2`): a typo'd flag never silently becomes a stack na
 Every option runs exactly the same code as the standalone commands. Prompts are
 skipped under `--json`, `--show-all`, `--pre-deploy`, and `--fail`. A non-TTY run
 never prompts: a required write decision without `--yes` errors with exit 2 (the
-safe side); `--yes` alone in a TTY auto-approves confirmations only (select prompts
-still show).
+safe side); `--yes` in a TTY skips the write confirmation AND each verb's selection
+multiselect — `record` records ALL, `ignore` ignores ALL, `revert` applies the full
+plan. Only `check`'s action menu (Record / Revert / Ignore / …) still shows under
+`--yes`.
 
 - **`check` with drift** offers `Record / Revert / Ignore / Decide per finding /
 Nothing` (see [The model](#the-model-one-verb-you-run-three-it-offers)). Each
@@ -577,7 +579,9 @@ valid JSON value nor JSONL; multi-stack `--json` was unparseable — issue #755.
 A **stack that errored or was skipped** before it could be checked still appears as an
 element so a consumer sees which stacks ran: it carries `"error": "<reason>"` alongside
 `"drifted": 0` and an empty `"findings": []`. (`error` is absent on a
-successfully-checked stack.)
+successfully-checked stack.) Its `stack` is `"<name> (<region>)"` as usual, EXCEPT
+when the failure is that no region could be resolved for the stack — then `stack`
+is the bare `"<name>"` (no ` (<region>)` suffix), since there is no region to name.
 
 A **stack deleted out of band** — its committed baseline proves it was once deployed but
 it is now gone from CloudFormation — is the strongest drift, so it carries
@@ -625,6 +629,17 @@ Optional per-finding fields, present only when they apply:
 - `modelReadFailed` (`true`) — an `added` resource whose full live model could not be
   read this run (`actual` is only the enumerator's identity snippet); it exists but is
   not change-watchable until the next check.
+- `wholeArrayRevert` (`{ path, value }`) — **internal, revert-only** metadata on a
+  `declared` per-element finding inside an unordered object-array (a set the
+  service reorders — SecurityGroup rules, PrefixList entries, …): it carries the
+  WHOLE declared array so `revert` replaces the array as a unit instead of
+  index-patching a sorted position that does not map to the live index.
+  Display-only for the report; a consumer can ignore it.
+- `siblingPolicyNames` (`"unresolved"`) — **internal, revert-only** sentinel on a
+  `declared` IAM Role `Policies` finding whose sibling `AWS::IAM::Policy` names
+  could not be resolved; `revert` reads it and refuses to act (a per-entry revert
+  could delete a managed inline policy). The only emitted value is the
+  `"unresolved"` string; a consumer can ignore it.
 - On an `added` finding, `desired` carries the **recorded baseline model** and `actual`
   the live one (so a recorded `added` resource that changed shows the delta), and
   `unrecorded` marks a never-recorded one as potential drift.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,8 +69,10 @@ OPTIONS
   --remove-unrecorded         (revert) REMOVE unrecorded values + DELETE unrecorded
                               added resources (never recorded; default: refuse —
                               record the ones that are right)
-  --yes, -y                   skip confirmation (revert) / overwrite notice (record) /
-                              ignore ALL shown drift without the multiselect (ignore)
+  --yes, -y                   skip the write confirm AND the op multiselect — apply the
+                              FULL plan (revert) / skip the selection multiselect +
+                              overwrite notice, record ALL (record) / ignore ALL shown
+                              drift without the multiselect (ignore)
   --help, -h    --version, -v
 
   Automation: check --fail / record --yes / ignore --yes / revert --yes (or


### PR DESCRIPTION
Closes #886

Four documentation/HELP bugs where the docs contradicted correct code behavior. Docs-only plus the `src/cli.ts` HELP string constant — no code behavior changed. Every claim was verified against the current code before editing.

## 1. Region precedence (README options table)
`resolve-stacks.ts` resolves `region: s.region ?? fallbackRegion` — a stack's own `env.region` ALWAYS wins; `--region` / `$AWS_REGION` / `$AWS_DEFAULT_REGION` / profile region are the fallback ONLY for env-agnostic stacks. The old `--region` row listed the flag first, implying it wins. Rewrote the row to state env.region wins.

## 2. `--yes` contract (README interactive-prompts intro)
Old text said select prompts still show under `--yes` — false for 3 of 4 verbs. Code: `record --yes` records ALL (skips the delta multiselect, `stack-actions.ts`), `ignore --yes` ignores ALL, `revert --yes` skips BOTH the op multiselect AND the write confirm (applies the full plan). Only `check`'s action menu still shows. Reworded accordingly.

## 3. HELP `--yes` line (`src/cli.ts`)
Expanded the two-line `--yes` entry so it conveys that revert skips the op multiselect (full plan applied) and record skips the selection multiselect (records ALL), not just "skip confirmation / overwrite notice".

## 4. Option-table + JSON gaps (README)
- `--verbose`: annotated that `record` accepts it too (`cli-args.ts` allowed set; `record.ts` `expandNested: a.verbose`).
- `--show-all`: added the `(check)` annotation (check-only in code).
- `--remove-unrecorded`: annotated that `check` also accepts it (for its inline revert).
- Documented the internal/optional JSON finding fields `wholeArrayRevert` and `siblingPolicyNames` (revert-only metadata; NOT stripped from `classify.ts`).
- Documented that the no-region ERROR element emits a bare `stackName` instead of `"<name> (<region>)"` (`check.ts` `stack: region ? ... : stackName`).

## Verification
- Every claim confirmed against current code (`resolve-stacks.ts`, `stack-actions.ts`, `cli-args.ts`, `check.ts`, `types.ts`) — all matched the issue; docs now match reality.
- Gates green: typecheck, lint+format (0 errors), build, and **3414 tests passed (79 files)**. No `--help` snapshot test needed updating.
- Docs consistent with code; live-tested the corrected `node dist/cli.js --help` output.
- Core integration suite deferred — the diff is docs + a HELP string constant with no runtime behavior to live-test against AWS.
- Only `README.md` and `src/cli.ts` touched — no forbidden src files.
