### PR TITLE
fix(synth): warn on ignored -c/--context for an assembly-dir --app (#956)

### DIFF
--- a/src/synth/synth.ts
+++ b/src/synth/synth.ts
@@ -35,6 +35,28 @@ export interface SynthStack {
 // discarded, so the stack is read against the wrong region (#742).
 export const CONCRETE_REGION = /^[a-z]{2}(-[a-z]+)+-\d+$/;
 
+/**
+ * Build the stderr message body (no `warning:` prefix — the caller adds it) for the case where
+ * `--app` points at a pre-synthesized cloud-assembly DIRECTORY (`cdk.out`) yet the user also
+ * passed `-c/--context`. There is no CDK app subprocess to feed context to — the assembly's
+ * templates were frozen at synth time — so the `-c` values are silently dropped. Returns `null`
+ * when it does NOT apply (a real CDK app command, or no context given), so the caller warns only
+ * on the ignored case (#956). Advisory only (a warning, not a refusal): the frozen assembly is
+ * still a valid drift source, the user is just misled into thinking their `-c` mattered.
+ */
+export function contextIgnoredWarning(
+  isDir: boolean,
+  context: Record<string, string>
+): string | null {
+  const keys = Object.keys(context);
+  if (!isDir || keys.length === 0) return null;
+  return (
+    `ignoring -c/--context (${keys.join(', ')}): --app points at a pre-synthesized cloud-assembly ` +
+    'directory, whose context was baked in at synth time — there is no CDK app to re-run with new ' +
+    'context. To apply new context, point --app at the CDK app itself (not its cdk.out).'
+  );
+}
+
 export async function synthApp(app: string, opts: SynthOptions = {}): Promise<SynthStack[]> {
   const { region, profile, context = {} } = opts;
   const toolkit = new Toolkit({
@@ -51,7 +73,10 @@ export async function synthApp(app: string, opts: SynthOptions = {}): Promise<Sy
   const isDir = existsSync(p) && statSync(p).isDirectory();
   let source;
   if (isDir) {
-    // pre-synthesized assembly: no subprocess to feed region/profile/context to
+    // pre-synthesized assembly: no subprocess to feed region/profile/context to. Any
+    // -c/--context the user passed is therefore dropped; warn so they are not misled (#956).
+    const ignored = contextIgnoredWarning(isDir, context);
+    if (ignored) console.error(`warning: ${ignored}`);
     source = await toolkit.fromAssemblyDirectory(p, { failOnMissingContext: false });
   } else {
     const hasOverrides = Object.keys(context).length > 0;

--- a/tests/synth-region.test.ts
+++ b/tests/synth-region.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vite-plus/test';
-import { CONCRETE_REGION } from '../src/synth/synth.js';
+import { contextIgnoredWarning, CONCRETE_REGION } from '../src/synth/synth.js';
 
 describe('CONCRETE_REGION (env.region pin recognition, #742)', () => {
   it('accepts commercial regions', () => {
@@ -31,5 +31,24 @@ describe('CONCRETE_REGION (env.region pin recognition, #742)', () => {
     ]) {
       expect(CONCRETE_REGION.test(r)).toBe(false);
     }
+  });
+});
+
+describe('contextIgnoredWarning (-c/--context dropped for an assembly-dir --app, #956)', () => {
+  it('warns (naming the keys) when --app is a pre-synthed dir AND context was passed', () => {
+    const msg = contextIgnoredWarning(true, { env: 'prod', foo: 'bar' });
+    expect(msg).not.toBeNull();
+    expect(msg).toContain('ignoring -c/--context');
+    expect(msg).toContain('env');
+    expect(msg).toContain('foo');
+    expect(msg).toContain('pre-synthesized cloud-assembly');
+  });
+
+  it('returns null for a pre-synthed dir when no context was passed', () => {
+    expect(contextIgnoredWarning(true, {})).toBeNull();
+  });
+
+  it('returns null for a real CDK app command even with context (context IS applied there)', () => {
+    expect(contextIgnoredWarning(false, { env: 'prod' })).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #956.

## Root cause
When `--app` resolves to a pre-synthesized cloud-assembly DIRECTORY (`cdk.out`), `synthApp` (`src/synth/synth.ts`) loads it via `toolkit.fromAssemblyDirectory(...)`. There is no CDK app subprocess to feed context/region/profile to — the assembly's templates were frozen at synth time — so any `-c/--context` the user passed is dropped WITHOUT warning. All four verbs accept `-c`, so a user passing context expecting it to matter (stack selection, revert targeting) is silently misled. The `else` branch (a real cdk app command) DOES apply context via `CdkAppMultiContext`.

## Fix
Emit a clear stderr warning in the `isDir` branch when the caller also passed non-empty context. Advisory only (a warning, not a refusal like #907's `--pre-deploy` case) — the frozen assembly is still a valid drift source; the user is just told their `-c` had no effect and how to apply it.

Warning text:

    warning: ignoring -c/--context (<keys>): --app points at a pre-synthesized cloud-assembly directory, whose context was baked in at synth time — there is no CDK app to re-run with new context. To apply new context, point --app at the CDK app itself (not its cdk.out).

Matches the existing #907 missing-context warning idiom in the same file.

## Helper + test
Extracted the decision into a pure, exported helper `contextIgnoredWarning(isDir, context): string | null` — returns the message body when isDir AND context is non-empty, else null. Unit-tested in `tests/synth-region.test.ts` (3 cases: dir+context warns and names the keys; dir+no-context returns null; real-app+context returns null). Avoids needing a heavy real assembly dir to exercise the warning path.

## Gates
typecheck / lint+format (0 errors) / build / tests all green — 84 files, 3495 tests pass.
