### PR TITLE
fix(read): transient kms:ListAliases failure misreported as permanent IAM denial (#963)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -14,6 +14,8 @@ import { READ_RETRY } from '../read/client-config.js';
 import {
   fetchManagedAliasTargets,
   kmsListAliasesDeniedWarning,
+  kmsListAliasesTransientWarning,
+  type ManagedAliasTargets,
   usesManagedKmsAlias,
 } from '../read/kms-aliases.js';
 import { type AddedChild, CHILD_ENUMERATORS } from '../read/child-enumerators.js';
@@ -45,6 +47,37 @@ function liveModelMap(reads: Map<string, ReadResult>): Map<string, Record<string
 // (a multi-stack run in the same region should not repeat it). Process-lifetime (matches
 // the per-region alias cache in kms-aliases.ts).
 const kmsDeniedWarned = new Set<string>();
+
+/**
+ * Decide + emit the kms:ListAliases degradation warning for a stack that declares an
+ * AWS-managed alias (R115 / #963). Two outcomes must NOT be conflated:
+ *   - DEFINITIVE denial (missing kms:ListAliases, cached by fetchManagedAliasTargets):
+ *     print the permanent "grant IAM for full coverage" warning ONCE per region (dedupe
+ *     via `deniedWarned`), because the whole region is degraded for the rest of the run.
+ *   - TRANSIENT failure (throttle / 5xx / network, NOT cached): print the "this is NOT an
+ *     IAM problem; no action needed" warning per stack and — critically — do NOT stamp
+ *     `deniedWarned`. The region is not poisoned, so the next stack in it re-queries and
+ *     may succeed silently (or surface a genuine denial that must still be reported).
+ * #789 stopped CACHING the transient result but left this WARNING half on the wrong
+ * branch (it printed the permanent-denied warning and poisoned the dedupe). `log` is
+ * injectable so both branches are unit-tested without running the whole gather.
+ */
+export function warnKmsAliasResolution(
+  resolved: ManagedAliasTargets,
+  region: string,
+  deniedWarned: Set<string>,
+  log: (msg: string) => void = console.error
+): void {
+  if (!resolved.denied) return;
+  if (resolved.transient) {
+    log(kmsListAliasesTransientWarning(region));
+    return;
+  }
+  if (!deniedWarned.has(region)) {
+    deniedWarned.add(region);
+    log(kmsListAliasesDeniedWarning(region));
+  }
+}
 
 // Bounded-concurrency live-read pool (pull-next-when-free): serial reads cost
 // ~300ms each, so 200+ resources took >1min; the SDK's adaptive retry handles
@@ -551,10 +584,7 @@ export async function gatherFindings(
   if (desired.resources.some((r) => usesManagedKmsAlias(r.declared))) {
     const resolved = await fetchManagedAliasTargets(region);
     kmsAliasTargets = resolved.targets;
-    if (resolved.denied && !kmsDeniedWarned.has(region)) {
-      kmsDeniedWarned.add(region);
-      console.error(kmsListAliasesDeniedWarning(region));
-    }
+    warnKmsAliasResolution(resolved, region, kmsDeniedWarned);
   }
   const classifyOpts = {
     accountId: desired.accountId,

--- a/tests/kms-transient-warn-963.test.ts
+++ b/tests/kms-transient-warn-963.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { warnKmsAliasResolution } from '../src/commands/gather.js';
+import {
+  kmsListAliasesDeniedWarning,
+  kmsListAliasesTransientWarning,
+} from '../src/read/kms-aliases.js';
+
+// #963: #789 stopped CACHING a transient kms:ListAliases failure but left the WARNING
+// half wired to the wrong branch — gather only checked `.denied`, so a transient blip
+// printed the permanent "denied — grant IAM" warning AND stamped the per-region
+// `kmsDeniedWarned` dedupe, silencing every later stack in the region (including a later
+// GENUINE denial). warnKmsAliasResolution must branch on `.transient`.
+
+describe('warnKmsAliasResolution — transient vs definitive (#963)', () => {
+  it('a TRANSIENT failure emits the transient warning, NOT the denied warning, and does NOT poison the region dedupe', () => {
+    const region = 'us-east-1';
+    const deniedWarned = new Set<string>();
+    const msgs: string[] = [];
+    const log = (m: string) => msgs.push(m);
+
+    // Transient blip (throttle / 5xx that survived retry): not cached, flagged transient.
+    warnKmsAliasResolution(
+      { targets: {}, denied: true, transient: true },
+      region,
+      deniedWarned,
+      log
+    );
+
+    expect(msgs).toEqual([kmsListAliasesTransientWarning(region)]);
+    // Must NOT have printed the permanent-IAM diagnosis...
+    expect(msgs[0]).not.toContain('Grant kms:ListAliases');
+    // ...and must NOT have poisoned the dedupe set, so a later genuine denial still warns.
+    expect(deniedWarned.has(region)).toBe(false);
+
+    // Next stack in the SAME region hits a real denial: it must STILL surface the
+    // permanent warning (the transient blip did not silence it).
+    warnKmsAliasResolution({ targets: {}, denied: true }, region, deniedWarned, log);
+    expect(msgs).toEqual([
+      kmsListAliasesTransientWarning(region),
+      kmsListAliasesDeniedWarning(region),
+    ]);
+    expect(deniedWarned.has(region)).toBe(true);
+  });
+
+  it('a DEFINITIVE denial emits the permanent warning once per region (dedupe holds)', () => {
+    const region = 'eu-west-1';
+    const deniedWarned = new Set<string>();
+    const msgs: string[] = [];
+    const log = (m: string) => msgs.push(m);
+
+    warnKmsAliasResolution({ targets: {}, denied: true }, region, deniedWarned, log);
+    // Second stack, same region: suppressed by the dedupe stamp.
+    warnKmsAliasResolution({ targets: {}, denied: true }, region, deniedWarned, log);
+
+    expect(msgs).toEqual([kmsListAliasesDeniedWarning(region)]);
+    expect(deniedWarned.has(region)).toBe(true);
+  });
+
+  it('a successful resolution (not denied) emits nothing and leaves the dedupe untouched', () => {
+    const region = 'ap-northeast-1';
+    const deniedWarned = new Set<string>();
+    const msgs: string[] = [];
+    warnKmsAliasResolution(
+      { targets: { 'alias/aws/sqs': 'key-sqs' }, denied: false },
+      region,
+      deniedWarned,
+      (m) => msgs.push(m)
+    );
+    expect(msgs).toEqual([]);
+    expect(deniedWarned.has(region)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #963

## Problem
#789 stopped *caching* a transient `kms:ListAliases` failure but never wired the *warning* half. `gather.ts` checked only `resolved.denied`, so a transient blip (throttle surviving retry / 5xx / network) printed the permanent "denied — grant IAM" warning AND stamped the process-lifetime `kmsDeniedWarned` set, silencing every later stack in that region this run — including a later genuine denial. `kmsListAliasesTransientWarning` existed, was exported and unit-tested, but had zero production callers (dead code).

## Fix
- Extracted the warning decision into an exported, testable `warnKmsAliasResolution(resolved, region, deniedWarned, log?)` in `src/commands/gather.ts`.
  - **Transient** (`resolved.transient`): emit `kmsListAliasesTransientWarning(region)` ("NOT an IAM permission problem; no action needed"), per stack, and do NOT stamp `kmsDeniedWarned` — so a later stack's retry can still surface a genuine denial.
  - **Definitive denial** (`denied && !transient`): keep the existing permanent warning + one-per-region dedupe stamp.
  - Not denied: nothing.
- Threaded the `ManagedAliasTargets` type + `kmsListAliasesTransientWarning` import into gather.ts.
- `regatherTouched` left as-is (takes only `.targets`; the primary gather already warned) — per the issue.

## Tests
New `tests/kms-transient-warn-963.test.ts`:
- a transient failure emits the transient warning (NOT the denied/grant-IAM warning) and does NOT poison `kmsDeniedWarned`; a subsequent genuine denial in the same region STILL warns.
- a definitive denial emits the permanent warning once per region (dedupe holds).
- a successful resolution emits nothing.

## Gates
typecheck / lint+format / build / `vp test run` (3516 passed, 87 files) all green.
