### PR TITLE
fix(diff): fold derived first-run echoes (CodeBuild/Secrets/NLB/MQ/Firehose) (#845)

### DIFF
--- a/src/diff/classify.ts
+++ b/src/diff/classify.ts
@@ -434,7 +434,14 @@ const CC_ALT_REPRESENTATION: Record<string, Record<string, string>> = {
   // An ALB reads back `SubnetMappings` (`[{SubnetId}]`) — the object-array echo of the
   // declared scalar `Subnets` list. Drop it when `Subnets` is declared so it is not
   // reported as a live-only property (the subnets ARE compared via `Subnets`).
-  'AWS::ElasticLoadBalancingV2::LoadBalancer': { SubnetMappings: 'Subnets' },
+  // #845: the mirror runs BOTH ways — an NLB declared with `SubnetMappings` reads back an
+  // undeclared scalar `Subnets` list echoing the same SubnetIds. Add the symmetric rule so
+  // that live-only `Subnets` is dropped when `SubnetMappings` is declared (the subnets ARE
+  // compared via the declared `SubnetMappings`).
+  'AWS::ElasticLoadBalancingV2::LoadBalancer': {
+    SubnetMappings: 'Subnets',
+    Subnets: 'SubnetMappings',
+  },
 };
 
 // #652/#643 SHAPE-MISMATCH SIBLING ECHO: a resource type offers two declarable shapes for
@@ -1456,6 +1463,43 @@ export function classifyResource(
       if (name) knownDefPaths = { ...knownDefPaths, 'Registry.Name': name };
     }
   }
+  // #845: a CodeBuild Project's undeclared `Artifacts.Name` echoes the declared project
+  // `Name` (AWS default-fills the artifact name to the project name when the template's
+  // Artifacts block declares no Name). Derive it from the declared top-level `Name` and
+  // equality-gate it (fold tier 2): an out-of-band change of the artifact name still surfaces.
+  if (resourceType === 'AWS::CodeBuild::Project') {
+    const name = declared['Name'];
+    if (typeof name === 'string') {
+      knownDefPaths = { ...knownDefPaths, 'Artifacts.Name': name };
+    }
+  }
+  // #845: a SecretsManager RotationSchedule declaring `RotationRules.ScheduleExpression`
+  // "rate(N days)" reads back an undeclared `RotationRules.AutomaticallyAfterDays: N` — AWS
+  // mirrors the rate-day count into the legacy scalar. Parse the declared rate and equality-
+  // gate the derived day count (fold tier 2): a re-scheduled rotation still surfaces.
+  if (resourceType === 'AWS::SecretsManager::RotationSchedule') {
+    const expr = (declared['RotationRules'] as Record<string, unknown> | undefined)?.[
+      'ScheduleExpression'
+    ];
+    const m = typeof expr === 'string' ? /^rate\((\d+)\s+days?\)$/.exec(expr.trim()) : null;
+    if (m) {
+      knownDefPaths = {
+        ...knownDefPaths,
+        'RotationRules.AutomaticallyAfterDays': Number(m[1]),
+      };
+    }
+  }
+  // #845: an AmazonMQ ACTIVEMQ broker that declares no `StorageType` reads back the AWS
+  // default `EFS` (ActiveMQ brokers default to EFS storage; RabbitMQ supports only EBS).
+  // Derive the default from the declared `EngineType` and equality-gate it (fold tier 2):
+  // an ActiveMQ broker pinned to EBS declares StorageType and is compared, and an out-of-band
+  // change away from the derived default still surfaces.
+  if (resourceType === 'AWS::AmazonMQ::Broker') {
+    const engineType = declared['EngineType'];
+    if (typeof engineType === 'string' && engineType.toUpperCase() === 'ACTIVEMQ') {
+      knownDef = { ...knownDef, StorageType: 'EFS' };
+    }
+  }
   // #701: an EventSourceMapping's default BatchSize depends on the source service — 10 for
   // SQS, 100 for Kinesis / DynamoDB streams / MSK / Kafka. Derive the expected default from
   // the declared EventSourceArn's service segment (arn:<p>:<service>:...) and equality-gate
@@ -2084,11 +2128,23 @@ export function classifyResource(
         const liveOnly = alignNameValueSubset(d.stateValue, d.awsValue, nvSubsetSpec);
         if (liveOnly) {
           for (const lo of liveOnly) {
+            const loRec = lo as Record<string, unknown>;
+            const loName = String(loRec[nvSubsetSpec.nameField]);
+            const loValue = loRec[nvSubsetSpec.valueField];
+            // #845: a Firehose Lambda processor whose declared Parameters omit `NumberOfRetries`
+            // reads back the AWS default `NumberOfRetries: "3"` — a service-filled first-run
+            // default, not user intent. Equality-gate the constant default so a clean stream
+            // stays clean; a processor that pins a different retry count declares it (compared)
+            // or, once recorded, an out-of-band change away from "3" still surfaces as undeclared.
+            const isFirehoseRetriesDefault =
+              resourceType === 'AWS::KinesisFirehose::DeliveryStream' &&
+              loName === 'NumberOfRetries' &&
+              loValue === '3';
             findings.push({
-              tier: 'undeclared',
+              tier: isFirehoseRetriesDefault ? 'atDefault' : 'undeclared',
               logicalId,
               resourceType,
-              path: `${d.path}[${String((lo as Record<string, unknown>)[nvSubsetSpec.nameField])}]`,
+              path: `${d.path}[${loName}]`,
               actual: lo,
               nested: true,
             });

--- a/tests/classify-845-derived.test.ts
+++ b/tests/classify-845-derived.test.ts
@@ -1,0 +1,193 @@
+// #845 — DERIVED first-run echoes (classify.ts tier-2 folds computed from declared inputs,
+// plus one symmetric CC_ALT_REPRESENTATION drop). Each fold satisfies the zero-first-run
+// invariant on a clean deploy while PRESERVING detection: a value diverging from the derived
+// default still surfaces as undeclared drift.
+//   - CodeBuild Artifacts.Name echoes the declared project Name,
+//   - Secrets RotationRules.AutomaticallyAfterDays derived from the declared rate(N days),
+//   - NLB live-only Subnets dropped when SubnetMappings is declared (symmetric alt rep),
+//   - AmazonMQ ACTIVEMQ StorageType default EFS,
+//   - Firehose Lambda-processor Parameters[NumberOfRetries] default "3".
+import { describe, expect, it } from 'vite-plus/test';
+import { classifyResource } from '../src/diff/classify.js';
+import type { DesiredResource, Finding, SchemaInfo } from '../src/types.js';
+
+const emptySchema: SchemaInfo = {
+  readOnly: new Set(),
+  writeOnly: new Set(),
+  createOnly: new Set(),
+  readOnlyPaths: [],
+  writeOnlyPaths: [],
+  createOnlyPaths: [],
+  defaults: {},
+  defaultPaths: {},
+};
+const tier = (fs: Finding[], t: string) =>
+  fs
+    .filter((f) => f.tier === t)
+    .map((f) => f.path)
+    .sort();
+const allPaths = (fs: Finding[]) => fs.map((f) => f.path).sort();
+const mk = (
+  resourceType: string,
+  declared: Record<string, unknown>,
+  physicalId = 'phys'
+): DesiredResource => ({
+  logicalId: 'R',
+  resourceType,
+  physicalId,
+  declared,
+});
+
+describe('#845 CodeBuild Artifacts.Name echoes declared project Name', () => {
+  it('folds Artifacts.Name to atDefault when it equals the declared Name', () => {
+    const res = mk('AWS::CodeBuild::Project', {
+      Name: 'my-build',
+      Artifacts: { Type: 'CODEPIPELINE' },
+    });
+    const f = classifyResource(
+      res,
+      {
+        Name: 'my-build',
+        Artifacts: { Type: 'CODEPIPELINE', Name: 'my-build' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('Artifacts.Name');
+    expect(tier(f, 'undeclared')).not.toContain('Artifacts.Name');
+  });
+  it('surfaces Artifacts.Name when it diverges from the declared Name — detection preserved', () => {
+    const res = mk('AWS::CodeBuild::Project', {
+      Name: 'my-build',
+      Artifacts: { Type: 'CODEPIPELINE' },
+    });
+    const f = classifyResource(
+      res,
+      {
+        Name: 'my-build',
+        Artifacts: { Type: 'CODEPIPELINE', Name: 'renamed-artifact' },
+      },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('Artifacts.Name');
+  });
+});
+
+describe('#845 Secrets RotationRules.AutomaticallyAfterDays derived from rate(N days)', () => {
+  it('folds AutomaticallyAfterDays to atDefault when it equals the declared rate day count', () => {
+    const res = mk('AWS::SecretsManager::RotationSchedule', {
+      RotationRules: { ScheduleExpression: 'rate(30 days)' },
+    });
+    const f = classifyResource(
+      res,
+      { RotationRules: { ScheduleExpression: 'rate(30 days)', AutomaticallyAfterDays: 30 } },
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain('RotationRules.AutomaticallyAfterDays');
+    expect(tier(f, 'undeclared')).not.toContain('RotationRules.AutomaticallyAfterDays');
+  });
+  it('surfaces AutomaticallyAfterDays when it diverges from the declared rate — detection preserved', () => {
+    const res = mk('AWS::SecretsManager::RotationSchedule', {
+      RotationRules: { ScheduleExpression: 'rate(30 days)' },
+    });
+    const f = classifyResource(
+      res,
+      { RotationRules: { ScheduleExpression: 'rate(30 days)', AutomaticallyAfterDays: 7 } },
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain('RotationRules.AutomaticallyAfterDays');
+  });
+});
+
+describe('#845 NLB live-only Subnets dropped when SubnetMappings declared', () => {
+  it('drops the live-only Subnets scalar mirror when SubnetMappings is declared', () => {
+    const res = mk('AWS::ElasticLoadBalancingV2::LoadBalancer', {
+      Type: 'network',
+      SubnetMappings: [{ SubnetId: 'subnet-a' }, { SubnetId: 'subnet-b' }],
+    });
+    const f = classifyResource(
+      res,
+      {
+        Type: 'network',
+        SubnetMappings: [{ SubnetId: 'subnet-a' }, { SubnetId: 'subnet-b' }],
+        Subnets: ['subnet-a', 'subnet-b'],
+      },
+      emptySchema
+    );
+    expect(allPaths(f)).not.toContain('Subnets');
+  });
+});
+
+describe('#845 AmazonMQ ACTIVEMQ StorageType default EFS', () => {
+  it('folds StorageType EFS to atDefault for an ACTIVEMQ broker declaring no StorageType', () => {
+    const res = mk('AWS::AmazonMQ::Broker', {
+      EngineType: 'ACTIVEMQ',
+      DeploymentMode: 'SINGLE_INSTANCE',
+    });
+    const f = classifyResource(res, { EngineType: 'ACTIVEMQ', StorageType: 'EFS' }, emptySchema);
+    expect(tier(f, 'atDefault')).toContain('StorageType');
+    expect(tier(f, 'undeclared')).not.toContain('StorageType');
+  });
+  it('surfaces an ACTIVEMQ broker whose StorageType is EBS (away from the EFS default) — detection preserved', () => {
+    const res = mk('AWS::AmazonMQ::Broker', {
+      EngineType: 'ACTIVEMQ',
+      DeploymentMode: 'SINGLE_INSTANCE',
+    });
+    const f = classifyResource(res, { EngineType: 'ACTIVEMQ', StorageType: 'EBS' }, emptySchema);
+    expect(tier(f, 'undeclared')).toContain('StorageType');
+  });
+});
+
+describe('#845 Firehose Lambda-processor Parameters[NumberOfRetries] default "3"', () => {
+  const roleArn = 'arn:aws:iam::111111111111:role/r';
+  const lambdaArn = 'arn:aws:lambda:us-east-1:111111111111:function:f';
+  const declaredProc = {
+    ExtendedS3DestinationConfiguration: {
+      ProcessingConfiguration: {
+        Enabled: true,
+        Processors: [
+          {
+            Type: 'Lambda',
+            Parameters: [{ ParameterName: 'LambdaArn', ParameterValue: lambdaArn }],
+          },
+        ],
+      },
+      RoleARN: roleArn,
+    },
+  };
+  const liveProc = (retries: string) => ({
+    ExtendedS3DestinationConfiguration: {
+      ProcessingConfiguration: {
+        Enabled: true,
+        Processors: [
+          {
+            Type: 'Lambda',
+            Parameters: [
+              { ParameterName: 'LambdaArn', ParameterValue: lambdaArn },
+              { ParameterName: 'NumberOfRetries', ParameterValue: retries },
+            ],
+          },
+        ],
+      },
+      RoleARN: roleArn,
+    },
+  });
+  const retriesPath =
+    'ExtendedS3DestinationConfiguration.ProcessingConfiguration.Processors.0.Parameters[NumberOfRetries]';
+  it('folds the server-injected NumberOfRetries "3" to atDefault', () => {
+    const f = classifyResource(
+      mk('AWS::KinesisFirehose::DeliveryStream', declaredProc),
+      liveProc('3'),
+      emptySchema
+    );
+    expect(tier(f, 'atDefault')).toContain(retriesPath);
+    expect(tier(f, 'undeclared')).not.toContain(retriesPath);
+  });
+  it('surfaces a non-default NumberOfRetries "5" — detection preserved', () => {
+    const f = classifyResource(
+      mk('AWS::KinesisFirehose::DeliveryStream', declaredProc),
+      liveProc('5'),
+      emptySchema
+    );
+    expect(tier(f, 'undeclared')).toContain(retriesPath);
+  });
+});

--- a/tests/classify.test.ts
+++ b/tests/classify.test.ts
@@ -2303,10 +2303,12 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
       },
     });
 
-    it('a reordered set + server-injected param is NOT declared drift; the live-only param surfaces as undeclared', () => {
+    it('a reordered set + server-injected param is NOT declared drift; the default NumberOfRetries folds to atDefault (#845)', () => {
       // AWS reorders the set (LambdaArn first) and injects NumberOfRetries=3 — exactly the
       // shape observed live on firehose-processors-rich. Declared subset of live by
-      // ParameterName -> no declared FP.
+      // ParameterName -> no declared FP. The server-injected NumberOfRetries="3" is the AWS
+      // default (#845), so the live-only entry folds to atDefault (not undeclared); a clean
+      // stream stays clean while a non-"3" retry count still surfaces (see below).
       const findings = classifyResource(
         res(T, declared),
         liveProcessing([
@@ -2318,14 +2320,33 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
         emptySchema
       );
       expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
-      const undeclared = findings.filter((f) => f.tier === 'undeclared');
-      expect(undeclared.map((f) => f.path)).toEqual([
+      expect(findings.filter((f) => f.tier === 'undeclared')).toEqual([]);
+      const atDefault = findings.filter((f) => f.tier === 'atDefault');
+      expect(atDefault.map((f) => f.path)).toEqual([
         'ExtendedS3DestinationConfiguration.ProcessingConfiguration.Processors.0.Parameters[NumberOfRetries]',
       ]);
-      expect(undeclared[0]).toMatchObject({
+      expect(atDefault[0]).toMatchObject({
         nested: true,
         actual: { ParameterName: 'NumberOfRetries', ParameterValue: '3' },
       });
+    });
+
+    it('a NON-default NumberOfRetries still surfaces as undeclared (#845 detection preserved)', () => {
+      // NumberOfRetries="5" diverges from the AWS default "3", so it is NOT folded — it
+      // surfaces as undeclared inventory (recorded; a later change still surfaces).
+      const undeclared = classifyResource(
+        res(T, declared),
+        liveProcessing([
+          { ParameterName: 'LambdaArn', ParameterValue: 'arn:aws:lambda:us-east-1:1:function:f' },
+          { ParameterName: 'NumberOfRetries', ParameterValue: '5' },
+          { ParameterName: 'RoleArn', ParameterValue: 'arn:aws:iam::1:role/r' },
+          { ParameterName: 'BufferSizeInMBs', ParameterValue: '1' },
+        ]),
+        emptySchema
+      ).filter((f) => f.tier === 'undeclared');
+      expect(undeclared.map((f) => f.path)).toEqual([
+        'ExtendedS3DestinationConfiguration.ProcessingConfiguration.Processors.0.Parameters[NumberOfRetries]',
+      ]);
     });
 
     it('a genuine change to a DECLARED parameter value still surfaces as declared drift (fail-closed)', () => {
@@ -2409,7 +2430,10 @@ describe('declared-compare false-positive classes from harvest4 (R75)', () => {
         emptySchema
       );
       expect(findings.filter((f) => f.tier === 'declared')).toEqual([]);
-      expect(findings.filter((f) => f.tier === 'undeclared').map((f) => f.path)).toEqual([
+      // #845: the server-injected NumberOfRetries="3" is the AWS default, so on any destination
+      // config it folds to atDefault (not undeclared) — the fold is destination-agnostic too.
+      expect(findings.filter((f) => f.tier === 'undeclared')).toEqual([]);
+      expect(findings.filter((f) => f.tier === 'atDefault').map((f) => f.path)).toEqual([
         'RedshiftDestinationConfiguration.ProcessingConfiguration.Processors.0.Parameters[NumberOfRetries]',
       ]);
     });

--- a/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
+++ b/tests/corpus/AWS__AmazonMQ__Broker.Broker.json
@@ -208,7 +208,7 @@
       "constructPath": "CdkRealDriftIntegAmazonMqVersionFp/Broker"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Broker",
       "resourceType": "AWS::AmazonMQ::Broker",
       "path": "StorageType",

--- a/tests/corpus/AWS__CodeBuild__Project.Build45A36621.json
+++ b/tests/corpus/AWS__CodeBuild__Project.Build45A36621.json
@@ -119,7 +119,7 @@
       "constructPath": "CdkRealDriftIntegCodepipelineRich/Build"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Build45A36621",
       "resourceType": "AWS::CodeBuild::Project",
       "path": "Artifacts.Name",

--- a/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
+++ b/tests/corpus/AWS__ElasticLoadBalancingV2__LoadBalancer.Nlb.subnetmappings.json
@@ -201,15 +201,6 @@
       "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
     },
     {
-      "tier": "undeclared",
-      "logicalId": "Nlb",
-      "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",
-      "path": "Subnets",
-      "actual": ["subnet-06375aa74c4098557", "subnet-09675102dd2b4e7d1"],
-      "physicalId": "arn:aws:elasticloadbalancing:us-east-1:111111111111:loadbalancer/net/CdkRealD-Nlb-NB5U8c26yJm1/dba9c61ba1aa1fcb",
-      "constructPath": "CdkRealDriftIntegNlbSubnetMappings/Nlb"
-    },
-    {
       "tier": "atDefault",
       "logicalId": "Nlb",
       "resourceType": "AWS::ElasticLoadBalancingV2::LoadBalancer",

--- a/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.processors.json
+++ b/tests/corpus/AWS__KinesisFirehose__DeliveryStream.Stream.processors.json
@@ -180,7 +180,7 @@
   },
   "expected": [
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Stream",
       "resourceType": "AWS::KinesisFirehose::DeliveryStream",
       "path": "ExtendedS3DestinationConfiguration.ProcessingConfiguration.Processors.0.Parameters[NumberOfRetries]",

--- a/tests/corpus/AWS__SecretsManager__RotationSchedule.Rotation9515E0C5.json
+++ b/tests/corpus/AWS__SecretsManager__RotationSchedule.Rotation9515E0C5.json
@@ -64,7 +64,7 @@
       "constructPath": "CdkRealDriftIntegSecretRotationRich/Rotation"
     },
     {
-      "tier": "undeclared",
+      "tier": "atDefault",
       "logicalId": "Rotation9515E0C5",
       "resourceType": "AWS::SecretsManager::RotationSchedule",
       "path": "RotationRules.AutomaticallyAfterDays",


### PR DESCRIPTION
Closes #845

Five corpus-baked first-run false positives of the DERIVED class — an undeclared/echo value AWS assigns that is a deterministic function of a declared input. Each is folded so a clean deploy shows zero potential drift, and each fold PRESERVES detection (equality-gated / symmetric-alt-rep, not value-independent): a value diverging from the derived default still surfaces as drift.

All folds live in `src/diff/classify.ts`:

1. **CodeBuild `Artifacts.Name`** — tier-2 derived `knownDefPaths`: gated against the declared top-level project `Name` (AWS default-fills the artifact name to the project name). A renamed artifact surfaces.
2. **Secrets `RotationRules.AutomaticallyAfterDays`** — tier-2 derived: parse the declared `RotationRules.ScheduleExpression` `rate(N days)` and gate the day count `N`. A re-scheduled rotation surfaces.
3. **NLB live-only `Subnets`** — symmetric `CC_ALT_REPRESENTATION` rule (`Subnets: 'SubnetMappings'`): drop the live scalar `Subnets` mirror when `SubnetMappings` is declared (the existing rule only dropped the other direction). The subnets are still compared via the declared `SubnetMappings`.
4. **AmazonMQ `StorageType`** — tier-2 derived `knownDef`: an ACTIVEMQ broker declaring no StorageType defaults to `EFS` (RabbitMQ supports only EBS). An ActiveMQ broker on EBS surfaces.
5. **Firehose Lambda-processor `Parameters[NumberOfRetries]`** — equality-gated constant applied to the name/value subset live-only entry in classify.ts: the AWS default `NumberOfRetries: "3"` folds to atDefault; a non-"3" count surfaces. (Distinct from #652's whole-object twin echo.)

All five were derivable from declared inputs — none required value-independent.

## Tests

- New `tests/classify-845-derived.test.ts` (9 cases): each fold asserts atDefault on the clean model AND (where meaningful) that a diverging value still surfaces as undeclared — detection preserved.
- Updated the two Firehose `Parameters[NumberOfRetries]` cases in `tests/classify.test.ts` to the new atDefault fold + a new non-default-surfaces case.
- Regenerated the 5 corpus `expected` snapshots (the visible, reviewable behavior change).

typecheck / lint+format / build / 3549 unit tests all green.