### PR TITLE
fix(ci): build before test so the json-empty dist-spawn test finds dist/cli.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,14 @@ jobs:
 
       - run: vp install --frozen-lockfile
       - run: vp run check
-      - run: vp run test
+      # Build BEFORE test: tests/json-empty-on-error.test.ts (#943/#988/#989) spawns the
+      # built `dist/cli.js` end to end, so `dist/` must exist when `vp run test` runs. The
+      # old order (test before build) left dist absent/stale and the spawned CLI exited 1
+      # ("Cannot find module") — 9 false failures on main only, green in local gates that
+      # `vp pack` first (#987-era CI red). `vp run build` is uncached (vite.config.ts), so
+      # this always rebuilds — no stale-dist replay.
       - run: vp run build
+      - run: vp run test
 
       # go-to-k/cdk-local#402 diagnostics (upstream Vite+ forks-pool crash, NOT a
       # cdk-real-drift issue): if a forks worker crashed ("Worker exited


### PR DESCRIPTION
## Problem
main CI (`check-build-test`) has been RED since the #943/#988/#989 merge: `tests/json-empty-on-error.test.ts` fails 9/9 with `expected 1 to be 2`.

## Root cause — NOT a code bug (the shipped CLI is correct)
That test spawns the **built** `dist/cli.js` end to end (it must, to exercise the process-level empty-JSON contract). But `.github/workflows/ci.yml` ran `vp run test` **before** `vp run build`, so `dist/` was absent/stale at test time and the spawned CLI exited 1 ("Cannot find module") instead of 2. It failed **only in CI** — local gates (and the PR author's worktree) `vp pack` first, per the repo's build-before-live-test rule, so they were green.

Verified: a fresh `vp run build` of current main makes `record/check --json --bogus` exit 2 with stdout `[]` (correct), and `vp run build && vp run test` → the 9 json-empty tests pass.

## Fix
Reorder `ci.yml`: `vp run build` before `vp run test`. `vp run build` is uncached (vite.config.ts), so it always rebuilds — no stale-dist replay. Tooling-only (`.github/**`), no src change.

Fixes the red main introduced by #943/#988/#989.