### PR TITLE
chore(corpus): OpenSearch Domain stale createOnlyPaths (#887)

### DIFF
--- a/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
+++ b/tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json
@@ -157,11 +157,7 @@
       "AdvancedSecurityOptions.SAMLOptions.MasterBackendRole",
       "AdvancedSecurityOptions.SAMLOptions.MasterUserName"
     ],
-    "createOnlyPaths": [
-      "AdvancedSecurityOptions.properties.Enabled",
-      "DomainName",
-      "EncryptionAtRestOptions.properties"
-    ],
+    "createOnlyPaths": ["DomainName"],
     "defaults": {},
     "defaultPaths": {}
   },


### PR DESCRIPTION
Closes #887.

## What was stale
`tests/corpus/AWS__OpenSearchService__Domain.OpenSearch587998CD.json` carried `createOnlyPaths` produced by an OLDER schema parser:

```
"createOnlyPaths": [
  "AdvancedSecurityOptions.properties.Enabled",
  "DomainName",
  "EncryptionAtRestOptions.properties"
]
```

Two entries are malformed artifacts:
- `EncryptionAtRestOptions.properties` — interior/trailing `/properties/` not collapsed.
- `AdvancedSecurityOptions.properties.Enabled` — a `conditionalCreateOnlyProperties` entry wrongly merged into `createOnlyPaths` (and again not collapsed).

Both bugs are fixed in `src/schema/schema-strip.ts`: `pointerToDotted` now collapses interior/trailing `/properties/`, and `parseSchema` maps ONLY `createOnlyProperties` (not `conditionalCreateOnlyProperties`) into `createOnlyPaths`. The stale fixture therefore drove corpus-replay through a revert-barring branch (`isUnderCreateOnly` treating parent `EncryptionAtRestOptions` as create-only) that the live parser never produces.

## What the current parser emits
Confirmed against the LIVE registry schema (`describe-type AWS::OpenSearchService::Domain`):
- `createOnlyProperties = ['/properties/DomainName']` -> `pointerToDotted` -> `"DomainName"`
- `conditionalCreateOnlyProperties = ['/properties/EncryptionAtRestOptions/properties', '/properties/AdvancedSecurityOptions/properties/Enabled']` -> NOT merged into `createOnlyPaths`

So the current parser emits `createOnlyPaths: ["DomainName"]`, which is what the fixture now carries. (`EncryptionAtRestOptions.KmsKeyId`'s `generated`-tier finding is driven by `GENERATED_NESTED_PATHS`, not `createOnlyPaths`, so it is unaffected.)

## Verification
- `vp test run corpus-replay` — green (678 passed).
- `vp run check` — 0 errors.

Corpus-only change; no `src/**` touched.

Note: the sibling fixture `AWS__OpenSearchService__Domain.Domain66AC69E0.json` carries the same stale-form `createOnlyPaths` (`["AdvancedSecurityOptions.Enabled", "DomainName", "EncryptionAtRestOptions"]`) — left untouched per #887's file scope, but a candidate for the same normalization.
