### PR TITLE
fix(diff): derive partition from shared partitionForRegion in classify.ts (#945)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -7,6 +7,7 @@
 //
 // Pure: no AWS calls. liveRaw is the CC API GetResource model (un-stripped).
 
+import { partitionForRegion } from '../desired/template-adapter.js';
 import {
   isArnNameMatch,
   isLogGroupArnWildcardMatch,
@@ -1460,11 +1461,9 @@ export function classifyResource(
   // the Sid / Id, so the compared shape is the single {Effect,Principal,Action,Resource}
   // statement (matching the KMS corpus). A policy scoped to anything else still surfaces.
   if (resourceType === 'AWS::KMS::Key' && opts.accountId !== undefined) {
-    const partition = opts.region?.startsWith('cn-')
-      ? 'aws-cn'
-      : opts.region?.startsWith('us-gov-')
-        ? 'aws-us-gov'
-        : 'aws';
+    // Derive the partition from the single canonical helper so every partition it supports
+    // (incl. the four ISO partitions) folds identically (#945). Unknown region → `aws` (as before).
+    const partition = opts.region !== undefined ? partitionForRegion(opts.region).partition : 'aws';
     // Build the RAW default policy and run it through the SAME canonicalization the live
     // side gets, so the two match regardless of canonicalization details (array-wrapping,
     // root-ARN reduction to the account id, key ordering).
@@ -1504,11 +1503,9 @@ export function classifyResource(
     // does not false-drift on every statement. Re-canonicalize so the expanded Resource arrays
     // sort identically to the live side. Needs the api id (physicalId) + account + region.
     if (physicalId && opts.accountId !== undefined && declared['Policy']) {
-      const partition = opts.region?.startsWith('cn-')
-        ? 'aws-cn'
-        : opts.region?.startsWith('us-gov-')
-          ? 'aws-us-gov'
-          : 'aws';
+      // Canonical partition helper (#945): folds ISO partitions too. Unknown region → `aws`.
+      const partition =
+        opts.region !== undefined ? partitionForRegion(opts.region).partition : 'aws';
       const arnPrefix = `arn:${partition}:execute-api:${opts.region ?? ''}:${opts.accountId}:${physicalId}`;
       declared['Policy'] = canonicalizePolicy(
         expandExecuteApiResources(declared['Policy'], arnPrefix) as Record<string, unknown>
@@ -2436,11 +2433,8 @@ export function classifyResource(
       opts.accountId !== undefined &&
       typeof v === 'string'
     ) {
-      const partition = opts.region.startsWith('cn-')
-        ? 'aws-cn'
-        : opts.region.startsWith('us-gov-')
-          ? 'aws-us-gov'
-          : 'aws';
+      // Canonical partition helper (#945): folds ISO partitions too. region is defined here.
+      const partition = partitionForRegion(opts.region).partition;
       const ctxArnDefault = ctxArnTemplate
         .replace('{partition}', partition)
         .replace('{region}', opts.region)

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1097,6 +1097,16 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(
       t({ Scope: 'arn:aws-cn:iam::111111111111:root' }, { ...opts, region: 'cn-north-1' }).atDefault
     ).toEqual(['Scope']);
+    // #945: ISO partitions must fold too (the CONTEXT_ARN_DEFAULTS {partition} substitution now
+    // derives from partitionForRegion, not the old cn-/us-gov--only ternary that fell back to aws)
+    expect(
+      t({ Scope: 'arn:aws-iso:iam::111111111111:root' }, { ...opts, region: 'us-iso-east-1' })
+        .atDefault
+    ).toEqual(['Scope']);
+    expect(
+      t({ Scope: 'arn:aws-iso-e:iam::111111111111:root' }, { ...opts, region: 'eu-isoe-west-1' })
+        .atDefault
+    ).toEqual(['Scope']);
     // with no resolved account/region the substitution is skipped → stays undeclared, never a
     // wrong fold
     expect(t({ Scope: 'arn:aws:iam::111111111111:root' }).undeclared).toEqual(['Scope']);
@@ -1167,6 +1177,19 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     expect(tiers(classifyResource(res, mkLive(arn), emptySchema)).declared.length).toBeGreaterThan(
       0
     );
+    // #945: in an ISO region the service echoes `arn:aws-iso*:execute-api:...`; the expansion must
+    // build the matching partition prefix (via partitionForRegion) so the fold still lands. Before
+    // the fix the cn-/us-gov--only ternary fell back to `arn:aws:` → a first-check false drift.
+    for (const [region, partition] of [
+      ['us-iso-east-1', 'aws-iso'],
+      ['eu-isoe-west-1', 'aws-iso-e'],
+    ]) {
+      const isoOpts = { accountId: '111111111111', region };
+      const isoArn = `arn:${partition}:execute-api:${region}:111111111111:${apiId}/*`;
+      expect(tiers(classifyResource(res, mkLive(isoArn), emptySchema, isoOpts)).declared).toEqual(
+        []
+      );
+    }
   });
 
   it('#705: Classic ELB Policies folds ONLY the default SSL policy; a downgrade / added policy surfaces', () => {

--- a/tests/noise-701-folds.test.ts
+++ b/tests/noise-701-folds.test.ts
@@ -195,4 +195,33 @@ describe('#701 KMS default KeyPolicy derived from the account root', () => {
       tier(classifyResource(res, { KeyPolicy: scoped }, emptySchema, opts), 'undeclared')
     ).toContain('KeyPolicy');
   });
+  // #945: the KMS site now derives the partition from the canonical partitionForRegion helper
+  // (folds the ISO partitions the old cn-/us-gov--only ternary missed). Note the root-ARN
+  // principal is already partition-tolerant — policy-canonical reduces `arn:aws*:iam::<acct>:root`
+  // to the bare account id — so this fold landed even before the fix; this guards that ISO regions
+  // stay ZERO potential drift on the default KeyPolicy regardless of the built prefix.
+  it.each([
+    ['us-iso-east-1', 'aws-iso'],
+    ['eu-isoe-west-1', 'aws-iso-e'],
+  ])('folds the ISO-partition default root policy in %s (partition %s)', (region, partition) => {
+    const isoPolicy = {
+      Version: '2012-10-17',
+      Id: 'key-default-1',
+      Statement: [
+        {
+          Sid: 'Enable IAM User Permissions',
+          Effect: 'Allow',
+          Principal: { AWS: `arn:${partition}:iam::111111111111:root` },
+          Action: 'kms:*',
+          Resource: '*',
+        },
+      ],
+    };
+    const f = classifyResource(res, { KeyPolicy: isoPolicy }, emptySchema, {
+      accountId: '111111111111',
+      region,
+    });
+    expect(tier(f, 'atDefault')).toContain('KeyPolicy');
+    expect(tier(f, 'undeclared')).not.toContain('KeyPolicy');
+  });
 });


### PR DESCRIPTION
Closes #945

Replaced the three copy-pasted `cn-`/`us-gov-`-only partition ternaries in `src/diff/classify.ts` with the canonical 7-partition `partitionForRegion` helper (already exported by `src/desired/template-adapter.ts`, imported with the ESM `.js` extension). The three sites:

- **#701 KMS default KeyPolicy** root ARN
- **#676 execute-api shorthand expansion** ARN prefix
- **CONTEXT_ARN_DEFAULTS `{partition}` substitution**

now derive the partition identically, so every partition the helper supports (incl. the four ISO partitions `aws-iso`/`aws-iso-b`/`aws-iso-f`/`aws-iso-e`) folds — a clean ISO-region first `check` stays ZERO potential drift on the execute-api and CONTEXT_ARN_DEFAULTS paths.

The `opts.region === undefined` fall-through-to-`aws` behavior is preserved (guarded before the call at the two optional-region sites; the third site is already inside a `region !== undefined` guard). No import cycle: `desired/` imports nothing from `diff/`, and `revert/writers.ts` already imports the same helper.

### Tests
Parameterized the existing #701 / #676 / #626 tests over `us-iso-east-1` and `eu-isoe-west-1`:
- execute-api (#676) and ResourceExplorer2 CONTEXT_ARN (#626) ISO cases **fail on main** (wrong `arn:aws:` prefix → false [Potential Drift]) and **pass with the fix**.
- KMS (#701) ISO case is a fold-lands guarantee; its root-ARN principal is already partition-tolerant via policy canonicalization (`arn:aws*:iam::<acct>:root` reduces to the bare account id), so that site was a copy-paste hazard rather than a reachable FP — the test documents ISO stays clean.

Gates: typecheck / lint+format / build / 3472 unit tests all green.