### PR TITLE
fix(check): fold whole-stack skips into --strict's coverage exit (#948)

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -396,6 +396,13 @@ export async function runCheck(args: string[]): Promise<number> {
       if (synthTemplates && !synthTemplates.has(sKey)) {
         console.error(`note: ${stackName}: not in the synth output — skipped (--pre-deploy)`);
         jsonError(stackName, region, 'not in the synth output — skipped (--pre-deploy)');
+        // #948: a stack resolveStacks discovered but the --pre-deploy synth did not
+        // produce is a WHOLE-stack coverage gap — every one of its resources went
+        // unread. --strict's contract ("exit 1 when coverage is incomplete") must catch
+        // it exactly as strictCoverageExit catches a single skipped resource, else a
+        // NAMED stack (`check Prod --pre-deploy --strict`) is silently un-covered — the
+        // same silent-pass resolveStacks hard-errors on a name matching nothing to avoid.
+        worst = Math.max(worst, a.strict ? 1 : 0);
         continue;
       }
       // The stack's synth template (always carried by resolveStacks) is the non-ASCII
@@ -669,6 +676,12 @@ export async function runCheck(args: string[]): Promise<number> {
       if (e instanceof StackNotCheckableError) {
         console.error(`note: ${stackName}: ${e.message} — skipped`);
         jsonError(stackName, region, `${e.message} — skipped`);
+        // #948: skipping an ENTIRE stack (REVIEW_IN_PROGRESS / *_IN_PROGRESS /
+        // ROLLBACK_COMPLETE) leaves every one of its resources unread — the maximal
+        // coverage gap. --strict must fail exactly as it does for one skipped resource;
+        // otherwise `check --all --strict --fail` greenlights CI while a whole stack went
+        // unexamined. Not drift (leave --fail untouched), purely a coverage axis.
+        worst = Math.max(worst, a.strict ? 1 : 0);
         continue;
       }
       console.error(`error: ${stackName}: ${(e as Error).message}`);

--- a/tests/strict-whole-stack-skip-948.test.ts
+++ b/tests/strict-whole-stack-skip-948.test.ts
@@ -1,0 +1,74 @@
+// #948 — a WHOLE-stack skip must contribute to `--strict`'s coverage-gap exit exactly
+// as one skipped RESOURCE does (strictCoverageExit). Two per-stack `continue` paths
+// dropped the stack from the run without bumping `worst`, so a CI run that examined
+// NOTHING for that stack exited 0:
+//   1. StackNotCheckableError (REVIEW_IN_PROGRESS / *_IN_PROGRESS / ROLLBACK_COMPLETE).
+//   2. A NAMED stack the --pre-deploy synth did not produce.
+// Both must exit 1 under --strict (the coverage axis, independent of --fail's drift
+// axis), and stay 0 when --strict is absent (a benign skip is not drift).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vite-plus/test';
+import { StackNotCheckableError } from '../src/aws-errors.js';
+
+const resolveStacksMock = vi.fn();
+const gatherFindingsMock = vi.fn();
+const synthAppMock = vi.fn();
+
+vi.mock('../src/commands/resolve-stacks.js', () => ({
+  resolveStacks: (...args: unknown[]) => resolveStacksMock(...args),
+}));
+vi.mock('../src/commands/gather.js', () => ({
+  gatherFindings: (...args: unknown[]) => gatherFindingsMock(...args),
+}));
+vi.mock('../src/synth/synth.js', () => ({
+  synthApp: (...args: unknown[]) => synthAppMock(...args),
+}));
+vi.mock('../src/synth/resolve-app.js', () => ({
+  resolveApp: () => 'app',
+}));
+
+import { runCheck } from '../src/commands/check.js';
+
+describe('check --strict on a whole-stack skip (#948)', () => {
+  beforeEach(() => {
+    resolveStacksMock.mockReset();
+    gatherFindingsMock.mockReset();
+    synthAppMock.mockReset();
+    // keep test output clean
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('1) StackNotCheckableError exits 1 under --strict', async () => {
+    resolveStacksMock.mockResolvedValue([{ stackName: 'Prod', region: 'us-east-1', template: {} }]);
+    gatherFindingsMock.mockRejectedValue(
+      new StackNotCheckableError('is being deleted (DELETE_IN_PROGRESS)')
+    );
+    expect(await runCheck(['--strict', '--fail'])).toBe(1);
+  });
+
+  it('1b) the same skip stays 0 without --strict (a benign skip is not drift)', async () => {
+    resolveStacksMock.mockResolvedValue([{ stackName: 'Prod', region: 'us-east-1', template: {} }]);
+    gatherFindingsMock.mockRejectedValue(
+      new StackNotCheckableError('is being deleted (DELETE_IN_PROGRESS)')
+    );
+    expect(await runCheck(['--fail'])).toBe(0);
+  });
+
+  it('2) a NAMED stack missing from the --pre-deploy synth exits 1 under --strict', async () => {
+    resolveStacksMock.mockResolvedValue([{ stackName: 'Prod', region: 'us-east-1', template: {} }]);
+    // the second synth produced a DIFFERENT stack — 'Prod' is absent from synthTemplates
+    synthAppMock.mockResolvedValue([
+      { stackName: 'SomethingElse', region: 'us-east-1', template: {} },
+    ]);
+    expect(await runCheck(['Prod', '--pre-deploy', '--fail', '--strict'])).toBe(1);
+  });
+
+  it('2b) the same missing named stack stays 0 without --strict', async () => {
+    resolveStacksMock.mockResolvedValue([{ stackName: 'Prod', region: 'us-east-1', template: {} }]);
+    synthAppMock.mockResolvedValue([
+      { stackName: 'SomethingElse', region: 'us-east-1', template: {} },
+    ]);
+    expect(await runCheck(['Prod', '--pre-deploy', '--fail'])).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #948

Two per-stack `continue` paths in check's multi-stack loop dropped the stack from the run without contributing to `worst`, so a CI run that examined NOTHING for that stack exited 0:

1. **StackNotCheckableError skip** (`check.ts` ~L669) — a REVIEW_IN_PROGRESS / *_IN_PROGRESS / ROLLBACK_COMPLETE stack is skipped, but `--strict` (contract: "exit 1 when coverage is incomplete — any resource skipped") exited 0 even though EVERY resource in the stack went unread.
2. **`--pre-deploy` "not in the synth output" skip** (`check.ts` ~L396) — a stack the user EXPLICITLY NAMED that resolveStacks discovered but the second synth did not produce is skipped and exited 0 under `--fail --strict`.

Both now fold `worst = Math.max(worst, a.strict ? 1 : 0)` before the `continue` — a whole-stack skip is the maximal coverage gap, caught by `--strict` exactly as strictCoverageExit catches one skipped resource. The `--fail` (drift) axis is untouched: a skip is a coverage gap, not drift.

Mirrors the #781 deleted-stack path (check.ts:659, `a.strict ? 1 : 0`).

## Tests
`tests/strict-whole-stack-skip-948.test.ts` — drives runCheck end-to-end (synth/gather mocked) for both paths: exit 1 under `--strict`, and unchanged 0 without `--strict` (a benign skip is not drift).