### PR TITLE
fix(baseline): baselineValueMatches reflexivity for free-form JSON/policy string values (#807)

### DIFF
--- a/src/baseline/baseline-file.ts
+++ b/src/baseline/baseline-file.ts
@@ -482,16 +482,31 @@ export function carryForwardUnreadable(
 /**
  * The single source of truth for "is this baseline value equal to the current
  * value?". `applyBaseline` (suppress vs surface) and `splitRecordedByBaseline`
- * (unchanged vs changed) MUST share this exact predicate. The baseline value is
+ * (unchanged vs changed) MUST share this exact predicate. BOTH sides are
  * re-canonicalized through the CURRENT pipeline so a baseline written under older
- * normalization rules still matches today's canonical live value (R6) — the
- * `currentCanonicalValue` side is expected to be already canonical.
+ * normalization rules still matches today's canonical live value (R6).
+ *
+ * #807: canonicalize the CURRENT side too, not just the baseline side. The caller's
+ * `currentCanonicalValue` is only canonical at the OUTER value — a free-form-map
+ * ENTRY (a Lambda env var, a Glue `Parameters` value, a Docker label) whose value is
+ * a JSON- or policy-shaped STRING keeps its ancestry-lost RAW string. Canonicalizing
+ * just the baseline side then policy-parses / JSON-minifies / key-sorts that bare
+ * string on the recorded side while the live side stays raw, so `deepEqual` is false
+ * forever — the predicate is not reflexive (`baselineValueMatches(v, v)` is false)
+ * and a re-record never converges. Running the SAME `canonicalizeForCompare` on both
+ * sides restores reflexivity for the whole free-form-string class (and composes
+ * cleanly with #767's identity-sort case). Idempotency of the pipeline means an
+ * already-canonical live value is unchanged, so this never weakens real change
+ * detection: two values that differ after canonicalization still compare unequal.
  */
 export function baselineValueMatches(
   baselineValue: unknown,
   currentCanonicalValue: unknown
 ): boolean {
-  return deepEqual(canonicalizeForCompare(baselineValue), currentCanonicalValue);
+  return deepEqual(
+    canonicalizeForCompare(baselineValue),
+    canonicalizeForCompare(currentCanonicalValue)
+  );
 }
 
 // Identity fields for the ELEMENT-LEVEL DELTA display only (R128) — deliberately

--- a/tests/baseline-reflexive-807.test.ts
+++ b/tests/baseline-reflexive-807.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { baselineValueMatches } from '../src/baseline/baseline-file.js';
+
+// #807: `baselineValueMatches` must be REFLEXIVE — `baselineValueMatches(v, v)`
+// has to be true for EVERY value, so a recorded value compared against the same
+// live value converges. It was not, because only the baseline side was run through
+// `canonicalizeForCompare` while the live side stayed raw. For a free-form-map ENTRY
+// whose value is a JSON- or policy-shaped STRING (a Lambda env var, a Glue
+// `Parameters` value, a Docker label), the recorded fragment lost its free-form
+// ancestry, so canonicalization policy-parsed / JSON-minified / key-sorted the
+// recorded side while the identical live side stayed a raw string → `deepEqual`
+// false forever, and a re-record never converged. The fix canonicalizes BOTH sides.
+describe('#807 baselineValueMatches reflexivity for free-form JSON/policy strings', () => {
+  it('(a) a pretty-printed JSON string env-var value matches itself', () => {
+    // e.g. a Lambda environment variable holding pretty-printed JSON config.
+    const prettyJson = JSON.stringify(
+      { featureFlags: { beta: true, alpha: false }, region: 'us-east-1' },
+      null,
+      2
+    );
+    expect(baselineValueMatches(prettyJson, prettyJson)).toBe(true);
+  });
+
+  it('(a2) a minified vs pretty form of the SAME JSON string matches', () => {
+    // A baseline recorded in one whitespace form still matches a live read in
+    // another whitespace / key order — the canonical (sorted, minified) form is equal.
+    const pretty = JSON.stringify({ b: 2, a: 1 }, null, 2);
+    const minified = '{"a":1,"b":2}';
+    expect(baselineValueMatches(pretty, minified)).toBe(true);
+  });
+
+  it('(b) a policy-shaped string value matches itself', () => {
+    // e.g. a resource-policy JSON stored as an opaque string fragment.
+    const policyString = JSON.stringify({
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }],
+    });
+    expect(baselineValueMatches(policyString, policyString)).toBe(true);
+  });
+
+  it('(b2) a pretty-printed policy string matches its minified twin', () => {
+    const doc = {
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }],
+    };
+    const pretty = JSON.stringify(doc, null, 4);
+    const minified = JSON.stringify(doc);
+    expect(baselineValueMatches(pretty, minified)).toBe(true);
+  });
+
+  it('reflexive for a plain (non-JSON) string too', () => {
+    const plain = 'a plain env-var value, not JSON at all';
+    expect(baselineValueMatches(plain, plain)).toBe(true);
+  });
+
+  it('reflexive for an object value (regression: object entries still match)', () => {
+    const obj = { A: '1', B: '2' };
+    expect(baselineValueMatches(obj, obj)).toBe(true);
+  });
+
+  // (c) regression: a genuinely different value must STILL be detected as changed —
+  // canonicalizing both sides restores reflexivity WITHOUT weakening change detection.
+  it('(c) a genuinely different JSON string value still returns false', () => {
+    const recorded = JSON.stringify({ enabled: true }, null, 2);
+    const changed = JSON.stringify({ enabled: false }, null, 2);
+    expect(baselineValueMatches(recorded, changed)).toBe(false);
+  });
+
+  it('(c2) a policy string with a changed Action still returns false', () => {
+    const recorded = JSON.stringify({
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:GetObject', Resource: '*' }],
+    });
+    const changed = JSON.stringify({
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Allow', Action: 's3:PutObject', Resource: '*' }],
+    });
+    expect(baselineValueMatches(recorded, changed)).toBe(false);
+  });
+
+  it('(c3) a changed plain string still returns false', () => {
+    expect(baselineValueMatches('old value', 'new value')).toBe(false);
+  });
+});

--- a/tests/baseline-reflexive-807.test.ts
+++ b/tests/baseline-reflexive-807.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vite-plus/test';
 import { baselineValueMatches } from '../src/baseline/baseline-file.js';
 
 // #807: `baselineValueMatches` must be REFLEXIVE — `baselineValueMatches(v, v)`


### PR DESCRIPTION
Closes #807.

## Root cause
`baselineValueMatches` ran `canonicalizeForCompare` on ONLY the recorded baseline value, comparing it against the raw `currentCanonicalValue` (assumed already canonical). But a free-form-map ENTRY — a Lambda env var, a Glue `Parameters` value, a Docker label — loses its free-form ancestry when reduced to a bare fragment. So a JSON- or policy-shaped STRING value gets policy-parsed / JSON-minified / key-sorted on the recorded side (`normWalk` starts at `freeForm=false`), while the identical live side stays a raw string. `deepEqual` is then false forever: the predicate is NOT reflexive (`baselineValueMatches(v, v)` is false) and a re-record never converges.

## Fix
Canonicalize BOTH sides through the same `canonicalizeForCompare`:

```ts
deepEqual(canonicalizeForCompare(baselineValue), canonicalizeForCompare(currentCanonicalValue))
```

This restores reflexivity for the whole free-form-string class (and composes with #767's identity-sort case). The pipeline is idempotent, so an already-canonical live value is unchanged — real change detection is not weakened: two values that differ after canonicalization still compare unequal.

Scope: `src/baseline/baseline-file.ts` only + a new test.

## Test
`tests/baseline-reflexive-807.test.ts` — FAILS without the fix (3 cases), PASSES with it:
- (a) a pretty-printed JSON env-var string matches itself; pretty vs minified same-JSON matches.
- (b) a policy-shaped string matches itself; pretty vs minified same-policy matches.
- (c) regression — a genuinely different JSON / policy / plain value STILL returns false.
- reflexive for plain strings and object values too.

## Gates
- `vp run typecheck` clean.
- `vp check --fix` — only 1 error remains, a PRE-EXISTING `no-base-to-string` in `src/diff/classify.ts` (present on base `7831fc1`, not touched here, owned by a parallel agent).
- `vp pack` builds.
- `vp test run` — 3548 passed (89 files), including the 9 new cases.