### PR TITLE
fix(revert): nullHuskRemovalOps positional array-remove index shift deletes wrong element (#968)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -300,10 +300,18 @@ export interface RevertPlan {
 // FAILING the revert of the unrelated property (#641 symptom 2). Emit `remove` ops that drop
 // the husk from CC's model too. Restricted to a PURE-null array (every element null): remove
 // the WHOLE property (absent = valid, and it dodges any minItems constraint an empty `[]`
-// would trip). Removing a KEY never shifts an array index, so the ops are order-independent
-// and safe to prepend to the real revert op. A REAL out-of-band edit produces non-null
-// objects (a mixed array is left untouched — not the observed husk shape), so detection and
-// legitimate reverts are unaffected.
+// would trip). A pure-null array usually sits under an OBJECT key (`.../TagFilters`), whose
+// remove never shifts an array index — but it can ALSO be an ARRAY ELEMENT itself
+// (`{ Rules: [[null], [null], { Keep: 1 }] }` -> `/Rules/0`, `/Rules/1`), whose remove IS
+// positional: RFC6902 `remove` splices the array, so applying `/Rules/0` first shifts every
+// later index left and `/Rules/1` would then delete the real-data element (#968). Every op
+// emitted here removes a DISJOINT pure-null subtree (the walk returns without recursing once
+// a pure-null array is found, so no op is an ancestor of another), so sorting them into
+// DESCENDING document order makes each remove address a position at or after every op still
+// to be applied — removing it can never shift a not-yet-applied array index. This keeps the
+// ops safe to prepend to the real revert op AND safe among themselves. A REAL out-of-band
+// edit produces non-null objects (a mixed array is left untouched — not the observed husk
+// shape), so detection and legitimate reverts are unaffected.
 function nullHuskRemovalOps(model: Record<string, unknown>): PatchOp[] {
   const ops: PatchOp[] = [];
   const walk = (value: unknown, pointer: string): void => {
@@ -320,7 +328,29 @@ function nullHuskRemovalOps(model: Record<string, unknown>): PatchOp[] {
     }
   };
   walk(model, '');
+  ops.sort((a, b) => compareDocOrderDescending(a.path, b.path));
   return ops;
+}
+
+// Total-order comparator putting two JSON pointers into DESCENDING document order: at the
+// first differing segment, larger index / lexically-greater key first (a numeric-vs-numeric
+// pair compares numerically so `/Rules/10` sorts before `/Rules/2`); if one pointer is a
+// prefix of the other, the deeper one first. Used to order `remove` ops so an earlier op
+// never splices an array position out from under a later op (#968).
+function compareDocOrderDescending(a: string, b: string): number {
+  const as = a.split('/').slice(1);
+  const bs = b.split('/').slice(1);
+  const n = Math.min(as.length, bs.length);
+  for (let i = 0; i < n; i++) {
+    if (as[i] === bs[i]) continue;
+    const ai = Number(as[i]);
+    const bi = Number(bs[i]);
+    const bothNumeric =
+      as[i] !== '' && bs[i] !== '' && Number.isInteger(ai) && Number.isInteger(bi);
+    if (bothNumeric) return bi - ai;
+    return as[i]! < bs[i]! ? 1 : -1;
+  }
+  return bs.length - as.length;
 }
 
 // dotted finding path ("A.B.0.C") -> RFC6902 JSON pointer ("/A/B/0/C"). Split on dots at

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -2674,16 +2674,18 @@ describe('#641 symptom 2 — CC revert strips bare-null array husks from the mod
     });
     expect(plan.items).toHaveLength(1);
     const ops = plan.items[0]!.ops;
-    // the husk removals lead, then the unrelated-property revert
+    // the husk removals lead (in DESCENDING document order — #968: these are both object-key
+    // removes so order is immaterial to correctness, but the sort emits Metrics before
+    // IntelligentTiering), then the unrelated-property revert
     expect(ops.map((o) => ({ op: o.op, path: o.path }))).toEqual([
-      { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
       { op: 'remove', path: '/MetricsConfigurations/1/TagFilters' },
+      { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
       { op: 'remove', path: '/VersioningConfiguration' },
     ]);
     // and they serialize to Cloud Control as pure remove ops (no value)
     expect(JSON.parse(toPatchDocument(plan.items[0]!))).toEqual([
-      { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
       { op: 'remove', path: '/MetricsConfigurations/1/TagFilters' },
+      { op: 'remove', path: '/IntelligentTieringConfigurations/0/TagFilters' },
       { op: 'remove', path: '/VersioningConfiguration' },
     ]);
   });
@@ -2735,6 +2737,71 @@ describe('#641 symptom 2 — CC revert strips bare-null array husks from the mod
     expect(plan.items).toHaveLength(1);
     expect(plan.items[0]!.kind).toBe('sdk');
     expect(plan.items[0]!.ops.every((o) => o.path !== '/Foo')).toBe(true);
+  });
+});
+
+describe('#968 — pure-null array husks nested INSIDE an array emit descending positional removes', () => {
+  // The husk walk recurses into array ELEMENTS, so a pure-null array that is itself an array
+  // element gets a `remove` at a NUMERIC pointer (a positional element removal). Cloud
+  // Control applies RFC6902 `remove` with SPLICE semantics, so emitting these ascending
+  // (`/Rules/0` then `/Rules/1`) shifts the array left and deletes the WRONG (real-data)
+  // element. The fix emits them in DESCENDING index order so no earlier remove shifts a
+  // later one. (Model CC's splice here — the repo's own applyOps uses non-splicing `delete`.)
+  const rfc6902Apply = (
+    model: Record<string, unknown>,
+    ops: readonly { op: string; path: string }[]
+  ): Record<string, unknown> => {
+    const out = structuredClone(model);
+    for (const op of ops) {
+      const segs = op.path
+        .split('/')
+        .slice(1)
+        .map((s) => s.replace(/~1/g, '/').replace(/~0/g, '~'));
+      let node: unknown = out;
+      for (let i = 0; i < segs.length - 1; i++) node = (node as Record<string, unknown>)[segs[i]!];
+      const last = segs[segs.length - 1]!;
+      if (Array.isArray(node))
+        node.splice(Number(last), 1); // SPLICE — shifts subsequent indices (as CC does)
+      else delete (node as Record<string, unknown>)[last];
+    }
+    return out;
+  };
+  const rulesRemoval = (): Finding =>
+    F({
+      tier: 'undeclared',
+      path: 'VersioningConfiguration',
+      actual: { Status: 'Enabled' },
+      unrecorded: true,
+    });
+
+  it('emits the sibling positional removes in DESCENDING index order', () => {
+    const plan = buildRevertPlan([rulesRemoval()], undefined, {
+      removeUnrecorded: true,
+      liveByLogical: new Map([['R', { Rules: [[null], [null], { Keep: 1 }] }]]),
+    });
+    const huskPaths = plan.items[0]!.ops.filter((o) => o.human.includes('husk')).map((o) => o.path);
+    expect(huskPaths).toEqual(['/Rules/1', '/Rules/0']);
+  });
+
+  it('applying the emitted husk ops (splice semantics) drops both husks and KEEPS the real element', () => {
+    const live = { Rules: [[null], [null], { Keep: 1 }] };
+    const plan = buildRevertPlan([rulesRemoval()], undefined, {
+      removeUnrecorded: true,
+      liveByLogical: new Map([['R', live]]),
+    });
+    const huskOps = plan.items[0]!.ops.filter((o) => o.human.includes('husk'));
+    // apply IN THE ORDER EMITTED — must not delete the real-data element
+    expect(rfc6902Apply(live, huskOps)).toEqual({ Rules: [{ Keep: 1 }] });
+  });
+
+  it('a guard: applying the SAME removes ascending WOULD delete the real element (documents the bug)', () => {
+    const live = { Rules: [[null], [null], { Keep: 1 }] };
+    // pre-fix emission order was ascending — prove that order corrupts the array
+    const ascending = [
+      { op: 'remove', path: '/Rules/0' },
+      { op: 'remove', path: '/Rules/1' },
+    ];
+    expect(rfc6902Apply(live, ascending)).toEqual({ Rules: [[null]] });
   });
 });
 


### PR DESCRIPTION
Closes #968

## Problem
`nullHuskRemovalOps` walks the live model and recurses into array ELEMENTS, so a pure-null array that is itself an array element emits a `remove` at a NUMERIC pointer (a positional element removal). Cloud Control applies RFC6902 `remove` with SPLICE semantics, so emitting siblings ascending (`/Rules/0` then `/Rules/1`) shifts the array left and `/Rules/1` then deletes the WRONG (real-data) element — e.g. `{ Rules: [[null], [null], { Keep: 1 }] }` loses `{ Keep: 1 }` and a husk survives. The function's old safety comment ("removing a KEY never shifts an array index") only held for the object-key husk shape.

## Fix
After the walk, sort the emitted `remove` ops into DESCENDING document order (a proper total order; numeric segments compared numerically). Every op removes a DISJOINT pure-null subtree (the walk returns without recursing once a pure-null array is found, so no op is an ancestor of another), so descending order guarantees each remove addresses a position at or after every op still to be applied — an earlier remove can never shift a not-yet-applied array index. This fixes same-array siblings AND cross-parent index shifts, and keeps the object-key husk behavior (order immaterial there).

Only `src/revert/plan.ts` changes; existing #641 object-key husk behavior is preserved (its two independent removes now emit in descending order — benign, test updated).

## Tests
Added a `#968` describe in `tests/revert-plan.test.ts`:
- asserts sibling positional removes emit in descending index order (`['/Rules/1', '/Rules/0']`);
- applies the emitted husk ops through a SPLICE-based RFC6902 applier (models CC; the repo's own `applyOps` uses non-splicing `delete`) and asserts `{ Keep: 1 }` survives;
- a guard test documenting that the pre-fix ascending order WOULD corrupt the array.

Both new correctness tests fail on `main` and pass with the fix. Full suite: 3516 passing.