### PR TITLE
fix(noise): fold GuardDuty Detector first-run defaults (#879) + Cognito UserPoolClient sorted attribute lists (#875)

### DIFF
--- a/src/normalize/noise.ts
+++ b/src/normalize/noise.ts
@@ -41,6 +41,27 @@ export const KNOWN_DEFAULTS: Record<string, Record<string, unknown>> = {
       IngressConfiguration: { IsPubliclyAccessible: true },
     },
   },
+  // A GuardDuty detector declared with only `Enable: true` reads back AWS's constant
+  // new-detector defaults for two undeclared top-level properties:
+  //   FindingPublishingFrequency — the CloudWatch/S3 publishing cadence defaults to
+  //     SIX_HOURS. Equality-gated: a user who lowers it out of band (e.g. FIFTEEN_MINUTES
+  //     or ONE_HOUR) no longer matches and re-surfaces as real undeclared drift.
+  //   DataSources — the legacy data-source surface AWS materializes fully enabled on a new
+  //     detector (S3 protection, EKS audit logs, EC2 EBS malware protection). Pinned as a
+  //     whole-object default; matchesKnownDefault is recursively subset-tolerant, so AWS
+  //     enriching the object with new sub-keys is tolerated while disabling any leaf (e.g.
+  //     S3Logs.Enable=false) breaks the match and re-surfaces. (`Features`, the newer
+  //     surface AWS EXTENDS over time, is folded value-independently — see
+  //     VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS.) Live-confirmed on a fresh
+  //     `Enable: true`-only detector (CdkrdHuntUGd, 2026-07-09; #879).
+  'AWS::GuardDuty::Detector': {
+    FindingPublishingFrequency: 'SIX_HOURS',
+    DataSources: {
+      MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+      S3Logs: { Enable: true },
+      Kubernetes: { AuditLogs: { Enable: true } },
+    },
+  },
   // A Managed Service for Apache Flink application that declares no ApplicationMode
   // reads back STREAMING — the constant service default for Flink runtimes (the only
   // other value, INTERACTIVE, requires a Zeppelin/Studio runtime, a different declared
@@ -2700,6 +2721,18 @@ export const VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS: Record<string, ReadonlySe
   //   without enumerating each. Both observed live first-run (LineLink cognito, my-app
   //   AimAssociation TOKEN "custom") with no out-of-band edit.
   'AWS::ApiGateway::Authorizer': new Set(['AuthType']),
+  //   AWS::GuardDuty::Detector.Features — a detector declared with only `Enable: true`
+  //   reads back the full list of protection Features AWS materializes on a new detector
+  //   ([{Name:"CLOUD_TRAIL",Status:"ENABLED"}, {Name:"DNS_LOGS",...}, ...]). AWS EXTENDS
+  //   this list over time — new feature names appear as GuardDuty ships them (AI_ANALYST,
+  //   S3_DATA_EVENTS, RUNTIME_MONITORING, …), so a pinned constant would rot into a false
+  //   positive the moment AWS adds one. Fold value-independent: the property is undeclared,
+  //   so whatever feature set AWS enabled is its default, never user intent — a user who
+  //   cares about a specific feature's status DECLARES `Features`, which is then compared in
+  //   the declared loop (detected). (The legacy `DataSources` surface + the SIX_HOURS
+  //   publishing cadence are stable constants folded via KNOWN_DEFAULTS above.) Live-confirmed
+  //   on a fresh `Enable: true`-only detector (CdkrdHuntUGd, 2026-07-09; #879).
+  'AWS::GuardDuty::Detector': new Set(['Features']),
   //   AWS::RDS::DBCluster / ::DBInstance — an Aurora cluster/instance that declares no explicit
   //   KMS key, availability-zone placement, or maintenance/backup window reads back the values
   //   AWS ASSIGNED at creation: a specific `KmsKeyId` (the account/CDK key — create-only, so it
@@ -4188,6 +4221,21 @@ export const UNORDERED_ARRAY_PROPS: Record<string, ReadonlySet<string>> = {
     // sibling OAuth lists above; a genuine URL add/remove still changes the multiset.
     'CallbackURLs',
     'LogoutURLs',
+    // Live-observed on a fresh cognito-callbackurls / CdkrdHuntUCase deploy: Cognito
+    // ALPHABETICALLY SORTS the attribute lists it echoes back — declared
+    // ReadAttributes ["phone_number","email","name","family_name","birthdate"] reads
+    // back ["birthdate","email","family_name","name","phone_number"]. These are
+    // set-semantic (order carries no meaning), so a positional compare false-drifts the
+    // identical attribute set as permanent declared-tier drift that survives `record` and
+    // churns on `revert` (Cognito re-sorts the rewritten value immediately). Same
+    // set-reorder class as the OAuth / URL siblings above; a genuine attribute add/remove
+    // still changes the multiset. SupportedIdentityProviders is the same set-semantic list
+    // (a single-element deploy left its order unobservable, but it is a provider SET). #875.
+    // NOTE: scoped strictly to these UserPoolClient lists — UserPool-level AliasAttributes
+    // was live-proven ORDER-PRESERVING and is deliberately NOT folded.
+    'ReadAttributes',
+    'WriteAttributes',
+    'SupportedIdentityProviders',
   ]),
   // R84 (observed live on a fresh harvest6 deploy): WAFv2 stores the IP address
   // set and echoes it in its own canonical order, so a fresh deploy reports the

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -1521,15 +1521,17 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
         ).declared
       ).toEqual(['ExplicitAuthFlows']);
       // the rule is per-type+per-prop: the same shape on an UNLISTED prop still reports
+      // (SomeOrderedProp is not in the UserPoolClient set; ReadAttributes/WriteAttributes
+      // are now folded — see the dedicated #875 test below).
       expect(
         tiers(
           classifyResource(
-            client({ ReadAttributes: ['email', 'name'] }),
-            { ReadAttributes: ['name', 'email'] },
+            client({ SomeOrderedProp: ['a', 'b'] }),
+            { SomeOrderedProp: ['b', 'a'] },
             emptySchema
           )
         ).declared
-      ).toEqual(['ReadAttributes']);
+      ).toEqual(['SomeOrderedProp']);
     });
 
     // Live-observed FP (cognito-callbackurls fixture): Cognito reorders the
@@ -1557,6 +1559,39 @@ describe('KNOWN_DEFAULTS suppression (R66 — dogfood-observed service defaults)
             classifyResource(
               client({ [prop]: ['https://z.example', 'https://a.example'] }),
               { [prop]: ['https://a.example', 'https://NEW.example'] },
+              emptySchema
+            )
+          ).declared
+        ).toEqual([prop]);
+      }
+    });
+
+    // #875: Cognito ALPHABETICALLY SORTS the attribute lists it echoes back — declared
+    // ReadAttributes ["phone_number","email","name"] reads back sorted ["email","name",
+    // "phone_number"], a permanent declared FP that survives record and churns on revert.
+    // Set-semantic, same class as the OAuth/URL siblings. SupportedIdentityProviders too.
+    it('UNORDERED_ARRAY_PROPS: Cognito ReadAttributes/WriteAttributes/SupportedIdentityProviders sort is NOT drift (#875)', () => {
+      const client = (declared: Record<string, unknown>): DesiredResource => ({
+        logicalId: 'Client',
+        resourceType: 'AWS::Cognito::UserPoolClient',
+        physicalId: 'client123',
+        declared,
+      });
+      for (const prop of ['ReadAttributes', 'WriteAttributes', 'SupportedIdentityProviders']) {
+        // declared in natural order, read back service-sorted -> no drift
+        expect(
+          classifyResource(
+            client({ [prop]: ['phone_number', 'email', 'name', 'family_name', 'birthdate'] }),
+            { [prop]: ['birthdate', 'email', 'family_name', 'name', 'phone_number'] },
+            emptySchema
+          )
+        ).toEqual([]);
+        // a genuine attribute add/remove still changes the multiset -> reports
+        expect(
+          tiers(
+            classifyResource(
+              client({ [prop]: ['phone_number', 'email', 'name'] }),
+              { [prop]: ['email', 'name', 'address'] },
               emptySchema
             )
           ).declared

--- a/tests/noise-guardduty-879.test.ts
+++ b/tests/noise-guardduty-879.test.ts
@@ -1,0 +1,125 @@
+// #879: GuardDuty::Detector first-run fold gaps mined from a clean, un-mutated LIVE deploy
+// (a fresh `Enable: true`-only detector, stack CdkrdHuntUGd). Three undeclared top-level
+// properties surfaced as [Potential Drift] on a first `check`:
+//   FindingPublishingFrequency -> tier-1 KNOWN_DEFAULTS constant "SIX_HOURS" (a user lowering
+//     it out of band still surfaces).
+//   DataSources -> tier-1 whole-object KNOWN_DEFAULTS default (recursively subset-tolerant, so
+//     AWS enrichment is tolerated; disabling any leaf re-surfaces).
+//   Features -> tier-3 VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS (AWS EXTENDS the list over
+//     time, so a pinned constant rots; the property is undeclared, so any value AWS returns
+//     is its default, not user intent).
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+
+const pathsByTier = (findings: Finding[], tier: string) =>
+  findings
+    .filter((f) => f.tier === tier)
+    .map((f) => f.path)
+    .sort();
+
+describe('#879 GuardDuty::Detector undeclared first-run defaults', () => {
+  const res: DesiredResource = {
+    logicalId: 'Detector',
+    resourceType: 'AWS::GuardDuty::Detector',
+    physicalId: '1fbe7ac257dc491d9992398365731fc9',
+    declared: { Enable: true },
+  };
+  // The full new-detector default DataSources object (live-harvested).
+  const defaultDataSources = {
+    MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+    S3Logs: { Enable: true },
+    Kubernetes: { AuditLogs: { Enable: true } },
+  };
+  // The full new-detector Features list (live-harvested), including a future-ish name.
+  const defaultFeatures = [
+    { Status: 'DISABLED', Name: 'AI_ANALYST' },
+    { Status: 'ENABLED', Name: 'CLOUD_TRAIL' },
+    { Status: 'ENABLED', Name: 'DNS_LOGS' },
+    { Status: 'ENABLED', Name: 'EBS_MALWARE_PROTECTION' },
+    { Status: 'ENABLED', Name: 'S3_DATA_EVENTS' },
+  ];
+  const cleanLive = {
+    Enable: true,
+    FindingPublishingFrequency: 'SIX_HOURS',
+    DataSources: defaultDataSources,
+    Features: defaultFeatures,
+  };
+
+  it('produces ZERO potential drift on a clean, un-mutated detector', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toEqual([]);
+  });
+
+  it('folds FindingPublishingFrequency=SIX_HOURS to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('FindingPublishingFrequency');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('FindingPublishingFrequency');
+  });
+
+  it('folds the whole-object DataSources default to atDefault', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('DataSources');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('DataSources');
+  });
+
+  it('folds DataSources when the live echo carries FEWER sub-keys than the pinned default', () => {
+    // matchesKnownDefault is recursively subset-tolerant: an older/leaner live echo that
+    // omits a sub-key the fuller pinned default lists still folds (the default is the
+    // superset). Here the live model omits the Kubernetes branch entirely.
+    const leaner = {
+      ...cleanLive,
+      DataSources: {
+        MalwareProtection: { ScanEc2InstanceWithFindings: { EbsVolumes: true } },
+        S3Logs: { Enable: true },
+      },
+    };
+    const f = classifyResource(res, leaner, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('DataSources');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('DataSources');
+  });
+
+  it('folds the Features list value-independently (folds AI_ANALYST + any future feature)', () => {
+    const f = classifyResource(res, cleanLive, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Features');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Features');
+  });
+
+  it('folds Features even after AWS adds a brand-new feature name', () => {
+    const withNewFeature = {
+      ...cleanLive,
+      Features: [...defaultFeatures, { Status: 'ENABLED', Name: 'BRAND_NEW_FEATURE_2027' }],
+    };
+    const f = classifyResource(res, withNewFeature, emptySchema);
+    expect(pathsByTier(f, 'atDefault')).toContain('Features');
+    expect(pathsByTier(f, 'undeclared')).not.toContain('Features');
+  });
+
+  it('surfaces an out-of-band FindingPublishingFrequency lower than the default', () => {
+    const changed = { ...cleanLive, FindingPublishingFrequency: 'FIFTEEN_MINUTES' };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('FindingPublishingFrequency');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('FindingPublishingFrequency');
+  });
+
+  it('surfaces an out-of-band disabled DataSources leaf (S3Logs.Enable=false)', () => {
+    const changed = {
+      ...cleanLive,
+      DataSources: { ...defaultDataSources, S3Logs: { Enable: false } },
+    };
+    const f = classifyResource(res, changed, emptySchema);
+    expect(pathsByTier(f, 'undeclared')).toContain('DataSources');
+    expect(pathsByTier(f, 'atDefault')).not.toContain('DataSources');
+  });
+});


### PR DESCRIPTION
Closes #879
Closes #875

Two first-run/declared false-positive folds landing in `src/normalize/noise.ts`.

**#879 — GuardDuty::Detector first-run FPs.** A fresh `Enable: true`-only detector surfaced 3 `[Potential Drift]` on a first `check`. Folded per the decision order:
- `FindingPublishingFrequency = "SIX_HOURS"` → tier-1 `KNOWN_DEFAULTS` constant (an out-of-band lower cadence still surfaces).
- `DataSources` → tier-1 whole-object `KNOWN_DEFAULTS` default (recursively subset-tolerant; disabling any leaf re-surfaces).
- `Features` → tier-3 `VALUE_INDEPENDENT_DEFAULT_TOPLEVEL_PATHS` (AWS EXTENDS this list over time — a pinned constant would rot; the property is undeclared so any value is AWS's default, not user intent).

**#875 — Cognito UserPoolClient sorted attribute lists.** `ReadAttributes`, `WriteAttributes`, `SupportedIdentityProviders` are alphabetically sorted by the service → permanent declared FP surviving `record`, churning on `revert`. Added the three to `UNORDERED_ARRAY_PROPS` alongside the 5 already-folded siblings. Scoped strictly to the client lists — UserPool-level `AliasAttributes` (order-preserving) is deliberately untouched.

**Tests:** new `tests/noise-guardduty-879.test.ts` (8 cases: each GD prop folds to atDefault on a clean model, subset-tolerant DataSources, value-independent Features incl. a future feature name, and out-of-band cadence/leaf changes still surface). `tests/classify.test.ts` gains a #875 case (the three Cognito lists compare equal regardless of order + a genuine add/remove still reports); its old "unlisted prop" counter-example was updated off `ReadAttributes` (now folded) to a synthetic prop. Both sets confirmed to FAIL without the fold. Full suite: 3548 passed.