### PR TITLE
feat(read): SDK read override for ACM Certificate (#974)

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,11 @@ covers them. **If you never run `revert`, cdkrd needs no write permissions at al
   `ses:DescribeReceiptRuleSet`, `ses:DescribeReceiptRule`, `ses:ListReceiptFilters`
   (the SES inbound receipt-rule family — `ReceiptRuleSet` / `ReceiptRule` /
   `ReceiptFilter` — has no Cloud Control handlers),
+  `acm:DescribeCertificate` + `acm:ListTagsForCertificate` (read an
+  `AWS::CertificateManager::Certificate` — the ACM registry type ships no Cloud
+  Control read handler, so every cert was silently skipped, including an
+  out-of-band `Options.CertificateTransparencyLoggingPreference` flip or an
+  out-of-band deletion of a cert an ALB / CloudFront / API domain still references),
   `glue:GetTable`, `logs:DescribeMetricFilters`, `scheduler:GetSchedule`,
   `cloudwatch:DescribeAnomalyDetectors` (reads an
   `AWS::CloudWatch::AnomalyDetector` — NON_PROVISIONABLE, no Cloud Control

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   "dependencies": {
     "@aws-cdk/cloud-assembly-api": "^2.2.5",
     "@aws-cdk/toolkit-lib": "^1.28.0",
+    "@aws-sdk/client-acm": "^3.1065.0",
     "@aws-sdk/client-api-gateway": "^3.1069.0",
     "@aws-sdk/client-apigatewayv2": "^3.1069.0",
     "@aws-sdk/client-appconfig": "^3.1069.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@aws-cdk/toolkit-lib':
         specifier: ^1.28.0
         version: 1.28.0(@aws-cdk/cli-plugin-contract@2.182.2)
+      '@aws-sdk/client-acm':
+        specifier: ^3.1065.0
+        version: 3.1084.0
       '@aws-sdk/client-api-gateway':
         specifier: ^3.1069.0
         version: 3.1069.0
@@ -309,6 +312,10 @@ packages:
     resolution: {integrity: sha512-zOXUUnilC6lgCsQtp77p/QNPmRlTES9Xi6tlDwbR6kfC/kz5PCzZckgHWm5z+8DskdwuMAbFDq61x3zr10GEEQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-acm@3.1084.0':
+    resolution: {integrity: sha512-B/QFW0iI+glZfBFzIqCNb8LYIIfw6EOw2dtSPeMPIJksnjVlH3IgtKS2zIflQHxl57M5M2P/dqzrLbWkiiDK8A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-api-gateway@3.1069.0':
     resolution: {integrity: sha512-dvel7Gi00YTVEl7Qkvvrf6SzFIg/6xGiCXIxmFTtz224Zmcg2Fh8fESy02exsCQNLjR+3JmLm5Aw9j3dTgKE1A==}
     engines: {node: '>=20.0.0'}
@@ -553,6 +560,10 @@ packages:
     resolution: {integrity: sha512-yqKcltLbtRh1ubzhRSldIs8jFHNZlyMlgoIccCC0aDVbrB99nXaBdmfr89mK7obWX/NVg4rAMpCpZ6dCDiVBtA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.975.1':
+    resolution: {integrity: sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     resolution: {integrity: sha512-4L/REssieLON1hVsTzZucP1p2u5jmPNejyh/9BCGZXr93IalBbhRPCrtKIKwMTu9yRGr/bcKzhrQocByKLSzLQ==}
     engines: {node: '>=20.0.0'}
@@ -573,6 +584,10 @@ packages:
     resolution: {integrity: sha512-Ah36tYkqyaVnaHkx7VseoTYrHUmwgBps3V+wnrC1idhIIMGlviH0FtrX9EIPdAlVHvXC7FQZLhmHBRz+pLaiWg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.57':
+    resolution: {integrity: sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.48':
     resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
     engines: {node: '>=20.0.0'}
@@ -587,6 +602,10 @@ packages:
 
   '@aws-sdk/credential-provider-http@3.972.57':
     resolution: {integrity: sha512-/vp6i5YEliJqRm5k/BDmYjAyRAMTdkjW6UciVRk9oh/0OfDCWeb/ih7hqte4lFvKXkIbsqe9AdK9LQK6NGardw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.59':
+    resolution: {integrity: sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.53':
@@ -605,6 +624,10 @@ packages:
     resolution: {integrity: sha512-pQIRiQQs+MUlVnJdWJ7/6KS0WxcLRVfut57OFgwC3cnM1F8mXw3Kh4gAVwj6AtvD6CWx8x6+po4ENRcqe64XrQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    resolution: {integrity: sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.52':
     resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
     engines: {node: '>=20.0.0'}
@@ -619,6 +642,10 @@ packages:
 
   '@aws-sdk/credential-provider-login@3.972.61':
     resolution: {integrity: sha512-jtrxWwC7slqxh7DnAWHrwsA3UwCsnlypdYtavGT7EX5p791wxWQys7QzkCZ7JvOMAyylDtPoxyV+ic0zg3rV9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.63':
+    resolution: {integrity: sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.55':
@@ -657,6 +684,10 @@ packages:
     resolution: {integrity: sha512-zyKVYDyMR9VQL/kPi03ygN2vtD9uLMuWRLoJ77KxgZZaS1VlJloI+SzleF9Zg4HWUI+AIu+ZRs8zsJFNqbrxsw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.66':
+    resolution: {integrity: sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.46':
     resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
     engines: {node: '>=20.0.0'}
@@ -671,6 +702,10 @@ packages:
 
   '@aws-sdk/credential-provider-process@3.972.55':
     resolution: {integrity: sha512-x0XjjF0l1WGRtK2vEhTZqCguQuAIZLep9l2+eeEmuxQQjjD3BlGQXY5xADR+l3t576UX+dxRkRtTjEu40l81Vw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.57':
+    resolution: {integrity: sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.52':
@@ -689,6 +724,10 @@ packages:
     resolution: {integrity: sha512-d/V0VRsz73i+PHhbult/tx0Y1+de1SNQVsXkcQCmpfeBq7uODy/RTxNsOLpT9ZVHxcRNzbQFuywLKC33fUMIxA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    resolution: {integrity: sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
     engines: {node: '>=20.0.0'}
@@ -703,6 +742,10 @@ packages:
 
   '@aws-sdk/credential-provider-web-identity@3.972.61':
     resolution: {integrity: sha512-Bv4n3NOI6hPy+rmr6Bw9R6LnBVRkcp3ncj2E2IKSYJG+0UkysSitWMvbgndNvMxDw7gE1pQ/ErwkNceuKwj7zQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    resolution: {integrity: sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-providers@3.1066.0':
@@ -767,6 +810,10 @@ packages:
     resolution: {integrity: sha512-ot6v8J5W8P0w6ryyuIkXP1bHZHTlvwtn83mVCYaBE0GJ6tJX4vPSBx7M98w9O4wmmDruFsDBUMjhEHA+OosUFQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.31':
+    resolution: {integrity: sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
@@ -777,6 +824,10 @@ packages:
 
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    resolution: {integrity: sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1066.0':
@@ -795,6 +846,10 @@ packages:
     resolution: {integrity: sha512-kduAeI6cL+zqwj3gjPh9LhuX7kBZ83msYxutavaR+UPm5K8J7iThJBvNRAsFNyWTji92CSU8dogUgvi9T0BehA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1083.0':
+    resolution: {integrity: sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.12':
     resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
     engines: {node: '>=20.0.0'}
@@ -811,12 +866,20 @@ packages:
     resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/types@3.974.0':
+    resolution: {integrity: sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-locate-window@3.965.7':
     resolution: {integrity: sha512-M0D6oIpohdNHjc7udzTHEQyot0+0iuA36jc2I9Hps+f/GtKi2HO/pyijQnCnNcwZqLB5+rtn81z3eZK/GyjAmA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/xml-builder@3.972.33':
     resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.34':
+    resolution: {integrity: sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -1531,12 +1594,20 @@ packages:
     resolution: {integrity: sha512-sEvpvkBVoMxjoek35XyJFn2ZD3EJ1RpiZrT47WaZodxzAIWS44zkdvbqGE/ZlugtjiQp62cffYZ9ldyRkjAGnA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.2':
+    resolution: {integrity: sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.3.8':
     resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.4.5':
     resolution: {integrity: sha512-LnjUTNG0GgQlKIq7IioeOrPaEmC5xOd1WtAz24TLSiYQnWX2uHr53GrFuQhkrJBktPYCMga/NbUOW7hFbSA2Cg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.7':
+    resolution: {integrity: sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.4.6':
@@ -1549,6 +1620,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.6.2':
     resolution: {integrity: sha512-q96PSDOAGw+X+nuELd7Cjebps0SYr+YlPbviEX9sLVw+VM4M7VV8hn1nL1mGS6urDu33eQ5A7WhlphaDO6kUyQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.4':
+    resolution: {integrity: sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -1579,6 +1654,10 @@ packages:
     resolution: {integrity: sha512-s0yAIRj6TVfHgl+QzVyqal1KMGZ9B5512IrxKc6+dOpw8fUmFL3CvuAhjv0J+aNjUPfVZ2IhqPEDvkB5Ncx9oA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.4':
+    resolution: {integrity: sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.3.6':
     resolution: {integrity: sha512-0rhHv1Ww27kajF6qewme2aRtJmKFtSwE6EZ2dj5KxdX/R3ANsUugqTnH0tvpZwGiQ3MOMhetuCGFAeKVv3/Onw==}
     engines: {node: '>=18.0.0'}
@@ -1589,6 +1668,10 @@ packages:
 
   '@smithy/signature-v4@5.6.1':
     resolution: {integrity: sha512-SqvuP75p/DmgWWI7jv4kf/UW+V4LFmlUn19s604SgAcRuJRB1vDnWwzZMYCLUcmKxko9wDn6iLgGEIpTNgZbIQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.3':
+    resolution: {integrity: sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.15.0':
@@ -3865,6 +3948,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-acm@3.1084.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-node': 3.972.66
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/client-api-gateway@3.1069.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -4631,6 +4725,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.975.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@aws-sdk/xml-builder': 3.972.34
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.2
+      '@smithy/signature-v4': 5.6.3
+      '@smithy/types': 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-cognito-identity@3.972.45':
     dependencies:
       '@aws-sdk/nested-clients': 3.997.20
@@ -4671,6 +4776,14 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.48':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4708,6 +4821,16 @@ snapshots:
       '@smithy/core': 3.29.0
       '@smithy/fetch-http-handler': 5.6.2
       '@smithy/node-http-handler': 4.9.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4775,6 +4898,22 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.1':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-login': 3.972.63
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.52':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4808,6 +4947,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -4937,6 +5085,20 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.66':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.57
+      '@aws-sdk/credential-provider-http': 3.972.59
+      '@aws-sdk/credential-provider-ini': 3.973.1
+      '@aws-sdk/credential-provider-process': 3.972.57
+      '@aws-sdk/credential-provider-sso': 3.973.1
+      '@aws-sdk/credential-provider-web-identity': 3.972.63
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/credential-provider-imds': 4.4.7
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.46':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -4966,6 +5128,14 @@ snapshots:
       '@aws-sdk/core': 3.974.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.57':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5009,6 +5179,16 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.1':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/token-providers': 3.1083.0
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.52':
     dependencies:
       '@aws-sdk/core': 3.974.27
@@ -5042,6 +5222,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.29
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.63':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5190,6 +5379,17 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.31':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.39
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/fetch-http-handler': 5.6.4
+      '@smithy/node-http-handler': 4.9.4
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.34':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -5208,6 +5408,13 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.973.15
       '@smithy/signature-v4': 5.6.1
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.39':
+    dependencies:
+      '@aws-sdk/types': 3.974.0
+      '@smithy/signature-v4': 5.6.3
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5247,6 +5454,15 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1083.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.1
+      '@aws-sdk/nested-clients': 3.997.31
+      '@aws-sdk/types': 3.974.0
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.12':
     dependencies:
       '@smithy/types': 4.15.0
@@ -5267,11 +5483,21 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@aws-sdk/types@3.974.0':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@aws-sdk/util-locate-window@3.965.7':
     dependencies:
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.34':
     dependencies:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
@@ -5861,6 +6087,11 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/core@3.29.2':
+    dependencies:
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.3.8':
     dependencies:
       '@smithy/core': 3.29.0
@@ -5870,6 +6101,12 @@ snapshots:
   '@smithy/credential-provider-imds@4.4.5':
     dependencies:
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.7':
+    dependencies:
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5888,6 +6125,12 @@ snapshots:
   '@smithy/fetch-http-handler@5.6.2':
     dependencies:
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.4':
+    dependencies:
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
@@ -5930,6 +6173,12 @@ snapshots:
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.4':
+    dependencies:
+      '@smithy/core': 3.29.2
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.3.6':
     dependencies:
       '@smithy/core': 3.29.0
@@ -5943,6 +6192,12 @@ snapshots:
   '@smithy/signature-v4@5.6.1':
     dependencies:
       '@smithy/core': 3.29.0
+      '@smithy/types': 4.15.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.2
       '@smithy/types': 4.15.0
       tslib: 2.8.1
 

--- a/src/read/overrides.ts
+++ b/src/read/overrides.ts
@@ -6,6 +6,11 @@
 // differ from the underlying target. Returns CFn-shaped properties for the
 // classifier; undefined when the target can't be resolved/read (→ skipped).
 
+import {
+  ACMClient,
+  DescribeCertificateCommand,
+  ListTagsForCertificateCommand,
+} from '@aws-sdk/client-acm';
 import { type ApiKey, AppSyncClient, ListApiKeysCommand } from '@aws-sdk/client-appsync';
 import { BudgetsClient, DescribeBudgetCommand } from '@aws-sdk/client-budgets';
 import { CloudControlClient, GetResourceCommand } from '@aws-sdk/client-cloudcontrol';
@@ -2074,7 +2079,86 @@ const readSesReceiptFilter: OverrideReader = async ({ physicalId, declared, regi
   };
 };
 
+// AWS::CertificateManager::Certificate — Cloud Control GetResource throws
+// UnsupportedActionException (the registry type exists but ships NO read handler), so
+// every ACM certificate was silently `skipped` on EVERY check (#974): undeclared drift,
+// an out-of-band flip of Options.CertificateTransparencyLoggingPreference (via
+// acm:update-certificate-options), a tag change, and — worst — an out-of-band DELETION of
+// a cert an ALB/CloudFront/API-domain still references were all invisible. Read via
+// acm:DescribeCertificate (physical id IS the cert ARN) + acm:ListTagsForCertificate.
+//
+// A ResourceNotFoundException from DescribeCertificate (the cert was deleted out of band)
+// is in NOT_FOUND_ERROR_NAMES, so letting it propagate makes the router map it to the
+// `deleted` tier — the whole point of adding a reader for a type whose skip previously
+// hid deletion.
+//
+// Fold care (core invariant — a clean deploy must produce ZERO first-run drift):
+//   - DomainName / SubjectAlternativeNames / KeyAlgorithm are createOnly and echo the
+//     declared values (KeyAlgorithm folds to its declared value, or to the RSA_2048 default
+//     when undeclared). SANs: AWS ALWAYS includes DomainName as the first SAN even when the
+//     template declares none; projecting the live SAN list then false-flagged an undeclared
+//     drift on every single-domain cert. So project SANs ONLY when the template declares
+//     them (a declared change is still detected; an undeclared, AWS-implied list stays quiet).
+//   - Options.CertificateTransparencyLoggingPreference defaults to ENABLED when undeclared.
+//     Since this reader cannot reach the noise.ts fold table, fold the default IN-READER:
+//     project Options only when the template DECLARES Options, OR when the live preference
+//     has moved AWAY from the ENABLED default (an out-of-band DISABLE). A clean cert with no
+//     declared Options and the live ENABLED default projects nothing here -> zero first-run
+//     drift; a DISABLE (out of band, or a declared value) still surfaces. This preserves
+//     out-of-band detection of the one meaningful, mutable Certificate property.
+//   - DomainValidationOptions is a createOnly write-time INPUT (ValidationDomain /
+//     HostedZoneId) that DescribeCertificate does not echo back verbatim (it returns
+//     resolved DomainValidation records with runtime CNAME/status), so it stays a readGap
+//     rather than a fabricated projection — projecting the runtime shape against the declared
+//     input shape would false-flag every cert.
+const ACM_DEFAULT_TRANSPARENCY = 'ENABLED';
+const readAcmCertificate: OverrideReader = async ({ physicalId, declared, region }) => {
+  const arn = str(physicalId);
+  // The CFn physical id of an ACM certificate IS its ARN; without it we cannot address it.
+  if (!arn || !arn.startsWith('arn:')) return undefined;
+  const c = new ACMClient({ region, ...READ_RETRY });
+  // ResourceNotFoundException (cert deleted out of band) propagates -> router maps `deleted`.
+  const cert = (await c.send(new DescribeCertificateCommand({ CertificateArn: arn }))).Certificate;
+  if (!cert) return undefined;
+  const model: Record<string, unknown> = {};
+  if (str(cert.DomainName)) model.DomainName = cert.DomainName;
+  if (str(cert.KeyAlgorithm)) model.KeyAlgorithm = cert.KeyAlgorithm;
+  // SANs only when declared — AWS always folds DomainName in as an implied SAN, so an
+  // undeclared live list would false-flag every single-domain cert (see note above).
+  const declaresSans =
+    Array.isArray(declared.SubjectAlternativeNames) && declared.SubjectAlternativeNames.length > 0;
+  const sans = (cert.SubjectAlternativeNames ?? []).filter(
+    (s): s is string => str(s) !== undefined
+  );
+  if (declaresSans && sans.length > 0) model.SubjectAlternativeNames = sans;
+  // CertificateTransparencyLoggingPreference: project only when declared OR moved away from
+  // the ENABLED default, so a clean undeclared cert folds to nothing (zero first-run drift)
+  // while an out-of-band DISABLE still surfaces.
+  const pref = str(cert.Options?.CertificateTransparencyLoggingPreference);
+  const declaresOptions =
+    declared.Options !== undefined &&
+    declared.Options !== null &&
+    typeof declared.Options === 'object';
+  if (pref && (declaresOptions || pref !== ACM_DEFAULT_TRANSPARENCY)) {
+    model.Options = { CertificateTransparencyLoggingPreference: pref };
+  }
+  // Tags — a separate ACM call. Absent/empty stays absent (FP-safe) on both sides.
+  try {
+    const t = await c.send(new ListTagsForCertificateCommand({ CertificateArn: arn }));
+    const tags = (t.Tags ?? [])
+      .filter((tag) => str(tag.Key) !== undefined)
+      .map((tag) => ({ Key: tag.Key as string, Value: tag.Value ?? '' }));
+    if (tags.length > 0) model.Tags = tags;
+  } catch {
+    // A ListTagsForCertificate failure (a narrow acm:ListTagsForCertificate permission gap
+    // or a transient throttle) must not drop the whole cert read to skipped — keep the
+    // certificate model without Tags rather than losing the DomainName/Options coverage.
+  }
+  return model;
+};
+
 export const SDK_OVERRIDES: Record<string, OverrideReader> = {
+  'AWS::CertificateManager::Certificate': readAcmCertificate,
   'AWS::SES::ReceiptRuleSet': readSesReceiptRuleSet,
   'AWS::SES::ReceiptRule': readSesReceiptRule,
   'AWS::SES::ReceiptFilter': readSesReceiptFilter,

--- a/tests/acm-certificate-reader-974.test.ts
+++ b/tests/acm-certificate-reader-974.test.ts
@@ -1,0 +1,118 @@
+import {
+  ACMClient,
+  DescribeCertificateCommand,
+  ListTagsForCertificateCommand,
+} from '@aws-sdk/client-acm';
+import { mockClient } from 'aws-sdk-client-mock';
+import { beforeEach, describe, expect, it } from 'vite-plus/test';
+import { SDK_OVERRIDES } from '../src/read/overrides.js';
+
+const acm = mockClient(ACMClient);
+
+const ARN = 'arn:aws:acm:us-east-1:123456789012:certificate/12345678-1234-1234-1234-123456789012';
+
+const ctx = (
+  physicalId: string,
+  declared: Record<string, unknown> = {},
+  region = 'us-east-1',
+  accountId = '123456789012'
+) => ({ physicalId, declared, region, accountId });
+
+const read = (c: ReturnType<typeof ctx>) =>
+  SDK_OVERRIDES['AWS::CertificateManager::Certificate'](c);
+
+beforeEach(() => {
+  acm.reset();
+});
+
+describe('AWS::CertificateManager::Certificate SDK override', () => {
+  it('maps DescribeCertificate + tags to the CFn live model and addresses by the ARN', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'example.com',
+        SubjectAlternativeNames: ['example.com', 'www.example.com'],
+        KeyAlgorithm: 'RSA_2048',
+        Options: { CertificateTransparencyLoggingPreference: 'ENABLED' },
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [{ Key: 'Name', Value: 'my-cert' }] });
+
+    // Template declares SANs + Options, so both are projected.
+    const out = await read(
+      ctx(ARN, {
+        SubjectAlternativeNames: ['example.com', 'www.example.com'],
+        Options: { CertificateTransparencyLoggingPreference: 'ENABLED' },
+      })
+    );
+    expect(out).toEqual({
+      DomainName: 'example.com',
+      KeyAlgorithm: 'RSA_2048',
+      SubjectAlternativeNames: ['example.com', 'www.example.com'],
+      Options: { CertificateTransparencyLoggingPreference: 'ENABLED' },
+      Tags: [{ Key: 'Name', Value: 'my-cert' }],
+    });
+    const call = acm.commandCalls(DescribeCertificateCommand)[0];
+    expect(call.args[0].input).toEqual({ CertificateArn: ARN });
+  });
+
+  it('folds the ENABLED transparency default and the implied SAN for a clean undeclared cert (ZERO first-run drift)', async () => {
+    // A minimal cert: template declares only DomainName. AWS returns DomainName as an
+    // implied SAN and the ENABLED transparency default. Neither must surface.
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'example.com',
+        SubjectAlternativeNames: ['example.com'], // AWS-implied — not declared
+        KeyAlgorithm: 'RSA_2048',
+        Options: { CertificateTransparencyLoggingPreference: 'ENABLED' }, // the default
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read(ctx(ARN, { DomainName: 'example.com' }));
+    expect(out).toEqual({ DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' });
+    expect(out).not.toHaveProperty('SubjectAlternativeNames');
+    expect(out).not.toHaveProperty('Options');
+    expect(out).not.toHaveProperty('Tags');
+  });
+
+  it('surfaces an out-of-band DISABLE of transparency even when Options is undeclared', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: {
+        CertificateArn: ARN,
+        DomainName: 'example.com',
+        Options: { CertificateTransparencyLoggingPreference: 'DISABLED' }, // moved away from default
+      },
+    });
+    acm.on(ListTagsForCertificateCommand).resolves({ Tags: [] });
+
+    const out = await read(ctx(ARN, { DomainName: 'example.com' }));
+    expect(out).toMatchObject({
+      Options: { CertificateTransparencyLoggingPreference: 'DISABLED' },
+    });
+  });
+
+  it('propagates ResourceNotFoundException so the router maps it to deleted', async () => {
+    const err = Object.assign(new Error('cert gone'), {
+      name: 'ResourceNotFoundException',
+    });
+    acm.on(DescribeCertificateCommand).rejects(err);
+    await expect(read(ctx(ARN))).rejects.toThrow('cert gone');
+  });
+
+  it('keeps the certificate model when ListTagsForCertificate fails (no whole-read drop)', async () => {
+    acm.on(DescribeCertificateCommand).resolves({
+      Certificate: { CertificateArn: ARN, DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' },
+    });
+    acm.on(ListTagsForCertificateCommand).rejects(new Error('AccessDenied'));
+
+    const out = await read(ctx(ARN, { DomainName: 'example.com' }));
+    expect(out).toEqual({ DomainName: 'example.com', KeyAlgorithm: 'RSA_2048' });
+  });
+
+  it('returns undefined when the physical id is not an ARN (target not resolvable)', async () => {
+    expect(await read(ctx(''))).toBeUndefined();
+    expect(await read(ctx('not-an-arn'))).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #974

## Problem

`AWS::CertificateManager::Certificate` ships **no Cloud Control read handler** (GetResource → `UnsupportedActionException`), so every ACM certificate was silently `skipped` on EVERY `check`. Undeclared drift, an out-of-band flip of `Options.CertificateTransparencyLoggingPreference` (via `acm update-certificate-options`), a tag change, and — worst — an out-of-band **deletion** of a cert an ALB / CloudFront / API custom-domain still references were all invisible (the failure was `UnsupportedActionException` = skipped, never a not-found, so the `deleted` tier could not fire).

## Fix

New `SDK_OVERRIDES` reader `readAcmCertificate` (same class as #716 IAM::AccessKey / #857 / #856), registered under `AWS::CertificateManager::Certificate`. The router already dispatches `SDK_OVERRIDES` generically, so no `router.ts` change was needed.

- Physical id IS the certificate ARN → `acm:DescribeCertificate`; `acm:ListTagsForCertificate` for `Tags`.
- Maps `DomainName`, `KeyAlgorithm`, `SubjectAlternativeNames`, `Options.CertificateTransparencyLoggingPreference`, `Tags`.
- A `ResourceNotFoundException` (already in `NOT_FOUND_ERROR_NAMES`) **propagates** → the router maps an out-of-band deletion to the `deleted` tier.

## Fold care (core invariant — a clean deploy must produce ZERO first-run drift)

Since the reader cannot reach the `noise.ts` fold table, the defaults are folded **in-reader** by declared-gating (mirrors the existing EIP / Budget reader pattern):

- **SANs**: AWS always folds `DomainName` in as an implied SAN even when none is declared → project SANs **only when the template declares them** (a declared change is still detected; the AWS-implied list stays quiet).
- **`CertificateTransparencyLoggingPreference`** (defaults to `ENABLED` when undeclared): project `Options` **only when the template declares Options OR the live value has moved away from the `ENABLED` default** (an out-of-band DISABLE). A clean cert with no declared Options + live `ENABLED` projects nothing → zero first-run drift; a DISABLE still surfaces, preserving out-of-band detection of the one meaningful mutable property.
- **`DomainValidationOptions`** is a createOnly write-time input that DescribeCertificate does not echo verbatim (it returns resolved runtime records) → left a readGap rather than fabricating a projection that would false-flag every cert.
- Tags: a ListTagsForCertificate failure keeps the cert model (no whole-read drop to skipped).

## Tests

New `tests/acm-certificate-reader-974.test.ts` (mocked `ACMClient` via `aws-sdk-client-mock`, mirroring `eip-reader.test.ts`), 6 cases:
- maps DescribeCertificate + tags and addresses by the ARN
- folds the ENABLED default + implied SAN for a clean undeclared cert (ZERO first-run drift)
- surfaces an out-of-band DISABLE even when Options is undeclared
- propagates `ResourceNotFoundException` (→ deleted)
- keeps the cert model when ListTagsForCertificate fails
- returns undefined when physical id is not an ARN

## Notes

- **New dependency**: `@aws-sdk/client-acm` (`^3.1065.0`) — ACM has no already-installed client; this follows the established `@aws-sdk/client-*` per-reader pattern (every override adds its own client package).
- README IAM-permissions list updated with `acm:DescribeCertificate` + `acm:ListTagsForCertificate`.
- Files: `src/read/overrides.ts`, `tests/acm-certificate-reader-974.test.ts`, `README.md`, `package.json`, `pnpm-lock.yaml`.
- All local gates green: typecheck / lint+format / build / 3545 unit tests.