### PR TITLE
fix(config): ignore-rule '/'-subtree coverage (parent rule + added ARN ids) (#903)

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,8 +480,11 @@ ignore:
   segment, bounded by `.`, `/`, and `[` (`*.DesiredCount` matches
   `<anyId>.DesiredCount`, not a deeper `Tbl.Config.DesiredCount`; `MyApi/*`
   matches a direct construct-path child but not a grandchild
-  `MyApi/Resource/Method`) — a parent `path` still covers child paths via the
-  subtree walk, so the segment bound does not under-match. Inside a `[...]`
+  `MyApi/Resource/Method`) — but an explicit parent `path` (e.g. `MyApi/Resource`)
+  still covers its whole `/`-subtree (`MyApi/Resource/Method.Prop`) via the
+  ancestor walk, symmetric with the `.` case, so the segment bound does not
+  under-match. A leaf-pinned wildcard like `MyApi/*.Prop` still does NOT cross
+  segments (it only matches a direct child's `.Prop`). Inside a `[...]`
   bracket key a `*` /
   `?` is **unbounded within that bracket** (the brackets delimit the key, so a `.`
   between them is data): `Alb.LoadBalancerAttributes[*]` and

--- a/src/commands/glob-match.ts
+++ b/src/commands/glob-match.ts
@@ -95,8 +95,8 @@ export function matchesGlob(pattern: string, name: string): boolean {
  * construct paths (`MyApi/Resource/Method`), so `MyApi/*` means "a direct child of
  * MyApi" — bounding `*` at `/` keeps it from leaking to arbitrarily deep descendants
  * (`MyApi/Resource/Method`). Deep-subtree coverage of a `/`-parent rule is still
- * handled by the ancestor walk in `pathMatches` (which trims at `.` / `[`; a rule that
- * means the whole subtree ends at the parent segment). Inside a `[...]` bracket a `/`
+ * handled by the ancestor walk in `pathMatches` (which trims at `.`, `[`, OR `/`, so a
+ * `/`-parent rule's whole subtree is covered — symmetric with `.`). Inside a `[...]` bracket a `/`
  * is DATA, not a boundary — the brackets already delimit the key — so it stays literal
  * there, exactly like `.`.
  *

--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -376,23 +376,26 @@ export function parseIgnoreRule(entry: IgnoreRuleObject): IgnoreRule {
 }
 
 /**
- * True when `pattern` matches `target` (= "<logicalId>.<path>"), either exactly or
- * as a PARENT path: a rule "X.Policies" also ignores child paths like
- * "X.Policies.0.PolicyName" AND "X.Policies[MyPol].PolicyName" (so ignoring a
- * structured property covers its leaves, including array / identity-keyed elements).
- * Parent matching walks ancestors at each `.` OR `[` boundary, combined with the glob.
+ * True when `pattern` matches `target` (= "<logicalId>.<path>" / a `/`-joined construct
+ * path), either exactly or as a PARENT path: a rule "X.Policies" also ignores child paths
+ * like "X.Policies.0.PolicyName" AND "X.Policies[MyPol].PolicyName" (so ignoring a
+ * structured property covers its leaves, including array / identity-keyed elements), and a
+ * rule "MyApi/Res" covers its whole construct-path subtree "MyApi/Res/Method.Prop".
+ * Parent matching walks ancestors at each `.`, `[`, OR `/` boundary, combined with the glob.
  */
 function pathMatches(pattern: string, target: string): boolean {
   if (matchesPathGlob(pattern, target)) return true;
   // A rule on a PARENT property ignores its whole subtree — including array / identity-
   // keyed children whose path glues the index to its key inside ONE dot-segment
-  // (`Policies[MyPol].PolicyName`, `Statement[0].Condition`, `Tags[env]`). Walk ancestor
-  // paths by trimming at each `.` OR `[` boundary (not just `.`), so a rule `X.Policies`
-  // covers `X.Policies[MyPol].PolicyName` and `X.Statement` covers
-  // `X.Statement[0].Condition` — the dot-only split silently failed for bracket children.
+  // (`Policies[MyPol].PolicyName`, `Statement[0].Condition`, `Tags[env]`) AND deeper
+  // construct-path descendants across `/` (`MyApi/Res/Method.Prop` under `MyApi/Res`, or
+  // an `added` child whose id is an ARN full of `/`). Walk ancestor paths by trimming at
+  // each `.`, `[`, OR `/` boundary, so a rule `X.Policies` covers `X.Policies[MyPol].Name`,
+  // `X.Statement` covers `X.Statement[0].Condition`, and `MyApi/Res` covers its `/`-subtree
+  // — symmetric with the `.` case (the dot/bracket-only split silently failed across `/`).
   let t = target;
   while (true) {
-    const cut = Math.max(t.lastIndexOf('.'), t.lastIndexOf('['));
+    const cut = Math.max(t.lastIndexOf('.'), t.lastIndexOf('['), t.lastIndexOf('/'));
     if (cut <= 0) break;
     t = t.slice(0, cut);
     if (matchesPathGlob(pattern, t)) return true;

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -149,6 +149,9 @@ describe('applyIgnores', () => {
   it('a `Parent/*` rule matches a DIRECT construct-path child but NOT a deeper descendant (#842)', () => {
     // A `/` is a real construct-path segment boundary; `Parent/*` means "a direct child",
     // so it must not leak to arbitrarily deep descendants (`Parent/Child/Grandchild`).
+    // The rule is LEAF-PINNED (`Parent/*.Policies`): even after the ancestor walk crosses
+    // `/` (#903), no `/`-sliced ancestor of `Parent/Child/Grandchild.Policies` ever ends in
+    // `.Policies`, so the grandchild still stays drift — like the `*.DesiredCount` bound.
     const child: Finding = {
       tier: 'undeclared',
       logicalId: 'ChildAAAA',
@@ -169,6 +172,67 @@ describe('applyIgnores', () => {
     expect(ign([child], 'MyStack', cfg([p('Parent/*.Policies')]))[0]?.tier).toBe('ignored');
     // …but the deeper `Parent/Child/Grandchild` must stay drift (no cross-slash leak)
     expect(ign([grandchild], 'MyStack', cfg([p('Parent/*.Policies')]))[0]?.tier).toBe('undeclared');
+  });
+
+  it('an explicit parent rule covers a `/`-subtree leaf finding (#903 exact repro)', () => {
+    // The ancestor walk now trims at `/` too, so `MyApi/Res` covers `MyApi/Res/Method.Prop`
+    // — symmetric with the `.` behavior. Before #903 the walk never crossed `/`, so a rule
+    // on an explicit construct-path parent could not ignore a deeper child.
+    const leaf: Finding = {
+      tier: 'undeclared',
+      logicalId: 'MethodCCCC',
+      constructPath: 'MyStack/MyApi/Res/Method',
+      resourceType: 'AWS::ApiGateway::Method',
+      path: 'Prop',
+      actual: { x: 1 },
+    };
+    expect(ign([leaf], 'MyStack', cfg([p('MyApi/Res')]))[0]?.tier).toBe('ignored');
+  });
+
+  it('a bare parent rule covers a deeper `/`-subtree finding', () => {
+    // `MyApi` (no wildcard) covers its whole construct-path subtree via the walk.
+    const deep: Finding = {
+      tier: 'undeclared',
+      logicalId: 'DeepDDDD',
+      constructPath: 'MyStack/MyApi/Res/Method/Sub',
+      resourceType: 'AWS::ApiGateway::Method',
+      path: 'Prop',
+      actual: { x: 1 },
+    };
+    expect(ign([deep], 'MyStack', cfg([p('MyApi')]))[0]?.tier).toBe('ignored');
+  });
+
+  it('an `added` child whose id is an ARN with `/` is ignorable by its parent rule (#903)', () => {
+    // An `added` finding keys on the constructPath `<parent>/<CC-identifier>` with an EMPTY
+    // path; a load balancer listener's CC identifier is an ARN full of `/`. Before #903 the
+    // `/`-bounded `*` plus the never-cross-`/` walk left it un-ignorable by ANY wildcard.
+    const arnChild: Finding = {
+      tier: 'added',
+      logicalId:
+        'MyLb/arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-lb/50dc6c495c0c9188/f2f7dc8efc522ab2',
+      constructPath:
+        'MyStack/MyLb/arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-lb/50dc6c495c0c9188/f2f7dc8efc522ab2',
+      resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+      path: '',
+    };
+    // ignorable by the bare parent rule…
+    expect(ign([arnChild], 'MyStack', cfg([p('MyLb')]))[0]?.tier).toBe('ignored');
+    // …and by the `*`-suffixed parent rule (deep coverage comes via the walk, like `.`)
+    expect(ign([arnChild], 'MyStack', cfg([p('MyLb/*')]))[0]?.tier).toBe('ignored');
+  });
+
+  it('a leaf-pinned `MyApi/*.Prop` rule does NOT ignore a grandchild `.Prop` (#842 spirit)', () => {
+    // Symmetric with `*.DesiredCount`: a wildcard with a `.Prop` leaf only matches a DIRECT
+    // child's `.Prop`, never a deeper `/`-descendant's — even after the walk crosses `/`.
+    const grandchild: Finding = {
+      tier: 'undeclared',
+      logicalId: 'GrandEEEE',
+      constructPath: 'MyStack/MyApi/Res/Method',
+      resourceType: 'AWS::ApiGateway::Method',
+      path: 'Prop',
+      actual: { x: 1 },
+    };
+    expect(ign([grandchild], 'MyStack', cfg([p('MyApi/*.Prop')]))[0]?.tier).toBe('undeclared');
   });
 
   it('a parent rule still covers a deep same-named leaf via the ancestor walk (no under-match)', () => {


### PR DESCRIPTION
Closes #903.

## Root cause
Ignore-rule matching (`applyIgnores` → `pathMatches`) walks a finding's ancestor paths so a parent rule covers its subtree. But the walk trimmed only at `.` and `[`, never `/`. Since within-stack construct paths and `added`-child ids are `/`-joined, this had two failures:

- An explicit parent rule `MyApi/Res` could NOT cover a deeper leaf `MyApi/Res/Method.Prop` — even though the dot-analog (`Tbl.Config` covering `Tbl.Config.DesiredCount`) worked.
- An `added` child whose CC identifier is an ARN full of `/` (e.g. an ELBv2 listener) was un-ignorable by ANY wildcard: `MyLb`, `MyLb/*`, `MyLb/arn:*` all failed, because `*` is bounded at `/` and the walk never crossed `/`.

## Fix
`src/config/config-file.ts` — add `t.lastIndexOf('/')` to the `Math.max(...)` cut in the ancestor walk so it ALSO trims at `/`. A parent rule now covers its `/`-subtree, symmetric with the `.`/`[` behavior (and this is what makes an `added` ARN-id child ignorable by its parent rule). Doc comment updated to match.

`matchesPathGlob`'s CODE is unchanged — its `/`-bound stays, so a bare `MyApi/*` still matches only ONE direct segment directly; deep coverage comes via the walk, exactly like `.`. Only the stale parenthetical comment (glob-match.ts) and the README ignore-glob paragraph were corrected to state the walk trims at `.`, `[`, or `/`.

## #842 stays green
The existing #842 test uses a LEAF-PINNED rule `Parent/*.Policies`. After the walk crosses `/`, no `/`-sliced ancestor of `Parent/Child/Grandchild.Policies` ends in `.Policies`, so the grandchild still stays drift — assertions unchanged (only the comment was refined to note the leaf-pinning distinction), consistent with the `*.DesiredCount` bound.

## Tests (fail without the fix, pass with it)
- explicit parent rule `MyApi/Res` ignores `MyApi/Res/Method` + `path: Prop` (the issue's exact repro)
- bare parent rule `MyApi` covers a deeper `/`-subtree finding
- an `added` ARN-id child (empty path) is ignored by `MyLb` AND `MyLb/*`
- negative: leaf-pinned `MyApi/*.Prop` does NOT ignore a grandchild's `.Prop` (#842 spirit)

Full suite: 81 files, 3459 tests pass.
