### PR TITLE
fix(record,ignore): commit-nudge footer under a partial multi-stack failure (#949)

### DIFF
--- a/src/commands/ignore.ts
+++ b/src/commands/ignore.ts
@@ -145,7 +145,11 @@ export async function runIgnore(args: string[]): Promise<number> {
     emitJsonArray(jsonReports);
     return worst;
   }
-  if (worst === 0 && wroteAny)
+  // Nudge to commit whenever a rule was actually written — gate on `wroteAny` alone, NOT
+  // `worst === 0`: in a multi-stack run the written ignore.yaml still needs committing even
+  // when a SIBLING stack errored (worst === 2). `wroteAny` still guards the all-cancelled
+  // case (nothing written → no footer). The exit code is unaffected (#949).
+  if (wroteAny)
     console.log('commit .cdkrd/ignore.yaml so the ignore rules apply for everyone going forward.');
   return worst;
 }

--- a/src/commands/record.ts
+++ b/src/commands/record.ts
@@ -139,8 +139,11 @@ export async function runRecord(args: string[]): Promise<number> {
   }
   // Only nudge the user to commit when a baseline was actually written — cancelling every
   // stack's record prompt leaves the files untouched, so the "commit …" footer would be a
-  // lie (#799).
-  if (worst === 0 && wroteAny)
+  // lie (#799). Gate on `wroteAny` alone, NOT `worst === 0`: in a multi-stack run a written
+  // baseline still needs committing even when a SIBLING stack errored (worst === 2). The
+  // exit code is unaffected — a written file the user might otherwise forget to commit is
+  // exactly what the footer must catch under a partial failure (#949).
+  if (wroteAny)
     console.log('commit the baseline file(s) so drift is detected against them going forward.');
   return worst;
 }

--- a/tests/ignore-footer-949.test.ts
+++ b/tests/ignore-footer-949.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// #949: in a MULTI-STACK `ignore` run with a PARTIAL failure — one stack writes a rule to
+// .cdkrd/ignore.yaml (wroteAny === true) but a SIBLING stack errors (worst === 2) — the
+// "commit .cdkrd/ignore.yaml …" footer was suppressed, because it was gated on
+// `worst === 0`. The user was never told to commit the file that WAS written. The footer
+// must now fire on `wroteAny` alone; the exit code (worst) is unchanged.
+//
+// resolveStacks yields TWO stacks so one can write while the other throws.
+
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: () =>
+    Promise.resolve([
+      { stackName: 'Dev', region: 'us-east-1', template: {} },
+      { stackName: 'Prod', region: 'us-east-1', template: {} },
+    ]),
+}));
+
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: () =>
+    Promise.resolve({ desired: { accountId: '111111111111', resources: [] }, findings: [] }),
+}));
+
+vi.mock('../src/commands/progress.js', () => ({
+  gatherWithProgress: (_show: boolean, _label: string, fn: () => unknown) => fn(),
+  progressLabel: () => '',
+}));
+
+vi.mock('../src/config/config-file.js', () => ({
+  loadConfig: () => Promise.resolve({}),
+  applyIgnores: (findings: unknown) => findings,
+}));
+
+// baseline reconciliation is not under test here — stub it to a clean pass-through.
+vi.mock('../src/baseline/baseline-file.js', () => ({
+  loadBaseline: () => Promise.resolve(null),
+  checkBaselineAccount: () => {},
+  applyBaseline: (findings: unknown) => findings,
+  declaredKeysByLogical: () => ({}),
+  physicalIdsByLogical: () => ({}),
+}));
+
+vi.mock('../src/cli-args.js', () => ({
+  parseCommonArgs: () => ({ profile: undefined, json: false, yes: true, verbose: false }),
+  isInteractive: () => false,
+}));
+
+const ignoreStack = vi.fn();
+vi.mock('../src/commands/stack-actions.js', () => ({
+  ignoreStack: (...a: unknown[]) => ignoreStack(...a),
+}));
+
+import { runIgnore } from '../src/commands/ignore.js';
+
+const FOOTER = 'commit .cdkrd/ignore.yaml so the ignore rules apply for everyone going forward.';
+
+describe('runIgnore — commit-nudge footer under a partial multi-stack failure (#949)', () => {
+  let logs: string[];
+  let origLog: typeof console.log;
+  let origErr: typeof console.error;
+
+  beforeEach(() => {
+    ignoreStack.mockReset();
+    logs = [];
+    origLog = console.log;
+    origErr = console.error;
+    console.log = (s: unknown) => logs.push(String(s));
+    console.error = () => {}; // silence the per-stack error line
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origErr;
+  });
+
+  it('PRINTS the footer when one stack wrote even though a sibling stack errored', async () => {
+    // Dev writes a rule; Prod throws (a generic error → worst 2).
+    ignoreStack
+      .mockResolvedValueOnce({ wrote: true, refused: false, added: 1 })
+      .mockRejectedValueOnce(new Error('boom'));
+    const rc = await runIgnore([]);
+    expect(rc).toBe(2); // exit code still reflects the sibling failure
+    expect(logs).toContain(FOOTER); // …but the written ignore.yaml must still be nudged to commit
+  });
+
+  it('SUPPRESSES the footer when every stack was cancelled (nothing written)', async () => {
+    // wroteAny stays false → no nudge, even though the run is otherwise clean.
+    ignoreStack.mockResolvedValue({ wrote: false, refused: false, added: 0 });
+    const rc = await runIgnore([]);
+    expect(rc).toBe(0);
+    expect(logs).not.toContain(FOOTER);
+  });
+});

--- a/tests/record-footer-949.test.ts
+++ b/tests/record-footer-949.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+
+// #949: in a MULTI-STACK `record` run with a PARTIAL failure — one stack writes a baseline
+// (wroteAny === true) but a SIBLING stack errors (worst === 2) — the "commit the baseline
+// file(s) …" footer was suppressed, because it was gated on `worst === 0`. The user was
+// never told to commit the file that WAS written (a real usability bug — they may forget
+// it). The footer must now fire on `wroteAny` alone; the exit code (worst) is unchanged.
+//
+// Same mocking shape as record-footer-799.test.ts, but resolveStacks yields TWO stacks so
+// one can write while the other throws.
+
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: () =>
+    Promise.resolve([
+      { stackName: 'Dev', region: 'us-east-1', template: {} },
+      { stackName: 'Prod', region: 'us-east-1', template: {} },
+    ]),
+}));
+
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: () => Promise.resolve({ desired: { accountId: '111111111111' }, findings: [] }),
+}));
+
+vi.mock('../src/commands/progress.js', () => ({
+  gatherWithProgress: (_show: boolean, _label: string, fn: () => unknown) => fn(),
+  progressLabel: () => '',
+}));
+
+vi.mock('../src/config/config-file.js', () => ({
+  loadConfig: () => Promise.resolve({}),
+  applyIgnores: (findings: unknown) => findings,
+}));
+
+vi.mock('../src/cli-args.js', () => ({
+  parseCommonArgs: () => ({ profile: undefined, json: false, yes: true, verbose: false }),
+  isInteractive: () => false,
+}));
+
+const recordStack = vi.fn();
+vi.mock('../src/commands/stack-actions.js', () => ({
+  recordStack: (...a: unknown[]) => recordStack(...a),
+}));
+
+import { runRecord } from '../src/commands/record.js';
+
+const FOOTER = 'commit the baseline file(s) so drift is detected against them going forward.';
+
+describe('runRecord — commit-nudge footer under a partial multi-stack failure (#949)', () => {
+  let logs: string[];
+  let origLog: typeof console.log;
+  let origErr: typeof console.error;
+
+  beforeEach(() => {
+    recordStack.mockReset();
+    logs = [];
+    origLog = console.log;
+    origErr = console.error;
+    console.log = (s: unknown) => logs.push(String(s));
+    console.error = () => {}; // silence the per-stack error line
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    console.error = origErr;
+  });
+
+  it('PRINTS the footer when one stack wrote even though a sibling stack errored', async () => {
+    // Dev writes a baseline; Prod throws (a generic error → worst 2).
+    recordStack
+      .mockResolvedValueOnce({ wrote: true, refused: false })
+      .mockRejectedValueOnce(new Error('boom'));
+    const rc = await runRecord([]);
+    expect(rc).toBe(2); // exit code still reflects the sibling failure
+    expect(logs).toContain(FOOTER); // …but the written baseline must still be nudged to commit
+  });
+
+  it('SUPPRESSES the footer when every stack was cancelled (nothing written)', async () => {
+    // wroteAny stays false → no nudge, even though the run is otherwise clean.
+    recordStack.mockResolvedValue({ wrote: false, refused: false });
+    const rc = await runRecord([]);
+    expect(rc).toBe(0);
+    expect(logs).not.toContain(FOOTER);
+  });
+});


### PR DESCRIPTION
Closes #949.

## Root cause
In a multi-stack `record`/`ignore` run with a PARTIAL failure, the "commit the baseline / ignore.yaml" footer nudge was gated on `worst === 0 && wroteAny`. If stack A recorded successfully (a file WAS written, `wroteAny === true`) but sibling stack B errored (`worst === 2`), the footer was suppressed — so the user was never told to commit the file that WAS written, risking a forgotten commit.

## Fix
Gate the footer on `wroteAny` alone in both `src/commands/record.ts` (~L143) and `src/commands/ignore.ts` (~L148):

- `if (worst === 0 && wroteAny)` -> `if (wroteAny)`

`wroteAny` still guards the all-cancelled case (nothing written -> no footer). The exit code (`worst`) is unchanged and still returned; only the informational footer gate changes. Adjacent comments updated to reflect the new semantics.

## Tests
- `tests/record-footer-949.test.ts` — two-stack run: one writes (wroteAny true), one throws (worst 2) -> footer IS emitted, exit code 2; plus the all-cancelled case still does NOT nudge.
- `tests/ignore-footer-949.test.ts` — same for `runIgnore`.

Full suite: 86 files, 3496 tests passing. typecheck + lint + build all green.
