### PR TITLE
fix(noise): move ScheduledAction EndTime fold from tier-3 to tier-1 constant (#946)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -1124,6 +1124,18 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
   'AWS::AutoScaling::WarmPool': {
     MinSize: 0,
   },
+  // A scheduled action that sets no end time reads back the literal string "null" — a
+  // serialized-null artifact from the SDK/CC read, a stable CONSTANT (not time-varying),
+  // so equality-gate it as a tier-1 default rather than value-independent (#946). Folding
+  // the exact "null" keeps a clean first-run zero-noise (#847), while ANY real EndTime a
+  // user (or an out-of-band `put-scheduled-update-group-action`) sets no longer matches
+  // "null" and surfaces as undeclared drift — a scheduled scaling action that silently
+  // expires is exactly the divergence we must catch. StartTime stays value-independent
+  // (see VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS): its next-occurrence is genuinely
+  // time-varying and cannot be pinned to a constant.
+  'AWS::AutoScaling::ScheduledAction': {
+    EndTime: 'null',
+  },
   'AWS::DocDB::DBCluster': {
     Port: 27017, // DocDB's fixed default port
     // DocumentDB's documented default backup retention (1 day) — surfaced as undeclared
@@ -2924,7 +2936,7 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   the ARN carries the machine's generated name segment). Not user intent when undeclared —
   //   fold value-independent. Live, hunt 2026-07-08 (#628).
   'AWS::StepFunctions::StateMachineAlias': new Set(['StateMachineArn']),
-  //   AWS::AutoScaling::ScheduledAction.StartTime / .EndTime — a scheduled action that declares
+  //   AWS::AutoScaling::ScheduledAction.StartTime — a scheduled action that declares
   //   a `Recurrence` (a cron expression) but no explicit `StartTime` reads back the concrete
   //   timestamp of the NEXT occurrence AWS computed from that recurrence (e.g. declared
   //   "0 9 * * MON-FRI" → live StartTime "2026-06-22T09:00:00Z"). It is UNDECLARED and
@@ -2932,11 +2944,11 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   `record` — a constant cannot pin it and it is not a stable function of the declared inputs
   //   (it depends on the wall-clock time of the read). Fold value-independent: whatever AWS
   //   computes is not user intent; a user who wants a specific StartTime DECLARES it, and it is
-  //   then compared in the declared loop. `EndTime` reads back the literal string "null" when no
-  //   end time is set (a serialized-null artifact from the SDK/CC read) — folding it here strips
-  //   that cosmetic stringified null. A DECLARED EndTime goes through the declared loop, compared.
-  //   Live, hunt 2026-07-09 (#847).
-  'AWS::AutoScaling::ScheduledAction': new Set(['StartTime', 'EndTime']),
+  //   then compared in the declared loop. `EndTime` is NOT here: its only default artifact is the
+  //   stable constant string "null" (the SDK/CC serialized-null when no end time is set), so it is
+  //   folded as an equality-gated tier-1 KNOWN_DEFAULTS entry instead — a real out-of-band EndTime
+  //   timestamp then surfaces rather than folding to any value (#946). Live, hunt 2026-07-09 (#847).
+  'AWS::AutoScaling::ScheduledAction': new Set(['StartTime']),
 };
 
 // R142: true when `value` equals a `|`/`:`/`/`-separated SEGMENT of the physical id.

--- a/tests/noise-firstrun-folds.test.ts
+++ b/tests/noise-firstrun-folds.test.ts
@@ -301,4 +301,11 @@ describe('#847 AutoScaling ScheduledAction StartTime / EndTime (undeclared, time
     expect(pathsByTier(f, 'atDefault')).toContain('EndTime');
     expect(pathsByTier(f, 'undeclared')).not.toContain('EndTime');
   });
+  it('surfaces a real out-of-band EndTime timestamp (not value-independent) (#946)', () => {
+    // A real end time set out of band (the scheduled action silently expires) must NOT fold:
+    // EndTime is a tier-1 equality-gated "null" constant, so any other value surfaces.
+    const f = classifyResource(res, { EndTime: '2026-07-10T00:00:00Z' }, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('EndTime');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('EndTime');
+  });
 });


### PR DESCRIPTION
Closes #946

`AWS::AutoScaling::ScheduledAction` `EndTime` was folded via
`VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (tier-3, folds ANY value), but its only
default artifact is the stable constant string `"null"` — a textbook tier-1
equality-gated default. Tier-3 misuse meant a REAL out-of-band `EndTime` timestamp
(a scheduled scaling action silently expiring forever) was permanently invisible.

## Change
- Removed `EndTime` from `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (kept `StartTime`,
  whose AWS-computed next-occurrence is genuinely time-varying — a legit tier-3).
- Added `'AWS::AutoScaling::ScheduledAction': { EndTime: 'null' }` to `KNOWN_DEFAULTS`
  (tier-1 equality gate). `'null'` is not trivial-empty, so it survives the
  `isTrivialEmpty` pre-gate.
- Updated the justifying comments on both entries.

## Effect
- `EndTime === 'null'` still folds to `atDefault` → first-run stays zero-noise
  (#847 goal preserved; corpus expected unchanged).
- Any OTHER `EndTime` value (a real timestamp) now SURFACES as undeclared/potential drift.

## Tests
`tests/noise-firstrun-folds.test.ts`:
- Kept: undeclared `EndTime: 'null'` → `atDefault`.
- Added: undeclared `EndTime: '2026-07-10T00:00:00Z'` → `undeclared` (surfaces).
  Verified this new case FAILS on main behavior and PASSES with the fix.

All gates green: typecheck, lint+format, build, 3471 unit tests.