### PR TITLE
fix(config): an added-tier ignore rule must not subtree-walk over a sibling resource (#990)

### DIFF
--- a/src/config/config-file.ts
+++ b/src/config/config-file.ts
@@ -397,8 +397,19 @@ export function parseIgnoreRule(entry: IgnoreRuleObject): IgnoreRule {
  * structured property covers its leaves, including array / identity-keyed elements), and a
  * rule "MyApi/Res" covers its whole construct-path subtree "MyApi/Res/Method.Prop".
  * Parent matching walks ancestors at each `.`, `[`, OR `/` boundary, combined with the glob.
+ *
+ * `wholeResource` marks an atomic, whole-resource target (an `added` finding — empty property
+ * path, so the target is just `<parentLogicalId>/<CC-identifier>`). Such a target has NO
+ * property subtree: the `.` / `[` inside it are DATA within the CC identifier
+ * (`example.com`, an ARN, `a[0]`), never property separators. Trimming there would walk into
+ * a DIFFERENT sibling resource whose identifier is this one extended by `.` / `[`
+ * (`MyApi/a` wrongly swallowing `MyApi/a.b`, `MyApi/a[0]`) — a silent over-suppression of the
+ * `added` out-of-band feature (issue #990). So in this mode the ancestor walk trims ONLY at
+ * `/` boundaries, which alone mark a resource boundary: a bare PARENT-resource rule (`MyLb`)
+ * still covers its added children across `/` (e.g. a listener child whose id is an ARN full
+ * of `/`, issue #903), while a rule for one whole resource can no longer reach a sibling.
  */
-function pathMatches(pattern: string, target: string): boolean {
+function pathMatches(pattern: string, target: string, wholeResource = false): boolean {
   if (matchesPathGlob(pattern, target)) return true;
   // A rule on a PARENT property ignores its whole subtree — including array / identity-
   // keyed children whose path glues the index to its key inside ONE dot-segment
@@ -408,9 +419,13 @@ function pathMatches(pattern: string, target: string): boolean {
   // each `.`, `[`, OR `/` boundary, so a rule `X.Policies` covers `X.Policies[MyPol].Name`,
   // `X.Statement` covers `X.Statement[0].Condition`, and `MyApi/Res` covers its `/`-subtree
   // — symmetric with the `.` case (the dot/bracket-only split silently failed across `/`).
+  // For a whole-resource (`added`) target the identifier is atomic, so trim ONLY at `/`
+  // (parent-RESOURCE coverage) — never at `.` / `[`, which would reach a sibling (#990).
   let t = target;
   while (true) {
-    const cut = Math.max(t.lastIndexOf('.'), t.lastIndexOf('['), t.lastIndexOf('/'));
+    const cut = wholeResource
+      ? t.lastIndexOf('/')
+      : Math.max(t.lastIndexOf('.'), t.lastIndexOf('['), t.lastIndexOf('/'));
     if (cut <= 0) break;
     t = t.slice(0, cut);
     if (matchesPathGlob(pattern, t)) return true;
@@ -470,6 +485,12 @@ export function applyIgnores(
     // the rule target is then just the id, matching ignoreRuleFor's empty-path form
     // (a trailing dot would only match via the parent-segment fallback — fragile).
     const suffix = f.path ? `.${f.path}` : '';
+    // An `added` finding is an atomic whole resource (`<parent>/<CC-identifier>`, empty
+    // path): its identifier's `.` / `[` are data, not a property subtree, so the ancestor
+    // walk must trim ONLY at `/` (parent-resource coverage) — otherwise a rule for one
+    // added resource over-suppresses a sibling whose id is this one extended by `.`/`[`
+    // (`P/a` swallowing `P/a.b.c`, `P/a[0]`) — a silent detection hole in `added` (#990).
+    const wholeResource = f.tier === 'added';
     const targets = [`${f.logicalId}${suffix}`];
     if (f.constructPath) {
       // The within-stack path is what the report shows and what `ignoreRuleFor` now writes;
@@ -484,7 +505,7 @@ export function applyIgnores(
         (r.stackGlob === undefined || matchesGlob(r.stackGlob, stackName)) &&
         (r.accountGlob === undefined || matchesGlob(r.accountGlob, accountId)) &&
         (r.regionGlob === undefined || matchesGlob(r.regionGlob, region)) &&
-        targets.some((t) => pathMatches(r.pathPattern, t))
+        targets.some((t) => pathMatches(r.pathPattern, t, wholeResource))
     );
     if (!hit) return f;
     // Clear the `unrecorded` flag (set by applyBaseline for a not-yet-recorded

--- a/tests/config-file.test.ts
+++ b/tests/config-file.test.ts
@@ -311,6 +311,64 @@ describe('applyIgnores', () => {
     expect(f?.tier).toBe('ignored');
   });
 
+  it('an `added` rule for `P/a` ignores EXACTLY that resource, never a `.`/`[`-extended sibling (#990)', () => {
+    // A whole-resource `added` target is atomic — its identifier's `.` / `[` are DATA, not a
+    // property subtree. The ancestor walk must NOT trim there, else a rule for one added
+    // resource silently over-suppresses a DIFFERENT added resource whose CC identifier is the
+    // first's extended by `.` or `[` (`example` vs `example.com`, `a` vs `a[0]`) — a silent
+    // detection hole in the `added` out-of-band feature, created by the user's own `ignore`.
+    const added = (parent: string, id: string): Finding => ({
+      tier: 'added',
+      logicalId: `${parent}/${id}`,
+      constructPath: `MyStack/${parent} ▸ ${id}`,
+      resourceType: 'AWS::ApiGateway::Resource',
+      path: '',
+    });
+    // the rule the verb writes for added('P','a') is the full literal identifier `P/a`
+    const rule = ignoreRuleFor(added('P', 'a'), 'S');
+    expect(rule.path).toBe('P/a');
+    // it ignores EXACTLY its own resource (WRITE→MATCH round-trip preserved)…
+    expect(ign([added('P', 'a')], 'S', cfg([rule]))[0]?.tier).toBe('ignored');
+    // …but NOT a distinct sibling whose id extends `P/a` by `.` or `[` (BUG on main: ignored)
+    expect(ign([added('P', 'a.b.c')], 'S', cfg([rule]))[0]?.tier).toBe('added');
+    expect(ign([added('P', 'a[0]')], 'S', cfg([rule]))[0]?.tier).toBe('added');
+    // …nor a plain hyphen-extended sibling (already correct on main; guard against regression)
+    expect(ign([added('P', 'a-x')], 'S', cfg([rule]))[0]?.tier).toBe('added');
+    // a dotted-identifier example (apex vs subdomain): a rule for `CDN/example` must not
+    // swallow the distinct added resource `CDN/example.com`
+    const cdnRule = ignoreRuleFor(added('CDN', 'example'), 'S');
+    expect(ign([added('CDN', 'example')], 'S', cfg([cdnRule]))[0]?.tier).toBe('ignored');
+    expect(ign([added('CDN', 'example.com')], 'S', cfg([cdnRule]))[0]?.tier).toBe('added');
+  });
+
+  it('a bare PARENT-resource rule still covers its added children across `/` (#903 not regressed)', () => {
+    // The `/`-boundary walk (parent-RESOURCE coverage) survives the #990 fix — only the
+    // `.`/`[` within-identifier trim is dropped. A rule on the parent `MyLb` still ignores an
+    // added listener child whose CC identifier is an ARN full of `/`.
+    const arnChild: Finding = {
+      tier: 'added',
+      logicalId:
+        'MyLb/arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-lb/50dc6c495c0c9188/f2f7dc8efc522ab2',
+      constructPath:
+        'MyStack/MyLb/arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/my-lb/50dc6c495c0c9188/f2f7dc8efc522ab2',
+      resourceType: 'AWS::ElasticLoadBalancingV2::Listener',
+      path: '',
+    };
+    expect(ign([arnChild], 'MyStack', cfg([p('MyLb')]))[0]?.tier).toBe('ignored');
+    expect(ign([arnChild], 'MyStack', cfg([p('MyLb/*')]))[0]?.tier).toBe('ignored');
+  });
+
+  it('the NON-added property subtree walk is unchanged by the #990 fix (`.`/`[` still trims)', () => {
+    // A real property path keeps its subtree coverage: a parent-property rule `Role.Policies`
+    // still ignores `Role.Policies[0].X` (the `.`/`[` walk that #990 only disables for added).
+    expect(
+      ign([undeclared('Role', 'Policies[0].X')], 'S', cfg([p('Role.Policies')]))[0]?.tier
+    ).toBe('ignored');
+    expect(
+      ign([declared('Role', 'Policies.0.PolicyName')], 'S', cfg([p('Role.Policies')]))[0]?.tier
+    ).toBe('ignored');
+  });
+
   it('matches the friendly constructPath too (CDK stacks; same id cdk-local targets)', () => {
     const f: Finding = {
       tier: 'undeclared',


### PR DESCRIPTION
Closes #990

A whole-resource `added` finding is atomic (`<parent>/<CC-identifier>`, empty property path): the `.` / `[` inside its identifier are DATA (`example.com`, an ARN, `a[0]`), not property separators. But `applyIgnores` → `pathMatches` ran the property-subtree ancestor walk on it, trimming at every `.` / `[` — so an ignore rule for one added resource (`P/a`) silently over-suppressed a DIFFERENT added resource whose id extended it (`P/a.b.c`, `P/a[0]`, `CDN/example` swallowing `CDN/example.com`). A silent detection hole in the `added` out-of-band feature, self-inflicted by the user's own `ignore`.

## Fix
For a whole-resource (`added`) target, the ancestor walk now trims ONLY at `/` (parent-RESOURCE coverage), never at `.` / `[`. A rule for one whole resource can no longer reach a sibling, while a bare PARENT-resource rule (`MyLb`) still covers its added children across `/` — including an ARN-id listener child (#903 preserved). The verb-written rule is the full literal identifier, so the WRITE→MATCH round-trip is intact (it still ignores exactly the originating finding). The non-added property subtree walk (`Role.Policies` covering `Role.Policies[0].X`) is unchanged.

## Tests
- `P/a` ignores EXACTLY `P/a`, not `P/a.b.c` / `P/a[0]` / `P/a-x`; `CDN/example` not `CDN/example.com` (fails on main, passes with fix).
- #903 bare-parent-covers-children-across-`/` still green (regression guard).
- non-added `.`/`[` subtree walk still green (regression guard).

All 3493 unit tests pass; typecheck / lint+format / build green.

Files: `src/config/config-file.ts`, `tests/config-file.test.ts`.