### PR TITLE
fix(read): ClientVPN endpoint-not-found → deleted tier (#966)

### DIFF
--- a/src/aws-errors.ts
+++ b/src/aws-errors.ts
@@ -81,6 +81,8 @@ export function classifyStackStatus(status: string | undefined): {
 //   EC2 EIP             : InvalidAllocationID.NotFound / InvalidAddress.NotFound
 //   EC2 LaunchTemplate  : InvalidLaunchTemplateId.NotFound (deleted launch template)
 //   EC2 NetworkAcl      : InvalidNetworkAclID.NotFound (NACL of a NetworkAclEntry deleted)
+//   EC2 ClientVPN       : InvalidClientVpnEndpointId.NotFound (endpoint of a deleted
+//                         Client VPN endpoint — its Describe{AuthorizationRules,TargetNetworks} children)
 //   Glue                : EntityNotFoundException (GetTable on a deleted table/db)
 //   DMS                 : ResourceNotFoundFault (Describe{Endpoints,ReplicationSubnetGroups})
 //   DAX                 : ClusterNotFoundFault / ParameterGroupNotFoundFault /
@@ -109,6 +111,11 @@ const NOT_FOUND_ERROR_NAMES = new Set([
   'InvalidLaunchTemplateId.NotFound',
   // EC2 DescribeNetworkAcls on a deleted NACL (readEc2NetworkAclEntry's parent NACL).
   'InvalidNetworkAclID.NotFound',
+  // EC2 ClientVPN DescribeClientVpnAuthorizationRules / DescribeClientVpnTargetNetworks on a
+  // deleted Client VPN endpoint (#534 added the readers, #966 folds their not-found → deleted).
+  // The association code (InvalidClientVpnAssociationId.NotFound) is a live-probe follow-up:
+  // unconfirmed against the AWS docs, so left out until a real probe surfaces it.
+  'InvalidClientVpnEndpointId.NotFound',
   'EntityNotFoundException',
   // DocumentDB describe-db-clusters / describe-db-instances on a deleted target.
   'DBClusterNotFoundFault',

--- a/tests/aws-errors.test.ts
+++ b/tests/aws-errors.test.ts
@@ -23,6 +23,7 @@ describe('isResourceNotFoundError', () => {
       'InvalidAddress.NotFound', // EC2 EIP
       'InvalidLaunchTemplateId.NotFound', // EC2 DescribeLaunchTemplateVersions (deleted template)
       'InvalidNetworkAclID.NotFound', // EC2 DescribeNetworkAcls (deleted NACL of a NetworkAclEntry)
+      'InvalidClientVpnEndpointId.NotFound', // EC2 ClientVPN Describe{AuthorizationRules,TargetNetworks} (deleted endpoint) (#966)
       'EntityNotFoundException', // Glue GetTable on a deleted table/db
       'DBClusterNotFoundFault', // DocumentDB describe-db-clusters
       'DBInstanceNotFoundFault', // DocumentDB describe-db-instances


### PR DESCRIPTION
Closes #966.

`NOT_FOUND_ERROR_NAMES` in `src/aws-errors.ts` maps per-service not-found error codes to the `deleted` tier. The ClientVPN family (endpoint-scoped child readers added by #534) was missed: an out-of-band-deleted Client VPN endpoint made `DescribeClientVpnAuthorizationRules` / `DescribeClientVpnTargetNetworks` throw `InvalidClientVpnEndpointId.NotFound`, which the router's override catch treated as `skipped` (footer-only, excluded from `--fail`) instead of `deleted`. VPN access infra could be torn down while `check --fail` stayed green.

## Change
- Add the documented `InvalidClientVpnEndpointId.NotFound` code to `NOT_FOUND_ERROR_NAMES`, near the other EC2 id-scoped codes, with a matching per-service comment and the doc-block line.
- Unit test in `tests/aws-errors.test.ts` asserts the code classifies as not-found (mapped to the `deleted` tier).

## Deferred
- The association code `InvalidClientVpnAssociationId.NotFound` is unconfirmed against the AWS docs, so it is intentionally left out (noted inline as a live-probe follow-up).
- The endpoint-reader throw-vs-empty behaviour is a live-probe follow-up; the child readers are the proven throwing case handled here.
