### PR TITLE
fix(revert): writer-routed KNOWN_DEFAULTS now converge on revert (#912)

### DIFF
--- a/src/revert/plan.ts
+++ b/src/revert/plan.ts
@@ -187,6 +187,43 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
   'AWS::EC2::Subnet\0AssignIpv6AddressOnCreation',
   'AWS::EC2::Subnet\0PrivateDnsNameOptionsOnLaunch',
   'AWS::EC2::Subnet\0EnableDns64',
+  // EC2 ModifyClientVpnEndpoint is a SELECTIVE-update API routed through an SDK writer
+  // (CLIENT_VPN_SCALAR_PARAMS): a `remove` deletes the key from the desired model, the
+  // writer skips the now-undefined param, and nothing is sent — Cloud Control-style
+  // "converge on omit" never applies (#912). Write the KNOWN_DEFAULTS defaults back
+  // explicitly so an out-of-band change converges. VpnPort (443) and
+  // DisconnectOnSessionTimeout (true) pull their values from KNOWN_DEFAULTS. SplitTunnel
+  // folds `atDefault` as a trivial-empty `false` (no KNOWN_DEFAULTS value), so an OOB
+  // `true` is otherwise unrevertable — its `false` default comes from
+  // REVERT_SET_DEFAULT_VALUES below, the EnableDns64 pattern.
+  'AWS::EC2::ClientVpnEndpoint\0VpnPort',
+  'AWS::EC2::ClientVpnEndpoint\0DisconnectOnSessionTimeout',
+  'AWS::EC2::ClientVpnEndpoint\0SplitTunnel',
+  // DocDB ModifyDBCluster / ModifyDBInstance are SELECTIVE-update APIs routed through SDK
+  // writers whose allowlists include these props: a `remove` empties the desired model and
+  // the writer sends nothing (`if (!any) return`) — a silent no-op (#912). Write the
+  // KNOWN_DEFAULTS defaults back explicitly. Port (27017) and BackupRetentionPeriod (1)
+  // pull from KNOWN_DEFAULTS; DeletionProtection folds `atDefault` as trivial-empty `false`
+  // (no KNOWN_DEFAULTS value — an OOB `true` is a real blocking mutation), so its `false`
+  // default comes from REVERT_SET_DEFAULT_VALUES below. DBInstance CACertificateIdentifier
+  // ('rds-ca-rsa2048-g1') pulls from KNOWN_DEFAULTS (explicit write reboots the instance
+  // with ApplyImmediately).
+  'AWS::DocDB::DBCluster\0Port',
+  'AWS::DocDB::DBCluster\0BackupRetentionPeriod',
+  'AWS::DocDB::DBCluster\0DeletionProtection',
+  'AWS::DocDB::DBInstance\0CACertificateIdentifier',
+  // OpenSearch UpdateDomainConfig is a documented SELECTIVE API routed through an SDK
+  // writer (OS_UPDATABLE_OPTIONS): a `remove` makes the option undefined, the writer omits
+  // it, and the API fired with only {DomainName} is a successful no-op (#912) — omit can
+  // NEVER converge, only an explicit set-default can. All four fold `atDefault` from the
+  // top-level KNOWN_DEFAULTS, so the set-default value comes from there. (DeploymentStrategyOptions
+  // is additionally absent from OS_UPDATABLE_OPTIONS — the writer allowlist gap #804 does
+  // not name — so its convergence still depends on that writer table; this entry ensures
+  // revert PLANS the correct set-default rather than a bare `remove`.)
+  'AWS::OpenSearchService::Domain\0SnapshotOptions',
+  'AWS::OpenSearchService::Domain\0AdvancedOptions',
+  'AWS::OpenSearchService::Domain\0IPAddressType',
+  'AWS::OpenSearchService::Domain\0DeploymentStrategyOptions',
 ]);
 
 // Set-default values for REVERT_SET_DEFAULT_PATHS entries whose default is a plain constant
@@ -195,6 +232,11 @@ const REVERT_SET_DEFAULT_PATHS = new Set<string>([
 // the path — KNOWN_DEFAULTS stays the primary source. Keyed `${resourceType}\0${path}`.
 const REVERT_SET_DEFAULT_VALUES: Record<string, unknown> = {
   'AWS::EC2::Subnet\0EnableDns64': false,
+  // ClientVpnEndpoint SplitTunnel and DocDB DBCluster DeletionProtection both fold
+  // `atDefault` as a trivial-empty `false` (no KNOWN_DEFAULTS value source), so their
+  // revert set-default value is the plain constant `false` here — the EnableDns64 pattern.
+  'AWS::EC2::ClientVpnEndpoint\0SplitTunnel': false,
+  'AWS::DocDB::DBCluster\0DeletionProtection': false,
 };
 
 /**

--- a/tests/revert-plan.test.ts
+++ b/tests/revert-plan.test.ts
@@ -461,6 +461,214 @@ describe('buildRevertPlan', () => {
     });
   });
 
+  it('#912: undeclared ClientVpnEndpoint VpnPort -> add op writing the 443 KNOWN_DEFAULTS default, not a no-op remove', () => {
+    // AWS::EC2::ClientVpnEndpoint VpnPort is a CLIENT_VPN_SCALAR_PARAMS writer prop: a bare
+    // `remove` deletes the key from the desired model, the selective ModifyClientVpnEndpoint
+    // writer skips the now-undefined param, and nothing is sent (#912). Revert must write the
+    // 443 KNOWN_DEFAULTS default explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::ClientVpnEndpoint',
+      path: 'VpnPort',
+      actual: 1194,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/VpnPort',
+      value: 443,
+      prior: 1194,
+    });
+  });
+
+  it('#912: undeclared ClientVpnEndpoint DisconnectOnSessionTimeout -> add op writing the true KNOWN_DEFAULTS default', () => {
+    // Same selective-writer no-op class as VpnPort; write the `true` KNOWN_DEFAULTS default.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::ClientVpnEndpoint',
+      path: 'DisconnectOnSessionTimeout',
+      actual: false,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DisconnectOnSessionTimeout',
+      value: true,
+      prior: false,
+    });
+  });
+
+  it('#912: undeclared ClientVpnEndpoint SplitTunnel -> add op writing the false default (REVERT_SET_DEFAULT_VALUES)', () => {
+    // SplitTunnel folds atDefault as a trivial-empty `false` (no KNOWN_DEFAULTS value), so an
+    // out-of-band `true` is otherwise unrevertable — a bare `remove` is dropped by the
+    // selective writer. The `false` default is sourced from REVERT_SET_DEFAULT_VALUES (the
+    // EnableDns64 pattern). Revert must write `false` explicitly (#912).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::EC2::ClientVpnEndpoint',
+      path: 'SplitTunnel',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SplitTunnel',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#912: undeclared DocDB DBCluster Port -> add op writing the 27017 KNOWN_DEFAULTS default, not a no-op remove', () => {
+    // AWS::DocDB::DBCluster Port is inside the ModifyDBCluster writer allowlist: a `remove`
+    // empties the desired model, the writer sends nothing (`if (!any) return`) — a silent
+    // no-op (#912). Revert must write the 27017 KNOWN_DEFAULTS default explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::DocDB::DBCluster',
+      path: 'Port',
+      actual: 27018,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/Port',
+      value: 27017,
+      prior: 27018,
+    });
+  });
+
+  it('#912: undeclared DocDB DBCluster BackupRetentionPeriod -> add op writing the 1 KNOWN_DEFAULTS default', () => {
+    // Same ModifyDBCluster selective-writer no-op class as Port; write the 1-day default.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::DocDB::DBCluster',
+      path: 'BackupRetentionPeriod',
+      actual: 7,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/BackupRetentionPeriod',
+      value: 1,
+      prior: 7,
+    });
+  });
+
+  it('#912: undeclared DocDB DBCluster DeletionProtection -> add op writing the false default (REVERT_SET_DEFAULT_VALUES)', () => {
+    // DeletionProtection folds atDefault as a trivial-empty `false` (no KNOWN_DEFAULTS value),
+    // so an out-of-band `true` — a real blocking mutation — is otherwise unrevertable. The
+    // `false` default is sourced from REVERT_SET_DEFAULT_VALUES. Revert must write `false`
+    // explicitly (#912).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::DocDB::DBCluster',
+      path: 'DeletionProtection',
+      actual: true,
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DeletionProtection',
+      value: false,
+      prior: true,
+    });
+  });
+
+  it('#912: undeclared DocDB DBInstance CACertificateIdentifier -> add op writing the default CA, not a no-op remove', () => {
+    // AWS::DocDB::DBInstance CACertificateIdentifier is inside the ModifyDBInstance writer
+    // allowlist: a `remove` empties the desired model, the writer sends nothing — a silent
+    // no-op (#912). Revert must write the default CA ('rds-ca-rsa2048-g1') explicitly (which
+    // reboots the instance with ApplyImmediately).
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::DocDB::DBInstance',
+      path: 'CACertificateIdentifier',
+      actual: 'rds-ca-2019',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/CACertificateIdentifier',
+      value: 'rds-ca-rsa2048-g1',
+      prior: 'rds-ca-2019',
+    });
+  });
+
+  it('#912: undeclared OpenSearch Domain IPAddressType -> add op writing the ipv4 KNOWN_DEFAULTS default, not a no-op remove', () => {
+    // AWS::OpenSearchService::Domain IPAddressType folds atDefault from KNOWN_DEFAULTS. The
+    // UpdateDomainConfig writer is a documented SELECTIVE API — a `remove` fires it with only
+    // {DomainName} (successful no-op, #912) so remove-by-omission can never converge. Revert
+    // must write the 'ipv4' default explicitly.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::OpenSearchService::Domain',
+      path: 'IPAddressType',
+      actual: 'dualstack',
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/IPAddressType',
+      value: 'ipv4',
+      prior: 'dualstack',
+    });
+  });
+
+  it('#912: undeclared OpenSearch Domain SnapshotOptions -> add op writing the whole KNOWN_DEFAULTS default object', () => {
+    // Same UpdateDomainConfig selective no-op class; write the whole KNOWN_DEFAULTS default.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::OpenSearchService::Domain',
+      path: 'SnapshotOptions',
+      actual: { AutomatedSnapshotStartHour: 3 },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/SnapshotOptions',
+      value: { AutomatedSnapshotStartHour: 0 },
+      prior: { AutomatedSnapshotStartHour: 3 },
+    });
+  });
+
+  it('#912: undeclared OpenSearch Domain AdvancedOptions -> add op writing the whole KNOWN_DEFAULTS default object', () => {
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::OpenSearchService::Domain',
+      path: 'AdvancedOptions',
+      actual: { override_main_response_version: 'true' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/AdvancedOptions',
+      value: {
+        override_main_response_version: 'false',
+        'rest.action.multi.allow_explicit_index': 'true',
+      },
+      prior: { override_main_response_version: 'true' },
+    });
+  });
+
+  it('#912: undeclared OpenSearch Domain DeploymentStrategyOptions -> add op writing the whole KNOWN_DEFAULTS default object', () => {
+    // DeploymentStrategyOptions is additionally absent from OS_UPDATABLE_OPTIONS (a #804
+    // allowlist gap); this entry ensures revert PLANS the correct set-default rather than a
+    // bare `remove`.
+    const f = F({
+      tier: 'undeclared',
+      resourceType: 'AWS::OpenSearchService::Domain',
+      path: 'DeploymentStrategyOptions',
+      actual: { DeploymentStrategy: 'Custom' },
+    });
+    const plan = buildRevertPlan([f], baseline([]));
+    expect(plan.items[0]!.ops[0]).toMatchObject({
+      op: 'add',
+      path: '/DeploymentStrategyOptions',
+      value: { DeploymentStrategy: 'CapacityOptimized' },
+      prior: { DeploymentStrategy: 'Custom' },
+    });
+  });
+
   it('Transfer Server SecurityPolicyName (SET-DEFAULT) -> add op writing the default policy, not a no-op remove', () => {
     // AWS::Transfer::Server SecurityPolicyName is in REVERT_SET_DEFAULT_PATHS: UpdateServer
     // leaves the policy UNCHANGED when it is OMITTED, so a bare `remove` of an out-of-band


### PR DESCRIPTION
Closes #912

All 20 pre-existing `REVERT_SET_DEFAULT_PATHS` entries were CC-routed types. Every KNOWN_DEFAULTS-folded property on an **SDK-writer type with a selective-update API** therefore planned a bare `remove` op that the writer silently drops (apply reports success; live value unchanged). This adds the missing writer-routed types so revert plans an explicit set-default `add` instead.

## Entries added to `REVERT_SET_DEFAULT_PATHS` (src/revert/plan.ts)

**F1 — EC2 ClientVpnEndpoint** (ModifyClientVpnEndpoint, selective / CLIENT_VPN_SCALAR_PARAMS):
- `VpnPort` (443, from KNOWN_DEFAULTS)
- `DisconnectOnSessionTimeout` (true, from KNOWN_DEFAULTS)
- `SplitTunnel` (false) — trivial-empty fold with no KNOWN_DEFAULTS value; OOB `true` was previously unrevertable. Value sourced from `REVERT_SET_DEFAULT_VALUES`, the EnableDns64 pattern.

**F2 — DocDB** (ModifyDBCluster / ModifyDBInstance, selective allowlists):
- DBCluster `Port` (27017), `BackupRetentionPeriod` (1) — from KNOWN_DEFAULTS
- DBCluster `DeletionProtection` (false) — trivial-empty fold, no KNOWN_DEFAULTS value; OOB `true` is a real blocking mutation, previously unrevertable. Value in `REVERT_SET_DEFAULT_VALUES`.
- DBInstance `CACertificateIdentifier` ('rds-ca-rsa2048-g1', from KNOWN_DEFAULTS)

**F3 — OpenSearch Domain** (UpdateDomainConfig, documented selective — remove-by-omission can never converge):
- `SnapshotOptions`, `AdvancedOptions`, `IPAddressType`, `DeploymentStrategyOptions` — all from the top-level KNOWN_DEFAULTS. `DeploymentStrategyOptions` is additionally an OS_UPDATABLE_OPTIONS allowlist gap (#804); this ensures revert PLANS the correct set-default.

## How the `false` set-defaults are expressed
`SplitTunnel` and `DeletionProtection` have no KNOWN_DEFAULTS value source (they fold trivial-empty), so their `false` default is added to `REVERT_SET_DEFAULT_VALUES` — the exact mechanism EnableDns64 already uses. The plan consults `KNOWN_DEFAULTS[type][path] ?? REVERT_SET_DEFAULT_VALUES[key]`.

Skipped F6 (WAFv2, needs-live probe) per scope.

## Tests (tests/revert-plan.test.ts)
12 new tests, one per fixed property, each asserting the planned op is an `add` with the correct default VALUE (not a bare `remove`), with `prior` = the OOB actual: ClientVpnEndpoint VpnPort/DisconnectOnSessionTimeout/SplitTunnel, DocDB DBCluster Port/BackupRetentionPeriod/DeletionProtection, DocDB DBInstance CACertificateIdentifier, OpenSearch IPAddressType/SnapshotOptions/AdvancedOptions/DeploymentStrategyOptions.

All green: typecheck, lint+format, build, 3550 unit tests.