### PR TITLE
fix(read): transient kms:ListAliases warns transient, does not poison the region dedupe (#963)

### DIFF
--- a/src/commands/gather.ts
+++ b/src/commands/gather.ts
@@ -13,7 +13,7 @@ import { resolveProperties } from '../normalize/intrinsic-resolver.js';
 import { READ_RETRY } from '../read/client-config.js';
 import {
   fetchManagedAliasTargets,
-  kmsListAliasesDeniedWarning,
+  kmsWarnDecision,
   usesManagedKmsAlias,
 } from '../read/kms-aliases.js';
 import { type AddedChild, CHILD_ENUMERATORS } from '../read/child-enumerators.js';
@@ -45,6 +45,11 @@ function liveModelMap(reads: Map<string, ReadResult>): Map<string, Record<string
 // (a multi-stack run in the same region should not repeat it). Process-lifetime (matches
 // the per-region alias cache in kms-aliases.ts).
 const kmsDeniedWarned = new Set<string>();
+// Regions already warned about a TRANSIENT kms:ListAliases failure (#963). A SEPARATE set
+// from kmsDeniedWarned so a transient blip's dedupe never masks a later stack's GENUINE
+// denial in the same region — the transient failure is not cached (kms-aliases.ts), so the
+// next stack re-queries and a real denial then still surfaces.
+const kmsTransientWarned = new Set<string>();
 
 // Bounded-concurrency live-read pool (pull-next-when-free): serial reads cost
 // ~300ms each, so 200+ resources took >1min; the SDK's adaptive retry handles
@@ -551,10 +556,19 @@ export async function gatherFindings(
   if (desired.resources.some((r) => usesManagedKmsAlias(r.declared))) {
     const resolved = await fetchManagedAliasTargets(region);
     kmsAliasTargets = resolved.targets;
-    if (resolved.denied && !kmsDeniedWarned.has(region)) {
-      kmsDeniedWarned.add(region);
-      console.error(kmsListAliasesDeniedWarning(region));
-    }
+    // A denied read is either a genuine IAM denial (permanent — grant kms:ListAliases) or
+    // a TRANSIENT blip (throttle/network/5xx; no action needed, retried next stack). Emit
+    // the RIGHT message and stamp the RIGHT dedupe set — a transient blip must NOT poison
+    // kmsDeniedWarned, or a later stack's real denial in this region would go unexplained (#963).
+    const decision = kmsWarnDecision(
+      region,
+      resolved,
+      kmsDeniedWarned.has(region),
+      kmsTransientWarned.has(region)
+    );
+    if (decision.stampDenied) kmsDeniedWarned.add(region);
+    if (decision.stampTransient) kmsTransientWarned.add(region);
+    if (decision.warning) console.error(decision.warning);
   }
   const classifyOpts = {
     accountId: desired.accountId,

--- a/src/read/kms-aliases.ts
+++ b/src/read/kms-aliases.ts
@@ -99,6 +99,37 @@ export function kmsListAliasesTransientWarning(region: string): string {
   );
 }
 
+/** Pure decision for the gather-time KMS warning: given a resolved ListAliases outcome
+ *  and the two per-region dedupe sets' membership, decide WHICH warning to emit (if any)
+ *  and WHICH set to stamp. The split is the #963 fix: a TRANSIENT failure must warn with
+ *  the transient message and stamp ONLY the transient set — it must NOT stamp the
+ *  permanent-denial set, or a later stack's GENUINE denial in the same region would be
+ *  silenced. Transient and denied dedupe independently (separate sets) so neither masks
+ *  the other. `warning` is null when nothing should print (not denied, or already warned
+ *  in that region). */
+export function kmsWarnDecision(
+  region: string,
+  resolved: Pick<ManagedAliasTargets, 'denied' | 'transient'>,
+  deniedWarned: boolean,
+  transientWarned: boolean
+): { warning: string | null; stampDenied: boolean; stampTransient: boolean } {
+  if (!resolved.denied) return { warning: null, stampDenied: false, stampTransient: false };
+  if (resolved.transient) {
+    // Transient blip: dedupe via the SEPARATE transient set; never touch the denial set.
+    return {
+      warning: transientWarned ? null : kmsListAliasesTransientWarning(region),
+      stampDenied: false,
+      stampTransient: !transientWarned,
+    };
+  }
+  // Genuine denial: dedupe via the permanent-denial set.
+  return {
+    warning: deniedWarned ? null : kmsListAliasesDeniedWarning(region),
+    stampDenied: !deniedWarned,
+    stampTransient: false,
+  };
+}
+
 /** True when any resolved declared value in the stack references an AWS-managed KMS
  *  alias, i.e. a ListAliases prefetch is worth doing. */
 export function usesManagedKmsAlias(v: unknown): boolean {

--- a/tests/kms-transient-789.test.ts
+++ b/tests/kms-transient-789.test.ts
@@ -4,7 +4,9 @@ import { beforeEach, describe, expect, it } from 'vite-plus/test';
 import {
   fetchManagedAliasTargets,
   isDefinitiveDenial,
+  kmsListAliasesDeniedWarning,
   kmsListAliasesTransientWarning,
+  kmsWarnDecision,
 } from '../src/read/kms-aliases.js';
 
 // #789: fetchManagedAliasTargets must cache ONLY definitive outcomes (success or a
@@ -99,6 +101,48 @@ describe('isDefinitiveDenial (#789)', () => {
     ).toBe(false);
     expect(isDefinitiveDenial({ name: 'TimeoutError' })).toBe(false);
     expect(isDefinitiveDenial(undefined)).toBe(false);
+  });
+});
+
+describe('kmsWarnDecision — transient vs genuine denial + dedupe split (#963)', () => {
+  const region = 'us-east-1';
+
+  it('a TRANSIENT failure emits the transient warning and stamps ONLY the transient set (never poisons the denial set)', () => {
+    const d = kmsWarnDecision(region, { denied: true, transient: true }, false, false);
+    expect(d.warning).toBe(kmsListAliasesTransientWarning(region));
+    expect(d.stampTransient).toBe(true);
+    // The #963 bug: a transient blip must NOT stamp the permanent-denial set, or a later
+    // stack's real denial in the same region would be silenced.
+    expect(d.stampDenied).toBe(false);
+  });
+
+  it('a GENUINE denial emits the denied warning and stamps the denial set', () => {
+    const d = kmsWarnDecision(region, { denied: true, transient: false }, false, false);
+    expect(d.warning).toBe(kmsListAliasesDeniedWarning(region));
+    expect(d.stampDenied).toBe(true);
+    expect(d.stampTransient).toBe(false);
+  });
+
+  it('a genuine denial still surfaces after a transient blip already warned in the region', () => {
+    // transientWarned=true (the blip already warned), deniedWarned=false → the real denial
+    // is NOT deduped away, because it uses the separate denial set.
+    const d = kmsWarnDecision(region, { denied: true, transient: false }, false, true);
+    expect(d.warning).toBe(kmsListAliasesDeniedWarning(region));
+    expect(d.stampDenied).toBe(true);
+  });
+
+  it('dedupes each kind independently: no repeat warning once its own set is stamped', () => {
+    expect(kmsWarnDecision(region, { denied: true, transient: true }, false, true).warning).toBe(
+      null
+    );
+    expect(kmsWarnDecision(region, { denied: true, transient: false }, true, false).warning).toBe(
+      null
+    );
+  });
+
+  it('a successful read (not denied) emits nothing and stamps nothing', () => {
+    const d = kmsWarnDecision(region, { denied: false }, false, false);
+    expect(d).toEqual({ warning: null, stampDenied: false, stampTransient: false });
   });
 });
 


### PR DESCRIPTION
Closes #963.

## Root cause
`gather.ts` consumed only `resolved.denied`, so a TRANSIENT `kms:ListAliases` blip (throttle/5xx/network — `fetchManagedAliasTargets` returns `{denied:true, transient:true}`) printed the PERMANENT "denied — grant IAM" warning AND stamped `kmsDeniedWarned`, silencing every later stack in that region this run — including a later stack's GENUINE denial. The correct `kmsListAliasesTransientWarning` existed, exported, unit-tested, but had zero production callers (#789 fixed only the cache half).

## Fix
A pure `kmsWarnDecision(region, resolved, deniedWarned, transientWarned)` helper splits transient vs denied and returns which warning + which dedupe set to stamp. gather.ts now uses TWO separate per-region sets (`kmsDeniedWarned`, new `kmsTransientWarned`) so a transient blip warns with the transient message, stamps only the transient set, and NEVER poisons the permanent-denial set. `regatherTouched` reads only `.targets` (never warns) — left unchanged, as verified.

## Test
`tests/kms-transient-789.test.ts` gains a `kmsWarnDecision` block (5 cases): transient → transient warning + stampTransient only; genuine → denied warning + stampDenied; a genuine denial still surfaces after a transient blip already warned; independent dedupe; success emits nothing. Full suite: 3518 tests green.
