### PR TITLE
docs: staleness batch (stack-selection / ListStackResources / ignore verb / Fn::Base64) (#972)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -21,7 +21,7 @@ un-deployed code edits would show as false "drift".
 
 ```
 1. baseline file load            .cdkrd/baselines/<stack>.<accountId>.<region>.json
-2. desired (declared):           GetTemplate + DescribeStackResources (phys-id map)
+2. desired (declared):           GetTemplate + ListStackResources (phys-id map)
                                  → intrinsic resolution
 3. live full state per resource: CC API GetResource (default)
                                  → SDK override (gap types) → skip+log
@@ -107,7 +107,7 @@ NEW (cdkd does NOT have these):
 
 - **schema-strip** — `describe-type` readOnly/writeOnly → strip set (cdkd hand-codes per-provider instead; this is our differentiator: less per-type code)
 - **policy canonicalizer** — scalar/array unify + statement sort + account-id↔root-ARN + Condition value-set canonicalize (scalar/array unify + sort) (no Version fabrication); cdkd only URL-decodes + JSON.parse, raw-compares → tolerates false positives
-- **desired-adapter** — GetTemplate + DescribeStackResources → resolved declared
+- **desired-adapter** — GetTemplate + ListStackResources → resolved declared
 - **baseline file I/O** — git-committed JSON (the `record` verb; KEEPS watching)
 - **ignore rules** — git-committed `.cdkrd/ignore.yaml` (hand-edited POLICY, so
   YAML to carry `#` comments saying WHY; baseline stays JSON because it is

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Full design and rationale: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 | --------------------- | ------------------------------------------------------------- |
 | `cdkrd check`         | every stack the CDK app defines, each in its own `env.region` |
 | `cdkrd check 'Dev*'`  | glob, matched against the app's stack names                   |
-| `cdkrd check MyStack` | one stack, selected by name from the app                      |
+| `cdkrd check MyStack` | every same-named stack (a name can repeat across regions)     |
 
 cdkrd resolves your CDK app to discover which stacks exist and to label findings by
 construct path. The app comes from `cdk.json` (when run in the project directory) or

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -216,7 +216,7 @@ Entry: [src/commands/check.ts](../src/commands/check.ts) → shared gather in
 
 ```
 1. resolve stacks        resolve-stacks.ts: synth-discover the app → all | exact names | globs
-2. desired (declared)    template-adapter.ts: GetTemplate + DescribeStackResources
+2. desired (declared)    template-adapter.ts: GetTemplate + ListStackResources
                          (phys-id map) + DescribeStacks (params) → intrinsic resolution
                          (--pre-deploy: LOCAL synth template replaces GetTemplate;
                          otherwise the synth template recovers GetTemplate's `?`-masked
@@ -337,8 +337,10 @@ checked.
 Resolves `Ref` / `Fn::Sub` / `Fn::If` (+ condition eval: Equals/And/Or/Not) /
 `Fn::Join` / `Fn::Select` / `Fn::GetAtt` (both the array form and the long-form
 `"LogicalId.Attr"` string) / `Fn::FindInMap` / `Fn::Split` / `Fn::Cidr` (the
-deterministic IPv4 subnet split) / `Fn::ImportValue` / `AWS::NoValue`, plus the
-`Fn::Sub` `${!Literal}` escape.
+deterministic IPv4 subnet split) / `Fn::Base64` (a pure, environment-INDEPENDENT
+transform — so declared EC2 UserData is compared instead of left UNRESOLVED) /
+`Fn::ImportValue` / `AWS::NoValue`, plus the `Fn::Sub` `${!Literal}` escape.
+`Fn::GetAZs` is deliberately NOT resolved (its value is environment-dependent).
 `Fn::FindInMap` resolves against `ctx.mappings` (from `template.Mappings`);
 `Fn::ImportValue` against `ctx.exports` (CFn cross-stack exports — see below);
 `Fn::Select` returns `UNRESOLVED` (not `undefined`) for an out-of-range index. All
@@ -902,8 +904,9 @@ until the next `record` upgrades the file (a stderr note says so).
 deployed to dev + prod (the very common `env: { account: PERSONAL || SHARED }` CDK
 pattern) gets one baseline file PER account, so they never collide and a
 personal-account run is not blocked by a committed shared-account baseline. Because
-the filename embeds the accountId — which only a gather (`DescribeStackResources`)
-resolves — `loadBaseline` is called AFTER the desired model is built (check was
+the filename embeds the accountId — which only a gather (`DescribeStacks`, whose
+`StackId` ARN carries the account) resolves — `loadBaseline` is called AFTER the
+desired model is built (check was
 already gather-then-load; revert + record's overwrite-check were reordered to match).
 The `accountId` FIELD remains as a **secondary guard** (`checkBaselineAccount`):
 a correctly-named file always matches, so it now only catches a file hand-copied or
@@ -1067,8 +1070,10 @@ a wrong-typed `ignore`, or an unknown top-level key (R62: a typo like `ignroe`
 would otherwise load as an empty config and silently disable every rule) — fails
 the run (exit 2) rather than silently dropping the rules. Applied even under `--show-all`
 (inventory un-suppresses the baseline, not the ignore rules); `--verbose` still lists
-the ignored entries. A CLI to manage rules (`cdkrd ignore <pattern>`) is a future
-open question (§13) — v1 is hand-edited. **Default text layout (R25, spacing
+the ignored entries. Rules can be hand-edited OR appended by the shipped
+`cdkrd ignore` verb (comment-preserving, append-only); a `cdkrd ignore --list`
+view to inspect the active rules without opening the file remains a future open
+question (§13 item 8). **Default text layout (R25, spacing
 R37/R48):** the three DRIFT tiers print in full; the INFORMATIONAL tiers are
 folded into an `info:` footer (per-tier counts + a reason breakdown, e.g.
 `skipped=24 (custom resource 12, override target unresolved 12)`) — a single


### PR DESCRIPTION
Closes #972. Docs-only staleness batch verified against source at HEAD.

1. **README stack-selection** (README.md L303) — was "one stack, selected by name from the app"; now "every same-named stack (a name can repeat across regions)". Verified: `src/commands/resolve-stacks.ts` L121-130 uses `discovered.filter((s) => s.stackName === name)` (all same-named instances across regions), shipped by #899/#884.

2. **ListStackResources for phys-id map** (DESIGN.md L24, L110; docs/ARCHITECTURE.md L219) — was `DescribeStackResources`; now `ListStackResources`. Verified: `src/desired/template-adapter.ts` L10/L165-201 pages `ListStackResourcesCommand` (DescribeStackResources caps at 100, CDK stacks reach ~500); no `DescribeStackResourcesCommand` import remains in that file. ARCHITECTURE L240's sibling-check `DescribeStackResources` (gather.ts L179) is correct and left untouched.
   - **L905 accountId note**: verified accountId is resolved from `DescribeStacks`' `StackId` ARN (template-adapter.ts L232-233 `stackId.split(':')[4]`), NOT ListStackResources — so this sentence was corrected to `DescribeStacks` (the accurate call), not blindly to ListStackResources.

3. **Shipped `ignore` verb** (docs/ARCHITECTURE.md L1070) — was "a future open question (§13) — v1 is hand-edited"; now states rules can be hand-edited OR appended by the shipped `cdkrd ignore` verb, with only `--list` remaining open. Verified: `src/commands/ignore.ts` + `addIgnoreRules` in `src/config/config-file.ts` L335 exist; matches §13 item 8 (L1275-1279).

4. **Fn::Base64 in intrinsic list** (docs/ARCHITECTURE.md §5) — added `Fn::Base64` to the resolver list and noted `Fn::GetAZs` is deliberately unresolved. Verified: `src/normalize/intrinsic-resolver.ts` L58 `case 'Fn::Base64'` resolves it (deterministic, environment-independent — so EC2 UserData is compared, not left UNRESOLVED); code comment L60 contrasts the environment-dependent `Fn::GetAZs`.

Docs-only: no src/tests/.github touched. `vp check --fix` passed (0 errors).