### PR TITLE
feat(report): implement the --json output contract for record/ignore/revert (#868)

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,23 @@ Optional per-finding fields, present only when they apply:
   the live one (so a recorded `added` resource that changed shows the delta), and
   `unrecorded` marks a never-recorded one as potential drift.
 
+`record` / `ignore` / `revert` also honor `--json` (for scripting / non-TTY use),
+each emitting the same **one-array-per-invocation** shape — one element per stack,
+all notes on stderr, `[]` on a top-level error. `--json` forces non-interactive
+mode: a `record` / `ignore` that would need the selection prompt refuses without
+`--yes` (`"refused": true`), and `revert` refuses the AWS write without `--yes`
+(`"exit": 2`). Per-verb element:
+
+- `record` → `{ "stack", "recorded": <n>, "wrote": <bool>, "baseline"?: "<path>",
+"refused"?: true, "error"?: "<reason>" }` — `recorded` is how many undeclared
+  value(s) were written.
+- `ignore` → `{ "stack", "added": <n>, "wrote": <bool>, "config"?:
+".cdkrd/ignore.yaml", "refused"?: true, "error"?: "<reason>" }` — `added` is how
+  many new rules were appended.
+- `revert` → `{ "stack", "reverted": <n>, "failed": <n>, "aborted": <bool>, "exit":
+<n>, "error"?: "<reason>" }` — `reverted` / `failed` count resources; `exit` is
+  that stack's contribution (0 clean / 1 drift remains / 2 failure).
+
 After publication this shape is a backward-compatible API.
 
 ## IAM permissions

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -18,6 +18,7 @@ import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
 import { ignoreStack } from './stack-actions.js';
+import { emitJsonArray, type IgnoreJson, stackLabel } from './verb-json.js';
 
 export async function runIgnore(args: string[]): Promise<number> {
   const a = parseCommonArgs(args, 'ignore');
@@ -36,22 +37,26 @@ export async function runIgnore(args: string[]): Promise<number> {
     stacks = await resolveStacks(a);
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    if (a.json) emitJsonArray([]); // keep stdout a valid (empty) JSON array on a top-level error (#868)
     return 2;
   }
   if (stacks.length === 0) {
     console.error('note: the CDK app defines no stacks — nothing to ignore');
+    if (a.json) emitJsonArray([]);
     return 0;
   }
 
+  const jsonReports: IgnoreJson[] = []; // #868: collected per stack, printed once after the loop
   let worst = 0;
   let wroteAny = false;
   // gather-phase spinner (see gatherWithProgress) — text mode + TTY only.
   const showProgress = !a.json && isInteractive();
   for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
-      console.error(
-        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
-      );
+      const msg =
+        'no region — set env on the stack, pass --region, or set a region for the AWS profile';
+      console.error(`error: ${stackName}: ${msg}`);
+      if (a.json) jsonReports.push({ stack: stackName, added: 0, wrote: false, error: msg });
       worst = Math.max(worst, 2);
       continue;
     }
@@ -80,16 +85,33 @@ export async function runIgnore(args: string[]): Promise<number> {
         stackName,
         findings: reconciled,
         yes: a.yes,
-        interactive: isInteractive(),
+        // --json is a scripting/non-TTY contract: never show the multiselect. (#868)
+        interactive: a.json ? false : isInteractive(),
         accountId: desired.accountId,
         region,
+        json: a.json,
       });
       if (result.wrote) wroteAny = true;
       // a non-interactive ignore that needed a decision but had no --yes refuses (R38)
       if (result.refused) worst = Math.max(worst, 2);
+      if (a.json)
+        jsonReports.push({
+          stack: stackLabel(stackName, region),
+          added: result.added,
+          wrote: result.wrote,
+          ...(result.refused && { refused: true }),
+          ...(result.path !== undefined && { config: result.path }),
+        });
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — nothing to ignore`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            added: 0,
+            wrote: false,
+            error: 'not deployed yet — nothing to ignore',
+          });
         continue;
       }
       // A stack that exists but has no meaningful deployed state (REVIEW_IN_PROGRESS /
@@ -97,11 +119,30 @@ export async function runIgnore(args: string[]): Promise<number> {
       // ignore, so one un-checkable stack must not drag the whole run to exit 2.
       if (e instanceof StackNotCheckableError) {
         console.error(`note: ${stackName}: ${e.message} — nothing to ignore`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            added: 0,
+            wrote: false,
+            error: `${e.message} — nothing to ignore`,
+          });
         continue;
       }
-      console.error(`error: ${stackName}: ${(e as Error).message}`);
+      const msg = (e as Error).message;
+      console.error(`error: ${stackName}: ${msg}`);
+      if (a.json)
+        jsonReports.push({
+          stack: stackLabel(stackName, region),
+          added: 0,
+          wrote: false,
+          error: msg,
+        });
       worst = Math.max(worst, 2);
     }
+  }
+  if (a.json) {
+    emitJsonArray(jsonReports);
+    return worst;
   }
   if (worst === 0 && wroteAny)
     console.log('commit .cdkrd/ignore.yaml so the ignore rules apply for everyone going forward.');

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -9,6 +9,7 @@ import { resolveStacks } from './resolve-stacks.js';
 import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
 import { recordStack } from './stack-actions.js';
+import { emitJsonArray, type RecordJson, stackLabel } from './verb-json.js';
 
 export async function runRecord(args: string[]): Promise<number> {
   const a = parseCommonArgs(args, 'record');
@@ -27,13 +28,18 @@ export async function runRecord(args: string[]): Promise<number> {
     stacks = await resolveStacks(a);
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    if (a.json) emitJsonArray([]); // keep stdout a valid (empty) JSON array on a top-level error (#868)
     return 2;
   }
   if (stacks.length === 0) {
     console.error('note: the CDK app defines no stacks — nothing to record');
+    if (a.json) emitJsonArray([]);
     return 0;
   }
 
+  // #868: in --json mode each stack's outcome is collected and printed once, after the
+  // loop, as ONE top-level JSON array (symmetric with check). Text mode leaves it empty.
+  const jsonReports: RecordJson[] = [];
   let worst = 0;
   // Did ANY stack actually write a baseline? Cancelling the record multiselect (or the
   // empty-baseline confirm) returns `{ wrote:false, refused:false }` — a clean no-op, not
@@ -45,9 +51,10 @@ export async function runRecord(args: string[]): Promise<number> {
   const showProgress = !a.json && isInteractive();
   for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
-      console.error(
-        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
-      );
+      const msg =
+        'no region — set env on the stack, pass --region, or set a region for the AWS profile';
+      console.error(`error: ${stackName}: ${msg}`);
+      if (a.json) jsonReports.push({ stack: stackName, recorded: 0, wrote: false, error: msg });
       worst = Math.max(worst, 2);
       continue;
     }
@@ -72,24 +79,62 @@ export async function runRecord(args: string[]): Promise<number> {
           config
         ),
         yes: a.yes,
-        interactive: isInteractive(),
+        // --json is a scripting/non-TTY contract: never show the interactive multiselect
+        // (it would block a pipe and pollute stdout). Without --yes this makes a
+        // decision-requiring record refuse (recorded in the JSON element). (#868)
+        interactive: a.json ? false : isInteractive(),
         expandNested: a.verbose, // --verbose itemizes the nested sub-keys (--show-all is the separate inventory mode, not a picker-detail flag)
+        json: a.json,
       });
       // a non-interactive record that needed a decision but had no --yes refuses (R38)
       if (result.refused) worst = Math.max(worst, 2);
       if (result.wrote) wroteAny = true;
+      if (a.json)
+        jsonReports.push({
+          stack: stackLabel(stackName, region),
+          recorded: result.count ?? 0,
+          wrote: result.wrote,
+          ...(result.refused && { refused: true }),
+          ...(result.path !== undefined && { baseline: result.path }),
+        });
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed yet — nothing to record`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            recorded: 0,
+            wrote: false,
+            error: 'not deployed yet — nothing to record',
+          });
         continue;
       }
       if (e instanceof StackNotCheckableError) {
         console.error(`note: ${stackName}: ${e.message} — nothing to record`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            recorded: 0,
+            wrote: false,
+            error: `${e.message} — nothing to record`,
+          });
         continue;
       }
-      console.error(`error: ${stackName}: ${(e as Error).message}`);
+      const msg = (e as Error).message;
+      console.error(`error: ${stackName}: ${msg}`);
+      if (a.json)
+        jsonReports.push({
+          stack: stackLabel(stackName, region),
+          recorded: 0,
+          wrote: false,
+          error: msg,
+        });
       worst = Math.max(worst, 2);
     }
+  }
+  if (a.json) {
+    emitJsonArray(jsonReports);
+    return worst;
   }
   // Only nudge the user to commit when a baseline was actually written — cancelling every
   // stack's record prompt leaves the files untouched, so the "commit …" footer would be a

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -17,6 +17,7 @@ import { gatherFindings } from './gather.js';
 import { gatherWithProgress, progressLabel } from './progress.js';
 import { resolveStacks } from './resolve-stacks.js';
 import { revertStack } from './stack-actions.js';
+import { emitJsonArray, type RevertJson, stackLabel } from './verb-json.js';
 
 export async function runRevert(args: string[]): Promise<number> {
   const a = parseCommonArgs(args, 'revert');
@@ -36,22 +37,34 @@ export async function runRevert(args: string[]): Promise<number> {
     stacks = await resolveStacks(a);
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    if (a.json) emitJsonArray([]); // keep stdout a valid (empty) JSON array on a top-level error (#868)
     return 2;
   }
   if (stacks.length === 0) {
     console.error('note: the CDK app defines no stacks — nothing to revert');
+    if (a.json) emitJsonArray([]);
     return 0;
   }
 
+  const jsonReports: RevertJson[] = []; // #868: collected per stack, printed once after the loop
   let worst = 0;
   // gather-phase spinner (see gatherWithProgress) — text mode + TTY only. The revert
   // confirm prompt fires AFTER the gather, so the spinner never overlaps it.
   const showProgress = !a.json && isInteractive();
   for (const [idx, { stackName, region, template }] of stacks.entries()) {
     if (!region) {
-      console.error(
-        `error: ${stackName}: no region — set env on the stack, pass --region, or set a region for the AWS profile`
-      );
+      const msg =
+        'no region — set env on the stack, pass --region, or set a region for the AWS profile';
+      console.error(`error: ${stackName}: ${msg}`);
+      if (a.json)
+        jsonReports.push({
+          stack: stackName,
+          reverted: 0,
+          failed: 0,
+          aborted: false,
+          exit: 2,
+          error: msg,
+        });
       worst = Math.max(worst, 2);
       continue;
     }
@@ -73,7 +86,7 @@ export async function runRevert(args: string[]): Promise<number> {
       if (baseline) checkBaselineAccount(baseline, gathered.desired.accountId, stackName);
       // standalone revert: an aborted confirm means nothing changed → exit 0 (the
       // outcome's `exit` already encodes that; `aborted` is only consulted by check).
-      const { exit } = await revertStack({
+      const outcome = await revertStack({
         stackName,
         region,
         gathered,
@@ -83,22 +96,62 @@ export async function runRevert(args: string[]): Promise<number> {
         yes: a.yes,
         removeUnrecorded: a.removeUnrecorded,
         verbose: a.verbose,
-        interactive: isInteractive(),
+        // --json is a scripting/non-TTY contract: never show the op multiselect / confirm.
+        // Without --yes this makes revert refuse the AWS write (exit 2 in the JSON). (#868)
+        interactive: a.json ? false : isInteractive(),
         ...(a.waitMs !== undefined && { waitMs: a.waitMs }),
+        json: a.json,
       });
-      worst = Math.max(worst, exit);
+      worst = Math.max(worst, outcome.exit);
+      if (a.json)
+        jsonReports.push({
+          stack: stackLabel(stackName, region),
+          reverted: outcome.reverted ?? 0,
+          failed: outcome.failed ?? 0,
+          aborted: outcome.aborted,
+          exit: outcome.exit,
+        });
     } catch (e) {
       if (isStackNotDeployed(e)) {
         console.error(`note: ${stackName}: not deployed — skipped`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            reverted: 0,
+            failed: 0,
+            aborted: false,
+            exit: 0,
+            error: 'not deployed — skipped',
+          });
         continue;
       }
       if (e instanceof StackNotCheckableError) {
         console.error(`note: ${stackName}: ${e.message} — skipped`);
+        if (a.json)
+          jsonReports.push({
+            stack: stackLabel(stackName, region),
+            reverted: 0,
+            failed: 0,
+            aborted: false,
+            exit: 0,
+            error: `${e.message} — skipped`,
+          });
         continue;
       }
-      console.error(`error: ${stackName}: ${(e as Error).message}`);
+      const msg = (e as Error).message;
+      console.error(`error: ${stackName}: ${msg}`);
+      if (a.json)
+        jsonReports.push({
+          stack: stackLabel(stackName, region),
+          reverted: 0,
+          failed: 0,
+          aborted: false,
+          exit: 2,
+          error: msg,
+        });
       worst = Math.max(worst, 2);
     }
   }
+  if (a.json) emitJsonArray(jsonReports);
   return worst;
 }

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -249,6 +249,10 @@ export interface RecordStackParams {
   // value individually (mirrors the report's --verbose fold-expansion; --show-all is the
   // separate inventory mode and suppresses the interactive prompt, so it never reaches here).
   expandNested?: boolean;
+  // #868: under `record --json` the human success line is suppressed (the caller emits a
+  // machine JSON element instead); notes/warnings still go to stderr. Defaults to text mode,
+  // so check's interactive path is unaffected.
+  json?: boolean;
 }
 
 /**
@@ -262,6 +266,8 @@ export interface RecordStackParams {
 export interface RecordResult {
   wrote: boolean;
   refused: boolean;
+  count?: number; // #868: how many undeclared value(s) were recorded (for --json)
+  path?: string; // #868: the baseline file written (for --json)
 }
 
 /**
@@ -394,12 +400,15 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
       physicalIdByLogical: physicalIdsByLogical(desired.resources),
     }
   );
-  console.log(style.ok(recordOutcomeMessage(stackName, path, count, refreshedOnly, !!existing)));
+  // #868: suppress the human success line under --json (the caller prints a JSON element);
+  // notes/warnings below still go to stderr, so stdout stays pure JSON.
+  if (!p.json)
+    console.log(style.ok(recordOutcomeMessage(stackName, path, count, refreshedOnly, !!existing)));
   // record's scope excludes declared/deleted: if such drift is present, say so —
   // it was NOT approved by this record and still stands (R117).
   const scopeNote = recordScopeNote(stackName, findings);
   if (scopeNote) console.error(scopeNote);
-  return { wrote: true, refused: false };
+  return { wrote: true, refused: false, count, path };
 }
 
 // ---- ignore ----
@@ -417,6 +426,9 @@ export interface IgnoreStackParams {
   // callers that cannot resolve them; a missing field is omitted from the rule (match-any).
   accountId?: string | undefined;
   region?: string | undefined;
+  // #868: under `ignore --json` the human lines are suppressed (the caller emits a JSON
+  // element); notes/errors still go to stderr. Defaults to text mode (check's path unaffected).
+  json?: boolean;
 }
 
 /**
@@ -432,6 +444,7 @@ export interface IgnoreResult {
   wrote: boolean;
   refused: boolean;
   added: number;
+  path?: string; // #868: the .cdkrd/ignore.yaml written (for --json)
 }
 
 /** Header for ignore's multiselect. The key hints are rendered by `bulkMultiselect`
@@ -484,7 +497,7 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
     (f) => f.tier === 'declared' || f.tier === 'undeclared' || f.tier === 'added'
   );
   if (ignorable.length === 0) {
-    console.log(style.clean(`${stackName}: no ignorable drift to ignore.`));
+    if (!p.json) console.log(style.clean(`${stackName}: no ignorable drift to ignore.`));
     return { wrote: false, refused: false, added: 0 };
   }
   let chosen = ignorable;
@@ -513,17 +526,19 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
   const { path, added, alreadyPresent } = await addIgnoreRules(
     chosen.map((f) => ignoreRuleFor(f, stackName, accountId, region))
   );
-  if (added.length > 0) {
-    const dup = alreadyPresent.length > 0 ? `, ${alreadyPresent.length} already present` : '';
-    console.log(style.ok(`ignore rule(s) added: ${path} (${added.length} new${dup})`));
-  } else {
-    console.log(
-      style.note(
-        `${stackName}: all ${alreadyPresent.length} selected rule(s) already present — config unchanged`
-      )
-    );
+  if (!p.json) {
+    if (added.length > 0) {
+      const dup = alreadyPresent.length > 0 ? `, ${alreadyPresent.length} already present` : '';
+      console.log(style.ok(`ignore rule(s) added: ${path} (${added.length} new${dup})`));
+    } else {
+      console.log(
+        style.note(
+          `${stackName}: all ${alreadyPresent.length} selected rule(s) already present — config unchanged`
+        )
+      );
+    }
   }
-  return { wrote: added.length > 0, refused: false, added: added.length };
+  return { wrote: added.length > 0, refused: false, added: added.length, path };
 }
 
 // ---- revert ----
@@ -689,6 +704,10 @@ export interface RevertStackParams {
   // Injected clock/sleep for the wait path so deadline-mode unit tests don't sleep.
   waitNow?: () => number;
   waitSleep?: (ms: number) => Promise<void>;
+  // #868: under `revert --json` all human output (the plan, per-op result lines, the
+  // convergence verdict) is suppressed; the caller emits a machine JSON element from the
+  // returned outcome. Notes/warnings still go to stderr. Defaults to text mode.
+  json?: boolean;
 }
 
 const CONVERGE_RETRY_DELAY_MS = 3000;
@@ -707,6 +726,8 @@ const CONVERGE_RETRY_DELAY_MS = 3000;
 export interface RevertOutcome {
   exit: number;
   aborted: boolean;
+  reverted?: number; // #868: resources successfully reverted (for --json); absent = 0
+  failed?: number; // #868: resources whose revert op failed (for --json); absent = 0
 }
 
 /**
@@ -746,6 +767,9 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     waitNow,
     waitSleep,
   } = p;
+  // #868: human stdout sink — silenced under --json so stdout carries only the JSON the
+  // caller prints. console.error (notes/warnings) is left untouched (stderr stays informative).
+  const out = p.json ? () => {} : console.log;
   let worst = 0;
   // R113: a standout undeclared value is surfaced to the user as [Potential Drift] (it is
   // NOT a folded default — we deliberately show it), so, like declared drift, it
@@ -789,16 +813,17 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   });
 
   if (plan.items.length === 0 && plan.notRevertable.length === 0) {
-    console.log(style.clean(`${stackName} (${region}): no drift to revert.`));
+    out(style.clean(`${stackName} (${region}): no drift to revert.`));
     return { exit: 0, aborted: false };
   }
-  printPlan(stackName, region, plan, {
-    verbose,
-    // Only when the unrecorded guard actually fires: with removals included the plan
-    // REMOVES those values, so a "no revert target — record first" note would
-    // contradict the plan printed right below it (R35 review).
-    unrecordedGuidance: !includeRemovals && drifted.some((f) => f.unrecorded === true),
-  });
+  if (!p.json)
+    printPlan(stackName, region, plan, {
+      verbose,
+      // Only when the unrecorded guard actually fires: with removals included the plan
+      // REMOVES those values, so a "no revert target — record first" note would
+      // contradict the plan printed right below it (R35 review).
+      unrecordedGuidance: !includeRemovals && drifted.some((f) => f.unrecorded === true),
+    });
   if (plan.items.length === 0) {
     // Findings exist but none are revertable (R35). That is NOT the clean
     // "no drift to revert" case — the findings still stand, so exit 1 (the same
@@ -810,13 +835,13 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       ...(dc > 0 ? [`${dc} drift(s)`] : []),
       ...(uc > 0 ? [`${uc} unrecorded value(s)`] : []),
     ];
-    console.log('\n' + style.drift(`nothing revertable — ${parts.join(' + ')} remain.`));
+    out('\n' + style.drift(`nothing revertable — ${parts.join(' + ')} remain.`));
     return { exit: 1, aborted: false };
   }
 
   if (dryRun) {
     const opCount = plan.items.reduce((n, i) => n + i.ops.length, 0);
-    console.log(
+    out(
       `\n(dry-run) would apply ${opCount} op(s) to ${plan.items.length} resource(s). No changes made.`
     );
     return { exit: 0, aborted: false };
@@ -839,12 +864,12 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
         revertSelectOptions(plan)
       );
       if (picked === undefined) {
-        console.log(style.note('aborted.'));
+        out(style.note('aborted.'));
         return { exit: 0, aborted: true };
       }
       plan = filterRevertPlan(plan, new Set(picked));
       if (plan.items.length === 0) {
-        console.log(style.note('nothing selected — aborted.'));
+        out(style.note('nothing selected — aborted.'));
         return { exit: 0, aborted: true };
       }
     }
@@ -853,7 +878,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
       message: revertConfirmMessage(stackName, opCount, plan.notRevertable.length),
     });
     if (isCancel(ok) || !ok) {
-      console.log(style.note('aborted.'));
+      out(style.note('aborted.'));
       return { exit: 0, aborted: true };
     }
   }
@@ -889,9 +914,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     onRetry: ({ attempt, delayMs, hint }) => {
       const reason = (hint ?? 'transient error').split(' — ')[0];
       const secs = Math.max(1, Math.round(delayMs / 1000));
-      console.log(
-        style.note(`    ↻ ${displayId}: ${reason} — retry ${attempt} (next in ${secs}s)…`)
-      );
+      out(style.note(`    ↻ ${displayId}: ${reason} — retry ${attempt} (next in ${secs}s)…`));
     },
   });
   // Partition `delete`-kind items out of the main loop: they are applied as a batch AFTER
@@ -994,18 +1017,23 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   }
   // Print ONE outcome per resource (a resource that split into a `cc` + `sdk` item
   // produced two results) so a fully reverted resource never prints `reverted:` twice.
-  for (const s of summarizeRevertResults(applied)) {
+  // #868: per-resource revert tallies for the --json element (summarize collapses a
+  // resource that split into cc + sdk items so it is counted once).
+  const summarized = summarizeRevertResults(applied);
+  const revertedCount = summarized.filter((s) => s.ok).length;
+  const failedCount = summarized.filter((s) => !s.ok).length;
+  for (const s of summarized) {
     if (s.ok) {
-      console.log(style.ok(`  reverted: ${s.displayId}`));
+      out(style.ok(`  reverted: ${s.displayId}`));
     } else {
-      console.log(style.fail(`  FAILED: ${s.displayId} — ${s.error}`));
+      out(style.fail(`  FAILED: ${s.displayId} — ${s.error}`));
       // Transient "resource is mid-update" failure that survived the retries: add a
       // targeted hint so the user knows this is retry-later, not a real failure. When we
       // did NOT already wait (`--wait` off), point at it as the one-command settle path.
       if (s.hint) {
         const suffix =
           waitMs === undefined ? ' (or re-run with --wait to block until it settles)' : '';
-        console.log(style.note(`    ↳ ${s.hint}${suffix}`));
+        out(style.note(`    ↳ ${s.hint}${suffix}`));
       }
     }
   }
@@ -1015,9 +1043,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // scaled with stack size, not with the revert); regatherTouched re-reads only
   // plan.items and carries every other finding forward from the original gather.
   const touched = new Set(plan.items.map((i) => i.logicalId));
-  console.log(
-    '\n' + style.note(`verifying convergence (re-reading ${touched.size} resource(s))...`)
-  );
+  out('\n' + style.note(`verifying convergence (re-reading ${touched.size} resource(s))...`));
   const reconcile = (findings: Finding[]): Finding[] =>
     applyIgnores(
       applyBaseline(findings, baseline, baselineOpts),
@@ -1088,13 +1114,13 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // Print the no-op removals FIRST so the "did not converge" verdict below has visible
   // evidence above it, mirroring the FAILED: lines' relationship to the unconfirmed count.
   for (const n of noOpRemovals)
-    console.log(
+    out(
       style.fail(
         `  NOT reverted: ${n.displayId}.${n.path} — removal was a no-op (the provider ignored the omitted property; it needs an explicit default write — see #597 / REVERT_SET_DEFAULT_PATHS)`
       )
     );
   const notConverged = unconfirmed + noOpRemovals.length;
-  console.log(
+  out(
     converged
       ? style.clean(`${stackName}: CLEAN after revert.`)
       : remaining > 0
@@ -1107,7 +1133,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // as "all good" when a decision is still pending — one dim pointer line (R62).
   const unrecordedLeft = unrecordedCount(post);
   if (unrecordedLeft > 0)
-    console.log(
+    out(
       style.note(
         `  (${unrecordedLeft} unrecorded value(s) still await a baseline — run cdkrd record)`
       )
@@ -1116,7 +1142,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // user at a re-run rather than implying success. (A failed delete already printed its
   // own `FAILED:` line above and bumped the exit to 2 in the apply loop.)
   if (unverified > 0)
-    console.log(
+    out(
       style.note(
         `  (${unverified} resource(s) could not be re-read to verify — re-run cdkrd check to confirm)`
       )
@@ -1124,12 +1150,12 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
   // Say WHICH drift survived — without this the user must re-run `check` just to
   // learn what didn't converge (R46). A terse id-per-line pointer, not a report;
   // capped so a no-baseline partial revert doesn't re-list 100+ lines (R52).
-  for (const line of formatSurvivingDrift(remainingDrift, stackName)) console.log(line);
+  for (const line of formatSurvivingDrift(remainingDrift, stackName)) out(line);
   // remaining drift, an unverifiable re-read, OR a no-op removal all mean "not confirmed
   // clean" → exit 1 (a failed delete/update already set 2). Never return 0 ("converged")
   // when we could not verify convergence.
   if (remaining > 0 || unverified > 0 || noOpRemovals.length > 0) worst = Math.max(worst, 1);
-  return { exit: worst, aborted: false };
+  return { exit: worst, aborted: false, reverted: revertedCount, failed: failedCount };
 }
 
 /**

--- a/src/commands/verb-json.ts
+++ b/src/commands/verb-json.ts
@@ -1,0 +1,45 @@
+// #868: the `--json` output contract for record / ignore / revert. Symmetric with
+// `check --json` (src/report/report.ts): stdout is ONE top-level JSON array, one element
+// per stack, and every note / warning / progress line goes to stderr so stdout stays a
+// single `JSON.parse`-able value. A whole-run failure before any stack is reached still
+// emits `[]` (never empty bytes) — the verbs call `emitJsonArray([])` on their early error
+// returns, mirroring check (#871). `error` appears only on a stack that failed or was
+// skipped before the action ran (like check's element).
+
+export interface RecordJson {
+  stack: string;
+  recorded: number; // undeclared value(s) written into the baseline
+  wrote: boolean; // a baseline file was actually written
+  refused?: boolean; // a decision was required but the run was non-interactive without --yes
+  baseline?: string; // the baseline file path (when written)
+  error?: string; // set only on a pre-record failure / skip
+}
+
+export interface IgnoreJson {
+  stack: string;
+  added: number; // new ignore rule(s) appended to .cdkrd/ignore.yaml
+  wrote: boolean;
+  refused?: boolean;
+  config?: string; // the .cdkrd/ignore.yaml path (when written)
+  error?: string;
+}
+
+export interface RevertJson {
+  stack: string;
+  reverted: number; // resources successfully reverted
+  failed: number; // resources whose revert op failed
+  aborted: boolean; // the confirm prompt was cancelled (no AWS write)
+  exit: number; // this stack's exit contribution (0 clean / 1 drift remains / 2 failure)
+  error?: string; // set only on a pre-revert failure / skip
+}
+
+// The per-stack element label — `<stack> (<region>)`, or bare `<stack>` when the region
+// could not be resolved. Matches check's element `stack` field so consumers key uniformly.
+export function stackLabel(stackName: string, region: string | undefined): string {
+  return region ? `${stackName} (${region})` : stackName;
+}
+
+// Print the whole invocation's JSON array once, on stdout (the machine channel).
+export function emitJsonArray(reports: readonly unknown[]): void {
+  console.log(JSON.stringify(reports, null, 2));
+}

--- a/tests/record-footer-799.test.ts
+++ b/tests/record-footer-799.test.ts
@@ -32,8 +32,11 @@ vi.mock('../src/config/config-file.js', () => ({
   applyIgnores: (findings: unknown) => findings,
 }));
 
+// json:false — this suite tests the TEXT-mode "commit …" footer. Under --json (#868) the
+// footer is intentionally suppressed (the JSON array is stdout), so text mode is the
+// correct fixture for the footer-gating behavior.
 vi.mock('../src/cli-args.js', () => ({
-  parseCommonArgs: () => ({ profile: undefined, json: true, yes: true, verbose: false }),
+  parseCommonArgs: () => ({ profile: undefined, json: false, yes: true, verbose: false }),
   isInteractive: () => false,
 }));
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -637,7 +637,7 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     cc.on(GetResourceCommand).resolves(liveRead('Enabled'));
 
     const { outcome, logs } = await run();
-    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(outcome).toMatchObject({ exit: 0, aborted: false });
     expect(logs).toContain('verifying convergence (re-reading 1 resource(s))...');
     expect(logs).toContain('s: CLEAN after revert.');
     // scoped: the single touched resource was read once — no full-stack re-gather,
@@ -652,7 +652,7 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     cc.on(GetResourceCommand).callsFake(() => liveRead(++reads === 1 ? 'Suspended' : 'Enabled'));
 
     const { outcome, logs } = await run();
-    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(outcome).toMatchObject({ exit: 0, aborted: false });
     expect(logs).toContain('s: CLEAN after revert.');
     expect(cc.commandCalls(GetResourceCommand)).toHaveLength(2);
   });
@@ -663,7 +663,7 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
     cc.on(GetResourceCommand).resolves(liveRead('Suspended'));
 
     const { outcome, logs } = await run();
-    expect(outcome).toEqual({ exit: 1, aborted: false });
+    expect(outcome).toMatchObject({ exit: 1, aborted: false });
     expect(logs).toContain('s: 1 drift(s) remain.');
     // R46: each surviving drift is listed (id.path + tier) so the user does not
     // have to re-run `check` just to learn what failed to converge.
@@ -810,7 +810,7 @@ describe('revertStack convergence re-check (R44 — scoped to touched resources)
       waitNow: () => 0, // constant clock < deadline → keep retrying (waitSleep is a no-op)
       waitSleep: () => Promise.resolve(),
     });
-    expect(outcome).toEqual({ exit: 0, aborted: false });
+    expect(outcome).toMatchObject({ exit: 0, aborted: false });
     expect(cc.commandCalls(UpdateResourceCommand).length).toBe(5); // 4 fails + 1 success
     expect(logs).toMatch(/↻ .*retry 1/); // per-retry progress line printed
     expect(logs).toContain('s: CLEAN after revert.');
@@ -888,7 +888,7 @@ describe('recordStack non-interactive refusal (R38)', () => {
         yes: true,
         interactive: false, // ignored when yes:true — --yes records all regardless
       });
-      expect(result).toEqual({ wrote: true, refused: false });
+      expect(result).toMatchObject({ wrote: true, refused: false });
       expect(existsSync(path)).toBe(true);
       const written = JSON.parse(readFileSync(path, 'utf8')) as BaselineFile;
       // the full undeclared set is recorded (no selective multiselect under --yes)
@@ -974,7 +974,7 @@ describe('recordStack preselectedKeys (R121 — per-finding path skips the multi
         interactive: true,
         preselectedKeys: new Set([keyA]),
       });
-      expect(result).toEqual({ wrote: true, refused: false });
+      expect(result).toMatchObject({ wrote: true, refused: false });
       const written = JSON.parse(readFileSync(path, 'utf8')) as BaselineFile;
       // only `a` recorded; `b` stays unrecorded (was not preselected)
       expect(written.recorded.map((e) => e.path)).toEqual(['AccelerateConfiguration']);

--- a/tests/verb-json-868.test.ts
+++ b/tests/verb-json-868.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { emitJsonArray, stackLabel } from '../src/commands/verb-json.js';
+
+// #868: record / ignore / revert now honor --json — one top-level JSON array, one element
+// per stack, symmetric with check. These tests pin the helpers + the top-level-error
+// contract ([] on stdout, never empty bytes). The per-stack element shape on a real
+// gather is exercised by the live-test (a deployed fixture).
+
+describe('verb-json helpers (#868)', () => {
+  it('stackLabel formats "<stack> (<region>)", or bare stack without a region', () => {
+    expect(stackLabel('A', 'us-east-1')).toBe('A (us-east-1)');
+    expect(stackLabel('A', undefined)).toBe('A');
+  });
+
+  it('emitJsonArray prints one JSON.parse-able array to stdout', () => {
+    const out: string[] = [];
+    const log = vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+      out.push(String(m));
+    });
+    emitJsonArray([{ stack: 'A', recorded: 2 }]);
+    expect(out).toHaveLength(1);
+    expect(JSON.parse(out[0]!)).toEqual([{ stack: 'A', recorded: 2 }]);
+    log.mockRestore();
+  });
+});
+
+// Drive each verb with synth mocked so resolveStacks throws → the top-level error path
+// must still leave stdout a valid empty array under --json (never empty bytes).
+vi.mock('../src/synth/resolve-app.js', () => ({ resolveApp: () => 'app' }));
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: () => Promise.reject(new Error('boom: un-synthesizable app')),
+}));
+
+import { runIgnore } from '../src/commands/ignore.js';
+import { runRecord } from '../src/commands/record.js';
+import { runRevert } from '../src/commands/revert.js';
+
+describe('record/ignore/revert --json emit [] on a top-level error (#868)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const runners: [string, (args: string[]) => Promise<number>][] = [
+    ['record', runRecord],
+    ['ignore', runIgnore],
+    ['revert', runRevert],
+  ];
+
+  for (const [name, run] of runners) {
+    it(`${name} --json prints "[]" and exits 2 when synth throws`, async () => {
+      const out: string[] = [];
+      const err: string[] = [];
+      vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+        out.push(String(m));
+      });
+      vi.spyOn(console, 'error').mockImplementation((m?: unknown) => {
+        err.push(String(m));
+      });
+
+      const code = await run(['--json', '--yes']);
+
+      expect(code).toBe(2);
+      expect(out).toHaveLength(1);
+      expect(JSON.parse(out[0]!)).toEqual([]); // parseable, never ''
+      expect(err.join('\n')).toContain('boom'); // the error still surfaces on stderr
+    });
+
+    it(`${name} (text mode) writes nothing to stdout on a top-level error`, async () => {
+      const out: string[] = [];
+      vi.spyOn(console, 'log').mockImplementation((m?: unknown) => {
+        out.push(String(m));
+      });
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const code = await run([]);
+      expect(code).toBe(2);
+      expect(out).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
Closes #868.

## Problem
`--json` sat in `GLOBAL_FLAGS` and was accepted by all four verbs, but only `check` emitted JSON — `record`/`ignore`/`revert` printed **plain text** on stdout with a success exit code, so `cdkrd revert --yes --json | jq` (a natural CI remediation script) got unparseable text. (The maintainer chose *implement* over *fail-fast*, bare-array symmetric with check.)

## Fix
Each verb now emits the **same one-top-level-array shape** as `check` — one element per stack, all notes/warnings on **stderr**, `[]` on a top-level error. `--json` **forces non-interactive** mode (never blocks a pipe on the multiselect): `record`/`ignore` refuse without `--yes` (`"refused": true`), `revert` refuses the AWS write without `--yes` (`"exit": 2`).

- New `src/commands/verb-json.ts`: the element types + `emitJsonArray` / `stackLabel` helpers.
- `stack-actions.ts` gains a `json` param that **suppresses the human stdout lines** (the return values now carry the counts / written paths); check's interactive/text path is untouched (`json` defaults off).

### Element shapes
- `record` → `{ stack, recorded, wrote, baseline?, refused?, error? }`
- `ignore` → `{ stack, added, wrote, config?, refused?, error? }`
- `revert` → `{ stack, reverted, failed, aborted, exit, error? }`

README JSON-contract section documents all three.

## Verification
- **Unit** (`tests/verb-json-868.test.ts`): helpers + `[]`-on-top-level-error for all three verbs; `stack-actions.test.ts` return-shape assertions updated for the additive fields; full suite 3399 green.
- **Live** (built binary): `record`/`ignore`/`revert --json` each emit a parseable array with the right per-verb element, notes on stderr. (A real deploy→record→revert cycle is deferred — no AWS-mutating logic changed, only output formatting + non-interactive gating.)