### PR TITLE
fix(check): case-insensitive hasBaselineForStack (deleted-detector FN) (#986)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -243,8 +243,16 @@ export function hasBaselineForStack(stackName: string): boolean {
   } catch {
     return false; // no `.cdkrd/baselines/` directory at all → nothing was ever recorded
   }
-  const prefix = `${stackName}.`;
-  return entries.some((f) => f.startsWith(prefix) && f.endsWith('.json'));
+  // #986: match the `<stackName>.` prefix CASE-INSENSITIVELY. `loadBaseline`'s `readFile`
+  // resolves case-insensitively on macOS/Windows (the dev default), where `mystack` and
+  // `MyStack` map to ONE on-disk baseline file — so a case-SENSITIVE `startsWith` here
+  // disagreed with it, missing a case-differing baseline and downgrading a truly deleted
+  // stack back to a benign "never deployed" skip (exit 0). Lowercasing both sides mirrors
+  // #870's case-insensitive collision semantics; a case-insensitive existence probe can
+  // only make the deleted-out-of-band detector MORE cautious (never a false positive: the
+  // `.json` suffix + `<stackName>.` separator still guard against bare-prefix collisions).
+  const prefix = `${stackName}.`.toLowerCase();
+  return entries.some((f) => f.toLowerCase().startsWith(prefix) && f.endsWith('.json'));
 }
 
 export async function runCheck(args: string[]): Promise<number> {

--- a/tests/deleted-stack-781.test.ts
+++ b/tests/deleted-stack-781.test.ts
@@ -74,6 +74,24 @@ describe('#781 deleted-out-of-band stack surfaces as drift, not a skip', () => {
       expect(hasBaselineForStack(STACK)).toBe(true);
     });
 
+    it('#986: matches a baseline whose on-disk name differs only in CASE', async () => {
+      // On a case-insensitive FS (macOS/Windows) `mystack` and `MyStack` map to ONE
+      // baseline file; `loadBaseline`'s `readFile` opens it either way. The existence probe
+      // must agree — a case-SENSITIVE prefix match missed the file and silently downgraded a
+      // truly deleted stack to a benign skip (exit 0). Baseline recorded as `MyStack.…json`,
+      // probed as `mystack`, must count. Passes on case-sensitive Linux CI too: the compare
+      // is case-insensitive in the code, independent of the FS's own case behavior.
+      await writeBaseline(STACK, ACCOUNT, REGION);
+      expect(hasBaselineForStack('mystack')).toBe(true);
+    });
+
+    it('#986: the case-insensitive match still guards against a bare-prefix collision', async () => {
+      // `MyStackExtra.<...>.json` must NOT satisfy hasBaselineForStack('mystack') even with
+      // the case-folded compare — the `<stackName>.` separator still bounds the prefix.
+      await writeBaseline('MyStackExtra', ACCOUNT, REGION);
+      expect(hasBaselineForStack('mystack')).toBe(false);
+    });
+
     it('does not match a DIFFERENT stack whose name shares no prefix', async () => {
       await writeBaseline('OtherStack', ACCOUNT, REGION);
       expect(hasBaselineForStack(STACK)).toBe(false);


### PR DESCRIPTION
Closes #986.

## Root cause
`hasBaselineForStack(stackName)` (`src/commands/check.ts`) did a **case-SENSITIVE** `readdirSync` prefix match. But on a case-insensitive filesystem (macOS/Windows — the dev default) the on-disk baseline `MyStack.<acct>.<region>.json` is opened case-insensitively by `loadBaseline`'s `readFile` — the two functions disagreed on "does a baseline exist?" for a name differing only in case. The sole caller (the `isStackNotDeployed` catch, ~L620) uses this to promote a gone stack from a benign "never deployed" skip to a `deleted`-out-of-band finding. A `false` here dropped the promotion → **false negative: `check --fail` exits 0 on a truly deleted stack** whose committed baseline proves it was once deployed. This is the read-side twin of the case-insensitive collision that #870 guarded on the load/write side (which never touched `hasBaselineForStack`).

## Fix
Make the `<stackName>.` prefix match **case-insensitive** — lowercase both sides of the `startsWith` compare, keeping the `.json` suffix and the `<stackName>.` separator guard. Chose the **simple always-case-insensitive** compare (not FS-gated): a case-insensitive existence probe can only make the deleted-detector MORE cautious (never a false positive — suffix + separator still guard bare-prefix collisions), matching #870's collision semantics. Region-threading (the #942 axis) is deliberately out of scope.

## Test
`tests/deleted-stack-781.test.ts`: baseline recorded as `MyStack.…json`, probed as `mystack` → true (fails without the fix; passes on case-sensitive Linux CI too). Plus a case-insensitive bare-prefix collision guard (`MyStackExtra` vs `mystack` → false). Existing same-case positive + genuine-absent negative retained.

Full suite: 84 files / 3492 tests pass; typecheck + lint/format + build green.
