### PR TITLE
fix(read): out-of-band deleted IAM AccessKey / AppSync ApiKey reach the deleted tier (#965)

### DIFF
--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -257,7 +257,12 @@ const readIamAccessKey: OverrideReader = async ({ declared, physicalId, region }
   // A user has at most 2 access keys, so a single ListAccessKeys page always suffices.
   const r = await c.send(new ListAccessKeysCommand({ UserName: userName }));
   const meta = (r.AccessKeyMetadata ?? []).find((m) => m.AccessKeyId === physicalId);
-  if (!meta) return undefined;
+  // The user exists (a deleted user throws NoSuchEntity above -> `deleted`) and the
+  // physical id IS the exact AccessKeyId, yet it is absent from the (authoritative,
+  // single-page) key list -> the key itself was deleted out of band (the common
+  // credential-rotation case). Throw ResourceGoneError so the router maps it to
+  // `deleted`, not `skipped`.
+  if (!meta) throw new ResourceGoneError(`AccessKey ${physicalId} absent from user ${userName}`);
   return { UserName: userName, Status: meta.Status };
 };
 
@@ -1934,8 +1939,20 @@ const readAppSyncApiKey: OverrideReader = async ({ physicalId, declared, region 
     if (keyId) k = keys.find((x) => x.id === keyId);
     nextToken = r.nextToken;
   } while (!k && nextToken);
-  if (!keyId) k = keys[0];
-  if (!k) return undefined; // key deleted out of band -> router maps undefined to skipped
+  if (keyId) {
+    // keyId was parsed from the ARN physical id and ALL ListApiKeys pages were
+    // accumulated (the loop only exits with no nextToken), yet the exact id is absent
+    // -> the key was deleted out of band. Throw ResourceGoneError so the router maps
+    // it to `deleted`, not `skipped`.
+    if (!k) throw new ResourceGoneError(`AppSync ApiKey ${keyId} absent from API ${apiId}`);
+  } else {
+    // Best-effort branch: no keyId in the physical id, so fall back to the first key.
+    // An empty list here is NOT definitively "this declared key is gone" (there was no
+    // exact id to look up) -> return undefined -> skipped (same rationale as
+    // readLambdaPermission's documented best-effort branch).
+    k = keys[0];
+    if (!k) return undefined;
+  }
   const model: Record<string, unknown> = { ApiId: apiId };
   if (k.description !== undefined && k.description !== '') model.Description = k.description;
   if (k.expires !== undefined) model.Expires = k.expires;

--- a/tests/overrides.test.ts
+++ b/tests/overrides.test.ts
@@ -267,18 +267,23 @@ describe('SDK overrides', () => {
     expect(out).toEqual({ UserName: 'svc', Status: 'Inactive' });
   });
 
-  it('IAM AccessKey (#716): undefined when no declared UserName or the key is not found', async () => {
+  it('IAM AccessKey (#716): undefined when no declared UserName', async () => {
+    // no UserName -> cannot resolve the owning user -> skipped, not a wrong deleted claim
+    expect(await SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({}, 'AKIATARGET'))).toBeUndefined();
+  });
+
+  it('IAM AccessKey (#965): the user exists but the exact key id is absent -> ResourceGoneError (deleted, not skipped)', async () => {
+    // ListAccessKeys succeeds (the user is present — a deleted user throws NoSuchEntity)
+    // yet the physical id (the AccessKeyId) is absent = the key was deleted out of band
+    // (credential rotation). The single page is authoritative (<=2 keys per user).
     iam.on(ListAccessKeysCommand).resolves({
       AccessKeyMetadata: [
         { UserName: 'svc', AccessKeyId: 'AKIAOTHER', Status: 'Active', CreateDate: new Date(0) },
       ],
     });
-    // no UserName -> cannot resolve the owning user
-    expect(await SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({}, 'AKIATARGET'))).toBeUndefined();
-    // the physical id is not among the user's keys -> undefined (falls back to skipped, no wrong read)
-    expect(
-      await SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({ UserName: 'svc' }, 'AKIATARGET'))
-    ).toBeUndefined();
+    await expect(
+      SDK_OVERRIDES['AWS::IAM::AccessKey'](ctx({ UserName: 'svc' }, 'AKIATARGET'))
+    ).rejects.toBeInstanceOf(ResourceGoneError);
   });
 
   it('Lambda Permission: matches statement by Action + Principal', async () => {
@@ -2268,9 +2273,20 @@ describe('SDK overrides', () => {
       expect(out).toMatchObject({ ApiId: 'fallback-api' });
     });
 
-    it('undefined when the keyed key is absent (deleted out of band -> skipped)', async () => {
+    it('#965: keyId parsed from the ARN but absent from all pages -> ResourceGoneError (deleted, not skipped)', async () => {
       appsync.on(ListApiKeysCommand).resolves({ apiKeys: [{ id: 'da2-different' }] });
-      expect(await SDK_OVERRIDES['AWS::AppSync::ApiKey'](ctx({}, ARN))).toBeUndefined();
+      await expect(SDK_OVERRIDES['AWS::AppSync::ApiKey'](ctx({}, ARN))).rejects.toBeInstanceOf(
+        ResourceGoneError
+      );
+    });
+
+    it('#965: the no-keyId best-effort branch stays undefined (not a definitive deletion)', async () => {
+      // physical id is not an ARN -> no keyId to look up. An empty key list here is NOT
+      // "this declared key is gone" (there was no exact id) -> undefined -> skipped.
+      appsync.on(ListApiKeysCommand).resolves({ apiKeys: [] });
+      expect(
+        await SDK_OVERRIDES['AWS::AppSync::ApiKey'](ctx({ ApiId: 'fallback-api' }, 'not-an-arn'))
+      ).toBeUndefined();
     });
 
     it('undefined when no apiId can be resolved', async () => {


### PR DESCRIPTION
Closes #965

## Problem

Two `SDK_OVERRIDES` readers resolved their target by an exact, definitive CFn physical id, successfully listed the containing collection, found the target ABSENT, and `return undefined` — which the router maps to `skipped: target not resolvable from template`. An out-of-band DELETION therefore never reached the `deleted` tier, and `check --fail` exited 0 while a declared credential/key was gone (a security-relevant false negative).

## Fix (`src/read/overrides.ts`)

- **`readIamAccessKey`**: the user exists (a deleted user already throws `NoSuchEntity` → `deleted`) and the physical id IS the exact `AccessKeyId`; a single `ListAccessKeys` page is authoritative (≤2 keys/user). Absent key → `throw new ResourceGoneError(...)` instead of `return undefined` (the common credential-rotation case).
- **`readAppSyncApiKey`**: when `keyId` was parsed from the ARN physical id and ALL `ListApiKeys` pages were accumulated yet the exact id is absent → `throw new ResourceGoneError(...)`. The `!keyId` fallback-to-`keys[0]` best-effort branch is kept as `return undefined` (same rationale as `readLambdaPermission`'s best-effort branch — no exact id to assert deletion).

`ResourceGoneError` is already mapped to the `deleted` tier via `isResourceNotFoundError` (`aws-errors.ts`). No other files touched.

## Tests (`tests/overrides.test.ts`)

- IAM AccessKey: user present but exact key id absent → rejects with `ResourceGoneError`; no-`UserName` still returns undefined.
- AppSync ApiKey: keyId parsed from ARN but absent from all pages → rejects with `ResourceGoneError`; the no-keyId best-effort branch (non-ARN physical id, empty list) still returns undefined.

All 3472 unit tests pass; typecheck / lint / build green.
