### PR TITLE
fix(noise): fold CFn-generated SecurityGroup GroupName as generated (#888)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -750,7 +750,7 @@ function isCfnGeneratedName(
   // The bare physical-id echo (value === physicalId) is a STRUCTURAL drop handled separately
   // — never fold it into a `generated` finding here, or a resource whose physical id IS its
   // CFn-generated name gains a phantom finding.
-  if (typeof value !== 'string' || !constructPath || value === physicalId) return false;
+  if (typeof value !== 'string' || value === physicalId) return false;
   // A bare LOGICAL-ID echo: for some types CloudFormation mints an auto-generated physical
   // name equal to the resource's LOGICAL ID verbatim — no `<stack>-` prefix, no extra random
   // suffix beyond the CDK hash already baked into the logical id (a BucketDeployment's
@@ -759,6 +759,24 @@ function isCfnGeneratedName(
   // already carries an 8-hex-char construct hash, so a user-chosen value coinciding is
   // effectively impossible — fold it. (aws-s3-deployment is a very common construct.)
   if (logicalId && value === logicalId) return true;
+  // The full CFn form `<stackName>-<logicalId>-<random>` anchored on the LOGICAL ID alone — the
+  // logical id is a WHOLE segment sitting between a `<prefix>-` and CFn's random suffix. This does
+  // NOT need the construct path: an implicitly-created resource (an RDS cluster's / DBProxy's
+  // auto-made AWS::EC2::SecurityGroup) can lose its `aws:cdk:path` metadata in the deployed
+  // template, so `constructPath` is undefined and the stack-prefix branches below never run — yet
+  // its undeclared GroupName still reads back `<stack>-<logicalId>-<random>` and floods the first
+  // run (#888). Requires a NON-EMPTY prefix segment before the logical id (`<prefix>-<logicalId>-
+  // <random>`, never a bare `<logicalId>-<random>` — that no-prefix form is over-broad for short
+  // raw-CFn logical ids, e.g. a WAFv2 WebACL "Edge-<random>", and stays scoped per type+path via
+  // GENERATED_LOGICALID_PREFIX_PATHS). A CDK logical id carries an 8-hex construct hash, so a
+  // user-chosen name ending in `-<thisLogicalId>-<random>` is effectively impossible — value-
+  // DEPENDENT, so a real user name (e.g. "my-custom-sg") still surfaces. Runs before the
+  // constructPath gate so it folds regardless of whether the path survived.
+  if (logicalId && CFN_RANDOM_SUFFIX.test(value)) {
+    const base = value.replace(CFN_RANDOM_SUFFIX, '');
+    if (base.length > logicalId.length && base.endsWith(`-${logicalId}`)) return true;
+  }
+  if (!constructPath) return false;
   const stackName = constructPath.split('/')[0];
   if (!stackName || !CFN_RANDOM_SUFFIX.test(value)) return false;
   if (value.startsWith(`${stackName}-`)) return true;

--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -2762,17 +2762,21 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   MaxCapacity — a Python-shell job — goes through the declared loop, compared). Observed live
   //   first-run on my-app-Exporter (five G.1X ETL jobs + one G.025X streaming job), no edit.
   'AWS::Glue::Job': new Set(['MaxCapacity', 'AllocatedCapacity']),
-  //   AWS::EC2::SecurityGroupIngress / ::SecurityGroupEgress.SourceSecurityGroupName — a rule that
-  //   references its peer group by id (`SourceSecurityGroupId`, the CDK default) declares no
-  //   `SourceSecurityGroupName`; AWS DERIVES and reads back the referenced group's NAME
-  //   ("my-app-Exporter-Glue-sg") from that id. It can never be a constant we pin (it embeds the
-  //   per-group name), and when undeclared it is a pure reflection of the declared
-  //   SourceSecurityGroupId, not user intent — a real change to the peer surfaces on
-  //   `SourceSecurityGroupId` in the declared loop. Fold value-independent. (A user who references
-  //   a peer by name — EC2-Classic style — DECLARES SourceSecurityGroupName, compared.) Observed
-  //   live first-run on my-app-Exporter's self-referencing Glue SG ingress, no edit.
+  //   AWS::EC2::SecurityGroupIngress.SourceSecurityGroupName / ::SecurityGroupEgress
+  //   .DestinationSecurityGroupName — a rule that references its peer group by id
+  //   (`SourceSecurityGroupId` / `DestinationSecurityGroupId`, the CDK default) declares no peer
+  //   NAME; AWS DERIVES and reads back the referenced group's NAME (a CFn-minted
+  //   `<stack>-<logicalId>-<random>` or a user-set name like "my-app-Exporter-Glue-sg") from that
+  //   id. It can never be a constant we pin (it embeds the per-group name), and when undeclared it
+  //   is a pure reflection of the declared peer-group id, not user intent — a real change to the
+  //   peer surfaces on `SourceSecurityGroupId` / `DestinationSecurityGroupId` in the declared loop.
+  //   Fold value-independent so it folds even when the peer group lives in ANOTHER stack (its name
+  //   carries a different `<stack>-` prefix, so isCfnGeneratedName misses it). (A user who
+  //   references a peer by name — EC2-Classic style — DECLARES the name, compared.) The egress key
+  //   is `DestinationSecurityGroupName`, NOT `SourceSecurityGroupName` (#888). Observed live first-
+  //   run on my-app-Exporter's self-referencing Glue SG ingress and #717's Aurora/DBProxy egress.
   'AWS::EC2::SecurityGroupIngress': new Set(['SourceSecurityGroupName']),
-  'AWS::EC2::SecurityGroupEgress': new Set(['SourceSecurityGroupName']),
+  'AWS::EC2::SecurityGroupEgress': new Set(['DestinationSecurityGroupName']),
   //   The RDS-family + cache engines all mirror the RDS precedent above: a cluster/instance
   //   that declares no maintenance / backup / snapshot window reads back a window AWS
   //   RANDOMLY ASSIGNED at creation (e.g. "sat:03:00-sat:04:00", "03:10-03:40"). It is not a

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1359,15 +1359,18 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
     ]);
     expect(t('AWS::Glue::Job', { MaxCapacity: 10 }).undeclared).toEqual([]);
 
-    // A rule referencing its peer by id (SourceSecurityGroupId) reads back the peer group's
-    // NAME — an AWS reflection of the declared id, never user intent when undeclared.
+    // A rule referencing its peer by id reads back the peer group's NAME — an AWS reflection of
+    // the declared id, never user intent when undeclared. Ingress echoes SourceSecurityGroupName,
+    // egress echoes DestinationSecurityGroupName (its declared id is DestinationSecurityGroupId) —
+    // #888 fixed the egress key, which had wrongly been SourceSecurityGroupName.
     expect(
       t('AWS::EC2::SecurityGroupIngress', { SourceSecurityGroupName: 'my-app-Exporter-Glue-sg' })
         .atDefault
     ).toEqual(['SourceSecurityGroupName']);
     expect(
-      t('AWS::EC2::SecurityGroupEgress', { SourceSecurityGroupName: 'some-other-sg' }).atDefault
-    ).toEqual(['SourceSecurityGroupName']);
+      t('AWS::EC2::SecurityGroupEgress', { DestinationSecurityGroupName: 'some-other-sg' })
+        .atDefault
+    ).toEqual(['DestinationSecurityGroupName']);
     expect(
       t('AWS::EC2::SecurityGroupIngress', { SourceSecurityGroupName: 'x' }).undeclared
     ).toEqual([]);
@@ -8580,17 +8583,27 @@ describe('CFn auto-generated name folding (generated tier)', () => {
     expect(tier('CdkRealDriftIntegIotVpces-NlbBC02D1613-Rz5FCsQXIO7E')).toBe('generated');
   });
 
-  it('no constructPath -> cannot derive the stack name -> never folds (safe)', () => {
+  it('no constructPath -> still folds via the logicalId-anchored branch (#888)', () => {
+    // An implicitly-created SG (an RDS cluster's / DBProxy's) can lose its aws:cdk:path in the
+    // deployed template, so the stack name cannot be derived. The undeclared name still reads back
+    // `<stack>-<logicalId>-<random>` — the logical id sits as a whole segment before CFn's random
+    // suffix — so it folds anchored on the logical id alone. (An undeclared GroupName can ONLY be
+    // the CFn-minted name; a user-set one is DECLARED and compared in the declared loop.)
     const r: DesiredResource = {
-      logicalId: 'Sg',
+      logicalId: 'ClusterSecurityGroup0921994B',
       resourceType: 'AWS::EC2::SecurityGroup',
       physicalId: 'sg-x',
       declared: {},
     };
-    const f = classifyResource(r, { GroupName: 'Any-Sg-8qZ9xcu9LOZR' }, bare).find(
-      (x) => x.path === 'GroupName'
-    );
-    expect(f?.tier).toBe('undeclared');
+    const tier = (name: string) =>
+      classifyResource(r, { GroupName: name }, bare).find((x) => x.path === 'GroupName')?.tier;
+    // `<stack>-<logicalId>-<random>` with the logical id as a whole non-first segment -> folds
+    expect(tier('Any-ClusterSecurityGroup0921994B-8qZ9xcu9LOZR')).toBe('generated');
+    // a value whose de-suffixed base does NOT end with this resource's logical id -> surfaces
+    expect(tier('Any-OtherLogicalId-8qZ9xcu9LOZR')).toBe('undeclared');
+    // a bare `<logicalId>-<random>` (no prefix segment) is NOT folded by this branch -> surfaces
+    // (that no-prefix form stays scoped per type+path to avoid over-folding short raw-CFn ids)
+    expect(tier('ClusterSecurityGroup0921994B-8qZ9xcu9LOZR')).toBe('undeclared');
   });
 
   // #509: a BucketDeployment's AwsCliLayer LayerName reads back its bare LOGICAL ID

--- a/tests/noise-888-sg-generated-name.test.ts
+++ b/tests/noise-888-sg-generated-name.test.ts
@@ -1,0 +1,159 @@
+// #888: an AWS::EC2::SecurityGroup that declares no GroupName reads back its CloudFormation-
+// minted physical name (`<stackName>-<logicalId>-<random>`) — pure AWS-assigned identity the
+// template never declared. On a clean, un-mutated deploy that must fold to zero [Potential
+// Drift] (the core invariant), not surface as undeclared drift. The same holds for the sibling
+// SecurityGroupIngress.SourceSecurityGroupName / SecurityGroupEgress.DestinationSecurityGroupName
+// echoes of a peer group's generated name. Every fold below still lets a genuine divergence
+// surface (a user-set literal GroupName is compared in the declared loop, so an undeclared user
+// name still shows).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+// A path surfaces as [Potential Drift] iff it lands in a NON-folded tier (undeclared / declared).
+const isFolded = (findings: Finding[], path: string) =>
+  !findings.some((f) => f.path === path && (f.tier === 'undeclared' || f.tier === 'declared'));
+
+describe('#888 SecurityGroup GroupName folds the CFn-generated physical name', () => {
+  const res: DesiredResource = {
+    logicalId: 'ClusterSecurityGroup0921994B',
+    resourceType: 'AWS::EC2::SecurityGroup',
+    physicalId: 'sg-0123456789abcdef0',
+    constructPath: 'Cdkrd717Verify/ClusterSecurityGroup0921994B/Resource',
+    declared: { GroupDescription: 'db access' },
+  };
+
+  it('folds an undeclared <stackName>-<logicalId>-<random> GroupName (no first-run noise)', () => {
+    const f = classifyResource(
+      res,
+      {
+        GroupDescription: 'db access',
+        GroupName: 'Cdkrd717Verify-ClusterSecurityGroup0921994B-h8SACJTYF1Ti',
+      },
+      emptySchema
+    );
+    expect(isFolded(f, 'GroupName')).toBe(true);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('GroupName');
+  });
+
+  it('folds even when constructPath is undefined (implicit SG lost aws:cdk:path — the live #888 case)', () => {
+    // An RDS cluster's / DBProxy's auto-created SG loses its construct path in the deployed
+    // template, so the stack name cannot be derived — the fold must anchor on the logicalId,
+    // which is the segment before CFn's random suffix. Fails on main (surfaces as undeclared).
+    const { constructPath: _drop, ...noPath } = res;
+    const f = classifyResource(
+      noPath,
+      {
+        GroupDescription: 'db access',
+        GroupName: 'Cdkrd717Verify-ClusterSecurityGroup0921994B-h8SACJTYF1Ti',
+      },
+      emptySchema
+    );
+    expect(isFolded(f, 'GroupName')).toBe(true);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('GroupName');
+  });
+
+  it('still surfaces a user-set literal GroupName that does not match the pattern', () => {
+    const f = classifyResource(
+      res,
+      { GroupDescription: 'db access', GroupName: 'my-custom-sg' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('GroupName');
+  });
+
+  it('still surfaces a user literal even with no constructPath (fold stays value-dependent)', () => {
+    const { constructPath: _drop, ...noPath } = res;
+    const f = classifyResource(
+      noPath,
+      { GroupDescription: 'db access', GroupName: 'my-custom-sg' },
+      emptySchema
+    );
+    expect(pathsByTier(f, 'undeclared')).toContain('GroupName');
+  });
+});
+
+describe('#888 SecurityGroupIngress.SourceSecurityGroupName echo folds', () => {
+  const res: DesiredResource = {
+    logicalId: 'IndirectPort',
+    resourceType: 'AWS::EC2::SecurityGroupIngress',
+    physicalId: 'sgr-abc',
+    constructPath: 'Cdkrd717Verify/IndirectPort/Resource',
+    declared: { GroupId: 'sg-1', IpProtocol: 'tcp', SourceSecurityGroupId: 'sg-2' },
+  };
+
+  it('folds the derived peer-group name (no first-run noise)', () => {
+    const f = classifyResource(
+      res,
+      {
+        GroupId: 'sg-1',
+        IpProtocol: 'tcp',
+        SourceSecurityGroupId: 'sg-2',
+        SourceSecurityGroupName: 'Cdkrd717Verify-ProxyProxySecurityGroupC42FC3CE-XWeDSyAblhvp',
+      },
+      emptySchema
+    );
+    expect(isFolded(f, 'SourceSecurityGroupName')).toBe(true);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('SourceSecurityGroupName');
+  });
+});
+
+describe('#888 SecurityGroupEgress.DestinationSecurityGroupName echo folds', () => {
+  const mk = (constructPath: string): DesiredResource => ({
+    logicalId: 'EgRule',
+    resourceType: 'AWS::EC2::SecurityGroupEgress',
+    physicalId: 'sgr-def',
+    constructPath,
+    declared: { GroupId: 'sg-1', IpProtocol: 'tcp', DestinationSecurityGroupId: 'sg-2' },
+  });
+
+  it('folds a same-stack derived peer-group name', () => {
+    const f = classifyResource(
+      mk('Cdkrd717Verify/EgRule/Resource'),
+      {
+        GroupId: 'sg-1',
+        IpProtocol: 'tcp',
+        DestinationSecurityGroupId: 'sg-2',
+        DestinationSecurityGroupName: 'Cdkrd717Verify-PeerSecurityGroupC42FC3CE-XWeDSyAblhvp',
+      },
+      emptySchema
+    );
+    expect(isFolded(f, 'DestinationSecurityGroupName')).toBe(true);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('DestinationSecurityGroupName');
+  });
+
+  // The value-independent fold must catch a CROSS-STACK peer name too — its `<otherStack>-`
+  // prefix means isCfnGeneratedName (which keys on THIS resource's stack prefix) misses it.
+  // This is the case the wrong `SourceSecurityGroupName` key left surfacing before #888.
+  it('folds a cross-stack derived peer-group name (isCfnGeneratedName cannot reach it)', () => {
+    const f = classifyResource(
+      mk('ThisStack/EgRule/Resource'),
+      {
+        GroupId: 'sg-1',
+        IpProtocol: 'tcp',
+        DestinationSecurityGroupId: 'sg-2',
+        DestinationSecurityGroupName: 'OtherStack-PeerSecurityGroupABC-XWeDSyAblhvp',
+      },
+      emptySchema
+    );
+    expect(isFolded(f, 'DestinationSecurityGroupName')).toBe(true);
+    expect(pathsByTier(f, 'undeclared')).not.toContain('DestinationSecurityGroupName');
+  });
+});


### PR DESCRIPTION
Closes #888

## Problem
On a clean, un-mutated deploy an `AWS::EC2::SecurityGroup` that declares no `GroupName` surfaced its CFn-minted physical name (`<stackName>-<logicalId>-<random>`) as a first-run `[Potential Drift]` — pure AWS-assigned identity the template never declared, so it violates the zero-potential-drift core invariant. The `AWS::EC2::SecurityGroupIngress.SourceSecurityGroupName` / `AWS::EC2::SecurityGroupEgress.DestinationSecurityGroupName` echoes of the same generated group name were sibling FPs.

## Root cause
The existing generated-name fold (`isCfnGeneratedName`) derives the stack name from `resource.constructPath`. For **implicitly-created** SGs (an RDS cluster's / DBProxy's auto-made SG) the deployed template carries no `aws:cdk:path`, so `constructPath` is `undefined`, `isCfnGeneratedName` bailed immediately, and `GroupName` surfaced. The egress twin in `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` also used the wrong key (`SourceSecurityGroupName` — egress rules echo `DestinationSecurityGroupName`), so a cross-stack egress name (whose `<otherStack>-` prefix `isCfnGeneratedName` can't reach) surfaced too.

## Fix (reuses the existing generated-name mechanism)
- `src/diff/classify.ts` — extend `isCfnGeneratedName` with a **constructPath-independent, logicalId-anchored** branch: a value of shape `<prefix>-<logicalId>-<random>` (the logical id as a whole non-first segment before CFn's random suffix) folds to `generated` even when the construct path was stripped. Value-DEPENDENT — a user-set literal (`my-custom-sg`) still surfaces; the bare `<logicalId>-<random>` no-prefix form is left to the scoped `GENERATED_LOGICALID_PREFIX_PATHS` to avoid over-folding short raw-CFn ids (e.g. a WAFv2 WebACL `Edge-<random>`).
- `src/normalize/noise.ts` — correct the egress value-independent key from `SourceSecurityGroupName` to `DestinationSecurityGroupName` so the egress peer-name echo folds robustly (incl. cross-stack), mirroring the ingress fold.

An undeclared `GroupName` can only ever be the CFn-minted name (a user-set one is DECLARED and compared in the declared loop), so first-run zero-noise is restored while declared-drift detection is preserved.

## Tests
- `tests/noise-888-sg-generated-name.test.ts` — GroupName generated-pattern folds (incl. the **no-constructPath** live case), user literal still surfaces (with and without constructPath), ingress `SourceSecurityGroupName` folds, egress `DestinationSecurityGroupName` folds (same-stack **and** cross-stack). The no-constructPath and cross-stack cases fail on main, pass with the fix.
- `tests/classify.test.ts` — updated the pre-#888 "no constructPath -> never folds" assertion to the corrected behavior + the egress-key case.

Gates: typecheck / lint+format / build / 3497 unit tests all green.