### PR TITLE
docs(limitations): AnomalyDetector + VPCCidrBlock are shipped, not skipped (#970)

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -68,11 +68,8 @@ the full design.
   Known CC-unreadable common types with no SDK override yet (all surface as
   `skipped`, never false drift): ACM `Certificate` and ELBv2
   `ListenerCertificate` (also impractical to live-test — ACM validation blocks
-  the create); CloudWatch `AnomalyDetector` and `InsightRule` (SDK-override
-  candidates); and `AWS::EC2::VPCCidrBlock` (composite `[Id, VpcId]` id whose
-  CFn physical id is only the child segment — an adapter candidate, though it is
-  an immutable association, so nothing can drift). Coverage gaps, not false
-  negatives.
+  the create); and CloudWatch `InsightRule` (an SDK-override candidate). Coverage
+  gaps, not false negatives.
 - **Non-ASCII template literals.** CloudFormation's `GetTemplate` (cdkrd's
   declared source) returns every non-ASCII character in a stored string literal
   as a literal `?` — so a declared value like an `AWS::SSM::Parameter`


### PR DESCRIPTION
Closes #970.

The "Unsupported / unreadable types" bullet in docs/limitations.md listed two types as uncovered that have actually shipped:

- **AWS::CloudWatch::AnomalyDetector** — read via the `readCloudWatchAnomalyDetector` SDK override (registered in `src/read/overrides.ts`) and revertable via `writeCloudWatchAnomalyDetector` (`src/revert/writers.ts`). README documents its IAM perms.
- **AWS::EC2::VPCCidrBlock** — checked via a `CC_IDENTIFIER_ADAPTERS` entry (`src/read/router.ts`, composite `Id|VpcId` id), with its ipv6 first-run noise folded in `src/normalize/noise.ts`.

Dropped both from the list. Kept the two claims still true at HEAD:
- ACM `Certificate` and ELBv2 `ListenerCertificate` (no reader).
- CloudWatch `InsightRule` (genuinely uncovered).

Docs-only change.