### PR TITLE
fix(revert): DocDB + ClientVpn selective writers drop remove ops (#984)

### DIFF
--- a/src/revert/writers.ts
+++ b/src/revert/writers.ts
@@ -588,10 +588,23 @@ const writeDocDbCluster: SdkWriter = async (ctx, ops) => {
   let any = false;
   for (const op of ops) {
     const top = op.path.replace(/^\//, '').split('/')[0];
-    if (top && DOCDB_CLUSTER_MODIFY_PARAMS.has(top) && desired[top] !== undefined) {
+    if (!top || !DOCDB_CLUSTER_MODIFY_PARAMS.has(top)) continue;
+    if (desired[top] !== undefined) {
       input[top] = desired[top];
-      any = true;
+    } else {
+      // A `remove` op (the desired value is now ABSENT) needs an EXPLICIT clearing value, or
+      // ModifyDBCluster — a selective/partial modify — keeps the live value and the revert
+      // silently non-converges (#913). DeletionProtection clears with an explicit `false`
+      // (ModifyDBCluster accepts DeletionProtection=false); BackupRetentionPeriod /
+      // PreferredBackupWindow / PreferredMaintenanceWindow / Port have NO expressible selective
+      // clear (AWS-assigned / required), so bar them honestly.
+      if (top === 'DeletionProtection') input.DeletionProtection = false;
+      else
+        throw new Error(
+          `DocDB DBCluster ${top} cannot be cleared via ModifyDBCluster (its unset state is AWS-assigned/required, not expressible in a selective modify); update it manually`
+        );
     }
+    any = true;
   }
   if (!any) return;
   await new DocDBClient({ region: ctx.region }).send(new ModifyDBClusterCommand(input));
@@ -624,10 +637,22 @@ const writeDocDbInstance: SdkWriter = async (ctx, ops) => {
   let any = false;
   for (const op of ops) {
     const top = op.path.replace(/^\//, '').split('/')[0];
-    if (top && DOCDB_INSTANCE_MODIFY_PARAMS.has(top) && desired[top] !== undefined) {
+    if (!top || !DOCDB_INSTANCE_MODIFY_PARAMS.has(top)) continue;
+    if (desired[top] !== undefined) {
       input[top] = desired[top];
-      any = true;
+    } else {
+      // A `remove` op needs an EXPLICIT clearing value, or ModifyDBInstance — a selective/partial
+      // modify — keeps the live value and the revert silently non-converges (#913).
+      // EnablePerformanceInsights clears with an explicit `false` (ModifyDBInstance accepts it);
+      // DBInstanceClass / PreferredMaintenanceWindow / CACertificateIdentifier have NO expressible
+      // selective clear (AWS-assigned / required), so bar them honestly.
+      if (top === 'EnablePerformanceInsights') input.EnablePerformanceInsights = false;
+      else
+        throw new Error(
+          `DocDB DBInstance ${top} cannot be cleared via ModifyDBInstance (its unset state is AWS-assigned/required, not expressible in a selective modify); update it manually`
+        );
     }
+    any = true;
   }
   if (!any) return;
   await new DocDBClient({ region: ctx.region }).send(new ModifyDBInstanceCommand(input));
@@ -1725,15 +1750,41 @@ const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
   const input: { ClientVpnEndpointId: string; [k: string]: unknown } = { ClientVpnEndpointId: id };
   let any = false;
   const tops = new Set(ops.map((op) => op.path.replace(/^\//, '').split('/')[0] ?? ''));
+  // A `remove` op (revert of an OOB-added value back to unset) must send an EXPLICIT clearing value
+  // — ModifyClientVpnEndpoint is a selective modify, so an omitted field keeps the live value and
+  // the revert silently non-converges (#913). Some clears are expressible, some are not.
+  const removed = (field: string): boolean =>
+    ops.some((o) => o.op === 'remove' && (o.path.replace(/^\//, '').split('/')[0] ?? '') === field);
   for (const top of tops) {
-    if (CLIENT_VPN_SCALAR_PARAMS.has(top) && desired[top] !== undefined) {
-      input[top] = desired[top];
-      any = true;
-    } else if (top === 'ConnectionLogOptions' && desired.ConnectionLogOptions !== undefined) {
-      input.ConnectionLogOptions = desired.ConnectionLogOptions;
-      any = true;
+    if (CLIENT_VPN_SCALAR_PARAMS.has(top)) {
+      if (desired[top] !== undefined) {
+        input[top] = desired[top];
+        any = true;
+      } else if (removed(top)) {
+        // ModifyClientVpnEndpoint expresses a clear for Description ('') and the booleans
+        // (SplitTunnel=false, DisconnectOnSessionTimeout=false); VpnPort / SessionTimeoutHours are
+        // numbers with NO expressible unset, so bar them honestly.
+        if (top === 'Description') input.Description = '';
+        else if (top === 'SplitTunnel') input.SplitTunnel = false;
+        else if (top === 'DisconnectOnSessionTimeout') input.DisconnectOnSessionTimeout = false;
+        else
+          throw new Error(
+            `EC2 ClientVpnEndpoint ${top} cannot be cleared via ModifyClientVpnEndpoint (its unset state is not expressible in a selective modify); update it manually`
+          );
+        any = true;
+      }
+    } else if (top === 'ConnectionLogOptions') {
+      if (desired.ConnectionLogOptions !== undefined) {
+        input.ConnectionLogOptions = desired.ConnectionLogOptions;
+        any = true;
+      } else if (removed('ConnectionLogOptions'))
+        throw new Error(
+          'EC2 ClientVpnEndpoint ConnectionLogOptions cannot be cleared via ModifyClientVpnEndpoint (its unset state is not expressible in a selective modify); update it manually'
+        );
     } else if (top === 'DnsServers') {
       const list = desired.DnsServers as string[] | undefined;
+      // An empty/absent desired list is itself an expressible clear ({Enabled:false}), so a
+      // DnsServers `remove` converges honestly here — no bar needed.
       input.DnsServers =
         Array.isArray(list) && list.length > 0
           ? { CustomDnsServers: list, Enabled: true }
@@ -1746,7 +1797,10 @@ const writeEc2ClientVpnEndpoint: SdkWriter = async (ctx, ops) => {
         input.SecurityGroupIds = list;
         input.VpcId = vpcId;
         any = true;
-      }
+      } else if (removed('SecurityGroupIds'))
+        throw new Error(
+          'EC2 ClientVpnEndpoint SecurityGroupIds cannot be cleared via ModifyClientVpnEndpoint (an endpoint cannot revert to no security group in a selective modify); update it manually'
+        );
     }
   }
   if (!any) return;

--- a/tests/writers.test.ts
+++ b/tests/writers.test.ts
@@ -1511,6 +1511,34 @@ describe('DocDB DBCluster writer (CC read+write gap)', () => {
     expect(docdb.commandCalls(ModifyDBClusterCommand)).toHaveLength(0);
   });
 
+  it('clears an OOB-added DeletionProtection on a remove (explicit false), not a silent drop (#984)', async () => {
+    stubClusterRead({ DeletionProtection: true });
+    docdb.on(ModifyDBClusterCommand).resolves({});
+    await SDK_WRITERS['AWS::DocDB::DBCluster'](ctx({ physicalId: CLID }), [
+      { op: 'remove', path: '/DeletionProtection', human: 'DeletionProtection -> (none)' },
+    ]);
+    const calls = docdb.commandCalls(ModifyDBClusterCommand);
+    expect(calls).toHaveLength(1);
+    // an omitted DeletionProtection would keep the live `true` (selective ModifyDBCluster) — the
+    // revert must send an explicit `false` so protection actually clears
+    expect(calls[0]!.args[0].input).toEqual({
+      DBClusterIdentifier: CLID,
+      ApplyImmediately: true,
+      DeletionProtection: false,
+    });
+  });
+
+  it('bars a BackupRetentionPeriod remove honestly (AWS-assigned unset, not expressible, #984)', async () => {
+    stubClusterRead();
+    await expect(
+      SDK_WRITERS['AWS::DocDB::DBCluster'](ctx({ physicalId: CLID }), [
+        { op: 'remove', path: '/BackupRetentionPeriod', human: 'BackupRetentionPeriod -> (none)' },
+      ])
+    ).rejects.toThrow(/BackupRetentionPeriod cannot be cleared/);
+    // never a silent no-op that reports success
+    expect(docdb.commandCalls(ModifyDBClusterCommand)).toHaveLength(0);
+  });
+
   it('throws when the cluster identifier is unresolvable', async () => {
     await expect(
       SDK_WRITERS['AWS::DocDB::DBCluster'](ctx({ physicalId: '', declared: {} }), [retentionOp(3)])
@@ -1556,6 +1584,39 @@ describe('DocDB DBInstance writer (CC read+write gap; mirror of the cluster writ
     await SDK_WRITERS['AWS::DocDB::DBInstance'](ctx({ physicalId: IID }), [
       { op: 'add', path: '/AutoMinorVersionUpgrade', value: false, human: 'x' },
     ]);
+    expect(docdb.commandCalls(ModifyDBInstanceCommand)).toHaveLength(0);
+  });
+
+  it('clears an OOB-added EnablePerformanceInsights on a remove (explicit false), not a silent drop (#984)', async () => {
+    stubInstanceRead({ EnablePerformanceInsights: true });
+    docdb.on(ModifyDBInstanceCommand).resolves({});
+    await SDK_WRITERS['AWS::DocDB::DBInstance'](ctx({ physicalId: IID }), [
+      {
+        op: 'remove',
+        path: '/EnablePerformanceInsights',
+        human: 'EnablePerformanceInsights -> (none)',
+      },
+    ]);
+    const calls = docdb.commandCalls(ModifyDBInstanceCommand);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.args[0].input).toEqual({
+      DBInstanceIdentifier: IID,
+      ApplyImmediately: true,
+      EnablePerformanceInsights: false,
+    });
+  });
+
+  it('bars a PreferredMaintenanceWindow remove honestly (AWS-assigned unset, not expressible, #984)', async () => {
+    stubInstanceRead();
+    await expect(
+      SDK_WRITERS['AWS::DocDB::DBInstance'](ctx({ physicalId: IID }), [
+        {
+          op: 'remove',
+          path: '/PreferredMaintenanceWindow',
+          human: 'PreferredMaintenanceWindow -> (none)',
+        },
+      ])
+    ).rejects.toThrow(/PreferredMaintenanceWindow cannot be cleared/);
     expect(docdb.commandCalls(ModifyDBInstanceCommand)).toHaveLength(0);
   });
 
@@ -2012,6 +2073,48 @@ describe('EC2 ClientVpnEndpoint writer (NON_PROVISIONABLE; ModifyClientVpnEndpoi
       SecurityGroupIds: ['sg-111'],
       VpcId: 'vpc-abc',
     });
+  });
+
+  it('clears OOB-added scalar props on a remove (Description="", SplitTunnel/DisconnectOnSessionTimeout=false), not a silent drop (#984)', async () => {
+    stubRead({ Description: 'oob', SplitTunnel: true, DisconnectOnSessionTimeout: true });
+    ec2.on(ModifyClientVpnEndpointCommand).resolves({});
+    await SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+      { op: 'remove', path: '/Description', human: 'Description -> (none)' },
+      { op: 'remove', path: '/SplitTunnel', human: 'SplitTunnel -> (none)' },
+      {
+        op: 'remove',
+        path: '/DisconnectOnSessionTimeout',
+        human: 'DisconnectOnSessionTimeout -> (none)',
+      },
+    ]);
+    // omitting these from a selective ModifyClientVpnEndpoint would keep the live values — the
+    // revert must send explicit clears so they actually converge
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)[0]!.args[0].input).toEqual({
+      ClientVpnEndpointId: CVID,
+      Description: '',
+      SplitTunnel: false,
+      DisconnectOnSessionTimeout: false,
+    });
+  });
+
+  it('bars a VpnPort remove honestly (numeric unset not expressible, #984)', async () => {
+    stubRead();
+    await expect(
+      SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+        { op: 'remove', path: '/VpnPort', human: 'VpnPort -> (none)' },
+      ])
+    ).rejects.toThrow(/VpnPort cannot be cleared/);
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)).toHaveLength(0);
+  });
+
+  it('bars a SecurityGroupIds remove honestly (cannot revert to no SG, #984)', async () => {
+    stubRead({ SecurityGroupIds: ['sg-111'] });
+    await expect(
+      SDK_WRITERS['AWS::EC2::ClientVpnEndpoint'](ctx({ physicalId: CVID }), [
+        { op: 'remove', path: '/SecurityGroupIds', human: 'SecurityGroupIds -> (none)' },
+      ])
+    ).rejects.toThrow(/SecurityGroupIds cannot be cleared/);
+    expect(ec2.commandCalls(ModifyClientVpnEndpointCommand)).toHaveLength(0);
   });
 
   it('throws when the endpoint id is unresolvable', async () => {


### PR DESCRIPTION
Closes #984

## Problem

Three partial/selective-update SDK writers silently dropped `remove` ops — the #913 anti-pattern (`if (... && desired[top] !== undefined) { ...; any = true } ... if (!any) return;`) that #928 fixed in four other writers but left here. For a `remove` op `desired[top]` is `undefined`, so the field was omitted; a selective modify keeps the live value, and the revert reported success while AWS was unchanged.

Affected writers: `writeDocDbCluster` (ModifyDBCluster), `writeDocDbInstance` (ModifyDBInstance), `writeEc2ClientVpnEndpoint` (ModifyClientVpnEndpoint).

## Fix (mirrors the #928 pattern)

For a `remove` op each writer now either sends an EXPLICIT clearing value where the API expresses "unset", or THROWS an honest not-revertable error where unset is AWS-assigned / not expressible — never a silent no-op:

- **DocDB DBCluster** — `DeletionProtection` clears with `false`; `BackupRetentionPeriod` / `PreferredBackupWindow` / `PreferredMaintenanceWindow` / `Port` throw.
- **DocDB DBInstance** — `EnablePerformanceInsights` clears with `false`; `DBInstanceClass` / `PreferredMaintenanceWindow` / `CACertificateIdentifier` throw.
- **EC2 ClientVpnEndpoint** — `Description` clears with `''`, `SplitTunnel` / `DisconnectOnSessionTimeout` with `false`; `VpnPort` / `SessionTimeoutHours` throw; `ConnectionLogOptions` / `SecurityGroupIds` throw on a remove; `DnsServers` remove already clears via `{Enabled:false}` (kept).

## Tests

7 new unit tests in `tests/writers.test.ts` (aws-sdk-client-mock), each verified to FAIL without the fix and PASS with it: clear-value assertions for the expressible cases and throw-not-silent-no-op assertions for the barred cases.

Gates: typecheck / lint+format / build / full test suite (3477 tests) all green.