### PR TITLE
fix(commands): region in per-stack decision prompts (#947)

### DIFF
--- a/src/commands/interactive-resolve.ts
+++ b/src/commands/interactive-resolve.ts
@@ -38,6 +38,7 @@ import {
   includeUnrecordedRemovals,
   recordStack,
   revertStack,
+  stackLabel,
 } from './stack-actions.js';
 
 export interface ResolveParams {
@@ -289,15 +290,20 @@ export function buildResolveOptions(
  *  (issue #539) — empty for a lone stack. Pure + exported. */
 export function resolveMenuMessage(
   stackName: string,
+  region: string,
   code: number,
   establishOnly = false,
   prefix = ''
 ): string {
+  // Name the region the same way the report header does (#947): after #899 exact-name
+  // selection iterates every same-named region instance, so a bare stackName here is
+  // indistinguishable across regions right at the top decision menu.
+  const label = stackLabel(stackName, region);
   if (establishOnly)
-    return `${prefix}${stackName}: no .cdkrd baseline yet — record the current state as your baseline?`;
+    return `${prefix}${label}: no .cdkrd baseline yet — record the current state as your baseline?`;
   return code === 1
-    ? `${prefix}${stackName}: drift found — what do you want to do?`
-    : `${prefix}${stackName}: potential drift found (live-only, no baseline yet) — what do you want to do?`;
+    ? `${prefix}${label}: drift found — what do you want to do?`
+    : `${prefix}${label}: potential drift found (live-only, no baseline yet) — what do you want to do?`;
 }
 
 export async function resolveInteractively(p: ResolveParams): Promise<number> {
@@ -343,7 +349,13 @@ export async function resolveInteractively(p: ResolveParams): Promise<number> {
     const options = buildResolveOptions(actions, decidable.length, recordLabel);
 
     const choice = await select({
-      message: resolveMenuMessage(p.stackName, code, establishOnly, p.positionPrefix ?? ''),
+      message: resolveMenuMessage(
+        p.stackName,
+        p.region,
+        code,
+        establishOnly,
+        p.positionPrefix ?? ''
+      ),
       options,
       initialValue: 'nothing',
     });

--- a/src/commands/stack-actions.ts
+++ b/src/commands/stack-actions.ts
@@ -60,6 +60,18 @@ const unrecordedCount = (findings: Finding[]): number =>
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 /**
+ * The per-stack label shown in a DECISION prompt — the SAME `Name (region)` form the
+ * report header uses (`check.ts` `${stackName} (${region})`). After #899 exact-name
+ * selection targets EVERY same-named region instance, so a bare `stackName` in a
+ * record/ignore/revert prompt is indistinguishable across regions (a wrong-region
+ * record/ignore/revert hazard, #947). Naming the region disambiguates them. Pure +
+ * exported so the wording is unit-tested.
+ */
+export function stackLabel(stackName: string, region: string): string {
+  return `${stackName} (${region})`;
+}
+
+/**
  * The revert confirm message (R52). When NOT-revertable findings exist (e.g. a
  * no-baseline first check with one declared drift and 100+ undeclared values),
  * users read "This WRITES to AWS" as "everything I just saw gets written" —
@@ -68,6 +80,7 @@ const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms
  */
 export function revertConfirmMessage(
   stackName: string,
+  region: string,
   opCount: number,
   notRevertableCount: number
 ): string {
@@ -75,7 +88,7 @@ export function revertConfirmMessage(
     notRevertableCount > 0
       ? ` Only the ${opCount} selected op(s) are written — the ${notRevertableCount} NOT-revertable finding(s) are untouched.`
       : '';
-  return `Apply ${opCount} revert op(s) to ${stackName}? This WRITES to AWS.${scope}`;
+  return `Apply ${opCount} revert op(s) to ${stackLabel(stackName, region)}? This WRITES to AWS.${scope}`;
 }
 
 /**
@@ -105,12 +118,12 @@ export function formatSurvivingDrift(remaining: Finding[], stackName = '', cap =
  * (the folded would just nag forever), whereas deselecting a standout to "record the rest"
  * IS useful — so standouts toggle, the folded always record. Pure + exported.
  */
-export function recordSelectMessage(stackName: string, foldedCount = 0): string {
+export function recordSelectMessage(stackName: string, region: string, foldedCount = 0): string {
   const fold =
     foldedCount > 0
       ? `; +${foldedCount} folded sub-key(s) ALWAYS recorded too (--verbose to itemize)`
       : '';
-  return `${stackName}: select undeclared value(s) to record (unselected stay reported)${fold}`;
+  return `${stackLabel(stackName, region)}: select undeclared value(s) to record (unselected stay reported)${fold}`;
 }
 
 /**
@@ -225,8 +238,8 @@ export function filterRevertPlan(plan: RevertPlan, picked: Set<string>): RevertP
   return { items, notRevertable: plan.notRevertable };
 }
 
-export function revertSelectMessage(stackName: string): string {
-  return `${stackName}: select the op(s) to revert (unselected are not written)`;
+export function revertSelectMessage(stackName: string, region: string): string {
+  return `${stackLabel(stackName, region)}: select the op(s) to revert (unselected are not written)`;
 }
 
 // ---- record ----
@@ -296,7 +309,7 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
   if (existing) checkBaselineAccount(existing, desired.accountId, stackName);
   if (!yes && existing)
     console.error(
-      `note: ${stackName}: will overwrite the existing baseline file on confirm (nothing written yet; it is git-tracked — review the diff afterwards). Pass --yes to silence.`
+      `note: ${stackLabel(stackName, region)}: will overwrite the existing baseline file on confirm (nothing written yet; it is git-tracked — review the diff afterwards). Pass --yes to silence.`
     );
   // Seed with this run's observed entries, then carry forward any prior baseline
   // entries for resources this run could NOT read (skipped / model-read-failed) so a
@@ -344,7 +357,7 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
           // Nothing to itemize (every changed value is a folded nested sub-key — the common
           // all-nested first run). A Yes/No commit replaces the empty multiselect.
           const proceed = await confirm({
-            message: `${stackName}: record ${folded.length} undeclared sub-key value(s)? (--verbose to itemize each)`,
+            message: `${stackLabel(stackName, region)}: record ${folded.length} undeclared sub-key value(s)? (--verbose to itemize each)`,
             initialValue: true,
           });
           if (isCancel(proceed) || !proceed) {
@@ -354,7 +367,7 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
           picked = changed.map((e) => recordedKey(e));
         } else {
           const fromPrompt = await bulkMultiselect(
-            recordSelectMessage(stackName, folded.length),
+            recordSelectMessage(stackName, region, folded.length),
             // default = all selected (→/← bulk-toggle from there)
             standout.map((e) => ({
               value: recordedKey(e),
@@ -382,7 +395,7 @@ export async function recordStack(p: RecordStackParams): Promise<RecordResult> {
       // Skipped on the per-finding path: the picker is the decision, no extra confirm.
       if (recorded.length === 0 && !preselectedKeys) {
         const proceed = await confirm({
-          message: `${stackName}: record nothing? This writes an EMPTY baseline — every undeclared value stays reported as unrecorded.`,
+          message: `${stackLabel(stackName, region)}: record nothing? This writes an EMPTY baseline — every undeclared value stays reported as unrecorded.`,
           initialValue: false,
         });
         if (isCancel(proceed) || !proceed) {
@@ -457,8 +470,8 @@ export interface IgnoreResult {
 
 /** Header for ignore's multiselect. The key hints are rendered by `bulkMultiselect`
  *  itself, so this is just the one-line prompt. Pure + exported for unit tests. */
-export function ignoreSelectMessage(stackName: string): string {
-  return `${stackName}: select drift to ignore — stops reporting it (writes .cdkrd/ignore.yaml)`;
+export function ignoreSelectMessage(stackName: string, region: string): string {
+  return `${stackLabel(stackName, region)}: select drift to ignore — stops reporting it (writes .cdkrd/ignore.yaml)`;
 }
 
 // Unique per-finding key for the multiselect (logicalId+path is unique within a stack;
@@ -517,7 +530,7 @@ export async function ignoreStack(p: IgnoreStackParams): Promise<IgnoreResult> {
       return { wrote: false, refused: true, added: 0 };
     }
     const picked = await bulkMultiselect(
-      ignoreSelectMessage(stackName),
+      ignoreSelectMessage(stackName, region),
       ignoreSelectOptions(ignorable, stackName)
     );
     if (picked === undefined) {
@@ -868,7 +881,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     // the findings, so revert every op of the plan — but still confirm the AWS write.
     if (!autoSelectAll) {
       const picked = await bulkMultiselect(
-        revertSelectMessage(stackName),
+        revertSelectMessage(stackName, region),
         revertSelectOptions(plan)
       );
       if (picked === undefined) {
@@ -883,7 +896,7 @@ export async function revertStack(p: RevertStackParams): Promise<RevertOutcome> 
     }
     const opCount = plan.items.reduce((n, i) => n + i.ops.length, 0);
     const ok = await confirm({
-      message: revertConfirmMessage(stackName, opCount, plan.notRevertable.length),
+      message: revertConfirmMessage(stackName, region, opCount, plan.notRevertable.length),
     });
     if (isCancel(ok) || !ok) {
       out(style.note('aborted.'));

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -174,29 +174,42 @@ describe('buildResolveOptions (R133 — the chain menu surface)', () => {
 
 describe('resolveMenuMessage (R133 — worded by remaining exit state)', () => {
   it('code 1 (drift remains) says drift found', () => {
-    expect(resolveMenuMessage('S', 1)).toContain('drift found');
+    expect(resolveMenuMessage('S', 'us-east-1', 1)).toContain('drift found');
   });
   it('code 0 (only unrecorded) says potential drift found', () => {
-    expect(resolveMenuMessage('S', 0)).toContain('potential drift found');
+    expect(resolveMenuMessage('S', 'us-east-1', 0)).toContain('potential drift found');
   });
   it('R141: establishOnly says "no .cdkrd baseline yet"', () => {
-    expect(resolveMenuMessage('S', 0, true)).toContain('no .cdkrd baseline yet');
+    expect(resolveMenuMessage('S', 'us-east-1', 0, true)).toContain('no .cdkrd baseline yet');
   });
 
   // issue #539: the multi-stack [i/N] position cue is carried into the interactive prompt.
   it('prefixes the [i/N] position cue before the stack name (drift)', () => {
-    expect(resolveMenuMessage('S', 1, false, '[2/3] ')).toBe(
-      '[2/3] S: drift found — what do you want to do?'
+    expect(resolveMenuMessage('S', 'us-east-1', 1, false, '[2/3] ')).toBe(
+      '[2/3] S (us-east-1): drift found — what do you want to do?'
     );
   });
   it('prefixes the [i/N] cue for the potential-drift and establish wordings too', () => {
-    expect(resolveMenuMessage('S', 0, false, '[2/3] ')).toMatch(
-      /^\[2\/3\] S: potential drift found/
+    expect(resolveMenuMessage('S', 'us-east-1', 0, false, '[2/3] ')).toMatch(
+      /^\[2\/3\] S \(us-east-1\): potential drift found/
     );
-    expect(resolveMenuMessage('S', 0, true, '[2/3] ')).toMatch(/^\[2\/3\] S: no \.cdkrd baseline/);
+    expect(resolveMenuMessage('S', 'us-east-1', 0, true, '[2/3] ')).toMatch(
+      /^\[2\/3\] S \(us-east-1\): no \.cdkrd baseline/
+    );
   });
   it('adds nothing when the prefix is empty (lone stack — default)', () => {
-    expect(resolveMenuMessage('S', 1)).toBe('S: drift found — what do you want to do?');
+    expect(resolveMenuMessage('S', 'us-east-1', 1)).toBe(
+      'S (us-east-1): drift found — what do you want to do?'
+    );
+  });
+
+  // #947: after #899 exact-name selection targets every same-named region instance, so the
+  // top decision menu must name the region the way the report header does.
+  it('names the region so two same-named different-region menus are DISTINCT (#947)', () => {
+    expect(resolveMenuMessage('Dup', 'us-east-1', 1)).toContain('Dup (us-east-1):');
+    expect(resolveMenuMessage('Dup', 'us-east-1', 1)).not.toBe(
+      resolveMenuMessage('Dup', 'us-west-2', 1)
+    );
   });
 });
 

--- a/tests/stack-actions.test.ts
+++ b/tests/stack-actions.test.ts
@@ -30,8 +30,10 @@ import {
   includeUnrecordedRemovals,
   resolveInteractiveRevertExit,
   revertConfirmMessage,
+  revertSelectMessage,
   revertSelectOptions,
   revertStack,
+  stackLabel,
   summarizeRevertResults,
 } from '../src/commands/stack-actions.js';
 
@@ -1034,14 +1036,26 @@ describe('recordStack preselectedKeys (R121 — per-finding path skips the multi
 
 describe('revertConfirmMessage (R52 — the confirm must scope what gets written)', () => {
   it('with NOT-revertable findings present, states ONLY the selected ops are written', () => {
-    const msg = revertConfirmMessage('s', 1, 113);
-    expect(msg).toContain('Apply 1 revert op(s) to s? This WRITES to AWS.');
+    const msg = revertConfirmMessage('s', 'us-east-1', 1, 113);
+    expect(msg).toContain('Apply 1 revert op(s) to s (us-east-1)? This WRITES to AWS.');
     expect(msg).toContain('Only the 1 selected op(s) are written');
     expect(msg).toContain('113 NOT-revertable finding(s) are untouched');
   });
 
   it('without NOT-revertable findings, no scope clause (nothing to disclaim)', () => {
-    expect(revertConfirmMessage('s', 2, 0)).toBe('Apply 2 revert op(s) to s? This WRITES to AWS.');
+    expect(revertConfirmMessage('s', 'us-west-2', 2, 0)).toBe(
+      'Apply 2 revert op(s) to s (us-west-2)? This WRITES to AWS.'
+    );
+  });
+
+  it('names the region (#947 — the AWS-write confirm must say WHICH region it mutates)', () => {
+    expect(revertConfirmMessage('Dup', 'eu-west-1', 1, 0)).toContain('to Dup (eu-west-1)?');
+  });
+
+  it('two same-named different-region instances produce DISTINCT confirm strings (#947)', () => {
+    expect(revertConfirmMessage('Dup', 'us-east-1', 1, 0)).not.toBe(
+      revertConfirmMessage('Dup', 'us-west-2', 1, 0)
+    );
   });
 });
 
@@ -1221,8 +1235,8 @@ describe('ignoreSelectOptions', () => {
 
 describe('recordSelectMessage (R49, R116 — bulkMultiselect renders the key hints now)', () => {
   it('is the one-line prompt header only (the space/→/←/enter hints live in bulkMultiselect)', () => {
-    const msg = recordSelectMessage('ApiStack');
-    expect(msg).toContain('ApiStack: select undeclared value(s) to record');
+    const msg = recordSelectMessage('ApiStack', 'us-east-1');
+    expect(msg).toContain('ApiStack (us-east-1): select undeclared value(s) to record');
     expect(msg).toContain('unselected stay reported');
     // the hint line moved into bulkMultiselect's render — the header is now single-line
     expect(msg).not.toContain('\n');
@@ -1230,7 +1244,7 @@ describe('recordSelectMessage (R49, R116 — bulkMultiselect renders the key hin
   });
 
   it('discloses that folded sub-keys are ALWAYS recorded when foldedCount > 0', () => {
-    const msg = recordSelectMessage('ApiStack', 23);
+    const msg = recordSelectMessage('ApiStack', 'us-east-1', 23);
     expect(msg).toContain('23 folded sub-key(s) ALWAYS recorded');
     expect(msg).toContain('--verbose');
     expect(msg).not.toContain('--show-all'); // --show-all is the separate inventory mode
@@ -1238,8 +1252,16 @@ describe('recordSelectMessage (R49, R116 — bulkMultiselect renders the key hin
   });
 
   it('no folded disclosure when there is nothing folded', () => {
-    expect(recordSelectMessage('ApiStack', 0)).not.toContain('folded');
-    expect(recordSelectMessage('ApiStack')).not.toContain('folded');
+    expect(recordSelectMessage('ApiStack', 'us-east-1', 0)).not.toContain('folded');
+    expect(recordSelectMessage('ApiStack', 'us-east-1')).not.toContain('folded');
+  });
+
+  it('names the region so a same-named multi-region record is not misendorsed (#947)', () => {
+    expect(recordSelectMessage('Dup', 'us-west-2')).toContain('Dup (us-west-2):');
+    // two same-named different-region pickers must present DISTINCT headers
+    expect(recordSelectMessage('Dup', 'us-east-1')).not.toBe(
+      recordSelectMessage('Dup', 'us-west-2')
+    );
   });
 });
 
@@ -1299,10 +1321,40 @@ describe('recordOutcomeMessage (R142 — day-1 init is not a cold "0 recorded")'
 
 describe('ignoreSelectMessage', () => {
   it('is a one-line header naming the stack + that it writes ignore.yaml', () => {
-    const msg = ignoreSelectMessage('ApiStack');
-    expect(msg).toContain('ApiStack');
+    const msg = ignoreSelectMessage('ApiStack', 'us-east-1');
+    expect(msg).toContain('ApiStack (us-east-1)');
     expect(msg).toContain('ignore.yaml');
     expect(msg).not.toContain('\n');
+  });
+
+  it('names the region so a same-named multi-region ignore is not misapplied (#947)', () => {
+    expect(ignoreSelectMessage('Dup', 'us-east-1')).not.toBe(
+      ignoreSelectMessage('Dup', 'us-west-2')
+    );
+  });
+});
+
+describe('revertSelectMessage (#947 — name the region in the op picker)', () => {
+  it('is a one-line header naming the stack + region', () => {
+    const msg = revertSelectMessage('ApiStack', 'us-east-1');
+    expect(msg).toContain('ApiStack (us-east-1): select the op(s) to revert');
+    expect(msg).not.toContain('\n');
+  });
+
+  it('two same-named different-region pickers produce DISTINCT headers', () => {
+    expect(revertSelectMessage('Dup', 'us-east-1')).not.toBe(
+      revertSelectMessage('Dup', 'us-west-2')
+    );
+  });
+});
+
+describe('stackLabel (#947 — the report-matching `Name (region)` decision label)', () => {
+  it('matches the report header format', () => {
+    expect(stackLabel('Dup', 'us-west-2')).toBe('Dup (us-west-2)');
+  });
+
+  it('two same-named different-region labels differ', () => {
+    expect(stackLabel('Dup', 'us-east-1')).not.toBe(stackLabel('Dup', 'us-west-2'));
   });
 });
 


### PR DESCRIPTION
Closes #947

After #899, exact-name selection targets EVERY same-named region instance (`check/record/ignore/revert Dup` iterate `Dup (us-east-1)` AND `Dup (us-west-2)`), but every interactive DECISION prompt rendered the bare `stackName` with no region — so two same-named instances presented byte-identical pickers (a wrong-region record/ignore/revert hazard). The report header already uses `${stackName} (${region})`; every decision prompt now matches it.

## What changed

New pure, exported `stackLabel(stackName, region)` helper in `src/commands/stack-actions.ts` renders the same `Name (region)` form the report header uses (`check.ts`). Threaded `region` into every per-stack decision-prompt helper + its call sites:

- `recordSelectMessage` — record multiselect header
- record's overwrite note, all-folded confirm, and empty-baseline confirm (inline in `recordStack`)
- `ignoreSelectMessage` — ignore multiselect header
- `revertSelectMessage` — revert op multiselect header
- `revertConfirmMessage` — the one AWS-write confirm now names the region it mutates
- `resolveMenuMessage` (`src/commands/interactive-resolve.ts`) — check's top decision menu

No signature plumbing beyond the helpers + their call sites: `recordStack`/`ignoreStack`/`revertStack` already receive `region` in their params, and the standalone `record.ts`/`ignore.ts` loops already pass `region` through those params, so the region reaches the prompt unchanged. Files touched are all under `src/commands/`.

## Tests

Updated the existing wording unit tests (`tests/stack-actions.test.ts`, `tests/check.test.ts`) to assert the region now appears, and added cases proving two same-named different-region invocations produce DISTINCT prompt strings for `stackLabel`, `recordSelectMessage`, `ignoreSelectMessage`, `revertSelectMessage`, `revertConfirmMessage`, and `resolveMenuMessage`. All 3548 unit tests green; typecheck / lint+format / build clean.