### PR TITLE
fix(synth): recursive nested-assembly missing-context aggregation (#987)

### DIFF
--- a/src/synth/missing-context.ts
+++ b/src/synth/missing-context.ts
@@ -14,6 +14,33 @@ export interface MissingContextEntry {
   readonly key: string;
 }
 
+/**
+ * Minimal structural shape of a cx-api `CloudAssembly` for missing-context aggregation. A CDK
+ * app that nests stacks inside a `Stage` synthesizes each Stage into its OWN nested assembly
+ * (`assembly-<Stage>/manifest.json`) carrying its own `missing` array; the top-level manifest's
+ * `missing` does NOT include them. We only need the per-assembly `manifest.missing` plus the
+ * recursion edge into nested assemblies (each `NestedCloudAssemblyArtifact.nestedAssembly`).
+ */
+export interface CloudAssemblyLike {
+  readonly manifest: { readonly missing?: readonly MissingContextEntry[] | undefined };
+  readonly nestedAssemblies: readonly { readonly nestedAssembly: CloudAssemblyLike }[];
+}
+
+/**
+ * Collect `missing` context entries across the top-level assembly AND every nested assembly
+ * (recursively — a Stage-in-Stage app nests arbitrarily deep). Mirrors how `stacksRecursively`
+ * descends `nestedAssemblies` so a dummy `vpc-12345` lookup inside a staged stack is not missed
+ * (#987 — the top-level-only read in #907 let one slip past `--pre-deploy`). Concatenates each
+ * assembly's raw entries; dedup/sort is left to `missingContextKeys`.
+ */
+export function collectMissingRecursively(assembly: CloudAssemblyLike): MissingContextEntry[] {
+  const out: MissingContextEntry[] = [...(assembly.manifest.missing ?? [])];
+  for (const nested of assembly.nestedAssemblies) {
+    out.push(...collectMissingRecursively(nested.nestedAssembly));
+  }
+  return out;
+}
+
 /** Unique, sorted missing-context keys (dedup by key). Empty array when nothing is missing. */
 export function missingContextKeys(missing: readonly MissingContextEntry[] | undefined): string[] {
   if (!missing || missing.length === 0) return [];

--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -6,7 +6,11 @@ import { existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { BaseCredentials, CdkAppMultiContext, Toolkit } from '@aws-cdk/toolkit-lib';
 import { QuietIoHost } from './io-host.js';
-import { missingContextKeys, missingContextWarning } from './missing-context.js';
+import {
+  collectMissingRecursively,
+  missingContextKeys,
+  missingContextWarning,
+} from './missing-context.js';
 
 export interface SynthOptions {
   region?: string | undefined;
@@ -75,7 +79,12 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
     // placeholders does not reflect real infrastructure. Always warn on discovery; under
     // `--pre-deploy` (synth template = declared source) REFUSE, because the fabricated
     // values would drive false declared drift and a revert would write them back to AWS.
-    const missingKeys = missingContextKeys(cached.cloudAssembly.manifest.missing);
+    // Aggregate `missing` RECURSIVELY across nested-Stage assemblies (mirroring the
+    // `stacksRecursively` descent below): a stack nested inside a CDK `Stage` records its
+    // unresolved lookups in its OWN nested manifest, not the top-level one, so a
+    // top-level-only read would let a dummy `vpc-12345` inside a staged stack slip past
+    // `--pre-deploy` — reintroducing exactly the false declared drift #907 blocks (#987).
+    const missingKeys = missingContextKeys(collectMissingRecursively(cached.cloudAssembly));
     if (missingKeys.length > 0) {
       const msg = missingContextWarning(missingKeys, { preDeploy: opts.preDeploy });
       if (opts.preDeploy) throw new Error(msg ?? 'unresolved CDK context lookups');

--- a/tests/missing-context-907.test.ts
+++ b/tests/missing-context-907.test.ts
@@ -5,9 +5,21 @@
 // would write vpc-12345 back). These tests pin the pure helpers that drive the new surface:
 // a warning on discovery, an escalated REFUSAL under --pre-deploy.
 import { describe, expect, it } from 'vite-plus/test';
-import { missingContextKeys, missingContextWarning } from '../src/synth/missing-context.js';
+import type { CloudAssemblyLike } from '../src/synth/missing-context.js';
+import {
+  collectMissingRecursively,
+  missingContextKeys,
+  missingContextWarning,
+} from '../src/synth/missing-context.js';
 
 const entry = (key: string) => ({ key, provider: 'vpc-provider', props: {} });
+
+// Build a CloudAssembly-shaped stub (structural — mirrors cx-api's `manifest.missing` +
+// `nestedAssemblies[].nestedAssembly`) for the recursive-aggregation tests (#987).
+const asm = (missing: { key: string }[], nested: CloudAssemblyLike[] = []): CloudAssemblyLike => ({
+  manifest: { missing },
+  nestedAssemblies: nested.map((nestedAssembly) => ({ nestedAssembly })),
+});
 
 describe('missingContextKeys (#907)', () => {
   it('is empty for undefined / empty missing (a clean assembly)', () => {
@@ -54,5 +66,42 @@ describe('missingContextWarning (#907)', () => {
 
   it('returns null under --pre-deploy too when nothing is missing (no false refusal)', () => {
     expect(missingContextWarning([], { preDeploy: true })).toBeNull();
+  });
+});
+
+describe('collectMissingRecursively (#987)', () => {
+  it('returns the top-level assembly missing entries (no nested assemblies)', () => {
+    const found = collectMissingRecursively(asm([entry('vpc-provider:top')]));
+    expect(found.map((m) => m.key)).toEqual(['vpc-provider:top']);
+  });
+
+  it('is empty for a clean assembly (no missing, no nested)', () => {
+    expect(collectMissingRecursively(asm([]))).toEqual([]);
+  });
+
+  it('descends into a nested-Stage assembly whose missing the top-level omits (#987)', () => {
+    // The Stage's stack records its unresolved lookup in the NESTED manifest; the top-level
+    // manifest is empty. A top-level-only read (the #907 guard) would miss it entirely.
+    const found = collectMissingRecursively(asm([], [asm([entry('vpc-provider:inside-stage')])]));
+    expect(found.map((m) => m.key)).toEqual(['vpc-provider:inside-stage']);
+  });
+
+  it('aggregates across a deeply-nested (Stage-in-Stage) topology', () => {
+    const found = collectMissingRecursively(
+      asm(
+        [entry('vpc-provider:top')],
+        [
+          asm([entry('vpc-provider:stage1')], [asm([entry('availability-zones:stage1.stage2')])]),
+          asm([entry('vpc-provider:stage2')]),
+        ]
+      )
+    );
+    // Feeding through missingContextKeys dedups + sorts — the real synth.ts wiring.
+    expect(missingContextKeys(found)).toEqual([
+      'availability-zones:stage1.stage2',
+      'vpc-provider:stage1',
+      'vpc-provider:stage2',
+      'vpc-provider:top',
+    ]);
   });
 });


### PR DESCRIPTION
Closes #987. Follow-up to #907/#938.

## Root cause
The #907 `--pre-deploy` guard in `src/synth/synth.ts` read only the top-level manifest:
```ts
const missingKeys = missingContextKeys(cached.cloudAssembly.manifest.missing);
```
A CDK app that nests stacks inside a `Stage` synthesizes each Stage into a NESTED assembly (`assembly-<Stage>/manifest.json`) with its OWN `missing` array. The guard never descended into `nestedAssemblies`, so a dummy `vpc-12345` lookup inside a staged stack slipped past `--pre-deploy` — reintroducing the exact false declared drift #907 blocks. This is the same nested-Stage topology the code one block below already handles via `stacksRecursively` (not `stacks`).

## Fix
Add a pure `collectMissingRecursively(cloudAssembly)` helper in `src/synth/missing-context.ts` that walks `nestedAssemblies[].nestedAssembly` recursively (mirroring the `stacksRecursively` descent) and concatenates each assembly's `manifest.missing`, then feed its result into the existing `missingContextKeys` in `synth.ts` (replacing the top-level-only read). `missingContextKeys` / `missingContextWarning` are untouched, so all #907 unit tests still pass. Accessors used: `manifest.missing`, `get nestedAssemblies()`, and `NestedCloudAssemblyArtifact.nestedAssembly` (confirmed against `@aws-cdk/cloud-assembly-api` d.ts + typecheck).

## Tests
Added a `collectMissingRecursively (#987)` suite in `tests/missing-context-907.test.ts` using the same pure-helper stub style: top-level-only, clean assembly, a nested-Stage case where the top level is empty but the nested assembly carries the entry (fails without the fix), and a deeply-nested Stage-in-Stage aggregation fed through `missingContextKeys`.

Gates green: typecheck (0 errors), lint/format, build, 3474 tests across 83 files.
