### PR TITLE
docs(gate): clarify verify-pr-gate cost for doc-like src edits + guard README table alignment

### DIFF
--- a/.claude/hooks/verify-pr-gate.sh
+++ b/.claude/hooks/verify-pr-gate.sh
@@ -164,6 +164,15 @@ The skill walks the full PR-readiness checklist:
   - retrospective + proposals for new rules / hooks / skills
   - PR title + body freshness vs the actual diff
 
+Not heavyweight for a doc-like src change: this gate intentionally keys on
+ANY src/** edit (the exemption above is all-or-nothing — a finer
+"behavior-free" heuristic can't be proven fail-safe, so it is not attempted).
+But when the src change is confined to --help / --version text or code
+comments, /verify-pr is CHEAP: its live-test is just `node dist/cli.js --help`
+and the real-AWS core integration suite may be DEFERRED (offline/unit/corpus-
+covered — state the deferral). The gate still applies because --help output is
+user-visible; it is NOT asking for a real-AWS deploy here.
+
 It is the ONLY legitimate setter of this marker. Do NOT call
 `markgate set verify-pr` directly from a shell to bypass this hook —
 the whole point of the gate is that an unverified PR cannot be opened

--- a/README.md
+++ b/README.md
@@ -343,6 +343,14 @@ CI (with `--yes`).
 
 ### Options
 
+<!-- Editor note: this table is hand-aligned to a fixed column width. The
+     alignment is COSMETIC only — GitHub renders the table regardless — but a
+     cell that overflows the width silently skews the `|` columns in the source.
+     When editing a row, re-pad the `option` and `meaning` cells (and the
+     separator row) to match, or accept that alignment is inconsequential and
+     leave cells natural-width. Don't chase pixel alignment at the cost of a
+     readable diff. -->
+
 | option                     | meaning                                                                                                                                                                                    |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `--region <r>`             | a stack's own `env.region` ALWAYS wins; for an env-AGNOSTIC stack (no `env`) it falls back to `--region` (or `$AWS_REGION` / `$AWS_DEFAULT_REGION`), else the `--profile`'s region         |


### PR DESCRIPTION
Two low-risk follow-ups surfaced by PR #941's `/verify-pr` retrospective (docs/tooling only — no `src/**`).

### 1. verify-pr-gate: clarify the src exemption instead of loosening it
The gate keys on ANY `src/**` edit, so a `--help`-string-only PR (like #941) triggers the full `/verify-pr`. I deliberately did **not** loosen the exemption: a "behavior-free src change" heuristic cannot be proven fail-safe (a `--help` string IS user-visible output and legitimately warrants a live-test), so loosening a safety gate against that is wrong. Instead the stale-marker block message now explains that for a src change confined to `--help`/`--version` text or code comments, `/verify-pr` is **cheap** — live-test = `node dist/cli.js --help`, and the real-AWS core suite may be deferred (offline/unit/corpus-covered). No gate logic changed; `verify-pr-gate.test.sh` still passes 15/15.

### 2. README options table alignment guard
Added an editor-note above the hand-aligned options table: the fixed-width alignment is cosmetic (GitHub renders regardless), but a cell overflow silently skews the `|` columns in the source. Warns future editors to re-pad or accept natural width, not chase pixel alignment at the cost of a readable diff.

### Gates
typecheck / lint (0 errors) / build / tests (3455 passed) all green; hook self-test + `verify-pr-gate.test.sh` (15/15) green. No `src/**` or `tests/**` touched.
