### PR TITLE
fix(read): UNRESOLVED parent-ref fail-safe across child enumerators (#962)

### DIFF
--- a/src/read/child-enumerators.ts
+++ b/src/read/child-enumerators.ts
@@ -118,8 +118,28 @@ import {
   type Subscription as SnsSubscription,
 } from '@aws-sdk/client-sns';
 import { READ_RETRY } from './client-config.js';
+import { hasUnresolved, UNRESOLVED } from '../normalize/intrinsic-resolver.js';
 import type { Desired } from '../desired/template-adapter.js';
 import type { DesiredResource } from '../types.js';
+
+// Fail-safe parent-ref match. A child enumerator links a DECLARED child to its enumerated
+// parent by comparing the child's parent-ref property (UserPoolId, TopicArn, FunctionName,
+// EventBusName, …) against the parent's physical id / ARN. When the intrinsic resolver could
+// NOT evaluate that declared property it is the UNRESOLVED symbol — a `{{resolve:...}}`
+// dynamic reference, a `Ref` to a no-default Parameter (#744), a degraded Fn::ImportValue
+// (#784), a non-string Fn::Sub, or a malformed Fn::Join that fails closed (#851). A bare
+// `===` then FAILS, so the declared child is dropped from the declared set and its LIVE
+// counterpart is falsely flagged `[Added] created out of band` — offering a DESTRUCTIVE
+// Cloud Control DeleteResource against a resource the template explicitly declares (#962).
+// Fail SAFE: "we couldn't resolve what the template says" must never become "this live
+// resource is out of band, delete it?", so an UNRESOLVED parent-ref counts as a POTENTIAL
+// match and the declared child is KEPT. Otherwise the declared value must equal one of the
+// candidate parent ids/ARNs (undefined candidates — e.g. an unresolved parent ARN — are
+// ignored). Mirrors classify.ts's `v === UNRESOLVED || hasUnresolved(v)` detection.
+function parentRefMatches(declaredValue: unknown, ...candidates: (string | undefined)[]): boolean {
+  if (declaredValue === UNRESOLVED || hasUnresolved(declaredValue)) return true;
+  return candidates.some((c) => c !== undefined && declaredValue === c);
+}
 
 // One out-of-band child resource: present live, absent from the template.
 export interface AddedChild {
@@ -318,7 +338,7 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
   const declaredResourceIds: string[] = [];
   const declaredMethodKeys: string[] = [];
   for (const r of desired.resources) {
-    if (r.declared.RestApiId !== apiId) continue;
+    if (!parentRefMatches(r.declared.RestApiId, apiId)) continue;
     if (r.resourceType === 'AWS::ApiGateway::Resource' && r.physicalId) {
       declaredResourceIds.push(r.physicalId);
     } else if (r.resourceType === 'AWS::ApiGateway::Method') {
@@ -343,22 +363,25 @@ async function enumerateRestApiChildren(ctx: EnumeratorContext): Promise<AddedCh
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::ApiGateway::Authorizer' &&
-      r.declared.RestApiId === apiId &&
+      parentRefMatches(r.declared.RestApiId, apiId) &&
       r.physicalId
     ) {
       declaredAuthorizerIds.push(r.physicalId);
-    } else if (r.resourceType === 'AWS::ApiGateway::Model' && r.declared.RestApiId === apiId) {
+    } else if (
+      r.resourceType === 'AWS::ApiGateway::Model' &&
+      parentRefMatches(r.declared.RestApiId, apiId)
+    ) {
       const name = typeof r.declared.Name === 'string' ? r.declared.Name : r.physicalId;
       if (name) declaredModelNames.push(name);
     } else if (
       r.resourceType === 'AWS::ApiGateway::RequestValidator' &&
-      r.declared.RestApiId === apiId &&
+      parentRefMatches(r.declared.RestApiId, apiId) &&
       r.physicalId
     ) {
       declaredValidatorIds.push(r.physicalId);
     } else if (
       r.resourceType === 'AWS::ApiGateway::GatewayResponse' &&
-      r.declared.RestApiId === apiId &&
+      parentRefMatches(r.declared.RestApiId, apiId) &&
       typeof r.declared.ResponseType === 'string'
     ) {
       declaredResponseTypes.push(r.declared.ResponseType);
@@ -816,7 +839,7 @@ async function enumerateHttpApiChildren(ctx: EnumeratorContext): Promise<AddedCh
   // Declared stages of THIS api. A Stage's physical id (Ref) IS its StageName.
   const declaredStageNames: string[] = [];
   for (const r of desired.resources) {
-    if (r.declared.ApiId !== apiId) continue;
+    if (!parentRefMatches(r.declared.ApiId, apiId)) continue;
     if (r.resourceType === 'AWS::ApiGatewayV2::Route' && r.physicalId) {
       declaredRouteIds.push(r.physicalId);
     } else if (r.resourceType === 'AWS::ApiGatewayV2::Integration' && r.physicalId) {
@@ -927,7 +950,7 @@ async function pageSubscriptions(client: SNSClient, topicArn: string): Promise<S
   return out;
 }
 
-async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+export async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const topicArn = parent.physicalId; // the Topic's physical id IS its ARN
   if (!topicArn) return [];
@@ -938,7 +961,7 @@ async function enumerateSnsTopicChildren(ctx: EnumeratorContext): Promise<AddedC
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::SNS::Subscription' &&
-      r.declared.TopicArn === topicArn &&
+      parentRefMatches(r.declared.TopicArn, topicArn) &&
       r.physicalId
     ) {
       declaredSubscriptionArns.push(r.physicalId);
@@ -1138,7 +1161,9 @@ async function pageLambdaVersions(
   return out;
 }
 
-async function enumerateLambdaFunctionChildren(ctx: EnumeratorContext): Promise<AddedChild[]> {
+export async function enumerateLambdaFunctionChildren(
+  ctx: EnumeratorContext
+): Promise<AddedChild[]> {
   const { parent, desired, region } = ctx;
   const functionName = parent.physicalId; // the Function's physical id is its name
   if (!functionName) return [];
@@ -1152,7 +1177,7 @@ async function enumerateLambdaFunctionChildren(ctx: EnumeratorContext): Promise<
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::EventSourceMapping' || !r.physicalId) continue;
     const fn = r.declared.FunctionName;
-    if (fn === functionName || (fnArn !== undefined && fn === fnArn)) {
+    if (parentRefMatches(fn, functionName, fnArn)) {
       declaredMappingIds.push(r.physicalId);
     }
   }
@@ -1166,7 +1191,7 @@ async function enumerateLambdaFunctionChildren(ctx: EnumeratorContext): Promise<
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::Url') continue;
     const target = r.declared.TargetFunctionArn;
-    const targetsThis = target === functionName || (fnArn !== undefined && target === fnArn);
+    const targetsThis = parentRefMatches(target, functionName, fnArn);
     if (targetsThis) {
       // The URL's FunctionArn (its primaryIdentifier) is the function's bare ARN for an
       // unqualified URL; prefer the resolved live function ARN, else the declared physicalId.
@@ -1179,30 +1204,28 @@ async function enumerateLambdaFunctionChildren(ctx: EnumeratorContext): Promise<
 
   // Declared aliases targeting THIS function. An AWS::Lambda::Alias's CFn physical id
   // (Ref) IS its AliasArn; its FunctionName resolves (via gather) to the function name or
-  // ARN. Prefer matching on the FunctionName targeting this function; fall back to
-  // including any alias whose FunctionName did not resolve (undefined) so a resolved-id
-  // mismatch never causes a declared alias to be flagged added.
+  // ARN. Match on the FunctionName targeting this function; parentRefMatches also keeps an
+  // alias whose FunctionName is UNRESOLVED (FunctionName is REQUIRED, so it is never
+  // genuinely absent — the earlier `fn === undefined` fail-safe was dead code, #962), so a
+  // resolved-id mismatch never causes a declared alias to be flagged added.
   const declaredAliasArns: string[] = [];
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::Alias' || !r.physicalId) continue;
-    const fn = r.declared.FunctionName;
-    const targetsThis = fn === functionName || (fnArn !== undefined && fn === fnArn);
-    if (targetsThis || fn === undefined) {
+    if (parentRefMatches(r.declared.FunctionName, functionName, fnArn)) {
       declaredAliasArns.push(r.physicalId);
     }
   }
 
   // Declared versions targeting THIS function. An AWS::Lambda::Version's CFn physical id
   // (Ref) IS its versioned FunctionArn; its FunctionName resolves (via gather) to the
-  // function name or ARN. Prefer matching on the FunctionName targeting this function; fall
-  // back to including any version whose FunctionName did not resolve (undefined) so a
-  // resolved-id mismatch never causes a declared version to be flagged added.
+  // function name or ARN. Match on the FunctionName targeting this function; parentRefMatches
+  // also keeps a version whose FunctionName is UNRESOLVED (the earlier `fn === undefined`
+  // fail-safe was dead code — FunctionName is REQUIRED, #962), so a resolved-id mismatch
+  // never causes a declared version to be flagged added.
   const declaredVersionArns: string[] = [];
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Lambda::Version' || !r.physicalId) continue;
-    const fn = r.declared.FunctionName;
-    const targetsThis = fn === functionName || (fnArn !== undefined && fn === fnArn);
-    if (targetsThis || fn === undefined) {
+    if (parentRefMatches(r.declared.FunctionName, functionName, fnArn)) {
       declaredVersionArns.push(r.physicalId);
     }
   }
@@ -1312,7 +1335,7 @@ async function enumerateEventBusChildren(ctx: EnumeratorContext): Promise<AddedC
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::Events::Rule') continue;
     const bus = r.declared.EventBusName;
-    if (bus !== busName && !(busArn !== undefined && bus === busArn)) continue;
+    if (!parentRefMatches(bus, busName, busArn)) continue;
     const raw = r.physicalId ?? (typeof r.declared.Name === 'string' ? r.declared.Name : undefined);
     if (raw) declaredRuleNames.push(raw.includes('|') ? raw.slice(raw.lastIndexOf('|') + 1) : raw);
   }
@@ -1489,19 +1512,19 @@ async function enumerateUserPoolChildren(ctx: EnumeratorContext): Promise<AddedC
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::Cognito::UserPoolClient' &&
-      r.declared.UserPoolId === userPoolId &&
+      parentRefMatches(r.declared.UserPoolId, userPoolId) &&
       r.physicalId
     ) {
       declaredClientIds.push(r.physicalId);
     } else if (
       r.resourceType === 'AWS::Cognito::UserPoolGroup' &&
-      r.declared.UserPoolId === userPoolId
+      parentRefMatches(r.declared.UserPoolId, userPoolId)
     ) {
       const name = typeof r.declared.GroupName === 'string' ? r.declared.GroupName : r.physicalId;
       if (name) declaredGroupNames.push(name);
     } else if (
       r.resourceType === 'AWS::Cognito::UserPoolResourceServer' &&
-      r.declared.UserPoolId === userPoolId
+      parentRefMatches(r.declared.UserPoolId, userPoolId)
     ) {
       const identifier =
         typeof r.declared.Identifier === 'string' ? r.declared.Identifier : r.physicalId;
@@ -1697,9 +1720,12 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
     if (r.resourceType !== 'AWS::AppSync::DataSource' || typeof r.declared.Name !== 'string') {
       continue;
     }
+    // Fail-safe: an UNRESOLVED ApiId (dynamic ref / no-default Param / degraded ImportValue)
+    // must not exclude a declared datasource (#962); only a RESOLVED, non-matching id does.
     const declaredApiId = r.declared.ApiId;
-    if (typeof declaredApiId !== 'string') continue;
-    if (bareApiId(declaredApiId) !== apiId) continue;
+    if (declaredApiId !== UNRESOLVED && !hasUnresolved(declaredApiId)) {
+      if (typeof declaredApiId !== 'string' || bareApiId(declaredApiId) !== apiId) continue;
+    }
     declaredDataSourceNames.push(r.declared.Name);
   }
 
@@ -1710,9 +1736,11 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
   const declaredResolverKeys: string[] = [];
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::AppSync::Resolver') continue;
+    // Fail-safe: an UNRESOLVED ApiId must not exclude a declared resolver (#962).
     const declaredApiId = r.declared.ApiId;
-    if (typeof declaredApiId !== 'string') continue;
-    if (bareApiId(declaredApiId) !== apiId) continue;
+    if (declaredApiId !== UNRESOLVED && !hasUnresolved(declaredApiId)) {
+      if (typeof declaredApiId !== 'string' || bareApiId(declaredApiId) !== apiId) continue;
+    }
     const { TypeName, FieldName } = r.declared;
     if (typeof TypeName !== 'string' || typeof FieldName !== 'string') continue;
     declaredResolverKeys.push(`${TypeName}|${FieldName}`);
@@ -1725,9 +1753,11 @@ async function enumerateGraphQLApiChildren(ctx: EnumeratorContext): Promise<Adde
   const declaredFunctionArns: string[] = [];
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::AppSync::FunctionConfiguration' || !r.physicalId) continue;
+    // Fail-safe: an UNRESOLVED ApiId must not exclude a declared function (#962).
     const declaredApiId = r.declared.ApiId;
-    if (typeof declaredApiId !== 'string') continue;
-    if (bareApiId(declaredApiId) !== apiId) continue;
+    if (declaredApiId !== UNRESOLVED && !hasUnresolved(declaredApiId)) {
+      if (typeof declaredApiId !== 'string' || bareApiId(declaredApiId) !== apiId) continue;
+    }
     declaredFunctionArns.push(r.physicalId);
   }
 
@@ -1892,7 +1922,10 @@ async function enumerateLogGroupChildren(ctx: EnumeratorContext): Promise<AddedC
   // literal declared FilterName when present.
   const declaredFilterNames: string[] = [];
   for (const r of desired.resources) {
-    if (r.resourceType !== 'AWS::Logs::MetricFilter' || r.declared.LogGroupName !== logGroupName) {
+    if (
+      r.resourceType !== 'AWS::Logs::MetricFilter' ||
+      !parentRefMatches(r.declared.LogGroupName, logGroupName)
+    ) {
       continue;
     }
     const name = typeof r.declared.FilterName === 'string' ? r.declared.FilterName : r.physicalId;
@@ -1905,7 +1938,7 @@ async function enumerateLogGroupChildren(ctx: EnumeratorContext): Promise<AddedC
   for (const r of desired.resources) {
     if (
       r.resourceType !== 'AWS::Logs::SubscriptionFilter' ||
-      r.declared.LogGroupName !== logGroupName
+      !parentRefMatches(r.declared.LogGroupName, logGroupName)
     ) {
       continue;
     }
@@ -1992,7 +2025,7 @@ async function enumerateLoadBalancerChildren(ctx: EnumeratorContext): Promise<Ad
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::ElasticLoadBalancingV2::Listener' &&
-      r.declared.LoadBalancerArn === lbArn &&
+      parentRefMatches(r.declared.LoadBalancerArn, lbArn) &&
       r.physicalId
     ) {
       declaredListenerArns.push(r.physicalId);
@@ -2067,7 +2100,7 @@ async function enumerateListenerChildren(ctx: EnumeratorContext): Promise<AddedC
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::ElasticLoadBalancingV2::ListenerRule' &&
-      r.declared.ListenerArn === listenerArn &&
+      parentRefMatches(r.declared.ListenerArn, listenerArn) &&
       r.physicalId
     ) {
       declaredRuleArns.push(r.physicalId);
@@ -2142,7 +2175,11 @@ async function enumerateVpcChildren(ctx: EnumeratorContext): Promise<AddedChild[
   // gather). A subnet's physical id IS its SubnetId.
   const declaredSubnetIds: string[] = [];
   for (const r of desired.resources) {
-    if (r.resourceType === 'AWS::EC2::Subnet' && r.declared.VpcId === vpcId && r.physicalId) {
+    if (
+      r.resourceType === 'AWS::EC2::Subnet' &&
+      parentRefMatches(r.declared.VpcId, vpcId) &&
+      r.physicalId
+    ) {
       declaredSubnetIds.push(r.physicalId);
     }
   }
@@ -2230,7 +2267,7 @@ async function enumerateRouteTableChildren(ctx: EnumeratorContext): Promise<Adde
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::EC2::Route' &&
-      r.declared.RouteTableId === routeTableId &&
+      parentRefMatches(r.declared.RouteTableId, routeTableId) &&
       typeof r.declared.DestinationCidrBlock === 'string'
     ) {
       declaredCidrs.push(r.declared.DestinationCidrBlock);
@@ -2309,7 +2346,7 @@ async function enumerateEcsClusterChildren(ctx: EnumeratorContext): Promise<Adde
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::ECS::Service' || !r.physicalId) continue;
     const decl = r.declared.Cluster;
-    if (decl === cluster || (clusterArn !== undefined && decl === clusterArn)) {
+    if (parentRefMatches(decl, cluster, clusterArn)) {
       declaredServiceArns.push(r.physicalId);
     }
   }
@@ -2375,7 +2412,7 @@ async function enumerateKmsKeyChildren(ctx: EnumeratorContext): Promise<AddedChi
   for (const r of desired.resources) {
     if (r.resourceType !== 'AWS::KMS::Alias') continue;
     const target = r.declared.TargetKeyId;
-    if (target !== keyId && !(keyArn !== undefined && target === keyArn)) continue;
+    if (!parentRefMatches(target, keyId, keyArn)) continue;
     const name = typeof r.declared.AliasName === 'string' ? r.declared.AliasName : r.physicalId;
     if (name) declaredAliasNames.push(name);
   }
@@ -2499,13 +2536,13 @@ async function enumerateAppConfigApplicationChildren(
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::AppConfig::Environment' &&
-      r.declared.ApplicationId === applicationId &&
+      parentRefMatches(r.declared.ApplicationId, applicationId) &&
       r.physicalId
     ) {
       declaredEnvironmentIds.push(r.physicalId);
     } else if (
       r.resourceType === 'AWS::AppConfig::ConfigurationProfile' &&
-      r.declared.ApplicationId === applicationId &&
+      parentRefMatches(r.declared.ApplicationId, applicationId) &&
       r.physicalId
     ) {
       declaredProfileIds.push(r.physicalId);
@@ -2594,7 +2631,7 @@ async function enumerateEfsFileSystemChildren(ctx: EnumeratorContext): Promise<A
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::EFS::MountTarget' &&
-      r.declared.FileSystemId === fileSystemId &&
+      parentRefMatches(r.declared.FileSystemId, fileSystemId) &&
       r.physicalId
     ) {
       declaredMountTargetIds.push(r.physicalId);
@@ -2693,7 +2730,7 @@ export async function enumerateRdsClusterChildren(ctx: EnumeratorContext): Promi
   for (const r of desired.resources) {
     if (
       r.resourceType === 'AWS::RDS::DBInstance' &&
-      r.declared.DBClusterIdentifier === clusterId &&
+      parentRefMatches(r.declared.DBClusterIdentifier, clusterId) &&
       r.physicalId
     ) {
       declaredInstanceIds.push(r.physicalId);

--- a/tests/child-enumerators.test.ts
+++ b/tests/child-enumerators.test.ts
@@ -1,13 +1,24 @@
 import {
+  LambdaClient,
+  ListAliasesCommand,
+  ListEventSourceMappingsCommand,
+  ListFunctionUrlConfigsCommand,
+  ListVersionsByFunctionCommand,
+} from '@aws-sdk/client-lambda';
+import {
   DescribeDBClustersCommand,
   DescribeDBInstancesCommand,
   RDSClient,
 } from '@aws-sdk/client-rds';
+import { ListSubscriptionsByTopicCommand, SNSClient } from '@aws-sdk/client-sns';
 import { mockClient } from 'aws-sdk-client-mock';
 import { describe, expect, it } from 'vite-plus/test';
+import { UNRESOLVED } from '../src/normalize/intrinsic-resolver.js';
 import type { EnumeratorContext } from '../src/read/child-enumerators.js';
 import {
+  enumerateLambdaFunctionChildren,
   enumerateRdsClusterChildren,
+  enumerateSnsTopicChildren,
   diffApiGatewayAuthorizers,
   diffApiGatewayChildren,
   diffApiGatewayGatewayResponses,
@@ -1687,5 +1698,101 @@ describe('diffEfsFileSystemChildren (EFS file system mount targets)', () => {
         ],
       })
     ).toEqual([]);
+  });
+});
+
+// #962: when a declared child's parent-linking property could not be resolved by the
+// intrinsic resolver (a `{{resolve:...}}` dynamic ref, a no-default Parameter Ref, a
+// degraded Fn::ImportValue, a non-string Fn::Sub, or a malformed Fn::Join that fails
+// closed), that property is the UNRESOLVED symbol — never a plain string that could match
+// the parent's physical id/ARN. A bare `===` match then failed, the declared child was
+// dropped from the declared set, and its LIVE counterpart was falsely flagged `[Added]`
+// (offering a DESTRUCTIVE DeleteResource against a resource the template declares). The
+// enumerators must fail SAFE: an UNRESOLVED parent-ref counts as a potential match, so the
+// declared child stays in the declared set and is NOT flagged added.
+describe('child enumerators fail safe on an UNRESOLVED parent-ref (#962)', () => {
+  it('Lambda alias: an UNRESOLVED FunctionName is NOT flagged added (defect 1)', async () => {
+    const aliasArn = 'arn:aws:lambda:us-east-1:111122223333:function:my-fn:live';
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [{ AliasArn: aliasArn, Name: 'live' }] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: {
+        // The declared alias targets this function, but its FunctionName is UNRESOLVED
+        // (e.g. an Fn::ImportValue with a degraded export). Its physical id IS the AliasArn.
+        resources: [
+          {
+            resourceType: 'AWS::Lambda::Alias',
+            physicalId: aliasArn,
+            declared: { FunctionName: UNRESOLVED },
+          },
+        ],
+        ctx: { liveAttrs: {} },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    // Fail-safe: the declared alias must NOT be reported as an out-of-band addition.
+    expect(added).toEqual([]);
+    lambda.restore();
+  });
+
+  it('Lambda alias: a live alias with NO declared counterpart is still flagged added', async () => {
+    // Guard against over-folding: the fail-safe must not suppress a genuine out-of-band alias.
+    const rogueArn = 'arn:aws:lambda:us-east-1:111122223333:function:my-fn:rogue';
+    const lambda = mockClient(LambdaClient);
+    lambda
+      .on(ListEventSourceMappingsCommand)
+      .resolves({ EventSourceMappings: [] })
+      .on(ListFunctionUrlConfigsCommand)
+      .resolves({ FunctionUrlConfigs: [] })
+      .on(ListAliasesCommand)
+      .resolves({ Aliases: [{ AliasArn: rogueArn, Name: 'rogue' }] })
+      .on(ListVersionsByFunctionCommand)
+      .resolves({ Versions: [] });
+    const ctx = {
+      parent: { physicalId: 'my-fn', logicalId: 'Fn' },
+      desired: { resources: [], ctx: { liveAttrs: {} } },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateLambdaFunctionChildren(ctx);
+    expect(added.map((a) => a.identifier)).toEqual([rogueArn]);
+    lambda.restore();
+  });
+
+  it('SNS subscription: an UNRESOLVED TopicArn is NOT flagged added (defect 2)', async () => {
+    const subArn =
+      'arn:aws:sns:us-east-1:111122223333:my-topic:00000000-1111-2222-3333-444444444444';
+    const sns = mockClient(SNSClient);
+    sns.on(ListSubscriptionsByTopicCommand).resolves({
+      Subscriptions: [{ SubscriptionArn: subArn, Protocol: 'sqs', Endpoint: 'q' }],
+    });
+    const ctx = {
+      parent: { physicalId: 'arn:aws:sns:us-east-1:111122223333:my-topic', logicalId: 'Topic' },
+      desired: {
+        // The declared subscription targets this topic, but its TopicArn is UNRESOLVED
+        // (e.g. a `Ref` to a no-default Parameter). Its physical id IS the SubscriptionArn.
+        resources: [
+          {
+            resourceType: 'AWS::SNS::Subscription',
+            physicalId: subArn,
+            declared: { TopicArn: UNRESOLVED },
+          },
+        ],
+        ctx: { liveAttrs: {} },
+      },
+      region: 'us-east-1',
+    } as unknown as EnumeratorContext;
+    const added = await enumerateSnsTopicChildren(ctx);
+    expect(added).toEqual([]);
+    sns.restore();
   });
 });


### PR DESCRIPTION
Closes #962.

## Root cause

Every child enumerator in `src/read/child-enumerators.ts` matched a DECLARED child to its
enumerated parent with strict equality against the parent's physical id/ARN
(`r.declared.UserPoolId === userPoolId`, `r.declared.TopicArn === topicArn`, an EventBus
`bus !== busName && bus !== busArn`, ...). When the intrinsic resolver could NOT evaluate
that declared property — a non-string `Fn::Sub`, a malformed `Fn::Join` that fails closed
(#851), a `{{resolve:...}}` dynamic ref, a `Ref` to a no-default Parameter (#744), an
`Fn::ImportValue` with a degraded export (#784) — the declared value is the `UNRESOLVED`
symbol. The `===` then FAILS, the declared child never enters the declared set, and its
LIVE counterpart is falsely reported `[Added] created out of band` — with a Cloud Control
`DeleteResource` revert offer against a resource the template explicitly declares.

Two defects:
1. The Lambda **alias/version** fail-safe checked the wrong sentinel: `fn === undefined`. An
   unresolvable `FunctionName` is the `UNRESOLVED` symbol, never `undefined` (and
   `FunctionName` is REQUIRED, so genuinely-absent can't happen) — so the promised fail-safe
   was dead code.
2. Every other enumerator had **no fallback** at all.

## Fix

A shared, file-local helper:

```ts
function parentRefMatches(declaredValue: unknown, ...candidates: (string | undefined)[]): boolean {
  if (declaredValue === UNRESOLVED || hasUnresolved(declaredValue)) return true;
  return candidates.some((c) => c !== undefined && declaredValue === c);
}
```

Fail SAFE: an UNRESOLVED parent-ref counts as a POTENTIAL match, so the declared child is
KEPT (never becomes a false `added` / delete offer). Otherwise the declared value must equal
one of the candidate parent ids/ARNs (undefined candidates — e.g. an unresolved parent ARN —
are ignored). `UNRESOLVED` + `hasUnresolved` are imported from
`../normalize/intrinsic-resolver.js`, mirroring the `v === UNRESOLVED || hasUnresolved(v)`
detection in `classify.ts`.

Applied at every parent-match site (enumeration logic otherwise unchanged):

- API Gateway v1 (RestApiId): Resource/Method, Authorizer, Model, RequestValidator, GatewayResponse
- API Gateway v2 (ApiId): Route/Integration/Authorizer/Stage
- SNS Topic (TopicArn): Subscription
- Lambda Function (FunctionName/TargetFunctionArn): EventSourceMapping, Url, Alias, Version — **defect 1** (replaces the dead `fn === undefined`)
- EventBridge EventBus (EventBusName): Rule
- Cognito UserPool (UserPoolId): Client, Group, ResourceServer
- AppSync GraphQLApi (ApiId): DataSource, Resolver, FunctionConfiguration (guarded so an UNRESOLVED id skips the `bareApiId` string comparison)
- CloudWatch Logs LogGroup (LogGroupName): MetricFilter, SubscriptionFilter
- ELBv2 LoadBalancer (LoadBalancerArn): Listener; ELBv2 Listener (ListenerArn): ListenerRule
- EC2 VPC (VpcId): Subnet; EC2 RouteTable (RouteTableId): Route
- ECS Cluster (Cluster): Service
- KMS Key (TargetKeyId): Alias
- AppConfig Application (ApplicationId): Environment, ConfigurationProfile
- EFS FileSystem (FileSystemId): MountTarget
- RDS DBCluster (DBClusterIdentifier): DBInstance

## Tests

`tests/child-enumerators.test.ts` — a new `#962` describe block driving the real
`enumerate*` functions (mocked SDK clients), each fails without the fix and passes with it:

- **Lambda alias (defect 1):** a declared alias whose `FunctionName` is `UNRESOLVED` is NOT flagged added.
- **Lambda alias over-fold guard:** a live alias with NO declared counterpart IS still flagged added.
- **SNS subscription (defect 2):** a declared subscription whose `TopicArn` is `UNRESOLVED` is NOT flagged added.

`enumerateLambdaFunctionChildren` and `enumerateSnsTopicChildren` are now exported (like the
existing `enumerateRdsClusterChildren`) so the parent-match path is unit-testable.

Full suite: **86 files / 3516 tests pass**; typecheck + lint/format + build all green.
