### PR TITLE
fix(config): re-validate rules in addIgnoreRules before writing (#991)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -220,10 +220,16 @@ export function ignoreRuleFor(
   accountId = '',
   region = ''
 ): IgnoreRuleObject {
-  const id =
+  const withinStack =
     finding.constructPath && finding.tier !== 'added'
       ? withinStackPath(finding.constructPath, stackName)
       : finding.logicalId;
+  // `withinStackPath` returns '' when the construct path is the stack root itself
+  // (`'MyStack/'` -> ''); with an empty `finding.path` that would strip the id to '' and
+  // yield `rule.path === ''` — the exact empty-path poison pill `loadConfig` rejects
+  // (issue #991). Fall back to `logicalId` (the CloudFormation key, ALWAYS present and
+  // non-empty) so the id — and thus the rule path — can never be empty.
+  const id = withinStack || finding.logicalId;
   // A finding path can legitimately CONTAIN a literal `*` / `?`: an API Gateway
   // `MethodSettings[*]` bracket key (from `HttpMethod: '*'`), an S3 lifecycle `Id`
   // like `clean*tmp`, a free-form Glue/ECS map key. Written verbatim, the glob matcher
@@ -331,6 +337,15 @@ export async function addIgnoreRules(
 ): Promise<{ path: string; added: IgnoreRuleObject[]; alreadyPresent: IgnoreRuleObject[] }> {
   const config = await loadConfig(); // validates first — a malformed file throws, not overwritten
   const { added, alreadyPresent } = mergeIgnoreRules(config.ignore, newRules);
+  // Re-validate the rules we are ABOUT to write with the SAME guards `loadConfig` applies
+  // on read (`validateIgnoreEntry`: empty-path + `isUniversalPath` + typed keys). This is
+  // the write-side twin of the read-side fail-fast: without it, a rule whose `path` is
+  // empty (`""`) or an all-wildcard universal pattern (`"*/*"`, `"**"`) would be written
+  // silently, then detonate (exit 2) on the NEXT `loadConfig` — which every verb calls —
+  // permanently bricking the file, i.e. the user's own `ignore` silently disables the
+  // tool (issue #991). Fail fast BEFORE writeFile so `ignore` can never write a poison
+  // pill (also self-guards a hand-authored bad rule appended through the verb).
+  added.forEach((rule, i) => validateIgnoreEntry(rule, i));
   // Only touch disk when something actually changed — an all-already-present run leaves
   // the file (and its git status) untouched.
   if (added.length > 0) {

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -645,6 +645,20 @@ describe('ignoreRuleFor', () => {
     expect(ignoreRuleFor(declared('ApiRole', 'Policies'))).toEqual({ path: 'ApiRole.Policies' });
   });
 
+  it('falls back to logicalId when the within-stack path strips to empty (stack-root construct path) (#991)', () => {
+    // `withinStackPath('MyStack/', 'MyStack')` returns '' — with an empty finding path that
+    // would strip the id to '' and produce `rule.path === ''`, the empty-path poison pill.
+    const f: Finding = {
+      tier: 'undeclared',
+      logicalId: 'ApiRole1234ABCD',
+      constructPath: 'MyStack/',
+      resourceType: 'AWS::IAM::Role',
+      path: '',
+    };
+    // the id falls back to the always-present logicalId, so the path is never empty
+    expect(ignoreRuleFor(f, 'MyStack')).toEqual({ path: 'ApiRole1234ABCD', stack: 'MyStack' });
+  });
+
   it('omits the trailing dot for a resource-level (empty path) finding', () => {
     const f: Finding = {
       tier: 'declared',
@@ -844,6 +858,29 @@ describe('addIgnoreRules', () => {
     expect(r.alreadyPresent).toEqual([p('A.y')]);
     // not rewritten — the original bytes survive (comments + layout intact)
     expect(await readFile('.cdkrd/ignore.yaml', 'utf8')).toBe(original);
+  });
+
+  it('REJECTS a universal ("*/*") rule before writing — no poison pill, next loadConfig stays clean (#991)', async () => {
+    await expect(addIgnoreRules([p('*/*', { stack: 'MyStack' })])).rejects.toThrow(/all-wildcard/);
+    // the write-side guard fired BEFORE writeFile, so the file was never created / bricked
+    await expect(loadConfig()).resolves.toEqual({ ignore: [] });
+  });
+
+  it('REJECTS an empty-path ("") rule before writing — no poison pill (#991)', async () => {
+    await expect(addIgnoreRules([p('', { stack: 'MyStack' })])).rejects.toThrow(
+      /must not be empty/
+    );
+    await expect(loadConfig()).resolves.toEqual({ ignore: [] });
+  });
+
+  it('a bad rule does not clobber an existing valid config (rejected before writeFile) (#991)', async () => {
+    await mkdir('.cdkrd', { recursive: true });
+    const original = 'ignore:\n  - path: Good.x\n';
+    await writeFile('.cdkrd/ignore.yaml', original, 'utf8');
+    await expect(addIgnoreRules([p('**')])).rejects.toThrow(/all-wildcard/);
+    // original bytes untouched, config still loads
+    expect(await readFile('.cdkrd/ignore.yaml', 'utf8')).toBe(original);
+    expect((await loadConfig()).ignore).toEqual([{ path: 'Good.x' }]);
   });
 
   it('writes the scope keys in canonical order (path, stack, account, region)', async () => {


### PR DESCRIPTION
Closes #991

`addIgnoreRules` (the only config-mutating entry point — the `ignore` verb + check's inline ignore) validated the EXISTING file via `loadConfig` but never ran `validateIgnoreEntry` on the rules it was about to write. So a rule with an empty (`""`) or all-wildcard universal (`"*/*"`, `"**"`) path was written silently, then detonated (exit 2) on the NEXT `loadConfig` — which every verb calls — permanently bricking the file. The user's own `ignore` silently disabled the tool.

Fix:
- `addIgnoreRules` now runs the merged `added` rules through the SAME `validateIgnoreEntry` guards `loadConfig` applies on read (empty-path + `isUniversalPath` + typed keys) and THROWS before `writeFile` — the write-side twin of the existing read-side fail-fast. No more silent self-brick; a rejected write never touches disk, so an existing valid config is preserved.
- `ignoreRuleFor` now falls back to the always-present `logicalId` when `withinStackPath` strips the id to empty (a stack-root construct path like `'MyStack/'`), so it can never produce an empty `rule.path` in the first place.

Tests (fail on main, pass with fix): universal (`*/*`) and empty (`""`) rules are rejected before writing (a subsequent `loadConfig` stays clean); a bad rule does not clobber an existing valid config; `ignoreRuleFor` empty-id fallback to logicalId.

Gates: typecheck / lint+format / build / unit (3474) all green.