### PR TITLE
fix(cli): flush stdout before process.exit so piped output is not truncated at 64KiB (#866)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@
 // check/record/ignore never write to AWS (record writes only the baseline FILE; ignore
 // writes only .cdkrd/ignore.yaml); revert is the one AWS-mutating command.
 import { readFileSync } from 'node:fs';
+import { flushAndExit } from './exit.js';
 import { runRecord } from './commands/record.js';
 import { runIgnore } from './commands/ignore.js';
 import { runCheck } from './commands/check.js';
@@ -126,7 +127,7 @@ async function main(argv: string[]): Promise<number> {
 }
 
 main(process.argv.slice(2))
-  .then((code) => process.exit(code))
+  .then((code) => flushAndExit(code))
   .catch((e: unknown) => {
     const msg = (e as { message?: string })?.message ?? String(e);
     if (/credential|could not load cred|security token/i.test(msg)) {
@@ -142,5 +143,5 @@ main(process.argv.slice(2))
     } else {
       console.error(`error: ${msg}`);
     }
-    process.exit(2);
+    return flushAndExit(2);
   });

--- a/src/exit.ts
+++ b/src/exit.ts
@@ -1,0 +1,28 @@
+// Process-exit helpers. `process.exit()` does NOT drain pending async writes on a PIPED
+// stdout — Node discards whatever exceeds the OS pipe buffer (~64 KiB). A large
+// `check --all --json` document (policy documents in desired/actual) easily exceeds that,
+// so `cdkrd check --json | jq` / `> report.json` in CI received a TRUNCATED, unparseable
+// half-document while the exit code still read 0/1 as normal (and text mode's `^result:`
+// grep could be cut mid-stream). We drain both std streams before exiting. (#866)
+
+// Resolve once the stream's write queue is flushed. Writes on a stream are ordered, so a
+// trailing zero-length write's callback fires only AFTER every prior chunk has reached the
+// pipe — awaiting it drains the buffer. Resolve immediately when nothing is buffered (or
+// the stream is already ended), and NEVER reject: an EPIPE from a reader that closed early
+// must not become an unhandled rejection that masks the real exit code.
+export function drain(stream: NodeJS.WriteStream): Promise<void> {
+  return new Promise((resolve) => {
+    if (stream.writableLength === 0 || stream.writableEnded) {
+      resolve();
+      return;
+    }
+    stream.write('', () => resolve());
+  });
+}
+
+// Flush stdout + stderr, then exit with `code`. This replaces a bare `process.exit(code)`
+// so a piped, larger-than-64-KiB payload is delivered whole instead of truncated.
+export async function flushAndExit(code: number): Promise<never> {
+  await Promise.all([drain(process.stdout), drain(process.stderr)]);
+  process.exit(code);
+}

--- a/tests/exit-866.test.ts
+++ b/tests/exit-866.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vite-plus/test';
+import { drain } from '../src/exit.js';
+
+// #866: process.exit() truncates a PIPED stdout at the OS pipe buffer because it does not
+// drain pending async writes. `drain` fixes that by awaiting the stream's write queue — a
+// trailing zero-length write's callback fires only after every prior chunk has flushed.
+// These tests pin drain's contract with a fake WriteStream so the pipe mechanics are
+// deterministic (the real >64 KiB truncation is covered end-to-end by the live-test).
+
+interface FakeStream {
+  writableLength: number;
+  writableEnded: boolean;
+  write: (chunk: string, cb: () => void) => void;
+}
+
+describe('drain (#866 — flush before exit)', () => {
+  it('resolves WITHOUT writing when nothing is buffered', async () => {
+    const write = vi.fn();
+    const s: FakeStream = { writableLength: 0, writableEnded: false, write };
+    await drain(s as unknown as NodeJS.WriteStream);
+    expect(write).not.toHaveBeenCalled(); // no spurious write on an empty buffer
+  });
+
+  it('resolves WITHOUT writing when the stream is already ended', async () => {
+    const write = vi.fn();
+    const s: FakeStream = { writableLength: 999, writableEnded: true, write };
+    await drain(s as unknown as NodeJS.WriteStream);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('waits for the flush callback before resolving when data is buffered', async () => {
+    let flush: (() => void) | undefined;
+    const write = vi.fn((_chunk: string, cb: () => void) => {
+      flush = cb; // capture the callback; do NOT fire it yet
+    });
+    const s: FakeStream = { writableLength: 70_000, writableEnded: false, write };
+
+    let resolved = false;
+    const p = drain(s as unknown as NodeJS.WriteStream).then(() => {
+      resolved = true;
+    });
+
+    // A zero-length write is queued but its callback has not fired → drain must NOT resolve
+    await Promise.resolve();
+    expect(write).toHaveBeenCalledOnce();
+    expect(write.mock.calls[0]![0]).toBe(''); // a trailing empty write, ordered after prior chunks
+    expect(resolved).toBe(false);
+
+    // Once the buffer flushes (callback fires), drain resolves.
+    flush!();
+    await p;
+    expect(resolved).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #866.

## Problem
`main().then(code => process.exit(code))` — `process.exit()` does **not** drain pending async writes on a **piped** stdout, so Node discards whatever exceeds the OS pipe buffer (~64 KiB). A large `check --all --json` document (policy documents in `desired`/`actual`) exceeds that, so `cdkrd check --json | jq` / `> report.json` in CI got a **truncated, unparseable half-document while the exit code still read 0/1 as normal**. Text mode's `^result:` grep was exposed the same way.

## Fix
New `src/exit.ts`:
- `drain(stream)` — awaits the write queue (a trailing zero-length write's callback fires only after every prior chunk has flushed; resolves immediately when nothing is buffered; **never rejects**, so an EPIPE from a closed reader can't mask the exit code).
- `flushAndExit(code)` — drains stdout **and** stderr, then `process.exit(code)`.

`cli.ts` calls `flushAndExit` on **both** the success and the catch paths (exit codes unchanged).

## Verification
- **Unit** (`tests/exit-866.test.ts`): `drain` resolves without writing on an empty/ended buffer, and waits for the flush callback before resolving when data is buffered.
- **Live (AWS-free harness)**: a bare `process.exit()` child truncates a 200 KiB piped write at **65536** bytes, while a child using the real `drain()`+exit delivers all **204800** bytes.

Part of the `--json` output-contract cluster (with #867/#871 merged, and #868).