### PR TITLE
fix(normalize): {Condition: name} in property position is literal data (#783)

### DIFF
--- a/src/normalize/intrinsic-resolver.ts
+++ b/src/normalize/intrinsic-resolver.ts
@@ -32,8 +32,16 @@ function isScalarInterpolant(v: unknown): boolean {
   return t === 'string' || t === 'number' || t === 'boolean';
 }
 
-export function resolve(node: unknown, ctx: ResolverContext): unknown {
-  if (Array.isArray(node)) return node.map((n) => resolve(n, ctx));
+// `inCondition` marks resolution that is happening in CONDITION-EVALUATION context
+// (a `Conditions`-section body reached via evalCondition, or a nested condition
+// operand), as opposed to PROPERTY-VALUE context. It is threaded so a bare single-key
+// `{Condition: <name>}` object is honored as the condition-reference intrinsic ONLY in
+// condition context — in property position it is literal data (a one-key map named
+// `Condition` inside a free-form JSON document), so evaluating it there would corrupt
+// the declared value (`{Foo: {Condition: 'IsProd'}}` -> `Foo: false`, an unknown name ->
+// UNRESOLVED). See #783.
+export function resolve(node: unknown, ctx: ResolverContext, inCondition = false): unknown {
+  if (Array.isArray(node)) return node.map((n) => resolve(n, ctx, inCondition));
   // A CloudFormation DYNAMIC REFERENCE (`{{resolve:ssm:…}}`,
   // `{{resolve:ssm-secure:…}}`, `{{resolve:secretsmanager:…}}`) is a deploy-time
   // string substitution: CFn replaces it with the live SSM parameter / secret value
@@ -202,7 +210,14 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
         return r === UNRESOLVED ? UNRESOLVED : !r;
       }
       case 'Condition':
-        return evalCondition(String(v), ctx);
+        // A bare `{Condition: <name>}` object is the condition-reference intrinsic ONLY
+        // when it appears in condition-evaluation context (an operand inside
+        // Fn::And/Or/Not, or a Conditions-section body). In PROPERTY position it is
+        // literal data — a one-key map that happens to be named `Condition` inside a
+        // free-form JSON document — so fall through to the data object-walk below rather
+        // than evaluate it (which would corrupt the declared value). See #783.
+        if (inCondition) return evalCondition(String(v), ctx);
+        break;
       default:
         // Any intrinsic we don't fully resolve → UNRESOLVED, so the declared
         // path is skipped (never reported as false drift).
@@ -211,7 +226,7 @@ export function resolve(node: unknown, ctx: ResolverContext): unknown {
     }
   }
   const out: Record<string, unknown> = {};
-  for (const [kk, vv] of Object.entries(obj)) out[kk] = resolve(vv, ctx);
+  for (const [kk, vv] of Object.entries(obj)) out[kk] = resolve(vv, ctx, inCondition);
   return out;
 }
 
@@ -240,7 +255,7 @@ function condVal(node: unknown, ctx: ResolverContext): boolean | typeof UNRESOLV
     const r = evalCondition(String((node as Record<string, unknown>)['Condition']), ctx);
     return r === UNRESOLVED ? UNRESOLVED : r === true;
   }
-  const r = resolve(node, ctx);
+  const r = resolve(node, ctx, true);
   if (r === true) return true;
   if (r === false) return false;
   return UNRESOLVED;
@@ -256,7 +271,7 @@ export function evalCondition(name: string, ctx: ResolverContext): boolean | typ
   // could. Failing closed to UNRESOLVED on the cycle is the safe direction (the
   // dependent Fn::If branch is then skipped, never mis-evaluated).
   ctx.condCache.set(name, UNRESOLVED);
-  const r = resolve(ctx.conditions[name], ctx);
+  const r = resolve(ctx.conditions[name], ctx, true);
   const val = r === true ? true : r === false ? false : UNRESOLVED;
   ctx.condCache.set(name, val);
   return val;

--- a/tests/intrinsic-condition-783.test.ts
+++ b/tests/intrinsic-condition-783.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { resolve } from '../src/normalize/intrinsic-resolver.js';
+import type { ResolverContext } from '../src/types.js';
+
+function ctx(over: Partial<ResolverContext> = {}): ResolverContext {
+  return {
+    params: { Env: 'prod' },
+    pseudo: {
+      'AWS::Region': 'us-east-1',
+      'AWS::AccountId': '123',
+      'AWS::Partition': 'aws',
+      'AWS::URLSuffix': 'amazonaws.com',
+      'AWS::StackName': 'S',
+      'AWS::StackId': 'id',
+    },
+    conditions: {},
+    physIds: {},
+    liveAttrs: {},
+    mappings: {},
+    exports: {},
+    condCache: new Map(),
+    ...over,
+  };
+}
+
+// Regression tests for #783: inside resource Properties, a single-key object
+// `{"Condition": "SomeName"}` is LITERAL DATA (a one-key map named `Condition` inside a
+// free-form JSON document), not the condition-reference intrinsic. CloudFormation honors
+// `Condition:` as a function only in the top-level `Conditions` section, as a
+// resource-level attribute, or inside `Fn::And/Or/Not` operands — NOT as a property
+// value. Evaluating it in property position corrupted the declared value
+// (`{Foo: {Condition: 'IsProd'}}` -> `Foo: false`) or dropped it to UNRESOLVED for an
+// unknown name.
+describe('intrinsic resolver: {Condition: name} in property position is literal (#783)', () => {
+  it('passes a single-key {Condition: <known name>} through UNCHANGED in property position', () => {
+    // The condition `IsProd` exists and is TRUE — but a property value must NOT be
+    // evaluated to `false`/`true`; it is literal data.
+    const c = ctx({ conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } } });
+    expect(resolve({ Foo: { Condition: 'IsProd' } }, c)).toEqual({ Foo: { Condition: 'IsProd' } });
+  });
+
+  it('keeps a single-key {Condition: <unknown name>} literal, not UNRESOLVED', () => {
+    // An unknown condition name previously resolved to UNRESOLVED (silent per-prop
+    // compare skip). It must stay literal data.
+    const c = ctx();
+    expect(resolve({ Bar: { Condition: 'Nope' } }, c)).toEqual({ Bar: { Condition: 'Nope' } });
+  });
+
+  it('leaves a bare top-level {Condition: name} literal in a property bag', () => {
+    const c = ctx({ conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } } });
+    expect(resolve({ Condition: 'IsProd' }, c)).toEqual({ Condition: 'IsProd' });
+  });
+
+  it('still resolves nested intrinsics that SHARE the object with a literal Condition key', () => {
+    // A property document may carry `Condition` as data alongside real intrinsics; only
+    // the >1-key object walk applies, and the sibling Ref must still resolve while the
+    // `Condition` string is untouched.
+    const c = ctx();
+    expect(resolve({ Condition: 'IsProd', Region: { Ref: 'AWS::Region' } }, c)).toEqual({
+      Condition: 'IsProd',
+      Region: 'us-east-1',
+    });
+  });
+
+  // Regression guard: legitimate condition machinery must be UNAFFECTED.
+  it('REGRESSION: Fn::If still evaluates its named condition correctly', () => {
+    const c = ctx({ conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } } });
+    expect(resolve({ 'Fn::If': ['IsProd', 'yes', 'no'] }, c)).toBe('yes');
+    const cNo = ctx({ conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'dev'] } } });
+    expect(resolve({ 'Fn::If': ['IsProd', 'yes', 'no'] }, cNo)).toBe('no');
+  });
+
+  it('REGRESSION: {Condition: name} as an Fn::And/Or/Not OPERAND is still honored', () => {
+    // In condition-evaluation context (an operand inside Fn::And/Or/Not) the
+    // `{Condition: name}` reference is still evaluated — only PROPERTY position is data.
+    const c = ctx({ conditions: { IsProd: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] } } });
+    expect(resolve({ 'Fn::And': [{ Condition: 'IsProd' }, true] }, c)).toBe(true);
+    expect(resolve({ 'Fn::Not': [{ Condition: 'IsProd' }] }, c)).toBe(false);
+    // And a condition BODY that references another condition through Fn::If's name still
+    // works end-to-end.
+    const chained = ctx({
+      conditions: {
+        Base: { 'Fn::Equals': [{ Ref: 'Env' }, 'prod'] },
+        Derived: { 'Fn::And': [{ Condition: 'Base' }, true] },
+      },
+    });
+    expect(resolve({ 'Fn::If': ['Derived', 'then', 'else'] }, chained)).toBe('then');
+  });
+});


### PR DESCRIPTION
Closes #783.

## Root cause
The intrinsic resolver's `case 'Condition':` evaluated **any** single-key `{Condition: <string>}` object as the condition-reference intrinsic. But inside resource **Properties**, such an object is literal data — CloudFormation honors `Condition:` as a function only in the top-level `Conditions` section, as a resource-level attribute, or inside `Fn::And/Or/Not` operands, **never** as a property value. So `{Foo: {Condition: 'IsProd'}}` resolved to `Foo: false` (a declared-tier false positive against the live literal object), and an unknown condition name dropped the property to `UNRESOLVED` (silent per-prop compare skip).

## Fix
Thread an internal `inCondition` flag through `resolve()`. The bare `Condition` intrinsic is honored **only** in condition-evaluation context — condition bodies reached via `evalCondition` and `{Condition: name}` operands inside `Fn::And/Or/Not` (via `condVal`). In **property position** a single-key `{Condition: name}` object falls through to the ordinary data object-walk, unchanged. `Fn::If`, `Fn::Equals/And/Or/Not` are unaffected (their real condition operands already flow through `condVal`/`evalCondition`, which now pass `inCondition = true`).

Only `src/normalize/intrinsic-resolver.ts` is touched.

## Test
New `tests/intrinsic-condition-783.test.ts`:
- `{Foo: {Condition: 'IsProd'}}` resolves **unchanged** (known + true condition present).
- `{Bar: {Condition: 'Nope'}}` stays literal, **not** UNRESOLVED (unknown name).
- Sibling intrinsics next to a literal `Condition` key still resolve.
- **Regression guards**: `Fn::If` still evaluates its named condition; `{Condition: name}` as an `Fn::And/Or/Not` operand and a chained condition body are still honored.

Verified the 3 property-position tests **fail without the fix** and pass with it; the 3 regression tests pass both ways. Full suite: 3545 tests green; `vp run check` clean (0 errors).