### PR TITLE
fix(check): whole-stack skips escape --strict exit aggregation (#948)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -396,6 +396,11 @@ export async function runCheck(args: string[]): Promise<number> {
       if (synthTemplates && !synthTemplates.has(sKey)) {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
         jsonError(stackName, region, 'not in the synth output — skipped (--pre-deploy)');
+        // #948: dropping a user-named stack from the run is the MAXIMAL coverage gap —
+        // nothing in it was checked — so under --strict it must fail (mirroring the
+        // deleted-stack fold below and one skipped RESOURCE already failing --strict).
+        // Without --strict, preserve the exit-0 skip.
+        worst = Math.max(worst, a.strict ? 1 : 0);
         continue;
       }
       // The stack's synth template (always carried by resolveStacks) is the non-ASCII
@@ -669,6 +674,11 @@ export async function runCheck(args: string[]): Promise<number> {
       if (e instanceof StackNotCheckableError) {
         console.error(`note: ${stackName}: ${e.message} — skipped`);
         jsonError(stackName, region, `${e.message} — skipped`);
+        // #948: skipping a whole stack (REVIEW_IN_PROGRESS / DELETE_IN_PROGRESS /
+        // ROLLBACK_COMPLETE) leaves it entirely unchecked — the maximal coverage gap —
+        // so under --strict it must fail (mirroring the deleted-stack fold above and a
+        // single skipped RESOURCE already failing --strict). Non-strict stays exit-0.
+        worst = Math.max(worst, a.strict ? 1 : 0);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/tests/check-strict-wholestack-948.test.ts
+++ b/tests/check-strict-wholestack-948.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { StackNotCheckableError } from '../src/aws-errors.js';
+
+// #948 — a whole stack dropped from the multi-stack loop (skipped, not checked) is the
+// MAXIMAL coverage gap, so under --strict it must exit 1 — the same contract a single
+// skipped RESOURCE and the deleted-stack path (#781) already honor. Two `continue` paths
+// used to drop the stack WITHOUT folding into `worst`, so `--strict` silently exited 0.
+//
+// runCheck resolves a CDK app (resolveApp) and discovers its stacks (discoverStacks),
+// then gathers findings per stack (gatherFindings) and — under --pre-deploy — synthesizes
+// the local app (synthApp) to build the declared-source templates. Mock exactly those.
+
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+const discoverStacksMock = vi.fn();
+const synthAppMock = vi.fn();
+vi.mock('../src/synth/synth.js', () => ({
+  discoverStacks: (...args: unknown[]) => discoverStacksMock(...args),
+  synthApp: (...args: unknown[]) => synthAppMock(...args),
+}));
+
+const gatherFindingsMock = vi.fn();
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: (...args: unknown[]) => gatherFindingsMock(...args),
+}));
+
+import { runCheck } from '../src/commands/check.js';
+
+// A single discovered stack, region-pinned so no profile-region lookup is needed.
+const oneStack = (stackName: string, region = 'us-east-1') => [
+  { stackName, region, template: {} as Record<string, unknown> },
+];
+
+describe('#948 StackNotCheckableError whole-stack skip contributes to --strict exit', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    discoverStacksMock.mockReset();
+    synthAppMock.mockReset();
+    gatherFindingsMock.mockReset();
+  });
+
+  it('--strict --fail exits 1 when a stack is DELETE_IN_PROGRESS (skipped, unchecked)', async () => {
+    discoverStacksMock.mockResolvedValue(oneStack('Prod'));
+    gatherFindingsMock.mockRejectedValue(
+      new StackNotCheckableError('stack is in DELETE_IN_PROGRESS')
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(await runCheck(['--strict', '--fail'])).toBe(1);
+  });
+
+  it('without --strict the same skip still exits 0 (report-only skip preserved)', async () => {
+    discoverStacksMock.mockResolvedValue(oneStack('Prod'));
+    gatherFindingsMock.mockRejectedValue(
+      new StackNotCheckableError('stack is in REVIEW_IN_PROGRESS')
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    // --fail alone (no --strict) must NOT fail: a skipped stack is not drift.
+    expect(await runCheck(['--fail'])).toBe(0);
+  });
+});
+
+describe('#948 --pre-deploy named stack missing from synth output contributes to --strict', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    discoverStacksMock.mockReset();
+    synthAppMock.mockReset();
+    gatherFindingsMock.mockReset();
+  });
+
+  it('--strict --fail exits 1 when a user-named stack is absent from the second synth', async () => {
+    // Discovery finds Prod, but the --pre-deploy synth produces only SomethingElse, so
+    // Prod's synth key is missing → the "not in the synth output — skipped" branch.
+    discoverStacksMock.mockResolvedValue(oneStack('Prod'));
+    synthAppMock.mockResolvedValue([
+      { stackName: 'SomethingElse', region: 'us-east-1', template: {} },
+    ]);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(await runCheck(['Prod', '--pre-deploy', '--fail', '--strict'])).toBe(1);
+    // gatherFindings must NEVER run — the stack was dropped before the gather phase.
+    expect(gatherFindingsMock).not.toHaveBeenCalled();
+  });
+
+  it('without --strict the same pre-deploy skip still exits 0', async () => {
+    discoverStacksMock.mockResolvedValue(oneStack('Prod'));
+    synthAppMock.mockResolvedValue([
+      { stackName: 'SomethingElse', region: 'us-east-1', template: {} },
+    ]);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    expect(await runCheck(['Prod', '--pre-deploy', '--fail'])).toBe(0);
+    expect(gatherFindingsMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #948.

## Root cause

`runCheck`'s multi-stack loop aggregates each stack's exit into `worst`, and
`--strict` is meant to exit 1 whenever coverage is INCOMPLETE (any resource — or
whole stack — left unchecked). Two `continue` paths dropped an ENTIRE stack from
the run WITHOUT folding into `worst`, so `--strict` silently exited 0 on the
maximal coverage gap:

1. **`StackNotCheckableError` skip** (`check.ts` catch block): a stack in
   `REVIEW_IN_PROGRESS` / `DELETE_IN_PROGRESS` / `ROLLBACK_COMPLETE` was skipped
   with a stderr note + `jsonError` + `continue`, no `worst` bump.
2. **`--pre-deploy` "not in the synth output" skip**: a user-named stack that
   discovery found but the second synth did not produce was skipped with a note +
   `continue`, exit 0 even under `--fail --strict`.

Contrast: the deleted-stack path (#781) already folds `a.strict ? 1 : 0` for a
whole-stack condition, and a single skipped RESOURCE inside a checked stack
already makes `--strict` exit 1 via `strictCoverageExit`.

## Fix

Both `continue` paths now fold `worst = Math.max(worst, a.strict ? 1 : 0)`,
mirroring the existing #781 idiom. Behavior WITHOUT `--strict` is unchanged (the
skip still exits 0). The "not deployed yet, no baseline" path is untouched (stays
exit 0 by design per #781). Surgical — only the strict fold is added; the loop is
not otherwise restructured. (The issue's optional "exit 2" suggestion was
deliberately NOT taken, to keep the change minimal.)

## Tests

New `tests/check-strict-wholestack-948.test.ts` (4 cases), mirroring the existing
`runCheck` mock harness (`resolveApp` / `discoverStacks` / `synthApp` /
`gatherFindings`):

- `StackNotCheckableError` (DELETE_IN_PROGRESS) under `--strict --fail` → exit 1
  (was 0).
- Same skip WITHOUT `--strict` (just `--fail`) → still exit 0 (regression guard).
- `--pre-deploy` named stack absent from the synth output under `--strict --fail`
  → exit 1 (was 0), and `gatherFindings` is never called.
- Same pre-deploy skip without `--strict` → still exit 0.

All gates green: typecheck / lint+format / build / 89 test files, 3543 tests.
