### PR TITLE
fix(read): Events::Rule on a custom event bus is silently skipped (#973)

### DIFF
--- a/src/read/router.ts
+++ b/src/read/router.ts
@@ -20,7 +20,12 @@ export interface ReadResult {
 // falls back to the physical id unchanged.
 export const CC_IDENTIFIER_ADAPTERS: Record<
   string,
-  (physicalId: string, declared: Record<string, unknown>) => string | undefined
+  (
+    physicalId: string,
+    declared: Record<string, unknown>,
+    region?: string,
+    account?: string
+  ) => string | undefined
 > = {
   // physical id = the API ARN (arn:...:apis/<apiId>); CC wants the bare ApiId.
   'AWS::AppSync::GraphQLApi': (pid) => (pid.startsWith('arn:') ? pid.split('/').pop() : pid),
@@ -342,6 +347,41 @@ export const CC_IDENTIFIER_ADAPTERS: Record<
   // prop (a Ref to the detector, resolvable). Verified live (#878, stack CdkrdHuntUGd,
   // us-east-1): `<DetectorId>|<FilterName>` reads; the reverse order returns NotFound.
   'AWS::GuardDuty::Filter': compositeWith('DetectorId'),
+  // Events::Rule on a CUSTOM event bus has the CFn physical id `<busName>|<ruleName>`
+  // (child-enumerators.ts:1306-1317 confirms the composite shape), but the CC
+  // primaryIdentifier is the single-segment rule ARN (`/properties/Arn`). Passing the
+  // raw `bus|name` composite → ValidationException → the rule is silently `skipped` on
+  // every check (#973, live-confirmed), so undeclared drift AND an out-of-band change to
+  // a declared prop (State/EventPattern/ScheduleExpression/Targets) are invisible. CC
+  // ALSO accepts the bare rule NAME, but it resolves that only against the DEFAULT bus —
+  // so naively stripping the `bus|` prefix would 404 a custom-bus rule → false `deleted`
+  // (the issue's explicit warning). The adapter therefore builds the FULL rule ARN
+  // `arn:<partition>:events:<region>:<account>:rule/<busName>/<ruleName>`. A default-bus
+  // rule (bare-name id, no `|`) and an already-ARN id pass through UNCHANGED (rule names
+  // and bus names cannot contain `|`, so the pipe unambiguously marks the composite).
+  // region/account come from readLive on the check path; on the revert-side call (no
+  // region/account) derive the ARN from the resolved declared EventBusName when CDK set
+  // it to the bus ARN (`:event-bus/<bus>` → `:rule/<bus>/<rule>`), else fall back to
+  // undefined (honest skip — no worse than today).
+  'AWS::Events::Rule': (pid, declared, region, account) => {
+    const bar = pid.lastIndexOf('|');
+    if (bar < 0) return pid; // default-bus bare name, or already the rule ARN
+    const busName = pid.slice(0, bar);
+    const ruleName = pid.slice(bar + 1);
+    // Prefer the resolved bus ARN — works even without region/account (revert-side).
+    const busArn = declared.EventBusName;
+    if (typeof busArn === 'string' && busArn.includes(':event-bus/'))
+      return `${busArn.replace(':event-bus/', ':rule/')}/${ruleName}`;
+    if (region && account) {
+      const partition = region.startsWith('cn-')
+        ? 'aws-cn'
+        : region.startsWith('us-gov-')
+          ? 'aws-us-gov'
+          : 'aws';
+      return `arn:${partition}:events:${region}:${account}:rule/${busName}/${ruleName}`;
+    }
+    return undefined;
+  },
 };
 
 // `${PolicyARN}|${ScalableDimension}` for a ScalingPolicy, extracting the
@@ -442,7 +482,9 @@ export async function readLive(
   }
   try {
     const identifier =
-      CC_IDENTIFIER_ADAPTERS[resourceType]?.(physicalId ?? '', declared) ?? physicalId ?? '';
+      CC_IDENTIFIER_ADAPTERS[resourceType]?.(physicalId ?? '', declared, region, accountId) ??
+      physicalId ??
+      '';
     const g = await cc.send(
       new GetResourceCommand({ TypeName: resourceType, Identifier: identifier })
     );

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -232,6 +232,75 @@ describe('readLive (CC identifier adapters, R74)', () => {
     expect(sent()).toBe('arn:aws:ecs:us-east-1:111111111111:service/my-cluster/my-svc');
   });
 
+  // #973: Events::Rule on a CUSTOM event bus has physical id `<busName>|<ruleName>`,
+  // which is NOT the CC primaryIdentifier (the single-segment rule ARN) — the raw
+  // composite ValidationException-skips. The adapter must build the full rule ARN, NOT
+  // strip to the bare name (a bare name resolves against the DEFAULT bus → false deleted).
+  it('Events::Rule (custom bus): derives the rule ARN from the declared bus ARN', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::Events::Rule',
+        physicalId: 'myBus|myRule',
+        declared: { EventBusName: 'arn:aws:events:us-east-1:111111111111:event-bus/myBus' },
+      }),
+      'us-east-1',
+      '111111111111'
+    );
+    // NOT the raw `myBus|myRule` composite (which is what an unadapted read would send).
+    expect(sent()).toBe('arn:aws:events:us-east-1:111111111111:rule/myBus/myRule');
+  });
+
+  it('Events::Rule (custom bus): constructs the rule ARN from region+account when EventBusName is a bare name', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({
+        resourceType: 'AWS::Events::Rule',
+        physicalId: 'myBus|myRule',
+        declared: { EventBusName: 'myBus' },
+      }),
+      'us-east-1',
+      '111111111111'
+    );
+    expect(sent()).toBe('arn:aws:events:us-east-1:111111111111:rule/myBus/myRule');
+  });
+
+  it('Events::Rule (custom bus): honors the region partition (aws-us-gov)', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Events::Rule', physicalId: 'myBus|myRule', declared: {} }),
+      'us-gov-west-1',
+      '111111111111'
+    );
+    expect(sent()).toBe('arn:aws-us-gov:events:us-gov-west-1:111111111111:rule/myBus/myRule');
+  });
+
+  it('Events::Rule (default bus): a bare-name physical id passes through UNCHANGED', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Events::Rule', physicalId: 'myRule', declared: {} }),
+      'us-east-1',
+      '111111111111'
+    );
+    expect(sent()).toBe('myRule');
+  });
+
+  it('Events::Rule: an already-ARN physical id passes through UNCHANGED', async () => {
+    cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
+    const arn = 'arn:aws:events:us-east-1:111111111111:rule/myRule';
+    await readLive(
+      cc as unknown as CloudControlClient,
+      res({ resourceType: 'AWS::Events::Rule', physicalId: arn, declared: {} }),
+      'us-east-1',
+      '111111111111'
+    );
+    expect(sent()).toBe(arn);
+  });
+
   it('types without an adapter keep the physical id as the identifier', async () => {
     cc.on(GetResourceCommand).resolves({ ResourceDescription: { Properties: '{}' } });
     await readLive(cc as unknown as CloudControlClient, res(), 'us-east-1', '1');


### PR DESCRIPTION
Closes #973

## Problem

An `AWS::Events::Rule` on a **custom** event bus has the CFn physical id `<busName>|<ruleName>`, but the Cloud Control primaryIdentifier is the single-segment rule ARN (`/properties/Arn`). `readLive` had no `CC_IDENTIFIER_ADAPTERS` entry for the type, so it passed the raw `bus|name` composite to `GetResourceCommand` -> `ValidationException` -> the rule was silently `skipped` on every check. Undeclared drift AND out-of-band changes to declared props (State/EventPattern/ScheduleExpression/Targets) were invisible and never revertable. Default-bus rules (bare-name id) were unaffected.

## Fix

Added `CC_IDENTIFIER_ADAPTERS['AWS::Events::Rule']` in `src/read/router.ts` that builds the **full rule ARN** from the composite:

- `<busName>|<ruleName>` -> `arn:<partition>:events:<region>:<account>:rule/<busName>/<ruleName>`.
- Prefers deriving the ARN from the resolved declared `EventBusName` when CDK set it to the bus ARN (`:event-bus/<bus>` -> `:rule/<bus>/<rule>`) — this also works on the revert-side call, which has no region/account.
- Otherwise constructs the ARN from `region`+`account` (threaded into the adapter signature as **optional** params, so the 2-arg revert-side call sites in `stack-actions.ts` still compile unchanged).
- A default-bus bare-name id (no `|`) and an already-ARN id pass through **unchanged**.

### Why not just strip `bus|` to the bare name?

CC does accept a bare rule name, but it resolves that only against the **default** bus — so a stripped custom-bus name would 404 -> a false `deleted` red finding (the issue's explicit warning). The adapter therefore builds the full ARN or bails to `undefined` (honest skip, no worse than today).

## Tests

Added 5 cases to `tests/router.test.ts` (adapter block): custom-bus ARN-from-EventBusName, custom-bus ARN-from-region/account, gov-partition, default-bus bare-name passthrough, already-ARN passthrough. The custom-bus cases fail without the adapter (raw composite would be sent).

## Gates

typecheck / lint+format / build / 3475 unit tests all green.

Note: could not live-verify the constructed ARN against a real custom-bus rule (only the default bus exists in the test account and resource creation was correctly sandbox-blocked); the identifier behavior is per the issue's live-confirmed probes.