### PR TITLE
fix(cli): close empty-JSON-on-error holes across all 4 verbs (#943, #988, #989)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,7 +128,8 @@ async function main(argv: string[]): Promise<number> {
   }
 }
 
-main(process.argv.slice(2))
+const argv = process.argv.slice(2);
+main(argv)
   .then((code) => flushAndExit(code))
   .catch((e: unknown) => {
     const msg = (e as { message?: string })?.message ?? String(e);
@@ -145,5 +146,11 @@ main(process.argv.slice(2))
     } else {
       console.error(`error: ${msg}`);
     }
+    // A throw that escapes a verb BEFORE it could emit its JSON — e.g. parseCommonArgs
+    // rejecting a bad flag at the top of run*, or check's --pre-deploy second synth — must
+    // still leave --json stdout a single JSON.parse-able value (`[]`), never empty bytes.
+    // The caught loadConfig/resolveStacks paths return a code (they don't reach here), so
+    // this central guard and those per-verb emits are mutually exclusive. (#943, #989)
+    if (argv.includes('--json')) console.log('[]');
     return flushAndExit(2);
   });

--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -29,6 +29,7 @@ export async function runIgnore(args: string[]): Promise<number> {
     config = await loadConfig();
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    if (a.json) emitJsonArray([]); // keep stdout a valid (empty) JSON array on a top-level error (#988)
     return 2;
   }
 

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -20,6 +20,7 @@ export async function runRecord(args: string[]): Promise<number> {
     config = await loadConfig();
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    if (a.json) emitJsonArray([]); // keep stdout a valid (empty) JSON array on a top-level error (#988)
     return 2;
   }
 

--- a/src/commands/revert.ts
+++ b/src/commands/revert.ts
@@ -29,6 +29,7 @@ export async function runRevert(args: string[]): Promise<number> {
     config = await loadConfig();
   } catch (e) {
     console.error(`error: ${(e as Error).message}`);
+    if (a.json) emitJsonArray([]); // keep stdout a valid (empty) JSON array on a top-level error (#988)
     return 2;
   }
 

--- a/tests/json-empty-on-error.test.ts
+++ b/tests/json-empty-on-error.test.ts
@@ -1,0 +1,89 @@
+// #943 / #988 / #989 — the "never empty bytes" JSON contract on a whole-run failure.
+// Under `--json`, every verb must leave stdout a single JSON.parse-able value (`[]`) even
+// when the run fails before any stack is reached, so a CI consumer's JSON.parse(stdout)
+// never throws on ''. Two failure classes were leaking empty stdout:
+//
+//   #943/#989: parseCommonArgs() runs at the TOP of each run*, OUTSIDE any try/catch, and
+//              throws on a bad flag. The throw escaped to cli.ts's main().catch, which had
+//              no --json awareness → empty stdout. Fixed centrally in cli.ts.
+//   #988:      each verb's FIRST early catch (loadConfig) forgot the `[]` emit the sibling
+//              resolveStacks catch already had. A malformed .cdkrd/ignore.yaml therefore
+//              left stdout empty. Fixed per-verb.
+//
+// Both live at the PROCESS level (the central catch is module-top-level in cli.ts; the
+// loadConfig throw needs a real bad config on disk), so we exercise the BUILT CLI end to
+// end — run `vp pack` before `vp test run`.
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+
+const CLI = fileURLToPath(new URL('../dist/cli.js', import.meta.url));
+
+function run(args: string[], cwd?: string) {
+  const r = spawnSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    // no AWS is reached — both failure classes short-circuit before any network call
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+const VERBS = ['record', 'ignore', 'revert'] as const;
+
+describe('--json emits [] (never empty stdout) on a whole-run failure (#943/#988/#989)', () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  // #943/#989 — parseCommonArgs throws on an unknown option, escaping run* to main().catch.
+  describe('a bad flag (parseCommonArgs throw) still yields stdout "[]" and exit 2', () => {
+    for (const verb of [...VERBS, 'check'] as const) {
+      it(`${verb} --json --bogus`, () => {
+        const { status, stdout, stderr } = run([verb, '--json', '--bogus']);
+        expect(status).toBe(2);
+        expect(JSON.parse(stdout)).toEqual([]); // parseable, never ''
+        expect(stdout.trim()).toBe('[]');
+        expect(stderr).toContain('unknown option'); // reason still on stderr
+      });
+    }
+
+    it('text mode (no --json) leaves stdout empty on the same bad flag', () => {
+      const { status, stdout, stderr } = run(['record', '--bogus']);
+      expect(status).toBe(2);
+      expect(stdout).toBe(''); // no stray stdout without --json
+      expect(stderr).toContain('unknown option');
+    });
+  });
+
+  // #988 — a malformed .cdkrd/ignore.yaml makes loadConfig() throw; the FIRST early catch
+  // must emit [] under --json just like the sibling resolveStacks catch.
+  describe('a malformed .cdkrd/ignore.yaml (loadConfig throw) still yields stdout "[]" and exit 2', () => {
+    function badConfigDir(): string {
+      const dir = mkdtempSync(join(tmpdir(), 'cdkrd-json-'));
+      dirs.push(dir);
+      mkdirSync(join(dir, '.cdkrd'), { recursive: true });
+      writeFileSync(join(dir, '.cdkrd', 'ignore.yaml'), 'ignores:\n  - {\n'); // unbalanced → YAML parse error
+      return dir;
+    }
+
+    for (const verb of VERBS) {
+      it(`${verb} --json under a broken ignore.yaml`, () => {
+        const { status, stdout, stderr } = run([verb, '--json'], badConfigDir());
+        expect(status).toBe(2);
+        expect(JSON.parse(stdout)).toEqual([]);
+        expect(stdout.trim()).toBe('[]');
+        expect(stderr).toMatch(/error:/);
+      });
+    }
+
+    it('text mode leaves stdout empty under the same broken config', () => {
+      const { status, stdout } = run(['record'], badConfigDir());
+      expect(status).toBe(2);
+      expect(stdout).toBe('');
+    });
+  });
+});


### PR DESCRIPTION
Closes #943
Closes #988
Closes #989

## Problem
Under `--json`, every verb must leave stdout a single `JSON.parse`-able value (`[]`) even on a whole-run failure — the documented "never empty bytes" contract (README). Two failure classes leaked empty stdout:

- **#943 / #989** — `parseCommonArgs(args, verb)` runs at the TOP of each `run*`, OUTSIDE any try/catch, and throws on a bad flag (unknown option, flag-value error, verb-inappropriate flag, mutually-exclusive scopes). The throw escaped to `cli.ts`'s `main().catch()`, which had no `--json` awareness, so it did `flushAndExit(2)` with zero stdout bytes. Same for check's un-wrapped `--pre-deploy` second synth.
- **#988** — in record/ignore/revert, the FIRST early catch (`loadConfig`) forgot the `[]` emit its sibling `resolveStacks` catch already had. A malformed `.cdkrd/ignore.yaml` therefore left stdout empty under `--json`.

## Fix
- **Central (`src/cli.ts`)** — `main().catch()` is now `--json`-aware: when the raw argv contains `--json`, `console.log('[]')` before `flushAndExit(2)`. One site covers all 4 verbs' `parseCommonArgs` throws AND check's `--pre-deploy` synth throw (#943, #989).
- **Per-verb (`record.ts` / `ignore.ts` / `revert.ts`)** — added `if (a.json) emitJsonArray([]);` to the `loadConfig` catch, matching the sibling `resolveStacks` catch (#988). check.ts already had this guard (untouched).

The caught `loadConfig` / `resolveStacks` paths `return 2` (never throw) and so never reach `main().catch` — the central guard and the per-verb emits are mutually exclusive (no double-print).

## Tests
New `tests/json-empty-on-error.test.ts` spawns the built CLI end to end (the bugs live at the process level):
- bad flag `<verb> --json --bogus` for record/ignore/revert/check → stdout exactly `[]`, exit 2 (central fix);
- malformed `.cdkrd/ignore.yaml` with `<verb> --json` for record/ignore/revert → stdout `[]`, exit 2 (loadConfig guard);
- text-mode (no `--json`) leaves stdout empty on the same failures.

Verified these fail without the fix (5 fail / 4 pass) and pass with it (9/9). Full suite green: 84 files, 3479 tests.
